### PR TITLE
Simplify selected results table handling

### DIFF
--- a/extensions/ql-vscode/src/view/alert-table.tsx
+++ b/extensions/ql-vscode/src/view/alert-table.tsx
@@ -1,10 +1,9 @@
-import cx from 'classnames';
 import * as path from 'path';
 import * as React from 'react';
 import * as Sarif from 'sarif';
 import { LocationStyle, ResolvableLocationValue } from 'semmle-bqrs';
 import * as octicons from './octicons';
-import { className, renderLocation, ResultTableProps, selectedClassName, zebraStripe } from './result-table-utils';
+import { className, renderLocation, ResultTableProps, zebraStripe } from './result-table-utils';
 import { PathTableResultSet } from './results';
 
 export type PathTableProps = ResultTableProps & { resultSet: PathTableResultSet };
@@ -99,11 +98,7 @@ export class PathTable extends React.Component<PathTableProps, PathTableState> {
   }
 
   render(): JSX.Element {
-    const { selected, databaseUri, resultSet } = this.props;
-
-    const tableClassName = cx(className, {
-      [selectedClassName]: selected
-    });
+    const { databaseUri, resultSet } = this.props;
 
     const rows: JSX.Element[] = [];
     const { numTruncatedResults, sourceLocationPrefix } = resultSet;
@@ -342,7 +337,7 @@ export class PathTable extends React.Component<PathTableProps, PathTableState> {
       </td></tr>);
     }
 
-    return <table className={tableClassName}>
+    return <table className={className}>
       <tbody>{rows}</tbody>
     </table>;
   }

--- a/extensions/ql-vscode/src/view/raw-results-table.tsx
+++ b/extensions/ql-vscode/src/view/raw-results-table.tsx
@@ -1,6 +1,5 @@
-import cx from 'classnames';
 import * as React from "react";
-import { className, renderLocation, ResultTableProps, selectedClassName, zebraStripe } from "./result-table-utils";
+import { renderLocation, ResultTableProps, zebraStripe, className } from "./result-table-utils";
 import { RawTableResultSet, ResultValue, vscode } from "./results";
 import { assertNever } from "../helpers-pure";
 import { SortDirection, SortState, RAW_RESULTS_LIMIT } from "../interface-types";
@@ -16,11 +15,7 @@ export class RawTable extends React.Component<RawTableProps, {}> {
   }
 
   render(): React.ReactNode {
-    const { resultSet, selected, databaseUri } = this.props;
-
-    const tableClassName = cx(className, {
-      [selectedClassName]: selected
-    });
+    const { resultSet, databaseUri } = this.props;
 
     let dataRows = this.props.resultSet.rows;
     let numTruncatedResults = 0;
@@ -52,7 +47,7 @@ export class RawTable extends React.Component<RawTableProps, {}> {
       </td></tr>);
     }
 
-    return <table className={tableClassName}>
+    return <table className={className}>
       <thead>
         <tr>
           {

--- a/extensions/ql-vscode/src/view/result-table-utils.tsx
+++ b/extensions/ql-vscode/src/view/result-table-utils.tsx
@@ -4,7 +4,6 @@ import { SortState } from '../interface-types';
 import { ResultSet, vscode } from './results';
 
 export interface ResultTableProps {
-  selected: boolean;
   resultSet: ResultSet;
   databaseUri: string;
   resultsPath: string | undefined;
@@ -14,8 +13,6 @@ export interface ResultTableProps {
 export const className = 'vscode-codeql__result-table';
 export const tableSelectionHeaderClassName = 'vscode-codeql__table-selection-header';
 export const toggleDiagnosticsClassName = `${className}-toggle-diagnostics`;
-export const selectedClassName = `${className}--selected`;
-export const toggleDiagnosticsSelectedClassName = `${toggleDiagnosticsClassName}--selected`;
 export const evenRowClassName = 'vscode-codeql__result-table-row--even';
 export const oddRowClassName = 'vscode-codeql__result-table-row--odd';
 export const pathRowClassName = 'vscode-codeql__result-table-row--path';

--- a/extensions/ql-vscode/src/view/resultsView.css
+++ b/extensions/ql-vscode/src/view/resultsView.css
@@ -1,11 +1,7 @@
 .vscode-codeql__result-table {
-  display: none;
+  display: table;
   border-collapse: collapse;
   width: 100%;
-}
-
-.vscode-codeql__result-table--selected {
-  display: table;
 }
 
 .vscode-codeql__table-selection-header {
@@ -18,22 +14,18 @@
 }
 
 .vscode-codeql__result-table-toggle-diagnostics {
-  display: none;
+  display: inline-block;
   text-align: left;
   margin-left: auto;
 }
 
-.vscode-codeql__result-table-toggle-diagnostics--selected {
-  display: inline-block;
-}
-
 /* Keep the checkbox and its label in horizontal alignment. */
-.vscode-codeql__result-table-toggle-diagnostics--selected label,
-.vscode-codeql__result-table-toggle-diagnostics--selected input {
+.vscode-codeql__result-table-toggle-diagnostics label,
+.vscode-codeql__result-table-toggle-diagnostics input {
   display: inline-block;
   vertical-align: middle;
 }
-.vscode-codeql__result-table-toggle-diagnostics--selected input {
+.vscode-codeql__result-table-toggle-diagnostics input {
   margin: 3px 3px 1px 3px;
 }
 


### PR DESCRIPTION
We don't need to render all tables and use css to hide the ones we
don't currently want to see. Instead have `render` return the dom that
should be visible given the current state.