### PR TITLE
Fix Query sort issues

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [UNRELEASED]
 
 - Max number of simultaneous queries launchable by runQueries command is now configurable by changing the codeQL.runningQueries.maxQueries setting.
+- Fix sorting of results. Some pages of results would have the wrong sort order and columns.
+- Remember previous sort order when reloading query results.
 
 ## 1.3.3 - 16 September 2020
 

--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -2,10 +2,15 @@ import * as fs from 'fs-extra';
 import * as glob from 'glob-promise';
 import * as yaml from 'js-yaml';
 import * as path from 'path';
-import { CancellationToken, ExtensionContext, ProgressOptions, window as Window, workspace } from 'vscode';
+import {
+  CancellationToken,
+  ExtensionContext,
+  ProgressOptions,
+  window as Window,
+  workspace
+} from 'vscode';
 import { CodeQLCliServer } from './cli';
 import { logger } from './logging';
-import { QueryInfo } from './run-queries';
 
 export interface ProgressUpdate {
   /**
@@ -143,24 +148,6 @@ export function getOnDiskWorkspaceFolders() {
       diskWorkspaceFolders.push(workspaceFolder.uri.fsPath);
   }
   return diskWorkspaceFolders;
-}
-
-/**
- * Gets a human-readable name for an evaluated query.
- * Uses metadata if it exists, and defaults to the query file name.
- */
-export function getQueryName(query: QueryInfo) {
-  // Queries run through quick evaluation are not usually the entire query file.
-  // Label them differently and include the line numbers.
-  if (query.quickEvalPosition !== undefined) {
-    const { line, endLine, fileName } = query.quickEvalPosition;
-    const lineInfo = line === endLine ? `${line}` : `${line}-${endLine}`;
-    return `Quick evaluation of ${path.basename(fileName)}:${lineInfo}`;
-  } else if (query.metadata && query.metadata.name) {
-    return query.metadata.name;
-  } else {
-    return path.basename(query.program.queryPath);
-  }
 }
 
 /**

--- a/extensions/ql-vscode/src/interface.ts
+++ b/extensions/ql-vscode/src/interface.ts
@@ -364,8 +364,13 @@ export class InterfaceManager extends DisposableObject {
         (resultSet) => resultSet.name == selectedTable
       )!;
 
+      // Use sorted results path if it exists. This may happen if we are
+      // reloading the results view after it has been sorted in the past.
+      const resultsPath = results.sortedResultsInfo.get(selectedTable)?.resultsPath
+        || results.query.resultsPaths.resultsPath;
+
       const chunk = await this.cliServer.bqrsDecode(
-        results.query.resultsPaths.resultsPath,
+        resultsPath,
         schema.name,
         {
           offset: schema.pagination?.offsets[0],

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/query-results.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/query-results.test.ts
@@ -1,0 +1,245 @@
+import * as chai from 'chai';
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import 'mocha';
+import 'sinon-chai';
+import * as Sinon from 'sinon';
+import * as chaiAsPromised from 'chai-as-promised';
+import { CompletedQuery, interpretResults } from '../../query-results';
+import { QueryInfo, QueryWithResults, tmpDir } from '../../run-queries';
+import { QueryHistoryConfig } from '../../config';
+import { EvaluationResult, QueryResultType } from '../../messages';
+import { SortDirection, SortedResultSetInfo } from '../../interface-types';
+import { CodeQLCliServer, SourceInfo } from '../../cli';
+
+chai.use(chaiAsPromised);
+const expect = chai.expect;
+
+describe('CompletedQuery', () => {
+  let disposeSpy: Sinon.SinonSpy;
+  let onDidChangeQueryHistoryConfigurationSpy: Sinon.SinonSpy;
+
+  beforeEach(() => {
+    disposeSpy = Sinon.spy();
+    onDidChangeQueryHistoryConfigurationSpy = Sinon.spy();
+  });
+
+  it('should construct a CompletedQuery', () => {
+    const completedQuery = mockCompletedQuery();
+
+    expect(completedQuery.logFileLocation).to.eq('mno');
+    expect(completedQuery.databaseName).to.eq('def');
+  });
+
+  it('should get the query name', () => {
+    const completedQuery = mockCompletedQuery();
+
+    // from the query path
+    expect(completedQuery.queryName).to.eq('stu');
+
+    // from the metadata
+    (completedQuery.query as any).metadata = {
+      name: 'vwx'
+    };
+    expect(completedQuery.queryName).to.eq('vwx');
+
+    // from quick eval position
+    (completedQuery.query as any).quickEvalPosition = {
+      line: 1,
+      endLine: 2,
+      fileName: '/home/users/yz'
+    };
+    expect(completedQuery.queryName).to.eq('Quick evaluation of yz:1-2');
+    (completedQuery.query as any).quickEvalPosition.endLine = 1;
+    expect(completedQuery.queryName).to.eq('Quick evaluation of yz:1');
+  });
+
+  it('should get the label', () => {
+    const completedQuery = mockCompletedQuery();
+    expect(completedQuery.getLabel()).to.eq('ghi');
+    completedQuery.options.label = '';
+    expect(completedQuery.getLabel()).to.eq('pqr');
+  });
+
+  it('should get the getResultsPath', () => {
+    const completedQuery = mockCompletedQuery();
+    // from results path
+    expect(completedQuery.getResultsPath('zxa', false)).to.eq('axa');
+
+    completedQuery.sortedResultsInfo.set('zxa', {
+      resultsPath: 'bxa'
+    } as SortedResultSetInfo);
+
+    // still from results path
+    expect(completedQuery.getResultsPath('zxa', false)).to.eq('axa');
+
+    // from sortedResultsInfo
+    expect(completedQuery.getResultsPath('zxa')).to.eq('bxa');
+  });
+
+  it('should get the statusString', () => {
+    const completedQuery = mockCompletedQuery();
+    expect(completedQuery.statusString).to.eq('failed');
+
+    completedQuery.result.message = 'Tremendously';
+    expect(completedQuery.statusString).to.eq('failed: Tremendously');
+
+    completedQuery.result.resultType = QueryResultType.OTHER_ERROR;
+    expect(completedQuery.statusString).to.eq('failed: Tremendously');
+
+    completedQuery.result.resultType = QueryResultType.CANCELLATION;
+    completedQuery.result.evaluationTime = 2000;
+    expect(completedQuery.statusString).to.eq('cancelled after 2 seconds');
+
+    completedQuery.result.resultType = QueryResultType.OOM;
+    expect(completedQuery.statusString).to.eq('out of memory');
+
+    completedQuery.result.resultType = QueryResultType.SUCCESS;
+    expect(completedQuery.statusString).to.eq('finished in 2 seconds');
+
+    completedQuery.result.resultType = QueryResultType.TIMEOUT;
+    expect(completedQuery.statusString).to.eq('timed out after 2 seconds');
+
+  });
+
+  it('should updateSortState', async () => {
+    const completedQuery = mockCompletedQuery();
+    const spy = Sinon.spy();
+    const mockServer = {
+      sortBqrs: spy
+    } as unknown as CodeQLCliServer;
+    const sortState = {
+      columnIndex: 1,
+      sortDirection: SortDirection.desc
+    };
+    await completedQuery.updateSortState(mockServer, 'result-name', sortState);
+    const expectedPath = path.join(tmpDir.name, 'sortedResults111-result-name.bqrs');
+    expect(spy).to.have.been.calledWith(
+      'axa',
+      expectedPath,
+      'result-name',
+      [sortState.columnIndex],
+      [sortState.sortDirection],
+    );
+
+    expect(completedQuery.sortedResultsInfo.get('result-name')).to.deep.equal({
+      resultsPath: expectedPath,
+      sortState
+    });
+
+    // delete the sort stae
+    await completedQuery.updateSortState(mockServer, 'result-name');
+    expect(completedQuery.sortedResultsInfo.size).to.eq(0);
+  });
+
+  it('should interpolate', () => {
+    const completedQuery = mockCompletedQuery();
+    (completedQuery as any).time = '123';
+    expect(completedQuery.interpolate('xxx')).to.eq('xxx');
+    expect(completedQuery.interpolate('%t %q %d %s %%')).to.eq('123 stu def failed %');
+    expect(completedQuery.interpolate('%t %q %d %s %%::%t %q %d %s %%')).to.eq('123 stu def failed %::123 stu def failed %');
+  });
+
+  it('should interpretResults', async () => {
+    const spy = Sinon.mock();
+    spy.returns('1234');
+    const mockServer = {
+      interpretBqrs: spy
+    } as unknown as CodeQLCliServer;
+
+    const interpretedResultsPath = path.join(tmpDir.name, 'interpreted.json');
+    const resultsPath = '123';
+    const sourceInfo = {};
+    const metadata = {
+      kind: 'my-kind',
+      id: 'my-id' as string | undefined
+    };
+    const results1 = await interpretResults(
+      mockServer,
+      metadata,
+      {
+        resultsPath, interpretedResultsPath
+      },
+      sourceInfo as SourceInfo
+    );
+
+    expect(results1).to.eq('1234');
+    expect(spy).to.have.been.calledWith(
+      metadata,
+      resultsPath, interpretedResultsPath, sourceInfo
+    );
+
+    // Try again, but with no id
+    spy.reset();
+    spy.returns('1234');
+    delete metadata.id;
+    const results2 = await interpretResults(
+      mockServer,
+      metadata,
+      {
+        resultsPath, interpretedResultsPath
+      },
+      sourceInfo as SourceInfo
+    );
+    expect(results2).to.eq('1234');
+    expect(spy).to.have.been.calledWith(
+      { kind: 'my-kind', id: 'dummy-id' },
+      resultsPath, interpretedResultsPath, sourceInfo
+    );
+
+    // try a third time, but this time we get from file
+    spy.reset();
+    fs.writeFileSync(interpretedResultsPath, JSON.stringify({
+      a: 6
+    }), 'utf8');
+    const results3 = await interpretResults(
+      mockServer,
+      metadata,
+      {
+        resultsPath, interpretedResultsPath
+      },
+      sourceInfo as SourceInfo
+    );
+    expect(results3).to.deep.eq({ a: 6 });
+  });
+
+  function mockCompletedQuery() {
+    return  new CompletedQuery(
+      mockQueryWithResults(),
+      mockQueryHistoryConfig()
+    );
+  }
+
+  function mockQueryWithResults(): QueryWithResults {
+    return {
+      query: {
+        program: {
+          queryPath: 'stu'
+        },
+        resultsPaths: {
+          resultsPath: 'axa'
+        },
+        queryID: 111
+      } as never as QueryInfo,
+      result: {} as never as EvaluationResult,
+      database: {
+        databaseUri: 'abc',
+        name: 'def'
+      },
+      options: {
+        label: 'ghi',
+        queryText: 'jkl',
+        isQuickQuery: false
+      },
+      logFileLocation: 'mno',
+      dispose: disposeSpy
+    };
+  }
+
+  function mockQueryHistoryConfig(): QueryHistoryConfig {
+    return {
+      onDidChangeQueryHistoryConfiguration: onDidChangeQueryHistoryConfigurationSpy,
+      format: 'pqr'
+    };
+  }
+});


### PR DESCRIPTION
Fix Query sort issues

## Fix invalid sort after reloading query results

With this change, we use the stored sort order if it exists
after reloading a query results page.

## Fix incorrect call to bqrs info when retrieving paginated results

When retrieving paginated results, need to make sure we are getting
page offsets from the correct results file.

Previously, we were incorrectly extracting page offsets from the default
(unsorted) file. With this change, we ensure that we get offsets from
the proper results file when there is a request for a page of results.

Resolves #586
Resolves #587

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Replace this with a description of the changes your pull request makes.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ n/a ] `@github/docs-content-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
