### PR TITLE
Add the commandRunner

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Max number of simultaneous queries launchable by runQueries command is now configurable by changing the `codeQL.runningQueries.maxQueries` setting.
 - Allow simultaneously run queries to be canceled in a single-click.
 - Prevent multiple upgrade dialogs from appearing when running simultaneous queries on upgradeable databases.
+- Allow simultaneously run queries to be canceled in a single-click.
 - Max number of simultaneous queries launchable by runQueries command is now configurable by changing the codeQL.runningQueries.maxQueries setting.
 - Fix sorting of results. Some pages of results would have the wrong sort order and columns.
 - Remember previous sort order when reloading query results.

--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Add friendly welcome message when the databases view is empty.
 - Add open query, open results, and remove query commands in the query history view title bar.
 - Max number of simultaneous queries launchable by runQueries command is now configurable by changing the `codeQL.runningQueries.maxQueries` setting.
+- Allow simultaneously run queries to be canceled in a single-click.
+- Prevent multiple upgrade dialogs from appearing when running simultaneous queries on upgradeable databases.
+- Max number of simultaneous queries launchable by runQueries command is now configurable by changing the codeQL.runningQueries.maxQueries setting.
 - Fix sorting of results. Some pages of results would have the wrong sort order and columns.
 - Remember previous sort order when reloading query results.
 - Fix proper escaping of backslashes in SARIF message strings.

--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -4,11 +4,9 @@
 
 - Add friendly welcome message when the databases view is empty.
 - Add open query, open results, and remove query commands in the query history view title bar.
-- Max number of simultaneous queries launchable by runQueries command is now configurable by changing the `codeQL.runningQueries.maxQueries` setting.
+- The maximum number of simultaneous queries launchable by the `CodeQL: Run Queries in Selected Files` command is now configurable by changing the `codeQL.runningQueries.maxQueries` setting.
 - Allow simultaneously run queries to be canceled in a single-click.
 - Prevent multiple upgrade dialogs from appearing when running simultaneous queries on upgradeable databases.
-- Allow simultaneously run queries to be canceled in a single-click.
-- Max number of simultaneous queries launchable by runQueries command is now configurable by changing the codeQL.runningQueries.maxQueries setting.
 - Fix sorting of results. Some pages of results would have the wrong sort order and columns.
 - Remember previous sort order when reloading query results.
 - Fix proper escaping of backslashes in SARIF message strings.

