### PR TITLE
Actions: Pin version of upload-artifact action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
           cp dist/*.vsix artifacts
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v2
         if: matrix.os == 'ubuntu-latest'
         with:
           name: vscode-codeql-extension

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
       # This is just in case the release itself fails and we want to access the built artifacts from Actions.
       # TODO Remove if not useful.
       - name: Upload artifacts
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v2
         with:
           name: vscode-codeql-extension
           path: artifacts


### PR DESCRIPTION
Improve security practices by pinning to a numbered version of the `upload-artifact` action.

## Checklist

- [N/A] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [N/A] Issues have been created for any UI or other user-facing changes made by this pull request.
- [N/A] `@github/docs-content-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
