### PR TITLE
Split queries

### DIFF
--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -6,7 +6,7 @@ import * as util from 'util';
 import { Logger, ProgressReporter } from "./logging";
 import { Disposable } from "vscode";
 import { DistributionProvider } from "./distribution";
-import { SortDirection } from "./interface-types";
+import { SortDirection, QueryMetadata } from "./interface-types";
 import { assertNever } from "./helpers-pure";
 
 /**
@@ -48,16 +48,6 @@ export interface DbInfo {
 export interface UpgradesInfo {
   scripts: string[];
   finalDbscheme: string;
-}
-
-/**
- * The expected output of `codeql resolve metadata`.
- */
-export interface QueryMetadata {
-  name?: string,
-  description?: string,
-  id?: string,
-  kind?: string
 }
 
 // `codeql bqrs interpret` requires both of these to be present or

--- a/extensions/ql-vscode/src/databases-ui.ts
+++ b/extensions/ql-vscode/src/databases-ui.ts
@@ -4,9 +4,10 @@ import { commands, Event, EventEmitter, ExtensionContext, ProviderResult, TreeDa
 import * as cli from './cli';
 import { DatabaseItem, DatabaseManager, getUpgradesDirectories } from "./databases";
 import { logger } from "./logging";
-import { clearCacheInDatabase, upgradeDatabase, UserCancellationException } from "./queries";
+import { clearCacheInDatabase, UserCancellationException } from "./run-queries";
 import * as qsClient from './queryserver-client';
 import { getOnDiskWorkspaceFolders } from "./helpers";
+import { upgradeDatabase } from './upgrades';
 
 type ThemableIconPath = { light: string, dark: string } | string;
 

--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import { CancellationToken, ProgressOptions, window as Window, workspace } from 'vscode';
 import { logger } from './logging';
-import { EvaluationInfo } from './queries';
+import { QueryInfo } from './run-queries';
 
 export interface ProgressUpdate {
   /**
@@ -121,16 +121,16 @@ export function getOnDiskWorkspaceFolders() {
  * Gets a human-readable name for an evaluated query.
  * Uses metadata if it exists, and defaults to the query file name.
  */
-export function getQueryName(info: EvaluationInfo) {
+export function getQueryName(query: QueryInfo) {
   // Queries run through quick evaluation are not usually the entire query file.
   // Label them differently and include the line numbers.
-  if (info.query.quickEvalPosition !== undefined) {
-    const { line, endLine, fileName } = info.query.quickEvalPosition;
+  if (query.quickEvalPosition !== undefined) {
+    const { line, endLine, fileName } = query.quickEvalPosition;
     const lineInfo = line === endLine ? `${line}` : `${line}-${endLine}`;
     return `Quick evaluation of ${path.basename(fileName)}:${lineInfo}`;
-  } else if (info.query.metadata && info.query.metadata.name) {
-    return info.query.metadata.name;
+  } else if (query.metadata && query.metadata.name) {
+    return query.metadata.name;
   } else {
-    return path.basename(info.query.program.queryPath);
+    return path.basename(query.program.queryPath);
   }
 }

--- a/extensions/ql-vscode/src/interface-types.ts
+++ b/extensions/ql-vscode/src/interface-types.ts
@@ -16,6 +16,14 @@ export interface DatabaseInfo {
   databaseUri: string;
 }
 
+/** Arbitrary query metadata */
+export interface QueryMetadata {	
+  name?: string,	
+  description?: string,	
+  id?: string,	
+  kind?: string	
+}
+
 export interface PreviousExecution {
   queryName: string;
   time: string;
@@ -31,7 +39,6 @@ export interface Interpretation {
 
 export interface ResultsInfo {
   resultsPath: string;
-  interpretedResultsPath: string;
 }
 
 export interface SortedResultSetInfo {
@@ -56,7 +63,7 @@ export interface SetStateMsg {
   sortedResultsMap: SortedResultsMap;
   interpretation: undefined | Interpretation;
   database: DatabaseInfo;
-  kind?: string;
+  metadata?: QueryMetadata
   /**
    * Whether to keep displaying the old results while rendering the new results.
    *
@@ -86,6 +93,7 @@ interface ViewSourceFileMsg {
 interface ToggleDiagnostics {
   t: 'toggleDiagnostics';
   databaseUri: string;
+  metadata?: QueryMetadata
   resultsPath: string;
   visible: boolean;
   kind?: string;

--- a/extensions/ql-vscode/src/interface-types.ts
+++ b/extensions/ql-vscode/src/interface-types.ts
@@ -37,8 +37,9 @@ export interface Interpretation {
   sarif: sarif.Log;
 }
 
-export interface ResultsInfo {
+export interface ResultsPaths {
   resultsPath: string;
+  interpretedResultsPath: string;
 }
 
 export interface SortedResultSetInfo {
@@ -60,6 +61,7 @@ export interface ResultsUpdatingMsg {
 export interface SetStateMsg {
   t: 'setState';
   resultsPath: string;
+  origResultsPaths: ResultsPaths;
   sortedResultsMap: SortedResultsMap;
   interpretation: undefined | Interpretation;
   database: DatabaseInfo;
@@ -94,7 +96,7 @@ interface ToggleDiagnostics {
   t: 'toggleDiagnostics';
   databaseUri: string;
   metadata?: QueryMetadata
-  resultsPath: string;
+  origResultsPaths: ResultsPaths;
   visible: boolean;
   kind?: string;
 };

--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -1,9 +1,8 @@
 import * as vscode from 'vscode';
 import { ExtensionContext, window as Window } from 'vscode';
-import { EvaluationInfo } from './queries';
-import * as helpers from './helpers';
-import * as messages from './messages';
 import { QueryHistoryConfig } from './config';
+import { CompletedQuery } from './query-results';
+import { QueryWithResults } from './run-queries';
 /**
  * query-history.ts
  * ------------
@@ -14,71 +13,9 @@ import { QueryHistoryConfig } from './config';
  */
 
 /**
- * One item in the user-displayed list of queries that have been run.
- */
-export class QueryHistoryItem {
-  queryName: string;
-  time: string;
-  databaseName: string;
-  info: EvaluationInfo;
-
-  constructor(
-    info: EvaluationInfo,
-    public config: QueryHistoryConfig,
-    public label?: string, // user-settable label
-  ) {
-    this.queryName = helpers.getQueryName(info);
-    this.databaseName = info.database.name;
-    this.info = info;
-    this.time = new Date().toLocaleString();
-  }
-
-  get statusString(): string {
-    switch (this.info.result.resultType) {
-      case messages.QueryResultType.CANCELLATION:
-        return `cancelled after ${this.info.result.evaluationTime / 1000} seconds`;
-      case messages.QueryResultType.OOM:
-        return `out of memory`;
-      case messages.QueryResultType.SUCCESS:
-        return `finished in ${this.info.result.evaluationTime / 1000} seconds`;
-      case messages.QueryResultType.TIMEOUT:
-        return `timed out after ${this.info.result.evaluationTime / 1000} seconds`;
-      case messages.QueryResultType.OTHER_ERROR:
-      default:
-        return `failed`;
-    }
-  }
-
-  interpolate(template: string): string {
-    const { databaseName, queryName, time, statusString } = this;
-    const replacements: { [k: string]: string } = {
-      t: time,
-      q: queryName,
-      d: databaseName,
-      s: statusString,
-      '%': '%',
-    };
-    return template.replace(/%(.)/g, (match, key) => {
-      const replacement = replacements[key];
-      return replacement !== undefined ? replacement : match;
-    });
-  }
-
-  getLabel(): string {
-    if (this.label !== undefined)
-      return this.label;
-    return this.config.format;
-  }
-
-  toString(): string {
-    return this.interpolate(this.getLabel());
-  }
-}
-
-/**
  * Tree data provider for the query history view.
  */
-class HistoryTreeDataProvider implements vscode.TreeDataProvider<QueryHistoryItem> {
+class HistoryTreeDataProvider implements vscode.TreeDataProvider<CompletedQuery> {
 
   /**
    * XXX: This idiom for how to get a `.fire()`-able event emitter was
@@ -86,21 +23,21 @@ class HistoryTreeDataProvider implements vscode.TreeDataProvider<QueryHistoryIte
    * involved and I hope there's something better that can be done
    * instead.
    */
-  private _onDidChangeTreeData: vscode.EventEmitter<QueryHistoryItem | undefined> = new vscode.EventEmitter<QueryHistoryItem | undefined>();
-  readonly onDidChangeTreeData: vscode.Event<QueryHistoryItem | undefined> = this._onDidChangeTreeData.event;
+  private _onDidChangeTreeData: vscode.EventEmitter<CompletedQuery | undefined> = new vscode.EventEmitter<CompletedQuery | undefined>();
+  readonly onDidChangeTreeData: vscode.Event<CompletedQuery | undefined> = this._onDidChangeTreeData.event;
 
-  private history: QueryHistoryItem[] = [];
+  private history: CompletedQuery[] = [];
 
   /**
    * When not undefined, must be reference-equal to an item in `this.databases`.
    */
-  private current: QueryHistoryItem | undefined;
+  private current: CompletedQuery | undefined;
 
   constructor() {
     this.history = [];
   }
 
-  getTreeItem(element: QueryHistoryItem): vscode.TreeItem {
+  getTreeItem(element: CompletedQuery): vscode.TreeItem {
     const it = new vscode.TreeItem(element.toString());
 
     it.command = {
@@ -112,7 +49,7 @@ class HistoryTreeDataProvider implements vscode.TreeDataProvider<QueryHistoryIte
     return it;
   }
 
-  getChildren(element?: QueryHistoryItem): vscode.ProviderResult<QueryHistoryItem[]> {
+  getChildren(element?: CompletedQuery): vscode.ProviderResult<CompletedQuery[]> {
     if (element == undefined) {
       return this.history;
     }
@@ -121,25 +58,25 @@ class HistoryTreeDataProvider implements vscode.TreeDataProvider<QueryHistoryIte
     }
   }
 
-  getParent(_element: QueryHistoryItem): vscode.ProviderResult<QueryHistoryItem> {
+  getParent(_element: CompletedQuery): vscode.ProviderResult<CompletedQuery> {
     return null;
   }
 
-  getCurrent(): QueryHistoryItem | undefined {
+  getCurrent(): CompletedQuery | undefined {
     return this.current;
   }
 
-  push(item: QueryHistoryItem): void {
+  push(item: CompletedQuery): void {
     this.current = item;
     this.history.push(item);
     this.refresh();
   }
 
-  setCurrentItem(item: QueryHistoryItem) {
+  setCurrentItem(item: CompletedQuery) {
     this.current = item;
   }
 
-  remove(item: QueryHistoryItem) {
+  remove(item: CompletedQuery) {
     if (this.current === item)
       this.current = undefined;
     const index = this.history.findIndex(i => i === item);
@@ -168,23 +105,24 @@ const DOUBLE_CLICK_TIME = 500;
 export class QueryHistoryManager {
   treeDataProvider: HistoryTreeDataProvider;
   ctx: ExtensionContext;
-  treeView: vscode.TreeView<QueryHistoryItem>;
-  selectedCallback: ((item: QueryHistoryItem) => void) | undefined;
-  lastItemClick: { time: Date, item: QueryHistoryItem } | undefined;
+  treeView: vscode.TreeView<CompletedQuery>;
+  selectedCallback: ((item: CompletedQuery) => void) | undefined;
+  lastItemClick: { time: Date, item: CompletedQuery } | undefined;
 
-  async invokeCallbackOn(queryHistoryItem: QueryHistoryItem) {
+
+  async invokeCallbackOn(queryHistoryItem: CompletedQuery) {
     if (this.selectedCallback !== undefined) {
       const sc = this.selectedCallback;
       await sc(queryHistoryItem);
     }
   }
 
-  async handleOpenQuery(queryHistoryItem: QueryHistoryItem) {
-    const textDocument = await vscode.workspace.openTextDocument(vscode.Uri.file(queryHistoryItem.info.query.program.queryPath));
+  async handleOpenQuery(queryHistoryItem: CompletedQuery) {
+    const textDocument = await vscode.workspace.openTextDocument(vscode.Uri.file(queryHistoryItem.query.program.queryPath));
     await vscode.window.showTextDocument(textDocument, vscode.ViewColumn.One);
   }
 
-  async handleRemoveHistoryItem(queryHistoryItem: QueryHistoryItem) {
+  async handleRemoveHistoryItem(queryHistoryItem: CompletedQuery) {
     this.treeDataProvider.remove(queryHistoryItem);
     const current = this.treeDataProvider.getCurrent();
     if (current !== undefined) {
@@ -193,7 +131,7 @@ export class QueryHistoryManager {
     }
   }
 
-  async handleSetLabel(queryHistoryItem: QueryHistoryItem) {
+  async handleSetLabel(queryHistoryItem: CompletedQuery) {
     const response = await vscode.window.showInputBox({
       prompt: 'Label:',
       placeHolder: '(use default)',
@@ -210,7 +148,7 @@ export class QueryHistoryManager {
     }
   }
 
-  async handleItemClicked(queryHistoryItem: QueryHistoryItem) {
+  async handleItemClicked(queryHistoryItem: CompletedQuery) {
     this.treeDataProvider.setCurrentItem(queryHistoryItem);
 
     const now = new Date();
@@ -232,7 +170,7 @@ export class QueryHistoryManager {
   constructor(
     ctx: ExtensionContext,
     private queryHistoryConfigListener: QueryHistoryConfig,
-    selectedCallback?: (item: QueryHistoryItem) => Promise<void>
+    selectedCallback?: (item: CompletedQuery) => Promise<void>
   ) {
     this.ctx = ctx;
     this.selectedCallback = selectedCallback;
@@ -256,9 +194,10 @@ export class QueryHistoryManager {
     });
   }
 
-  push(evaluationInfo: EvaluationInfo) {
-    const item = new QueryHistoryItem(evaluationInfo, this.queryHistoryConfigListener);
+  addQuery(info: QueryWithResults): CompletedQuery {
+    const item = new CompletedQuery(info, this.queryHistoryConfigListener);
     this.treeDataProvider.push(item);
     this.treeView.reveal(item, { select: true });
+    return item;
   }
 }

--- a/extensions/ql-vscode/src/query-results.ts
+++ b/extensions/ql-vscode/src/query-results.ts
@@ -1,0 +1,129 @@
+import { QueryWithResults, tmpDir, QueryInfo } from "./run-queries";
+import * as messages from './messages';
+import * as helpers from './helpers';
+import * as cli from './cli';
+import * as sarif from 'sarif';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import { SortState, SortedResultSetInfo, DatabaseInfo, QueryMetadata } from "./interface-types";
+import { QueryHistoryConfig } from "./config";
+
+export class CompletedQuery implements QueryWithResults {
+  readonly time: string;
+  readonly query: QueryInfo;
+  readonly result: messages.EvaluationResult;
+  readonly database: DatabaseInfo;
+
+  /**
+   * Map from result set name to SortedResultSetInfo.
+   */
+  sortedResultsInfo: Map<string, SortedResultSetInfo>;
+
+
+  constructor(
+    evalaution: QueryWithResults,
+    public config: QueryHistoryConfig,
+    public label?: string, // user-settable label
+  ) {
+    this.query = evalaution.query;
+    this.result = evalaution.result;
+    this.database = evalaution.database;
+    this.time = new Date().toLocaleString();
+    this.sortedResultsInfo = new Map();
+  }
+
+  get databaseName(): string {
+    return this.database.name;
+  }
+  get queryName(): string {
+    return helpers.getQueryName(this.query);
+  }
+
+  /**
+   * Holds if this query should produce interpreted results.
+   */
+  canInterpretedResults(): Promise<boolean> {
+    return this.query.dbItem.hasMetadataFile();
+  }
+
+  get statusString(): string {
+    switch (this.result.resultType) {
+      case messages.QueryResultType.CANCELLATION:
+        return `cancelled after ${this.result.evaluationTime / 1000} seconds`;
+      case messages.QueryResultType.OOM:
+        return `out of memory`;
+      case messages.QueryResultType.SUCCESS:
+        return `finished in ${this.result.evaluationTime / 1000} seconds`;
+      case messages.QueryResultType.TIMEOUT:
+        return `timed out after ${this.result.evaluationTime / 1000} seconds`;
+      case messages.QueryResultType.OTHER_ERROR:
+      default:
+        return `failed`;
+    }
+  }
+
+
+  interpolate(template: string): string {
+    const { databaseName, queryName, time, statusString } = this;
+    const replacements: { [k: string]: string } = {
+      t: time,
+      q: queryName,
+      d: databaseName,
+      s: statusString,
+      '%': '%',
+    };
+    return template.replace(/%(.)/g, (match, key) => {
+      const replacement = replacements[key];
+      return replacement !== undefined ? replacement : match;
+    });
+  }
+
+  getLabel(): string {
+    if (this.label !== undefined)
+      return this.label;
+    return this.config.format;
+  }
+
+  toString(): string {
+    return this.interpolate(this.getLabel());
+  }
+  async updateSortState(server: cli.CodeQLCliServer, resultSetName: string, sortState: SortState | undefined): Promise<void> {
+    if (sortState === undefined) {
+      this.sortedResultsInfo.delete(resultSetName);
+      return;
+    }
+
+    const sortedResultSetInfo: SortedResultSetInfo = {
+      resultsPath: path.join(tmpDir.name, `sortedResults${this.query.queryID}-${resultSetName}.bqrs`),
+      sortState
+    };
+
+    await server.sortBqrs(this.query.resultsPaths.resultsPath, sortedResultSetInfo.resultsPath, resultSetName, [sortState.columnIndex], [sortState.direction]);
+    this.sortedResultsInfo.set(resultSetName, sortedResultSetInfo);
+  }
+
+}
+
+/**
+ * Call cli command to interpret results.
+ */
+export async function interpretResults(server: cli.CodeQLCliServer, metadata: QueryMetadata | undefined, resultsPath: string, sourceInfo?: cli.SourceInfo): Promise<sarif.Log> {
+  const interpretedResultsPath = resultsPath + ".interpreted.sarif"
+
+  if (await fs.pathExists(interpretedResultsPath)) {
+    return JSON.parse(await fs.readFile(interpretedResultsPath, 'utf8'));
+  }
+  if (metadata === undefined) {
+    throw new Error('Can\'t interpret results without query metadata');
+  }
+  let { kind, id } = metadata;
+  if (kind === undefined) {
+    throw new Error('Can\'t interpret results without query metadata including kind');
+  }
+  if (id === undefined) {
+    // Interpretation per se doesn't really require an id, but the
+    // SARIF format does, so in the absence of one, we use a dummy id.
+    id = "dummy-id";
+  }
+  return await server.interpretBqrs({ kind, id }, resultsPath, interpretedResultsPath, sourceInfo);
+}

--- a/extensions/ql-vscode/src/sarif-utils.ts
+++ b/extensions/ql-vscode/src/sarif-utils.ts
@@ -1,0 +1,124 @@
+import * as Sarif from "sarif"
+import * as path from "path"
+import { LocationStyle, ResolvableLocationValue } from "semmle-bqrs";
+
+export interface SarifLink {
+  dest: number
+  text: string
+}
+
+
+type ParsedSarifLocation =
+  | ResolvableLocationValue
+  // Resolvable locations have a `file` field, but it will sometimes include
+  // a source location prefix, which contains build-specific information the user
+  // doesn't really need to see. We ensure that `userVisibleFile` will not contain
+  // that, and is appropriate for display in the UI.
+  & { userVisibleFile: string }
+  | { t: 'NoLocation', hint: string };
+
+export type SarifMessageComponent = string | SarifLink
+
+/**
+ * Unescape "[", "]" and "\\" like in sarif plain text messages
+ */
+export function unescapeSarifText(message: string): string {
+  return message.replace(/\\\[/g, "[").replace(/\\\]/g, "]").replace(/\\\\/, "\\");
+}
+
+export function parseSarifPlainTextMessage(message: string): SarifMessageComponent[] {
+  let results: SarifMessageComponent[] = [];
+
+  // We want something like "[linkText](4)", except that "[" and "]" may be escaped. The lookbehind asserts
+  // that the initial [ is not escaped. Then we parse a link text with "[" and "]" escaped. Then we parse the numerical target.
+  // Technically we could have any uri in the target but we don't output that yet.
+  // The possibility of escaping outside the link is not mentioned in the sarif spec but we always output sartif this way.
+  const linkRegex = /(?<=(?<!\\)(\\\\)*)\[(?<linkText>([^\\\]\[]|\\\\|\\\]|\\\[)*)\]\((?<linkTarget>[0-9]+)\)/g;
+  let result: RegExpExecArray | null;
+  let curIndex = 0;
+  while ((result = linkRegex.exec(message)) !== null) {
+    results.push(unescapeSarifText(message.substring(curIndex, result.index)));
+    const linkText = result.groups!["linkText"];
+    const linkTarget = +result.groups!["linkTarget"];
+    results.push({ dest: linkTarget, text: unescapeSarifText(linkText) });
+    curIndex = result.index + result[0].length;
+  }
+  results.push(unescapeSarifText(message.substring(curIndex, message.length)));
+  return results;
+}
+
+
+/**
+ * Computes a path normalized to reflect conventional normalization
+ * of windows paths into zip archive paths.
+ * @param sourceLocationPrefix The source location prefix of a database. May be
+ * unix style `/foo/bar/baz` or windows-style `C:\foo\bar\baz`.
+ * @param sarifRelativeUri A uri relative to sourceLocationPrefix.
+ * @returns A string that is valid for the `.file` field of a `FivePartLocation`:
+ * directory separators are normalized, but drive letters `C:` may appear.
+ */
+export function getPathRelativeToSourceLocationPrefix(sourceLocationPrefix: string, sarifRelativeUui: string) {
+  const normalizedSourceLocationPrefix = sourceLocationPrefix.replace(/\\/g, '/');
+  return path.join(normalizedSourceLocationPrefix, decodeURIComponent(sarifRelativeUui));
+}
+
+export function parseSarifLocation(loc: Sarif.Location, sourceLocationPrefix: string): ParsedSarifLocation {
+  const physicalLocation = loc.physicalLocation;
+  if (physicalLocation === undefined)
+    return { t: 'NoLocation', hint: 'no physical location' };
+  if (physicalLocation.artifactLocation === undefined)
+    return { t: 'NoLocation', hint: 'no artifact location' };
+  if (physicalLocation.artifactLocation.uri === undefined)
+    return { t: 'NoLocation', hint: 'artifact location has no uri' };
+
+  // This is not necessarily really an absolute uri; it could either be a
+  // file uri or a relative uri.
+  const uri = physicalLocation.artifactLocation.uri;
+
+  const fileUriRegex = /^file:/;
+  const effectiveLocation = uri.match(fileUriRegex) ?
+    decodeURIComponent(uri.replace(fileUriRegex, '')) :
+    getPathRelativeToSourceLocationPrefix(sourceLocationPrefix, uri);
+  const userVisibleFile = uri.match(fileUriRegex) ?
+    decodeURIComponent(uri.replace(fileUriRegex, '')) :
+    uri;
+
+  if (physicalLocation.region === undefined) {
+    // If the region property is absent, the physicalLocation object refers to the entire file.
+    // Source: https://docs.oasis-open.org/sarif/sarif/v2.1.0/cs01/sarif-v2.1.0-cs01.html#_Toc16012638.
+    // TODO: Do we get here if we provide a non-filesystem URL?
+    return {
+      t: LocationStyle.WholeFile,
+      file: effectiveLocation,
+      userVisibleFile,
+    };
+  } else {
+    const region = physicalLocation.region;
+    // We assume that the SARIF we're given always has startLine
+    // This is not mandated by the SARIF spec, but should be true of
+    // SARIF output by our own tools.
+    const lineStart = region.startLine!;
+
+    // These defaults are from SARIF 2.1.0 spec, section 3.30.2, "Text Regions"
+    // https://docs.oasis-open.org/sarif/sarif/v2.1.0/cs01/sarif-v2.1.0-cs01.html#_Ref493492556
+    const lineEnd = region.endLine === undefined ? lineStart : region.endLine;
+    const colStart = region.startColumn === undefined ? 1 : region.startColumn;
+
+    // We also assume that our tools will always supply `endColumn` field, which is
+    // fortunate, since the SARIF spec says that it defaults to the end of the line, whose
+    // length we don't know at this point in the code.
+    //
+    // It is off by one with respect to the way vscode counts columns in selections.
+    const colEnd = region.endColumn! - 1;
+
+    return {
+      t: LocationStyle.FivePart,
+      file: effectiveLocation,
+      userVisibleFile,
+      lineStart,
+      colStart,
+      lineEnd,
+      colEnd,
+    };
+  }
+}

--- a/extensions/ql-vscode/src/upgrades.ts
+++ b/extensions/ql-vscode/src/upgrades.ts
@@ -1,0 +1,171 @@
+import * as vscode from 'vscode';
+import { DatabaseItem } from './databases';
+import * as helpers from './helpers';
+import { logger  } from './logging';
+import * as messages from './messages';
+import * as qsClient from './queryserver-client';
+import { UserCancellationException, upgradesTmpDir } from './run-queries';
+/**
+ * Checks whether the given database can be upgraded to the given target DB scheme,
+ * and whether the user wants to proceed with the upgrade.
+ * Reports errors to both the user and the console.
+ * @returns the `UpgradeParams` needed to start the upgrade, if the upgrade is possible and was confirmed by the user, or `undefined` otherwise.
+ */
+async function checkAndConfirmDatabaseUpgrade(qs: qsClient.QueryServerClient, db: DatabaseItem, targetDbScheme: vscode.Uri, upgradesDirectories: vscode.Uri[]):
+  Promise<messages.UpgradeParams | undefined> {
+  if (db.contents === undefined || db.contents.dbSchemeUri === undefined) {
+    helpers.showAndLogErrorMessage("Database is invalid, and cannot be upgraded.")
+    return;
+  }
+  const params: messages.UpgradeParams = {
+    fromDbscheme: db.contents.dbSchemeUri.fsPath,
+    toDbscheme: targetDbScheme.fsPath,
+    additionalUpgrades: upgradesDirectories.map(uri => uri.fsPath)
+  };
+
+  let checkUpgradeResult: messages.CheckUpgradeResult;
+  try {
+    qs.logger.log('Checking database upgrade...');
+    checkUpgradeResult = await checkDatabaseUpgrade(qs, params);
+  }
+  catch (e) {
+    helpers.showAndLogErrorMessage(`Database cannot be upgraded: ${e}`);
+    return;
+  }
+  finally {
+    qs.logger.log('Done checking database upgrade.')
+  }
+
+  const checkedUpgrades = checkUpgradeResult.checkedUpgrades;
+  if (checkedUpgrades === undefined) {
+    const error = checkUpgradeResult.upgradeError || '[no error message available]';
+    await helpers.showAndLogErrorMessage(`Database cannot be upgraded: ${error}`);
+    return;
+  }
+
+  if (checkedUpgrades.scripts.length === 0) {
+    await helpers.showAndLogInformationMessage('Database is already up to date; nothing to do.');
+    return;
+  }
+
+  let curSha = checkedUpgrades.initialSha;
+  let descriptionMessage = '';
+  for (const script of checkedUpgrades.scripts) {
+    descriptionMessage += `Would perform upgrade: ${script.description}\n`;
+    descriptionMessage += `\t-> Compatibility: ${script.compatibility}\n`;
+    curSha = script.newSha;
+  }
+
+  const targetSha = checkedUpgrades.targetSha;
+  if (curSha != targetSha) {
+    // Newlines aren't rendered in notifications: https://github.com/microsoft/vscode/issues/48900
+    // A modal dialog would be rendered better, but is more intrusive.
+    await helpers.showAndLogErrorMessage(`Database cannot be upgraded to the target database scheme.
+    Can upgrade from ${checkedUpgrades.initialSha} (current) to ${curSha}, but cannot reach ${targetSha} (target).`);
+    // TODO: give a more informative message if we think the DB is ahead of the target DB scheme
+    return;
+  }
+
+  logger.log(descriptionMessage);
+  // Ask the user to confirm the upgrade.
+  const shouldUpgrade = await helpers.showBinaryChoiceDialog(`Should the database ${db.databaseUri.fsPath} be upgraded?\n\n${descriptionMessage}`);
+  if (shouldUpgrade) {
+    return params;
+  }
+  else {
+    throw new UserCancellationException('User cancelled the database upgrade.');
+  }
+}
+
+/**
+ * Command handler for 'Upgrade Database'.
+ * Attempts to upgrade the given database to the given target DB scheme, using the given directory of upgrades.
+ * First performs a dry-run and prompts the user to confirm the upgrade.
+ * Reports errors during compilation and evaluation of upgrades to the user.
+ */
+export async function upgradeDatabase(qs: qsClient.QueryServerClient, db: DatabaseItem, targetDbScheme: vscode.Uri, upgradesDirectories: vscode.Uri[]):
+  Promise<messages.RunUpgradeResult | undefined> {
+  const upgradeParams = await checkAndConfirmDatabaseUpgrade(qs, db, targetDbScheme, upgradesDirectories);
+
+  if (upgradeParams === undefined) {
+    return;
+  }
+
+  let compileUpgradeResult: messages.CompileUpgradeResult;
+  try {
+    compileUpgradeResult = await compileDatabaseUpgrade(qs, upgradeParams);
+  }
+  catch (e) {
+    helpers.showAndLogErrorMessage(`Compilation of database upgrades failed: ${e}`);
+    return;
+  }
+  finally {
+    qs.logger.log('Done compiling database upgrade.')
+  }
+
+  if (compileUpgradeResult.compiledUpgrades === undefined) {
+    const error = compileUpgradeResult.error || '[no error message available]';
+    helpers.showAndLogErrorMessage(`Compilation of database upgrades failed: ${error}`);
+    return;
+  }
+
+  try {
+    qs.logger.log('Running the following database upgrade:');
+    qs.logger.log(compileUpgradeResult.compiledUpgrades.scripts.map(s => s.description.description).join('\n'));
+    return await runDatabaseUpgrade(qs, db, compileUpgradeResult.compiledUpgrades);
+  }
+  catch (e) {
+    helpers.showAndLogErrorMessage(`Database upgrade failed: ${e}`);
+    return;
+  }
+  finally {
+    qs.logger.log('Done running database upgrade.')
+  }
+}
+
+async function checkDatabaseUpgrade(qs: qsClient.QueryServerClient, upgradeParams: messages.UpgradeParams):
+  Promise<messages.CheckUpgradeResult> {
+  return helpers.withProgress({
+    location: vscode.ProgressLocation.Notification,
+    title: "Checking for database upgrades",
+    cancellable: true,
+  }, (progress, token) => qs.sendRequest(messages.checkUpgrade, upgradeParams, token, progress));
+}
+
+async function compileDatabaseUpgrade(qs: qsClient.QueryServerClient, upgradeParams: messages.UpgradeParams):
+  Promise<messages.CompileUpgradeResult> {
+  const params: messages.CompileUpgradeParams = {
+    upgrade: upgradeParams,
+    upgradeTempDir: upgradesTmpDir.name
+  }
+
+  return helpers.withProgress({
+    location: vscode.ProgressLocation.Notification,
+    title: "Compiling database upgrades",
+    cancellable: true,
+  }, (progress, token) => qs.sendRequest(messages.compileUpgrade, params, token, progress));
+}
+
+async function runDatabaseUpgrade(qs: qsClient.QueryServerClient, db: DatabaseItem, upgrades: messages.CompiledUpgrades):
+  Promise<messages.RunUpgradeResult> {
+
+  if (db.contents === undefined || db.contents.datasetUri === undefined) {
+    throw new Error('Can\'t upgrade an invalid database.');
+  }
+  const database: messages.Dataset = {
+    dbDir: db.contents.datasetUri.fsPath,
+    workingSet: 'default'
+  };
+
+  const params: messages.RunUpgradeParams = {
+    db: database,
+    timeoutSecs: qs.config.timeoutSecs,
+    toRun: upgrades
+  };
+
+  return helpers.withProgress({
+    location: vscode.ProgressLocation.Notification,
+    title: "Running database upgrades",
+    cancellable: true,
+  }, (progress, token) => qs.sendRequest(messages.runUpgrade, params, token, progress));
+}

--- a/extensions/ql-vscode/src/view/alert-table.tsx
+++ b/extensions/ql-vscode/src/view/alert-table.tsx
@@ -2,73 +2,16 @@ import * as path from 'path';
 import * as React from 'react';
 import * as Sarif from 'sarif';
 import * as Keys from '../result-keys';
-import { LocationStyle, ResolvableLocationValue } from 'semmle-bqrs';
+import { LocationStyle } from 'semmle-bqrs';
 import * as octicons from './octicons';
 import { className, renderLocation, ResultTableProps, zebraStripe, selectableZebraStripe, jumpToLocation } from './result-table-utils';
 import { PathTableResultSet, onNavigation, NavigationEvent } from './results';
+import { parseSarifPlainTextMessage, parseSarifLocation } from '../sarif-utils';
 
 export type PathTableProps = ResultTableProps & { resultSet: PathTableResultSet };
 export interface PathTableState {
   expanded: { [k: string]: boolean };
   selectedPathNode: undefined | Keys.PathNode;
-}
-
-interface SarifLink {
-  dest: number
-  text: string
-}
-
-type ParsedSarifLocation =
-  | ResolvableLocationValue
-  // Resolvable locations have a `file` field, but it will sometimes include
-  // a source location prefix, which contains build-specific information the user
-  // doesn't really need to see. We ensure that `userVisibleFile` will not contain
-  // that, and is appropriate for display in the UI.
-  & { userVisibleFile: string }
-  | { t: 'NoLocation', hint: string };
-
-type SarifMessageComponent = string | SarifLink
-
-/**
- * Unescape "[", "]" and "\\" like in sarif plain text messages
- */
-function unescapeSarifText(message: string): string {
-  return message.replace(/\\\[/g, "[").replace(/\\\]/g, "]").replace(/\\\\/, "\\");
-}
-
-function parseSarifPlainTextMessage(message: string): SarifMessageComponent[] {
-  let results: SarifMessageComponent[] = [];
-
-  // We want something like "[linkText](4)", except that "[" and "]" may be escaped. The lookbehind asserts
-  // that the initial [ is not escaped. Then we parse a link text with "[" and "]" escaped. Then we parse the numerical target.
-  // Technically we could have any uri in the target but we don't output that yet.
-  // The possibility of escaping outside the link is not mentioned in the sarif spec but we always output sartif this way.
-  const linkRegex = /(?<=(?<!\\)(\\\\)*)\[(?<linkText>([^\\\]\[]|\\\\|\\\]|\\\[)*)\]\((?<linkTarget>[0-9]+)\)/g;
-  let result: RegExpExecArray | null;
-  let curIndex = 0;
-  while ((result = linkRegex.exec(message)) !== null) {
-    results.push(unescapeSarifText(message.substring(curIndex, result.index)));
-    const linkText = result.groups!["linkText"];
-    const linkTarget = +result.groups!["linkTarget"];
-    results.push({ dest: linkTarget, text: unescapeSarifText(linkText) });
-    curIndex = result.index + result[0].length;
-  }
-  results.push(unescapeSarifText(message.substring(curIndex, message.length)));
-  return results;
-}
-
-/**
- * Computes a path normalized to reflect conventional normalization
- * of windows paths into zip archive paths.
- * @param sourceLocationPrefix The source location prefix of a database. May be
- * unix style `/foo/bar/baz` or windows-style `C:\foo\bar\baz`.
- * @param sarifRelativeUri A uri relative to sourceLocationPrefix.
- * @returns A string that is valid for the `.file` field of a `FivePartLocation`:
- * directory separators are normalized, but drive letters `C:` may appear.
- */
-export function getPathRelativeToSourceLocationPrefix(sourceLocationPrefix: string, sarifRelativeUui: string) {
-  const normalizedSourceLocationPrefix = sourceLocationPrefix.replace(/\\/g, '/');
-  return path.join(normalizedSourceLocationPrefix, decodeURIComponent(sarifRelativeUui));
 }
 
 export class PathTable extends React.Component<PathTableProps, PathTableState> {
@@ -321,66 +264,5 @@ export class PathTable extends React.Component<PathTableProps, PathTableState> {
 
   componentWillUnmount() {
     onNavigation.removeListener(this.handleNavigationEvent);
-  }
-}
-
-function parseSarifLocation(loc: Sarif.Location, sourceLocationPrefix: string): ParsedSarifLocation {
-  const physicalLocation = loc.physicalLocation;
-  if (physicalLocation === undefined)
-    return { t: 'NoLocation', hint: 'no physical location' };
-  if (physicalLocation.artifactLocation === undefined)
-    return { t: 'NoLocation', hint: 'no artifact location' };
-  if (physicalLocation.artifactLocation.uri === undefined)
-    return { t: 'NoLocation', hint: 'artifact location has no uri' };
-
-  // This is not necessarily really an absolute uri; it could either be a
-  // file uri or a relative uri.
-  const uri = physicalLocation.artifactLocation.uri;
-
-  const fileUriRegex = /^file:/;
-  const effectiveLocation = uri.match(fileUriRegex) ?
-    decodeURIComponent(uri.replace(fileUriRegex, '')) :
-    getPathRelativeToSourceLocationPrefix(sourceLocationPrefix, uri);
-  const userVisibleFile = uri.match(fileUriRegex) ?
-    decodeURIComponent(uri.replace(fileUriRegex, '')) :
-    uri;
-
-  if (physicalLocation.region === undefined) {
-    // If the region property is absent, the physicalLocation object refers to the entire file.
-    // Source: https://docs.oasis-open.org/sarif/sarif/v2.1.0/cs01/sarif-v2.1.0-cs01.html#_Toc16012638.
-    // TODO: Do we get here if we provide a non-filesystem URL?
-    return {
-      t: LocationStyle.WholeFile,
-      file: effectiveLocation,
-      userVisibleFile,
-    };
-  } else {
-    const region = physicalLocation.region;
-    // We assume that the SARIF we're given always has startLine
-    // This is not mandated by the SARIF spec, but should be true of
-    // SARIF output by our own tools.
-    const lineStart = region.startLine!;
-
-    // These defaults are from SARIF 2.1.0 spec, section 3.30.2, "Text Regions"
-    // https://docs.oasis-open.org/sarif/sarif/v2.1.0/cs01/sarif-v2.1.0-cs01.html#_Ref493492556
-    const lineEnd = region.endLine === undefined ? lineStart : region.endLine;
-    const colStart = region.startColumn === undefined ? 1 : region.startColumn;
-
-    // We also assume that our tools will always supply `endColumn` field, which is
-    // fortunate, since the SARIF spec says that it defaults to the end of the line, whose
-    // length we don't know at this point in the code.
-    //
-    // It is off by one with respect to the way vscode counts columns in selections.
-    const colEnd = region.endColumn! - 1;
-
-    return {
-      t: LocationStyle.FivePart,
-      file: effectiveLocation,
-      userVisibleFile,
-      lineStart,
-      colStart,
-      lineEnd,
-      colEnd,
-    };
   }
 }

--- a/extensions/ql-vscode/src/view/result-table-utils.tsx
+++ b/extensions/ql-vscode/src/view/result-table-utils.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { LocationValue, ResolvableLocationValue, tryGetResolvableLocation } from 'semmle-bqrs';
-import { SortState } from '../interface-types';
+import { SortState, QueryMetadata } from '../interface-types';
 import { ResultSet, vscode } from './results';
 
 export interface ResultTableProps {
   resultSet: ResultSet;
   databaseUri: string;
+  metadata?: QueryMetadata
   resultsPath: string | undefined;
   sortState?: SortState;
 }

--- a/extensions/ql-vscode/src/view/result-tables.tsx
+++ b/extensions/ql-vscode/src/view/result-tables.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DatabaseInfo, Interpretation, SortState } from '../interface-types';
+import { DatabaseInfo, Interpretation, SortState, QueryMetadata } from '../interface-types';
 import { PathTable } from './alert-table';
 import { RawTable } from './raw-results-table';
 import { ResultTableProps, tableSelectionHeaderClassName, toggleDiagnosticsClassName } from './result-table-utils';
@@ -12,8 +12,8 @@ export interface ResultTablesProps {
   rawResultSets: readonly ResultSet[];
   interpretation: Interpretation | undefined;
   database: DatabaseInfo;
+  metadata? : QueryMetadata
   resultsPath: string | undefined;
-  kind: string | undefined;
   sortStates: Map<string, SortState>;
   isLoadingNewResults: boolean;
 }
@@ -95,7 +95,7 @@ export class ResultTables
   render(): React.ReactNode {
     const { selectedTable } = this.state;
     const resultSets = this.getResultSets();
-    const { database, resultsPath, kind } = this.props;
+    const { database, resultsPath, metadata } = this.props;
 
     // Only show the Problems view display checkbox for the alerts table.
     const diagnosticsCheckBox = selectedTable === ALERTS_TABLE_NAME ?
@@ -107,7 +107,7 @@ export class ResultTables
               resultsPath: resultsPath,
               databaseUri: database.databaseUri,
               visible: e.target.checked,
-              kind: kind
+              metadata: metadata
             });
           }
         }} />
@@ -157,11 +157,9 @@ class ResultTable extends React.Component<ResultTableProps, {}> {
     const { resultSet } = this.props;
     switch (resultSet.t) {
       case 'RawResultSet': return <RawTable
-        resultSet={resultSet} databaseUri={this.props.databaseUri}
-        resultsPath={this.props.resultsPath} sortState={this.props.sortState} />;
+        {...this.props} resultSet={resultSet} />;
       case 'SarifResultSet': return <PathTable
-        resultSet={resultSet} databaseUri={this.props.databaseUri}
-        resultsPath={this.props.resultsPath} />;
+        {...this.props} resultSet={resultSet} />;
     }
   }
 }

--- a/extensions/ql-vscode/src/view/result-tables.tsx
+++ b/extensions/ql-vscode/src/view/result-tables.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DatabaseInfo, Interpretation, SortState, QueryMetadata } from '../interface-types';
+import { DatabaseInfo, Interpretation, SortState, QueryMetadata, ResultsPaths } from '../interface-types';
 import { PathTable } from './alert-table';
 import { RawTable } from './raw-results-table';
 import { ResultTableProps, tableSelectionHeaderClassName, toggleDiagnosticsClassName } from './result-table-utils';
@@ -13,7 +13,8 @@ export interface ResultTablesProps {
   interpretation: Interpretation | undefined;
   database: DatabaseInfo;
   metadata? : QueryMetadata
-  resultsPath: string | undefined;
+  resultsPath: string ;
+  origResultsPaths: ResultsPaths;
   sortStates: Map<string, SortState>;
   isLoadingNewResults: boolean;
 }
@@ -95,7 +96,7 @@ export class ResultTables
   render(): React.ReactNode {
     const { selectedTable } = this.state;
     const resultSets = this.getResultSets();
-    const { database, resultsPath, metadata } = this.props;
+    const { database, resultsPath, metadata, origResultsPaths } = this.props;
 
     // Only show the Problems view display checkbox for the alerts table.
     const diagnosticsCheckBox = selectedTable === ALERTS_TABLE_NAME ?
@@ -104,7 +105,7 @@ export class ResultTables
           if (resultsPath !== undefined) {
             vscode.postMessage({
               t: 'toggleDiagnostics',
-              resultsPath: resultsPath,
+              origResultsPaths: origResultsPaths,
               databaseUri: database.databaseUri,
               visible: e.target.checked,
               metadata: metadata

--- a/extensions/ql-vscode/src/view/results.tsx
+++ b/extensions/ql-vscode/src/view/results.tsx
@@ -3,7 +3,7 @@ import * as Rdom from 'react-dom';
 import * as bqrs from 'semmle-bqrs';
 import { ElementBase, LocationValue, PrimitiveColumnValue, PrimitiveTypeKind, ResultSetSchema, tryGetResolvableLocation } from 'semmle-bqrs';
 import { assertNever } from '../helpers-pure';
-import { DatabaseInfo, FromResultsViewMsg, Interpretation, IntoResultsViewMsg, SortedResultSetInfo, SortState, NavigatePathMsg, QueryMetadata } from '../interface-types';
+import { DatabaseInfo, FromResultsViewMsg, Interpretation, IntoResultsViewMsg, SortedResultSetInfo, SortState, NavigatePathMsg, QueryMetadata, ResultsPaths } from '../interface-types';
 import { ResultTables } from './result-tables';
 import { EventHandlers as EventHandlerList } from './event-handler-list';
 
@@ -127,6 +127,7 @@ async function parseResultSets(response: Response): Promise<readonly ResultSet[]
 
 interface ResultsInfo {
   resultsPath: string;
+  origResultsPaths: ResultsPaths;
   database: DatabaseInfo;
   interpretation: Interpretation | undefined;
   sortedResultsMap: Map<string, SortedResultSetInfo>;
@@ -186,6 +187,7 @@ class App extends React.Component<{}, ResultsViewState> {
       case 'setState':
         this.updateStateWithNewResultsInfo({
           resultsPath: msg.resultsPath,
+          origResultsPaths: msg.origResultsPaths,
           sortedResultsMap: new Map(Object.entries(msg.sortedResultsMap)),
           database: msg.database,
           interpretation: msg.interpretation,
@@ -304,11 +306,12 @@ class App extends React.Component<{}, ResultsViewState> {
 
   render() {
     const displayedResults = this.state.displayedResults;
-    if (displayedResults.results !== null) {
+    if (displayedResults.results !== null && displayedResults.resultsInfo !== null) {
       return <ResultTables rawResultSets={displayedResults.results.resultSets}
         interpretation={displayedResults.resultsInfo ? displayedResults.resultsInfo.interpretation : undefined}
         database={displayedResults.results.database}
-        resultsPath={displayedResults.resultsInfo ? displayedResults.resultsInfo.resultsPath : undefined}
+        origResultsPaths={displayedResults.resultsInfo.origResultsPaths}
+        resultsPath={displayedResults.resultsInfo.resultsPath}
         metadata={displayedResults.resultsInfo ? displayedResults.resultsInfo.metadata : undefined}
         sortStates={displayedResults.results.sortStates}
         isLoadingNewResults={this.state.isExpectingResultsUpdate || this.state.nextResultsInfo !== null} />;

--- a/extensions/ql-vscode/src/view/results.tsx
+++ b/extensions/ql-vscode/src/view/results.tsx
@@ -3,7 +3,7 @@ import * as Rdom from 'react-dom';
 import * as bqrs from 'semmle-bqrs';
 import { ElementBase, LocationValue, PrimitiveColumnValue, PrimitiveTypeKind, ResultSetSchema, tryGetResolvableLocation } from 'semmle-bqrs';
 import { assertNever } from '../helpers-pure';
-import { DatabaseInfo, FromResultsViewMsg, Interpretation, IntoResultsViewMsg, SortedResultSetInfo, SortState, NavigatePathMsg } from '../interface-types';
+import { DatabaseInfo, FromResultsViewMsg, Interpretation, IntoResultsViewMsg, SortedResultSetInfo, SortState, NavigatePathMsg, QueryMetadata } from '../interface-types';
 import { ResultTables } from './result-tables';
 import { EventHandlers as EventHandlerList } from './event-handler-list';
 
@@ -127,7 +127,6 @@ async function parseResultSets(response: Response): Promise<readonly ResultSet[]
 
 interface ResultsInfo {
   resultsPath: string;
-  kind: string | undefined;
   database: DatabaseInfo;
   interpretation: Interpretation | undefined;
   sortedResultsMap: Map<string, SortedResultSetInfo>;
@@ -135,6 +134,7 @@ interface ResultsInfo {
    * See {@link SetStateMsg.shouldKeepOldResultsWhileRendering}.
    */
   shouldKeepOldResultsWhileRendering: boolean;
+  metadata?: QueryMetadata
 }
 
 interface Results {
@@ -186,11 +186,11 @@ class App extends React.Component<{}, ResultsViewState> {
       case 'setState':
         this.updateStateWithNewResultsInfo({
           resultsPath: msg.resultsPath,
-          kind: msg.kind,
           sortedResultsMap: new Map(Object.entries(msg.sortedResultsMap)),
           database: msg.database,
           interpretation: msg.interpretation,
-          shouldKeepOldResultsWhileRendering: msg.shouldKeepOldResultsWhileRendering
+          shouldKeepOldResultsWhileRendering: msg.shouldKeepOldResultsWhileRendering,
+          metadata: msg.metadata
         });
 
         this.loadResults();
@@ -309,7 +309,7 @@ class App extends React.Component<{}, ResultsViewState> {
         interpretation={displayedResults.resultsInfo ? displayedResults.resultsInfo.interpretation : undefined}
         database={displayedResults.results.database}
         resultsPath={displayedResults.resultsInfo ? displayedResults.resultsInfo.resultsPath : undefined}
-        kind={displayedResults.resultsInfo ? displayedResults.resultsInfo.kind : undefined}
+        metadata={displayedResults.resultsInfo ? displayedResults.resultsInfo.metadata : undefined}
         sortStates={displayedResults.results.sortStates}
         isLoadingNewResults={this.state.isExpectingResultsUpdate || this.state.nextResultsInfo !== null} />;
     }

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/sarifMessageParsingTest.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/sarifMessageParsingTest.test.ts
@@ -1,0 +1,39 @@
+import 'mocha';
+import { expect } from "chai";
+
+import { parseSarifPlainTextMessage } from '../../sarif-utils';
+
+
+describe('parsing sarif', () => {
+  it('should be able to parse a simple message from the spec', async function () {
+    const message = "Tainted data was used. The data came from [here](3)."
+    const results = parseSarifPlainTextMessage(message);
+    expect(results).to.deep.equal([
+      "Tainted data was used. The data came from ",
+      { dest: 3, text: "here" }, "."
+    ]);
+  });
+
+  it('should be able to parse a complex message from the spec', async function () {
+    const message = "Prohibited term used in [para\\[0\\]\\\\spans\\[2\\]](1)."
+    const results = parseSarifPlainTextMessage(message);
+    expect(results).to.deep.equal([
+      "Prohibited term used in ",
+      { dest: 1, text: "para[0]\\spans[2]" }, "."
+    ]);
+  });
+  it('should be able to parse a broken complex message from the spec', async function () {
+    const message = "Prohibited term used in [para\\[0\\]\\\\spans\\[2\\](1)."
+    const results = parseSarifPlainTextMessage(message);
+    expect(results).to.deep.equal([
+       "Prohibited term used in [para[0]\\spans[2](1)." 
+    ]);
+  });
+  it('should be able to parse a message with extra escaping the spec', async function () {
+    const message = "Tainted data was used. The data came from \\[here](3)."
+    const results = parseSarifPlainTextMessage(message);
+    expect(results).to.deep.equal([
+       "Tainted data was used. The data came from [here](3)." 
+    ]);
+  });
+});


### PR DESCRIPTION
Split up query running, upgrade running, and operations on queries post run. The main point is clearly separating which state is post query run state (such as the locations of the sorted results) compared to the immutable results of running the query.