### PR TITLE
Only look for codeql.zip assets

### DIFF
--- a/extensions/ql-vscode/src/distribution.ts
+++ b/extensions/ql-vscode/src/distribution.ts
@@ -327,8 +327,13 @@ class ExtensionSpecificDistributionManager {
 
   private async getLatestRelease(): Promise<Release> {
     const release = await this.createReleasesApiConsumer().getLatestRelease(this._versionConstraint, this._config.includePrerelease);
-    if (release.assets.length !== 1) {
-      throw new Error("Release had an unexpected number of assets");
+    // FIXME: Look for platform-specific codeql distribution if available
+    release.assets = release.assets.filter(asset => asset.name === 'codeql.zip');
+    if (release.assets.length === 0) {
+      throw new Error("Release had no asset named codeql.zip");
+    }
+    else if (release.assets.length > 1) {
+      throw new Error("Release had more than one asset named codeql.zip");
     }
     return release;
   }


### PR DESCRIPTION
There are now multiple release assets available. Make sure we don't
throw an error when looking for the codeql distribution.

Fixes https://github.com/github/vscode-codeql/issues/419.