### PR TITLE
Reduce update check frequency

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -4,8 +4,10 @@ import * as archiveFilesystemProvider from './archive-filesystem-provider';
 import { DistributionConfigListener, QueryServerConfigListener, QueryHistoryConfigListener } from './config';
 import { DatabaseManager } from './databases';
 import { DatabaseUI } from './databases-ui';
-import { DistributionUpdateCheckResultKind, DistributionManager, FindDistributionResult, FindDistributionResultKind, GithubApiError,
-  DEFAULT_DISTRIBUTION_VERSION_CONSTRAINT, GithubRateLimitedError } from './distribution';
+import {
+  DistributionUpdateCheckResultKind, DistributionManager, FindDistributionResult, FindDistributionResultKind, GithubApiError,
+  DEFAULT_DISTRIBUTION_VERSION_CONSTRAINT, GithubRateLimitedError
+} from './distribution';
 import * as helpers from './helpers';
 import { spawnIdeServer } from './ide-server';
 import { InterfaceManager, WebviewReveal } from './interface';
@@ -83,29 +85,32 @@ export async function activate(ctx: ExtensionContext): Promise<void> {
     helpers.showAndLogErrorMessage(`Can't execute ${command}: waiting to finish loading CodeQL CLI.`);
   });
 
-  interface ReportingConfig {
+  interface DistributionUpdateConfig {
+    isUserInitiated: boolean;
     shouldDisplayMessageWhenNoUpdates: boolean;
-    shouldErrorIfUpdateFails: boolean;
   }
 
-  async function installOrUpdateDistributionWithProgressTitle(progressTitle: string, reportingConfig: ReportingConfig): Promise<void> {
-    const result = await distributionManager.checkForUpdatesToExtensionManagedDistribution();
+  async function installOrUpdateDistributionWithProgressTitle(progressTitle: string, config: DistributionUpdateConfig): Promise<void> {
+    const minSecondsSinceLastUpdateCheck = config.isUserInitiated ? 0 : 86400;
+    const noUpdatesLoggingFunc = config.shouldDisplayMessageWhenNoUpdates ?
+      helpers.showAndLogInformationMessage : async (message: string) => logger.log(message);
+    const result = await distributionManager.checkForUpdatesToExtensionManagedDistribution(minSecondsSinceLastUpdateCheck);
     switch (result.kind) {
-      case DistributionUpdateCheckResultKind.AlreadyUpToDate:
-        if (reportingConfig.shouldDisplayMessageWhenNoUpdates) {
-          helpers.showAndLogInformationMessage("CodeQL CLI already up to date.");
-        }
+      case DistributionUpdateCheckResultKind.AlreadyCheckedRecentlyResult:
+        logger.log("Didn't perform CodeQL CLI update check since a check was already performed within the previous " +
+          `${minSecondsSinceLastUpdateCheck} seconds.`);
         break;
-      case DistributionUpdateCheckResultKind.InvalidDistributionLocation:
-        if (reportingConfig.shouldDisplayMessageWhenNoUpdates) {
-          helpers.showAndLogErrorMessage("CodeQL CLI is installed externally so could not be updated.");
-        }
+      case DistributionUpdateCheckResultKind.AlreadyUpToDate:
+        await noUpdatesLoggingFunc("CodeQL CLI already up to date.");
+        break;
+      case DistributionUpdateCheckResultKind.InvalidLocation:
+        await noUpdatesLoggingFunc("CodeQL CLI is installed externally so could not be updated.");
         break;
       case DistributionUpdateCheckResultKind.UpdateAvailable:
         if (beganMainExtensionActivation) {
           const updateAvailableMessage = `Version "${result.updatedRelease.name}" of the CodeQL CLI is now available. ` +
             "The update will be installed after Visual Studio Code restarts. Restart now to upgrade?";
-          ctx.globalState.update(shouldUpdateOnNextActivationKey, true);
+          await ctx.globalState.update(shouldUpdateOnNextActivationKey, true);
           if (await helpers.showInformationMessageWithAction(updateAvailableMessage, "Restart and Upgrade")) {
             await commands.executeCommand("workbench.action.reloadWindow");
           }
@@ -118,7 +123,7 @@ export async function activate(ctx: ExtensionContext): Promise<void> {
           await helpers.withProgress(progressOptions, progress =>
             distributionManager.installExtensionManagedDistributionRelease(result.updatedRelease, progress));
 
-          ctx.globalState.update(shouldUpdateOnNextActivationKey, false);
+          await ctx.globalState.update(shouldUpdateOnNextActivationKey, false);
           helpers.showAndLogInformationMessage(`CodeQL CLI updated to version "${result.updatedRelease.name}".`);
         }
         break;
@@ -127,7 +132,7 @@ export async function activate(ctx: ExtensionContext): Promise<void> {
     }
   }
 
-  async function installOrUpdateDistribution(reportingConfig: ReportingConfig): Promise<void> {
+  async function installOrUpdateDistribution(config: DistributionUpdateConfig): Promise<void> {
     if (isInstallingOrUpdatingDistribution) {
       throw new Error("Already installing or updating CodeQL CLI");
     }
@@ -137,11 +142,11 @@ export async function activate(ctx: ExtensionContext): Promise<void> {
     const messageText = willUpdateCodeQl ? "Updating CodeQL CLI" :
       codeQlInstalled ? "Checking for updates to CodeQL CLI" : "Installing CodeQL CLI";
     try {
-      await installOrUpdateDistributionWithProgressTitle(messageText, reportingConfig);
+      await installOrUpdateDistributionWithProgressTitle(messageText, config);
     } catch (e) {
       // Don't rethrow the exception, because if the config is changed, we want to be able to retry installing
       // or updating the distribution.
-      const alertFunction = (codeQlInstalled && !reportingConfig.shouldErrorIfUpdateFails) ?
+      const alertFunction = (codeQlInstalled && !config.isUserInitiated) ?
         helpers.showAndLogWarningMessage : helpers.showAndLogErrorMessage;
       const taskDescription = (willUpdateCodeQl ? "update" :
         codeQlInstalled ? "check for updates to" : "install") + " CodeQL CLI";
@@ -180,8 +185,8 @@ export async function activate(ctx: ExtensionContext): Promise<void> {
     return result;
   }
 
-  async function installOrUpdateThenTryActivate(reportingConfig: ReportingConfig): Promise<void> {
-    await installOrUpdateDistribution(reportingConfig);
+  async function installOrUpdateThenTryActivate(config: DistributionUpdateConfig): Promise<void> {
+    await installOrUpdateDistribution(config);
 
     // Display the warnings even if the extension has already activated.
     const distributionResult = await getDistributionDisplayingDistributionWarnings();
@@ -194,8 +199,8 @@ export async function activate(ctx: ExtensionContext): Promise<void> {
         const chosenAction = await helpers.showAndLogErrorMessage(`Can't execute ${command}: missing CodeQL CLI.`, installActionName);
         if (chosenAction === installActionName) {
           installOrUpdateThenTryActivate({
-            shouldDisplayMessageWhenNoUpdates: false,
-            shouldErrorIfUpdateFails: true
+            isUserInitiated: true,
+            shouldDisplayMessageWhenNoUpdates: false
           });
         }
       });
@@ -203,17 +208,17 @@ export async function activate(ctx: ExtensionContext): Promise<void> {
   }
 
   ctx.subscriptions.push(distributionConfigListener.onDidChangeDistributionConfiguration(() => installOrUpdateThenTryActivate({
-    shouldDisplayMessageWhenNoUpdates: false,
-    shouldErrorIfUpdateFails: true
+    isUserInitiated: true,
+    shouldDisplayMessageWhenNoUpdates: false
   })));
   ctx.subscriptions.push(commands.registerCommand(checkForUpdatesCommand, () => installOrUpdateThenTryActivate({
-    shouldDisplayMessageWhenNoUpdates: true,
-    shouldErrorIfUpdateFails: true
+    isUserInitiated: true,
+    shouldDisplayMessageWhenNoUpdates: true
   })));
 
   await installOrUpdateThenTryActivate({
-    shouldDisplayMessageWhenNoUpdates: false,
-    shouldErrorIfUpdateFails: !!ctx.globalState.get(shouldUpdateOnNextActivationKey)
+    isUserInitiated: !!ctx.globalState.get(shouldUpdateOnNextActivationKey),
+    shouldDisplayMessageWhenNoUpdates: false
   });
 }
 

--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -46,10 +46,10 @@ export function withProgress<R>(
 /**
  * Show an error message and log it to the console
  *
- * @param message — The message to show.
- * @param items — A set of items that will be rendered as actions in the message.
+ * @param message The message to show.
+ * @param items A set of items that will be rendered as actions in the message.
  *
- * @return — A thenable that resolves to the selected item or undefined when being dismissed.
+ * @return A thenable that resolves to the selected item or undefined when being dismissed.
  */
 export function showAndLogErrorMessage(message: string, ...items: string[]): Thenable<string | undefined> {
   logger.log(message);
@@ -58,10 +58,10 @@ export function showAndLogErrorMessage(message: string, ...items: string[]): The
 /**
  * Show a warning message and log it to the console
  *
- * @param message — The message to show.
- * @param items — A set of items that will be rendered as actions in the message.
+ * @param message The message to show.
+ * @param items A set of items that will be rendered as actions in the message.
  *
- * @return — A thenable that resolves to the selected item or undefined when being dismissed.
+ * @return A thenable that resolves to the selected item or undefined when being dismissed.
  */
 export function showAndLogWarningMessage(message: string, ...items: string[]): Thenable<string | undefined> {
   logger.log(message);
@@ -70,10 +70,10 @@ export function showAndLogWarningMessage(message: string, ...items: string[]): T
 /**
  * Show an information message and log it to the console
  *
- * @param message — The message to show.
- * @param items — A set of items that will be rendered as actions in the message.
+ * @param message The message to show.
+ * @param items A set of items that will be rendered as actions in the message.
  *
- * @return — A thenable that resolves to the selected item or undefined when being dismissed.
+ * @return A thenable that resolves to the selected item or undefined when being dismissed.
  */
 export function showAndLogInformationMessage(message: string, ...items: string[]): Thenable<string | undefined> {
   logger.log(message);
@@ -82,9 +82,9 @@ export function showAndLogInformationMessage(message: string, ...items: string[]
 
 /**
  * Opens a modal dialog for the user to make a yes/no choice.
- * @param message — The message to show.
+ * @param message The message to show.
  *
- * @return — `true` if the user clicks 'Yes', `false` if the user clicks 'No' or cancels the dialog.
+ * @return `true` if the user clicks 'Yes', `false` if the user clicks 'No' or cancels the dialog.
  */
 export async function showBinaryChoiceDialog(message: string): Promise<boolean> {
   const yesItem = { title: 'Yes', isCloseAffordance: false };
@@ -95,10 +95,10 @@ export async function showBinaryChoiceDialog(message: string): Promise<boolean> 
 
 /**
  * Show an information message with a customisable action.
- * @param message — The message to show.
- * @param actionMessage - The call to action message.
+ * @param message The message to show.
+ * @param actionMessage The call to action message.
  *
- * @return — `true` if the user clicks the action, `false` if the user cancels the dialog.
+ * @return `true` if the user clicks the action, `false` if the user cancels the dialog.
  */
 export async function showInformationMessageWithAction(message: string, actionMessage: string): Promise<boolean> {
   const actionItem = { title: actionMessage, isCloseAffordance: false };

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/helpers.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/helpers.test.ts
@@ -1,0 +1,104 @@
+import { expect } from "chai";
+import "mocha";
+import { ExtensionContext, Memento } from "vscode";
+import { InvocationRateLimiter } from "../../helpers";
+
+describe("Invocation rate limiter", () => {
+  function createInvocationRateLimiter<T>(funcIdentifier: string, func: () => Promise<T>): InvocationRateLimiter<T> {
+    return new InvocationRateLimiter(new MockExtensionContext(), funcIdentifier, func);
+  }
+
+  it("initially invokes function", async () => {
+    let numTimesFuncCalled = 0;
+    const invocationRateLimiter = createInvocationRateLimiter("funcid", async () => {
+      numTimesFuncCalled++;
+    });
+    await invocationRateLimiter.invokeFunctionIfIntervalElapsed(100);
+    expect(numTimesFuncCalled).to.equal(1);
+  });
+
+  it("doesn't invoke function within time period", async () => {
+    let numTimesFuncCalled = 0;
+    const invocationRateLimiter = createInvocationRateLimiter("funcid", async () => {
+      numTimesFuncCalled++;
+    });
+    await invocationRateLimiter.invokeFunctionIfIntervalElapsed(100);
+    await invocationRateLimiter.invokeFunctionIfIntervalElapsed(100);
+    expect(numTimesFuncCalled).to.equal(1);
+  });
+
+  it("invoke function again after 0s time period has elapsed", async () => {
+    let numTimesFuncCalled = 0;
+    const invocationRateLimiter = createInvocationRateLimiter("funcid", async () => {
+      numTimesFuncCalled++;
+    });
+    await invocationRateLimiter.invokeFunctionIfIntervalElapsed(0);
+    await invocationRateLimiter.invokeFunctionIfIntervalElapsed(0);
+    expect(numTimesFuncCalled).to.equal(2);
+  });
+
+  it("invoke function again after 1s time period has elapsed", async () => {
+    let numTimesFuncCalled = 0;
+    const invocationRateLimiter = createInvocationRateLimiter("funcid", async () => {
+      numTimesFuncCalled++;
+    });
+    await invocationRateLimiter.invokeFunctionIfIntervalElapsed(1);
+    await new Promise((resolve, _reject) => setTimeout(() => resolve(), 1000));
+    await invocationRateLimiter.invokeFunctionIfIntervalElapsed(1);
+    expect(numTimesFuncCalled).to.equal(2);
+  });
+
+  it("invokes functions with different rate limiters", async () => {
+    let numTimesFuncACalled = 0;
+    const invocationRateLimiterA = createInvocationRateLimiter("funcid", async () => {
+      numTimesFuncACalled++;
+    });
+    let numTimesFuncBCalled = 0;
+    const invocationRateLimiterB = createInvocationRateLimiter("funcid", async () => {
+      numTimesFuncBCalled++;
+    });
+    await invocationRateLimiterA.invokeFunctionIfIntervalElapsed(100);
+    await invocationRateLimiterB.invokeFunctionIfIntervalElapsed(100);
+    expect(numTimesFuncACalled).to.equal(1);
+    expect(numTimesFuncBCalled).to.equal(1);
+  });
+});
+
+class MockExtensionContext implements ExtensionContext {
+  subscriptions: { dispose(): unknown; }[] = [];
+  workspaceState: Memento = new MockMemento();
+  globalState: Memento = new MockMemento();
+  extensionPath: string = "";
+  asAbsolutePath(_relativePath: string): string {
+    throw new Error("Method not implemented.");
+  }
+  storagePath: string = "";
+  globalStoragePath: string = "";
+  logPath: string = "";
+}
+
+class MockMemento implements Memento {
+  map = new Map<any, any>();
+
+  /**
+   * Return a value.
+   *
+   * @param key A string.
+   * @param defaultValue A value that should be returned when there is no
+   * value (`undefined`) with the given key.
+   * @return The stored value or the defaultValue.
+   */
+  get<T>(key: string, defaultValue?: T): T {
+    return this.map.has(key) ? this.map.get(key) : defaultValue;
+  }
+
+  /**
+   * Store a value. The value must be JSON-stringifyable.
+   *
+   * @param key A string.
+   * @param value A value. MUST not contain cyclic references.
+   */
+  async update(key: string, value: any): Promise<void> {
+    this.map.set(key, value);
+  }
+}


### PR DESCRIPTION
Implement a rate limiter for function invocations and use it to limit non-user-triggered CLI update checks to once per 24 hours.  This helps to avoid hitting the GitHub API limits of 60 requests per hour for unauthenticated IPs.