### PR TITLE
Use semver instead of homegrown version data.

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -26,6 +26,7 @@ dependencies:
   '@types/react': 16.9.23
   '@types/react-dom': 16.9.5
   '@types/sarif': 2.1.2
+  '@types/semver': 7.2.0
   '@types/sinon': 7.5.2
   '@types/sinon-chai': 3.2.3
   '@types/through2': 2.0.34
@@ -68,6 +69,7 @@ dependencies:
   react: 16.13.0
   react-dom: 16.13.0_react@16.13.0
   reflect-metadata: 0.1.13
+  semver: 7.3.2
   sinon: 9.0.1
   sinon-chai: 3.5.0_chai@4.2.0+sinon@9.0.1
   style-loader: 0.23.1
@@ -508,6 +510,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-TELZl5h48KaB6SFZqTuaMEw1hrGuusbBcH+yfMaaHdS2pwDr3RTH4CVN0LyY1kqSiDm9PPvAMx8FJ0LUZreOCQ==
+  /@types/semver/7.2.0:
+    dependencies:
+      '@types/node': 12.12.30
+    dev: false
+    resolution:
+      integrity: sha512-TbB0A8ACUWZt3Y6bQPstW9QNbhNeebdgLX4T/ZfkrswAfUzRiXrgd9seol+X379Wa589Pu4UEx9Uok0D4RjRCQ==
   /@types/sinon-chai/3.2.3:
     dependencies:
       '@types/chai': 4.2.11
@@ -6210,6 +6218,13 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+  /semver/7.3.2:
+    dev: false
+    engines:
+      node: '>=10'
+    hasBin: true
+    resolution:
+      integrity: sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
   /serialize-javascript/2.1.2:
     dev: false
     resolution:
@@ -7921,6 +7936,7 @@ packages:
       '@types/react': 16.9.23
       '@types/react-dom': 16.9.5
       '@types/sarif': 2.1.2
+      '@types/semver': 7.2.0
       '@types/sinon': 7.5.2
       '@types/sinon-chai': 3.2.3
       '@types/tmp': 0.1.0
@@ -7955,6 +7971,7 @@ packages:
       proxyquire: 2.1.3
       react: 16.13.0
       react-dom: 16.13.0_react@16.13.0
+      semver: 7.3.2
       sinon: 9.0.1
       sinon-chai: 3.5.0_chai@4.2.0+sinon@9.0.1
       style-loader: 0.23.1
@@ -7978,7 +7995,7 @@ packages:
     dev: false
     name: '@rush-temp/vscode-codeql'
     resolution:
-      integrity: sha512-ClyrIRqnMYMmVHtHvW8MvS4GrRSt/dXY3lxBpxSv3wSJ67pEvWKea+DJyeVN2zaHz1/7gAOWQHhwBz6O3lEq6w==
+      integrity: sha512-fFiBMYIWAoxYSQdmNOwJKO9IowYr66ZE3eX2ric645oK7mAPZQ+yX/jiOo71jzmtV0DvPMZAmFGAxmg7yHOHAQ==
       tarball: 'file:projects/vscode-codeql.tgz'
     version: 0.0.0
 registry: ''
@@ -8010,6 +8027,7 @@ specifiers:
   '@types/react': ^16.8.17
   '@types/react-dom': ^16.8.4
   '@types/sarif': ~2.1.2
+  '@types/semver': ~7.2.0
   '@types/sinon': ~7.5.2
   '@types/sinon-chai': ~3.2.3
   '@types/through2': ~2.0.34
@@ -8052,6 +8070,7 @@ specifiers:
   react: ^16.8.6
   react-dom: ^16.8.6
   reflect-metadata: ~0.1.13
+  semver: ~7.3.2
   sinon: ~9.0.0
   sinon-chai: ~3.5.0
   style-loader: ~0.23.1

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -590,7 +590,8 @@
     "vscode-languageclient": "^6.1.3",
     "vscode-test-adapter-api": "~1.7.0",
     "vscode-test-adapter-util": "~0.7.0",
-    "minimist": "~1.2.5"
+    "minimist": "~1.2.5",
+    "semver": "~7.3.2"
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",
@@ -649,7 +650,8 @@
     "eslint-plugin-react": "~7.19.0",
     "husky": "~4.2.5",
     "lint-staged": "~10.2.2",
