### PR TITLE
Add node v14 to allowed node versions

### DIFF
--- a/rush.json
+++ b/rush.json
@@ -9,7 +9,8 @@
   "pnpmOptions": {
     "strictPeerDependencies": true
   },
-  "nodeSupportedVersionRange": ">=10.13.0 <13.0.0",
+  "nodeSupportedVersionRange": ">=10.13.0 <15.0.0",
+  "suppressNodeLtsWarning": true,
   "ensureConsistentVersions": true,
   "projectFolderMinDepth": 2,
   "projectFolderMaxDepth": 2,


### PR DESCRIPTION
Small PR to help local development on new versions of node. You'll still get a warning, but at least it will work.