### PR TITLE
fix: Readable error message for invalid file

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -56,7 +56,7 @@ let isInstallingOrUpdatingDistribution = false;
  *
  * @param excludedCommands List of commands for which we should not register error stubs.
  */
-function registerErrorStubs(excludedCommands: string[], stubGenerator: (command: string) => () => void) {
+function registerErrorStubs(excludedCommands: string[], stubGenerator: (command: string) => () => void): void {
   // Remove existing stubs
   errorStubs.forEach(stub => stub.dispose());
 
@@ -229,7 +229,7 @@ export async function activate(ctx: ExtensionContext): Promise<void> {
   });
 }
 
-async function activateWithInstalledDistribution(ctx: ExtensionContext, distributionManager: DistributionManager) {
+async function activateWithInstalledDistribution(ctx: ExtensionContext, distributionManager: DistributionManager): Promise<void> {
   beganMainExtensionActivation = true;
   // Remove any error stubs command handlers left over from first part
   // of activation.
@@ -270,7 +270,7 @@ async function activateWithInstalledDistribution(ctx: ExtensionContext, distribu
     await intm.showResults(query, forceReveal, false);
   }
 
-  async function compileAndRunQuery(quickEval: boolean, selectedQuery: Uri | undefined) {
+  async function compileAndRunQuery(quickEval: boolean, selectedQuery: Uri | undefined): Promise<void> {
     if (qs !== undefined) {
       try {
         const dbItem = await databaseUI.getDatabaseItem();
@@ -294,7 +294,7 @@ async function activateWithInstalledDistribution(ctx: ExtensionContext, distribu
 
   ctx.subscriptions.push(tmpDirDisposal);
 
-  let client = new LanguageClient('CodeQL Language Server', () => spawnIdeServer(qlConfigurationListener), {
+  const client = new LanguageClient('CodeQL Language Server', () => spawnIdeServer(qlConfigurationListener), {
     documentSelector: [
       { language: 'ql', scheme: 'file' },
       { language: 'yaml', scheme: 'file', pattern: '**/qlpack.yml' }

--- a/extensions/ql-vscode/src/run-queries.ts
+++ b/extensions/ql-vscode/src/run-queries.ts
@@ -337,7 +337,7 @@ async function determineSelectedQuery(selectedResourceUri: vscode.Uri | undefine
   const queryPath = queryUri.fsPath || '';
 
   if (!queryPath.endsWith('.ql')) {
-    throw new Error('The selected resource is not a QL file.');
+    throw new Error('The selected resource is not a CodeQL query file; It should have the extension ".ql".');
   }
 
   // Whether we chose the file from the active editor or from a context menu,

--- a/extensions/ql-vscode/src/run-queries.ts
+++ b/extensions/ql-vscode/src/run-queries.ts
@@ -334,7 +334,11 @@ async function determineSelectedQuery(selectedResourceUri: vscode.Uri | undefine
   if (queryUri.scheme !== 'file') {
     throw new Error('Can only run queries that are on disk.');
   }
-  const queryPath = queryUri.fsPath;
+  const queryPath = queryUri.fsPath || '';
+
+  if (!queryPath.endsWith('.ql')) {
+    throw new Error('The selected resource is not a QL file.');
+  }
 
   // Whether we chose the file from the active editor or from a context menu,
   // if the same file is open with unsaved changes in the active editor,


### PR DESCRIPTION
Display an understandable error message when trying to Run Query on
a qll file. Closes https://github.com/github/codeql-coreql-team/issues/201