--- a/extensions/ql-vscode/src/astViewer.ts
+++ b/extensions/ql-vscode/src/astViewer.ts
@@ -3,7 +3,6 @@ import {
   ExtensionContext,
   TreeDataProvider,
   EventEmitter,
-  commands,
   Event,
   ProviderResult,
   TreeItemCollapsibleState,
@@ -19,6 +18,7 @@ import { DatabaseItem } from './databases';
 import { UrlValue, BqrsId } from './bqrs-cli-types';
 import { showLocation } from './interface-utils';
 import { isStringLoc, isWholeFileLoc, isLineColumnLoc } from './bqrs-utils';
+import { commandRunner } from './helpers';
 
 
 export interface AstItem {
@@ -45,10 +45,10 @@ class AstViewerDataProvider implements TreeDataProvider<AstItem> {
     this._onDidChangeTreeData.event;
 
   constructor() {
-    commands.registerCommand('codeQLAstViewer.gotoCode',
-      async (item: AstItem) => {
-        await showLocation(item.fileLocation);
-      });
+    commandRunner('codeQLAstViewer.gotoCode',
+    async (item: AstItem) => {
+      await showLocation(item.fileLocation);
+    });
   }
 
   refresh(): void {
@@ -109,7 +109,7 @@ export class AstViewer {
       showCollapseAll: true
     });
 
-    commands.registerCommand('codeQLAstViewer.clear', () => {
+    commandRunner('codeQLAstViewer.clear', async () => {
       this.clear();
     });
 

--- a/extensions/ql-vscode/src/astViewer.ts
+++ b/extensions/ql-vscode/src/astViewer.ts
@@ -20,7 +20,6 @@ import { showLocation } from './interface-utils';
 import { isStringLoc, isWholeFileLoc, isLineColumnLoc } from './bqrs-utils';
 import { commandRunner } from './helpers';
 
-
 export interface AstItem {
   id: BqrsId;
   label?: string;

--- a/extensions/ql-vscode/src/contextual/templateProvider.ts
+++ b/extensions/ql-vscode/src/contextual/templateProvider.ts
@@ -44,7 +44,7 @@ export class TemplateQueryDefinitionProvider implements vscode.DefinitionProvide
   }
 
   private async getDefinitions(uriString: string): Promise<vscode.LocationLink[]> {
-    return await withProgress({
+    return withProgress({
       location: vscode.ProgressLocation.Notification,
       cancellable: true,
       title: 'Finding definitions'
@@ -91,7 +91,7 @@ export class TemplateQueryReferenceProvider implements vscode.ReferenceProvider 
   }
 
   private async getReferences(uriString: string): Promise<FullLocationLink[]> {
-    return await withProgress({
+    return withProgress({
       location: vscode.ProgressLocation.Notification,
       cancellable: true,
       title: 'Finding references'

--- a/extensions/ql-vscode/src/databases-ui.ts
+++ b/extensions/ql-vscode/src/databases-ui.ts
@@ -9,8 +9,7 @@ import {
   TreeItem,
   Uri,
   window,
-  env,
-  ProgressLocation
+  env
 } from 'vscode';
 import * as fs from 'fs-extra';
 
@@ -23,6 +22,7 @@ import {
 } from './databases';
 import {
   commandRunner,
+  commandRunnerWithProgress,
   getOnDiskWorkspaceFolders,
   ProgressCallback,
   showAndLogErrorMessage
@@ -233,79 +233,66 @@ export class DatabaseUI extends DisposableObject {
 
     logger.log('Registering database panel commands.');
     ctx.subscriptions.push(
-      commandRunner(
+      commandRunnerWithProgress(
         'codeQL.setCurrentDatabase',
         this.handleSetCurrentDatabase,
         {
-          location: ProgressLocation.Notification,
           title: 'Importing database from archive',
-          cancellable: false,
         }
       )
     );
     ctx.subscriptions.push(
-      commandRunner(
+      commandRunnerWithProgress(
         'codeQL.upgradeCurrentDatabase',
         this.handleUpgradeCurrentDatabase,
         {
-          location: ProgressLocation.Notification,
           title: 'Upgrading current database',
           cancellable: true,
         }
       )
     );
     ctx.subscriptions.push(
-      commandRunner(
+      commandRunnerWithProgress(
         'codeQL.clearCache',
         this.handleClearCache,
         {
-          location: ProgressLocation.Notification,
           title: 'Clearing Cache',
-          cancellable: false,
         })
     );
 
     ctx.subscriptions.push(
-      commandRunner(
+      commandRunnerWithProgress(
         'codeQLDatabases.chooseDatabaseFolder',
         this.handleChooseDatabaseFolder,
         {
-          location: ProgressLocation.Notification,
           title: 'Adding database from folder',
-          cancellable: false,
         }
       )
     );
     ctx.subscriptions.push(
-      commandRunner(
+      commandRunnerWithProgress(
         'codeQLDatabases.chooseDatabaseArchive',
         this.handleChooseDatabaseArchive,
         {
-          location: ProgressLocation.Notification,
           title: 'Adding database from archive',
-          cancellable: false,
         }
       )
     );
     ctx.subscriptions.push(
-      commandRunner(
+      commandRunnerWithProgress(
         'codeQLDatabases.chooseDatabaseInternet',
         this.handleChooseDatabaseInternet,
         {
-          location: ProgressLocation.Notification,
           title: 'Adding database from URL',
-          cancellable: false,
         }
       )
     );
     ctx.subscriptions.push(
-      commandRunner(
+      commandRunnerWithProgress(
         'codeQLDatabases.chooseDatabaseLgtm',
         this.handleChooseDatabaseLgtm,
         {
-          location: ProgressLocation.Notification,
           title: 'Adding database from LGTM',
-          cancellable: false,
         })
     );
     ctx.subscriptions.push(
@@ -333,11 +320,10 @@ export class DatabaseUI extends DisposableObject {
       )
     );
     ctx.subscriptions.push(
-      commandRunner(
+      commandRunnerWithProgress(
         'codeQLDatabases.upgradeDatabase',
         this.handleUpgradeDatabase,
         {
-          location: ProgressLocation.Notification,
           title: 'Upgrading database',
           cancellable: true,
         }
@@ -522,9 +508,9 @@ export class DatabaseUI extends DisposableObject {
   };
 
   private handleSetCurrentDatabase = async (
-    uri: Uri,
     progress: ProgressCallback,
     token: CancellationToken,
+    uri: Uri,
   ): Promise<void> => {
     try {
       // Assume user has selected an archive if the file has a .zip extension

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -165,12 +165,10 @@ export async function activate(ctx: ExtensionContext): Promise<void> {
           }
         } else {
           const progressOptions: ProgressOptions = {
-            location: ProgressLocation.Notification,
             title: progressTitle,
-            cancellable: false,
+            location: ProgressLocation.Notification,
           };
 
-          // Avoid using commandRunner here because this function is called upon extension activation
           await helpers.withProgress(progressOptions, progress =>
             distributionManager.installExtensionManagedDistributionRelease(result.updatedRelease, progress));
 
@@ -459,7 +457,7 @@ async function activateWithInstalledDistribution(
 
   logger.log('Registering top-level command palette commands.');
   ctx.subscriptions.push(
-    helpers.commandRunner(
+    helpers.commandRunnerWithProgress(
       'codeQL.runQuery',
       async (
         progress: helpers.ProgressCallback,
@@ -467,14 +465,13 @@ async function activateWithInstalledDistribution(
         uri: Uri | undefined
       ) => await compileAndRunQuery(false, uri, progress, token),
       {
-        location: ProgressLocation.Notification,
         title: 'Running query',
         cancellable: true
       }
     )
   );
   ctx.subscriptions.push(
-    helpers.commandRunner(
+    helpers.commandRunnerWithProgress(
       'codeQL.runQueries',
       async (
         progress: helpers.ProgressCallback,
@@ -533,13 +530,12 @@ async function activateWithInstalledDistribution(
         ));
       },
       {
-        location: ProgressLocation.Notification,
         title: 'Running queries',
         cancellable: true
       })
   );
   ctx.subscriptions.push(
-    helpers.commandRunner(
+    helpers.commandRunnerWithProgress(
       'codeQL.quickEval',
       async (
         progress: helpers.ProgressCallback,
@@ -547,17 +543,19 @@ async function activateWithInstalledDistribution(
         uri: Uri | undefined
       ) => await compileAndRunQuery(true, uri, progress, token),
       {
-        location: ProgressLocation.Notification,
         title: 'Running query',
         cancellable: true
       })
   );
   ctx.subscriptions.push(
-    helpers.commandRunner('codeQL.quickQuery', async (
+    helpers.commandRunnerWithProgress('codeQL.quickQuery', async (
       progress: helpers.ProgressCallback,
       token: CancellationToken
     ) =>
-      displayQuickQuery(ctx, cliServer, databaseUI, progress, token)
+      displayQuickQuery(ctx, cliServer, databaseUI, progress, token),
+      {
+        title: 'Run Quick Query'
+      }
     )
   );
 
@@ -586,28 +584,24 @@ async function activateWithInstalledDistribution(
     )
   );
   ctx.subscriptions.push(
-    helpers.commandRunner('codeQL.chooseDatabaseLgtm', (
+    helpers.commandRunnerWithProgress('codeQL.chooseDatabaseLgtm', (
       progress: helpers.ProgressCallback,
       token: CancellationToken
     ) =>
       databaseUI.handleChooseDatabaseLgtm(progress, token),
       {
-        location: ProgressLocation.Notification,
         title: 'Adding database from LGTM',
-        cancellable: false,
       })
   );
   ctx.subscriptions.push(
-    helpers.commandRunner('codeQL.chooseDatabaseInternet', (
+    helpers.commandRunnerWithProgress('codeQL.chooseDatabaseInternet', (
       progress: helpers.ProgressCallback,
       token: CancellationToken
     ) =>
       databaseUI.handleChooseDatabaseInternet(progress, token),
 
       {
-        location: ProgressLocation.Notification,
         title: 'Adding database from URL',
-        cancellable: false,
       })
   );
 
@@ -627,7 +621,7 @@ async function activateWithInstalledDistribution(
   );
 
   const astViewer = new AstViewer(ctx);
-  ctx.subscriptions.push(helpers.commandRunner('codeQL.viewAst', async (
+  ctx.subscriptions.push(helpers.commandRunnerWithProgress('codeQL.viewAst', async (
     progress: helpers.ProgressCallback,
     token: CancellationToken
   ) => {
@@ -637,7 +631,6 @@ async function activateWithInstalledDistribution(
       astViewer.updateRoots(await ast.getRoots(), ast.db, ast.fileName);
     }
   }, {
-    location: ProgressLocation.Notification,
     cancellable: true,
     title: 'Calculate AST'
   }));

--- a/extensions/ql-vscode/src/interface-utils.ts
+++ b/extensions/ql-vscode/src/interface-utils.ts
@@ -151,33 +151,35 @@ export async function showResolvableLocation(
 }
 
 export async function showLocation(location?: Location) {
-  if (location) {
-    const doc = await workspace.openTextDocument(location.uri);
-    const editorsWithDoc = Window.visibleTextEditors.filter(
-      (e) => e.document === doc
-    );
-    const editor =
-      editorsWithDoc.length > 0
-        ? editorsWithDoc[0]
-        : await Window.showTextDocument(doc, ViewColumn.One);
-    const range = location.range;
-    // When highlighting the range, vscode's occurrence-match and bracket-match highlighting will
-    // trigger based on where we place the cursor/selection, and will compete for the user's attention.
-    // For reference:
-    // - Occurences are highlighted when the cursor is next to or inside a word or a whole word is selected.
-    // - Brackets are highlighted when the cursor is next to a bracket and there is an empty selection.
-    // - Multi-line selections explicitly highlight line-break characters, but multi-line decorators do not.
-    //
-    // For single-line ranges, select the whole range, mainly to disable bracket highlighting.
-    // For multi-line ranges, place the cursor at the beginning to avoid visual artifacts from selected line-breaks.
-    // Multi-line ranges are usually large enough to overshadow the noise from bracket highlighting.
-    const selectionEnd =
-      range.start.line === range.end.line ? range.end : range.start;
-    editor.selection = new Selection(range.start, selectionEnd);
-    editor.revealRange(range, TextEditorRevealType.InCenter);
-    editor.setDecorations(shownLocationDecoration, [range]);
-    editor.setDecorations(shownLocationLineDecoration, [range]);
+  if (!location) {
+    return;
   }
+
+  const doc = await workspace.openTextDocument(location.uri);
+  const editorsWithDoc = Window.visibleTextEditors.filter(
+    (e) => e.document === doc
+  );
+  const editor =
+    editorsWithDoc.length > 0
+      ? editorsWithDoc[0]
+      : await Window.showTextDocument(doc, ViewColumn.One);
+  const range = location.range;
+  // When highlighting the range, vscode's occurrence-match and bracket-match highlighting will
+  // trigger based on where we place the cursor/selection, and will compete for the user's attention.
+  // For reference:
+  // - Occurences are highlighted when the cursor is next to or inside a word or a whole word is selected.
+  // - Brackets are highlighted when the cursor is next to a bracket and there is an empty selection.
+  // - Multi-line selections explicitly highlight line-break characters, but multi-line decorators do not.
+  //
+  // For single-line ranges, select the whole range, mainly to disable bracket highlighting.
+  // For multi-line ranges, place the cursor at the beginning to avoid visual artifacts from selected line-breaks.
+  // Multi-line ranges are usually large enough to overshadow the noise from bracket highlighting.
+  const selectionEnd =
+    range.start.line === range.end.line ? range.end : range.start;
+  editor.selection = new Selection(range.start, selectionEnd);
+  editor.revealRange(range, TextEditorRevealType.InCenter);
+  editor.setDecorations(shownLocationDecoration, [range]);
+  editor.setDecorations(shownLocationLineDecoration, [range]);
 }
 
 const findMatchBackground = new ThemeColor('editor.findMatchBackground');

--- a/extensions/ql-vscode/src/interface.ts
+++ b/extensions/ql-vscode/src/interface.ts
@@ -32,6 +32,7 @@ import {
   RawResultsSortState,
 } from './interface-types';
 import { Logger } from './logging';
+import { commandRunner } from './helpers';
 import * as messages from './messages';
 import { CompletedQuery, interpretResults } from './query-results';
 import { QueryInfo, tmpDir } from './run-queries';
@@ -121,13 +122,13 @@ export class InterfaceManager extends DisposableObject {
     );
     logger.log('Registering path-step navigation commands.');
     this.push(
-      vscode.commands.registerCommand(
+      commandRunner(
         'codeQLQueryResults.nextPathStep',
         this.navigatePathStep.bind(this, 1)
       )
     );
     this.push(
-      vscode.commands.registerCommand(
+      commandRunner(
         'codeQLQueryResults.previousPathStep',
         this.navigatePathStep.bind(this, -1)
       )
@@ -145,7 +146,7 @@ export class InterfaceManager extends DisposableObject {
     );
   }
 
-  navigatePathStep(direction: number): void {
+  async navigatePathStep(direction: number): Promise<void> {
     this.postMessage({ t: 'navigatePath', direction });
   }
 

--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -209,51 +209,51 @@ export class QueryHistoryManager {
     });
     logger.log('Registering query history panel commands.');
     ctx.subscriptions.push(
-      vscode.commands.registerCommand(
+      helpers.commandRunner(
         'codeQLQueryHistory.openQuery',
         this.handleOpenQuery.bind(this)
       )
     );
     ctx.subscriptions.push(
-      vscode.commands.registerCommand(
+      helpers.commandRunner(
         'codeQLQueryHistory.removeHistoryItem',
         this.handleRemoveHistoryItem.bind(this)
       )
     );
     ctx.subscriptions.push(
-      vscode.commands.registerCommand(
+      helpers.commandRunner(
         'codeQLQueryHistory.setLabel',
         this.handleSetLabel.bind(this)
       )
     );
     ctx.subscriptions.push(
-      vscode.commands.registerCommand(
+      helpers.commandRunner(
         'codeQLQueryHistory.compareWith',
         this.handleCompareWith.bind(this)
       )
     );
     ctx.subscriptions.push(
-      vscode.commands.registerCommand(
+      helpers.commandRunner(
         'codeQLQueryHistory.showQueryLog',
         this.handleShowQueryLog.bind(this)
       )
     );
     ctx.subscriptions.push(
-      vscode.commands.registerCommand(
+      helpers.commandRunner(
         'codeQLQueryHistory.showQueryText',
         this.handleShowQueryText.bind(this)
       )
     );
     ctx.subscriptions.push(
-      vscode.commands.registerCommand(
+      helpers.commandRunner(
         'codeQLQueryHistory.viewSarif',
         this.handleViewSarif.bind(this)
       )
     );
     ctx.subscriptions.push(
-      vscode.commands.registerCommand(
+      helpers.commandRunner(
         'codeQLQueryHistory.itemClicked',
-        async (item) => {
+        async (item: CompletedQuery) => {
           return this.handleItemClicked(item, [item]);
         }
       )
@@ -424,22 +424,18 @@ export class QueryHistoryManager {
       return;
     }
 
-    try {
-      const queryName = singleItem.queryName.endsWith('.ql')
-        ? singleItem.queryName
-        : singleItem.queryName + '.ql';
-      const params = new URLSearchParams({
-        isQuickEval: String(!!singleItem.query.quickEvalPosition),
-        queryText: encodeURIComponent(await this.getQueryText(singleItem)),
-      });
-      const uri = vscode.Uri.parse(
-        `codeql:${singleItem.query.queryID}-${queryName}?${params.toString()}`
-      );
-      const doc = await vscode.workspace.openTextDocument(uri);
-      await vscode.window.showTextDocument(doc, { preview: false });
-    } catch (e) {
-      helpers.showAndLogErrorMessage(e.message);
-    }
+    const queryName = singleItem.queryName.endsWith('.ql')
+      ? singleItem.queryName
+      : singleItem.queryName + '.ql';
+    const params = new URLSearchParams({
+      isQuickEval: String(!!singleItem.query.quickEvalPosition),
+      queryText: encodeURIComponent(await this.getQueryText(singleItem)),
+    });
+    const uri = vscode.Uri.parse(
+      `codeql:${singleItem.query.queryID}-${queryName}?${params.toString()}`
+    );
+    const doc = await vscode.workspace.openTextDocument(uri);
+    await vscode.window.showTextDocument(doc, { preview: false });
   }
 
   async handleViewSarif(
@@ -450,20 +446,16 @@ export class QueryHistoryManager {
       return;
     }
 
-    try {
-      const hasInterpretedResults = await singleItem.query.canHaveInterpretedResults();
-      if (hasInterpretedResults) {
-        await this.tryOpenExternalFile(
-          singleItem.query.resultsPaths.interpretedResultsPath
-        );
-      } else {
-        const label = singleItem.getLabel();
-        helpers.showAndLogInformationMessage(
-          `Query ${label} has no interpreted results.`
-        );
-      }
-    } catch (e) {
-      helpers.showAndLogErrorMessage(e.message);
+    const hasInterpretedResults = await singleItem.query.canHaveInterpretedResults();
+    if (hasInterpretedResults) {
+      await this.tryOpenExternalFile(
+        singleItem.query.resultsPaths.interpretedResultsPath
+      );
+    } else {
+      const label = singleItem.getLabel();
+      helpers.showAndLogInformationMessage(
+        `Query ${label} has no interpreted results.`
+      );
     }
   }
 

--- a/extensions/ql-vscode/src/run-queries.ts
+++ b/extensions/ql-vscode/src/run-queries.ts
@@ -258,7 +258,9 @@ async function getSelectedPosition(editor: TextEditor): Promise<messages.Positio
 async function checkDbschemeCompatibility(
   cliServer: cli.CodeQLCliServer,
   qs: qsClient.QueryServerClient,
-  query: QueryInfo
+  query: QueryInfo,
+  progress: helpers.ProgressCallback,
+  token: CancellationToken,
 ): Promise<void> {
   const searchPath = helpers.getOnDiskWorkspaceFolders();
 
@@ -293,7 +295,9 @@ async function checkDbschemeCompatibility(
         qs,
         query.dbItem,
         Uri.file(finalDbscheme),
-        getUpgradesDirectories(scripts)
+        getUpgradesDirectories(scripts),
+        progress,
+        token
       );
     }
   }
@@ -481,7 +485,7 @@ export async function compileAndRunQueryAgainstDatabase(
   }
 
   const query = new QueryInfo(qlProgram, db, packConfig.dbscheme, quickEvalPosition, metadata, templates);
-  await checkDbschemeCompatibility(cliServer, qs, query);
+  await checkDbschemeCompatibility(cliServer, qs, query, progress, token);
 
   let errors;
   try {

--- a/extensions/ql-vscode/src/upgrades.ts
+++ b/extensions/ql-vscode/src/upgrades.ts
@@ -4,7 +4,7 @@ import * as helpers from './helpers';
 import { logger } from './logging';
 import * as messages from './messages';
 import * as qsClient from './queryserver-client';
-import { upgradesTmpDir, UserCancellationException } from './run-queries';
+import { upgradesTmpDir } from './run-queries';
 
 /**
  * Maximum number of lines to include from database upgrade message,
@@ -101,7 +101,7 @@ async function checkAndConfirmDatabaseUpgrade(
     return params;
   }
   else {
-    throw new UserCancellationException('User cancelled the database upgrade.');
+    throw new helpers.UserCancellationException('User cancelled the database upgrade.');
   }
 }
 
@@ -112,7 +112,9 @@ async function checkAndConfirmDatabaseUpgrade(
  * Reports errors during compilation and evaluation of upgrades to the user.
  */
 export async function upgradeDatabase(
-  qs: qsClient.QueryServerClient, db: DatabaseItem, targetDbScheme: vscode.Uri, upgradesDirectories: vscode.Uri[]
+  qs: qsClient.QueryServerClient,
+  db: DatabaseItem, targetDbScheme: vscode.Uri,
+  upgradesDirectories: vscode.Uri[]
 ): Promise<messages.RunUpgradeResult | undefined> {
   const upgradeParams = await checkAndConfirmDatabaseUpgrade(qs, db, targetDbScheme, upgradesDirectories);
 
@@ -155,6 +157,7 @@ export async function upgradeDatabase(
 async function checkDatabaseUpgrade(
   qs: qsClient.QueryServerClient, upgradeParams: messages.UpgradeParams
 ): Promise<messages.CheckUpgradeResult> {
+  // Avoid using commandRunner here because this function might be called upon extension activation
   return helpers.withProgress({
     location: vscode.ProgressLocation.Notification,
     title: 'Checking for database upgrades',
@@ -170,6 +173,7 @@ async function compileDatabaseUpgrade(
     upgradeTempDir: upgradesTmpDir.name
   };
 
+  // Avoid using commandRunner here because this function might be called upon extension activation
   return helpers.withProgress({
     location: vscode.ProgressLocation.Notification,
     title: 'Compiling database upgrades',
@@ -195,6 +199,7 @@ async function runDatabaseUpgrade(
     toRun: upgrades
   };
 
+  // Avoid using commandRunner here because this function might be called upon extension activation
   return helpers.withProgress({
     location: vscode.ProgressLocation.Notification,
     title: 'Running database upgrades',

--- a/extensions/ql-vscode/src/vscode-utils/ui-service.ts
+++ b/extensions/ql-vscode/src/vscode-utils/ui-service.ts
@@ -1,5 +1,6 @@
-import { commands, TreeDataProvider, window } from 'vscode';
+import { TreeDataProvider, window } from 'vscode';
 import { DisposableObject } from './disposable-object';
+import { commandRunner } from '../helpers';
 
 /**
  * A VS Code service that interacts with the UI, including handling commands.
@@ -16,7 +17,7 @@ export class UIService extends DisposableObject {
    * @remarks The command handler is automatically unregistered when the service is disposed.
    */
   protected registerCommand(command: string, callback: (...args: any[]) => any): void {
-    this.push(commands.registerCommand(command, callback, this));
+    this.push(commandRunner(command, callback.bind(this)));
   }
 
   protected registerTreeDataProvider<T>(viewId: string, treeDataProvider: TreeDataProvider<T>):


### PR DESCRIPTION
The commandRunner wraps all vscode command registrations. It provides
uniform error handling and an optional progress monitor.

In general, progress monitors should only be created by the
commandRunner and passed through to the locations that use it.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Resolves #464.
Resolves #534.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] `@github/docs-content-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
