### PR TITLE
Ensure query compare order matches expectation

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fix unzipping of large files.
+- Ensure compare order is consistent when selecting two queries to compare. The first query selected is always the _from_ query and the query selected later is always the _to_ query.
 
 ## 1.3.0 - 22 June 2020
 

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
@@ -169,6 +169,42 @@ describe('query-history', () => {
       }
     });
   });
+
+  describe('updateCompareWith', () => {
+    it('should update compareWithItem when there is a single item', () => {
+      const queryHistory = createMockQueryHistory([]);
+      queryHistory.updateCompareWith(['a']);
+      expect(queryHistory.compareWithItem).to.be.eq('a');
+    });
+
+    it('should delete compareWithItem when there are 0 items', () => {
+      const queryHistory = createMockQueryHistory([]);
+      queryHistory.compareWithItem = 'a';
+      queryHistory.updateCompareWith([]);
+      expect(queryHistory.compareWithItem).to.be.undefined;
+    });
+
+    it('should delete compareWithItem when there are more than 2 items', () => {
+      const queryHistory = createMockQueryHistory([]);
+      queryHistory.compareWithItem = 'a';
+      queryHistory.updateCompareWith(['a', 'b', 'c']);
+      expect(queryHistory.compareWithItem).to.be.undefined;
+    });
+
+    it('should delete compareWithItem when there are 2 items and disjoint from compareWithItem', () => {
+      const queryHistory = createMockQueryHistory([]);
+      queryHistory.compareWithItem = 'a';
+      queryHistory.updateCompareWith(['b', 'c']);
+      expect(queryHistory.compareWithItem).to.be.undefined;
+    });
+
+    it('should do nothing when compareWithItem exists and exactly 2 items', () => {
+      const queryHistory = createMockQueryHistory([]);
+      queryHistory.compareWithItem = 'a';
+      queryHistory.updateCompareWith(['a', 'b']);
+      expect(queryHistory.compareWithItem).to.be.eq('a');
+    });
+  });
 });
 
 function createMockQueryHistory(allHistory: {}[]) {
@@ -177,6 +213,8 @@ function createMockQueryHistory(allHistory: {}[]) {
     findOtherQueryToCompare: (QueryHistoryManager.prototype as any).findOtherQueryToCompare,
     treeDataProvider: {
       allHistory
-    }
+    },
+    updateCompareWith: (QueryHistoryManager.prototype as any).updateCompareWith,
+    compareWithItem: undefined as undefined | string,
   };
 }


### PR DESCRIPTION
A user typically expects that the first selection would be
the query that they are comparing _from_ and the second query
is being compared _to_.

This commit ensures that something like this expectation will
always hold.

So, when there are two queries selected, the first one selected
will always be _from_ and appear on the left side of the compare
view. The one selected later will be _to_ and appear on the right.

There is a corner case when there are 3 or more selected queries
and a user *unselects* a query. We do not track the selection
order of the remaining two queries.

Fixes #470.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] `@github/product-docs-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
