### PR TITLE
Add open type support from AST Viewer

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -366,6 +366,10 @@
         "title": "Go To Code"
       },
       {
+        "command": "codeQLAstViewer.openType",
+        "title": "Find AST Type"
+      },
+      {
         "command": "codeQLAstViewer.clear",
         "title": "Clear AST",
         "icon": {
@@ -502,6 +506,11 @@
           "command": "codeQLTests.acceptOutput",
           "group": "qltest@2",
           "when": "view == test-explorer && viewItem == testWithSource"
+        },
+        {
+          "command": "codeQLAstViewer.openType",
+          "group": "navigation",
+          "when": "view == codeQLAstViewer"
         }
       ],
       "explorer/context": [
@@ -623,6 +632,10 @@
         },
         {
           "command": "codeQLAstViewer.gotoCode",
+          "when": "false"
+        },
+        {
+          "command": "codeQLAstViewer.openType",
           "when": "false"
         },
         {

--- a/extensions/ql-vscode/src/databases.ts
+++ b/extensions/ql-vscode/src/databases.ts
@@ -496,16 +496,18 @@ export class DatabaseManager extends DisposableObject {
   }
 
   public async openDatabase(
-    uri: vscode.Uri, options?: DatabaseOptions
+    uri: vscode.Uri,
+    options?: DatabaseOptions
   ): Promise<DatabaseItem> {
-
     const contents = await resolveDatabaseContents(uri);
     const realOptions = options || {};
     // Ignore the source archive for QLTest databases by default.
     const isQLTestDatabase = path.extname(uri.fsPath) === '.testproj';
+    const ignoreSourceArchive = (realOptions.ignoreSourceArchive !== undefined)
+        ? realOptions.ignoreSourceArchive
+        : isQLTestDatabase;
     const fullOptions: FullDatabaseOptions = {
-      ignoreSourceArchive: (realOptions.ignoreSourceArchive !== undefined) ?
-        realOptions.ignoreSourceArchive : isQLTestDatabase,
+      ignoreSourceArchive,
       displayName: realOptions.displayName,
       dateAdded: realOptions.dateAdded || Date.now()
     };

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -622,7 +622,7 @@ async function activateWithInstalledDistribution(
     new TemplateQueryReferenceProvider(cliServer, qs, dbm)
   );
 
-  const astViewer = new AstViewer();
+  const astViewer = new AstViewer(cliServer);
   ctx.subscriptions.push(astViewer);
   ctx.subscriptions.push(helpers.commandRunnerWithProgress('codeQL.viewAst', async (
     progress: helpers.ProgressCallback,

--- a/extensions/ql-vscode/src/quick-query.ts
+++ b/extensions/ql-vscode/src/quick-query.ts
@@ -2,11 +2,9 @@ import * as fs from 'fs-extra';
 import * as yaml from 'js-yaml';
 import * as path from 'path';
 import { CancellationToken, ExtensionContext, window as Window, workspace, Uri } from 'vscode';
-import { ErrorCodes, ResponseError } from 'vscode-languageclient';
 import { CodeQLCliServer } from './cli';
 import { DatabaseUI } from './databases-ui';
 import * as helpers from './helpers';
-import { logger } from './logging';
 
 const QUICK_QUERIES_DIR_NAME = 'quick-queries';
 const QUICK_QUERY_QUERY_NAME = 'quick-query.ql';
@@ -14,21 +12,6 @@ const QUICK_QUERY_WORKSPACE_FOLDER_NAME = 'Quick Queries';
 
 export function isQuickQueryPath(queryPath: string): boolean {
   return path.basename(queryPath) === QUICK_QUERY_QUERY_NAME;
-}
-
-/**
- * `getBaseText` heuristically returns an appropriate import statement
- * prelude based on the filename of the dbscheme file given. TODO: add
- * a 'default import' field to the qlpack itself, and use that.
- */
-function getBaseText(dbschemeBase: string) {
-  if (dbschemeBase == 'semmlecode.javascript.dbscheme') return 'import javascript\n\nselect ""';
-  if (dbschemeBase == 'semmlecode.cpp.dbscheme') return 'import cpp\n\nselect ""';
-  if (dbschemeBase == 'semmlecode.dbscheme') return 'import java\n\nselect ""';
-  if (dbschemeBase == 'semmlecode.python.dbscheme') return 'import python\n\nselect ""';
-  if (dbschemeBase == 'semmlecode.csharp.dbscheme') return 'import csharp\n\nselect ""';
-  if (dbschemeBase == 'go.dbscheme') return 'import go\n\nselect ""';
-  return 'select ""';
 }
 
 function getQuickQueriesDir(ctx: ExtensionContext): string {
@@ -40,9 +23,6 @@ function getQuickQueriesDir(ctx: ExtensionContext): string {
   fs.ensureDir(queriesPath, { mode: 0o700 });
   return queriesPath;
 }
-
-
-
 
 /**
  * Show a buffer the user can enter a simple query into.
@@ -63,73 +43,67 @@ export async function displayQuickQuery(
     );
   }
 
-  try {
-    const workspaceFolders = workspace.workspaceFolders || [];
-    const queriesDir = await getQuickQueriesDir(ctx);
+  const workspaceFolders = workspace.workspaceFolders || [];
+  const queriesDir = await getQuickQueriesDir(ctx);
 
-    // If there is already a quick query open, don't clobber it, just
-    // show it.
-    const existing = workspace.textDocuments.find(doc => path.basename(doc.uri.fsPath) === QUICK_QUERY_QUERY_NAME);
-    if (existing !== undefined) {
-      Window.showTextDocument(existing);
-      return;
-    }
+  // If there is already a quick query open, don't clobber it, just
+  // show it.
+  const existing = workspace.textDocuments.find(doc => path.basename(doc.uri.fsPath) === QUICK_QUERY_QUERY_NAME);
+  if (existing !== undefined) {
+    Window.showTextDocument(existing);
+    return;
+  }
 
-    // We need to have a multi-root workspace to make quick query work
-    // at all. Changing the workspace from single-root to multi-root
-    // causes a restart of the whole extension host environment, so we
-    // basically can't do anything that survives that restart.
-    //
-    // So if we are currently in a single-root workspace (of which the
-    // only reliable signal appears to be `workspace.workspaceFile`
-    // being undefined) just let the user know that they're in for a
-    // restart.
-    if (workspace.workspaceFile === undefined) {
-      const makeMultiRoot = await helpers.showBinaryChoiceDialog('Quick query requires multiple folders in the workspace. Reload workspace as multi-folder workspace?');
-      if (makeMultiRoot) {
-        updateQuickQueryDir(queriesDir, workspaceFolders.length, 0);
-      }
-      return;
-    }
-
-    const index = workspaceFolders.findIndex(folder => folder.name === QUICK_QUERY_WORKSPACE_FOLDER_NAME);
-    if (index === -1)
+  // We need to have a multi-root workspace to make quick query work
+  // at all. Changing the workspace from single-root to multi-root
+  // causes a restart of the whole extension host environment, so we
+  // basically can't do anything that survives that restart.
+  //
+  // So if we are currently in a single-root workspace (of which the
+  // only reliable signal appears to be `workspace.workspaceFile`
+  // being undefined) just let the user know that they're in for a
+  // restart.
+  if (workspace.workspaceFile === undefined) {
+    const makeMultiRoot = await helpers.showBinaryChoiceDialog('Quick query requires multiple folders in the workspace. Reload workspace as multi-folder workspace?');
+    if (makeMultiRoot) {
       updateQuickQueryDir(queriesDir, workspaceFolders.length, 0);
-    else
-      updateQuickQueryDir(queriesDir, index, 1);
-
-    // We're going to infer which qlpack to use from the current database
-    const dbItem = await databaseUI.getDatabaseItem(progress, token);
-    if (dbItem === undefined) {
-      throw new Error('Can\'t start quick query without a selected database');
     }
-
-    const datasetFolder = await dbItem.getDatasetFolder(cliServer);
-    const { qlpack, dbscheme } = await helpers.resolveDatasetFolder(cliServer, datasetFolder);
-    const quickQueryQlpackYaml: any = {
-      name: 'quick-query',
-      version: '1.0.0',
-      libraryPathDependencies: [qlpack]
-    };
-
-    const qlFile = path.join(queriesDir, QUICK_QUERY_QUERY_NAME);
-    const qlPackFile = path.join(queriesDir, 'qlpack.yml');
-    await fs.writeFile(qlFile, getBaseText(path.basename(dbscheme)), 'utf8');
-    await fs.writeFile(qlPackFile, yaml.safeDump(quickQueryQlpackYaml), 'utf8');
-    Window.showTextDocument(await workspace.openTextDocument(qlFile));
+    return;
   }
 
-  // TODO: clean up error handling for top-level commands like this
-  catch (e) {
-    if (e instanceof helpers.UserCancellationException) {
-      logger.log(e.message);
-    }
-    else if (e instanceof ResponseError && e.code == ErrorCodes.RequestCancelled) {
-      logger.log(e.message);
-    }
-    else if (e instanceof Error)
-      helpers.showAndLogErrorMessage(e.message);
-    else
-      throw e;
+  const index = workspaceFolders.findIndex(folder => folder.name === QUICK_QUERY_WORKSPACE_FOLDER_NAME);
+  if (index === -1) {
+    updateQuickQueryDir(queriesDir, workspaceFolders.length, 0);
+  } else {
+    updateQuickQueryDir(queriesDir, index, 1);
   }
+
+  // We're going to infer which qlpack to use from the current database
+  const dbItem = await databaseUI.getDatabaseItem(progress, token);
+  if (dbItem === undefined) {
+    throw new Error('Can\'t start quick query without a selected database');
+  }
+  const datasetFolder = await dbItem.getDatasetFolder(cliServer);
+  const qlFile = await createQlFile(cliServer, datasetFolder, queriesDir, '\nselect ""');
+  Window.showTextDocument(await workspace.openTextDocument(qlFile));
+}
+
+export async function createQlFile(
+  cliServer: CodeQLCliServer,
+  datasetFolder: string,
+  queriesDir: string,
+  text: string
+) {
+  const { qlpack, language } = await helpers.resolveDatasetFolder(cliServer, datasetFolder);
+  const quickQueryQlpackYaml: any = {
+    name: 'quick-query',
+    version: '1.0.0',
+    libraryPathDependencies: [qlpack]
+  };
+  const fullText = `import ${language}\n${text}`;
+  const qlFile = path.join(queriesDir, QUICK_QUERY_QUERY_NAME);
+  const qlPackFile = path.join(queriesDir, 'qlpack.yml');
+  await fs.writeFile(qlFile, fullText, 'utf8');
+  await fs.writeFile(qlPackFile, yaml.safeDump(quickQueryQlpackYaml), 'utf8');
+  return qlFile;
 }

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/astViewer.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/astViewer.test.ts
@@ -7,6 +7,7 @@ import * as yaml from 'js-yaml';
 import { AstViewer, AstItem } from '../../astViewer';
 import { commands, Range } from 'vscode';
 import { DatabaseItem } from '../../databases';
+import { CodeQLCliServer } from '../../cli';
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;
@@ -32,7 +33,7 @@ describe('AstViewer', () => {
 
   it('should update the viewer roots', () => {
     const item = {} as DatabaseItem;
-    viewer = new AstViewer();
+    viewer = new AstViewer({} as CodeQLCliServer);
     viewer.updateRoots(astRoots, item, 'def/abc');
 
     expect((viewer as any).treeDataProvider.roots).to.eq(astRoots);
@@ -63,7 +64,7 @@ describe('AstViewer', () => {
     fsPath = 'def/abc',
   ) {
     const item = {} as DatabaseItem;
-    viewer = new AstViewer();
+    viewer = new AstViewer({} as CodeQLCliServer);
     viewer.updateRoots(astRoots, item, fsPath);
     const spy = sinon.spy();
     (viewer as any).treeView.reveal = spy;


### PR DESCRIPTION
**Note** This is still a draft. The UX here is off. When you invoke the Open AST Type command, you are navigated to the search bar and you lose your place in the AST Viewer. I'm not a fan of this. However, it might be the case that even with this poor UX, we are better served having the feature than not.

We make the assumption that AST items whose label start with a bracketed 
name refer to a Code QL AST type.

We would like to use the language server's open type command, but that 
requires a file URI and a text location in that file.

Instead, we use a file search. This is an experimental feature. Let's 
see if it is useful.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Fixes #614. This is an alternative implementation that gets us part-way to the desired goal and maybe it is sufficient for now.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] `@github/docs-content-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
