### PR TITLE
Display more logs when testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,9 +89,11 @@ jobs:
           cd extensions/ql-vscode
           sudo apt-get install xvfb
           /usr/bin/xvfb-run npm run integration
+          cat /home/runner/.npm/_logs/*/*-debug.log
 
       - name: Run integration tests (Windows)
         if: matrix.os == 'windows-latest'
         run: |
           cd extensions/ql-vscode
           npm run integration
+          type C:\npm\cache\_logs\*-debug.log


### PR DESCRIPTION
Somtimes, not repeatably, the integration tests return a
nonzero status code, for example
https://github.com/github/vscode-codeql/runs/447216379?check_suite_focus=true
on ubuntu
and https://github.com/github/vscode-codeql/runs/444364540?check_suite_focus=true
on windows. Send those logs to stdout so they show up in the actions log.