### PR TITLE
Allow max queries to be configurable

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [UNRELEASED]
 
+- Max number of simultaneous queries launchable by runQueries command is now configurable by changing the codeQL.runningQueries.maxQueries setting.
+
 ## 1.3.3 - 16 September 2020
 
 - Fix display of raw results entities with label but no url.

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -152,6 +152,11 @@
           "default": false,
           "description": "Enable automatically saving a modified query file when running a query."
         },
+        "codeQL.runningQueries.maxQueries": {
+          "type": "integer",
+          "default": 20,
+          "description": "Max number of simultaneous queries to run using the 'CodeQL: Run Queries' command."
+        },
         "codeQL.queryHistory.format": {
           "type": "string",
           "default": "[%t] %q on %d - %s",

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -67,6 +67,7 @@ const NUMBER_OF_THREADS_SETTING = new Setting('numberOfThreads', RUNNING_QUERIES
 const TIMEOUT_SETTING = new Setting('timeout', RUNNING_QUERIES_SETTING);
 const MEMORY_SETTING = new Setting('memory', RUNNING_QUERIES_SETTING);
 const DEBUG_SETTING = new Setting('debug', RUNNING_QUERIES_SETTING);
+export const MAX_QUERIES = new Setting('maxQueries', RUNNING_QUERIES_SETTING);
 export const AUTOSAVE_SETTING = new Setting('autoSave', RUNNING_QUERIES_SETTING);
 
 /** When these settings change, the running query server should be restarted. */

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -18,7 +18,7 @@ import { testExplorerExtensionId, TestHub } from 'vscode-test-adapter-api';
 import { AstViewer } from './astViewer';
 import * as archiveFilesystemProvider from './archive-filesystem-provider';
 import { CodeQLCliServer } from './cli';
-import { DistributionConfigListener, QueryHistoryConfigListener, QueryServerConfigListener } from './config';
+import { DistributionConfigListener, MAX_QUERIES, QueryHistoryConfigListener, QueryServerConfigListener } from './config';
 import * as languageSupport from './languageSupport';
 import { DatabaseManager } from './databases';
 import { DatabaseUI } from './databases-ui';
@@ -466,11 +466,11 @@ async function activateWithInstalledDistribution(
     commands.registerCommand(
       'codeQL.runQueries',
       async (_: Uri | undefined, multi: Uri[]) => {
-        const maxQueryCount = 20;
+        const maxQueryCount = MAX_QUERIES.getValue() as number;
         try {
           const [files, dirFound] = await gatherQlFiles(multi.map(uri => uri.fsPath));
           if (files.length > maxQueryCount) {
-            throw new Error(`You tried to run ${files.length} queries, but the maximum is ${maxQueryCount}. Try selecting fewer queries.`);
+            throw new Error(`You tried to run ${files.length} queries, but the maximum is ${maxQueryCount}. Try selecting fewer queries or changing the 'codeQL.runningQueries.maxQueries' setting.`);
           }
           // warn user and display selected files when a directory is selected because some ql
           // files may be hidden from the user.


### PR DESCRIPTION
Max number of simultaneous queries launchable by runQueries command is
now configurable by codeQL.runningQueries.maxQueries.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Resolves #463.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] `@github/docs-content-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
