### PR TITLE
Add query history items at query start time

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           fetch-depth: 1
 
@@ -46,7 +46,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
     # TODO Share steps with the main workflow.
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
 
       - uses: actions/setup-node@v1
         with:

--- a/extensions/ql-vscode/src/interface.ts
+++ b/extensions/ql-vscode/src/interface.ts
@@ -13,7 +13,7 @@ import { assertNever } from './helpers-pure';
 import { FromResultsViewMsg, Interpretation, INTERPRETED_RESULTS_PER_RUN_LIMIT, IntoResultsViewMsg, QueryMetadata, ResultsPaths, SortedResultSetInfo, SortedResultsMap, InterpretedResultsSortState, SortDirection } from './interface-types';
 import { Logger } from './logging';
 import * as messages from './messages';
-import { CompletedQuery, interpretResults } from './query-results';
+import { RunningOrCompletedQuery, interpretResults } from './query-results';
 import { QueryInfo, tmpDir } from './run-queries';
 import { parseSarifLocation, parseSarifPlainTextMessage } from './sarif-utils';
 
@@ -110,7 +110,7 @@ function sortInterpretedResults(results: Sarif.Result[], sortState: InterpretedR
 }
 
 export class InterfaceManager extends DisposableObject {
-  private _displayedQuery?: CompletedQuery;
+  private _displayedQuery?: RunningOrCompletedQuery;
   private _panel: vscode.WebviewPanel | undefined;
   private _panelLoaded = false;
   private _panelLoadedCallBacks: (() => void)[] = [];
@@ -161,7 +161,7 @@ export class InterfaceManager extends DisposableObject {
     return this._panel;
   }
 
-  private async changeSortState(update: (query: CompletedQuery) => Promise<void>): Promise<void> {
+  private async changeSortState(update: (query: RunningOrCompletedQuery) => Promise<void>): Promise<void> {
     if (this._displayedQuery === undefined) {
       showAndLogErrorMessage("Failed to sort results since evaluation info was unknown.");
       return;
@@ -247,8 +247,8 @@ export class InterfaceManager extends DisposableObject {
    * UI interaction requesting results, e.g. clicking on a query
    * history entry.
    */
-  public async showResults(results: CompletedQuery, forceReveal: WebviewReveal, shouldKeepOldResultsWhileRendering: boolean = false): Promise<void> {
-    if (results.result.resultType !== messages.QueryResultType.SUCCESS) {
+  public async showResults(results: RunningOrCompletedQuery, forceReveal: WebviewReveal, shouldKeepOldResultsWhileRendering: boolean = false): Promise<void> {
+    if (results.result === undefined || results.result.resultType !== messages.QueryResultType.SUCCESS) {
       return;
     }
 

--- a/extensions/ql-vscode/src/query-results.ts
+++ b/extensions/ql-vscode/src/query-results.ts
@@ -9,10 +9,15 @@ import { RawResultsSortState, SortedResultSetInfo, DatabaseInfo, QueryMetadata, 
 import { QueryHistoryConfig } from "./config";
 import { QueryHistoryItemOptions } from "./query-history";
 
-export class CompletedQuery implements QueryWithResults {
+/**
+ * Keeps track of all information for a running or completed query for
+ * the purposes of the query history view. The query is still running
+ * if `result` is undefined, and completed if `result` exists.
+ */
+export class RunningOrCompletedQuery implements QueryWithResults {
   readonly time: string;
   readonly query: QueryInfo;
-  readonly result: messages.EvaluationResult;
+  result?: messages.EvaluationResult;
   readonly database: DatabaseInfo;
   options: QueryHistoryItemOptions;
 
@@ -57,6 +62,9 @@ export class CompletedQuery implements QueryWithResults {
   }
 
   get statusString(): string {
+    if (this.result === undefined) {
+      return 'running';
+    }
     switch (this.result.resultType) {
       case messages.QueryResultType.CANCELLATION:
         return `cancelled after ${this.result.evaluationTime / 1000} seconds`;
@@ -94,8 +102,8 @@ export class CompletedQuery implements QueryWithResults {
     return this.config.format;
   }
 
-  get didRunSuccessfully(): boolean {
-    return this.result.resultType === messages.QueryResultType.SUCCESS;
+  get hadErrors(): boolean {
+    return this.result !== undefined && this.result.resultType !== messages.QueryResultType.SUCCESS;
   }
 
   toString(): string {


### PR DESCRIPTION
Add query history items right when the user initiates a query, rather
than waiting until query compilation/execution has finished. This
leads to a more predictable ordering of query history items.

This doesn't affect user-facing behavior other than timing.

Fixes https://github.com/github/codeql-coreql-team/issues/277