-    "prettier": "~2.0.5"
+    "prettier": "~2.0.5",
+    "@types/semver": "~7.2.0"
   },
   "husky": {
     "hooks": {

--- a/extensions/ql-vscode/src/cli-version.ts
+++ b/extensions/ql-vscode/src/cli-version.ts
@@ -1,10 +1,11 @@
+import { parse, SemVer } from 'semver';
 import { runCodeQlCliCommand } from "./cli";
 import { Logger } from "./logging";
 
 /**
  * Get the version of a CodeQL CLI.
  */
-export async function getCodeQlCliVersion(codeQlPath: string, logger: Logger): Promise<Version | undefined> {
+export async function getCodeQlCliVersion(codeQlPath: string, logger: Logger): Promise<SemVer | null> {
   const output: string = await runCodeQlCliCommand(
     codeQlPath,
     ["version"],
@@ -12,85 +13,5 @@ export async function getCodeQlCliVersion(codeQlPath: string, logger: Logger): P
     "Checking CodeQL version",
     logger
   );
-  return tryParseVersionString(output.trim());
-}
-
-/**
- * Try to parse a version string, returning undefined if we can't parse it.
- * 
- * Version strings must contain a major, minor, and patch version.  They may optionally
- * start with "v" and may optionally contain some "tail" string after the major, minor, and
- * patch versions, for example as in `v2.1.0+baf5bff`.
- */
-export function tryParseVersionString(versionString: string): Version | undefined {
-  const match = versionString.match(versionRegex);
-  if (match === null) {
-    return undefined;
-  }
-  return {
-    buildMetadata: match[5],
-    majorVersion: Number.parseInt(match[1], 10),
-    minorVersion: Number.parseInt(match[2], 10),
-    patchVersion: Number.parseInt(match[3], 10),
-    prereleaseVersion: match[4],
-    rawString: versionString,
-  };
-}
-
-/**
- * Regex for parsing semantic versions
- * 
- * From the semver spec https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
- */
-const versionRegex = new RegExp(String.raw`^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)` +
-  String.raw`(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?` +
-  String.raw`(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`);
-
-/**
- * A version of the CodeQL CLI.
- */
-export interface Version {
-  /**
-   * Build metadata
-   * 
-   * For example, this will be `abcdef0` for version 2.1.0-alpha.1+abcdef0.
-   * Build metadata must be ignored when comparing versions. 
-   */
-  buildMetadata: string | undefined;
-
-  /**
-   * Major version number
-   * 
-   * For example, this will be `2` for version 2.1.0-alpha.1+abcdef0.
-   */
-  majorVersion: number;
-
-  /**
-   * Minor version number
-   * 
-   * For example, this will be `1` for version 2.1.0-alpha.1+abcdef0.
-   */
-  minorVersion: number;
-
-  /**
-   * Patch version number
-   * 
-   * For example, this will be `0` for version 2.1.0-alpha.1+abcdef0.
-   */
-  patchVersion: number;
-
-  /**
-   * Prerelease version
-   * 
-   * For example, this will be `alpha.1` for version 2.1.0-alpha.1+abcdef0.
-   * The prerelease version must be considered when comparing versions.
-   */
-  prereleaseVersion: string | undefined;
-
-  /**
-   * Raw version string
-   * 
-   * For example, this will be `2.1.0-alpha.1+abcdef0` for version 2.1.0-alpha.1+abcdef0.
-   */
-  rawString: string;
+  return parse(output.trim());
 }

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -182,7 +182,7 @@ export async function activate(ctx: ExtensionContext): Promise<void> {
     const result = await distributionManager.getDistribution();
     switch (result.kind) {
       case FindDistributionResultKind.CompatibleDistribution:
-        logger.log(`Found compatible version of CodeQL CLI (version ${result.version.rawString})`);
+        logger.log(`Found compatible version of CodeQL CLI (version ${result.version.raw})`);
         break;
       case FindDistributionResultKind.IncompatibleDistribution:
         helpers.showAndLogWarningMessage("The current version of the CodeQL CLI is incompatible with this extension.");

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/cli-version.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/cli-version.test.ts
@@ -1,50 +1,50 @@
 import { expect } from "chai";
 import "mocha";
-import { tryParseVersionString } from "../../cli-version";
+import { parse } from "semver";
 
 describe("Version parsing", () => {
   it("should accept version without prerelease and build metadata", () => {
-    const v = tryParseVersionString("3.2.4")!;
-    expect(v.majorVersion).to.equal(3);
-    expect(v.minorVersion).to.equal(2);
-    expect(v.patchVersion).to.equal(4);
-    expect(v.prereleaseVersion).to.be.undefined;
-    expect(v.buildMetadata).to.be.undefined;
+    const v = parse("3.2.4")!;
+    expect(v.major).to.equal(3);
+    expect(v.minor).to.equal(2);
+    expect(v.patch).to.equal(4);
+    expect(v.prerelease).to.eql([]);
+    expect(v.build).to.eql([]);
   });
 
   it("should accept v at the beginning of the version", () => {
-    const v = tryParseVersionString("v3.2.4")!;
-    expect(v.majorVersion).to.equal(3);
-    expect(v.minorVersion).to.equal(2);
-    expect(v.patchVersion).to.equal(4);
-    expect(v.prereleaseVersion).to.be.undefined;
-    expect(v.buildMetadata).to.be.undefined;
+    const v = parse("v3.2.4")!;
+    expect(v.major).to.equal(3);
+    expect(v.minor).to.equal(2);
+    expect(v.patch).to.equal(4);
+    expect(v.prerelease).to.eql([]);
+    expect(v.build).to.eql([]);
   });
 
   it("should accept version with prerelease", () => {
-    const v = tryParseVersionString("v3.2.4-alpha.0")!;
-    expect(v.majorVersion).to.equal(3);
-    expect(v.minorVersion).to.equal(2);
-    expect(v.patchVersion).to.equal(4);
-    expect(v.prereleaseVersion).to.equal("alpha.0");
-    expect(v.buildMetadata).to.be.undefined;
+    const v = parse("v3.2.4-alpha0")!;
+    expect(v.major).to.equal(3);
+    expect(v.minor).to.equal(2);
+    expect(v.patch).to.equal(4);
+    expect(v.prerelease).to.eql(["alpha0"]);
+    expect(v.build).to.eql([]);
   });
 
   it("should accept version with prerelease and build metadata", () => {
-    const v = tryParseVersionString("v3.2.4-alpha.0+abcdef0")!;
-    expect(v.majorVersion).to.equal(3);
-    expect(v.minorVersion).to.equal(2);
-    expect(v.patchVersion).to.equal(4);
-    expect(v.prereleaseVersion).to.equal("alpha.0");
-    expect(v.buildMetadata).to.equal("abcdef0");
+    const v = parse("v3.2.4-alpha0+abcdef0")!;
+    expect(v.major).to.equal(3);
+    expect(v.minor).to.equal(2);
+    expect(v.patch).to.equal(4);
+    expect(v.prerelease).to.eql(["alpha0"]);
+    expect(v.build).to.eql(["abcdef0"]);
   });
 
   it("should accept version with build metadata", () => {
-    const v = tryParseVersionString("v3.2.4+abcdef0")!;
-    expect(v.majorVersion).to.equal(3);
-    expect(v.minorVersion).to.equal(2);
-    expect(v.patchVersion).to.equal(4);
-    expect(v.prereleaseVersion).to.be.undefined;
-    expect(v.buildMetadata).to.equal("abcdef0");
+    const v = parse("v3.2.4+abcdef0")!;
+    expect(v.major).to.equal(3);
+    expect(v.minor).to.equal(2);
+    expect(v.patch).to.equal(4);
+    expect(v.prerelease).to.eql([]);
+    expect(v.build).to.eql(["abcdef0"]);
   });
 });


### PR DESCRIPTION
Two assumptions that were true before that are no longer true:
 - That a prelease string may contain '.'. The `semver` module parses
   this as a delimiter between multiple prerelease specifiers.

       > semver.parse('v1.0.0-a.0')
       SemVer {
         options: { loose: false, includePrerelease: false },
         loose: false,
         includePrerelease: false,
         raw: 'v1.0.0-a.0',
         major: 1,
         minor: 0,
         patch: 0,
         prerelease: [ 'a', 0 ],
         build: [],
         version: '1.0.0-a.0' }

 - That a missing prerelease or build specifier is represented
   as `undefined`. It's now represented as `[]`.

I don't think either of these cause problems, but I'm noting them here
in case anyone can think of a reason why they might.