### PR TITLE
Return undefined for finding file ranges on empty URI

### DIFF
--- a/extensions/ql-vscode/src/bqrs-utils.ts
+++ b/extensions/ql-vscode/src/bqrs-utils.ts
@@ -68,7 +68,7 @@ function isWholeFileMatch(matches: RegExpExecArray): boolean {
  *
  * @param uri A file uri
  */
-function isEmptyPath(uriStr: string) {
+export function isEmptyPath(uriStr: string) {
   return !uriStr || uriStr === 'file:/';
 }
 

--- a/extensions/ql-vscode/src/contextual/fileRangeFromURI.ts
+++ b/extensions/ql-vscode/src/contextual/fileRangeFromURI.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 
 import { UrlValue, LineColumnLocation } from '../bqrs-cli-types';
+import { isEmptyPath } from '../bqrs-utils';
 import { DatabaseItem } from '../databases';
 
 
@@ -11,6 +12,9 @@ export default function fileRangeFromURI(uri: UrlValue | undefined, db: Database
     return undefined;
   } else {
     const loc = uri as LineColumnLocation;
+    if (isEmptyPath(loc.uri)) {
+      return undefined;
+    }
     const range = new vscode.Range(Math.max(0, (loc.startLine || 0) - 1),
       Math.max(0, (loc.startColumn || 0) - 1),
       Math.max(0, (loc.endLine || 0) - 1),

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/contextual/fileRangeFromURI.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/contextual/fileRangeFromURI.test.ts
@@ -12,6 +12,16 @@ describe('fileRangeFromURI', () => {
     expect(fileRangeFromURI('hucairz', createMockDatabaseItem())).to.be.undefined;
   });
 
+  it('should return undefined when value is an empty uri', () => {
+    expect(fileRangeFromURI({
+      uri: 'file:/',
+      startLine: 1,
+      startColumn: 2,
+      endLine: 3,
+      endColumn: 4,
+    } as LineColumnLocation, createMockDatabaseItem())).to.be.undefined;
+  });
+
   it('should return a range for a WholeFileLocation', () => {
     expect(fileRangeFromURI({
       uri: 'file:///hucairz',

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/databases.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/databases.test.ts
@@ -2,11 +2,18 @@ import 'vscode-test';
 import 'mocha';
 import * as sinon from 'sinon';
 import { expect } from 'chai';
-import { ExtensionContext } from 'vscode';
+import { ExtensionContext, Uri } from 'vscode';
 
-import { DatabaseEventKind, DatabaseItem, DatabaseManager } from '../../databases';
+import {
+  DatabaseEventKind,
+  DatabaseItem,
+  DatabaseManager,
+  DatabaseItemImpl,
+  DatabaseContents
+} from '../../databases';
 import { QueryServerConfig } from '../../config';
 import { Logger } from '../../logging';
+import { encodeSourceArchiveUri } from '../../archive-filesystem-provider';
 
 describe('databases', () => {
   let databaseManager: DatabaseManager;
@@ -77,5 +84,106 @@ describe('databases', () => {
       item: mockDbItem,
       kind: DatabaseEventKind.Rename
     });
+  });
+
+  describe('resolveSourceFile', () => {
+    describe('unzipped source archive', () => {
+      it('should resolve a source file in an unzipped database', () => {
+        const db = createMockDB();
+        const resolved = db.resolveSourceFile('abc');
+        expect(resolved.toString()).to.eq('file:///sourceArchive-uri/abc');
+      });
+
+      it('should resolve a source file in an unzipped database with trailing slash', () => {
+        const db = createMockDB(Uri.parse('file:/sourceArchive-uri/'));
+        const resolved = db.resolveSourceFile('abc');
+        expect(resolved.toString()).to.eq('file:///sourceArchive-uri/abc');
+      });
+
+      it('should resolve a source uri in an unzipped database with trailing slash', () => {
+        const db = createMockDB(Uri.parse('file:/sourceArchive-uri/'));
+        const resolved = db.resolveSourceFile('file:/abc');
+        expect(resolved.toString()).to.eq('file:///sourceArchive-uri/abc');
+      });
+    });
+
+    describe('no source archive', () => {
+      it('should resolve a file', () => {
+        const db = createMockDB(Uri.parse('file:/sourceArchive-uri/'));
+        (db as any)._contents.sourceArchiveUri = undefined;
+        const resolved = db.resolveSourceFile('abc');
+        expect(resolved.toString()).to.eq('file:///abc');
+      });
+
+      it('should resolve an empty file', () => {
+        const db = createMockDB(Uri.parse('file:/sourceArchive-uri/'));
+        (db as any)._contents.sourceArchiveUri = undefined;
+        const resolved = db.resolveSourceFile('file:');
+        expect(resolved.toString()).to.eq('file:///database-uri');
+      });
+    });
+
+    describe('zipped source archive', () => {
+      it('should encode a source archive url', () => {
+        const db = createMockDB(encodeSourceArchiveUri({
+          sourceArchiveZipPath: 'sourceArchive-uri',
+          pathWithinSourceArchive: 'def'
+        }));
+        const resolved = db.resolveSourceFile(Uri.file('abc').toString());
+
+        // must recreate an encoded archive uri instead of typing out the
+        // text since the uris will be different on windows and ubuntu.
+        expect(resolved.toString()).to.eq(encodeSourceArchiveUri({
+          sourceArchiveZipPath: 'sourceArchive-uri',
+          pathWithinSourceArchive: 'def/abc'
+        }).toString());
+      });
+
+      it('should encode a source archive url with trailing slash', () => {
+        const db = createMockDB(encodeSourceArchiveUri({
+          sourceArchiveZipPath: 'sourceArchive-uri',
+          pathWithinSourceArchive: 'def/'
+        }));
+        const resolved = db.resolveSourceFile(Uri.file('abc').toString());
+
+        // must recreate an encoded archive uri instead of typing out the
+        // text since the uris will be different on windows and ubuntu.
+        expect(resolved.toString()).to.eq(encodeSourceArchiveUri({
+          sourceArchiveZipPath: 'sourceArchive-uri',
+          pathWithinSourceArchive: 'def/abc'
+        }).toString());
+      });
+
+      it('should encode an empty source archive url', () => {
+        const db = createMockDB(encodeSourceArchiveUri({
+          sourceArchiveZipPath: 'sourceArchive-uri',
+          pathWithinSourceArchive: 'def'
+        }));
+        const resolved = db.resolveSourceFile('file:');
+        expect(resolved.toString()).to.eq('codeql-zip-archive://1-18/sourceArchive-uri/def');
+      });
+    });
+
+    it('should handle an empty file', () => {
+      const db = createMockDB(Uri.parse('file:/sourceArchive-uri/'));
+      const resolved = db.resolveSourceFile('');
+      expect(resolved.toString()).to.eq('file:///sourceArchive-uri/');
+    });
+    function createMockDB(
+      sourceArchiveUri = Uri.parse('file:/sourceArchive-uri'),
+      databaseUri = Uri.parse('file:/database-uri')
+    ) {
+      return new DatabaseItemImpl(
+        databaseUri,
+        {
+          sourceArchiveUri
+        } as DatabaseContents,
+        {
+          dateAdded: 123,
+          ignoreSourceArchive: false
+        },
+        () => { /**/ }
+      );
+    }
   });
 });


### PR DESCRIPTION
Also, refactor resolveSourceFile to make it easier to read.
And add unit tests for resolveSourceFile.

This fixes a bug where clicking on an item in the AST viewer when the location is invalid threw an exception.

This PR also fixes a bug in resolveSourceFile where the `pathWithinSourceArchive` was being removed and appended to the `sourceArchiveZipPath`. In normal situations, we don't hit this bug because most database source archive uris have an empty path for the `pathWithinSourceArchive`.

## Checklist

- [ n/a ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ n/a ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ n/a ] `@github/docs-content-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
