### PR TITLE
Fix auto-upgrade script path

### DIFF
--- a/extensions/ql-vscode/src/databases-ui.ts
+++ b/extensions/ql-vscode/src/databases-ui.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import { DisposableObject } from "semmle-vscode-utils";
 import { commands, Event, EventEmitter, ExtensionContext, ProviderResult, TreeDataProvider, TreeItem, Uri, window } from "vscode";
 import * as cli from './cli';
-import { DatabaseItem, DatabaseManager } from "./databases";
+import { DatabaseItem, DatabaseManager, getUpgradesDirectories } from "./databases";
 import { logger } from "./logging";
 import { clearCacheInDatabase, upgradeDatabase, UserCancellationException } from "./queries";
 import * as qsClient from './queryserver-client';
@@ -189,15 +189,10 @@ export class DatabaseUI extends DisposableObject {
       logger.log('Could not determine target dbscheme to upgrade to.');
       return;
     }
-
-    const parentDirs = scripts.map(dir => path.dirname(dir));
-    const uniqueParentDirs = new Set(parentDirs);
     const targetDbSchemeUri = Uri.file(finalDbscheme);
 
-
-    const upgradesDirectories = Array.from(uniqueParentDirs).map(filePath => Uri.file(filePath));
     try {
-      await upgradeDatabase(this.queryServer, databaseItem, targetDbSchemeUri, upgradesDirectories);
+      await upgradeDatabase(this.queryServer, databaseItem, targetDbSchemeUri, getUpgradesDirectories(scripts));
     }
     catch (e) {
       if (e instanceof UserCancellationException) {

--- a/extensions/ql-vscode/src/databases.ts
+++ b/extensions/ql-vscode/src/databases.ts
@@ -629,3 +629,13 @@ export class DatabaseManager extends DisposableObject {
     this.ctx.workspaceState.update(DB_LIST, this._databaseItems.map(item => item.getPersistedState()));
   }
 }
+
+/**
+ * Get the set of directories containing upgrades, given a list of
+ * scripts returned by the cli's upgrade resolution.
+ */
+export function getUpgradesDirectories(scripts: string[]): vscode.Uri[] {
+  const parentDirs = scripts.map(dir => path.dirname(dir));
+  const uniqueParentDirs = new Set(parentDirs);
+  return Array.from(uniqueParentDirs).map(filePath => vscode.Uri.file(filePath));
+}


### PR DESCRIPTION
This was a simple case of passing entirely the wrong data as an
argument to the `upgradeDatabase` call in `queries.ts`. We were
passing the list of search paths for upgrades, when we should have
been passing the list of directories directly containing upgrade
scripts to be applied.

Fixes #168.