### PR TITLE
Fixes to how we lint automatically

### DIFF
--- a/extensions/ql-vscode/.eslintrc.js
+++ b/extensions/ql-vscode/.eslintrc.js
@@ -26,10 +26,7 @@ module.exports = {
     "@typescript-eslint/no-explicit-any": "off",
     "prefer-const": ["warn", {"destructuring": "all"}],
     "indent": "off",
-    "@typescript-eslint/indent": ["error", 2, {
-      "SwitchCase": 1,
-      "FunctionDeclaration": { "body": 1, "parameters": 1 }
-    }],
+    "@typescript-eslint/indent": "off",
     "@typescript-eslint/no-throw-literal": "error",
     "no-useless-escape": 0
   },

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -483,7 +483,7 @@
     "postinstall": "npm rebuild && node ./node_modules/vscode/bin/install",
     "format": "tsfmt -r",
     "lint": "eslint src test --ext .ts,.tsx",
-    "lint-staged": "lint-staged"
+    "format-staged": "lint-staged"
   },
   "dependencies": {
     "child-process-promise": "^2.2.1",
@@ -567,7 +567,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm run lint-staged",
+      "pre-commit": "npm run format-staged",
       "pre-push": "npm run lint"
     }
   },

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -480,7 +480,7 @@
     "preintegration": "rm -rf ./out/vscode-tests && gulp",
     "integration": "node ./out/vscode-tests/run-integration-tests.js",
     "update-vscode": "node ./node_modules/vscode/bin/install",
-    "postinstall": "node ./node_modules/vscode/bin/install",
+    "postinstall": "npm rebuild && node ./node_modules/vscode/bin/install",
     "format": "tsfmt -r",
     "lint": "eslint src test --ext .ts,.tsx",
     "lint-staged": "lint-staged"
@@ -567,7 +567,8 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm run lint-staged"
+      "pre-commit": "npm run lint-staged",
+      "pre-push": "npm run lint"
     }
   },
   "lint-staged": {
@@ -575,7 +576,6 @@
       "prettier --write"
     ],
     "./**/*.{ts,tsx}": [
-      "eslint --fix --debug",
       "tsfmt -r"
     ]
   }


### PR DESCRIPTION
Run lint on prepush. Also, remove indentation checking from eslint, handled by tsfmt instead.