### PR TITLE
Log if a database metadata file could not be found

### DIFF
--- a/extensions/ql-vscode/src/databases.ts
+++ b/extensions/ql-vscode/src/databases.ts
@@ -227,9 +227,9 @@ export interface DatabaseItem {
   resolveSourceFile(file: string | undefined): vscode.Uri;
 
   /**
-   * Holds if the database item has a `.dbinfo` file.
+   * Holds if the database item has a `.dbinfo` or `codeql-database.yml` file.
    */
-  hasDbInfo(): boolean;
+  hasMetadataFile(): Promise<boolean>;
 
   /**
    * Returns `sourceLocationPrefix` of exported database.
@@ -359,9 +359,11 @@ class DatabaseItemImpl implements DatabaseItem {
   /**
    * Holds if the database item refers to an exported snapshot
    */
-  public hasDbInfo(): boolean {
-    return fs.existsSync(path.join(this.databaseUri.fsPath, '.dbinfo'))
-      || fs.existsSync(path.join(this.databaseUri.fsPath, 'codeql-database.yml'));;
+  public async hasMetadataFile(): Promise<boolean> {
+    return (await Promise.all([
+      fs.pathExists(path.join(this.databaseUri.fsPath, '.dbinfo')),
+      fs.pathExists(path.join(this.databaseUri.fsPath, 'codeql-database.yml'))
+    ])).some(x => x);
   }
 
   /**

--- a/extensions/ql-vscode/src/queries.ts
+++ b/extensions/ql-vscode/src/queries.ts
@@ -150,8 +150,12 @@ export class QueryInfo {
   /**
    * Holds if this query should produce interpreted results.
    */
-  hasInterpretedResults(): boolean {
-    return this.dbItem.hasDbInfo();
+  async hasInterpretedResults(): Promise<boolean> {
+    const hasMetadataFile = await this.dbItem.hasMetadataFile();
+    if (!hasMetadataFile) {
+      logger.log("Cannot produce interpreted results since the database does not have a .dbinfo or codeql-database.yml file.");
+    }
+    return hasMetadataFile;
   }
 
   async updateSortState(server: cli.CodeQLCliServer, resultSetName: string, sortState: SortState | undefined): Promise<void> {


### PR DESCRIPTION
This is a key cause of not being able to produce interpreted results, so logging this case when it occurs helps us debug a lack of interpreted results.

Also make the database metadata check async.