### PR TITLE
Filters qltest-discovery

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add the AST Viewer to inspect the QL AST of a source file in a database. Currently, only available for C/C++ sources.
 - Fix pagination when there are no results.
 - Suppress database downloaded from URL message when action canceled.
+- Fix QL test discovery to avoid showing duplicate tests in the test explorer.
 
 ## 1.3.1 - 7 July 2020
 

--- a/extensions/ql-vscode/src/discovery.ts
+++ b/extensions/ql-vscode/src/discovery.ts
@@ -1,4 +1,5 @@
 import { DisposableObject } from './vscode-utils/disposable-object';
+import { showAndLogErrorMessage } from './helpers';
 
 /**
  * Base class for "discovery" operations, which scan the file system to find specific kinds of
@@ -9,7 +10,7 @@ export abstract class Discovery<T> extends DisposableObject {
   private retry = false;
   private discoveryInProgress = false;
 
-  constructor() {
+  constructor(private readonly name: string) {
     super();
   }
 
@@ -59,6 +60,11 @@ export abstract class Discovery<T> extends DisposableObject {
         this.update(results);
       }
     });
+
+    discoveryPromise.catch(err => {
+      showAndLogErrorMessage(`${this.name} failed. Reason: ${err.message}`);
+    });
+
     discoveryPromise.finally(() => {
       if (this.retry) {
         // Another refresh request came in while we were still running a previous discovery

--- a/extensions/ql-vscode/src/qlpack-discovery.ts
+++ b/extensions/ql-vscode/src/qlpack-discovery.ts
@@ -20,7 +20,7 @@ export class QLPackDiscovery extends Discovery<QlpacksInfo> {
     private readonly workspaceFolder: WorkspaceFolder,
     private readonly cliServer: CodeQLCliServer
   ) {
-    super();
+    super('QL Pack Discovery');
 
     // Watch for any changes to `qlpack.yml` files in this workspace folder.
     // TODO: The CLI server should tell us what paths to watch for.

--- a/extensions/ql-vscode/src/qlpack-discovery.ts
+++ b/extensions/ql-vscode/src/qlpack-discovery.ts
@@ -16,9 +16,10 @@ export class QLPackDiscovery extends Discovery<QlpacksInfo> {
   private readonly watcher = this.push(new MultiFileSystemWatcher());
   private _qlPacks: readonly QLPack[] = [];
 
-  constructor(private readonly workspaceFolder: WorkspaceFolder,
-    private readonly cliServer: CodeQLCliServer) {
-
+  constructor(
+    private readonly workspaceFolder: WorkspaceFolder,
+    private readonly cliServer: CodeQLCliServer
+  ) {
     super();
 
     // Watch for any changes to `qlpack.yml` files in this workspace folder.
@@ -26,8 +27,6 @@ export class QLPackDiscovery extends Discovery<QlpacksInfo> {
     this.watcher.addWatch(new RelativePattern(this.workspaceFolder, '**/qlpack.yml'));
     this.watcher.addWatch(new RelativePattern(this.workspaceFolder, '**/.codeqlmanifest.json'));
     this.push(this.watcher.onDidChange(this.handleQLPackFileChanged, this));
-
-    this.refresh();
   }
 
   public get onDidChangeQLPacks(): Event<void> { return this._onDidChangeQLPacks.event; }

