### PR TITLE
Add command for restarting the query server.

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CodeQL for Visual Studio Code: Changelog
 
+## 1.0.6
+
+- Add command to restart query server.
+
 ## 1.0.5 - 13 February 2020
 
 - Add an icon next to any failed query runs in the query history

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -206,6 +206,10 @@
       {
         "command": "codeQLQueryHistory.setLabel",
         "title": "Set Label"
+      },
+      {
+        "command": "codeQL.restartQueryServer",
+        "title": "CodeQL: Restart Query Server"
       }
     ],
     "menus": {

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -28,6 +28,7 @@
     "onCommand:codeQLDatabases.chooseDatabase",
     "onCommand:codeQLDatabases.setCurrentDatabase",
     "onCommand:codeQL.quickQuery",
+    "onCommand:codeQL.restartQueryServer",
     "onWebviewPanel:resultsView",
     "onFileSystem:codeql-zip-archive"
   ],

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -308,6 +308,13 @@ async function activateWithInstalledDistribution(ctx: ExtensionContext, distribu
   ctx.subscriptions.push(commands.registerCommand('codeQL.runQuery', async (uri: Uri | undefined) => await compileAndRunQuery(false, uri)));
   ctx.subscriptions.push(commands.registerCommand('codeQL.quickEval', async (uri: Uri | undefined) => await compileAndRunQuery(true, uri)));
   ctx.subscriptions.push(commands.registerCommand('codeQL.quickQuery', async () => displayQuickQuery(ctx, cliServer, databaseUI)));
+  ctx.subscriptions.push(commands.registerCommand('codeQL.restartQueryServer', async () => {
+    await qs.restartQueryServer();
+    const response = await Window.showInformationMessage('CodeQL Query Server restarted', 'Ok', 'Show Log');
+    if (response === 'Show Log') {
+      qs.showLog();
+    }
+  }));
 
   ctx.subscriptions.push(client.start());
 }

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -310,7 +310,7 @@ async function activateWithInstalledDistribution(ctx: ExtensionContext, distribu
   ctx.subscriptions.push(commands.registerCommand('codeQL.quickQuery', async () => displayQuickQuery(ctx, cliServer, databaseUI)));
   ctx.subscriptions.push(commands.registerCommand('codeQL.restartQueryServer', async () => {
     await qs.restartQueryServer();
-    const response = await Window.showInformationMessage('CodeQL Query Server restarted', 'Ok', 'Show Log');
+    const response = await Window.showInformationMessage('CodeQL Query Server restarted', 'Show Log');
     if (response === 'Show Log') {
       qs.showLog();
     }

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -310,7 +310,7 @@ async function activateWithInstalledDistribution(ctx: ExtensionContext, distribu
   ctx.subscriptions.push(commands.registerCommand('codeQL.quickQuery', async () => displayQuickQuery(ctx, cliServer, databaseUI)));
   ctx.subscriptions.push(commands.registerCommand('codeQL.restartQueryServer', async () => {
     await qs.restartQueryServer();
-    const response = await Window.showInformationMessage('CodeQL Query Server restarted', 'Show Log');
+    const response = await Window.showInformationMessage('CodeQL Query Server restarted.', 'Show Log');
     if (response === 'Show Log') {
       qs.showLog();
     }

--- a/extensions/ql-vscode/src/logging.ts
+++ b/extensions/ql-vscode/src/logging.ts
@@ -6,6 +6,12 @@ export interface Logger {
   log(message: string): void;
   /** Writes the given log message, not followed by a newline. */
   logWithoutTrailingNewline(message: string): void;
+  /**
+   * Reveal this channel in the UI.
+   *
+   * @param preserveFocus When `true` the channel will not take focus.
+   */
+  show(preserveFocus?: boolean): void;
 }
 
 export type ProgressReporter = Progress<{ message: string }>;
@@ -28,6 +34,9 @@ export class OutputChannelLogger extends DisposableObject implements Logger {
     this.outputChannel.append(message);
   }
 
+  show(preserveFocus?: boolean) {
+    this.outputChannel.show(preserveFocus);
+  }
 }
 
 /** The global logger for the extension. */

--- a/extensions/ql-vscode/src/queryserver-client.ts
+++ b/extensions/ql-vscode/src/queryserver-client.ts
@@ -56,7 +56,10 @@ export class QueryServerClient extends DisposableObject {
     super();
     // When the query server configuration changes, restart the query server.
     if (config.onDidChangeQueryServerConfiguration !== undefined) {
-      this.push(config.onDidChangeQueryServerConfiguration(async () => await this.restartQueryServer(), this));
+      this.push(config.onDidChangeQueryServerConfiguration(async () => {
+        this.logger.log('Restarting query server due to configuration changes...');
+        await this.restartQueryServer();
+      }, this));
     }
     this.withProgressReporting = withProgressReporting;
     this.nextCallback = 0;
@@ -77,10 +80,13 @@ export class QueryServerClient extends DisposableObject {
   }
 
   /** Restarts the query server by disposing of the current server process and then starting a new one. */
-  private async restartQueryServer() {
-    this.logger.log('Restarting query server due to configuration changes...');
+  async restartQueryServer() {
     this.stopQueryServer();
     await this.startQueryServer();
+  }
+
+  async showLog() {
+    this.logger.show();
   }
 
   /** Starts a new query server process, sending progress messages to the status bar. */

--- a/extensions/ql-vscode/test/pure-tests/query-test.ts
+++ b/extensions/ql-vscode/test/pure-tests/query-test.ts
@@ -10,7 +10,7 @@ import { CancellationTokenSource } from 'vscode-jsonrpc';
 import * as messages from '../../src/messages';
 import * as qsClient from '../../src/queryserver-client';
 import * as cli from '../../src/cli';
-import { ProgressReporter } from '../../src/logging';
+import { ProgressReporter, Logger } from '../../src/logging';
 
 
 declare module "url" {
@@ -75,8 +75,8 @@ const queryTestCases: QueryTestCase[] = [
   }
 ];
 
-describe('using the query server', function () {
-  before(function () {
+describe('using the query server', function() {
+  before(function() {
     if (process.env["CODEQL_PATH"] === undefined) {
       console.log('The environment variable CODEQL_PATH is not set. The query server tests, which require the CodeQL CLI, will be skipped.');
       this.skip();
@@ -100,13 +100,14 @@ describe('using the query server', function () {
     }
   });
 
-  it('should be able to start the query server', async function () {
+  it('should be able to start the query server', async function() {
     const consoleProgressReporter: ProgressReporter = {
-      report: (v: {message: string}) => console.log(`progress reporter says ${v.message}`)
+      report: (v: { message: string }) => console.log(`progress reporter says ${v.message}`)
     };
-    const logger = {
+    const logger: Logger = {
       log: (s: string) => console.log('logger says', s),
-      logWithoutTrailingNewline: (s: string) => console.log('logger says', s)
+      logWithoutTrailingNewline: (s: string) => console.log('logger says', s),
+      show: () => { },
     };
     cliServer = new cli.CodeQLCliServer({
       async getCodeQlPathWithoutVersionCheck(): Promise<string | undefined> {
@@ -137,7 +138,7 @@ describe('using the query server', function () {
     const evaluationSucceeded = new Checkpoint<void>();
     const parsedResults = new Checkpoint<void>();
 
-    it(`should be able to compile query ${queryName}`, async function () {
+    it(`should be able to compile query ${queryName}`, async function() {
       await queryServerStarted.done();
       expect(fs.existsSync(queryTestCase.queryPath)).to.be.true;
       try {
@@ -169,7 +170,7 @@ describe('using the query server', function () {
       }
     });
 
-    it(`should be able to run query ${queryName}`, async function () {
+    it(`should be able to run query ${queryName}`, async function() {
       try {
         await compilationSucceeded.done();
         const callbackId = qs.registerCallback(_res => {
@@ -201,7 +202,7 @@ describe('using the query server', function () {
     });
 
     const actualResultSets: ResultSets = {};
-    it(`should be able to parse results of query ${queryName}`, async function () {
+    it(`should be able to parse results of query ${queryName}`, async function() {
       let fileReader: FileReader | undefined;
       try {
         await evaluationSucceeded.done();
@@ -222,7 +223,7 @@ describe('using the query server', function () {
       }
     });
 
-    it(`should have correct results for query ${queryName}`, async function () {
+    it(`should have correct results for query ${queryName}`, async function() {
       await parsedResults.done();
       expect(actualResultSets!).not.to.be.empty;
       expect(Object.keys(actualResultSets!).sort()).to.eql(Object.keys(queryTestCase.expectedResultSets).sort());


### PR DESCRIPTION
Include a convenience button to show the query server log in case the
reason the user wants to restart the server is that it's acting
unexpectedly and they want to investigate why.

Fixes https://github.com/github/vscode-codeql/issues/243.

`@github/product-docs-dsp`: this adds a command `CodeQL: Restart Query Server` to the command palette.
