### PR TITLE
Exclude documentation from CI workflow (WIP don't merge)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,13 @@
 name: Build Extension
-on: [push, pull_request]
+on:
+  push:
+    paths:
+    - '**'
+    - '!**.md'
+  pull_request:
+    paths:
+    - '**'
+    - '!**.md'
 
 jobs:
   build:


### PR DESCRIPTION
Actions appears to be computing the diff with respect to the pull request base, so that a commit will trigger the workflow if the pull request as a whole contains any changes that modify non-markdown files, which is slightly unfortunate, but still an improvement for tiny documentation PRs.