### PR TITLE
Bump version to 1.0.2

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -4,7 +4,7 @@
   "description": "CodeQL for Visual Studio Code",
   "author": "GitHub",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "publisher": "GitHub",
   "license": "MIT",
   "icon": "media/VS-marketplace-CodeQL-icon.png",


### PR DESCRIPTION
Now that we've released 1.0.1, all subsequent builds should be prerelease versions of 1.0.2