### PR TITLE
Store the current counter value and use it for the sorted results path.

### DIFF
--- a/extensions/ql-vscode/src/queries.ts
+++ b/extensions/ql-vscode/src/queries.ts
@@ -48,7 +48,7 @@ export class QueryInfo {
    */
   sortedResultsInfo: Map<string, SortedResultSetInfo>;
   dataset: vscode.Uri; // guarantee the existence of a well-defined dataset dir at this point
-
+  queryId: number;
   constructor(
     public program: messages.QlProgram,
     public dbItem: DatabaseItem,
@@ -56,17 +56,17 @@ export class QueryInfo {
     public quickEvalPosition?: messages.Position,
     public metadata?: cli.QueryMetadata,
   ) {
-    this.compiledQueryPath = path.join(tmpDir.name, `compiledQuery${queryCounter}.qlo`);
+    this.queryId = queryCounter++;
+    this.compiledQueryPath = path.join(tmpDir.name, `compiledQuery${this.queryId}.qlo`);
     this.resultsInfo = {
-      resultsPath: path.join(tmpDir.name, `results${queryCounter}.bqrs`),
-      interpretedResultsPath: path.join(tmpDir.name, `interpretedResults${queryCounter}.sarif`)
+      resultsPath: path.join(tmpDir.name, `results${this.queryId}.bqrs`),
+      interpretedResultsPath: path.join(tmpDir.name, `interpretedResults${this.queryId}.sarif`)
     };
     this.sortedResultsInfo = new Map();
     if (dbItem.contents === undefined) {
       throw new Error('Can\'t run query on invalid database.');
     }
     this.dataset = dbItem.contents.datasetUri;
-    queryCounter++;
   }
 
   async run(
@@ -160,7 +160,7 @@ export class QueryInfo {
     }
 
     const sortedResultSetInfo: SortedResultSetInfo = {
-      resultsPath: path.join(tmpDir.name, `sortedResults${queryCounter}-${resultSetName}.bqrs`),
+      resultsPath: path.join(tmpDir.name, `sortedResults${this.queryId}-${resultSetName}.bqrs`),
       sortState
     };
 

--- a/extensions/ql-vscode/src/queries.ts
+++ b/extensions/ql-vscode/src/queries.ts
@@ -30,7 +30,6 @@ export const tmpDirDisposal = {
   }
 };
 
-let queryCounter = 0;
 
 export class UserCancellationException extends Error { }
 
@@ -43,6 +42,8 @@ export class UserCancellationException extends Error { }
 export class QueryInfo {
   compiledQueryPath: string;
   resultsInfo: ResultsInfo;
+  private static nextQueryId = 0;
+
   /**
    * Map from result set name to SortedResultSetInfo.
    */
@@ -56,7 +57,7 @@ export class QueryInfo {
     public quickEvalPosition?: messages.Position,
     public metadata?: cli.QueryMetadata,
   ) {
-    this.queryId = queryCounter++;
+    this.queryId = QueryInfo.nextQueryId++;
     this.compiledQueryPath = path.join(tmpDir.name, `compiledQuery${this.queryId}.qlo`);
     this.resultsInfo = {
       resultsPath: path.join(tmpDir.name, `results${this.queryId}.bqrs`),


### PR DESCRIPTION
This way they don't clash when switching between sorted queries. As the filename wasn't assigned in the constructor, it was using the value for the next run query rather than the id for the current query.