### PR TITLE
Update changelog to include line about experimental AST Viewer

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix pagination when there are no results.
 - Suppress database downloaded from URL message when action canceled.
 - Fix QL test discovery to avoid showing duplicate tests in the test explorer.
+- Add experimental AST Viewer for Go and C++. To enable, add `"codeQL.experimentalAstViewer": true` to the user settings file.
 
 ## 1.3.1 - 7 July 2020
 


### PR DESCRIPTION
@github/docs-content-dsp we are going to be doing a release later today. I am adding a line in the changelog about the experimental AST Viewer mostly because I've already gotten a bunch of questions about it and how to enable. Until the feature flag is removed, I don't think we need official documentation for it. Are you all fine with that?

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [n/a] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] `@github/docs-content-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
