### PR TITLE
Avoid showing a link when the underlying path is empty

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix display of raw results entities with label but no url.
 - Fix bug where sort order is forgotten when changing raw results page.
+- Avoid showing a location link in results view when a result item has an empty location.
 
 ## 1.3.2 - 12 August 2020
 

--- a/extensions/ql-vscode/src/bqrs-utils.ts
+++ b/extensions/ql-vscode/src/bqrs-utils.ts
@@ -16,17 +16,24 @@ const FILE_LOCATION_REGEX = /file:\/\/(.+):([0-9]+):([0-9]+):([0-9]+):([0-9]+)/;
 export function tryGetResolvableLocation(
   loc: LocationValue | undefined
 ): ResolvableLocationValue | undefined {
+  let resolvedLoc;
   if (loc === undefined) {
-    return undefined;
+    resolvedLoc = undefined;
   } else if (loc.t === LocationStyle.FivePart && loc.file) {
-    return loc;
+    resolvedLoc = loc;
   } else if (loc.t === LocationStyle.WholeFile && loc.file) {
-    return loc;
+    resolvedLoc = loc;
   } else if (loc.t === LocationStyle.String && loc.loc) {
-    return tryGetLocationFromString(loc);
+    resolvedLoc = tryGetLocationFromString(loc);
   } else {
-    return undefined;
+    resolvedLoc = undefined;
   }
+
+  if (resolvedLoc && isEmptyPath(resolvedLoc.file)) {
+    resolvedLoc = undefined;
+  }
+
+  return resolvedLoc;
 }
 
 export function tryGetLocationFromString(
@@ -61,4 +68,15 @@ function isWholeFileMatch(matches: RegExpExecArray): boolean {
     matches[4] === '0' &&
     matches[5] === '0'
   );
+}
+
+/**
+ * Checks whether the file path is empty. For now, just check whether
+ * the file path is empty. If so, we do not want to render this location
+ * as a link.
+ *
+ * @param path A file path
+ */
+function isEmptyPath(path: string) {
+  return !path || path === '/';
 }

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/interface-utils.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/interface-utils.test.ts
@@ -119,6 +119,26 @@ describe('interface-utils', () => {
       );
     });
 
+    it('should resolve a five-part location with an empty path', () => {
+      const mockDatabaseItem: DatabaseItem = ({
+        resolveSourceFile: sinon.stub().returns(vscode.Uri.parse('abc')),
+      } as unknown) as DatabaseItem;
+
+      expect(
+        tryResolveLocation(
+          {
+            t: LocationStyle.FivePart,
+            colStart: 1,
+            colEnd: 3,
+            lineStart: 4,
+            lineEnd: 5,
+            file: '',
+          },
+          mockDatabaseItem
+        )
+      ).to.be.undefined;
+    });
+
     it('should resolve a string location for whole file', () => {
       const mockDatabaseItem: DatabaseItem = ({
         resolveSourceFile: sinon.stub().returns(vscode.Uri.parse('abc')),


### PR DESCRIPTION
A common situation when a file is not relevant for a particular result
is to return an empty file path location.

Currently, we are displaying this situation as a hyperlink in the
results, but when clicking on the link, there is an error.

To mirror the behaviour of Eclipse, we should avoid showing a link here.
This commit changes that behaviour.

Fixes #545 

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [n/a] `@github/docs-content-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.

Not notifying `@github/docs-content-dsp` because this is a small change that external users will unlikely to come across.
