### PR TITLE
Default to disabling word based auto-complete when editing QL.

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.0.4
 
+- Disable word-based autocomplete by default.
+
 ## 1.0.3 - 13 January 2020
 
 - Reduce the frequency of CodeQL CLI update checks to help avoid hitting GitHub API limits of 60 requests per

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -42,6 +42,9 @@
     "configurationDefaults": {
       "[ql]": {
         "editor.wordBasedSuggestions": false
+      },
+      "[dbscheme]": {
+        "editor.wordBasedSuggestions": false
       }
     },
     "languages": [

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -39,6 +39,11 @@
     "language-configuration.json"
   ],
   "contributes": {
+    "configurationDefaults": {
+      "[ql]": {
+        "editor.wordBasedSuggestions": false
+      }
+    },
     "languages": [
       {
         "id": "ql",


### PR DESCRIPTION
Addresses at least one point of https://github.com/github/vscode-codeql/issues/216.