### PR TITLE
Fix other locations where we create an invalid codeql-zip-archive uri

### DIFF
--- a/extensions/ql-vscode/src/archive-filesystem-provider.ts
+++ b/extensions/ql-vscode/src/archive-filesystem-provider.ts
@@ -90,6 +90,19 @@ export function encodeSourceArchiveUri(ref: ZipFileReference): vscode.Uri {
   });
 }
 
+/**
+ * Convenience method to create a codeql-zip-archive with a path to the root
+ * archive
+ *
+ * @param pathToArchive the filesystem path to the root of the archive
+ */
+export function encodeArchiveBasePath(sourceArchiveZipPath: string) {
+  return encodeSourceArchiveUri({
+    sourceArchiveZipPath,
+    pathWithinSourceArchive: ''
+  });
+}
+
 const sourceArchiveUriAuthorityPattern = /^(\d+)-(\d+)$/;
 
 class InvalidSourceArchiveUriError extends Error {

--- a/extensions/ql-vscode/src/contextual/locationFinder.ts
+++ b/extensions/ql-vscode/src/contextual/locationFinder.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 
-import { decodeSourceArchiveUri, zipArchiveScheme } from '../archive-filesystem-provider';
+import { decodeSourceArchiveUri, encodeArchiveBasePath } from '../archive-filesystem-provider';
 import { ColumnKindCode, EntityValue, getResultSetSchema, ResultSetSchema } from '../bqrs-cli-types';
 import { CodeQLCliServer } from '../cli';
 import { DatabaseManager, DatabaseItem } from '../databases';
@@ -44,7 +44,7 @@ export async function getLocationsForUriString(
   filter: (src: string, dest: string) => boolean
 ): Promise<FullLocationLink[]> {
   const uri = decodeSourceArchiveUri(vscode.Uri.parse(uriString));
-  const sourceArchiveUri = vscode.Uri.file(uri.sourceArchiveZipPath).with({ scheme: zipArchiveScheme });
+  const sourceArchiveUri = encodeArchiveBasePath(uri.sourceArchiveZipPath);
 
   const db = dbm.findDatabaseItemBySourceArchive(sourceArchiveUri);
   if (!db) {

--- a/extensions/ql-vscode/src/contextual/templateProvider.ts
+++ b/extensions/ql-vscode/src/contextual/templateProvider.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 
-import { decodeSourceArchiveUri, zipArchiveScheme } from '../archive-filesystem-provider';
+import { decodeSourceArchiveUri, encodeArchiveBasePath, zipArchiveScheme } from '../archive-filesystem-provider';
 import { CodeQLCliServer } from '../cli';
 import { DatabaseManager } from '../databases';
 import { CachedOperation, ProgressCallback, withProgress } from '../helpers';
@@ -148,7 +148,7 @@ export class TemplatePrintAstProvider {
     }
 
     const zippedArchive = decodeSourceArchiveUri(uri);
-    const sourceArchiveUri = vscode.Uri.file(zippedArchive.sourceArchiveZipPath).with({ scheme: zipArchiveScheme });
+    const sourceArchiveUri = encodeArchiveBasePath(zippedArchive.sourceArchiveZipPath);
     const db = this.dbm.findDatabaseItemBySourceArchive(sourceArchiveUri);
 
     if (!db) {

--- a/extensions/ql-vscode/src/databases.ts
+++ b/extensions/ql-vscode/src/databases.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 import * as cli from './cli';
 import { ExtensionContext } from 'vscode';
 import { showAndLogErrorMessage, showAndLogWarningMessage, showAndLogInformationMessage } from './helpers';
-import { zipArchiveScheme, encodeSourceArchiveUri, decodeSourceArchiveUri } from './archive-filesystem-provider';
+import { zipArchiveScheme, encodeArchiveBasePath, decodeSourceArchiveUri, encodeSourceArchiveUri } from './archive-filesystem-provider';
 import { DisposableObject } from './vscode-utils/disposable-object';
 import { QueryServerConfig } from './config';
 import { Logger, logger } from './logging';
@@ -122,10 +122,7 @@ async function findSourceArchive(
     if (await fs.pathExists(basePath)) {
       return vscode.Uri.file(basePath);
     } else if (await fs.pathExists(zipPath)) {
-      return encodeSourceArchiveUri({
-        pathWithinSourceArchive: '',
-        sourceArchiveZipPath: zipPath
-      });
+      return encodeArchiveBasePath(zipPath);
     }
   }
   if (!silent) {
@@ -439,10 +436,7 @@ export class DatabaseItemImpl implements DatabaseItem {
     const sourceArchive = this.sourceArchive;
     if (sourceArchive === undefined || !sourceArchive.fsPath.endsWith('.zip'))
       return undefined;
-    return encodeSourceArchiveUri({
-      pathWithinSourceArchive: '/',
-      sourceArchiveZipPath: sourceArchive.fsPath,
-    });
+    return encodeArchiveBasePath(sourceArchive.fsPath);
   }
 
   /**

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/archive-filesystem-provider.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/archive-filesystem-provider.test.ts
@@ -1,7 +1,14 @@
 import { expect } from 'chai';
 import * as path from 'path';
 
-import { encodeSourceArchiveUri, ArchiveFileSystemProvider, decodeSourceArchiveUri, ZipFileReference, zipArchiveScheme } from '../../archive-filesystem-provider';
+import {
+  encodeSourceArchiveUri,
+  encodeArchiveBasePath,
+  ArchiveFileSystemProvider,
+  decodeSourceArchiveUri,
+  ZipFileReference,
+  zipArchiveScheme
+} from '../../archive-filesystem-provider';
 import { FileType, FileSystemError, Uri } from 'vscode';
 
 describe('archive-filesystem-provider', () => {
@@ -145,6 +152,15 @@ describe('source archive uri encoding', function() {
       expect(output).to.eql(testCase.input);
     });
   }
+
+  it('should encode a uri at the root of the archive', () => {
+    const path = '/a/b/c/src.zip';
+    const uri = encodeArchiveBasePath(path);
+    expect(uri.path).to.eq(path);
+    expect(decodeSourceArchiveUri(uri).pathWithinSourceArchive).to.eq('');
+    expect(decodeSourceArchiveUri(uri).sourceArchiveZipPath).to.eq(path);
+    expect(uri.authority).to.eq('0-14');
+  });
 
   it('should handle malformed uri with no authority', () => {
     // This handles codeql-zip-archive uris generated using the `with` method


### PR DESCRIPTION
Also, create a convenience function for generating a codeql-zip-archive
at the root of the archive.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->


## Checklist

- [n/a] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [n/a] Issues have been created for any UI or other user-facing changes made by this pull request.
- [n/a] `@github/docs-content-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
