### PR TITLE
Explicitly use the workspace-configured locale

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Report error when selecting invalid database.
 - Add descriptive message for database archive import failure.
+- Respect VSCode's i18n locale setting when formatting dates and sorting strings.
 
 ## 1.2.2 - 8 June 2020
 

--- a/extensions/ql-vscode/src/databases-ui.ts
+++ b/extensions/ql-vscode/src/databases-ui.ts
@@ -1,6 +1,8 @@
 import * as path from 'path';
 import { DisposableObject } from '@github/codeql-vscode-utils';
 import { commands, Event, EventEmitter, ExtensionContext, ProviderResult, TreeDataProvider, TreeItem, Uri, window, env } from 'vscode';
+import * as fs from 'fs-extra';
+
 import * as cli from './cli';
 import { DatabaseItem, DatabaseManager, getUpgradesDirectories } from './databases';
 import { getOnDiskWorkspaceFolders, showAndLogErrorMessage } from './helpers';
@@ -9,7 +11,6 @@ import { clearCacheInDatabase, UserCancellationException } from './run-queries';
 import * as qsClient from './queryserver-client';
 import { upgradeDatabase } from './upgrades';
 import { importArchiveDatabase, promptImportInternetDatabase, promptImportLgtmDatabase } from './databaseFetcher';
-import * as fs from 'fs-extra';
 
 type ThemableIconPath = { light: string; dark: string } | string;
 
