### PR TITLE
Add suggestive message to alerts view when 0 alerts, >0 raw results.

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CodeQL for Visual Studio Code: Changelog
 
+## 1.1.3
+
+- Add a suggestion in alerts view to view raw results, when there are
+  raw results but no alerts.
+
 ## 1.1.2 - 28 April 2020
 
 - Implement syntax highlighting for the new `unique` aggregate.

--- a/extensions/ql-vscode/src/view/alert-table.tsx
+++ b/extensions/ql-vscode/src/view/alert-table.tsx
@@ -69,6 +69,14 @@ export class PathTable extends React.Component<PathTableProps, PathTableState> {
     });
   }
 
+  renderNoResults(): JSX.Element {
+    if (this.props.nonemptyRawResults) {
+      return <span>No Alerts. See <a href='#' onClick={this.props.showRawResults}>raw results</a>.</span>;
+    } else {
+      return <span>No Alerts</span>;
+    }
+  }
+
   render(): JSX.Element {
     const { databaseUri, resultSet } = this.props;
 
@@ -156,12 +164,13 @@ export class PathTable extends React.Component<PathTableProps, PathTableState> {
       return (e) => this.toggle(e, indices);
     };
 
-    const noResults = <span>No Results</span>; // TODO: Maybe make this look nicer
+    if (resultSet.sarif.runs.length === 0 ||
+      resultSet.sarif.runs[0].results === undefined ||
+      resultSet.sarif.runs[0].results.length === 0) {
+      return this.renderNoResults();
+    }
 
     let expansionIndex = 0;
-
-    if (resultSet.sarif.runs.length === 0) return noResults;
-    if (resultSet.sarif.runs[0].results === undefined) return noResults;
 
     resultSet.sarif.runs[0].results.forEach((result, resultIndex) => {
       const text = result.message.text || '[no text]';

--- a/extensions/ql-vscode/src/view/result-table-utils.tsx
+++ b/extensions/ql-vscode/src/view/result-table-utils.tsx
@@ -10,6 +10,18 @@ export interface ResultTableProps {
   metadata?: QueryMetadata;
   resultsPath: string | undefined;
   sortState?: RawResultsSortState;
+
+  /**
+   * Holds if there are any raw results. When that is the case, we
+   * want to direct users to pay attention to raw results if
+   * interpreted results are empty.
+   */
+  nonemptyRawResults: boolean;
+
+  /**
+   * Callback to show raw results.
+   */
+  showRawResults: () => void;
 }
 
 export const className = 'vscode-codeql__result-table';

--- a/extensions/ql-vscode/src/view/result-tables.tsx
+++ b/extensions/ql-vscode/src/view/result-tables.tsx
@@ -123,6 +123,7 @@ export class ResultTables
     const resultSets = this.getResultSets();
 
     const resultSet = resultSets.find(resultSet => resultSet.schema.name == selectedTable);
+    const nonemptyRawResults = resultSets.some(resultSet => resultSet.t == 'RawResultSet' && resultSet.rows.length > 0);
     const numberOfResults = resultSet && renderResultCountString(resultSet);
 
     return <div>
@@ -149,7 +150,9 @@ export class ResultTables
         <ResultTable key={resultSet.schema.name} resultSet={resultSet}
           databaseUri={this.props.database.databaseUri}
           resultsPath={this.props.resultsPath}
-          sortState={this.props.sortStates.get(resultSet.schema.name)} />
+          sortState={this.props.sortStates.get(resultSet.schema.name)}
+          nonemptyRawResults={nonemptyRawResults}
+          showRawResults={() => { this.setState({ selectedTable: SELECT_TABLE_NAME }) }} />
       }
     </div>;
   }


### PR DESCRIPTION
The message includes a clickable link that takes you directly to the raw results view. Fixes https://github.com/github/codeql-coreql-team/issues/383.

`@github/product-docs-dsp` not sure if this needs docs.