--- a/extensions/ql-vscode/src/qltest-discovery.ts
+++ b/extensions/ql-vscode/src/qltest-discovery.ts
@@ -119,7 +119,7 @@ export class QLTestDiscovery extends Discovery<QLTestDiscoveryResults> {
     private readonly workspaceFolder: WorkspaceFolder,
     private readonly cliServer: CodeQLCliServer
   ) {
-    super();
+    super('QL Test Discovery');
 
     this.push(this.qlPackDiscovery.onDidChangeQLPacks(this.handleDidChangeQLPacks, this));
     this.push(this.watcher.onDidChange(this.handleDidChange, this));

--- a/extensions/ql-vscode/src/qltest-discovery.ts
+++ b/extensions/ql-vscode/src/qltest-discovery.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import { QLPackDiscovery, QLPack } from './qlpack-discovery';
 import { Discovery } from './discovery';
-import { EventEmitter, Event, Uri, RelativePattern, WorkspaceFolder, env } from 'vscode';
+import { EventEmitter, Event, Uri, RelativePattern, WorkspaceFolder, env, workspace } from 'vscode';
 import { MultiFileSystemWatcher } from './vscode-utils/multi-file-system-watcher';
 import { CodeQLCliServer } from './cli';
 
@@ -180,7 +180,7 @@ export class QLTestDiscovery extends Discovery<QLTestDiscoveryResults> {
    */
   private isRelevantQlPack(qlPack: QLPack): boolean {
     return qlPack.name.endsWith('-tests')
-      && qlPack.uri.fsPath.startsWith(this.workspaceFolder.uri.fsPath);
+      && workspace.getWorkspaceFolder(qlPack.uri)?.index === this.workspaceFolder.index;
   }
 
   /**

--- a/extensions/ql-vscode/src/test-adapter.ts
+++ b/extensions/ql-vscode/src/test-adapter.ts
@@ -98,7 +98,9 @@ export class QLTestAdapter extends DisposableObject implements TestAdapter {
     super();
 
     this.qlPackDiscovery = this.push(new QLPackDiscovery(workspaceFolder, cliServer));
-    this.qlTestDiscovery = this.push(new QLTestDiscovery(this.qlPackDiscovery, cliServer));
+    this.qlTestDiscovery = this.push(new QLTestDiscovery(this.qlPackDiscovery, workspaceFolder, cliServer));
+    this.qlPackDiscovery.refresh();
+    this.qlTestDiscovery.refresh();
 
     this.push(this.qlTestDiscovery.onDidChangeTests(this.discoverTests, this));
   }

--- a/extensions/ql-vscode/src/vscode-tests/minimal-workspace/qltest-discovery.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/minimal-workspace/qltest-discovery.test.ts
@@ -1,6 +1,7 @@
 import 'vscode-test';
 import 'mocha';
-import { Uri } from 'vscode';
+import * as path from 'path';
+import { Uri, workspace } from 'vscode';
 import { expect } from 'chai';
 
 import { QLTestDiscovery } from '../../qltest-discovery';
@@ -10,28 +11,29 @@ describe('qltest-discovery', () => {
     it('should check if a qlpack is relevant', () => {
       const qlTestDiscover: any = new QLTestDiscovery(
         { onDidChangeQLPacks: () => ({}) } as any,
-        { uri: Uri.parse('file:///a/b/c') } as any,
+        { index: 0 } as any,
         {} as any
       );
 
+      const uri = workspace.workspaceFolders![0].uri;
       expect(qlTestDiscover.isRelevantQlPack({
         name: '-hucairz',
-        uri: Uri.parse('file:///a/b/c/d')
+        uri
       })).to.be.false;
 
       expect(qlTestDiscover.isRelevantQlPack({
         name: '-tests',
-        uri: Uri.parse('file:///a/b/')
+        uri: Uri.file('/a/b/')
       })).to.be.false;
 
       expect(qlTestDiscover.isRelevantQlPack({
         name: '-tests',
-        uri: Uri.parse('file:///a/b/c')
+        uri
       })).to.be.true;
 
       expect(qlTestDiscover.isRelevantQlPack({
         name: '-tests',
-        uri: Uri.parse('file:///a/b/c/d')
+        uri: Uri.file(path.join(uri.fsPath, 'other'))
       })).to.be.true;
     });
   });

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/contextual/queryResolver.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/contextual/queryResolver.test.ts
@@ -41,14 +41,20 @@ describe('queryResolver', () => {
       });
     });
 
-    it('should throw an error when there are no queries found', () => {
+    it('should throw an error when there are no queries found', async () => {
       mockCli.resolveQueriesInSuite.returns([]);
 
-      expect(module.resolveQueries(
-        mockCli, 'my-qlpack', KeyType.DefinitionQuery)
-      ).to.be.rejectedWith(
-        'Couldn\'t find any queries tagged ide-contextual-queries/local-definitions for qlpack my-qlpack'
-      );
+      // TODO: Figure out why chai-as-promised isn't failing the test on an
+      // unhandled rejection.
+      try {
+        await module.resolveQueries(mockCli, 'my-qlpack', KeyType.DefinitionQuery);
+        // should reject
+        expect(true).to.be.false;
+      } catch (e) {
+        expect(e.message).to.eq(
+          'Couldn\'t find any queries tagged ide-contextual-queries/local-definitions for qlpack my-qlpack'
+        );
+      }
     });
   });
 
@@ -78,7 +84,8 @@ describe('queryResolver', () => {
 
       '../helpers': {
         resolveDatasetFolder: resolveDatasetFolderSpy,
-        getOnDiskWorkspaceFolders: () => ({})
+        getOnDiskWorkspaceFolders: () => ({}),
+        showAndLogErrorMessage: () => ({})
       }
     });
   }

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/qltest-discovery.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/qltest-discovery.test.ts
@@ -1,0 +1,38 @@
+import 'vscode-test';
+import 'mocha';
+import { Uri } from 'vscode';
+import { expect } from 'chai';
+
+import { QLTestDiscovery } from '../../qltest-discovery';
+
+describe('qltest-discovery', () => {
+  describe('isRelevantQlPack', () => {
+    it('should check if a qlpack is relevant', () => {
+      const qlTestDiscover: any = new QLTestDiscovery(
+        { onDidChangeQLPacks: () => ({}) } as any,
+        { uri: Uri.parse('file:///a/b/c') } as any,
+        {} as any
+      );
+
+      expect(qlTestDiscover.isRelevantQlPack({
+        name: '-hucairz',
+        uri: Uri.parse('file:///a/b/c/d')
+      })).to.be.false;
+
+      expect(qlTestDiscover.isRelevantQlPack({
+        name: '-tests',
+        uri: Uri.parse('file:///a/b/')
+      })).to.be.false;
+
+      expect(qlTestDiscover.isRelevantQlPack({
+        name: '-tests',
+        uri: Uri.parse('file:///a/b/c')
+      })).to.be.true;
+
+      expect(qlTestDiscover.isRelevantQlPack({
+        name: '-tests',
+        uri: Uri.parse('file:///a/b/c/d')
+      })).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
qlpack tests that are not contained within the current workspace folder
will be filtered from the test runner view.

This also fixes a test that should have been failing but wasn't.

Fixes #517.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] `@github/product-docs-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
