### PR TITLE
Revert "Use codeql.exe instead of codeql.cmd on Windows"

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -85,7 +85,7 @@
           "scope": "machine",
           "type": "string",
           "default": "",
-          "description": "Path to the CodeQL executable that should be used by the CodeQL extension. The executable is named `codeql` on Linux/Mac and `codeql.exe` on Windows. This overrides all other CodeQL CLI settings."
+          "description": "Path to the CodeQL executable that should be used by the CodeQL extension. The executable is named `codeql` on Linux/Mac and `codeql.cmd` on Windows. This overrides all other CodeQL CLI settings."
         },
         "codeQL.runningQueries.numberOfThreads": {
           "type": "integer",

--- a/extensions/ql-vscode/src/distribution.ts
+++ b/extensions/ql-vscode/src/distribution.ts
@@ -502,7 +502,7 @@ export function versionCompare(a: Version, b: Version): number {
 }
 
 function codeQlLauncherName(): string {
-  return (os.platform() === "win32") ? "codeql.exe" : "codeql";
+  return (os.platform() === "win32") ? "codeql.cmd" : "codeql";
 }
 
 function isRedirectStatusCode(statusCode: number): boolean {


### PR DESCRIPTION
Reverts github/vscode-codeql#211

We need to (1) make a new CLI release and (2) update the extension's CLI version constraint before launching CodeQL via `codeql.exe`.