### PR TITLE
Fix AST viewer bug where nodes with id=0 did not have children

### DIFF
--- a/extensions/ql-vscode/src/contextual/astBuilder.ts
+++ b/extensions/ql-vscode/src/contextual/astBuilder.ts
@@ -92,14 +92,14 @@ export default class AstBuilder {
           };
 
           idToItem.set(id, item as RootAstItem);
-          const parent = idToItem.get(childToParent.get(id) || -1);
+          const parent = idToItem.get(childToParent.has(id) ? childToParent.get(id)! : -1);
 
           if (parent) {
             const astItem = item as AstItem;
             astItem.parent = parent;
             parent.children.push(astItem);
           }
-          const children = parentToChildren.get(id) || [];
+          const children = parentToChildren.has(id) ? parentToChildren.get(id)! : [];
           children.forEach(childId => {
             const child = idToItem.get(childId) as AstItem | undefined;
             if (child) {

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/contextual/astBuilder.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/contextual/astBuilder.test.ts
@@ -110,7 +110,7 @@ describe('AstBuilder', () => {
 
 const expectedRoots = [
   {
-    id: 26362,
+    id: 0,
     label: '[TopLevelFunction] int disable_interrupts()',
     location: {
       uri: 'file:/opt/src/arch/sandbox/lib/interrupts.c',

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/data/astBuilder.json
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/data/astBuilder.json
@@ -62,7 +62,7 @@
       ],
       [
         {
-          "id": 26362,
+          "id": 0,
           "label": "[TopLevelFunction] int disable_interrupts()",
           "url": {
             "uri": "file:/opt/src/arch/sandbox/lib/interrupts.c",
@@ -77,7 +77,7 @@
       ],
       [
         {
-          "id": 26362,
+          "id": 0,
           "label": "[TopLevelFunction] int disable_interrupts()",
           "url": {
             "uri": "file:/opt/src/arch/sandbox/lib/interrupts.c",
@@ -384,7 +384,7 @@
     "tuples": [
       [
         {
-          "id": 26362,
+          "id": 0,
           "label": "[TopLevelFunction] int disable_interrupts()",
           "url": {
             "uri": "file:/opt/src/arch/sandbox/lib/interrupts.c",
@@ -410,7 +410,7 @@
       ],
       [
         {
-          "id": 26362,
+          "id": 0,
           "label": "[TopLevelFunction] int disable_interrupts()",
           "url": {
             "uri": "file:/opt/src/arch/sandbox/lib/interrupts.c",
@@ -436,7 +436,7 @@
       ],
       [
         {
-          "id": 26362,
+          "id": 0,
           "label": "[TopLevelFunction] int disable_interrupts()",
           "url": {
             "uri": "file:/opt/src/arch/sandbox/lib/interrupts.c",
@@ -462,7 +462,7 @@
       ],
       [
         {
-          "id": 26362,
+          "id": 0,
           "label": "[TopLevelFunction] int disable_interrupts()",
           "url": {
             "uri": "file:/opt/src/arch/sandbox/lib/interrupts.c",
@@ -967,11 +967,6 @@
         "kind": "String"
       }
     ],
-    "tuples": [
-      [
-        "semmle.graphKind",
-        "tree"
-      ]
-    ]
+    "tuples": [["semmle.graphKind", "tree"]]
   }
 ]


### PR DESCRIPTION
Small bug I noticed when viewing AST of Go queries.