### PR TITLE
Use single file upgrades where possible.

### DIFF
--- a/extensions/ql-vscode/src/pure/messages.ts
+++ b/extensions/ql-vscode/src/pure/messages.ts
@@ -401,6 +401,11 @@ export interface CompileUpgradeParams {
    * A directory to store parts of the compiled upgrade
    */
   upgradeTempDir: string;
+  /** 
+   * Enable single file upgrades, set to true to allow
+   * using single file upgrades.
+   */
+  singleFileUpgrades?: boolean;
 }
 
 /**
@@ -487,10 +492,42 @@ export interface UpgradeDescription {
   newSha: string;
 }
 
+
+export type CompiledUpgrades = MultiFileCompiledUpgrades | SingleFileCompiledUpgrade
+
 /**
- * A compiled upgrade.
+ * A compiled upgrade. 
+ * The upgrade is spread among multiple files.
  */
-export interface CompiledUpgrades {
+export interface MultiFileCompiledUpgrades {
+  /**
+  * The initial sha of the dbscheme to upgrade from
+  */
+  initialSha: string;
+  /**
+   * The path to the new dataset statistics
+   */
+  newStatsPath: string;
+  /**
+   * The path to the new dataset dbscheme
+   */
+  newDbscheme: string;
+  /**
+   * The steps in the upgrade path
+   */
+  scripts: CompiledUpgradeScript[];
+  /**
+   * Will never exist in an old result
+   */
+  compiledUpgradeFile?: never;
+  /**
+   * The sha of the target dataset.
+   */
+  targetSha: string;
+}
+
+
+export interface SingleFileCompiledUpgrade {
   /**
   * The initial sha of the dbscheme to upgrade from
   */
@@ -502,7 +539,11 @@ export interface CompiledUpgrades {
   /**
    * The steps in the upgrade path
    */
-  scripts: CompiledUpgradeScript[];
+  descriptions: UpgradeDescription[];
+  /**
+   * The file containing the upgrade
+   */
+  compiledUpgradeFile: string;
   /**
    * The sha of the target dataset.
    */

--- a/extensions/ql-vscode/src/pure/messages.ts
+++ b/extensions/ql-vscode/src/pure/messages.ts
@@ -380,8 +380,8 @@ export namespace ResultColumnKind {
    */
   export const BOOLEAN = 3;
   /**
- * A column of type `date`
- */
+   * A column of type `date`
+   */
   export const DATE = 4;
   /**
    * A column of a non-primitive type
@@ -401,11 +401,11 @@ export interface CompileUpgradeParams {
    * A directory to store parts of the compiled upgrade
    */
   upgradeTempDir: string;
-  /** 
+  /**
    * Enable single file upgrades, set to true to allow
    * using single file upgrades.
    */
-  singleFileUpgrades?: boolean;
+  singleFileUpgrades: true;
 }
 
 /**
@@ -515,7 +515,7 @@ interface CompiledUpgradesBase {
 
 
 /**
- * A compiled upgrade. 
+ * A compiled upgrade.
  * The upgrade is spread among multiple files.
  */
 interface MultiFileCompiledUpgrades extends CompiledUpgradesBase {
@@ -535,7 +535,7 @@ interface MultiFileCompiledUpgrades extends CompiledUpgradesBase {
 
 
 /**
- * A compiled upgrade. 
+ * A compiled upgrade.
  * The upgrade is in a single file.
  */
 export interface SingleFileCompiledUpgrade extends CompiledUpgradesBase {

--- a/extensions/ql-vscode/src/pure/messages.ts
+++ b/extensions/ql-vscode/src/pure/messages.ts
@@ -496,10 +496,9 @@ export interface UpgradeDescription {
 export type CompiledUpgrades = MultiFileCompiledUpgrades | SingleFileCompiledUpgrade
 
 /**
- * A compiled upgrade. 
- * The upgrade is spread among multiple files.
+ * The parts shared by all compiled upgrades
  */
-export interface MultiFileCompiledUpgrades {
+interface CompiledUpgradesBase {
   /**
   * The initial sha of the dbscheme to upgrade from
   */
@@ -508,6 +507,18 @@ export interface MultiFileCompiledUpgrades {
    * The path to the new dataset statistics
    */
   newStatsPath: string;
+  /**
+   * The sha of the target dataset.
+   */
+  targetSha: string;
+}
+
+
+/**
+ * A compiled upgrade. 
+ * The upgrade is spread among multiple files.
+ */
+interface MultiFileCompiledUpgrades extends CompiledUpgradesBase {
   /**
    * The path to the new dataset dbscheme
    */
@@ -520,34 +531,22 @@ export interface MultiFileCompiledUpgrades {
    * Will never exist in an old result
    */
   compiledUpgradeFile?: never;
-  /**
-   * The sha of the target dataset.
-   */
-  targetSha: string;
 }
 
 
-export interface SingleFileCompiledUpgrade {
-  /**
-  * The initial sha of the dbscheme to upgrade from
-  */
-  initialSha: string;
-  /**
-   * The path to the new dataset statistics
-   */
-  newStatsPath: string;
+/**
+ * A compiled upgrade. 
+ * The upgrade is in a single file.
+ */
+export interface SingleFileCompiledUpgrade extends CompiledUpgradesBase {
   /**
    * The steps in the upgrade path
    */
   descriptions: UpgradeDescription[];
   /**
-   * The file containing the upgrade
+   * A path to a file containing the upgrade
    */
   compiledUpgradeFile: string;
-  /**
-   * The sha of the target dataset.
-   */
-  targetSha: string;
 }
 
 /**

--- a/extensions/ql-vscode/src/upgrades.ts
+++ b/extensions/ql-vscode/src/upgrades.ts
@@ -150,7 +150,11 @@ export async function upgradeDatabase(
 
   try {
     qs.logger.log('Running the following database upgrade:');
-    qs.logger.log(compileUpgradeResult.compiledUpgrades.scripts.map(s => s.description.description).join('\n'));
+    if (compileUpgradeResult.compiledUpgrades.compiledUpgradeFile === undefined) {
+      qs.logger.log(compileUpgradeResult.compiledUpgrades.scripts.map(s => s.description.description).join('\n'));
+    } else {
+      qs.logger.log(compileUpgradeResult.compiledUpgrades.descriptions.map(s => s.description).join('\n'));
+    }
     return await runDatabaseUpgrade(qs, db, compileUpgradeResult.compiledUpgrades, progress, token);
   }
   catch (e) {
@@ -185,7 +189,8 @@ async function compileDatabaseUpgrade(
 ): Promise<messages.CompileUpgradeResult> {
   const params: messages.CompileUpgradeParams = {
     upgrade: upgradeParams,
-    upgradeTempDir: upgradesTmpDir.name
+    upgradeTempDir: upgradesTmpDir.name,
+    singleFileUpgrades: true
   };
 
   progress({

--- a/extensions/ql-vscode/src/upgrades.ts
+++ b/extensions/ql-vscode/src/upgrades.ts
@@ -150,6 +150,9 @@ export async function upgradeDatabase(
 
   try {
     qs.logger.log('Running the following database upgrade:');
+    // We use the presence of compiledUpgradeFile to check
+    // if it is multifile or not. We need to explicitly check undefined
+    // as the types claim the empty string is a valid value
     if (compileUpgradeResult.compiledUpgrades.compiledUpgradeFile === undefined) {
       qs.logger.log(compileUpgradeResult.compiledUpgrades.scripts.map(s => s.description.description).join('\n'));
     } else {


### PR DESCRIPTION
Where possible use the new single file form of upgrades. Older versions of `codeql` simply ignore the `singleFileUpgrades` property and give multifile upgrades. Hence we can just set the new flag and see which sort of upgrade we get pack. If a version of codeql returns a multi file upgrade then it certainly supports running them so there are no issues there.