### PR TITLE
Changelog: Add release date

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CodeQL for Visual Studio Code: Changelog
 
-## 1.1.2
+## 1.1.2 - 28 April 2020
 
 - Implement syntax highlighting for the new `unique` aggregate.
 - Implement XML syntax highlighting for `.qhelp` files.


### PR DESCRIPTION
The latest changelog entry (for 1.1.2) didn't include the date. Is it possible to include this retroactively? 