### PR TITLE
chore: Fix security warning in minimist

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -8,7 +8,7 @@ dependencies:
   '@rush-temp/semmle-vscode-utils': 'file:projects/semmle-vscode-utils.tgz'
   '@rush-temp/typescript-config': 'file:projects/typescript-config.tgz'
   '@rush-temp/vscode-codeql': 'file:projects/vscode-codeql.tgz'
-  '@types/chai': 4.2.10
+  '@types/chai': 4.2.11
   '@types/chai-as-promised': 7.1.2
   '@types/child-process-promise': 2.2.1
   '@types/classnames': 2.2.10
@@ -19,7 +19,7 @@ dependencies:
   '@types/js-yaml': 3.12.2
   '@types/jszip': 3.1.7
   '@types/mocha': 5.2.7
-  '@types/node': 12.12.29
+  '@types/node': 12.12.30
   '@types/node-fetch': 2.5.5
   '@types/npm-packlist': 1.1.1
   '@types/react': 16.9.23
@@ -29,7 +29,7 @@ dependencies:
   '@types/tmp': 0.1.0
   '@types/unzipper': 0.10.2
   '@types/vinyl': 2.0.4
-  '@types/vscode': 1.42.0
+  '@types/vscode': 1.43.0
   '@types/webpack': 4.41.7
   '@types/xml2js': 0.4.5
   '@typescript-eslint/eslint-plugin': 2.23.0_2510d86781fe783b47b58303c18a0d9b
@@ -50,6 +50,7 @@ dependencies:
   js-yaml: 3.13.1
   jsonc-parser: 2.1.1
   leb: 0.3.0
+  minimist: 1.2.5
   mocha: 6.2.2
   mocha-sinon: 2.1.0
   node-fetch: 2.6.0
@@ -59,7 +60,7 @@ dependencies:
   react: 16.13.0
   react-dom: 16.13.0_react@16.13.0
   reflect-metadata: 0.1.13
-  sinon: 9.0.0
+  sinon: 9.0.1
   style-loader: 0.23.1
   through2: 3.0.1
   tmp: 0.1.0
@@ -326,17 +327,17 @@ packages:
       integrity: sha512-VQgHxyPMTj3hIlq9SY1mctqx+Jj8kpQfoLvDlVSDNOyuYs8JYfkuY3OW/4+dO657yPmNhHpePRx0/Tje5ImNVQ==
   /@types/chai-as-promised/7.1.2:
     dependencies:
-      '@types/chai': 4.2.10
+      '@types/chai': 4.2.11
     dev: false
     resolution:
       integrity: sha512-PO2gcfR3Oxa+u0QvECLe1xKXOqYTzCmWf0FhLhjREoW3fPAVamjihL7v1MOVLJLsnAMdLcjkfrs01yvDMwVK4Q==
-  /@types/chai/4.2.10:
+  /@types/chai/4.2.11:
     dev: false
     resolution:
-      integrity: sha512-TlWWgb21+0LdkuFqEqfmy7NEgfB/7Jjux15fWQAh3P93gbmXuwTM/vxEdzW89APIcI2BgKR48yjeAkdeH+4qvQ==
+      integrity: sha512-t7uW6eFafjO+qJ3BIV2gGUyZs27egcNRkUdalkud+Qa3+kg//f129iuOFivHDXQ+vnU3fDXuwgv0cqMCbcE8sw==
   /@types/child-process-promise/2.2.1:
     dependencies:
-      '@types/node': 12.12.29
+      '@types/node': 12.12.30
     dev: false
     resolution:
       integrity: sha512-xZ4kkF82YkmqPCERqV9Tj0bVQj3Tk36BqGlNgxv5XhifgDRhwAqp+of+sccksdpZRbbPsNwMOkmUqOnLgxKtGw==
@@ -362,20 +363,20 @@ packages:
       integrity: sha512-Q5Vn3yjTDyCMV50TB6VRIbQNxSE4OmZR86VSbGaNpfUolm0iePBB4KdEEHmxoY5sT2+2DIvXW0rvMDP2nHZ4Mg==
   /@types/fs-extra/5.0.4:
     dependencies:
-      '@types/node': 12.12.29
+      '@types/node': 12.12.30
     dev: false
     resolution:
       integrity: sha512-DsknoBvD8s+RFfSGjmERJ7ZOP1HI0UZRA3FSI+Zakhrc/Gy26YQsLI+m5V5DHxroHRJqCDLKJp7Hixn8zyaF7g==
   /@types/fs-extra/8.1.0:
     dependencies:
