### PR TITLE
Open editor containing query location in non-preview mode

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [UNRELEASED]
 
+- Editors opened by navigating from the results view are no longer opened in _preview mode_. Now they are opened as a persistent editor. [#630](https://github.com/github/vscode-codeql/pull/630)
+
 ## 1.3.6 - 4 November 2020
 
 - Fix URI encoding for databases that were created with special characters in their paths. [#648](https://github.com/github/vscode-codeql/pull/648)

--- a/extensions/ql-vscode/src/interface-utils.ts
+++ b/extensions/ql-vscode/src/interface-utils.ts
@@ -167,7 +167,13 @@ export async function showLocation(location?: Location) {
   const editor =
     editorsWithDoc.length > 0
       ? editorsWithDoc[0]
-      : await Window.showTextDocument(doc, ViewColumn.One);
+      : await Window.showTextDocument(
+        doc, {
+        // avoid preview mode so editor is sticky and will be added to navigation and search histories.
+        preview: false,
+        viewColumn: ViewColumn.One,
+      });
+
   const range = location.range;
   // When highlighting the range, vscode's occurrence-match and bracket-match highlighting will
   // trigger based on where we place the cursor/selection, and will compete for the user's attention.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

~~Adds a new config option to control this behavior. If this behavior is
generally desirable, we will remove the option and avoid using preview
editors for all users.~~

Not going with a config setting as I don't feel like we should be cluttering up the settings page.

This change partially mitigates the limitations with how vscode handles editors backed by custom uri providers.

See https://github.com/github/vscode-codeql/issues/500#issuecomment-712301680 for an explanation of what this does and why we should do it.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [n/a] `@github/docs-content-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
