### PR TITLE
Add command to view the DIL of a query

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix proper escaping of backslashes in SARIF message strings.
 - Allow setting `codeQL.runningQueries.numberOfThreads` and `codeQL.runningTests.numberOfThreads` to 0, (which is interpreted as 'use one thread per core on the machine').
 - Clear the problems view of all CodeQL query results when a database is removed.
+- Add a `View DIL` command on query history items. This opens a text editor containing the Datalog Intermediary Language representation of the compiled query.
 
 ## 1.3.3 - 16 September 2020
 

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -330,6 +330,10 @@
         "title": "View SARIF"
       },
       {
+        "command": "codeQLQueryHistory.viewDil",
+        "title": "View DIL"
+      },
+      {
         "command": "codeQLQueryHistory.setLabel",
         "title": "Set Label"
       },
@@ -485,6 +489,11 @@
           "when": "view == codeQLQueryHistory && viewItem == interpretedResultsItem"
         },
         {
+          "command": "codeQLQueryHistory.viewDil",
+          "group": "9_qlCommands",
+          "when": "view == codeQLQueryHistory"
+        },
+        {
           "command": "codeQLTests.showOutputDifferences",
           "group": "qltest@1",
           "when": "view == test-explorer && viewItem == testWithSource"
@@ -598,6 +607,10 @@
         },
         {
           "command": "codeQLQueryHistory.viewSarif",
+          "when": "false"
+        },
+        {
+          "command": "codeQLQueryHistory.viewDil",
           "when": "false"
         },
         {

--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -650,6 +650,14 @@ export class CodeQLCliServer implements Disposable {
       'Resolving queries',
     );
   }
+
+  async generateDil(qloFile: string, outFile: string): Promise<void> {
+    await this.runCodeQlCliCommand(
+      ['query', 'decompile'],
+      ['--kind', 'dil', '-o', outFile, qloFile],
+      'Generating DIL',
+    );
+  }
 }
 
 /**

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -353,6 +353,7 @@ async function activateWithInstalledDistribution(
 
   const qhm = new QueryHistoryManager(
     ctx,
+    qs,
     queryHistoryConfigurationListener,
     showResults,
     async (from: CompletedQuery, to: CompletedQuery) =>

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/run-queries.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/run-queries.test.ts
@@ -1,0 +1,99 @@
+import * as chai from 'chai';
+import * as path from 'path';
+import 'mocha';
+import 'sinon-chai';
+import * as sinon from 'sinon';
+import * as chaiAsPromised from 'chai-as-promised';
+
+import { QueryInfo } from '../../run-queries';
+import { QlProgram, Severity, compileQuery } from '../../messages';
+import { DatabaseItem } from '../../databases';
+
+chai.use(chaiAsPromised);
+const expect = chai.expect;
+
+describe('run-queries', () => {
+  it('should create a QueryInfo', () => {
+    const info = createMockQueryInfo();
+
+    const queryID = info.queryID;
+    expect(path.basename(info.compiledQueryPath)).to.eq(`compiledQuery${queryID}.qlo`);
+    expect(path.basename(info.dilPath)).to.eq(`results${queryID}.dil`);
+    expect(path.basename(info.resultsPaths.resultsPath)).to.eq(`results${queryID}.bqrs`);
+    expect(path.basename(info.resultsPaths.interpretedResultsPath)).to.eq(`interpretedResults${queryID}.sarif`);
+    expect(info.dataset).to.eq('file:///abc');
+  });
+
+  describe('compile', () => {
+    it('should compile', async () => {
+      const info = createMockQueryInfo();
+      const qs = createMockQueryServerClient();
+      const mockProgress = 'progress-monitor';
+      const mockCancel = 'cancel-token';
+
+      const results = await info.compile(
+        qs as any,
+        mockProgress as any,
+        mockCancel as any
+      );
+
+      expect(results).to.deep.eq([
+        { message: 'err', severity: Severity.ERROR }
+      ]);
+
+      expect(qs.sendRequest).to.have.been.calledOnceWith(
+        compileQuery,
+        {
+          compilationOptions: {
+            computeNoLocationUrls: true,
+            failOnWarnings: false,
+            fastCompilation: false,
+            includeDilInQlo: true,
+            localChecking: false,
+            noComputeGetUrl: false,
+            noComputeToString: false,
+          },
+          extraOptions: {
+            timeoutSecs: 5
+          },
+          queryToCheck: 'my-program',
+          resultPath: info.compiledQueryPath,
+          target: { query: {} }
+        },
+        mockCancel,
+        mockProgress
+      );
+    });
+  });
+
+  function createMockQueryInfo() {
+    return new QueryInfo(
+      'my-program' as unknown as QlProgram,
+      {
+        contents: {
+          datasetUri: 'file:///abc'
+        }
+      } as unknown as DatabaseItem,
+      'my-scheme' // queryDbscheme
+    );
+  }
+
+  function createMockQueryServerClient() {
+    return {
+      config: {
+        timeoutSecs: 5
+      },
+      sendRequest: sinon.stub().returns(new Promise(resolve => {
+        resolve({
+          messages: [
+            { message: 'err', severity: Severity.ERROR },
+            { message: 'warn', severity: Severity.WARNING },
+          ]
+        });
+      })),
+      logger: {
+        log: sinon.spy()
+      }
+    };
+  }
+});


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Simple command that generates the DIL for a query if it doesn't exist and then opens it in an editor.

Fixes #395.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] `@github/docs-content-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
