### PR TITLE
Add commands for navigating the steps on a path

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -170,6 +170,14 @@
       {
         "command": "codeQLQueryHistory.itemClicked",
         "title": "Query History Item"
+      },
+      {
+        "command": "codeQLQueryResults.nextPathStep",
+        "title": "CodeQL: Show Next Step on Path"
+      },
+      {
+        "command": "codeQLQueryResults.previousPathStep",
+        "title": "CodeQL: Show Previous Step on Path"
       }
     ],
     "menus": {

--- a/extensions/ql-vscode/src/interface-types.ts
+++ b/extensions/ql-vscode/src/interface-types.ts
@@ -65,7 +65,15 @@ export interface SetStateMsg {
   shouldKeepOldResultsWhileRendering: boolean;
 };
 
-export type IntoResultsViewMsg = ResultsUpdatingMsg | SetStateMsg;
+/** Advance to the next or previous path no in the path viewer */
+export interface NavigatePathMsg {
+  t: 'navigatePath',
+
+  /** 1 for next, -1 for previous */
+  direction: number;
+}
+
+export type IntoResultsViewMsg = ResultsUpdatingMsg | SetStateMsg | NavigatePathMsg;
 
 export type FromResultsViewMsg = ViewSourceFileMsg | ToggleDiagnostics | ChangeSortMsg | ResultViewLoaded;
 

--- a/extensions/ql-vscode/src/interface.ts
+++ b/extensions/ql-vscode/src/interface.ts
@@ -99,6 +99,12 @@ export class InterfaceManager extends DisposableObject {
     super();
     this.push(this._diagnosticCollection);
     this.push(vscode.window.onDidChangeTextEditorSelection(this.handleSelectionChange.bind(this)));
+    this.push(vscode.commands.registerCommand('codeQLQueryResults.nextPathStep', this.navigatePathStep.bind(this, 1)));
+    this.push(vscode.commands.registerCommand('codeQLQueryResults.previousPathStep', this.navigatePathStep.bind(this, -1)));
+  }
+
+  navigatePathStep(direction: number) {
+    this.postMessage({ t: "navigatePath", direction });
   }
 
   // Returns the webview panel, creating it if it doesn't already

--- a/extensions/ql-vscode/src/result-keys.ts
+++ b/extensions/ql-vscode/src/result-keys.ts
@@ -1,0 +1,95 @@
+import * as sarif from 'sarif';
+
+/**
+ * Identifies one of the results in a result set by its index in the result list.
+ */
+export interface Result {
+  resultIndex: number;
+}
+
+/**
+ * Identifies one of the paths associated with a result.
+ */
+export interface Path extends Result {
+  pathIndex: number;
+}
+
+/**
+ * Identifies one of the nodes in a path.
+ */
+export interface PathNode extends Path {
+  pathNodeIndex: number;
+}
+
+/** Alias for `undefined` but more readable in some cases */
+export const none: PathNode | undefined = undefined;
+
+/**
+ * Looks up a specific result in a result set.
+ */
+export function getResult(sarif: sarif.Log, key: Result): sarif.Result | undefined {
+  if (sarif.runs.length === 0) return undefined;
+  if (sarif.runs[0].results === undefined) return undefined;
+  let results = sarif.runs[0].results;
+  return results[key.resultIndex];
+}
+
+/**
+ * Looks up a specific path in a result set.
+ */
+export function getPath(sarif: sarif.Log, key: Path): sarif.ThreadFlow | undefined {
+  let result = getResult(sarif, key);
+  if (result === undefined) return undefined;
+  let index = -1;
+  if (result.codeFlows === undefined) return undefined;
+  for (let codeFlows of result.codeFlows) {
+    for (let threadFlow of codeFlows.threadFlows) {
+      ++index;
+      if (index == key.pathIndex)
+        return threadFlow;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Looks up a specific path node in a result set.
+ */
+export function getPathNode(sarif: sarif.Log, key: PathNode): sarif.Location | undefined {
+  let path = getPath(sarif, key);
+  if (path === undefined) return undefined;
+  return path.locations[key.pathNodeIndex];
+}
+
+/**
+ * Returns true if the two keys are both `undefined` or contain the same set of indices.
+ */
+export function equals(key1: PathNode | undefined, key2: PathNode | undefined): boolean {
+  if (key1 === key2) return true;
+  if (key1 === undefined || key2 === undefined) return false;
+  return key1.resultIndex === key2.resultIndex && key1.pathIndex === key2.pathIndex && key1.pathNodeIndex === key2.pathNodeIndex;
+}
+
+/**
+ * Returns true if the two keys contain the same set of indices and neither are `undefined`.
+ */
+export function equalsNotUndefined(key1: PathNode | undefined, key2: PathNode | undefined): boolean {
+  if (key1 === undefined || key2 === undefined) return false;
+  return key1.resultIndex === key2.resultIndex && key1.pathIndex === key2.pathIndex && key1.pathNodeIndex === key2.pathNodeIndex;
+}
+
+/**
+ * Returns the list of paths in the given SARIF result.
+ *
+ * Path nodes indices are relative to this flattened list.
+ */
+export function getAllPaths(result: sarif.Result): sarif.ThreadFlow[] {
+  if (result.codeFlows === undefined) return [];
+  let paths = [];
+  for (const codeFlow of result.codeFlows) {
+    for (const threadFlow of codeFlow.threadFlows) {
+      paths.push(threadFlow);
+    }
+  }
+  return paths;
+}

--- a/extensions/ql-vscode/src/result-keys.ts
+++ b/extensions/ql-vscode/src/result-keys.ts
@@ -30,7 +30,7 @@ export const none: PathNode | undefined = undefined;
 export function getResult(sarif: sarif.Log, key: Result): sarif.Result | undefined {
   if (sarif.runs.length === 0) return undefined;
   if (sarif.runs[0].results === undefined) return undefined;
-  let results = sarif.runs[0].results;
+  const results = sarif.runs[0].results;
   return results[key.resultIndex];
 }
 

--- a/extensions/ql-vscode/src/view/event-handler-list.ts
+++ b/extensions/ql-vscode/src/view/event-handler-list.ts
@@ -1,0 +1,25 @@
+export type EventHandler<T> = (event: T) => void;
+
+/**
+ * A set of listeners for events of type `T`.
+ */
+export class EventHandlers<T> {
+    private handlers: EventHandler<T>[] = [];
+
+    public addListener(handler: EventHandler<T>) {
+        this.handlers.push(handler);
+    }
+
+    public removeListener(handler: EventHandler<T>) {
+        let index = this.handlers.indexOf(handler);
+        if (index !== -1) {
+            this.handlers.splice(index, 1);
+        }
+    }
+
+    public fire(event: T) {
+        for (let handler of this.handlers) {
+            handler(event);
+        }
+    }
+}

--- a/extensions/ql-vscode/src/view/result-table-utils.tsx
+++ b/extensions/ql-vscode/src/view/result-table-utils.tsx
@@ -24,15 +24,19 @@ export function jumpToLocationHandler(
   callback?: () => void
 ): (e: React.MouseEvent) => void {
   return (e) => {
-    vscode.postMessage({
-      t: 'viewSourceFile',
-      loc,
-      databaseUri
-    });
+    jumpToLocation(loc, databaseUri);
     e.preventDefault();
     e.stopPropagation();
     if (callback) callback();
   };
+}
+
+export function jumpToLocation(loc: ResolvableLocationValue, databaseUri: string) {
+  vscode.postMessage({
+    t: 'viewSourceFile',
+    loc,
+    databaseUri
+  });
 }
 
 /**

--- a/extensions/ql-vscode/src/view/result-table-utils.tsx
+++ b/extensions/ql-vscode/src/view/result-table-utils.tsx
@@ -16,10 +16,12 @@ export const toggleDiagnosticsClassName = `${className}-toggle-diagnostics`;
 export const evenRowClassName = 'vscode-codeql__result-table-row--even';
 export const oddRowClassName = 'vscode-codeql__result-table-row--odd';
 export const pathRowClassName = 'vscode-codeql__result-table-row--path';
+export const selectedRowClassName = 'vscode-codeql__result-table-row--selected';
 
 export function jumpToLocationHandler(
   loc: ResolvableLocationValue,
-  databaseUri: string
+  databaseUri: string,
+  callback?: () => void
 ): (e: React.MouseEvent) => void {
   return (e) => {
     vscode.postMessage({
@@ -29,6 +31,7 @@ export function jumpToLocationHandler(
     });
     e.preventDefault();
     e.stopPropagation();
+    if (callback) callback();
   };
 }
 
@@ -36,7 +39,7 @@ export function jumpToLocationHandler(
  * Render a location as a link which when clicked displays the original location.
  */
 export function renderLocation(loc: LocationValue | undefined, label: string | undefined,
-  databaseUri: string, title?: string): JSX.Element {
+  databaseUri: string, title?: string, callback?: () => void): JSX.Element {
 
   // If the label was empty, use a placeholder instead, so the link is still clickable.
   let displayLabel = label;
@@ -51,7 +54,7 @@ export function renderLocation(loc: LocationValue | undefined, label: string | u
       return <a href="#"
         className="vscode-codeql__result-table-location-link"
         title={title}
-        onClick={jumpToLocationHandler(resolvableLoc, databaseUri)}>{displayLabel}</a>;
+        onClick={jumpToLocationHandler(resolvableLoc, databaseUri, callback)}>{displayLabel}</a>;
     } else {
       return <span title={title}>{displayLabel}</span>;
     }
@@ -63,5 +66,15 @@ export function renderLocation(loc: LocationValue | undefined, label: string | u
  * Returns the attributes for a zebra-striped table row at position `index`.
  */
 export function zebraStripe(index: number, ...otherClasses: string[]): { className: string } {
-  return { className: [(index % 2) ? oddRowClassName : evenRowClassName, otherClasses].join(' ') };
+  return { className: [(index % 2) ? oddRowClassName : evenRowClassName, ...otherClasses].join(' ') };
+}
+
+/**
+ * Returns the attributes for a zebra-striped table row at position `index`,
+ * with highlighting if `isSelected` is true.
+ */
+export function selectableZebraStripe(isSelected: boolean, index: number, ...otherClasses: string[]): { className: string } {
+  return isSelected
+      ? { className: [selectedRowClassName, ...otherClasses].join(' ') }
+      : zebraStripe(index, ...otherClasses)
 }

--- a/extensions/ql-vscode/src/view/results.tsx
+++ b/extensions/ql-vscode/src/view/results.tsx
@@ -3,8 +3,9 @@ import * as Rdom from 'react-dom';
 import * as bqrs from 'semmle-bqrs';
 import { ElementBase, LocationValue, PrimitiveColumnValue, PrimitiveTypeKind, ResultSetSchema, tryGetResolvableLocation } from 'semmle-bqrs';
 import { assertNever } from '../helpers-pure';
-import { DatabaseInfo, FromResultsViewMsg, Interpretation, IntoResultsViewMsg, SortedResultSetInfo, SortState } from '../interface-types';
+import { DatabaseInfo, FromResultsViewMsg, Interpretation, IntoResultsViewMsg, SortedResultSetInfo, SortState, NavigatePathMsg } from '../interface-types';
 import { ResultTables } from './result-tables';
+import { EventHandlers as EventHandlerList } from './event-handler-list';
 
 /**
  * results.tsx
@@ -156,6 +157,13 @@ interface ResultsViewState {
   isExpectingResultsUpdate: boolean;
 }
 
+export type NavigationEvent = NavigatePathMsg;
+
+/**
+ * Event handlers to be notified of navigation events coming from outside the webview.
+ */
+export const onNavigation = new EventHandlerList<NavigationEvent>();
+
 /**
  * A minimal state container for displaying results.
  */
@@ -191,6 +199,9 @@ class App extends React.Component<{}, ResultsViewState> {
         this.setState({
           isExpectingResultsUpdate: true
         });
+        break;
+      case 'navigatePath':
+        onNavigation.fire(msg);
         break;
       default:
         assertNever(msg);

--- a/extensions/ql-vscode/src/view/resultsView.css
+++ b/extensions/ql-vscode/src/view/resultsView.css
@@ -87,6 +87,10 @@ select {
   background-color: var(--vscode-textBlockQuote-background);
 }
 
+.vscode-codeql__result-table-row--selected {
+  background-color: var(--vscode-editor-findMatchBackground);
+}
+
 td.vscode-codeql__icon-cell {
   text-align: center;
   position: relative;


### PR DESCRIPTION
This adds the command `CodeQL: Show Next Step on Path` and `CodeQL: Show Previous Step on Path` for navigating the steps on the currently shown path.

The idea is that you can add keybindings for these commands to navigate the path without the mouse. Doing this with the mouse required quite a bit of zig-zag eye tracking between the code view and result view.

You still have to click one of the steps on a path to "choose" that path. There are currently no commands for switching between results or paths. It would be nice to have a fully keyboard-controllable result view, but I think I'll leave that for a future PR.

It's a bit of a hassle to make the result view remember which path node was previously clicked. For this we need a way to reference a specific part of the result set, that is, a result index, path index, and a path step index. I introduced the types `Keys.Result`, `Keys.Path`, and `Keys.PathNode` to represent such indices.

Commit-by-commit review recommended.