### PR TITLE
feat: XML syntax highlighting for qhelp files

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -77,6 +77,15 @@
           ".dbscheme"
         ],
         "configuration": "./language-configuration.json"
+      },
+      {
+        "id": "xml",
+        "aliases": [
+          "qhelp"
+        ],
+        "extensions": [
+          ".qhelp"
+        ]
       }
     ],
     "grammars": [


### PR DESCRIPTION
Provides basic XML syntax highlighting for qhelp files as described in issue #325.

I noticed the need for qhelp file features after annoying @aschackmull with bad XML in my qhelp file 😉

This change tells vscode to interpret qhelp files as XML as seen in this screenshot:

![qhelp-syntax-highlighting](https://user-images.githubusercontent.com/176818/78498581-b5cad980-773a-11ea-93b9-a3a9549c479f.png)



## Open questions
* It is not clear to me if name is qhelp or Qhelp? As both variants are used in the [Query help style guide](https://github.com/Semmle/ql/blob/master/docs/query-help-style-guide.md)
* I was not sure whether I (as an external contributor) should add this small feature to the CHANGELOG and cc product-docs-dsp?

## Checklist

- [ ] [CHANGELOG.md](../extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.  (#325)
- [ ] `@github/product-docs-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
