### PR TITLE
Clear problems view when a database is removed

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -4,12 +4,11 @@
 
 - Add friendly welcome message when the databases view is empty.
 - Add open query, open results, and remove query commands in the query history view title bar.
-- Max number of simultaneous queries launchable by runQueries command is now configurable by changing the codeQL.runningQueries.maxQueries setting.
+- Max number of simultaneous queries launchable by runQueries command is now configurable by changing the `codeQL.runningQueries.maxQueries` setting.
 - Fix sorting of results. Some pages of results would have the wrong sort order and columns.
 - Remember previous sort order when reloading query results.
 - Fix proper escaping of backslashes in SARIF message strings.
 - Allow setting `codeQL.runningQueries.numberOfThreads` and `codeQL.runningTests.numberOfThreads` to 0, (which is interpreted as 'use one thread per core on the machine').
-- Clear the problems view of all Code QL problems when a database is removed.
 - Clear the problems view of all CodeQL query results when a database is removed.
 
 ## 1.3.3 - 16 September 2020

--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fix proper escaping of backslashes in SARIF message strings.
 - Allow setting `codeQL.runningQueries.numberOfThreads` and `codeQL.runningTests.numberOfThreads` to 0, (which is interpreted as 'use one thread per core on the machine').
 - Clear the problems view of all Code QL problems when a database is removed.
+- Clear the problems view of all CodeQL query results when a database is removed.
 
 ## 1.3.3 - 16 September 2020
 

--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Remember previous sort order when reloading query results.
 - Fix proper escaping of backslashes in SARIF message strings.
 - Allow setting `codeQL.runningQueries.numberOfThreads` and `codeQL.runningTests.numberOfThreads` to 0, (which is interpreted as 'use one thread per core on the machine').
+- Clear the problems view of all Code QL problems when a database is removed.
 
 ## 1.3.3 - 16 September 2020
 