-      '@types/node': 12.12.29
+      '@types/node': 12.12.30
     dev: false
     resolution:
       integrity: sha512-UoOfVEzAUpeSPmjm7h1uk5MH6KZma2z2O7a75onTGjnNvAvMVrPzPL/vBbT65iIGHWj6rokwfmYcmxmlSf2uwg==
   /@types/glob-stream/6.1.0:
     dependencies:
       '@types/glob': 7.1.1
-      '@types/node': 12.12.29
+      '@types/node': 12.12.30
     dev: false
     resolution:
       integrity: sha512-RHv6ZQjcTncXo3thYZrsbAVwoy4vSKosSWhuhuQxLOTv74OJuFQxXkmUuZCr3q9uNBEVCvIzmZL/FeRNbHZGUg==
@@ -383,7 +384,7 @@ packages:
     dependencies:
       '@types/events': 3.0.0
       '@types/minimatch': 3.0.3
-      '@types/node': 12.12.29
+      '@types/node': 12.12.30
     dev: false
     resolution:
       integrity: sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==
@@ -413,7 +414,7 @@ packages:
       integrity: sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
   /@types/jszip/3.1.7:
     dependencies:
-      '@types/node': 12.12.29
+      '@types/node': 12.12.30
     dev: false
     resolution:
       integrity: sha512-+XQKNI5zpxutK05hO67huUTw/2imXCuJWjnFdU63tRES/xXSX1yVR9cv/QAdO6Rii2y2tTHbzjQ4i2apLfuK0Q==
@@ -427,7 +428,7 @@ packages:
       integrity: sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==
   /@types/node-fetch/2.5.5:
     dependencies:
-      '@types/node': 12.12.29
+      '@types/node': 12.12.30
       form-data: 3.0.0
     dev: false
     resolution:
@@ -436,10 +437,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg==
-  /@types/node/12.12.29:
+  /@types/node/12.12.30:
     dev: false
     resolution:
-      integrity: sha512-yo8Qz0ygADGFptISDj3pOC9wXfln/5pQaN/ysDIzOaAWXt73cNHmtEC8zSO2Y+kse/txmwIAJzkYZ5fooaS5DQ==
+      integrity: sha512-sz9MF/zk6qVr3pAnM0BSQvYIBK44tS75QC5N+VbWSE4DjCV/pJ+UzCW/F+vVnl7TkOPcuwQureKNtSSwjBTaMg==
   /@types/node/8.5.8:
     dev: false
     resolution:
@@ -479,7 +480,7 @@ packages:
       integrity: sha512-/gG2M/Imw7cQFp8PGvz/SwocNrmKFjFsm5Pb8HdbHkZ1K8pmuPzOX4VeVoiEecFCVf4CsN1r3/BRvx+6sNqwtQ==
   /@types/through2/2.0.34:
     dependencies:
-      '@types/node': 12.12.29
+      '@types/node': 12.12.30
     dev: false
     resolution:
       integrity: sha512-nhRG8+RuG/L+0fAZBQYaRflXKjTrHOKH8MFTChnf+dNVMxA3wHYYrfj0tztK0W51ABXjGfRCDc0vRkecCOrsow==
@@ -505,14 +506,14 @@ packages:
       integrity: sha512-j4iepCSuY2JGW/hShVtUBagic0klYNFIXP7VweavnYnNC2EjiKxJFeaS9uaJmAT0ty9sQSqTS1aagWMZMV0HyA==
   /@types/unzipper/0.10.2:
     dependencies:
-      '@types/node': 12.12.29
+      '@types/node': 12.12.30
     dev: false
     resolution:
       integrity: sha512-VgYoNEyj8xkz9I+RTWD00iB9JVViK/RBteNDjOIV3/kdCUPaskka7xAZfFlIxRwKGSPf77F8yje5bJt2PefofQ==
   /@types/vinyl-fs/2.4.11:
     dependencies:
       '@types/glob-stream': 6.1.0
-      '@types/node': 12.12.29
+      '@types/node': 12.12.30
       '@types/vinyl': 2.0.4
     dev: false
     resolution:
@@ -520,17 +521,17 @@ packages:
   /@types/vinyl/2.0.4:
     dependencies:
       '@types/expect': 1.20.4
