### PR TITLE
Remove build before launch in launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,6 @@
       "outFiles": [
         "${workspaceRoot}/extensions/ql-vscode/out/**/*.js",
       ],
-      "preLaunchTask": "Build",
       "env": {
         // uncomment to allow debugging the language server Java process from a remote java debugger
         // "DEBUG_LANGUAGE_SERVER": "true"
@@ -62,7 +61,6 @@
       "outFiles": [
         "${workspaceRoot}/extensions/ql-vscode/out/**/*.js",
       ],
-      "preLaunchTask": "Build"
     },
     {
       "name": "Launch Integration Tests - Minimal Workspace (vscode-codeql)",
@@ -79,7 +77,6 @@
       "outFiles": [
         "${workspaceRoot}/extensions/ql-vscode/out/**/*.js",
       ],
-      "preLaunchTask": "Build"
     }
   ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,9 +46,18 @@ From the command line, go to the directory `extensions/ql-vscode` and run
 
 ```shell
 npm run build
+npm run watch
 ```
 
-Alternatively, you can build the extension within VS Code via `Terminal > Run Build Task...` (or `Ctrl+Shift+B` with the default key bindings).
+Alternatively, you can build the extension within VS Code via `Terminal > Run Build Task...` (or `Ctrl+Shift+B` with the default key bindings). And you can run the watch command via `Terminal > Run Task` and then select `npm watch` from the menu.
+
+Before running any of the launch commands, be sure to have run the `build` command to ensure that the JavaScript is compiled and the resources are copied to the proper location.
+
+We recommend that you keep`npm run watch` running in the backgound and you only need to re-run  `npm run build` in the following situations:
+
+1. on first checkout
+2. whenever any of the non-TypeScript resources have changed
+3. on any change to files included in the webview
 
 ### Installing the extension
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ Alternatively, you can build the extension within VS Code via `Terminal > Run Bu
 
 Before running any of the launch commands, be sure to have run the `build` command to ensure that the JavaScript is compiled and the resources are copied to the proper location.
 
-We recommend that you keep`npm run watch` running in the backgound and you only need to re-run  `npm run build` in the following situations:
+We recommend that you keep `npm run watch` running in the backgound and you only need to re-run `npm run build` in the following situations:
 
 1. on first checkout
 2. whenever any of the non-TypeScript resources have changed


### PR DESCRIPTION
And update contributing with new instructions.

This will make it easier for core developers to quickly launch and relaunch tasks, though it will make it harder for new and occasional devs to keep their environment up to date. Thoughts?

## Checklist

- [ n/a ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ n/a ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ n/a ] `@github/docs-content-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
