### PR TITLE
Fix broken launch config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -50,14 +50,13 @@
       "request": "launch",
       "runtimeExecutable": "${execPath}",
       "args": [
-        "${workspaceRoot}/extensions/ql-vscode/out/**/*.js",
+        "--extensionDevelopmentPath=${workspaceRoot}/extensions/ql-vscode",
         "--extensionTestsPath=${workspaceRoot}/extensions/ql-vscode/out/vscode-tests/no-workspace/index"
       ],
       "stopOnEntry": false,
       "sourceMaps": true,
       "outFiles": [
         "${workspaceRoot}/extensions/ql-vscode/out/**/*.js",
-        "${workspaceRoot}/extensions/ql-vscode/out/vscode-tests/**/*.js"
       ],
       "preLaunchTask": "Build"
     },
@@ -67,7 +66,7 @@
       "request": "launch",
       "runtimeExecutable": "${execPath}",
       "args": [
-        "${workspaceRoot}/extensions/ql-vscode/out/**/*.js",
+        "--extensionDevelopmentPath=${workspaceRoot}/extensions/ql-vscode",
         "--extensionTestsPath=${workspaceRoot}/extensions/ql-vscode/out/vscode-tests/minimal-workspace/index",
         "${workspaceRoot}/extensions/ql-vscode/test/data"
       ],
@@ -75,7 +74,6 @@
       "sourceMaps": true,
       "outFiles": [
         "${workspaceRoot}/extensions/ql-vscode/out/**/*.js",
-        "${workspaceRoot}/extensions/ql-vscode/out/vscode-tests/**/*.js"
       ],
       "preLaunchTask": "Build"
     }


### PR DESCRIPTION
We need to provide the `--extensionDevelopmentPath` flag in these
launch configurations.

It appears to be unnecessary to include
`${workspaceRoot}/extensions/ql-vscode/out/vscode-tests/**/*.js`
in addition to the strictly more general pattern
${workspaceRoot}/extensions/ql-vscode/out/**/*.js

An unfortunate UI fact appears to be that the log of the gulp build is
focused whenever these tasks are run, even though the log you actually
care about seeing is in the `Debug Console` section. Not sure how to
fix that.
