### PR TITLE
Pin nodejs version during Actions build.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,10 @@ jobs:
         with:
           fetch-depth: 1
 
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '10.18.1'
+
       - name: Build
         run: |
           cd build
@@ -45,6 +49,10 @@ jobs:
         uses: actions/checkout@v1
         with:
           fetch-depth: 1
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '10.18.1'
 
       # We have to build the dependencies in `lib` before running any tests.
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@master
 
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '10.18.1'
+
       # The checkout action does not fetch the master branch.
       # Fetch the master branch so that we can base the version bump PR against master.
       - name: Fetch master branch


### PR DESCRIPTION
This solves the problem of whatever node/npm ubuntu-latest happens to
have in /usr/local/bin/{node,npm} producing `Error: Cannot find module
'semver'` errors when it is misconfigured in the image.

(cf. https://askubuntu.com/questions/1152570/npm-cant-find-module-semver-error-in-ubuntu-19-04)