### PR TITLE
Ask user to open sarif file externally when too large

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Report error when selecting invalid database.
 - Add descriptive message for database archive import failure.
 - Respect VSCode's i18n locale setting when formatting dates and sorting strings.
+- Allow the opening of large Sarif files externally from VSCode.
 
 ## 1.2.2 - 8 June 2020
 

--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -118,7 +118,7 @@ export async function showBinaryChoiceDialog(message: string): Promise<boolean> 
   const yesItem = { title: 'Yes', isCloseAffordance: false };
   const noItem = { title: 'No', isCloseAffordance: true };
   const chosenItem = await Window.showInformationMessage(message, { modal: true }, yesItem, noItem);
-  return chosenItem?.title === 'Yes';
+  return chosenItem?.title === yesItem.title;
 }
 
 /**

--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -118,7 +118,7 @@ export async function showBinaryChoiceDialog(message: string): Promise<boolean> 
   const yesItem = { title: 'Yes', isCloseAffordance: false };
   const noItem = { title: 'No', isCloseAffordance: true };
   const chosenItem = await Window.showInformationMessage(message, { modal: true }, yesItem, noItem);
-  return chosenItem === yesItem;
+  return chosenItem?.title === 'Yes';
 }
 
 /**

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/query-hstory.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/query-hstory.test.ts
@@ -1,0 +1,84 @@
+import * as chai from "chai";
+import "mocha";
+import * as vscode from "vscode";
+import * as sinon from "sinon";
+// import * as sinonChai from 'sinon-chai';
+import * as chaiAsPromised from "chai-as-promised";
+import { logger } from "../../logging";
+import { QueryHistoryManager } from "../../query-history";
+
+chai.use(chaiAsPromised);
+const expect = chai.expect;
+
+
+
+describe('query-history', () => {
+
+  describe("tryOpenExternalFile", () => {
+    let showTextDocumentSpy: sinon.SinonStub;
+    let showInformationMessageSpy: sinon.SinonStub;
+    let executeCommandSpy: sinon.SinonStub;
+    let logSpy: sinon.SinonStub;
+
+    let tryOpenExternalFile: Function;
+
+    beforeEach(() => {
+      showTextDocumentSpy = sinon.stub(vscode.window, "showTextDocument");
+      showInformationMessageSpy = sinon.stub(
+        vscode.window,
+        "showInformationMessage"
+      );
+      executeCommandSpy = sinon.stub(vscode.commands, "executeCommand");
+      logSpy = sinon.stub(logger, "log");
+      tryOpenExternalFile = (QueryHistoryManager.prototype as any).tryOpenExternalFile;
+      logSpy;
+      executeCommandSpy;
+    });
+
+    afterEach(() => {
+      (vscode.window.showTextDocument as sinon.SinonStub).restore();
+      (vscode.commands.executeCommand as sinon.SinonStub).restore();
+      (logger.log as sinon.SinonStub).restore();
+      (vscode.window.showInformationMessage as sinon.SinonStub).restore();
+    });
+
+    it("should open an external file", async () => {
+      await tryOpenExternalFile('xxx');
+      expect(showTextDocumentSpy).to.have.been.calledOnceWith(
+        vscode.Uri.file('xxx')
+      );
+      expect(executeCommandSpy).not.to.have.been.called;
+    });
+
+    [
+      "too large to open",
+      "Files above 50MB cannot be synchronized with extensions",
+    ].forEach(msg => {
+      it(`should fail to open a file because "${msg}" and open externally`, async () => {
+        showTextDocumentSpy.throws(new Error(msg));
+        showInformationMessageSpy.returns({ title: "Yes" });
+
+        await tryOpenExternalFile("xxx");
+        const uri = vscode.Uri.file("xxx");
+        expect(showTextDocumentSpy).to.have.been.calledOnceWith(
+          uri
+        );
+        expect(executeCommandSpy).to.have.been.calledOnceWith(
+          "revealFileInOS",
+          uri
+        );
+      });
+
+      it(`should fail to open a file because "${msg}" and NOT open externally`, async () => {
+        showTextDocumentSpy.throws(new Error(msg));
+        showInformationMessageSpy.returns({ title: "No" });
+
+        await tryOpenExternalFile("xxx");
+        const uri = vscode.Uri.file("xxx");
+        expect(showTextDocumentSpy).to.have.been.calledOnceWith(uri);
+        expect(showInformationMessageSpy).to.have.been.called;
+        expect(executeCommandSpy).not.to.have.been.called;
+      });
+    });
+  });
+});


### PR DESCRIPTION
Use the same mechanism that we are using for log files to open
large sarif files. This is because the extension is not
capable of opening large (>50MB) files due to vscode restrictions.

Fixes #418.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/master/CONTRIBUTING.md#submitting-a-pull-request.
-->

Replace this with a description of the changes your pull request makes.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/master/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] `@github/product-docs-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
