### PR TITLE
Remove reference to npx in luanch config

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -10,7 +10,7 @@
         "kind": "build",
         "isDefault": true
       },
-      "command": "npx gulp buildWithoutPackage --verbose",
+      "command": "npm run build",
       "options": {
         "cwd": "extensions/ql-vscode/"
       },


### PR DESCRIPTION
Users should not need to install npx in order to launch the extension. This also simplifies the launch script to use `npm` everywhere.