-      '@types/node': 12.12.29
+      '@types/node': 12.12.30
     dev: false
     resolution:
       integrity: sha512-2o6a2ixaVI2EbwBPg1QYLGQoHK56p/8X/sGfKbFC8N6sY9lfjsMf/GprtkQkSya0D4uRiutRZ2BWj7k3JvLsAQ==
-  /@types/vscode/1.42.0:
+  /@types/vscode/1.43.0:
     dev: false
     resolution:
-      integrity: sha512-ds6TceMsh77Fs0Mq0Vap6Y72JbGWB8Bay4DrnJlf5d9ui2RSe1wis13oQm+XhguOeH1HUfLGzaDAoupTUtgabw==
+      integrity: sha512-kIaR9qzd80rJOxePKpCB/mdy00mz8Apt2QA5Y6rdrKFn13QNFNeP3Hzmsf37Bwh/3cS7QjtAeGSK7wSqAU0sYQ==
   /@types/webpack-sources/0.1.6:
     dependencies:
-      '@types/node': 12.12.29
+      '@types/node': 12.12.30
       '@types/source-list-map': 0.1.2
       source-map: 0.6.1
     dev: false
@@ -539,7 +540,7 @@ packages:
   /@types/webpack/4.41.7:
     dependencies:
       '@types/anymatch': 1.3.1
-      '@types/node': 12.12.29
+      '@types/node': 12.12.30
       '@types/tapable': 1.0.5
       '@types/uglify-js': 3.0.4
       '@types/webpack-sources': 0.1.6
@@ -549,7 +550,7 @@ packages:
       integrity: sha512-OQG9viYwO0V1NaNV7d0n79V+n6mjOV30CwgFPIfTzwmk8DHbt+C4f2aBGdCYbo3yFyYD6sjXfqqOjwkl1j+ulA==
   /@types/xml2js/0.4.5:
     dependencies:
-      '@types/node': 12.12.29
+      '@types/node': 12.12.30
     dev: false
     resolution:
       integrity: sha512-yohU3zMn0fkhlape1nxXG2bLEGZRc1FeqF80RoHaYXJN7uibaauXfhzhOJr1Xh36sn+/tx21QAOf07b/xYVk1w==
@@ -1371,7 +1372,7 @@ packages:
       infer-owner: 1.0.4
       lru-cache: 5.1.1
       mississippi: 3.0.0
-      mkdirp: 0.5.1
+      mkdirp: 0.5.3
       move-concurrently: 1.0.1
       promise-inflight: 1.0.1
       rimraf: 2.7.1
@@ -1733,7 +1734,7 @@ packages:
       aproba: 1.2.0
       fs-write-stream-atomic: 1.0.10
       iferr: 0.1.5
-      mkdirp: 0.5.1
+      mkdirp: 0.5.3
       rimraf: 2.7.1
       run-queue: 1.0.3
     dev: false
@@ -1832,7 +1833,7 @@ packages:
       postcss-modules-scope: 2.1.1
       postcss-modules-values: 3.0.0
       postcss-value-parser: 4.0.3
-      schema-utils: 2.6.4
+      schema-utils: 2.6.5
       webpack: 4.42.0_webpack@4.42.0
     dev: false
     engines:
@@ -1913,7 +1914,7 @@ packages:
       integrity: sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
   /debug/4.1.1:
     dependencies:
-      ms: 2.1.1
+      ms: 2.1.2
     dev: false
     resolution:
       integrity: sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
@@ -2362,7 +2363,7 @@ packages:
       levn: 0.3.0
       lodash: 4.17.15
       minimatch: 3.0.4
-      mkdirp: 0.5.1
+      mkdirp: 0.5.3
       natural-compare: 1.4.0
       optionator: 0.8.3
       progress: 2.0.3
@@ -2372,7 +2373,7 @@ packages:
       strip-json-comments: 3.0.1
       table: 5.4.6
       text-table: 0.2.0
-      v8-compile-cache: 2.0.3
+      v8-compile-cache: 2.1.0
     dev: false
     engines:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
@@ -2806,7 +2807,7 @@ packages:
     dependencies:
       graceful-fs: 4.2.3
       inherits: 2.0.4
-      mkdirp: 0.5.1
+      mkdirp: 0.5.3
       rimraf: 2.7.1
     dev: false
     engines:
