### PR TITLE
Allow pagination for interpreted results

### DIFF
--- a/extensions/ql-vscode/src/adapt.ts
+++ b/extensions/ql-vscode/src/adapt.ts
@@ -1,5 +1,6 @@
 import { DecodedBqrsChunk, ResultSetSchema, ColumnKind, Column, ColumnValue } from './bqrs-cli-types';
 import { LocationValue, ResultSetSchema as AdaptedSchema, ColumnSchema, ColumnType, LocationStyle } from 'semmle-bqrs';
+import { ResultSet } from './interface-types';
 
 // FIXME: This is a temporary bit of impedance matching to convert
 // from the types provided by ./bqrs-cli-types, to the types used by
@@ -130,5 +131,5 @@ export interface ExtensionParsedResultSets {
   numPages: number;
   selectedTable?: string; // when undefined, means 'show default table'
   resultSetNames: string[];
-  resultSet: RawResultSet;
+  resultSet: ResultSet;
 }

--- a/extensions/ql-vscode/src/adapt.ts
+++ b/extensions/ql-vscode/src/adapt.ts
@@ -129,6 +129,7 @@ export interface ExtensionParsedResultSets {
   t: 'ExtensionParsed';
   pageNumber: number;
   numPages: number;
+  numInterpretedPages: number;
   selectedTable?: string; // when undefined, means 'show default table'
   resultSetNames: string[];
   resultSet: ResultSet;

--- a/extensions/ql-vscode/src/interface-types.ts
+++ b/extensions/ql-vscode/src/interface-types.ts
@@ -24,11 +24,6 @@ export type PathTableResultSet = {
 export type ResultSet = RawTableResultSet | PathTableResultSet;
 
 /**
- * Only ever show this many results per run in interpreted results.
- */
-export const INTERPRETED_RESULTS_PER_RUN_LIMIT = 100;
-
-/**
  * Only ever show this many rows in a raw result table.
  */
 export const RAW_RESULTS_LIMIT = 10000;

--- a/extensions/ql-vscode/src/interface-types.ts
+++ b/extensions/ql-vscode/src/interface-types.ts
@@ -121,6 +121,7 @@ export interface ShowInterpretedPageMsg {
   metadata?: QueryMetadata;
   pageNumber: number;
   numPages: number;
+  resultSetNames: string[];
 }
 
 /** Advance to the next or previous path no in the path viewer */

--- a/extensions/ql-vscode/src/interface-types.ts
+++ b/extensions/ql-vscode/src/interface-types.ts
@@ -38,6 +38,11 @@ export const RAW_RESULTS_LIMIT = 10000;
  */
 export const RAW_RESULTS_PAGE_SIZE = 100;
 
+/**
+ * Show this many rows in an interpreted results table at a time.
+ */
+export const INTERPRETED_RESULTS_PAGE_SIZE = 100;
+
 export interface DatabaseInfo {
   name: string;
   databaseUri: string;

--- a/extensions/ql-vscode/src/interface-types.ts
+++ b/extensions/ql-vscode/src/interface-types.ts
@@ -113,6 +113,13 @@ export interface SetStateMsg {
   parsedResultSets: ParsedResultSets;
 }
 
+export interface ShowInterpretedPageMsg {
+  t: 'showInterpretedPage';
+  interpretation: Interpretation;
+  pageNumber: number;
+  totalPages: number;
+}
+
 /** Advance to the next or previous path no in the path viewer */
 export interface NavigatePathMsg {
   t: 'navigatePath';
@@ -124,6 +131,7 @@ export interface NavigatePathMsg {
 export type IntoResultsViewMsg =
   | ResultsUpdatingMsg
   | SetStateMsg
+  | ShowInterpretedPageMsg
   | NavigatePathMsg;
 
 export type FromResultsViewMsg =

--- a/extensions/ql-vscode/src/interface-types.ts
+++ b/extensions/ql-vscode/src/interface-types.ts
@@ -61,6 +61,7 @@ export interface PreviousExecution {
 export interface Interpretation {
   sourceLocationPrefix: string;
   numTruncatedResults: number;
+  numTotalResults: number;
   /**
    * sortState being undefined means don't sort, just present results in the order
    * they appear in the sarif file.

--- a/extensions/ql-vscode/src/interface-types.ts
+++ b/extensions/ql-vscode/src/interface-types.ts
@@ -116,8 +116,10 @@ export interface SetStateMsg {
 export interface ShowInterpretedPageMsg {
   t: 'showInterpretedPage';
   interpretation: Interpretation;
+  database: DatabaseInfo;
+  metadata?: QueryMetadata;
   pageNumber: number;
-  totalPages: number;
+  numPages: number;
 }
 
 /** Advance to the next or previous path no in the path viewer */

--- a/extensions/ql-vscode/src/interface.ts
+++ b/extensions/ql-vscode/src/interface.ts
@@ -407,7 +407,7 @@ export class InterfaceManager extends DisposableObject {
       database: this._displayedQuery.database,
       metadata: this._displayedQuery.query.metadata,
       pageNumber,
-      totalPages: Math.ceil(this._interpretation.sarif.runs[0].results.length / INTERPRETED_RESULTS_PAGE_SIZE),
+      numPages: Math.ceil(this._interpretation.sarif.runs[0].results.length / INTERPRETED_RESULTS_PAGE_SIZE),
     });
   }
 

--- a/extensions/ql-vscode/src/interface.ts
+++ b/extensions/ql-vscode/src/interface.ts
@@ -392,6 +392,9 @@ export class InterfaceManager extends DisposableObject {
   public async showPageOfInterpretedResults(
     pageNumber: number
   ): Promise<void> {
+    if (this._displayedQuery === undefined) {
+      throw new Error(`Trying to show interpreted results but displayed query was undefined`);
+    }
     if (this._interpretation === undefined) {
       throw new Error(`Trying to show interpreted results but interpretation was undefined`);
     }
@@ -401,6 +404,8 @@ export class InterfaceManager extends DisposableObject {
     await this.postMessage({
       t: 'showInterpretedPage',
       interpretation: this.getPageOfInterpretedResults(pageNumber),
+      database: this._displayedQuery.database,
+      metadata: this._displayedQuery.query.metadata,
       pageNumber,
       totalPages: Math.ceil(this._interpretation.sarif.runs[0].results.length / INTERPRETED_RESULTS_PAGE_SIZE),
     });

--- a/extensions/ql-vscode/src/interface.ts
+++ b/extensions/ql-vscode/src/interface.ts
@@ -362,7 +362,7 @@ export class InterfaceManager extends DisposableObject {
           t: 'ExtensionParsed',
           pageNumber: 0,
           numPages: numPagesOfResultSet(resultSet),
-          resultSet,
+          resultSet: { t: 'RawResultSet', ...resultSet },
           selectedTable: undefined,
           resultSetNames,
         };
@@ -456,7 +456,7 @@ export class InterfaceManager extends DisposableObject {
     const parsedResultSets: ParsedResultSets = {
       t: 'ExtensionParsed',
       pageNumber,
-      resultSet,
+      resultSet: { t: 'RawResultSet', ...resultSet },
       numPages: numPagesOfResultSet(resultSet),
       selectedTable: selectedTable,
       resultSetNames,

--- a/extensions/ql-vscode/src/interface.ts
+++ b/extensions/ql-vscode/src/interface.ts
@@ -388,13 +388,13 @@ export class InterfaceManager extends DisposableObject {
     pageNumber: number
   ): Promise<void> {
     if (this._displayedQuery === undefined) {
-      throw new Error(`Trying to show interpreted results but displayed query was undefined`);
+      throw new Error('Trying to show interpreted results but displayed query was undefined');
     }
     if (this._interpretation === undefined) {
-      throw new Error(`Trying to show interpreted results but interpretation was undefined`);
+      throw new Error('Trying to show interpreted results but interpretation was undefined');
     }
     if (this._interpretation.sarif.runs[0].results === undefined) {
-      throw new Error(`Trying to show interpreted results but results were undefined`);
+      throw new Error('Trying to show interpreted results but results were undefined');
     }
 
     const resultSetSchemas = await this.getResultSetSchemas(this._displayedQuery);
@@ -524,7 +524,7 @@ export class InterfaceManager extends DisposableObject {
           INTERPRETED_RESULTS_PAGE_SIZE * pageNumber,
           INTERPRETED_RESULTS_PAGE_SIZE * (pageNumber + 1)
         )
-      }
+      };
     }
 
     if (this._interpretation === undefined) {
@@ -537,7 +537,7 @@ export class InterfaceManager extends DisposableObject {
     return {
       ...interp,
       sarif: { ...interp.sarif, runs: [getPageOfRun(interp.sarif.runs[0])] },
-    }
+    };
   }
 
   private async interpretResultsInfo(

--- a/extensions/ql-vscode/src/interface.ts
+++ b/extensions/ql-vscode/src/interface.ts
@@ -494,10 +494,18 @@ export class InterfaceManager extends DisposableObject {
       if (run.results !== undefined)
         sortInterpretedResults(run.results, sortState);
     });
+
+    const numTotalResults = (() => {
+      if (sarif.runs.length === 0) return 0;
+      if (sarif.runs[0].results === undefined) return 0;
+      return sarif.runs[0].results.length;
+    })();
+
     const interpretation: Interpretation = {
       sarif,
       sourceLocationPrefix,
       numTruncatedResults: 0,
+      numTotalResults,
       sortState,
     };
     this._interpretation = interpretation;

--- a/extensions/ql-vscode/src/interface.ts
+++ b/extensions/ql-vscode/src/interface.ts
@@ -294,7 +294,8 @@ export class InterfaceManager extends DisposableObject {
       return;
     }
 
-    const interpretation = await this.interpretResultsInfo(
+    this._interpretation = undefined;
+    const interpretationPage = await this.interpretResultsInfo(
       results.query,
       results.interpretedResultsSortState
     );
@@ -372,7 +373,7 @@ export class InterfaceManager extends DisposableObject {
 
     await this.postMessage({
       t: 'setState',
-      interpretation,
+      interpretation: interpretationPage,
       origResultsPaths: results.query.resultsPaths,
       resultsPath: this.convertPathToWebviewUri(
         results.query.resultsPaths.resultsPath
@@ -580,7 +581,7 @@ export class InterfaceManager extends DisposableObject {
         );
       }
     }
-    return this.getPageOfInterpretedResults(0);
+    return this._interpretation && this.getPageOfInterpretedResults(0);
   }
 
   private async showResultsAsDiagnostics(

--- a/extensions/ql-vscode/src/interface.ts
+++ b/extensions/ql-vscode/src/interface.ts
@@ -97,6 +97,10 @@ function numPagesOfResultSet(resultSet: RawResultSet): number {
   return Math.ceil(resultSet.schema.tupleCount / RAW_RESULTS_PAGE_SIZE);
 }
 
+function numInterpretedPages(interpretation: Interpretation | undefined): number {
+  return Math.ceil((interpretation?.sarif.runs[0].results?.length || 0) / INTERPRETED_RESULTS_PAGE_SIZE);
+}
+
 export class InterfaceManager extends DisposableObject {
   private _displayedQuery?: CompletedQuery;
   private _interpretation?: Interpretation;
@@ -352,11 +356,11 @@ export class InterfaceManager extends DisposableObject {
         );
         const adaptedSchema = adaptSchema(schema);
         const resultSet = adaptBqrs(adaptedSchema, chunk);
-
         return {
           t: 'ExtensionParsed',
           pageNumber: 0,
           numPages: numPagesOfResultSet(resultSet),
+          numInterpretedPages: numInterpretedPages(this._interpretation),
           resultSet: { t: 'RawResultSet', ...resultSet },
           selectedTable: undefined,
           resultSetNames,
@@ -407,7 +411,7 @@ export class InterfaceManager extends DisposableObject {
       metadata: this._displayedQuery.query.metadata,
       pageNumber,
       resultSetNames,
-      numPages: Math.ceil(this._interpretation.sarif.runs[0].results.length / INTERPRETED_RESULTS_PAGE_SIZE),
+      numPages: numInterpretedPages(this._interpretation),
     });
   }
 
@@ -460,6 +464,7 @@ export class InterfaceManager extends DisposableObject {
       pageNumber,
       resultSet: { t: 'RawResultSet', ...resultSet },
       numPages: numPagesOfResultSet(resultSet),
+      numInterpretedPages: numInterpretedPages(this._interpretation),
       selectedTable: selectedTable,
       resultSetNames,
     };

--- a/extensions/ql-vscode/src/view/result-tables.tsx
+++ b/extensions/ql-vscode/src/view/result-tables.tsx
@@ -68,13 +68,13 @@ function renderResultCountString(resultSet: ResultSet): JSX.Element {
 export class ResultTables
   extends React.Component<ResultTablesProps, ResultTablesState> {
 
-  private static _getResultSetsOfProps(props: ResultTablesProps): ResultSet[] {
+  private getResultSets(): ResultSet[] {
     const resultSets: ResultSet[] =
       // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
       // @ts-ignore 2783
-      props.rawResultSets.map((rs) => ({ t: 'RawResultSet', ...rs }));
+      this.props.rawResultSets.map((rs) => ({ t: 'RawResultSet', ...rs }));
 
-    if (props.interpretation != undefined) {
+    if (this.props.interpretation != undefined) {
       resultSets.push({
         t: 'SarifResultSet',
         // FIXME: The values of version, columns, tupleCount are
@@ -83,14 +83,10 @@ export class ResultTables
         // out.
         schema: { name: ALERTS_TABLE_NAME, version: 0, columns: [], tupleCount: 1 },
         name: ALERTS_TABLE_NAME,
-        ...props.interpretation,
+        ...this.props.interpretation,
       });
     }
     return resultSets;
-  }
-
-  private getResultSets(): ResultSet[] {
-    return ResultTables._getResultSetsOfProps(this.props);
   }
 
   private getResultSetNames(resultSets: ResultSet[]): string[] {
@@ -114,12 +110,7 @@ export class ResultTables
 
   constructor(props: ResultTablesProps) {
     super(props);
-    this.state = ResultTables.getDerivedStateFromProps(props);
-  }
-
-  // Static lifecycle method which is called by react when props change.
-  static getDerivedStateFromProps(props: Readonly<ResultTablesProps>, _prevState?: ResultTablesState): ResultTablesState {
-    const selectedTable = props.parsedResultSets.selectedTable || getDefaultResultSet(ResultTables._getResultSetsOfProps(props));
+    const selectedTable = props.parsedResultSets.selectedTable || getDefaultResultSet(this.getResultSets());
     let selectedPage: string;
 
     switch (props.parsedResultSets.t) {
@@ -130,7 +121,7 @@ export class ResultTables
         selectedPage = '';
         break;
     }
-    return { selectedTable, selectedPage };
+    this.state = { selectedTable, selectedPage };
   }
 
   private onTableSelectionChange = (event: React.ChangeEvent<HTMLSelectElement>): void => {

--- a/extensions/ql-vscode/src/view/result-tables.tsx
+++ b/extensions/ql-vscode/src/view/result-tables.tsx
@@ -50,9 +50,7 @@ function getResultCount(resultSet: ResultSet): number {
     case 'RawResultSet':
       return resultSet.schema.tupleCount;
     case 'SarifResultSet':
-      if (resultSet.sarif.runs.length === 0) return 0;
-      if (resultSet.sarif.runs[0].results === undefined) return 0;
-      return resultSet.sarif.runs[0].results.length + resultSet.numTruncatedResults;
+      return resultSet.numTotalResults;
   }
 }
 

--- a/extensions/ql-vscode/src/view/result-tables.tsx
+++ b/extensions/ql-vscode/src/view/result-tables.tsx
@@ -112,14 +112,6 @@ export class ResultTables
     return this.props.parsedResultSets.t === 'ExtensionParsed';
   }
 
-  /**
-   * Holds if we actually should show pagination interface right now. This is
-   * true as long as the result sets we're given are marked to permit it.
-   */
-  paginationEnabled(): boolean {
-    return this.paginationAllowed();
-  }
-
   constructor(props: ResultTablesProps) {
     super(props);
     this.state = ResultTables.getDerivedStateFromProps(props);
@@ -232,7 +224,7 @@ export class ResultTables
   }
 
   renderButtons(): JSX.Element {
-    if (this.props.parsedResultSets.t === 'ExtensionParsed' && this.paginationEnabled())
+    if (this.props.parsedResultSets.t === 'ExtensionParsed' && this.paginationAllowed())
       return this.renderPageButtons(this.props.parsedResultSets);
     else
       return <span />;

--- a/extensions/ql-vscode/src/view/result-tables.tsx
+++ b/extensions/ql-vscode/src/view/result-tables.tsx
@@ -112,12 +112,10 @@ export class ResultTables
 
   /**
    * Holds if we actually should show pagination interface right now. This is
-   * still false for the time being when we're viewing alerts.
+   * true as long as the result sets we're given are marked to permit it.
    */
   paginationEnabled(): boolean {
-    return this.paginationAllowed() &&
-      this.props.parsedResultSets.selectedTable !== ALERTS_TABLE_NAME &&
-      this.state.selectedTable !== ALERTS_TABLE_NAME;
+    return this.paginationAllowed()
   }
 
   constructor(props: ResultTablesProps) {

--- a/extensions/ql-vscode/src/view/result-tables.tsx
+++ b/extensions/ql-vscode/src/view/result-tables.tsx
@@ -117,7 +117,7 @@ export class ResultTables
    * true as long as the result sets we're given are marked to permit it.
    */
   paginationEnabled(): boolean {
-    return this.paginationAllowed()
+    return this.paginationAllowed();
   }
 
   constructor(props: ResultTablesProps) {

--- a/extensions/ql-vscode/src/view/result-tables.tsx
+++ b/extensions/ql-vscode/src/view/result-tables.tsx
@@ -143,9 +143,8 @@ export class ResultTables
 
   private onTableSelectionChange = (event: React.ChangeEvent<HTMLSelectElement>): void => {
     const selectedTable = event.target.value;
-    const fetchPageFromExtension = this.paginationAllowed() && selectedTable !== ALERTS_TABLE_NAME;
 
-    if (fetchPageFromExtension) {
+    if (this.paginationAllowed()) {
       vscode.postMessage({
         t: 'changePage',
         pageNumber: 0,

--- a/extensions/ql-vscode/src/view/result-tables.tsx
+++ b/extensions/ql-vscode/src/view/result-tables.tsx
@@ -224,6 +224,7 @@ export class ResultTables
         onBlur={e => choosePage(e.target.value)}
         onKeyDown={e => { if (e.keyCode === 13) choosePage((e.target as HTMLInputElement).value); }}
       />
+      / {resultSets.numPages}
       <button value=">" onClick={nextPage} >&gt;</button>
     </span>;
   }

--- a/extensions/ql-vscode/src/view/results.tsx
+++ b/extensions/ql-vscode/src/view/results.tsx
@@ -202,6 +202,7 @@ class App extends React.Component<{}, ResultsViewState> {
           parsedResultSets: {
             t: 'ExtensionParsed',
             numPages: msg.numPages,
+            numInterpretedPages: msg.numPages,
             resultSetNames: msg.resultSetNames,
             pageNumber: msg.pageNumber,
             resultSet: {

--- a/extensions/ql-vscode/src/view/results.tsx
+++ b/extensions/ql-vscode/src/view/results.tsx
@@ -197,7 +197,7 @@ class App extends React.Component<{}, ResultsViewState> {
         this.loadResults();
         break;
       case 'showInterpretedPage':
-        const resultsInfo: ResultsInfo = {
+        this.updateStateWithNewResultsInfo({
           resultsPath: '', // FIXME: Not used for interpreted, refactor so this is not needed
           parsedResultSets: {
             t: 'ExtensionParsed',
@@ -218,8 +218,7 @@ class App extends React.Component<{}, ResultsViewState> {
           interpretation: msg.interpretation,
           shouldKeepOldResultsWhileRendering: true,
           metadata: msg.metadata,
-        };
-        this.updateStateWithNewResultsInfo(resultsInfo);
+        });
         this.loadResults();
         break;
       case 'resultsUpdating':

--- a/extensions/ql-vscode/src/view/results.tsx
+++ b/extensions/ql-vscode/src/view/results.tsx
@@ -197,23 +197,30 @@ class App extends React.Component<{}, ResultsViewState> {
         this.loadResults();
         break;
       case 'showInterpretedPage':
-        this.updateStateWithNewResultsInfo({
+        const resultsInfo: ResultsInfo = {
           resultsPath: '...', // XXX
           parsedResultSets: {
             t: 'ExtensionParsed',
             numPages: msg.numPages,
             resultSetNames: ['alerts'], // XXX get the other result set names from the extension
             pageNumber: msg.pageNumber,
-            resultSet: undefined as any, // XXX this is awkward
+            resultSet: {
+              t: 'SarifResultSet',
+              name: ALERTS_TABLE_NAME,
+              schema: { name: ALERTS_TABLE_NAME, version: 0, columns: [], tupleCount: 1 },
+              ...msg.interpretation,
+            },
             selectedTable: ALERTS_TABLE_NAME,
           },
           origResultsPaths: undefined as any,
-          sortedResultsMap: undefined as any,
+          sortedResultsMap: new Map(), // XXX ?
           database: msg.database,
           interpretation: msg.interpretation,
-          shouldKeepOldResultsWhileRendering: false,
+          shouldKeepOldResultsWhileRendering: true,
           metadata: msg.metadata,
-        });
+        };
+        this.updateStateWithNewResultsInfo(resultsInfo);
+        this.loadResults();
         break;
       case 'resultsUpdating':
         this.setState({

--- a/extensions/ql-vscode/src/view/results.tsx
+++ b/extensions/ql-vscode/src/view/results.tsx
@@ -195,6 +195,9 @@ class App extends React.Component<{}, ResultsViewState> {
 
         this.loadResults();
         break;
+      case 'showInterpretedPage':
+        // TODO: show interpreted page
+        break;
       case 'resultsUpdating':
         this.setState({
           isExpectingResultsUpdate: true,

--- a/extensions/ql-vscode/src/view/results.tsx
+++ b/extensions/ql-vscode/src/view/results.tsx
@@ -17,6 +17,7 @@ import {
   NavigatePathMsg,
   QueryMetadata,
   ResultsPaths,
+  ALERTS_TABLE_NAME,
 } from '../interface-types';
 import { EventHandlers as EventHandlerList } from './event-handler-list';
 import { ResultTables } from './result-tables';
@@ -196,7 +197,23 @@ class App extends React.Component<{}, ResultsViewState> {
         this.loadResults();
         break;
       case 'showInterpretedPage':
-        // TODO: show interpreted page
+        this.updateStateWithNewResultsInfo({
+          resultsPath: '...', // XXX
+          parsedResultSets: {
+            t: 'ExtensionParsed',
+            numPages: msg.numPages,
+            resultSetNames: ['alerts'], // XXX get the other result set names from the extension
+            pageNumber: msg.pageNumber,
+            resultSet: undefined as any, // XXX this is awkward
+            selectedTable: ALERTS_TABLE_NAME,
+          },
+          origResultsPaths: undefined as any,
+          sortedResultsMap: undefined as any,
+          database: msg.database,
+          interpretation: msg.interpretation,
+          shouldKeepOldResultsWhileRendering: false,
+          metadata: msg.metadata,
+        });
         break;
       case 'resultsUpdating':
         this.setState({

--- a/extensions/ql-vscode/src/view/results.tsx
+++ b/extensions/ql-vscode/src/view/results.tsx
@@ -198,11 +198,11 @@ class App extends React.Component<{}, ResultsViewState> {
         break;
       case 'showInterpretedPage':
         const resultsInfo: ResultsInfo = {
-          resultsPath: '...', // XXX
+          resultsPath: '', // FIXME: Not used for interpreted, refactor so this is not needed
           parsedResultSets: {
             t: 'ExtensionParsed',
             numPages: msg.numPages,
-            resultSetNames: ['alerts'], // XXX get the other result set names from the extension
+            resultSetNames: msg.resultSetNames,
             pageNumber: msg.pageNumber,
             resultSet: {
               t: 'SarifResultSet',
@@ -212,8 +212,8 @@ class App extends React.Component<{}, ResultsViewState> {
             },
             selectedTable: ALERTS_TABLE_NAME,
           },
-          origResultsPaths: undefined as any,
-          sortedResultsMap: new Map(), // XXX ?
+          origResultsPaths: undefined as any, // FIXME: Not used for interpreted, refactor so this is not needed
+          sortedResultsMap: new Map(), // FIXME: Not used for interpreted, refactor so this is not needed
           database: msg.database,
           interpretation: msg.interpretation,
           shouldKeepOldResultsWhileRendering: true,

--- a/extensions/ql-vscode/src/view/results.tsx
+++ b/extensions/ql-vscode/src/view/results.tsx
@@ -368,8 +368,10 @@ class App extends React.Component<{}, ResultsViewState> {
       displayedResults.resultsInfo !== null
     ) {
       const parsedResultSets = displayedResults.resultsInfo.parsedResultSets;
+      const key = (parsedResultSets.t === 'ExtensionParsed' ? (parsedResultSets.selectedTable || '') + parsedResultSets.pageNumber : '');
       return (
         <ResultTables
+          key={key}
           parsedResultSets={parsedResultSets}
           rawResultSets={displayedResults.results.resultSets}
           interpretation={


### PR DESCRIPTION
Enable pagination for interpreted as well as raw results.

This is still under feature flag, so no user-facing changes quite yet, but the flag can possibly be enabled for everyone once this lands. There will be a number of code cleanups available at that point.