### PR TITLE
Fix archive encoding when there is an empty uri authority

### DIFF
--- a/extensions/ql-vscode/src/archive-filesystem-provider.ts
+++ b/extensions/ql-vscode/src/archive-filesystem-provider.ts
@@ -100,6 +100,14 @@ class InvalidSourceArchiveUriError extends Error {
 
 /** Decodes an encoded source archive URI into its corresponding paths. Inverse of `encodeSourceArchiveUri`. */
 export function decodeSourceArchiveUri(uri: vscode.Uri): ZipFileReference {
+  if (!uri.authority) {
+    // Uri is malformed, but this is recoverable
+    logger.log(`Warning: ${new InvalidSourceArchiveUriError(uri).message}`);
+    return {
+      pathWithinSourceArchive: '',
+      sourceArchiveZipPath: uri.path
+    };
+  }
   const match = sourceArchiveUriAuthorityPattern.exec(uri.authority);
   if (match === null)
     throw new InvalidSourceArchiveUriError(uri);

--- a/extensions/ql-vscode/src/databases.ts
+++ b/extensions/ql-vscode/src/databases.ts
@@ -121,13 +121,18 @@ async function findSourceArchive(
 
     if (await fs.pathExists(basePath)) {
       return vscode.Uri.file(basePath);
-    }
-    else if (await fs.pathExists(zipPath)) {
-      return vscode.Uri.file(zipPath).with({ scheme: zipArchiveScheme });
+    } else if (await fs.pathExists(zipPath)) {
+      return encodeSourceArchiveUri({
+        pathWithinSourceArchive: '',
+        sourceArchiveZipPath: zipPath
+      });
     }
   }
-  if (!silent)
-    showAndLogInformationMessage(`Could not find source archive for database '${databasePath}'. Assuming paths are absolute.`);
+  if (!silent) {
+    showAndLogInformationMessage(
+      `Could not find source archive for database '${databasePath}'. Assuming paths are absolute.`
+    );
+  }
   return undefined;
 }
 


### PR DESCRIPTION
This commit fixes a bug uncovered by
c66fe07b06eee4843775a1bb2516fae53840e422.

The findSourceArchive function in databases.ts creates a
codeql-zip-archive uri with an empty authority component. This will
fail to decode. Until recently, this situation never happened. But in
the commit linked above, we start decoding some of these incorrectly
encoded uris.

This commit fixes that issue.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->


## Checklist

- [n/a] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [n/a] Issues have been created for any UI or other user-facing changes made by this pull request.
- [n/a] `@github/docs-content-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
