### PR TITLE
Avoid running query when a user cancels when there are unsaved changes

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.3.3 - [UNRELEASED]
 
 - Fix display of raw results entities with label but no url.
-- Fix bug where sort order is forgotten when changing raw results page
+- Fix bug where sort order is forgotten when changing raw results page.
 
 ## 1.3.2 - 12 August 2020
 

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -408,7 +408,11 @@ async function activateWithInstalledDistribution(
         await showResultsForCompletedQuery(item, WebviewReveal.NotForced);
       } catch (e) {
         if (e instanceof UserCancellationException) {
-          helpers.showAndLogWarningMessage(e.message);
+          if (e.silent) {
+            logger.log(e.message);
+          } else {
+            helpers.showAndLogWarningMessage(e.message);
+          }
         } else if (e instanceof Error) {
           helpers.showAndLogErrorMessage(e.message);
         } else {


### PR DESCRIPTION
Fixes #538

Adds a new menu item to cancel a query run when the query is unsaved.

Also, ensures that no warning message is sent to the console.

The dialog now looks like this:

<img width="724" alt="_Extension_Development_Host__-_UnsafeDollarCall_ql_—_vscode-codeql-starter__Workspace_●" src="https://user-images.githubusercontent.com/363559/90910117-b089c680-e38b-11ea-92d0-9bb7e273ed94.png">

The new menu item is highlighted in red. This change is minor enough that I don't think it needs a changelog entry.

## Checklist

- [n/a] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [n/a] `@github/docs-content-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
