### PR TITLE
Increase timeout for query unit tests

### DIFF
--- a/extensions/ql-vscode/test/pure-tests/query-test.ts
+++ b/extensions/ql-vscode/test/pure-tests/query-test.ts
@@ -83,6 +83,10 @@ describe('using the query server', function () {
     }
   });
 
+  // Note this does not work with arrow functions as the test case bodies:
+  // ensure they are all written with standard anonymous functions.
+  this.timeout(10000);
+
   const codeQlPath = process.env["CODEQL_PATH"]!;
   let qs: qsClient.QueryServerClient;
   let cliServer: cli.CodeQLCliServer;
@@ -95,6 +99,7 @@ describe('using the query server', function () {
       cliServer.dispose();
     }
   });
+
   it('should be able to start the query server', async function () {
     const consoleProgressReporter: ProgressReporter = {
       report: (v: {message: string}) => console.log(`progress reporter says ${v.message}`)
@@ -125,10 +130,6 @@ describe('using the query server', function () {
     await qs.startQueryServer();
     queryServerStarted.resolve();
   });
-
-  // Note this does not work with arrow functions as the test case bodies:
-  // ensure they are all written with standard anonymous functions.
-  this.timeout(5000);
 
   for (const queryTestCase of queryTestCases) {
     const queryName = path.basename(queryTestCase.queryPath);


### PR DESCRIPTION
This pull increases the timeout for the query unit tests to avoid transient test failures like https://github.com/github/vscode-codeql/commit/e966c339d35766550b91a85eda1a93d8cb822112/checks?check_suite_id=383124497 resulting from the query server not starting up in time.