### PR TITLE
fix: Avoid auto-updating the codeql binaries

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Add new command in query history view to view the log file of a
   query.
-- Avoid updating the CodeQL binaries without user acknowledgment.
+- Request user acknowledgment before updating the CodeQL binaries.
 
 ## 1.1.0 - 17 March 2020
 

--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add new command in query history view to view the log file of a
   query.
+- Avoid updating the CodeQL binaries without user acknowledgment.
 
 ## 1.1.0 - 17 March 2020
 

--- a/extensions/ql-vscode/src/distribution.ts
+++ b/extensions/ql-vscode/src/distribution.ts
@@ -94,6 +94,11 @@ export class DistributionManager implements DistributionProvider {
     };
   }
 
+  public async hasDistribution(): Promise<boolean> {
+    const result = await this.getDistribution();
+    return result.kind !== FindDistributionResultKind.NoDistribution;
+  }
+
   /**
    * Returns the path to a possibly-compatible CodeQL launcher binary, or undefined if a binary not be found.
    */
@@ -208,7 +213,11 @@ class ExtensionSpecificDistributionManager {
     const extensionSpecificRelease = this.getInstalledRelease();
     const latestRelease = await this.getLatestRelease();
 
-    if (extensionSpecificRelease !== undefined && codeQlPath !== undefined && latestRelease.id === extensionSpecificRelease.id) {
+    if (
+      extensionSpecificRelease !== undefined &&
+      codeQlPath !== undefined &&
+      latestRelease.id === extensionSpecificRelease.id
+    ) {
       return createAlreadyUpToDateResult();
     }
     return createUpdateAvailableResult(latestRelease);

--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -179,8 +179,12 @@ export class InvocationRateLimiter<T> {
   public async invokeFunctionIfIntervalElapsed(minSecondsSinceLastInvocation: number): Promise<InvocationRateLimiterResult<T>> {
     const updateCheckStartDate = this._createDate();
     const lastInvocationDate = this.getLastInvocationDate();
-    if (minSecondsSinceLastInvocation && lastInvocationDate && lastInvocationDate <= updateCheckStartDate &&
-      lastInvocationDate.getTime() + minSecondsSinceLastInvocation * 1000 > updateCheckStartDate.getTime()) {
+    if (
+      minSecondsSinceLastInvocation &&
+      lastInvocationDate &&
+      lastInvocationDate <= updateCheckStartDate &&
+      lastInvocationDate.getTime() + minSecondsSinceLastInvocation * 1000 > updateCheckStartDate.getTime()
+    ) {
       return createRateLimitedResult();
     }
     const result = await this._func();


### PR DESCRIPTION
On startup, if a new binary is available, request user acceptance
before starting the update.

Fixes #283
