### PR TITLE
Make links variable-width without underline

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CodeQL for Visual Studio Code: Changelog
 
+## 1.1.5
+
+- Links in results are no longer underlined and monospaced.
+
 ## 1.1.4 - 13 May 2020
 
 - Add the ability to download and install databases archives from the internet.

--- a/extensions/ql-vscode/src/view/resultsView.css
+++ b/extensions/ql-vscode/src/view/resultsView.css
@@ -75,7 +75,7 @@
 }
 
 .vscode-codeql__result-table-location-link {
-  font-family: SFMono-Regular, Consolas, "Liberation Mono", Menlo, Courier, monospace;
+  text-decoration: none;
 }
 
 select {


### PR DESCRIPTION
These are two independent changes.
- The monospace font used in links made the text larger so that less text could fit on the screen. It also suggested that all link text was an code snippet, which it isn't. The advantage of a fixed-width font, vertical alignment, was not put to any use.
- Underlining of links made it almost impossible to distinguish a space from an underscore.

Before:
![vscode-underline](https://user-images.githubusercontent.com/308293/81908683-d30c8680-95c9-11ea-9683-78636790fe04.png)

After:
![vscode-no-underline](https://user-images.githubusercontent.com/308293/81908706-d99afe00-95c9-11ea-9f15-d97b87e8958d.png)

Notice how it's practically impossible to tell underscores from spaces in the underlined link for `unpack_index_entry output argument [cache_nr]` (row 11).

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/master/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] `@github/product-docs-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