@@ -3698,20 +3699,29 @@ packages:
       integrity: sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
   /json5/1.0.1:
     dependencies:
-      minimist: 1.2.0
+      minimist: 1.2.5
     dev: false
     hasBin: true
     resolution:
       integrity: sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
   /json5/2.1.1:
     dependencies:
-      minimist: 1.2.0
+      minimist: 1.2.5
     dev: false
     engines:
       node: '>=6'
     hasBin: true
     resolution:
       integrity: sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==
+  /json5/2.1.2:
+    dependencies:
+      minimist: 1.2.5
+    dev: false
+    engines:
+      node: '>=6'
+    hasBin: true
+    resolution:
+      integrity: sha512-MoUOQ4WdiN3yxhm7NEVJSJrieAo5hNSLQ5sj05OTRHPL9HOBy8u4Bu88jsC1jvqAdN+E1bJmsUcZH+1HQxliqQ==
   /jsonc-parser/2.1.1:
     dev: false
     resolution:
@@ -4158,10 +4168,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
-  /minimist/1.2.0:
+  /minimist/1.2.5:
     dev: false
     resolution:
-      integrity: sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
+      integrity: sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
   /minipass/2.9.0:
     dependencies:
       safe-buffer: 5.2.0
@@ -4204,10 +4214,19 @@ packages:
   /mkdirp/0.5.1:
     dependencies:
       minimist: 0.0.8
+    deprecated: Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)
     dev: false
     hasBin: true
     resolution:
       integrity: sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
+  /mkdirp/0.5.3:
+    dependencies:
+      minimist: 1.2.5
+    deprecated: Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)
+    dev: false
+    hasBin: true
+    resolution:
+      integrity: sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==
   /mocha-sinon/2.1.0:
     dev: false
     engines:
@@ -4250,7 +4269,7 @@ packages:
       aproba: 1.2.0
       copy-concurrently: 1.0.5
       fs-write-stream-atomic: 1.0.10
-      mkdirp: 0.5.1
+      mkdirp: 0.5.3
       rimraf: 2.7.1
       run-queue: 1.0.3
     dev: false
@@ -4264,6 +4283,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
+  /ms/2.1.2:
+    dev: false
+    resolution:
+      integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
   /mute-stdout/1.0.1:
     dev: false
     engines:
@@ -4822,7 +4845,7 @@ packages:
       integrity: sha1-mkr9bfBj3Egm+T+6SpnPIj9mbLg=
   /parse5/3.0.3:
     dependencies:
-      '@types/node': 12.12.29
+      '@types/node': 12.12.30
     dev: false
     resolution:
       integrity: sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==
@@ -5562,7 +5585,7 @@ packages:
       node: '>= 4'
     resolution:
       integrity: sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==
-  /schema-utils/2.6.4:
+  /schema-utils/2.6.5:
     dependencies:
       ajv: 6.12.0
       ajv-keywords: 3.4.1_ajv@6.12.0
@@ -5570,7 +5593,7 @@ packages:
     engines:
       node: '>= 8.9.0'
     resolution:
-      integrity: sha512-VNjcaUxVnEeun6B2fiiUDjXXBtD4ZSH7pdbfIu1pOFwgptDPLMo/z9jr4sUfsjFVPqDCEin/F7IYlq7/E6yDbQ==
+      integrity: sha512-5KXuwKziQrTVHh8j/Uxz+QUbxkaLW9X/86NBlx/gnKgtsZA2GIVMUn17qWhRFwF8jdYb3Dig5hRO/W5mZqy6SQ==
   /semver-greatest-satisfied-range/1.1.0:
     dependencies:
       sver-compat: 1.5.0
@@ -5651,7 +5674,7 @@ packages:
     dev: false
     resolution:
       integrity: sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
-  /sinon/9.0.0:
+  /sinon/9.0.1:
     dependencies:
       '@sinonjs/commons': 1.7.1
       '@sinonjs/fake-timers': 6.0.0
@@ -5662,7 +5685,7 @@ packages:
       supports-color: 7.1.0
     dev: false
     resolution:
