### PR TITLE
Add onEnterRules for language config

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CodeQL for Visual Studio Code: Changelog
 
+## 1.2.1
+
+- Better formatting and autoindentation when adding qldoc comments to `.ql` and `.qll` files.
+
 ## 1.2.0 - 19 May 2020
 
 - Enable 'Go to Definition' and 'Go to References' on source archive

--- a/extensions/ql-vscode/language-configuration.json
+++ b/extensions/ql-vscode/language-configuration.json
@@ -1,72 +1,38 @@
 {
-    "comments": {
-        // symbol used for single line comment. Remove this entry if your language does not support line comments
-        "lineComment": "//",
-        // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
-        "blockComment": [
-            "/*",
-            "*/"
-        ]
-    },
-    // symbols used as brackets
-    "brackets": [
-        [
-            "{",
-            "}"
-        ],
-        [
-            "[",
-            "]"
-        ],
-        [
-            "(",
-            ")"
-        ]
-    ],
-    // symbols that are auto closed when typing
-    "autoClosingPairs": [
-        [
-            "{",
-            "}"
-        ],
-        [
-            "[",
-            "]"
-        ],
-        [
-            "(",
-            ")"
-        ],
-        [
-            "\"",
-            "\""
-        ],
-        [
-            "'",
-            "'"
-        ]
-    ],
-    // symbols that that can be used to surround a selection
-    "surroundingPairs": [
-        [
-            "{",
-            "}"
-        ],
-        [
-            "[",
-            "]"
-        ],
-        [
-            "(",
-            ")"
-        ],
-        [
-            "\"",
-            "\""
-        ],
-        [
-            "'",
-            "'"
-        ]
-    ]
+  "comments": {
+    "lineComment": "//",
+    "blockComment": ["/*", "*/"]
+  },
+  "brackets": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"]
+  ],
+  "autoClosingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "[", "close": "]" },
+    { "open": "(", "close": ")" },
+    { "open": "'", "close": "'", "notIn": ["string", "comment"] },
+    { "open": "\"", "close": "\"", "notIn": ["string"] },
+    { "open": "/**", "close": " */", "notIn": ["string"] }
+  ],
+  "autoCloseBefore": ";:.=}])> \n\t",
+  "surroundingPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"],
+    ["'", "'"],
+    ["\"", "\""]
+  ],
+  "folding": {
+    "markers": {
+      "start": "^\\s*//\\s*#?region\\b",
+      "end": "^\\s*//\\s*#?endregion\\b"
+    }
+  },
+  "wordPattern": "(-?\\d*\\.\\d\\w*)|([^\\~\\!\\@\\#\\%\\^\\&\\*\\(\\)\\-\\=\\+\\[\\{\\]\\}\\\\\\|\\;\\:\\'\\\"\\.\\<\\>\\/\\?\\s]+)",
+  "indentationRules": {
+    "increaseIndentPattern": "^((?!.*?\\/\\*).*\\*/)?\\s*[\\}\\]].*$",
+    "decreaseIndentPattern": "^((?!\\/\\/).)*(\\{[^}\"']*|\\([^)\"']*|\\[[^\\]\"']*)$"
+  }
 }

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -4,6 +4,7 @@ import { testExplorerExtensionId, TestHub } from 'vscode-test-adapter-api';
 import * as archiveFilesystemProvider from './archive-filesystem-provider';
 import { CodeQLCliServer } from './cli';
 import { DistributionConfigListener, QueryHistoryConfigListener, QueryServerConfigListener } from './config';
+import * as languageSupport from './languageSupport';
 import { DatabaseManager } from './databases';
 import { DatabaseUI } from './databases-ui';
 import { TemplateQueryDefinitionProvider, TemplateQueryReferenceProvider } from './definitions';
@@ -78,6 +79,7 @@ export async function activate(ctx: ExtensionContext): Promise<void> {
   logger.log('Starting CodeQL extension');
 
   initializeLogging(ctx);
+  languageSupport.install();
 
   const distributionConfigListener = new DistributionConfigListener();
   ctx.subscriptions.push(distributionConfigListener);

--- a/extensions/ql-vscode/src/languageSupport.ts
+++ b/extensions/ql-vscode/src/languageSupport.ts
@@ -1,0 +1,52 @@
+import { IndentAction, languages } from "vscode";
+
+
+/**
+ * OnEnterRules are available in language-configurations, but you cannot specify them in the language-configuration.json.
+ * They can only be specified programmatically.
+ *
+ * Also, we should keep the language-configuration.json as a json file and register it in the package.json because
+ * it is registered first, before the extension is activated, so language features are available quicker.
+ *
+ * See https://github.com/microsoft/vscode/issues/11514
+ * See https://github.com/microsoft/vscode/blob/master/src/vs/editor/test/common/modes/supports/javascriptOnEnterRules.ts
+ */
+export function install() {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const langConfig = require('../language-configuration.json');
+  // setLanguageConfiguration requires a regexp for the wordpattern, not a string
+  langConfig.wordPattern = new RegExp(langConfig.wordPattern);
+  langConfig.onEnterRules = onEnterRules;
+
+  languages.setLanguageConfiguration('ql', langConfig);
+  languages.setLanguageConfiguration('qll', langConfig);
+  languages.setLanguageConfiguration('dbscheme', langConfig);
+
+}
+
+const onEnterRules = [
+  {
+    // e.g. /** | */
+    beforeText: /^\s*\/\*\*(?!\/)([^\*]|\*(?!\/))*$/,
+    afterText: /^\s*\*\/$/,
+    action: { indentAction: IndentAction.IndentOutdent, appendText: ' * ' }
+  }, {
+    // e.g. /** ...|
+    beforeText: /^\s*\/\*\*(?!\/)([^\*]|\*(?!\/))*$/,
+    action: { indentAction: IndentAction.None, appendText: ' * ' }
+  }, {
+    // e.g.  * ...|
+    beforeText: /^(\t|[ ])*[ ]\*([ ]([^\*]|\*(?!\/))*)?$/,
+    oneLineAboveText: /^(\s*(\/\*\*|\*)).*/,
+    action: { indentAction: IndentAction.None, appendText: '* ' }
+  }, {
+    // e.g.  */|
+    beforeText: /^(\t|[ ])*[ ]\*\/\s*$/,
+    action: { indentAction: IndentAction.None, removeText: 1 }
+  },
+  {
+    // e.g.  *-----*/|
+    beforeText: /^(\t|[ ])*[ ]\*[^/]*\*\/\s*$/,
+    action: { indentAction: IndentAction.None, removeText: 1 }
+  }
+];


### PR DESCRIPTION
This change provides proper indent/outdent for block comments. Through
onEnterRules. Because onEnterRules are not exactly API, I had to use
a back door to implement them.

Also, it tweaks the language-configuration.json by adding more support
for things like word boundaries and auto-closing pairs.

Since QL has similar syntactical items as JavaScriot, I started with
the JS lang config and removed single quotes and back ticks.

Fixes #171 

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/master/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] `@github/product-docs-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
