### PR TITLE
Download platform-specific releases if they are available.

### DIFF
--- a/extensions/ql-vscode/src/distribution.ts
+++ b/extensions/ql-vscode/src/distribution.ts
@@ -377,7 +377,7 @@ class ExtensionSpecificDistributionManager {
       release => {
         const matchingAssets = release.assets.filter(asset => asset.name === requiredAssetName);
         if (matchingAssets.length === 0) {
-          // For example, this could be a release with only platform-specific assets.
+          // For example, this could be a release with no platform-specific assets.
           logger.log(`INFO: Ignoring a release with no assets named ${requiredAssetName}`);
           return false;
         }

--- a/extensions/ql-vscode/src/distribution.ts
+++ b/extensions/ql-vscode/src/distribution.ts
@@ -378,7 +378,7 @@ class ExtensionSpecificDistributionManager {
   private async getLatestRelease(): Promise<Release> {
     const requiredAssetName = this.getRequiredAssetName();
     logger.log(`Searching for latest release including ${requiredAssetName}. `);
-    const release = await this.createReleasesApiConsumer().getLatestRelease(
+    return this.createReleasesApiConsumer().getLatestRelease(
       this._versionRange,
       this._config.includePrerelease,
       release => {

--- a/extensions/ql-vscode/src/distribution.ts
+++ b/extensions/ql-vscode/src/distribution.ts
@@ -377,7 +377,7 @@ class ExtensionSpecificDistributionManager {
 
   private async getLatestRelease(): Promise<Release> {
     const requiredAssetName = this.getRequiredAssetName();
-    logger.log(`Searching for latest release including ${requiredAssetName}. `);
+    logger.log(`Searching for latest release including ${requiredAssetName}.`);
     return this.createReleasesApiConsumer().getLatestRelease(
       this._versionRange,
       this._config.includePrerelease,

--- a/extensions/ql-vscode/src/distribution.ts
+++ b/extensions/ql-vscode/src/distribution.ts
@@ -395,7 +395,6 @@ class ExtensionSpecificDistributionManager {
         return true;
       }
     );
-    return release;
   }
 
   private createReleasesApiConsumer(): ReleasesApiConsumer {

--- a/extensions/ql-vscode/src/distribution.ts
+++ b/extensions/ql-vscode/src/distribution.ts
@@ -308,7 +308,7 @@ class ExtensionSpecificDistributionManager {
         assets.map(asset => asset.name).join(', '));
     }
 
-    const assetStream = await this.createReleasesApiConsumer().streamBinaryContentOfAsset(release.assets[0]);
+    const assetStream = await this.createReleasesApiConsumer().streamBinaryContentOfAsset(assets[0]);
     const tmpDirectory = await fs.mkdtemp(path.join(os.tmpdir(), "vscode-codeql"));
 
     try {


### PR DESCRIPTION
Choose platform-specific release asset based on platform, falling back
to `codeql.zip` if platform is unknown, or platform-specific release
asset is unavailable.