### PR TITLE
Ensure extension dir

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -480,7 +480,7 @@
     "preintegration": "rm -rf ./out/vscode-tests && gulp",
     "integration": "node ./out/vscode-tests/run-integration-tests.js",
     "update-vscode": "node ./node_modules/vscode/bin/install",
-    "postinstall": "node ./node_modules/vscode/bin/install",
+    "postinstall": "npm rebuild && node ./node_modules/vscode/bin/install",
     "format": "tsfmt -r",
     "lint": "eslint src test --ext .ts,.tsx",
     "lint-staged": "lint-staged"
@@ -567,7 +567,8 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm run lint-staged"
+      "pre-commit": "npm run lint-staged",
+      "pre-push": "npm run lint"
     }
   },
   "lint-staged": {
@@ -575,7 +576,6 @@
       "prettier --write"
     ],
     "./**/*.{ts,tsx}": [
-      "eslint --fix --debug",
       "tsfmt -r"
     ]
   }

--- a/extensions/ql-vscode/src/databaseFetcher.ts
+++ b/extensions/ql-vscode/src/databaseFetcher.ts
@@ -42,6 +42,7 @@ async function databaseFetcher(
   if (!storagePath) {
     throw new Error("No storage path specified.");
   }
+  await fs.ensureDir(storagePath)
   const unzipPath = await getStorageFolder(storagePath, databaseUrl);
 
   const response = await fetch.default(databaseUrl);


### PR DESCRIPTION
Fixes a bug where it's possible to fail on importing a database because the parent folder doesn't exist.