### PR TITLE
Remove 'qhelp' as global alias for 'xml' filetype

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -80,9 +80,6 @@
       },
       {
         "id": "xml",
-        "aliases": [
-          "qhelp"
-        ],
         "extensions": [
           ".qhelp"
         ]


### PR DESCRIPTION
Fixes https://github.com/github/vscode-codeql/issues/339.