--- a/extensions/ql-vscode/src/databases-ui.ts
+++ b/extensions/ql-vscode/src/databases-ui.ts
@@ -16,6 +16,7 @@ import * as fs from 'fs-extra';
 
 import * as cli from './cli';
 import {
+  DatabaseChangedEvent,
   DatabaseItem,
   DatabaseManager,
   getUpgradesDirectories,
@@ -72,9 +73,7 @@ class DatabaseTreeDataProvider extends DisposableObject
   implements TreeDataProvider<DatabaseItem> {
   private _sortOrder = SortOrder.NameAsc;
 
-  private readonly _onDidChangeTreeData = new EventEmitter<
-    DatabaseItem | undefined
-  >();
+  private readonly _onDidChangeTreeData = new EventEmitter<DatabaseItem | undefined>();
   private currentDatabaseItem: DatabaseItem | undefined;
 
   constructor(
@@ -101,19 +100,19 @@ class DatabaseTreeDataProvider extends DisposableObject
     return this._onDidChangeTreeData.event;
   }
 
-  private handleDidChangeDatabaseItem = (
-    databaseItem: DatabaseItem | undefined
-  ): void => {
-    this._onDidChangeTreeData.fire(databaseItem);
+  private handleDidChangeDatabaseItem = (event: DatabaseChangedEvent): void => {
+    // Note that events from the databse manager are instances of DatabaseChangedEvent
+    // and events fired by the UI are instances of DatabaseItem
+    this._onDidChangeTreeData.fire(event.item);
   };
 
   private handleDidChangeCurrentDatabaseItem = (
-    databaseItem: DatabaseItem | undefined
+    event: DatabaseChangedEvent
   ): void => {
     if (this.currentDatabaseItem) {
       this._onDidChangeTreeData.fire(this.currentDatabaseItem);
     }
-    this.currentDatabaseItem = databaseItem;
+    this.currentDatabaseItem = event.item;
     if (this.currentDatabaseItem) {
       this._onDidChangeTreeData.fire(this.currentDatabaseItem);
     }

--- a/extensions/ql-vscode/src/databases-ui.ts
+++ b/extensions/ql-vscode/src/databases-ui.ts
@@ -103,6 +103,9 @@ class DatabaseTreeDataProvider extends DisposableObject
   private handleDidChangeDatabaseItem = (event: DatabaseChangedEvent): void => {
     // Note that events from the databse manager are instances of DatabaseChangedEvent
     // and events fired by the UI are instances of DatabaseItem
+
+    // When event.item is undefined, then the entire tree is refreshed.
+    // When event.item is a db item, then only that item is refreshed.
     this._onDidChangeTreeData.fire(event.item);
   };
 

--- a/extensions/ql-vscode/src/databases.ts
+++ b/extensions/ql-vscode/src/databases.ts
@@ -273,10 +273,12 @@ class DatabaseItemImpl implements DatabaseItem {
   /** A cache of database info */
   private _dbinfo: cli.DbInfo | undefined;
 
-  public constructor(public readonly databaseUri: vscode.Uri,
-    contents: DatabaseContents | undefined, private options: FullDatabaseOptions,
-    private readonly onChanged: (event: DatabaseChangedEvent) => void) {
-
+  public constructor(
+    public readonly databaseUri: vscode.Uri,
+    contents: DatabaseContents | undefined,
+    private options: FullDatabaseOptions,
+    private readonly onChanged: (event: DatabaseChangedEvent) => void
+  ) {
     this._contents = contents;
   }
 
@@ -483,9 +485,11 @@ export class DatabaseManager extends DisposableObject {
   private readonly _databaseItems: DatabaseItemImpl[] = [];
   private _currentDatabaseItem: DatabaseItem | undefined = undefined;
 
-  constructor(private ctx: ExtensionContext,
+  constructor(
+    private ctx: ExtensionContext,
     public config: QueryServerConfig,
-    public logger: Logger) {
+    public logger: Logger
+  ) {
     super();
 
     this.loadPersistedState();  // Let this run async.
@@ -655,6 +659,7 @@ export class DatabaseManager extends DisposableObject {
   private async addDatabaseItem(item: DatabaseItemImpl) {
     this._databaseItems.push(item);
     this.updatePersistedDatabaseList();
+    // note that we use undefined as the item in order to reset the entire tree
     this._onDidChangeDatabaseItem.fire({
       item: undefined,
       kind: DatabaseEventKind.Add
@@ -694,6 +699,7 @@ export class DatabaseManager extends DisposableObject {
         e => logger.log(`Failed to delete '${item.databaseUri.path}'. Reason: ${e.message}`));
     }
 
+    // note that we use undefined as the item in order to reset the entire tree
     this._onDidChangeDatabaseItem.fire({
       item: undefined,
       kind: DatabaseEventKind.Remove

--- a/extensions/ql-vscode/src/interface-types.ts
+++ b/extensions/ql-vscode/src/interface-types.ts
@@ -86,6 +86,10 @@ export interface ResultsUpdatingMsg {
   t: 'resultsUpdating';
 }
 
+/**
+ * Message to set the initial state of the results view with a new
+ * query.
+ */
 export interface SetStateMsg {
   t: 'setState';
   resultsPath: string;
@@ -109,6 +113,10 @@ export interface SetStateMsg {
   parsedResultSets: ParsedResultSets;
 }
 
+/**
+ * Message indicating that the results view should display interpreted
+ * results.
+ */
 export interface ShowInterpretedPageMsg {
   t: 'showInterpretedPage';
   interpretation: Interpretation;
@@ -127,10 +135,17 @@ export interface NavigatePathMsg {
   direction: number;
 }
 
+/**
+ * A message indicating that the results view should untoggle the
+ * "Show results in Problems view" checkbox.
+ */
 export interface UntoggleShowProblemsMsg {
   t: 'untoggleShowProblems';
 }
 
+/**
+ * A message sent into the results view.
+ */
 export type IntoResultsViewMsg =
   | ResultsUpdatingMsg
   | SetStateMsg
@@ -138,6 +153,9 @@ export type IntoResultsViewMsg =
   | NavigatePathMsg
   | UntoggleShowProblemsMsg;
 
+/**
+ * A message sent from the results view.
+ */
 export type FromResultsViewMsg =
   | ViewSourceFileMsg
   | ToggleDiagnostics
@@ -146,12 +164,21 @@ export type FromResultsViewMsg =
   | ResultViewLoaded
   | ChangePage;
 
+/**
+ * Message from the results view to open a database source
+ * file at the provided location.
+ */
 export interface ViewSourceFileMsg {
   t: 'viewSourceFile';
   loc: ResolvableLocationValue;
   databaseUri: string;
 }
 
+
+/**
+ * Message from the results view to toggle the display of
+ * query diagnostics.
+ */
 interface ToggleDiagnostics {
   t: 'toggleDiagnostics';
   databaseUri: string;
@@ -161,10 +188,18 @@ interface ToggleDiagnostics {
   kind?: string;
 }
 
+/**
+ * Message from the results view to signal that loading the results
+ * is complete.
+ */
 interface ResultViewLoaded {
   t: 'resultViewLoaded';
 }
 
+/**
+ * Message from the results view to signal a request to change the
+ * page.
+ */
 interface ChangePage {
   t: 'changePage';
   pageNumber: number; // 0-indexed, displayed to the user as 1-indexed
@@ -188,6 +223,9 @@ export interface InterpretedResultsSortState {
   sortDirection: SortDirection;
 }
 
+/**
+ * Message from the results view to request a sorting change.
+ */
 interface ChangeRawResultsSortMsg {
   t: 'changeSort';
   resultSetName: string;
@@ -198,6 +236,9 @@ interface ChangeRawResultsSortMsg {
   sortState?: RawResultsSortState;
 }
 
+/**
+ * Message from the results view to request a sorting change in interpreted results.
+ */
 interface ChangeInterpretedResultsSortMsg {
   t: 'changeInterpretedSort';
   /**
@@ -207,21 +248,33 @@ interface ChangeInterpretedResultsSortMsg {
   sortState?: InterpretedResultsSortState;
 }
 
+/**
+ * Message from the compare view to the extension.
+ */
 export type FromCompareViewMessage =
   | CompareViewLoadedMessage
   | ChangeCompareMessage
   | ViewSourceFileMsg
   | OpenQueryMessage;
 
+/**
+ * Message from the compare view to signal the completion of loading results.
+ */
 interface CompareViewLoadedMessage {
   t: 'compareViewLoaded';
 }
 
+/**
+ * Message from the compare view to request opening a query.
+ */
 export interface OpenQueryMessage {
   readonly t: 'openQuery';
   readonly kind: 'from' | 'to';
 }
 
+/**
+ * Message from the compare view to request changing the result set to compare.
+ */
 interface ChangeCompareMessage {
   t: 'changeCompare';
   newResultSetName: string;
@@ -229,6 +282,9 @@ interface ChangeCompareMessage {
 
 export type ToCompareViewMessage = SetComparisonsMessage;
 
+/**
+ * Message to the compare view that specifies the query results to compare.
+ */
 export interface SetComparisonsMessage {
   readonly t: 'setComparisons';
   readonly stats: {

--- a/extensions/ql-vscode/src/interface-types.ts
+++ b/extensions/ql-vscode/src/interface-types.ts
@@ -127,11 +127,16 @@ export interface NavigatePathMsg {
   direction: number;
 }
 
+export interface UntoggleShowProblemsMsg {
+  t: 'untoggleShowProblems';
+}
+
 export type IntoResultsViewMsg =
   | ResultsUpdatingMsg
   | SetStateMsg
   | ShowInterpretedPageMsg
-  | NavigatePathMsg;
+  | NavigatePathMsg
+  | UntoggleShowProblemsMsg;
 
 export type FromResultsViewMsg =
   | ViewSourceFileMsg

--- a/extensions/ql-vscode/src/interface.ts
+++ b/extensions/ql-vscode/src/interface.ts
@@ -13,7 +13,7 @@ import {
 } from 'vscode';
 import * as cli from './cli';
 import { CodeQLCliServer } from './cli';
-import { DatabaseItem, DatabaseManager } from './databases';
+import { DatabaseEventKind, DatabaseItem, DatabaseManager } from './databases';
 import { showAndLogErrorMessage } from './helpers';
 import { assertNever } from './helpers-pure';
 import {
@@ -134,13 +134,13 @@ export class InterfaceManager extends DisposableObject {
     );
 
     this.push(
-      this.databaseManager.onDidChangeDatabaseItem(() => {
-        // Consider only clearing database items when a database
-        // is removed and only clearing items from that database.
-        this._diagnosticCollection.clear();
-        this.postMessage({
-          t: 'untoggleShowProblems'
-        });
+      this.databaseManager.onDidChangeDatabaseItem(({ kind }) => {
+        if (kind === DatabaseEventKind.Remove) {
+          this._diagnosticCollection.clear();
+          this.postMessage({
+            t: 'untoggleShowProblems'
+          });
+        }
       })
     );
   }

--- a/extensions/ql-vscode/src/interface.ts
+++ b/extensions/ql-vscode/src/interface.ts
@@ -132,6 +132,17 @@ export class InterfaceManager extends DisposableObject {
         this.navigatePathStep.bind(this, -1)
       )
     );
+
+    this.push(
+      this.databaseManager.onDidChangeDatabaseItem(() => {
+        // Consider only clearing database items when a database
+        // is removed and only clearing items from that database.
+        this._diagnosticCollection.clear();
+        this.postMessage({
+          t: 'untoggleShowProblems'
+        });
+      })
+    );
   }
 
   navigatePathStep(direction: number): void {

--- a/extensions/ql-vscode/src/view/result-tables.tsx
+++ b/extensions/ql-vscode/src/view/result-tables.tsx
@@ -110,7 +110,7 @@ export class ResultTables
     };
   }
 
-  untoggleProbemsView() {
+  untoggleProblemsView() {
     this.setState({
       problemsViewSelected: false
     });
@@ -286,11 +286,7 @@ export class ResultTables
   // TODO: Duplicated from results.tsx consider a way to
   // avoid this duplication
   componentDidMount(): void {
-    this.vscodeMessageHandler = (evt) =>
-      evt.origin === window.origin
-        ? this.handleMessage(evt.data as IntoResultsViewMsg)
-        : console.error(`Invalid event origin ${evt.origin}`);
-
+    this.vscodeMessageHandler = this.vscodeMessageHandler.bind(this);
     window.addEventListener('message', this.vscodeMessageHandler);
   }
 
@@ -300,9 +296,11 @@ export class ResultTables
     }
   }
 
-  private vscodeMessageHandler:
-    | ((ev: MessageEvent) => void)
-    | undefined = undefined;
+  private vscodeMessageHandler(evt: MessageEvent) {
+    evt.origin === window.origin
+      ? this.handleMessage(evt.data as IntoResultsViewMsg)
+      : console.error(`Invalid event origin ${evt.origin}`);
+  }
 }
 
 class ResultTable extends React.Component<ResultTableProps, {}> {

--- a/extensions/ql-vscode/src/view/results.tsx
+++ b/extensions/ql-vscode/src/view/results.tsx
@@ -137,6 +137,11 @@ class App extends React.Component<{}, ResultsViewState> {
       case 'navigatePath':
         onNavigation.fire(msg);
         break;
+
+      case 'untoggleShowProblems':
+        // noop
+        break;
+
       default:
         assertNever(msg);
     }

--- a/extensions/ql-vscode/src/view/results.tsx
+++ b/extensions/ql-vscode/src/view/results.tsx
@@ -287,11 +287,7 @@ class App extends React.Component<{}, ResultsViewState> {
   }
 
   componentDidMount(): void {
-    this.vscodeMessageHandler = (evt) =>
-      evt.origin === window.origin
-        ? this.handleMessage(evt.data as IntoResultsViewMsg)
-        : console.error(`Invalid event origin ${evt.origin}`);
-
+    this.vscodeMessageHandler = this.vscodeMessageHandler.bind(this);
     window.addEventListener('message', this.vscodeMessageHandler);
   }
 
@@ -301,9 +297,11 @@ class App extends React.Component<{}, ResultsViewState> {
     }
   }
 
-  private vscodeMessageHandler:
-    | ((ev: MessageEvent) => void)
-    | undefined = undefined;
+  private vscodeMessageHandler(evt: MessageEvent) {
+    evt.origin === window.origin
+      ? this.handleMessage(evt.data as IntoResultsViewMsg)
+      : console.error(`Invalid event origin ${evt.origin}`);
+  }
 }
 
 Rdom.render(<App />, document.getElementById('root'));

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/databases.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/databases.test.ts
@@ -1,0 +1,79 @@
+import 'vscode-test';
+import 'mocha';
+import * as sinon from 'sinon';
+import { expect } from 'chai';
+import { ExtensionContext } from 'vscode';
+
+import { DatabaseEventKind, DatabaseItem, DatabaseManager } from '../../databases';
+import { QueryServerConfig } from '../../config';
+import { Logger } from '../../logging';
+
+describe('databases', () => {
+  let databaseManager: DatabaseManager;
+  let updateSpy: sinon.SinonSpy;
+
+  beforeEach(() => {
+    updateSpy = sinon.spy();
+    databaseManager = new DatabaseManager(
+      {
+        workspaceState: {
+          update: updateSpy
+        }
+      } as unknown as ExtensionContext,
+      {} as QueryServerConfig,
+      {} as Logger,
+    );
+  });
+
+  it('should fire events when adding and removing a db item', () => {
+    const mockDbItem = {
+      databaseUri: 'file:/abc',
+      getPersistedState() {
+        return this.databaseUri;
+      }
+    };
+    const spy = sinon.spy();
+    databaseManager.onDidChangeDatabaseItem(spy);
+    (databaseManager as any).addDatabaseItem(mockDbItem);
+
+    expect((databaseManager as any)._databaseItems).to.deep.eq([mockDbItem]);
+    expect(updateSpy).to.have.been.calledWith('databaseList', ['file:/abc']);
+    expect(spy).to.have.been.calledWith({
+      item: undefined,
+      kind: DatabaseEventKind.Add
+    });
+
+    sinon.reset();
+
+    // now remove the item
+    databaseManager.removeDatabaseItem(mockDbItem as unknown as DatabaseItem);
+    expect((databaseManager as any)._databaseItems).to.deep.eq([]);
+    expect(updateSpy).to.have.been.calledWith('databaseList', []);
+    expect(spy).to.have.been.calledWith({
+      item: undefined,
+      kind: DatabaseEventKind.Remove
+    });
+  });
+
+  it('should rename a db item and emit an event', () => {
+    const mockDbItem = {
+      databaseUri: 'file:/abc',
+      name: 'abc',
+      getPersistedState() {
+        return this.name;
+      }
+    };
+    const spy = sinon.spy();
+    databaseManager.onDidChangeDatabaseItem(spy);
+    (databaseManager as any).addDatabaseItem(mockDbItem);
+
+    databaseManager.renameDatabaseItem(mockDbItem as unknown as DatabaseItem, 'new name');
+
+    expect(mockDbItem.name).to.eq('new name');
+    expect(updateSpy).to.have.been.calledWith('databaseList', ['new name']);
+    expect(spy).to.have.been.calledWith({
+      item: undefined,
+      kind: DatabaseEventKind.Rename
+    });
+  });
+});

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/databases.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/databases.test.ts
@@ -27,9 +27,10 @@ describe('databases', () => {
 
   it('should fire events when adding and removing a db item', () => {
     const mockDbItem = {
-      databaseUri: 'file:/abc',
+      databaseUri: { path: 'file:/abc' },
+      name: 'abc',
       getPersistedState() {
-        return this.databaseUri;
+        return this.name;
       }
     };
     const spy = sinon.spy();
@@ -37,7 +38,7 @@ describe('databases', () => {
     (databaseManager as any).addDatabaseItem(mockDbItem);
 
     expect((databaseManager as any)._databaseItems).to.deep.eq([mockDbItem]);
-    expect(updateSpy).to.have.been.calledWith('databaseList', ['file:/abc']);
+    expect(updateSpy).to.have.been.calledWith('databaseList', ['abc']);
     expect(spy).to.have.been.calledWith({
       item: undefined,
       kind: DatabaseEventKind.Add
@@ -66,13 +67,14 @@ describe('databases', () => {
     const spy = sinon.spy();
     databaseManager.onDidChangeDatabaseItem(spy);
     (databaseManager as any).addDatabaseItem(mockDbItem);
+    sinon.restore();
 
     databaseManager.renameDatabaseItem(mockDbItem as unknown as DatabaseItem, 'new name');
 
     expect(mockDbItem.name).to.eq('new name');
     expect(updateSpy).to.have.been.calledWith('databaseList', ['new name']);
     expect(spy).to.have.been.calledWith({
-      item: undefined,
+      item: mockDbItem,
       kind: DatabaseEventKind.Rename
     });
   });


### PR DESCRIPTION
This commit fixes the problem whereby a database is removed and the
problems associated with queries run from that database stick around
in the problems view.

Also, once problems are cleared, we need to make sure that we uncheck
the checkbox in the results view.

This commit has several limitations:

1. There is duplicated code for message handling in both results.tsx and
result-tables.tsx.
2. Problems are cleared whenever there is *any* change to any database.
Ideally we should only clear problems when a database is removed and
only problems associated with that database. I'll fix part of this in
a future commit.

Resolves #525

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ n/a ] `@github/docs-content-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
