### PR TITLE
Fix double-encoding of "#" in webview URI conversion

### DIFF
--- a/extensions/ql-vscode/src/interface.ts
+++ b/extensions/ql-vscode/src/interface.ts
@@ -74,7 +74,7 @@ function getHtmlForWebview(webview: vscode.Webview, scriptUriOnDisk: vscode.Uri,
 
 /** Converts a filesystem URI into a webview URI string that the given panel can use to read the file. */
 export function fileUriToWebviewUri(panel: vscode.WebviewPanel, fileUriOnDisk: Uri): string {
-  return encodeURI(panel.webview.asWebviewUri(fileUriOnDisk).toString(true));
+  return panel.webview.asWebviewUri(fileUriOnDisk).toString();
 }
 
 /** Converts a URI string received from a webview into a local filesystem URI for the same resource. */

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/webview-uri.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/webview-uri.test.ts
@@ -1,11 +1,14 @@
 import { expect } from "chai";
+import * as path from "path";
 import * as tmp from "tmp";
 import { window, ViewColumn, Uri } from "vscode";
 import { fileUriToWebviewUri, webviewUriToFileUri } from '../../interface';
 
 describe('webview uri conversion', function () {
-  it('should correctly round trip from filesystem to webview and back', function () {
-    const tmpFile = tmp.fileSync({ prefix: 'uri_test_', postfix: '.bqrs', keep: false });
+  const fileSuffix = '.bqrs';
+
+  function setupWebview(filePrefix: string) {
+    const tmpFile = tmp.fileSync({ prefix: `uri_test_${filePrefix}_`, postfix: fileSuffix, keep: false });
     const fileUriOnDisk = Uri.file(tmpFile.name);
     const panel = window.createWebviewPanel(
       'test panel',
@@ -26,9 +29,23 @@ describe('webview uri conversion', function () {
     // CSP allowing nothing, to prevent warnings.
     const html = `<html><head><meta http-equiv="Content-Security-Policy" content="default-src 'none';"></head></html>`;
     panel.webview.html = html;
-
+    return {
+      fileUriOnDisk,
+      panel
+    }
+  }
+  
+  it('should correctly round trip from filesystem to webview and back', function () {
+    const { fileUriOnDisk, panel } = setupWebview('');
     const webviewUri = fileUriToWebviewUri(panel, fileUriOnDisk);
     const reconstructedFileUri = webviewUriToFileUri(webviewUri);
     expect(reconstructedFileUri.toString(true)).to.equal(fileUriOnDisk.toString(true));
+  });
+
+  it("does not double-encode # in URIs", function () {
+    const { fileUriOnDisk, panel } = setupWebview('#');
+    const webviewUri = fileUriToWebviewUri(panel, fileUriOnDisk);
+    const parsedUri = Uri.parse(webviewUri);
+    expect(path.basename(parsedUri.path, fileSuffix)).to.equal(path.basename(fileUriOnDisk.path, fileSuffix));
   });
 });


### PR DESCRIPTION
This fixes sorting for result sets with a "#" in their name.  Add an integration test to verify this behaviour.