### PR TITLE
feat: Allow large log files to be opened externally

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -58,7 +58,6 @@ hour for unauthenticated IPs.
 - Fix the automatic upgrading of CodeQL databases when using upgrade scripts from the workspace.
 - Allow removal of items from the CodeQL Query History view.
 
-
 ## 1.0.0 - 14 November 2019
 
 Initial release of CodeQL for Visual Studio Code.


### PR DESCRIPTION
If the user tries to open a log file that is too large for vscode's
extension mechanism to handle, reveal the file in the finder/explorer
and let the user open in an external program.

Fixes #301 