### PR TITLE
Force undefined version if version command fails

### DIFF
--- a/extensions/ql-vscode/src/cli-version.ts
+++ b/extensions/ql-vscode/src/cli-version.ts
@@ -6,12 +6,19 @@ import { Logger } from "./logging";
  * Get the version of a CodeQL CLI.
  */
 export async function getCodeQlCliVersion(codeQlPath: string, logger: Logger): Promise<semver.SemVer | undefined> {
-  const output: string = await runCodeQlCliCommand(
-    codeQlPath,
-    ["version"],
-    ["--format=terse"],
-    "Checking CodeQL version",
-    logger
-  );
-  return semver.parse(output.trim()) || undefined;
+  try {
+    const output: string = await runCodeQlCliCommand(
+      codeQlPath,
+      ["version"],
+      ["--format=terse"],
+      "Checking CodeQL version",
+      logger
+    );
+    return semver.parse(output.trim()) || undefined;
+  } catch (e) {
+    // Failed to run the version command. This might happen if the cli version is _really_ old, or it is corrupted.
+    // Either way, we can't determine compatibility.
+    logger.log(`Failed to run 'codeql version'. Reason: ${e.message}`);
+    return undefined;
+  }
 }

--- a/extensions/ql-vscode/src/distribution.ts
+++ b/extensions/ql-vscode/src/distribution.ts
@@ -80,15 +80,15 @@ export class DistributionManager implements DistributionProvider {
 
     /**
      * Specifies whether prerelease versions of the CodeQL CLI should be accepted.
-     * 
+     *
      * Suppose a user sets the includePrerelease config option, obtains a prerelease, then decides
      * they no longer want a prerelease, so unsets the includePrerelease config option.
      * Unsetting the includePrerelease config option should trigger an update check, and this
      * update check should present them an update that returns them back to a non-prerelease
      * version.
-     * 
+     *
      * Therefore, we adopt the following:
-     * 
+     *
      * - If the user is managing their own CLI, they can use a prerelease without specifying the
      * includePrerelease option.
      * - If the user is using an extension-managed CLI, then prereleases are only accepted when the


### PR DESCRIPTION
The assumption is that the cli is old or corrupted. In either case we want to upgrade.
