### PR TITLE
feat: Display warning when codeql.cmd is used

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add new command in query history view to view the log file of a
   query.
 - Request user acknowledgment before updating the CodeQL binaries.
+- Warn when using the deprecated `codeql.cmd` launcher on windows.
 
 ## 1.1.0 - 17 March 2020
 

--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -58,7 +58,6 @@ hour for unauthenticated IPs.
 - Fix the automatic upgrading of CodeQL databases when using upgrade scripts from the workspace.
 - Allow removal of items from the CodeQL Query History view.
 
-
 ## 1.0.0 - 14 November 2019
 
 Initial release of CodeQL for Visual Studio Code.

--- a/extensions/ql-vscode/test/pure-tests/logging.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/logging.test.ts
@@ -1,3 +1,4 @@
+import 'chai/register-should';
 import * as chai from 'chai';
 import * as fs from 'fs-extra';
 import * as path from 'path';
@@ -8,7 +9,6 @@ import * as sinon from 'sinon';
 import * as pq from 'proxyquire';
 
 const proxyquire = pq.noPreserveCache().noCallThru();
-chai.should();
 chai.use(sinonChai);
 const expect = chai.expect;
 


### PR DESCRIPTION
The old launcher has been deprecated and codeql.exe is
recommended.

Fixes #287.