@@ -98,9 +99,9 @@ class DatabaseTreeDataProvider extends DisposableObject
       return this.databaseManager.databaseItems.slice(0).sort((db1, db2) => {
         switch (this.sortOrder) {
           case SortOrder.NameAsc:
-            return db1.name.localeCompare(db2.name);
+            return db1.name.localeCompare(db2.name, env.language);
           case SortOrder.NameDesc:
-            return db2.name.localeCompare(db1.name);
+            return db2.name.localeCompare(db1.name, env.language);
           case SortOrder.DateAddedAsc:
             return (db1.dateAdded || 0) - (db2.dateAdded || 0);
           case SortOrder.DateAddedDesc:

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -1,4 +1,4 @@
-import { commands, Disposable, ExtensionContext, extensions, languages, ProgressLocation, ProgressOptions, Uri, window as Window } from 'vscode';
+import { commands, Disposable, ExtensionContext, extensions, languages, ProgressLocation, ProgressOptions, Uri, window as Window, env } from 'vscode';
 import { LanguageClient } from 'vscode-languageclient';
 import { testExplorerExtensionId, TestHub } from 'vscode-test-adapter-api';
 import * as archiveFilesystemProvider from './archive-filesystem-provider';
@@ -178,7 +178,7 @@ export async function activate(ctx: ExtensionContext): Promise<void> {
 
       if (e instanceof GithubRateLimitedError) {
         alertFunction(`Rate limited while trying to ${taskDescription}. Please try again after ` +
-          `your rate limit window resets at ${e.rateLimitResetDate.toLocaleString()}.`);
+          `your rate limit window resets at ${e.rateLimitResetDate.toLocaleString(env.language)}.`);
       } else if (e instanceof GithubApiError) {
         alertFunction(`Encountered GitHub API error while trying to ${taskDescription}. ` + e);
       }

--- a/extensions/ql-vscode/src/interface.ts
+++ b/extensions/ql-vscode/src/interface.ts
@@ -4,8 +4,9 @@ import * as Sarif from 'sarif';
 import { FivePartLocation, LocationStyle, LocationValue, ResolvableLocationValue, tryGetResolvableLocation, WholeFileLocation } from 'semmle-bqrs';
 import { DisposableObject } from '@github/codeql-vscode-utils';
 import * as vscode from 'vscode';
-import { Diagnostic, DiagnosticRelatedInformation, DiagnosticSeverity, languages, Location, Range, Uri, window as Window, workspace } from 'vscode';
+import { Diagnostic, DiagnosticRelatedInformation, DiagnosticSeverity, languages, Location, Range, Uri, window as Window, workspace, env } from 'vscode';
 import * as cli from './cli';
+
 import { CodeQLCliServer } from './cli';
 import { DatabaseItem, DatabaseManager } from './databases';
 import { showAndLogErrorMessage } from './helpers';
@@ -108,7 +109,7 @@ function sortInterpretedResults(results: Sarif.Result[], sortState: InterpretedR
         results.sort((a, b) =>
           a.message.text === undefined ? 0 :
             b.message.text === undefined ? 0 :
-              multiplier * (a.message.text?.localeCompare(b.message.text)));
+              multiplier * (a.message.text?.localeCompare(b.message.text, env.language)));
         break;
       default:
         assertNever(sortState.sortBy);

--- a/extensions/ql-vscode/src/qltest-discovery.ts
+++ b/extensions/ql-vscode/src/qltest-discovery.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import { QLPackDiscovery } from './qlpack-discovery';
 import { Discovery } from './discovery';
-import { EventEmitter, Event, Uri, RelativePattern } from 'vscode';
+import { EventEmitter, Event, Uri, RelativePattern, env } from 'vscode';
 import { MultiFileSystemWatcher } from '@github/codeql-vscode-utils';
 import { CodeQLCliServer } from './cli';
 
@@ -55,7 +55,7 @@ export class QLTestDirectory extends QLTestNode {
   }
 
   public finish(): void {
-    this._children.sort((a, b) => a.name.localeCompare(b.name));
+    this._children.sort((a, b) => a.name.localeCompare(b.name, env.language));
     for (const child of this._children) {
       child.finish();
     }

--- a/extensions/ql-vscode/src/query-results.ts
+++ b/extensions/ql-vscode/src/query-results.ts
@@ -1,3 +1,5 @@
+import { env } from 'vscode';
+
 import { QueryWithResults, tmpDir, QueryInfo } from "./run-queries";
 import * as messages from './messages';
 import * as helpers from './helpers';
@@ -43,7 +45,7 @@ export class CompletedQuery implements QueryWithResults {
     this.options = evaluation.options;
     this.dispose = evaluation.dispose;
 
-    this.time = new Date().toLocaleString();
+    this.time = new Date().toLocaleString(env.language);
     this.sortedResultsInfo = new Map();
   }
 

--- a/extensions/ql-vscode/src/run-queries.ts
+++ b/extensions/ql-vscode/src/run-queries.ts
@@ -226,7 +226,9 @@ async function convertToQlPath(filePath: string): Promise<string> {
       const fileName = path.basename(filePath);
       const fileNames = await promisify<string, string[]>(fs.readdir)(dir);
       for (const name of fileNames) {
-        // leave the locale argument empty so that the default OS locale is used.
+        // Leave the locale argument empty so that the default OS locale is used.
+        // We do this because this operation works on filesystem entities, which
+        // use the os locale, regardless of the locale of the running VS Code instance.
         if (fileName.localeCompare(name, undefined, { sensitivity: 'accent' }) === 0) {
           return path.join(dir, name);
         }

--- a/extensions/ql-vscode/src/run-queries.ts
+++ b/extensions/ql-vscode/src/run-queries.ts
@@ -226,6 +226,7 @@ async function convertToQlPath(filePath: string): Promise<string> {
       const fileName = path.basename(filePath);
       const fileNames = await promisify<string, string[]>(fs.readdir)(dir);
       for (const name of fileNames) {
+        // leave the locale argument empty so that the default OS locale is used.
         if (fileName.localeCompare(name, undefined, { sensitivity: 'accent' }) === 0) {
           return path.join(dir, name);
         }


### PR DESCRIPTION
When the `env.language` value is not passed as the locale, OS-default
locale is used. This change ensures that we use the workspace locale
where we want and explicitly calls out where we should continue to use
the OS-default.

Fixes #440.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/master/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] `@github/product-docs-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
