### PR TITLE
Add a debug flag to allow remote debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,11 @@
       "outFiles": [
         "${workspaceRoot}/extensions/ql-vscode/out/**/*.js",
       ],
-      "preLaunchTask": "Build"
+      "preLaunchTask": "Build",
+      "env": {
+        // uncomment to allow debugging the language server Java process from a remote java debugger
+        // "DEBUG_LANGUAGE_SERVER": "true"
+      }
     },
     {
       "name": "Launch Unit Tests (vscode-codeql)",

--- a/extensions/ql-vscode/src/ide-server.ts
+++ b/extensions/ql-vscode/src/ide-server.ts
@@ -11,11 +11,15 @@ import { ideServerLogger } from './logging';
 /** Starts a new CodeQL language server process, sending progress messages to the status bar. */
 export async function spawnIdeServer(config: QueryServerConfig): Promise<StreamInfo> {
   return window.withProgress({ title: 'CodeQL language server', location: ProgressLocation.Window }, async (progressReporter, _) => {
+    const args = ['--check-errors', 'ON_CHANGE'];
+    if (shouldDebug()) {
+      args.push('-J=-agentlib:jdwp=transport=dt_socket,address=localhost:9009,server=y,suspend=n,quiet=y');
+    }
     const child = cli.spawnServer(
       config.codeQlPath,
       'CodeQL language server',
       ['execute', 'language-server'],
-      ['--check-errors', 'ON_CHANGE'],
+      args,
       ideServerLogger,
       data => ideServerLogger.log(data.toString(), { trailingNewline: false }),
       data => ideServerLogger.log(data.toString(), { trailingNewline: false }),
@@ -23,4 +27,10 @@ export async function spawnIdeServer(config: QueryServerConfig): Promise<StreamI
     );
     return { writer: child.stdin!, reader: child.stdout! };
   });
+}
+
+function shouldDebug() {
+  return 'DEBUG_LANGUAGE_SERVER' in process.env
+    && process.env.DEBUG_LANGUAGE_SERVER !== '0'
+    && process.env.DEBUG_LANGUAGE_SERVER?.toLocaleLowerCase() !== 'false';
 }


### PR DESCRIPTION
With this flag on, it is possible to remote-debug the language server in a java debugger.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Replace this with a description of the changes your pull request makes.

## Checklist

- [n/a] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [n/a] Issues have been created for any UI or other user-facing changes made by this pull request.
- [n/a] `@github/docs-content-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