-      integrity: sha512-c4bREcvuK5VuEGyMW/Oim9I3Rq49Vzb0aMdxouFaA44QCFpilc5LJOugrX+mkrvikbqCimxuK+4cnHVNnLR41g==
+      integrity: sha512-iTTyiQo5T94jrOx7X7QLBZyucUJ2WvL9J13+96HMfm2CGoJYbIPqRfl6wgNcqmzk0DI28jeGx5bUTXizkrqBmg==
   /slice-ansi/2.1.0:
     dependencies:
       ansi-styles: 3.2.1
@@ -6087,7 +6110,7 @@ packages:
       fs-minipass: 1.2.7
       minipass: 2.9.0
       minizlib: 1.3.3
-      mkdirp: 0.5.1
+      mkdirp: 0.5.3
       safe-buffer: 5.2.0
       yallist: 3.1.1
     dev: false
@@ -6103,7 +6126,7 @@ packages:
       schema-utils: 1.0.0
       serialize-javascript: 2.1.2
       source-map: 0.6.1
-      terser: 4.6.6
+      terser: 4.6.7
       webpack: 4.42.0_webpack@4.42.0
       webpack-sources: 1.4.3
       worker-farm: 1.7.0
@@ -6114,7 +6137,7 @@ packages:
       webpack: ^4.0.0
     resolution:
       integrity: sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==
-  /terser/4.6.6:
+  /terser/4.6.7:
     dependencies:
       commander: 2.20.3
       source-map: 0.6.1
@@ -6124,7 +6147,7 @@ packages:
       node: '>=6.0.0'
     hasBin: true
     resolution:
-      integrity: sha512-4lYPyeNmstjIIESr/ysHg2vUPRGf2tzF9z2yYwnowXVuVzLEamPN1Gfrz7f8I9uEPuHcbFlW4PLIAsJoxXyJ1g==
+      integrity: sha512-fmr7M1f7DBly5cX2+rFDvmGBAaaZyPrHYK4mMdHEDAdNTqXSZgSOfqsfGq2HqPGT/1V0foZZuCZFx8CHKgAk3g==
   /text-table/0.2.0:
     dev: false
     resolution:
@@ -6557,6 +6580,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==
+  /v8-compile-cache/2.1.0:
+    dev: false
+    resolution:
+      integrity: sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==
   /v8flags/3.1.3:
     dependencies:
       homedir-polyfill: 1.0.3
@@ -6778,7 +6805,7 @@ packages:
       loader-utils: 1.4.0
       memory-fs: 0.4.1
       micromatch: 3.1.10
-      mkdirp: 0.5.1
+      mkdirp: 0.5.3
       neo-async: 2.6.1
       node-libs-browser: 2.2.1
       schema-utils: 1.0.0
@@ -6877,7 +6904,7 @@ packages:
   /write-json5-file/2.1.2:
     dependencies:
       graceful-fs: 4.2.3
-      json5: 2.1.1
+      json5: 2.1.2
       make-dir: 3.0.2
       sort-keys: 4.0.0
       write-file-atomic: 2.4.3
@@ -6900,7 +6927,7 @@ packages:
       integrity: sha512-OHzbrlgjw/K/BAH6LdEOcSQFz5nkk0I/25CjKLIVFvcg2Ej7+QE/GTnitgqWnhlsdghor7OV5gfttQPGogQ1XA==
   /write/1.0.3:
     dependencies:
-      mkdirp: 0.5.1
+      mkdirp: 0.5.3
     dev: false
     engines:
       node: '>=4'
@@ -6935,6 +6962,13 @@ packages:
     dev: false
     resolution:
       integrity: sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==
+  /yargs-parser/13.1.2:
+    dependencies:
+      camelcase: 5.3.1
+      decamelize: 1.2.0
+    dev: false
+    resolution:
+      integrity: sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==
   /yargs-parser/5.0.0:
     dependencies:
       camelcase: 3.0.0
@@ -6963,7 +6997,7 @@ packages:
       string-width: 3.1.0
       which-module: 2.0.0
       y18n: 4.0.0
-      yargs-parser: 13.1.1
+      yargs-parser: 13.1.2
     dev: false
     resolution:
       integrity: sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==
@@ -7038,7 +7072,7 @@ packages:
       '@types/fs-extra': 8.1.0
       '@types/gulp': 4.0.6
       '@types/js-yaml': 3.12.2
-      '@types/node': 12.12.29
+      '@types/node': 12.12.30
       '@types/npm-packlist': 1.1.1
       '@types/through2': 2.0.34
       '@types/vinyl': 2.0.4
