### PR TITLE
Chore: Retry tests more aggressively on windows

### DIFF
--- a/extensions/ql-vscode/src/vscode-tests/run-integration-tests.ts
+++ b/extensions/ql-vscode/src/vscode-tests/run-integration-tests.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import * as os from 'os';
 import { runTests } from 'vscode-test';
 
 // A subset of the fields in TestOptions from vscode-test, which we
@@ -23,6 +24,11 @@ async function runTestsWithRetryOnSegfault(suite: Suite, tries: number): Promise
     } catch (err) {
       if (err === 'SIGSEGV') {
         console.error('Test runner segfaulted.');
+        if (t < tries - 1)
+          console.error('Retrying...');
+      }
+      else if (os.platform() === 'win32') {
+        console.error(`Test runner caught exception (${err})`);
         if (t < tries - 1)
           console.error('Retrying...');
       }


### PR DESCRIPTION
There are some flaky CI test failures that manifest only as a message
like

    [main 2020-06-01T16:09:47.671Z] [VS Code]: render process crashed!

(and only afaict on windows) which I am not sure how to detect at the
moment. If that message is occurring in the exception caught at this
stage, we can check for it.