### PR TITLE
A few versioning fixes

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -4,7 +4,7 @@
   "description": "CodeQL for Visual Studio Code",
   "author": "GitHub",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "publisher": "GitHub",
   "license": "MIT",
   "icon": "media/VS-marketplace-CodeQL-icon.png",

--- a/tools/build-tasks/src/deploy.ts
+++ b/tools/build-tasks/src/deploy.ts
@@ -154,7 +154,7 @@ export async function deployPackage(packageJsonPath: string): Promise<DeployedPa
 
     if (isDevBuild) {
       // NOTE: rootPackage.name had better not have any regex metacharacters
-      const oldDevBuildPattern = new RegExp('^' + rootPackage.name + '[^/]+-dev[0-9.]+.vsix$');
+      const oldDevBuildPattern = new RegExp('^' + rootPackage.name + '[^/]+-dev[0-9.]+\\.vsix$');
       // Dev package filenames are of the form
       //    vscode-codeql-0.0.1-dev.2019.9.27.19.55.20.vsix
       (await fs.readdir(distDir)).filter(name => name.match(oldDevBuildPattern)).map(build => {


### PR DESCRIPTION
- Bumps the version of the extension to 1.0.1. We should bump the version immediately after every official release, so that any builds that happen after the release are treated as prerelease versions of the next release.

- Separates the components of the timestamp in the version number for non-release builds. This just makes it easier to read. I also left off the milliseconds, which were kind of overkill, and switched to using UTC time to avoid time-zone ambiguity.

- Updates the version number in the copy of the extension's `package.json` that winds up in the actual .vsix, so VS Code actually sees the version as being the proper prelease version.