### PR TITLE
Fix position of change note

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add new command in query history to view the query text of the
   selected query (note that this may be different from the current
   contents of the query file if the file has been edited).
+- Add ability to sort CodeQL databases by name or by date added.
 
 ## 1.1.1 - 23 March 2020
 
@@ -16,7 +17,6 @@
   query.
 - Request user acknowledgment before updating the CodeQL binaries.
 - Warn when using the deprecated `codeql.cmd` launcher on Windows.
-- Add ability to sort QL databases by name or by date added.
 
 ## 1.1.0 - 17 March 2020
 


### PR DESCRIPTION
The ability to sort databases (from https://github.com/github/vscode-codeql/pull/332) hasn't been released yet, so I imagine the change note should be under 1.1.2 instead of 1.1.1.

(I've also changed "QL databases" to "CodeQL databases" to reflect the [terminology in the docs](https://help.semmle.com/codeql-note.html).)