### PR TITLE
Enable unused value compiler checks

### DIFF
--- a/configs/typescript-config/common.tsconfig.json
+++ b/configs/typescript-config/common.tsconfig.json
@@ -15,7 +15,9 @@
     "preserveWatchOutput": true,
     "newLine": "lf",
     "noImplicitReturns": true,
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
   },
   "include": [
     "../../src/**/*.ts"

--- a/extensions/ql-vscode/src/archive-filesystem-provider.ts
+++ b/extensions/ql-vscode/src/archive-filesystem-provider.ts
@@ -163,7 +163,7 @@ export class ArchiveFileSystemProvider implements vscode.FileSystemProvider {
   // metadata
 
   async stat(uri: vscode.Uri): Promise<vscode.FileStat> {
-    return await this._lookup(uri, false);
+    return await this._lookup(uri);
   }
 
   async readDirectory(uri: vscode.Uri): Promise<[string, vscode.FileType][]> {
@@ -180,7 +180,7 @@ export class ArchiveFileSystemProvider implements vscode.FileSystemProvider {
   // file contents
 
   async readFile(uri: vscode.Uri): Promise<Uint8Array> {
-    const data = (await this._lookupAsFile(uri, false)).data;
+    const data = (await this._lookupAsFile(uri)).data;
     if (data) {
       return data;
     }
@@ -189,25 +189,25 @@ export class ArchiveFileSystemProvider implements vscode.FileSystemProvider {
 
   // write operations, all disabled
 
-  writeFile(uri: vscode.Uri, content: Uint8Array, options: { create: boolean, overwrite: boolean }): void {
+  writeFile(_uri: vscode.Uri, _content: Uint8Array, _options: { create: boolean, overwrite: boolean }): void {
     throw this.readOnlyError;
   }
 
-  rename(oldUri: vscode.Uri, newUri: vscode.Uri, options: { overwrite: boolean }): void {
+  rename(_oldUri: vscode.Uri, _newUri: vscode.Uri, _options: { overwrite: boolean }): void {
     throw this.readOnlyError;
   }
 
-  delete(uri: vscode.Uri): void {
+  delete(_uri: vscode.Uri): void {
     throw this.readOnlyError;
   }
 
-  createDirectory(uri: vscode.Uri): void {
+  createDirectory(_uri: vscode.Uri): void {
     throw this.readOnlyError;
   }
 
   // content lookup
 
-  private async _lookup(uri: vscode.Uri, silent: boolean): Promise<Entry> {
+  private async _lookup(uri: vscode.Uri): Promise<Entry> {
     const ref = decodeSourceArchiveUri(uri);
     const archive = await this.getArchive(ref.sourceArchiveZipPath);
 
@@ -238,8 +238,8 @@ export class ArchiveFileSystemProvider implements vscode.FileSystemProvider {
     throw vscode.FileSystemError.FileNotFound(uri);
   }
 
-  private async _lookupAsFile(uri: vscode.Uri, silent: boolean): Promise<File> {
-    let entry = await this._lookup(uri, silent);
+  private async _lookupAsFile(uri: vscode.Uri): Promise<File> {
+    let entry = await this._lookup(uri);
     if (entry instanceof File) {
       return entry;
     }

--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -154,7 +154,7 @@ export class CodeQLCliServer implements Disposable {
     if (!config) {
       throw new Error("Failed to find codeql distribution")
     }
-    return spawnServer(config, "CodeQL CLI Server", ["execute", "cli-server"], [], this.logger, data => { })
+    return spawnServer(config, "CodeQL CLI Server", ["execute", "cli-server"], [], this.logger, _data => {})
   }
 
   private async runCodeQlCliInternal(command: string[], commandArgs: string[], description: string): Promise<string> {

--- a/extensions/ql-vscode/src/databases-ui.ts
+++ b/extensions/ql-vscode/src/databases-ui.ts
@@ -90,7 +90,7 @@ class DatabaseTreeDataProvider extends DisposableObject
     }
   }
 
-  public getParent(element: DatabaseItem): ProviderResult<DatabaseItem> {
+  public getParent(_element: DatabaseItem): ProviderResult<DatabaseItem> {
     return null;
   }
 
@@ -128,7 +128,7 @@ async function chooseDatabaseDir(): Promise<Uri | undefined> {
 }
 
 export class DatabaseUI extends DisposableObject {
-  public constructor(private ctx: ExtensionContext, private cliserver: cli.CodeQLCliServer, private databaseManager: DatabaseManager,
+  public constructor(ctx: ExtensionContext, private cliserver: cli.CodeQLCliServer, private databaseManager: DatabaseManager,
     private readonly queryServer: qsClient.QueryServerClient | undefined) {
 
     super();

--- a/extensions/ql-vscode/src/databases.ts
+++ b/extensions/ql-vscode/src/databases.ts
@@ -413,7 +413,7 @@ class DatabaseItemImpl implements DatabaseItem {
  * >1000ms) log a warning, and resolve to undefined.
  */
 function eventFired<T>(event: vscode.Event<T>, timeoutMs: number = 1000): Promise<T | undefined> {
-  return new Promise((res, rej) => {
+  return new Promise((res, _rej) => {
     let timeout: NodeJS.Timeout | undefined;
     let disposable: vscode.Disposable | undefined;
     function dispose() {

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -49,7 +49,7 @@ let isInstallingOrUpdatingDistribution = false;
  *
  * @param excludedCommands List of commands for which we should not register error stubs.
  */
-function registerErrorStubs(ctx: ExtensionContext, excludedCommands: string[], stubGenerator: (command: string) => () => void) {
+function registerErrorStubs(excludedCommands: string[], stubGenerator: (command: string) => () => void) {
   // Remove existing stubs
   errorStubs.forEach(stub => stub.dispose());
 
@@ -79,7 +79,7 @@ export async function activate(ctx: ExtensionContext): Promise<void> {
 
   const shouldUpdateOnNextActivationKey = "shouldUpdateOnNextActivation";
 
-  registerErrorStubs(ctx, [checkForUpdatesCommand], command => () => {
+  registerErrorStubs([checkForUpdatesCommand], command => () => {
     helpers.showAndLogErrorMessage(`Can't execute ${command}: waiting to finish loading CodeQL CLI.`);
   });
 
@@ -189,7 +189,7 @@ export async function activate(ctx: ExtensionContext): Promise<void> {
     if (!beganMainExtensionActivation && distributionResult.kind !== FindDistributionResultKind.NoDistribution) {
       await activateWithInstalledDistribution(ctx, distributionManager);
     } else if (distributionResult.kind === FindDistributionResultKind.NoDistribution) {
-      registerErrorStubs(ctx, [checkForUpdatesCommand], command => async () => {
+      registerErrorStubs([checkForUpdatesCommand], command => async () => {
         const installActionName = "Install CodeQL CLI";
         const chosenAction = await helpers.showAndLogErrorMessage(`Can't execute ${command}: missing CodeQL CLI.`, installActionName);
         if (chosenAction === installActionName) {

--- a/extensions/ql-vscode/src/interface.ts
+++ b/extensions/ql-vscode/src/interface.ts
@@ -199,7 +199,7 @@ export class InterfaceManager extends DisposableObject {
   }
 
   private waitForPanelLoaded(): Promise<void> {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve, _reject) => {
       if (this._panelLoaded) {
         resolve();
       } else {

--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -89,7 +89,6 @@ class HistoryTreeDataProvider implements vscode.TreeDataProvider<QueryHistoryIte
   private _onDidChangeTreeData: vscode.EventEmitter<QueryHistoryItem | undefined> = new vscode.EventEmitter<QueryHistoryItem | undefined>();
   readonly onDidChangeTreeData: vscode.Event<QueryHistoryItem | undefined> = this._onDidChangeTreeData.event;
 
-  private ctx: ExtensionContext;
   private history: QueryHistoryItem[] = [];
 
   /**
@@ -97,8 +96,7 @@ class HistoryTreeDataProvider implements vscode.TreeDataProvider<QueryHistoryIte
    */
   private current: QueryHistoryItem | undefined;
 
-  constructor(ctx: ExtensionContext) {
-    this.ctx = ctx;
+  constructor() {
     this.history = [];
   }
 
@@ -123,7 +121,7 @@ class HistoryTreeDataProvider implements vscode.TreeDataProvider<QueryHistoryIte
     }
   }
 
-  getParent(element: QueryHistoryItem): vscode.ProviderResult<QueryHistoryItem> {
+  getParent(_element: QueryHistoryItem): vscode.ProviderResult<QueryHistoryItem> {
     return null;
   }
 
@@ -238,7 +236,7 @@ export class QueryHistoryManager {
   ) {
     this.ctx = ctx;
     this.selectedCallback = selectedCallback;
-    const treeDataProvider = this.treeDataProvider = new HistoryTreeDataProvider(ctx);
+    const treeDataProvider = this.treeDataProvider = new HistoryTreeDataProvider();
     this.treeView = Window.createTreeView('codeQLQueryHistory', { treeDataProvider });
     this.treeView.onDidChangeSelection(async ev => {
       if (ev.selection.length == 0) {

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/distribution.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/distribution.test.ts
@@ -48,7 +48,7 @@ describe("Releases API consumer", () => {
 
   it("picking latest release: is based on version", async () => {
     class MockReleasesApiConsumer extends ReleasesApiConsumer {
-      protected async makeApiCall(apiPath: string, additionalHeaders: { [key: string]: string } = {}): Promise<fetch.Response> {
+      protected async makeApiCall(apiPath: string): Promise<fetch.Response> {
         if (apiPath === `/repos/${owner}/${repo}/releases`) {
           return Promise.resolve(new fetch.Response(JSON.stringify(sampleReleaseResponse)));
         }
@@ -64,7 +64,7 @@ describe("Releases API consumer", () => {
 
   it("picking latest release: obeys version constraints", async () => {
     class MockReleasesApiConsumer extends ReleasesApiConsumer {
-      protected async makeApiCall(apiPath: string, additionalHeaders: { [key: string]: string } = {}): Promise<fetch.Response> {
+      protected async makeApiCall(apiPath: string): Promise<fetch.Response> {
         if (apiPath === `/repos/${owner}/${repo}/releases`) {
           return Promise.resolve(new fetch.Response(JSON.stringify(sampleReleaseResponse)));
         }
@@ -83,7 +83,7 @@ describe("Releases API consumer", () => {
 
   it("picking latest release: includes prereleases when option set", async () => {
     class MockReleasesApiConsumer extends ReleasesApiConsumer {
-      protected async makeApiCall(apiPath: string, additionalHeaders: { [key: string]: string } = {}): Promise<fetch.Response> {
+      protected async makeApiCall(apiPath: string): Promise<fetch.Response> {
         if (apiPath === `/repos/${owner}/${repo}/releases`) {
           return Promise.resolve(new fetch.Response(JSON.stringify(sampleReleaseResponse)));
         }
@@ -112,7 +112,7 @@ describe("Releases API consumer", () => {
     ];
 
     class MockReleasesApiConsumer extends ReleasesApiConsumer {
-      protected async makeApiCall(apiPath: string, additionalHeaders: { [key: string]: string } = {}): Promise<fetch.Response> {
+      protected async makeApiCall(apiPath: string): Promise<fetch.Response> {
         if (apiPath === `/repos/${owner}/${repo}/releases`) {
           const responseBody: GithubRelease[] = [{
             "assets": expectedAssets,

--- a/extensions/ql-vscode/test/pure-tests/query-test.ts
+++ b/extensions/ql-vscode/test/pure-tests/query-test.ts
@@ -100,7 +100,7 @@ describe('using the query server', function () {
     };
     const logger = {
       log: (s: string) => console.log('logger says', s),
-      logWithoutTrailingNewline: (s: string) => { }
+      logWithoutTrailingNewline: (s: string) => console.log('logger says', s)
     };
     cliServer = new cli.CodeQLCliServer({
       async getCodeQlPathWithoutVersionCheck(): Promise<string | undefined> {
@@ -167,7 +167,7 @@ describe('using the query server', function () {
     it(`should be able to run query ${queryName}`, async function () {
       try {
         await compilationSucceeded.done();
-        const callbackId = qs.registerCallback(res => {
+        const callbackId = qs.registerCallback(_res => {
           evaluationSucceeded.resolve();
         });
         const queryToRun: messages.QueryToRun = {

--- a/lib/semmle-bqrs/src/bqrs-custom.ts
+++ b/lib/semmle-bqrs/src/bqrs-custom.ts
@@ -166,7 +166,7 @@ type ParseTupleAction = (src: readonly ColumnValue[], dest: any) => void;
 type TupleParser<T> = (src: readonly ColumnValue[]) => T;
 
 export class CustomResultSet<TTuple> {
-  public constructor(private reader: ResultSetReader, private readonly type: { new(): TTuple },
+  public constructor(private reader: ResultSetReader,
     private readonly tupleParser: TupleParser<TTuple>) {
   }
 
@@ -192,7 +192,7 @@ class CustomResultSetBinder {
     const binder = new CustomResultSetBinder(rowType, reader.schema);
     const tupleParser = binder.bindRoot<TTuple>();
 
-    return new CustomResultSet<TTuple>(reader, rowType, tupleParser);
+    return new CustomResultSet<TTuple>(reader, tupleParser);
   }
 
   private bindRoot<TTuple>(): TupleParser<TTuple> {

--- a/lib/semmle-io/src/digester.ts
+++ b/lib/semmle-io/src/digester.ts
@@ -124,7 +124,7 @@ export class StreamDigester {
   }
 
   /**
-   * Implements an async read that span multple buffers.
+   * Implements an async read that spans multiple buffers.
    *
    * @param canReadFunc Callback function to determine how many bytes are required to complete the
    *  read operation.
@@ -186,7 +186,7 @@ export class StreamDigester {
   private readKnownSizeAcrossSeam<T>(byteCount: number,
     readFunc: (buffer: Buffer, offset: number) => T): Promise<T> {
 
-    return this.readAcrossSeam((buffer, offset, availableByteCount) => byteCount, readFunc);
+    return this.readAcrossSeam((_buffer, _offset, _availableByteCount) => byteCount, readFunc);
   }
 
   private readKnownSize<T>(byteCount: number, readFunc: (buffer: Buffer, offset: number) => T):

--- a/tools/build-tasks/src/textmate.ts
+++ b/tools/build-tasks/src/textmate.ts
@@ -218,7 +218,7 @@ function transformFile(yaml: any) {
 }
 
 export function transpileTextMateGrammar() {
-  return through.obj((file: Vinyl, encoding: string, callback: Function): void => {
+  return through.obj((file: Vinyl, _encoding: string, callback: Function): void => {
     if (file.isNull()) {
       callback(null, file);
     }

--- a/tools/build-tasks/src/typescript.ts
+++ b/tools/build-tasks/src/typescript.ts
@@ -43,7 +43,7 @@ export function compileTypeScript() {
   return tsProject.src()
     .pipe(sourcemaps.init())
     .pipe(tsProject(goodReporter()))
-    .pipe(sourcemaps.mapSources((sourcePath, file) => {
+    .pipe(sourcemaps.mapSources((sourcePath, _file) => {
       // The source path is kind of odd, because it's relative to the `tsconfig.json` file in the
       // `typescript-config` package, which lives in the `node_modules` directory of the package
       // that is being built. It starts out as something like '../../../src/foo.ts', and we need to


### PR DESCRIPTION
Specifically the `noUnusedLocals` and `noUnusedParameters` options.  This will mean that we catch these types of warning at compile-time rather than on the PR.

To fix unused locals, I've removed some `private` annotations on constructor parameters where the property was unused.  For unused parameters, I've removed the parameter from internal functions and prefixed an underscore.