@@ -7063,12 +7097,12 @@ packages:
     peerDependencies:
       glob: '*'
     resolution:
-      integrity: sha512-NkoIMaJdASYX4NjcB+nsEk/8Ff/2RLvHwL0efNOny3no6aNuJ3EkpNK0ZdX7HQdmTdY3IJPmjoJ3Rn4pkbxgdA==
+      integrity: sha512-14DvfY6Fj3HXp2/CNJ2zNh9MA8zPw9mUcr8WqkSsYvJow7JMcIlJ//OOONwpoSWtfrk1bk6Cin7jj9H79ItHQQ==
       tarball: 'file:projects/build-tasks.tgz'
     version: 0.0.0
   'file:projects/semmle-bqrs.tgz_typescript@3.8.3':
     dependencies:
-      '@types/node': 12.12.29
+      '@types/node': 12.12.30
       leb: 0.3.0
       reflect-metadata: 0.1.13
       typescript-formatter: 7.2.2_typescript@3.8.3
@@ -7078,13 +7112,13 @@ packages:
     peerDependencies:
       typescript: '*'
     resolution:
-      integrity: sha512-lE3FBYrOVF1JH0ZqvF4YA+bed3JPWYucsnFe+XL140a/YR19XD+TTHIfov7VpR9qdyWfARgvmR+gf2qsguXTKQ==
+      integrity: sha512-24GdnvMbGfQIWMfgDhift+kYJDnG7dX03NrpX4ajZ2rckteysvq2/K7XI1OXGvUuqrt3m0/+GRDHpSI9XKDJJA==
       tarball: 'file:projects/semmle-bqrs.tgz'
     version: 0.0.0
   'file:projects/semmle-io-node.tgz_typescript@3.8.3':
     dependencies:
       '@types/fs-extra': 8.1.0
-      '@types/node': 12.12.29
+      '@types/node': 12.12.30
       fs-extra: 8.1.0
       typescript-formatter: 7.2.2_typescript@3.8.3
     dev: false
@@ -7093,12 +7127,12 @@ packages:
     peerDependencies:
       typescript: '*'
     resolution:
-      integrity: sha512-MD9edC5HjrCfPmhktw6XmWotUmperj27/hDZiuMbuSlJ4jRKyiBtJ8Vk2Y4U41TrzsBlJfAwZW8tetPw5ujiLg==
+      integrity: sha512-Bj0ax/bASrHV7tamOuXZZdd3UOB4NBKdjdszIRaDvDRTu8RlEst+TVoUhkfy30qb2/6ePp3/juOJyyiBJN7u8Q==
       tarball: 'file:projects/semmle-io-node.tgz'
     version: 0.0.0
   'file:projects/semmle-io.tgz_typescript@3.8.3':
     dependencies:
-      '@types/node': 12.12.29
+      '@types/node': 12.12.30
       leb: 0.3.0
       typescript-formatter: 7.2.2_typescript@3.8.3
     dev: false
@@ -7107,31 +7141,31 @@ packages:
     peerDependencies:
       typescript: '*'
     resolution:
-      integrity: sha512-ta1lLi1COIeFwpwH523cWheWx6OE8GTqguQmOA7G6CwRF41RYbbREf/4KlOLKO/uG2akhhl+3gcWY2c5/VDC/A==
+      integrity: sha512-NtyviDSevxbd+hj4J66LucOzo8LU2hJ1Jh0eHw0Qu3tRZPUT8HcQlseyy29AvZR8n8eppfEZiAm/JdiHfmRPMA==
       tarball: 'file:projects/semmle-io.tgz'
     version: 0.0.0
   'file:projects/semmle-vscode-utils.tgz':
     dependencies:
-      '@types/node': 12.12.29
-      '@types/vscode': 1.42.0
+      '@types/node': 12.12.30
+      '@types/vscode': 1.43.0
       typescript: 3.8.3
       typescript-formatter: 7.2.2_typescript@3.8.3
     dev: false
     name: '@rush-temp/semmle-vscode-utils'
     resolution:
-      integrity: sha512-Dbwt0/Wd0VNKkRZRjFQv3hmGy/UDt36HDtEDsNgZIcQACoY1j2+mJavpQ+ZzCg4Ftj06eHDVk+ptzUEd+8Ybzw==
+      integrity: sha512-5y5r8SDoN9Fp44naC9gUe8rOexeckXg2T0h9QCJAIcEgnFqOxzRc6Rv9gbMUStFKNh+rFlvmYmgPAdg5QkfgUg==
       tarball: 'file:projects/semmle-vscode-utils.tgz'
     version: 0.0.0
   'file:projects/typescript-config.tgz':
     dev: false
     name: '@rush-temp/typescript-config'
     resolution:
