### PR TITLE
Support sorting for interpreted alerts 

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add an icon next to any failed query runs in the query history
   view.
+- Add the ability to sort alerts by alert message.
 
 ## 1.0.4 - 24 January 2020
 

--- a/extensions/ql-vscode/src/interface-types.ts
+++ b/extensions/ql-vscode/src/interface-types.ts
@@ -17,11 +17,11 @@ export interface DatabaseInfo {
 }
 
 /** Arbitrary query metadata */
-export interface QueryMetadata {	
-  name?: string,	
-  description?: string,	
-  id?: string,	
-  kind?: string	
+export interface QueryMetadata {
+  name?: string,
+  description?: string,
+  id?: string,
+  kind?: string
 }
 
 export interface PreviousExecution {
@@ -34,6 +34,7 @@ export interface PreviousExecution {
 export interface Interpretation {
   sourceLocationPrefix: string;
   numTruncatedResults: number;
+  sortState: InterpretedResultsSortState;
   sarif: sarif.Log;
 }
 
@@ -44,7 +45,7 @@ export interface ResultsPaths {
 
 export interface SortedResultSetInfo {
   resultsPath: string;
-  sortState: SortState;
+  sortState: RawResultsSortState;
 }
 
 export type SortedResultsMap = { [resultSet: string]: SortedResultSetInfo };
@@ -84,7 +85,12 @@ export interface NavigatePathMsg {
 
 export type IntoResultsViewMsg = ResultsUpdatingMsg | SetStateMsg | NavigatePathMsg;
 
-export type FromResultsViewMsg = ViewSourceFileMsg | ToggleDiagnostics | ChangeSortMsg | ResultViewLoaded;
+export type FromResultsViewMsg =
+  | ViewSourceFileMsg
+  | ToggleDiagnostics
+  | ChangeRawResultsSortMsg
+  | ChangeInterpretedResultsSortMsg
+  | ResultViewLoaded;
 
 interface ViewSourceFileMsg {
   t: 'viewSourceFile';
@@ -109,13 +115,22 @@ export enum SortDirection {
   asc, desc
 }
 
-export interface SortState {
+export interface RawResultsSortState {
   columnIndex: number;
   direction: SortDirection;
 }
 
-interface ChangeSortMsg {
+export interface InterpretedResultsSortState {
+  sortBy: 'file-position' | 'alert-message';
+}
+
+interface ChangeRawResultsSortMsg {
   t: 'changeSort';
   resultSetName: string;
-  sortState?: SortState;
+  sortState?: RawResultsSortState;
+}
+
+interface ChangeInterpretedResultsSortMsg {
+  t: 'changeInterpretedSort';
+  sortState?: InterpretedResultsSortState;
 }

--- a/extensions/ql-vscode/src/interface-types.ts
+++ b/extensions/ql-vscode/src/interface-types.ts
@@ -121,7 +121,7 @@ export interface RawResultsSortState {
 }
 
 export type InterpretedResultsSortColumn =
-  'file-position' | 'alert-message';
+  'alert-message';
 
 export interface InterpretedResultsSortState {
   sortBy: InterpretedResultsSortColumn;

--- a/extensions/ql-vscode/src/interface-types.ts
+++ b/extensions/ql-vscode/src/interface-types.ts
@@ -120,8 +120,11 @@ export interface RawResultsSortState {
   direction: SortDirection;
 }
 
+export type InterpretedResultsSortOrder =
+  'file-position' | 'alert-message';
+
 export interface InterpretedResultsSortState {
-  sortBy: 'file-position' | 'alert-message';
+  sortBy: InterpretedResultsSortOrder;
 }
 
 interface ChangeRawResultsSortMsg {

--- a/extensions/ql-vscode/src/interface-types.ts
+++ b/extensions/ql-vscode/src/interface-types.ts
@@ -34,7 +34,7 @@ export interface PreviousExecution {
 export interface Interpretation {
   sourceLocationPrefix: string;
   numTruncatedResults: number;
-  sortState: InterpretedResultsSortState;
+  sortState?: InterpretedResultsSortState;
   sarif: sarif.Log;
 }
 
@@ -120,11 +120,12 @@ export interface RawResultsSortState {
   direction: SortDirection;
 }
 
-export type InterpretedResultsSortOrder =
+export type InterpretedResultsSortColumn =
   'file-position' | 'alert-message';
 
 export interface InterpretedResultsSortState {
-  sortBy: InterpretedResultsSortOrder;
+  sortBy: InterpretedResultsSortColumn;
+  sortDirection: SortDirection;
 }
 
 interface ChangeRawResultsSortMsg {

--- a/extensions/ql-vscode/src/interface-types.ts
+++ b/extensions/ql-vscode/src/interface-types.ts
@@ -117,7 +117,7 @@ export enum SortDirection {
 
 export interface RawResultsSortState {
   columnIndex: number;
-  direction: SortDirection;
+  sortDirection: SortDirection;
 }
 
 export type InterpretedResultsSortColumn =

--- a/extensions/ql-vscode/src/interface-types.ts
+++ b/extensions/ql-vscode/src/interface-types.ts
@@ -34,8 +34,10 @@ export interface PreviousExecution {
 export interface Interpretation {
   sourceLocationPrefix: string;
   numTruncatedResults: number;
-  // sortState being undefined means don't sort, just present results in the order
-  // they appear in the sarif file.
+  /**
+   * sortState being undefined means don't sort, just present results in the order
+   * they appear in the sarif file.
+   */
   sortState?: InterpretedResultsSortState;
   sarif: sarif.Log;
 }
@@ -130,17 +132,21 @@ export interface InterpretedResultsSortState {
   sortDirection: SortDirection;
 }
 
-// sortState being undefined means don't sort, just present results in the order
-// they appear in the bqrs file.
 interface ChangeRawResultsSortMsg {
   t: 'changeSort';
   resultSetName: string;
+  /**
+   * sortState being undefined means don't sort, just present results in the order
+   * they appear in the sarif file.
+   */
   sortState?: RawResultsSortState;
 }
 
-// sortState being undefined means don't sort, just present results in the order
-// they appear in the sarif file.
 interface ChangeInterpretedResultsSortMsg {
   t: 'changeInterpretedSort';
+  /**
+   * sortState being undefined means don't sort, just present results in the order
+   * they appear in the sarif file.
+   */
   sortState?: InterpretedResultsSortState;
 }

--- a/extensions/ql-vscode/src/interface-types.ts
+++ b/extensions/ql-vscode/src/interface-types.ts
@@ -34,6 +34,8 @@ export interface PreviousExecution {
 export interface Interpretation {
   sourceLocationPrefix: string;
   numTruncatedResults: number;
+  // sortState being undefined means don't sort, just present results in the order
+  // they appear in the sarif file.
   sortState?: InterpretedResultsSortState;
   sarif: sarif.Log;
 }
@@ -128,12 +130,16 @@ export interface InterpretedResultsSortState {
   sortDirection: SortDirection;
 }
 
+// sortState being undefined means don't sort, just present results in the order
+// they appear in the bqrs file.
 interface ChangeRawResultsSortMsg {
   t: 'changeSort';
   resultSetName: string;
   sortState?: RawResultsSortState;
 }
 
+// sortState being undefined means don't sort, just present results in the order
+// they appear in the sarif file.
 interface ChangeInterpretedResultsSortMsg {
   t: 'changeInterpretedSort';
   sortState?: InterpretedResultsSortState;

--- a/extensions/ql-vscode/src/interface.ts
+++ b/extensions/ql-vscode/src/interface.ts
@@ -269,7 +269,7 @@ export class InterfaceManager extends DisposableObject {
   }
 
   private async getTruncatedResults(metadata: QueryMetadata | undefined, resultsPaths: ResultsPaths, sourceInfo: cli.SourceInfo | undefined, sourceLocationPrefix: string): Promise<Interpretation> {
-    const sarif = await interpretResults(this.cliServer, metadata, resultsPaths.interpretedResultsPath, sourceInfo);
+    const sarif = await interpretResults(this.cliServer, metadata, resultsPaths.resultsPath, sourceInfo);
     // For performance reasons, limit the number of results we try
     // to serialize and send to the webview. TODO: possibly also
     // limit number of paths per result, number of steps per path,

--- a/extensions/ql-vscode/src/interface.ts
+++ b/extensions/ql-vscode/src/interface.ts
@@ -86,15 +86,22 @@ export function webviewUriToFileUri(webviewUri: string): Uri {
   return Uri.file(path);
 }
 
+function sortMultiplier(sortDirection: SortDirection): number {
+  switch (sortDirection) {
+    case SortDirection.asc: return 1;
+    case SortDirection.desc: return -1;
+  }
+}
+
 function sortInterpretedResults(results: Sarif.Result[], sortState: InterpretedResultsSortState | undefined): void {
   if (sortState !== undefined) {
-    const direction = sortState.sortDirection === SortDirection.asc ? 1 : -1;
+    const multiplier = sortMultiplier(sortState.sortDirection);
     switch (sortState.sortBy) {
       case 'alert-message':
         results.sort((a, b) =>
           a.message.text === undefined ? 0 :
             b.message.text === undefined ? 0 :
-              direction * (a.message.text?.localeCompare(b.message.text)));
+              multiplier * (a.message.text?.localeCompare(b.message.text)));
         break;
       default:
         assertNever(sortState.sortBy);

--- a/extensions/ql-vscode/src/interface.ts
+++ b/extensions/ql-vscode/src/interface.ts
@@ -87,11 +87,6 @@ export function webviewUriToFileUri(webviewUri: string): Uri {
 }
 
 function sortInterpretedResults(results: Sarif.Result[], sortState: InterpretedResultsSortState | undefined): void {
-  function locToString(locs: Sarif.Location[] | undefined): string {
-    if (locs === undefined) return '';
-    return JSON.stringify(locs[0]) || '';
-  }
-
   if (sortState !== undefined) {
     const direction = sortState.sortDirection === SortDirection.asc ? 1 : -1;
     switch (sortState.sortBy) {
@@ -100,10 +95,6 @@ function sortInterpretedResults(results: Sarif.Result[], sortState: InterpretedR
           a.message.text === undefined ? 0 :
             b.message.text === undefined ? 0 :
               direction * (a.message.text?.localeCompare(b.message.text)));
-        break;
-      case 'file-position':
-        results.sort((a, b) =>
-          direction * locToString(a.locations).localeCompare(locToString(b.locations)));
         break;
       default:
         assertNever(sortState.sortBy);

--- a/extensions/ql-vscode/src/query-results.ts
+++ b/extensions/ql-vscode/src/query-results.ts
@@ -21,7 +21,7 @@ export class CompletedQuery implements QueryWithResults {
    */
   sortedResultsInfo: Map<string, SortedResultSetInfo>;
 
-  /*
+  /**
    * How we're currently sorting alerts. This is not mere interface
    * state due to truncation; on re-sort, we want to read in the file
    * again, sort it, and only ship off a reasonable number of results

--- a/extensions/ql-vscode/src/query-results.ts
+++ b/extensions/ql-vscode/src/query-results.ts
@@ -113,7 +113,7 @@ export class CompletedQuery implements QueryWithResults {
       sortState
     };
 
-    await server.sortBqrs(this.query.resultsPaths.resultsPath, sortedResultSetInfo.resultsPath, resultSetName, [sortState.columnIndex], [sortState.direction]);
+    await server.sortBqrs(this.query.resultsPaths.resultsPath, sortedResultSetInfo.resultsPath, resultSetName, [sortState.columnIndex], [sortState.sortDirection]);
     this.sortedResultsInfo.set(resultSetName, sortedResultSetInfo);
   }
 

--- a/extensions/ql-vscode/src/query-results.ts
+++ b/extensions/ql-vscode/src/query-results.ts
@@ -25,9 +25,10 @@ export class CompletedQuery implements QueryWithResults {
    * How we're currently sorting alerts. This is not mere interface
    * state due to truncation; on re-sort, we want to read in the file
    * again, sort it, and only ship off a reasonable number of results
-   * to the webview.
+   * to the webview. Undefined means to use whatever order is in the
+   * sarif file.
    */
-  interpretedResultsSortState: InterpretedResultsSortState = { sortBy: 'file-position' };
+  interpretedResultsSortState: InterpretedResultsSortState | undefined;
 
   constructor(
     evalaution: QueryWithResults,

--- a/extensions/ql-vscode/src/query-results.ts
+++ b/extensions/ql-vscode/src/query-results.ts
@@ -118,9 +118,7 @@ export class CompletedQuery implements QueryWithResults {
   }
 
   async updateInterpretedSortState(_server: cli.CodeQLCliServer, sortState: InterpretedResultsSortState | undefined): Promise<void> {
-    if (sortState !== undefined) {
-      this.interpretedResultsSortState = sortState;
-    }
+    this.interpretedResultsSortState = sortState;
   }
 }
 

--- a/extensions/ql-vscode/src/query-results.ts
+++ b/extensions/ql-vscode/src/query-results.ts
@@ -116,8 +116,10 @@ export class CompletedQuery implements QueryWithResults {
     this.sortedResultsInfo.set(resultSetName, sortedResultSetInfo);
   }
 
-  async updateInterpretedSortState(_server: cli.CodeQLCliServer, _sortState: InterpretedResultsSortState | undefined): Promise<void> {
-
+  async updateInterpretedSortState(_server: cli.CodeQLCliServer, sortState: InterpretedResultsSortState | undefined): Promise<void> {
+    if (sortState !== undefined) {
+      this.interpretedResultsSortState = sortState;
+    }
   }
 }
 

--- a/extensions/ql-vscode/src/view/alert-table.tsx
+++ b/extensions/ql-vscode/src/view/alert-table.tsx
@@ -15,8 +15,6 @@ export interface PathTableState {
   selectedPathNode: undefined | Keys.PathNode;
 }
 
-type InterpretedResultsColumn = InterpretedResultsSortColumn | 'file-position';
-
 export class PathTable extends React.Component<PathTableProps, PathTableState> {
   constructor(props: PathTableProps) {
     super(props);
@@ -56,18 +54,15 @@ export class PathTable extends React.Component<PathTableProps, PathTableState> {
     }
   }
 
-  getNextSortState(column: InterpretedResultsColumn): InterpretedResultsSortState | undefined {
-    if (column === 'file-position') {
-      return undefined;
-    }
+  getNextSortState(column: InterpretedResultsSortColumn): InterpretedResultsSortState | undefined {
     const oldSortState = this.props.resultSet.sortState;
     const prevDirection = oldSortState && oldSortState.sortBy === column ? oldSortState.sortDirection : undefined;
-    const nextDirection = nextSortDirection(prevDirection);
+    const nextDirection = nextSortDirection(prevDirection, true);
     return nextDirection === undefined ? undefined :
       { sortBy: column, sortDirection: nextDirection };
   }
 
-  toggleSortStateForColumn(column: InterpretedResultsSortColumn | 'file-position'): void {
+  toggleSortStateForColumn(column: InterpretedResultsSortColumn): void {
     vscode.postMessage({
       t: 'changeInterpretedSort',
       sortState: this.getNextSortState(column),
@@ -80,8 +75,7 @@ export class PathTable extends React.Component<PathTableProps, PathTableState> {
     const header = <thead>
       <tr>
         <th colSpan={2}></th>
-        <th className={this.sortClass('alert-message') + ' vscode-codeql__alert-message-cell'} colSpan={2} onClick={() => this.toggleSortStateForColumn('alert-message')}>Message</th>
-        <th className={'sort-none vscode-codeql__location-cell'} onClick={() => this.toggleSortStateForColumn('file-position')}>Location</th>
+        <th className={this.sortClass('alert-message') + ' vscode-codeql__alert-message-cell'} colSpan={3} onClick={() => this.toggleSortStateForColumn('alert-message')}>Message</th>
       </tr>
     </thead>;
 

--- a/extensions/ql-vscode/src/view/alert-table.tsx
+++ b/extensions/ql-vscode/src/view/alert-table.tsx
@@ -15,6 +15,8 @@ export interface PathTableState {
   selectedPathNode: undefined | Keys.PathNode;
 }
 
+type InterpretedResultsColumn = InterpretedResultsSortColumn | 'file-position';
+
 export class PathTable extends React.Component<PathTableProps, PathTableState> {
   constructor(props: PathTableProps) {
     super(props);
@@ -54,16 +56,21 @@ export class PathTable extends React.Component<PathTableProps, PathTableState> {
     }
   }
 
-  toggleSortStateForColumn(column: InterpretedResultsSortColumn): void {
+  getNextSortState(column: InterpretedResultsColumn): InterpretedResultsSortState | undefined {
+    if (column === 'file-position') {
+      return undefined;
+    }
     const oldSortState = this.props.resultSet.sortState;
     const prevDirection = oldSortState && oldSortState.sortBy === column ? oldSortState.sortDirection : undefined;
     const nextDirection = nextSortDirection(prevDirection);
-    const sortState: InterpretedResultsSortState | undefined =
-      nextDirection === undefined ? undefined :
-        { sortBy: column, sortDirection: nextDirection };
+    return nextDirection === undefined ? undefined :
+      { sortBy: column, sortDirection: nextDirection };
+  }
+
+  toggleSortStateForColumn(column: InterpretedResultsSortColumn | 'file-position'): void {
     vscode.postMessage({
       t: 'changeInterpretedSort',
-      sortState,
+      sortState: this.getNextSortState(column),
     });
   }
 
@@ -74,7 +81,7 @@ export class PathTable extends React.Component<PathTableProps, PathTableState> {
       <tr>
         <th colSpan={2}></th>
         <th className={this.sortClass('alert-message') + ' vscode-codeql__alert-message-cell'} colSpan={2} onClick={() => this.toggleSortStateForColumn('alert-message')}>Message</th>
-        <th className={this.sortClass('file-position') + ' vscode-codeql__location-cell'} onClick={() => this.toggleSortStateForColumn('file-position')}>Location</th>
+        <th className={'sort-none vscode-codeql__location-cell'} onClick={() => this.toggleSortStateForColumn('file-position')}>Location</th>
       </tr>
     </thead>;
 

--- a/extensions/ql-vscode/src/view/raw-results-table.tsx
+++ b/extensions/ql-vscode/src/view/raw-results-table.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
-import { renderLocation, ResultTableProps, zebraStripe, className } from "./result-table-utils";
+import { renderLocation, ResultTableProps, zebraStripe, className, nextSortDirection } from "./result-table-utils";
 import { RawTableResultSet, ResultValue, vscode } from "./results";
-import { assertNever } from "../helpers-pure";
 import { SortDirection, RAW_RESULTS_LIMIT, RawResultsSortState } from "../interface-types";
 
 export type RawTableProps = ResultTableProps & {
@@ -84,7 +83,6 @@ export class RawTable extends React.Component<RawTableProps, {}> {
   }
 }
 
-
 /**
  * Render one column of a tuple.
  */
@@ -97,17 +95,5 @@ function renderTupleValue(v: ResultValue, databaseUri: string): JSX.Element {
   }
   else {
     return renderLocation(v.location, v.label, databaseUri);
-  }
-}
-
-function nextSortDirection(direction: SortDirection | undefined): SortDirection {
-  switch (direction) {
-    case SortDirection.asc:
-      return SortDirection.desc;
-    case SortDirection.desc:
-    case undefined:
-      return SortDirection.asc;
-    default:
-      return assertNever(direction);
   }
 }

--- a/extensions/ql-vscode/src/view/raw-results-table.tsx
+++ b/extensions/ql-vscode/src/view/raw-results-table.tsx
@@ -2,11 +2,11 @@ import * as React from "react";
 import { renderLocation, ResultTableProps, zebraStripe, className } from "./result-table-utils";
 import { RawTableResultSet, ResultValue, vscode } from "./results";
 import { assertNever } from "../helpers-pure";
-import { SortDirection, SortState, RAW_RESULTS_LIMIT } from "../interface-types";
+import { SortDirection, RAW_RESULTS_LIMIT, RawResultsSortState } from "../interface-types";
 
 export type RawTableProps = ResultTableProps & {
   resultSet: RawTableResultSet,
-  sortState?: SortState;
+  sortState?: RawResultsSortState;
 };
 
 export class RawTable extends React.Component<RawTableProps, {}> {

--- a/extensions/ql-vscode/src/view/raw-results-table.tsx
+++ b/extensions/ql-vscode/src/view/raw-results-table.tsx
@@ -54,7 +54,7 @@ export class RawTable extends React.Component<RawTableProps, {}> {
               <th key={-1}><b>#</b></th>,
               ...resultSet.schema.columns.map((col, index) => {
                 const displayName = col.name || `[${index}]`;
-                const sortDirection = this.props.sortState && index === this.props.sortState.columnIndex ? this.props.sortState.direction : undefined;
+                const sortDirection = this.props.sortState && index === this.props.sortState.columnIndex ? this.props.sortState.sortDirection : undefined;
                 return <th className={"sort-" + (sortDirection !== undefined ? SortDirection[sortDirection] : "none")} key={index} onClick={() => this.toggleSortStateForColumn(index)}><b>{displayName}</b></th>;
               })
             ]
@@ -69,11 +69,11 @@ export class RawTable extends React.Component<RawTableProps, {}> {
 
   private toggleSortStateForColumn(index: number) {
     const sortState = this.props.sortState;
-    const prevDirection = sortState && sortState.columnIndex === index ? sortState.direction : undefined;
+    const prevDirection = sortState && sortState.columnIndex === index ? sortState.sortDirection : undefined;
     const nextDirection = nextSortDirection(prevDirection);
     const nextSortState = nextDirection === undefined ? undefined : {
       columnIndex: index,
-      direction: nextDirection
+      sortDirection: nextDirection
     };
     vscode.postMessage({
       t: 'changeSort',

--- a/extensions/ql-vscode/src/view/result-table-utils.tsx
+++ b/extensions/ql-vscode/src/view/result-table-utils.tsx
@@ -13,6 +13,7 @@ export interface ResultTableProps {
 
 export const className = 'vscode-codeql__result-table';
 export const tableSelectionHeaderClassName = 'vscode-codeql__table-selection-header';
+export const alertExtrasClassName = `${className}-alert-extras`;
 export const toggleDiagnosticsClassName = `${className}-toggle-diagnostics`;
 export const evenRowClassName = 'vscode-codeql__result-table-row--even';
 export const oddRowClassName = 'vscode-codeql__result-table-row--odd';

--- a/extensions/ql-vscode/src/view/result-table-utils.tsx
+++ b/extensions/ql-vscode/src/view/result-table-utils.tsx
@@ -88,12 +88,14 @@ export function selectableZebraStripe(isSelected: boolean, index: number, ...oth
 
 /**
  * Returns the next sort direction when cycling through sort directions while clicking.
+ * if `includeUndefined` is true, include `undefined` in the cycle.
  */
-export function nextSortDirection(direction: SortDirection | undefined): SortDirection {
+export function nextSortDirection(direction: SortDirection | undefined, includeUndefined?: boolean): SortDirection | undefined {
   switch (direction) {
     case SortDirection.asc:
       return SortDirection.desc;
     case SortDirection.desc:
+      return includeUndefined ? undefined : SortDirection.asc;
     case undefined:
       return SortDirection.asc;
     default:

--- a/extensions/ql-vscode/src/view/result-table-utils.tsx
+++ b/extensions/ql-vscode/src/view/result-table-utils.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { LocationValue, ResolvableLocationValue, tryGetResolvableLocation } from 'semmle-bqrs';
-import { RawResultsSortState, QueryMetadata } from '../interface-types';
+import { RawResultsSortState, QueryMetadata, SortDirection } from '../interface-types';
 import { ResultSet, vscode } from './results';
+import { assertNever } from '../helpers-pure';
 
 export interface ResultTableProps {
   resultSet: ResultSet;
@@ -83,4 +84,19 @@ export function selectableZebraStripe(isSelected: boolean, index: number, ...oth
   return isSelected
     ? { className: [selectedRowClassName, ...otherClasses].join(' ') }
     : zebraStripe(index, ...otherClasses)
+}
+
+/**
+ * Returns the next sort direction when cycling through sort directions while clicking.
+ */
+export function nextSortDirection(direction: SortDirection | undefined): SortDirection {
+  switch (direction) {
+    case SortDirection.asc:
+      return SortDirection.desc;
+    case SortDirection.desc:
+    case undefined:
+      return SortDirection.asc;
+    default:
+      return assertNever(direction);
+  }
 }

--- a/extensions/ql-vscode/src/view/result-table-utils.tsx
+++ b/extensions/ql-vscode/src/view/result-table-utils.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { LocationValue, ResolvableLocationValue, tryGetResolvableLocation } from 'semmle-bqrs';
-import { SortState, QueryMetadata } from '../interface-types';
+import { RawResultsSortState, QueryMetadata } from '../interface-types';
 import { ResultSet, vscode } from './results';
 
 export interface ResultTableProps {
@@ -8,7 +8,7 @@ export interface ResultTableProps {
   databaseUri: string;
   metadata?: QueryMetadata
   resultsPath: string | undefined;
-  sortState?: SortState;
+  sortState?: RawResultsSortState;
 }
 
 export const className = 'vscode-codeql__result-table';
@@ -80,6 +80,6 @@ export function zebraStripe(index: number, ...otherClasses: string[]): { classNa
  */
 export function selectableZebraStripe(isSelected: boolean, index: number, ...otherClasses: string[]): { className: string } {
   return isSelected
-      ? { className: [selectedRowClassName, ...otherClasses].join(' ') }
-      : zebraStripe(index, ...otherClasses)
+    ? { className: [selectedRowClassName, ...otherClasses].join(' ') }
+    : zebraStripe(index, ...otherClasses)
 }

--- a/extensions/ql-vscode/src/view/result-tables.tsx
+++ b/extensions/ql-vscode/src/view/result-tables.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DatabaseInfo, Interpretation, RawResultsSortState, QueryMetadata, ResultsPaths, InterpretedResultsSortOrder, InterpretedResultsSortState } from '../interface-types';
+import { DatabaseInfo, Interpretation, RawResultsSortState, QueryMetadata, ResultsPaths, InterpretedResultsSortState } from '../interface-types';
 import { PathTable } from './alert-table';
 import { RawTable } from './raw-results-table';
 import { ResultTableProps, tableSelectionHeaderClassName, toggleDiagnosticsClassName, alertExtrasClassName } from './result-table-utils';
@@ -94,15 +94,8 @@ export class ResultTables
     this.setState({ selectedTable: event.target.value });
   }
 
-  private onSortChange = (event: React.ChangeEvent<HTMLSelectElement>): void => {
-    vscode.postMessage({
-      t: 'changeInterpretedSort',
-      sortState: { sortBy: event.target.value as InterpretedResultsSortOrder },
-    });
-  }
-
   private alertTableExtras(): JSX.Element | undefined {
-    const { database, resultsPath, metadata, origResultsPaths, interpretedSortState } = this.props;
+    const { database, resultsPath, metadata, origResultsPaths } = this.props;
 
     const displayProblemsAsAlertsToggle =
       <div className={toggleDiagnosticsClassName}>
@@ -120,15 +113,7 @@ export class ResultTables
         <label htmlFor="toggle-diagnostics">Show results in Problems view</label>
       </div>;
 
-    const interpretedResultsSortSelect = <select value={interpretedSortState?.sortBy || 'file-position'}
-      onChange={this.onSortChange}>
-      <option value={'file-position'}>Source File Position</option>
-      <option value={'alert-message'}>Alert Message</option>
-    </select>;
-
     return <div className={alertExtrasClassName}>
-      Sort:
-      {interpretedResultsSortSelect}
       {displayProblemsAsAlertsToggle}
     </div>
   }

--- a/extensions/ql-vscode/src/view/result-tables.tsx
+++ b/extensions/ql-vscode/src/view/result-tables.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DatabaseInfo, Interpretation, SortState, QueryMetadata, ResultsPaths } from '../interface-types';
+import { DatabaseInfo, Interpretation, RawResultsSortState, QueryMetadata, ResultsPaths } from '../interface-types';
 import { PathTable } from './alert-table';
 import { RawTable } from './raw-results-table';
 import { ResultTableProps, tableSelectionHeaderClassName, toggleDiagnosticsClassName } from './result-table-utils';
@@ -12,10 +12,10 @@ export interface ResultTablesProps {
   rawResultSets: readonly ResultSet[];
   interpretation: Interpretation | undefined;
   database: DatabaseInfo;
-  metadata? : QueryMetadata
-  resultsPath: string ;
+  metadata?: QueryMetadata
+  resultsPath: string;
   origResultsPaths: ResultsPaths;
-  sortStates: Map<string, SortState>;
+  sortStates: Map<string, RawResultsSortState>;
   isLoadingNewResults: boolean;
 }
 

--- a/extensions/ql-vscode/src/view/result-tables.tsx
+++ b/extensions/ql-vscode/src/view/result-tables.tsx
@@ -151,7 +151,7 @@ export class ResultTables
           resultsPath={this.props.resultsPath}
           sortState={this.props.sortStates.get(resultSet.schema.name)} />
       }
-    </div >;
+    </div>;
   }
 }
 

--- a/extensions/ql-vscode/src/view/results.tsx
+++ b/extensions/ql-vscode/src/view/results.tsx
@@ -314,6 +314,7 @@ class App extends React.Component<{}, ResultsViewState> {
         resultsPath={displayedResults.resultsInfo.resultsPath}
         metadata={displayedResults.resultsInfo ? displayedResults.resultsInfo.metadata : undefined}
         sortStates={displayedResults.results.sortStates}
+        interpretedSortState={displayedResults.resultsInfo.interpretation?.sortState}
         isLoadingNewResults={this.state.isExpectingResultsUpdate || this.state.nextResultsInfo !== null} />;
     }
     else {

--- a/extensions/ql-vscode/src/view/results.tsx
+++ b/extensions/ql-vscode/src/view/results.tsx
@@ -3,7 +3,7 @@ import * as Rdom from 'react-dom';
 import * as bqrs from 'semmle-bqrs';
 import { ElementBase, LocationValue, PrimitiveColumnValue, PrimitiveTypeKind, ResultSetSchema, tryGetResolvableLocation } from 'semmle-bqrs';
 import { assertNever } from '../helpers-pure';
-import { DatabaseInfo, FromResultsViewMsg, Interpretation, IntoResultsViewMsg, SortedResultSetInfo, SortState, NavigatePathMsg, QueryMetadata, ResultsPaths } from '../interface-types';
+import { DatabaseInfo, FromResultsViewMsg, Interpretation, IntoResultsViewMsg, SortedResultSetInfo, RawResultsSortState, NavigatePathMsg, QueryMetadata, ResultsPaths } from '../interface-types';
 import { ResultTables } from './result-tables';
 import { EventHandlers as EventHandlerList } from './event-handler-list';
 
@@ -140,7 +140,7 @@ interface ResultsInfo {
 
 interface Results {
   resultSets: readonly ResultSet[];
-  sortStates: Map<string, SortState>;
+  sortStates: Map<string, RawResultsSortState>;
   database: DatabaseInfo;
 }
 
@@ -298,7 +298,7 @@ class App extends React.Component<{}, ResultsViewState> {
     }));
   }
 
-  private getSortStates(resultsInfo: ResultsInfo): Map<string, SortState> {
+  private getSortStates(resultsInfo: ResultsInfo): Map<string, RawResultsSortState> {
     const entries = Array.from(resultsInfo.sortedResultsMap.entries());
     return new Map(entries.map(([key, sortedResultSetInfo]) =>
       [key, sortedResultSetInfo.sortState]));

--- a/extensions/ql-vscode/src/view/resultsView.css
+++ b/extensions/ql-vscode/src/view/resultsView.css
@@ -112,8 +112,12 @@ td.vscode-codeql__path-index-cell {
   text-align: right;
 }
 
-td.vscode-codeql__location-cell {
-  text-align: right;
+.vscode-codeql__alert-message-cell {
+  text-align: left !important;
+}
+
+.vscode-codeql__location-cell {
+  text-align: right !important;
 }
 
 .vscode-codeql__vertical-rule {

--- a/extensions/ql-vscode/src/view/resultsView.css
+++ b/extensions/ql-vscode/src/view/resultsView.css
@@ -13,10 +13,14 @@
   border: 0;
 }
 
-.vscode-codeql__result-table-toggle-diagnostics {
+.vscode-codeql__result-table-alert-extras {
   display: inline-block;
   text-align: left;
   margin-left: auto;
+}
+
+.vscode-codeql__result-table-toggle-diagnostics  {
+  display: inline-block;
 }
 
 /* Keep the checkbox and its label in horizontal alignment. */
@@ -26,7 +30,7 @@
   vertical-align: middle;
 }
 .vscode-codeql__result-table-toggle-diagnostics input {
-  margin: 3px 3px 1px 3px;
+  margin: 3px 3px 1px 13px;
 }
 
 

--- a/extensions/ql-vscode/src/view/resultsView.css
+++ b/extensions/ql-vscode/src/view/resultsView.css
@@ -119,6 +119,8 @@ td.vscode-codeql__path-index-cell {
   text-align: right;
 }
 
+/* Both of these are !important to override the
+   .vscode-codeql__result-table th { text-align: center } above */
 .vscode-codeql__alert-message-cell {
   text-align: left !important;
 }

--- a/extensions/ql-vscode/src/view/resultsView.css
+++ b/extensions/ql-vscode/src/view/resultsView.css
@@ -45,6 +45,13 @@
   opacity: 0.6;
 }
 
+.vscode-codeql__result-table .sort-asc,
+.vscode-codeql__result-table .sort-desc,
+.vscode-codeql__result-table .sort-none {
+   cursor: pointer;
+   user-select: none;
+}
+
 .vscode-codeql__result-table .sort-none::after {
   /* Want to take up the same space as the other sort directions */
   content: " ▲";

--- a/extensions/ql-vscode/src/vscode-tests/minimal-workspace/activation.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/minimal-workspace/activation.test.ts
@@ -10,7 +10,7 @@ describe('launching with a minimal workspace', async () => {
   it('should not activate the extension at first', () => {
     assert(ext!.isActive === false);
   });
-  it('should activate the extension when a .ql file is opened', async function () {
+  it('should activate the extension when a .ql file is opened', async function() {
     const folders = vscode.workspace.workspaceFolders;
     assert(folders && folders.length === 1);
     const folderPath = folders![0].uri.fsPath;

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/archive-filesystem-provider.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/archive-filesystem-provider.test.ts
@@ -14,7 +14,7 @@ describe("archive filesystem provider", () => {
   });
 });
 
-describe('source archive uri encoding', function () {
+describe('source archive uri encoding', function() {
   const testCases: { name: string, input: ZipFileReference }[] = [
     {
       name: 'mixed case and unicode',
@@ -30,7 +30,7 @@ describe('source archive uri encoding', function () {
     }
   ];
   for (const testCase of testCases) {
-    it(`should work round trip with ${testCase.name}`, function () {
+    it(`should work round trip with ${testCase.name}`, function() {
       const output = decodeSourceArchiveUri(encodeSourceArchiveUri(testCase.input));
       expect(output).to.eql(testCase.input);
     });

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/distribution.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/distribution.test.ts
@@ -151,8 +151,8 @@ describe("Release version ordering", () => {
       patchVersion,
       prereleaseVersion,
       rawString: `${majorVersion}.${minorVersion}.${patchVersion}` +
-      prereleaseVersion ? `-${prereleaseVersion}` : "" +
-      buildMetadata ? `+${buildMetadata}` : ""
+        prereleaseVersion ? `-${prereleaseVersion}` : "" +
+          buildMetadata ? `+${buildMetadata}` : ""
     };
   }
 

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/webview-uri.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/webview-uri.test.ts
@@ -4,7 +4,7 @@ import * as tmp from "tmp";
 import { window, ViewColumn, Uri } from "vscode";
 import { fileUriToWebviewUri, webviewUriToFileUri } from '../../interface';
 
-describe('webview uri conversion', function () {
+describe('webview uri conversion', function() {
   const fileSuffix = '.bqrs';
 
   function setupWebview(filePrefix: string) {
@@ -21,7 +21,7 @@ describe('webview uri conversion', function () {
         ]
       }
     );
-    after(function () {
+    after(function() {
       panel.dispose();
       tmpFile.removeCallback();
     });
@@ -34,15 +34,15 @@ describe('webview uri conversion', function () {
       panel
     }
   }
-  
-  it('should correctly round trip from filesystem to webview and back', function () {
+
+  it('should correctly round trip from filesystem to webview and back', function() {
     const { fileUriOnDisk, panel } = setupWebview('');
     const webviewUri = fileUriToWebviewUri(panel, fileUriOnDisk);
     const reconstructedFileUri = webviewUriToFileUri(webviewUri);
     expect(reconstructedFileUri.toString(true)).to.equal(fileUriOnDisk.toString(true));
   });
 
-  it("does not double-encode # in URIs", function () {
+  it("does not double-encode # in URIs", function() {
     const { fileUriOnDisk, panel } = setupWebview('#');
     const webviewUri = fileUriToWebviewUri(panel, fileUriOnDisk);
     const parsedUri = Uri.parse(webviewUri);


### PR DESCRIPTION
Adds a drop-down to the interpreted results display which allows sorting by alert message, in addition to the current default of the order that the sarif file arrives in, which colocates results that occur in the same source file in the order that they appear in the source file.

Fixes https://github.com/github/vscode-codeql/issues/196.