### PR TITLE
Use codeql.exe instead of codeql.cmd on Windows

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -85,7 +85,7 @@
           "scope": "machine",
           "type": "string",
           "default": "",
-          "description": "Path to the CodeQL executable that should be used by the CodeQL extension. The executable is named `codeql` on Linux/Mac and `codeql.cmd` on Windows. This overrides all other CodeQL CLI settings."
+          "description": "Path to the CodeQL executable that should be used by the CodeQL extension. The executable is named `codeql` on Linux/Mac and `codeql.exe` on Windows. This overrides all other CodeQL CLI settings."
         },
         "codeQL.runningQueries.numberOfThreads": {
           "type": "integer",

--- a/extensions/ql-vscode/src/distribution.ts
+++ b/extensions/ql-vscode/src/distribution.ts
@@ -502,7 +502,7 @@ export function versionCompare(a: Version, b: Version): number {
 }
 
 function codeQlLauncherName(): string {
-  return (os.platform() === "win32") ? "codeql.cmd" : "codeql";
+  return (os.platform() === "win32") ? "codeql.exe" : "codeql";
 }
 
 function isRedirectStatusCode(statusCode: number): boolean {


### PR DESCRIPTION
We just merged a change so that the main CodeQL executable on Windows is called `codeql.exe`. For now, `codeql.cmd` still exists as a wrapper, so we have some leeway in making this change.