### PR TITLE
feat: Include query text in history hover

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Implement syntax highlighting for the new `unique` aggregate.
 - Implement XML syntax highlighting for `.qhelp` files.
 - Add option to auto save queries before running them.
+- Add new command in query history to view the query text of the
+  selected query (note that this may be different from the current
+  contents of the query file if the file has been edited).
 
 ## 1.1.1 - 23 March 2020
 

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -227,6 +227,10 @@
         "title": "Show Query Log"
       },
       {
+        "command": "codeQLQueryHistory.showQueryText",
+        "title": "Show Query Text"
+      },
+      {
         "command": "codeQLQueryResults.nextPathStep",
         "title": "CodeQL: Show Next Step on Path"
       },
@@ -296,6 +300,11 @@
           "when": "view == codeQLQueryHistory"
         },
         {
+          "command": "codeQLQueryHistory.showQueryText",
+          "group": "9_qlCommands",
+          "when": "view == codeQLQueryHistory"
+        },
+        {
           "command": "codeQLTests.showOutputDifferences",
           "group": "qltest@1",
           "when": "view == test-explorer && viewItem == testWithSource"
@@ -353,6 +362,10 @@
         },
         {
           "command": "codeQLQueryHistory.showQueryLog",
+          "when": "false"
+        },
+        {
+          "command": "codeQLQueryHistory.showQueryText",
           "when": "false"
         },
         {

--- a/extensions/ql-vscode/src/query-results.ts
+++ b/extensions/ql-vscode/src/query-results.ts
@@ -14,7 +14,7 @@ export class CompletedQuery implements QueryWithResults {
   readonly query: QueryInfo;
   readonly result: messages.EvaluationResult;
   readonly database: DatabaseInfo;
-  readonly logFileLocation?: string
+  readonly logFileLocation?: string;
   options: QueryHistoryItemOptions;
   dispose: () => void;
 


### PR DESCRIPTION
Include the text of the query file when hovering. For quick eval, only 
show the selected text.

Long files are truncated in the hover. It looks like vscode limits tooltips to only a few hundred chars.

Not sure if showing the text for all queries makes sense. The other option is to only show expanded tooltips for quick eval.