### PR TITLE
Remove feature flag guard around source archive jump-to-definition

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CodeQL for Visual Studio Code: Changelog
 
+## 1.2.0
+
+- Add CodeQL-query-powered handlers for 'Go to Definition' and 'Go To
+  References' on source archive files.
+
 ## 1.1.5
 
 - Links in results are no longer underlined and monospaced.

--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 1.2.0
 
-- Add CodeQL-query-powered handlers for 'Go to Definition' and 'Go To
-  References' on source archive files.
+- Enable 'Go to Definition' and 'Go to References' on source archive
+  files in CodeQL databases. This is handled by a CodeQL query.
 
 ## 1.1.5
 

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -42,10 +42,10 @@ const ROOT_SETTING = new Setting('codeQL');
 // Enable experimental features
 
 /**
- * Any settings below deliberately not in package.json so that they do
- * not appear in the settings ui in vscode itself. If users want to
- * enable experimental features, they can add them directly in their
- * vscode settings json file.
+ * Any settings below are deliberately not in package.json so that
+ * they do not appear in the settings ui in vscode itself. If users
+ * want to enable experimental features, they can add them directly in
+ * their vscode settings json file.
  */
 
 /* Advanced setting: used to enable bqrs parsing in the cli instead of in the webview. */

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -42,13 +42,11 @@ const ROOT_SETTING = new Setting('codeQL');
 // Enable experimental features
 
 /**
- * This setting is deliberately not in package.json so that it does
+ * Any settings below deliberately not in package.json so that they do
  * not appear in the settings ui in vscode itself. If users want to
- * enable experimental features, they can add
- * "codeQl.experimentalFeatures" directly in their vscode settings
- * json file.
+ * enable experimental features, they can add them directly in their
+ * vscode settings json file.
  */
-export const EXPERIMENTAL_FEATURES_SETTING = new Setting('experimentalFeatures', ROOT_SETTING);
 
 /* Advanced setting: used to enable bqrs parsing in the cli instead of in the webview. */
 export const EXPERIMENTAL_BQRS_SETTING = new Setting('experimentalBqrsParsing', ROOT_SETTING);

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -3,7 +3,7 @@ import { LanguageClient } from 'vscode-languageclient';
 import { testExplorerExtensionId, TestHub } from 'vscode-test-adapter-api';
 import * as archiveFilesystemProvider from './archive-filesystem-provider';
 import { CodeQLCliServer } from './cli';
-import { DistributionConfigListener, QueryHistoryConfigListener, QueryServerConfigListener, EXPERIMENTAL_FEATURES_SETTING } from './config';
+import { DistributionConfigListener, QueryHistoryConfigListener, QueryServerConfigListener } from './config';
 import { DatabaseManager } from './databases';
 import { DatabaseUI } from './databases-ui';
 import { TemplateQueryDefinitionProvider, TemplateQueryReferenceProvider } from './definitions';
@@ -339,16 +339,16 @@ async function activateWithInstalledDistribution(ctx: ExtensionContext, distribu
 
   ctx.subscriptions.push(client.start());
 
-  if (EXPERIMENTAL_FEATURES_SETTING.getValue()) {
-    languages.registerDefinitionProvider(
-      { scheme: archiveFilesystemProvider.zipArchiveScheme },
-      new TemplateQueryDefinitionProvider(cliServer, qs, dbm)
-    );
-    languages.registerReferenceProvider(
-      { scheme: archiveFilesystemProvider.zipArchiveScheme },
-      new TemplateQueryReferenceProvider(cliServer, qs, dbm)
-    );
-  }
+  // Jump-to-definition and find-references
+  languages.registerDefinitionProvider(
+    { scheme: archiveFilesystemProvider.zipArchiveScheme },
+    new TemplateQueryDefinitionProvider(cliServer, qs, dbm)
+  );
+  languages.registerReferenceProvider(
+    { scheme: archiveFilesystemProvider.zipArchiveScheme },
+    new TemplateQueryReferenceProvider(cliServer, qs, dbm)
+  );
+
 }
 
 function getContextStoragePath(ctx: ExtensionContext) {


### PR DESCRIPTION
## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/master/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] `@github/product-docs-dsp` has been notified, we probably want to wait on https://github.com/github/semmle-docs/issues/5 before merging this.