### PR TITLE
Add decoration to focused item

### DIFF
--- a/extensions/ql-vscode/src/interface.ts
+++ b/extensions/ql-vscode/src/interface.ts
@@ -98,6 +98,7 @@ export class InterfaceManager extends DisposableObject {
 
     super();
     this.push(this._diagnosticCollection);
+    this.push(vscode.window.onDidChangeTextEditorSelection(this.handleSelectionChange.bind(this)));
   }
 
   // Returns the webview panel, creating it if it doesn't already
@@ -398,16 +399,40 @@ export class InterfaceManager extends DisposableObject {
       sortState: info.sortState
     };
   }
+
+  private handleSelectionChange(event: vscode.TextEditorSelectionChangeEvent) {
+    if (event.kind === vscode.TextEditorSelectionChangeKind.Command) {
+      return; // Ignore selection events we caused ourselves.
+    }
+    let editor = vscode.window.activeTextEditor;
+    if (editor !== undefined) {
+      editor.setDecorations(shownLocationDecoration, []);
+      editor.setDecorations(shownLocationLineDecoration, []);
+    }
+  }
 }
+
+const findMatchBackground = new vscode.ThemeColor('editor.findMatchBackground');
+const findRangeHighlightBackground = new vscode.ThemeColor('editor.findRangeHighlightBackground');
+
+const shownLocationDecoration = vscode.window.createTextEditorDecorationType({
+  backgroundColor: findMatchBackground,
+});
+
+const shownLocationLineDecoration = vscode.window.createTextEditorDecorationType({
+  backgroundColor: findRangeHighlightBackground,
+  isWholeLine: true
+});
 
 async function showLocation(loc: ResolvableLocationValue, databaseItem: DatabaseItem): Promise<void> {
   const resolvedLocation = tryResolveLocation(loc, databaseItem);
   if (resolvedLocation) {
     const doc = await workspace.openTextDocument(resolvedLocation.uri);
     const editor = await Window.showTextDocument(doc, vscode.ViewColumn.One);
-    const sel = new vscode.Selection(resolvedLocation.range.start, resolvedLocation.range.end);
-    editor.selection = sel;
-    editor.revealRange(sel, vscode.TextEditorRevealType.InCenter);
+    editor.selection = new vscode.Selection(resolvedLocation.range.start, resolvedLocation.range.end);
+    editor.revealRange(resolvedLocation.range, vscode.TextEditorRevealType.InCenter);
+    editor.setDecorations(shownLocationDecoration, [resolvedLocation.range]);
+    editor.setDecorations(shownLocationLineDecoration, [resolvedLocation.range]);
   }
 }
 

--- a/extensions/ql-vscode/src/interface.ts
+++ b/extensions/ql-vscode/src/interface.ts
@@ -434,7 +434,7 @@ async function showLocation(loc: ResolvableLocationValue, databaseItem: Database
     // trigger based on where we place the cursor/selection, and will compete for the user's attention.
     // For reference:
     // - Occurences are highlighted when the cursor is next to or inside a word or a whole word is selected.
-    // - Brackets are highlighted when the cursor is next to a bracket and there is a non-empty selection.
+    // - Brackets are highlighted when the cursor is next to a bracket and there is an empty selection.
     // - Multi-line selections explicitly highlight line-break characters, but multi-line decorators do not.
     //
     // For single-line ranges, select the whole range, mainly to disable bracket highlighting.


### PR DESCRIPTION
When following a link from the result viewer, we highlighted the target range simply by selecting it. 

When this range is an identifier, it triggers vscode's occurrence-match highlighting, which makes it hard to see at a glance what was highlighted. This PR introduces decorators to highlight it a bit more, using the same colors as in search/replace.

The decoration is cleared on any selection change event in that editor.

Before
-
<img width="535" alt="Screenshot 2019-11-15 at 12 40 14" src="https://user-images.githubusercontent.com/42069257/68944145-19149900-07a5-11ea-9beb-250e0276e3fc.png">

After
-
<img width="536" alt="Screenshot 2019-11-15 at 12 40 08" src="https://user-images.githubusercontent.com/42069257/68944159-203ba700-07a5-11ea-885b-6b7c17614ac0.png">
