### PR TITLE
Augments the pagination styling

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Ensure compare order is consistent when selecting two queries to compare. The first query selected is always the _from_ query and the query selected later is always the _to_ query.
 - Ensure added databases have zipped source locations for databases added as archives or downloaded from the internet.
 - Fix bug where it is not possible to add databases starting with `db-*`.
+- Change styling of pagination section of the results page.
 
 ## 1.3.0 - 22 June 2020
 

--- a/extensions/ql-vscode/src/view/result-tables.tsx
+++ b/extensions/ql-vscode/src/view/result-tables.tsx
@@ -213,14 +213,20 @@ export class ResultTables
       });
     };
 
-    return <span>
-      <button onClick={prevPage} >&lt;</button>
-      <input size={3} value={this.state.selectedPage} onChange={onChange}
+    return <span className="vscode-codeql__table-selection-header">
+      <button onClick={prevPage} >&#xab;</button>
+      <input
+        type="number"
+        size={3}
+        value={this.state.selectedPage}
+        onChange={onChange}
         onBlur={e => choosePage(e.target.value)}
         onKeyDown={e => { if (e.keyCode === 13) choosePage((e.target as HTMLInputElement).value); }}
       />
-      / {numPages}
-      <button value=">" onClick={nextPage} >&gt;</button>
+      <span>
+        / {numPages}
+      </span>
+      <button value=">" onClick={nextPage} >&#xbb;</button>
     </span>;
   }
 

--- a/extensions/ql-vscode/src/view/resultsView.css
+++ b/extensions/ql-vscode/src/view/resultsView.css
@@ -7,16 +7,47 @@
 .vscode-codeql__table-selection-header {
   display: flex;
   padding: 0.5em 0;
+  align-items: center;
 }
 
 .vscode-codeql__table-selection-header select {
   border: 0;
 }
 
+.vscode-codeql__table-selection-header button {
+  padding: 0.3rem;
+  margin: 0.2rem;
+  border-radius: 5px;
+  color: var(--vscode-editor-foreground);
+  background-color: var(--vscode-editorGutter-background);
+  cursor: pointer;
+  opacity: 0.8;
+}
+
+.vscode-codeql__table-selection-header button:hover {
+  opacity: 1;
+}
+
+.vscode-codeql__table-selection-header input[type="number"] {
+  border-radius: 0;
+  padding: 0.3rem;
+  margin: 0.2rem;
+  width: 2rem;
+  border-radius: 0;
+  color: var(--vscode-editor-foreground);
+  border: 0;
+  border-bottom: 1px solid var(--vscode-editor-foreground);
+  background-color: var(--vscode-editorGutter-background);
+  border-radius: 0;
+  outline: none;
+}
+
 .vscode-codeql__result-table-alert-extras {
   display: inline-block;
   text-align: left;
   margin-left: auto;
+  background-color: transparent;
+  color: inherit;
 }
 
 .vscode-codeql__result-table-toggle-diagnostics {
@@ -34,11 +65,11 @@
   margin: 3px 3px 1px 13px;
 }
 
-
 .vscode-codeql__result-table th {
   border-top: 1px solid rgba(88, 96, 105, 0.25);
   border-bottom: 1px solid rgba(88, 96, 105, 0.25);
-  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
+  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial,
+    sans-serif, Apple Color Emoji, Segoe UI Emoji;
   background: rgba(225, 228, 232, 0.25);
   padding: 0.25em 0.5em;
   text-align: center;
@@ -146,7 +177,7 @@ td.vscode-codeql__path-index-cell {
 
 .octicon {
   fill: var(--vscode-editor-foreground);
-  margin-top: .25em;
+  margin-top: 0.25em;
 }
 
 .octicon-light {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Some small changes that add consistency and modernizes the layout of the pagination section.

Should be based off of `jcreed:jcreed/interpreted-pagination` #481. This is light theme: 
<img width="167" alt="_Extension_Development_Host__-_CodeQL_Query_Results_—_vscode-codeql-starter__Workspace_" src="https://user-images.githubusercontent.com/363559/86403552-c9ff7380-bc62-11ea-8fb3-c213980ff79d.png">

And this is dark:
<img width="182" alt="_Extension_Development_Host__-_CodeQL_Query_Results_—_vscode-codeql-starter__Workspace_" src="https://user-images.githubusercontent.com/363559/86403594-de437080-bc62-11ea-8e35-6d1361bfae30.png">

I'm sure we could do better if we had an actual designer look at this, but this is probably good for now.

This is a follow-up review for #481.


## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] `@github/product-docs-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
