### PR TITLE
Add "Show log" button for all messages

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CodeQL for Visual Studio Code: Changelog
 
+## 1.0.7
+
+- Add a "Show log" button to all information, error, and warning
+  popups that will display the CodeQL extension log.
+- Display a message when a query times out.
+- Show canceled queries in query history.
+
 ## 1.0.6 - 28 February 2020
 
 - Add command to restart query server.

--- a/extensions/ql-vscode/src/databases.ts
+++ b/extensions/ql-vscode/src/databases.ts
@@ -571,7 +571,7 @@ export class DatabaseManager extends DisposableObject {
       }
     } catch (e) {
       // database list had an unexpected type - nothing to be done?
-      showAndLogErrorMessage('Database list loading failed: ${}', e.message);
+      showAndLogErrorMessage(`Database list loading failed: ${e.message}`);
     }
   }
 

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -201,7 +201,9 @@ export async function activate(ctx: ExtensionContext): Promise<void> {
     } else if (distributionResult.kind === FindDistributionResultKind.NoDistribution) {
       registerErrorStubs([checkForUpdatesCommand], command => async () => {
         const installActionName = "Install CodeQL CLI";
-        const chosenAction = await helpers.showAndLogErrorMessage(`Can't execute ${command}: missing CodeQL CLI.`, installActionName);
+        const chosenAction = await helpers.showAndLogErrorMessage(`Can't execute ${command}: missing CodeQL CLI.`, {
+          items: [installActionName]
+        });
         if (chosenAction === installActionName) {
           installOrUpdateThenTryActivate({
             isUserInitiated: true,
@@ -319,10 +321,7 @@ async function activateWithInstalledDistribution(ctx: ExtensionContext, distribu
   ctx.subscriptions.push(commands.registerCommand('codeQL.quickQuery', async () => displayQuickQuery(ctx, cliServer, databaseUI)));
   ctx.subscriptions.push(commands.registerCommand('codeQL.restartQueryServer', async () => {
     await qs.restartQueryServer();
-    const response = await Window.showInformationMessage('CodeQL Query Server restarted.', 'Show Log');
-    if (response === 'Show Log') {
-      qs.showLog();
-    }
+    helpers.showAndLogInformationMessage('CodeQL Query Server restarted.', { outputLogger: queryServerLogger });
   }));
 
   ctx.subscriptions.push(client.start());

--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -51,9 +51,8 @@ export function withProgress<R>(
  *
  * @return A thenable that resolves to the selected item or undefined when being dismissed.
  */
-export function showAndLogErrorMessage(message: string, ...items: string[]): Thenable<string | undefined> {
-  logger.log(message);
-  return Window.showErrorMessage(message, ...items);
+export async function showAndLogErrorMessage(message: string, ...items: string[]): Promise<string | undefined> {
+  return internalShowAndLog(message, Window.showErrorMessage, ...items);
 }
 /**
  * Show a warning message and log it to the console
@@ -63,9 +62,8 @@ export function showAndLogErrorMessage(message: string, ...items: string[]): The
  *
  * @return A thenable that resolves to the selected item or undefined when being dismissed.
  */
-export function showAndLogWarningMessage(message: string, ...items: string[]): Thenable<string | undefined> {
-  logger.log(message);
-  return Window.showWarningMessage(message, ...items);
+export async function showAndLogWarningMessage(message: string, ...items: string[]): Promise<string | undefined> {
+  return internalShowAndLog(message, Window.showWarningMessage, ...items);
 }
 /**
  * Show an information message and log it to the console
@@ -75,9 +73,18 @@ export function showAndLogWarningMessage(message: string, ...items: string[]): T
  *
  * @return A thenable that resolves to the selected item or undefined when being dismissed.
  */
-export function showAndLogInformationMessage(message: string, ...items: string[]): Thenable<string | undefined> {
+export async function showAndLogInformationMessage(message: string, ...items: string[]): Promise<string | undefined> {
+  return internalShowAndLog(message, Window.showInformationMessage, ...items);
+}
+
+async function internalShowAndLog(message: string, fn: Function, ...items: string[]): Promise<string | undefined> {
   logger.log(message);
-  return Window.showInformationMessage(message, ...items);
+  const label = 'Show log';
+  const result = await fn(message, label, ...items);
+  if (result === label) {
+    logger.show();
+  }
+  return result;
 }
 
 /**

--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -47,42 +47,57 @@ export function withProgress<R>(
  * Show an error message and log it to the console
  *
  * @param message The message to show.
- * @param items A set of items that will be rendered as actions in the message.
+ * @param options.outputLogger The output logger that will receive the message
+ * @param options.items A set of items that will be rendered as actions in the message.
  *
- * @return A thenable that resolves to the selected item or undefined when being dismissed.
+ * @return A promise that resolves to the selected item or undefined when being dismissed.
  */
-export async function showAndLogErrorMessage(message: string, ...items: string[]): Promise<string | undefined> {
-  return internalShowAndLog(message, Window.showErrorMessage, ...items);
+export async function showAndLogErrorMessage(message: string, {
+  outputLogger = logger,
+  items = [] as string[]
+} = {}): Promise<string | undefined> {
+  return internalShowAndLog(message, items, outputLogger, Window.showErrorMessage);
 }
 /**
  * Show a warning message and log it to the console
  *
  * @param message The message to show.
- * @param items A set of items that will be rendered as actions in the message.
+ * @param options.outputLogger The output logger that will receive the message
+ * @param options.items A set of items that will be rendered as actions in the message.
  *
- * @return A thenable that resolves to the selected item or undefined when being dismissed.
+ * @return A promise that resolves to the selected item or undefined when being dismissed.
  */
-export async function showAndLogWarningMessage(message: string, ...items: string[]): Promise<string | undefined> {
-  return internalShowAndLog(message, Window.showWarningMessage, ...items);
+export async function showAndLogWarningMessage(message: string, {
+  outputLogger = logger,
+  items = [] as string[]
+} = {}): Promise<string | undefined> {
+  return internalShowAndLog(message, items, outputLogger, Window.showWarningMessage);
 }
 /**
  * Show an information message and log it to the console
  *
  * @param message The message to show.
- * @param items A set of items that will be rendered as actions in the message.
+ * @param options.outputLogger The output logger that will receive the message
+ * @param options.items A set of items that will be rendered as actions in the message.
  *
- * @return A thenable that resolves to the selected item or undefined when being dismissed.
+ * @return A promise that resolves to the selected item or undefined when being dismissed.
  */
-export async function showAndLogInformationMessage(message: string, ...items: string[]): Promise<string | undefined> {
-  return internalShowAndLog(message, Window.showInformationMessage, ...items);
+export async function showAndLogInformationMessage(message: string, {
+  outputLogger = logger,
+  items = [] as string[]
+} = {}): Promise<string | undefined> {
+  return internalShowAndLog(message, items, outputLogger, Window.showInformationMessage);
 }
 
-async function internalShowAndLog(message: string, fn: Function, ...items: string[]): Promise<string | undefined> {
-  logger.log(message);
-  const label = 'Show log';
+type ShowMessageFn = (message: string, ...items: string[]) => Thenable<string | undefined>;
+
+async function internalShowAndLog(message: string, items: string[], outputLogger = logger,
+  fn: ShowMessageFn): Promise<string | undefined> {
+  const label = 'Show Log';
+  outputLogger.log(message);
   const result = await fn(message, label, ...items);
   if (result === label) {
-    logger.show();
+    outputLogger.show();
   }
   return result;
 }


### PR DESCRIPTION
This change ensures that "Show log" is available on all messages
from the extension. It's important to note that the only place that
was specifying an "item" before was doing it incorrectly. That's
been fixed.

Closes #287

## Checklist

- [x] [CHANGELOG.md](../extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
