### PR TITLE
Remove feature flag for the AST Viewer

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Allow setting `codeQL.runningQueries.numberOfThreads` and `codeQL.runningTests.numberOfThreads` to 0, (which is interpreted as 'use one thread per core on the machine').
 - Clear the problems view of all CodeQL query results when a database is removed.
 - Add a `View DIL` command on query history items. This opens a text editor containing the Datalog Intermediary Language representation of the compiled query.
+- Remove feature flag for the AST Viewer. For more information on how to use the AST Viewer, [see the documentation](https://help.semmle.com/codeql/codeql-for-vscode/procedures/exploring-the-structure-of-your-source-code.html).
 
 ## 1.3.3 - 16 September 2020
 

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -423,7 +423,7 @@
         },
         {
           "command": "codeQLAstViewer.clear",
-          "when": "view == codeQLAstViewer && config.codeQL.experimentalAstViewer == true",
+          "when": "view == codeQLAstViewer",
           "group": "navigation"
         }
       ],
@@ -513,7 +513,7 @@
         {
           "command": "codeQL.viewAst",
           "group": "9_qlCommands",
-          "when": "resourceScheme == codeql-zip-archive && config.codeQL.experimentalAstViewer == true"
+          "when": "resourceScheme == codeql-zip-archive"
         },
         {
           "command": "codeQL.runQueries",
@@ -662,16 +662,14 @@
         },
         {
           "id": "codeQLAstViewer",
-          "name": "AST Viewer",
-          "when": "config.codeQL.experimentalAstViewer == true"
+          "name": "AST Viewer"
         }
       ]
     },
     "viewsWelcome": [
       {
         "view": "codeQLAstViewer",
-        "contents": "Run the 'CodeQL: View AST' command on an open source file from a Code QL database.\n[View AST](command:codeQL.viewAst)",
-        "when": "config.codeQL.experimentalAstViewer == true"
+        "contents": "Run the 'CodeQL: View AST' command on an open source file from a Code QL database.\n[View AST](command:codeQL.viewAst)"
       },
       {
         "view": "codeQLQueryHistory",

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -219,6 +219,3 @@ export class QueryHistoryConfigListener extends ConfigListener implements QueryH
  * want to enable experimental features, they can add them directly in
  * their vscode settings json file.
  */
-
-/* Advanced setting: used to enable the AST Viewer. */
-export const EXPERIMENTAL_AST_VIEWER = new Setting('experimentalAstViewer', ROOT_SETTING);


### PR DESCRIPTION
Resolves #476. This is the final PR in this extension for the AST Viewer. It simply removes the feature flag. This PR should not be merged until https://github.com/github/codeql/issues/3956 is closed and the documentation is released.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [n/a] `@github/docs-content-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
