### PR TITLE
Highlight `unique` as a keyword

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CodeQL for Visual Studio Code: Changelog
 
+## 1.1.2
+
+- Implement syntax highlighting for the new `unique` aggregate.
+
 ## 1.1.1 - 23 March 2020
 
 - Fix quick evaluation in `.qll` files.

--- a/extensions/ql-vscode/syntaxes/ql.tmLanguage.yml
+++ b/extensions/ql-vscode/syntaxes/ql.tmLanguage.yml
@@ -422,6 +422,11 @@ repository:
       keyword: 'true'
     name: constant.language.boolean.true.ql
 
+  unique:
+    match:
+      keyword: 'unique'
+    name: keyword.aggregate.unique.ql
+
   where:
     match:
       keyword: 'where'
@@ -478,6 +483,8 @@ repository:
     - include: '#then'
     - include: '#this'
     - include: '#true'
+    # `unique` is not really a keyword, but we'll highlight it as if it is.
+    - include: '#unique'
     - include: '#where'
 
   # A keyword that can be the first token of a predicate declaration.


### PR DESCRIPTION
Fixes #329 

`unique` is really a context-sensitive keyword, but that's even more of a hassle in a TextMate grammars than it is in the compiler itself. We'll just highlight it as a real keyword. The worst that will happen is that existing variables and predicates named "unique" will be highlighted like keywords, which will hopefully just encourage QL developers to rename those anyway.

## Checklist

- [x] [CHANGELOG.md](../extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] `@github/product-docs-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