-      integrity: sha512-qJbtY2jvt6LKkmUt/seiYyXSEB6Oip/rW+SxofQEnpyplgIQv7whTZb6g5pwlSLGl8goTaQFm4NfazKhFmxXvQ==
+      integrity: sha512-XuUIySaNoooIduvehnlKYaHqZJmmQoCqB1RtKhNszjCYZaSSJAnKVucViWBf5oNLKSNP7NchrD7gcoBlQ3xYvw==
       tarball: 'file:projects/typescript-config.tgz'
     version: 0.0.0
   'file:projects/vscode-codeql.tgz':
     dependencies:
-      '@types/chai': 4.2.10
+      '@types/chai': 4.2.11
       '@types/chai-as-promised': 7.1.2
       '@types/child-process-promise': 2.2.1
       '@types/classnames': 2.2.10
@@ -7142,14 +7176,14 @@ packages:
       '@types/js-yaml': 3.12.2
       '@types/jszip': 3.1.7
       '@types/mocha': 5.2.7
-      '@types/node': 12.12.29
+      '@types/node': 12.12.30
       '@types/node-fetch': 2.5.5
       '@types/react': 16.9.23
       '@types/react-dom': 16.9.5
       '@types/sarif': 2.1.2
       '@types/tmp': 0.1.0
       '@types/unzipper': 0.10.2
-      '@types/vscode': 1.42.0
+      '@types/vscode': 1.43.0
       '@types/webpack': 4.41.7
       '@types/xml2js': 0.4.5
       '@typescript-eslint/eslint-plugin': 2.23.0_2510d86781fe783b47b58303c18a0d9b
@@ -7167,13 +7201,14 @@ packages:
       gulp-sourcemaps: 2.6.5
       gulp-typescript: 5.0.1_typescript@3.8.3
       js-yaml: 3.13.1
+      minimist: 1.2.5
       mocha: 6.2.2
       mocha-sinon: 2.1.0
       node-fetch: 2.6.0
       npm-run-all: 4.1.5
       react: 16.13.0
       react-dom: 16.13.0_react@16.13.0
-      sinon: 9.0.0
+      sinon: 9.0.1
       style-loader: 0.23.1
       through2: 3.0.1
       tmp: 0.1.0
@@ -7195,10 +7230,9 @@ packages:
     dev: false
     name: '@rush-temp/vscode-codeql'
     resolution:
-      integrity: sha512-k2FwvquGbFZ3IZb22wpYq220ijuGaG2oAgw5b/vnJ8ZnqBZGATYF6+0T5xZd/hQ7bRgRLDt0wKNni+7VK83ZAQ==
+      integrity: sha512-XEQBLdsSWxofNXxh6Uwah2wvOUgMi/yGuU2afjauGOegrsH1G2DdKZ4kbbhfxKsEE7xxlQb4G8mu7SqjPt1Dag==
       tarball: 'file:projects/vscode-codeql.tgz'
     version: 0.0.0
-registry: ''
 specifiers:
   '@microsoft/node-core-library': ~3.13.0
   '@microsoft/rush-lib': ~5.20.0
@@ -7251,6 +7285,7 @@ specifiers:
   js-yaml: ^3.12.0
   jsonc-parser: ~2.1.0
   leb: ^0.3.0
+  minimist: ~1.2.5
   mocha: ~6.2.1
   mocha-sinon: ~2.1.0
   node-fetch: ~2.6.0

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -396,7 +396,8 @@
     "vscode-jsonrpc": "^4.0.0",
     "vscode-languageclient": "^5.2.1",
     "vscode-test-adapter-api": "~1.7.0",
-    "vscode-test-adapter-util": "~0.7.0"
+    "vscode-test-adapter-util": "~0.7.0",
+    "minimist": "~1.2.5"
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",


### PR DESCRIPTION
There is a security warning for minimist. The extension only depends
on it transitively. Not all of its direct dependencies have updated it
yet. I don't like having to add a dependency like this, but if it
avoids github screaming at us, then I think we should.
