### PR TITLE
Add error message when there are no definitions/references queries available.

### DIFF
--- a/extensions/ql-vscode/src/definitions.ts
+++ b/extensions/ql-vscode/src/definitions.ts
@@ -34,6 +34,13 @@ function tagOfKeyType(keyType: KeyType): string {
   }
 }
 
+function nameOfKeyType(keyType: KeyType): string {
+  switch (keyType) {
+    case KeyType.DefinitionQuery: return "definitions";
+    case KeyType.ReferenceQuery: return "references";
+  }
+}
+
 async function resolveQueries(cli: CodeQLCliServer, qlpack: string, keyType: KeyType): Promise<string[]> {
   const suiteFile = tmp.fileSync({ postfix: '.qls' }).name;
   const suiteYaml = { qlpack, include: { kind: 'definitions', 'tags contain': tagOfKeyType(keyType) } };
@@ -41,7 +48,10 @@ async function resolveQueries(cli: CodeQLCliServer, qlpack: string, keyType: Key
 
   const queries = await cli.resolveQueriesInSuite(suiteFile, helpers.getOnDiskWorkspaceFolders());
   if (queries.length === 0) {
-    throw new Error("Couldn't find any queries for qlpack");
+    vscode.window.showErrorMessage(
+      `No ${nameOfKeyType(keyType)} queries (tagged "${tagOfKeyType(keyType)}") could be found in the current library path. It might be necessary to upgrade the CodeQL libraries.`
+    );
+    throw new Error(`Couldn't find any queries tagged ${tagOfKeyType(keyType)} for qlpack ${qlpack}`);
   }
   return queries;
 }


### PR DESCRIPTION
Turns out we were already raising an exception, but the `DefinitionProvider`/`ReferencesProvider` helpfully silently swallows raised exceptions. (well, they get logged to console, but that's as good as silent from the average user's perspective). I don't see any way to suppress the 'zero definitions/references found' popup, but at least we can clarify *why* zero were found with this message.

I included the specific tag that's being looked for by the extension, since I think it might potentially help advanced users debug what's going on in the event that the issue is *not* merely upgrading, but the queries being missing or improperly located or something because of some future refactoring. 

Fixes #387.