### PR TITLE
Use `Open` instead of `Extract` to open zip files

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CodeQL for Visual Studio Code: Changelog
 
+## [Unreleased]
+
+- Fix unzipping of large files.
+
 ## 1.3.0 - 22 June 2020
 
 - Report error when selecting invalid database.

--- a/extensions/ql-vscode/src/databaseFetcher.ts
+++ b/extensions/ql-vscode/src/databaseFetcher.ts
@@ -9,6 +9,7 @@ import {
 } from 'vscode';
 import * as fs from 'fs-extra';
 import * as path from 'path';
+
 import { DatabaseManager, DatabaseItem } from './databases';
 import {
   ProgressCallback,
@@ -261,19 +262,9 @@ function validateHttpsUrl(databaseUrl: string) {
 }
 
 async function readAndUnzip(databaseUrl: string, unzipPath: string) {
-  const unzipStream = unzipper.Extract({
-    path: unzipPath,
-  });
-
-  await new Promise((resolve, reject) => {
-    // we already know this is a file scheme
-    const databaseFile = Uri.parse(databaseUrl).fsPath;
-    const stream = fs.createReadStream(databaseFile);
-    stream.on('error', reject);
-    unzipStream.on('error', reject);
-    unzipStream.on('close', resolve);
-    stream.pipe(unzipStream);
-  });
+  const databaseFile = Uri.parse(databaseUrl).fsPath;
+  const directory = await unzipper.Open.file(databaseFile);
+  await directory.extract({ path: unzipPath });
 }
 
 async function fetchAndUnzip(
@@ -288,6 +279,7 @@ async function fetchAndUnzip(
   const unzipStream = unzipper.Extract({
     path: unzipPath,
   });
+
   progressCallback?.({
     maxStep: 3,
     message: 'Unzipping database',


### PR DESCRIPTION
This allows opening zip files whose local headers are not correct.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Fixes #468.


## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] `@github/product-docs-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
