### PR TITLE
Retry integration tests when they fail

### DIFF
--- a/extensions/ql-vscode/src/vscode-tests/run-integration-tests.ts
+++ b/extensions/ql-vscode/src/vscode-tests/run-integration-tests.ts
@@ -29,7 +29,7 @@ async function runTestsWithRetry(suite: Suite, tries: number): Promise<void> {
     } catch (err) {
       console.error(`Exception raised while running tests: ${err}`);
       if (t < tries - 1)
-        console.error('Retrying...');
+        console.log('Retrying...');
     }
   }
   console.error(`Tried running suite ${tries} time(s), still failed, giving up.`);
@@ -67,10 +67,10 @@ async function main() {
     ];
 
     for (const integrationTestSuite of integrationTestSuites) {
-      await runTestsWithRetry(integrationTestSuite, 2);
+      await runTestsWithRetry(integrationTestSuite, 3);
     }
   } catch (err) {
-    console.error('Unexpected exception while running tests');
+    console.error(`Unexpected exception while running tests: ${err}`);
     process.exit(1);
   }
 }

--- a/extensions/ql-vscode/src/vscode-tests/run-integration-tests.ts
+++ b/extensions/ql-vscode/src/vscode-tests/run-integration-tests.ts
@@ -1,6 +1,41 @@
 import * as path from 'path';
 import { runTests } from 'vscode-test';
 
+// A subset of the fields in TestOptions from vscode-test, which we
+// would simply use instead, but for the fact that it doesn't export
+// it.
+type Suite = {
+  extensionDevelopmentPath: string,
+  extensionTestsPath: string,
+  launchArgs: string[]
+};
+
+/**
+ * Run an integration test suite `suite` at most `tries` times, or
+ * until it succeeds, whichever comes first.
+ *
+ * TODO: Presently there is no way to distinguish a legitimately
+ * failed test run from the test runner being terminated by a signal.
+ * If in the future there arises a way to distinguish these cases
+ * (e.g. https://github.com/microsoft/vscode-test/pull/56) only retry
+ * in the terminated-by-signal case.
+ */
+async function runTestsWithRetry(suite: Suite, tries: number): Promise<void> {
+  for (let t = 0; t < tries; t++) {
+    try {
+      // Download and unzip VS Code if necessary, and run the integration test suite.
+      await runTests(suite);
+      return;
+    } catch (err) {
+      console.error(`Exception raised while running tests: ${err}`);
+      if (t < tries - 1)
+        console.error('Retrying...');
+    }
+  }
+  console.error(`Tried running suite ${tries} time(s), still failed, giving up.`);
+  process.exit(1);
+}
+
 /**
  * Integration test runner. Launches the VSCode Extension Development Host with this extension installed.
  * See https://github.com/microsoft/vscode-test/blob/master/sample/test/runTest.ts
@@ -32,11 +67,10 @@ async function main() {
     ];
 
     for (const integrationTestSuite of integrationTestSuites) {
-      // Download and unzip VS Code if necessary, and run the integration test suite.
-      await runTests(integrationTestSuite);
+      await runTestsWithRetry(integrationTestSuite, 2);
     }
   } catch (err) {
-    console.error('Failed to run tests');
+    console.error('Unexpected exception while running tests');
     process.exit(1);
   }
 }


### PR DESCRIPTION
Integration tests have been flaky. I tracked down the problem to the vscode electron binary sometimes segfaulting *after* all tests have been successfully run. The information the test runner gets from `vscode-test` unfortunately does not distinguish this segfault from test failure. See comments for what we could do about this.

I tried bisecting which integration test, if any, was causing the problem, without much success --- locally I get a segfault rate of about 0.5%-5% depending on which tests are present. It seems like the fewer tests are included in the suite, the fewer segfaults, but artificially duplicating tests doesn't make the segfaults tractably common. A minimal commandline to (possibly) trigger the segfault, after `npm run integration` has been run at least once, is
```
$PATH_UP_TO/vscode-codeql/.vscode-test/vscode-1.42.1/VSCode-linux-x64/code  \
  --disable-extensions \
  --extensionDevelopmentPath=$PATH_UP_TO/vscode-codeql/extensions/ql-vscode \
  --extensionTestsPath=$PATH_UP_TO/vscode-codeql//extensions/ql-vscode/out/vscode-tests/no-workspace/index
```
I wrapped this in a bash while loop waiting for `$?` to be 139. The `.vscode-test/vscode-1.42.1/VSCode-linux-x64/code` binary downloaded by `vscode-test` is stripped of debugging symbols so I wasn't able to get any insight from the coredump.