### PR TITLE
Ensure decoded archive fs paths are never empty

### DIFF
--- a/extensions/ql-vscode/src/archive-filesystem-provider.ts
+++ b/extensions/ql-vscode/src/archive-filesystem-provider.ts
@@ -117,7 +117,7 @@ export function decodeSourceArchiveUri(uri: vscode.Uri): ZipFileReference {
     // Uri is malformed, but this is recoverable
     logger.log(`Warning: ${new InvalidSourceArchiveUriError(uri).message}`);
     return {
-      pathWithinSourceArchive: '',
+      pathWithinSourceArchive: '/',
       sourceArchiveZipPath: uri.path
     };
   }
@@ -129,7 +129,7 @@ export function decodeSourceArchiveUri(uri: vscode.Uri): ZipFileReference {
   if (isNaN(zipPathStartIndex) || isNaN(zipPathEndIndex))
     throw new InvalidSourceArchiveUriError(uri);
   return {
-    pathWithinSourceArchive: uri.path.substring(zipPathEndIndex),
+    pathWithinSourceArchive: uri.path.substring(zipPathEndIndex) || '/',
     sourceArchiveZipPath: uri.path.substring(zipPathStartIndex, zipPathEndIndex),
   };
 }

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/archive-filesystem-provider.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/archive-filesystem-provider.test.ts
@@ -142,7 +142,7 @@ describe('source archive uri encoding', function() {
       name: 'Empty path',
       input: {
         sourceArchiveZipPath: '/home/folder/src.zip',
-        pathWithinSourceArchive: ''
+        pathWithinSourceArchive: '/'
       }
     }
   ];
@@ -153,11 +153,22 @@ describe('source archive uri encoding', function() {
     });
   }
 
+  it('should decode an empty path as a "/"', () => {
+    const uri = encodeSourceArchiveUri({
+      pathWithinSourceArchive: '',
+      sourceArchiveZipPath: 'a/b/c'
+    });
+    expect(decodeSourceArchiveUri(uri)).to.deep.eq({
+      pathWithinSourceArchive: '/',
+      sourceArchiveZipPath: 'a/b/c'
+    });
+  });
+
   it('should encode a uri at the root of the archive', () => {
     const path = '/a/b/c/src.zip';
     const uri = encodeArchiveBasePath(path);
     expect(uri.path).to.eq(path);
-    expect(decodeSourceArchiveUri(uri).pathWithinSourceArchive).to.eq('');
+    expect(decodeSourceArchiveUri(uri).pathWithinSourceArchive).to.eq('/');
     expect(decodeSourceArchiveUri(uri).sourceArchiveZipPath).to.eq(path);
     expect(uri.authority).to.eq('0-14');
   });
@@ -168,7 +179,7 @@ describe('source archive uri encoding', function() {
     expect(uri.authority).to.eq('');
     expect(decodeSourceArchiveUri(uri)).to.deep.eq({
       sourceArchiveZipPath: '/a/b/c/src.zip',
-      pathWithinSourceArchive: ''
+      pathWithinSourceArchive: '/'
     });
   });
 });


### PR DESCRIPTION
Empty paths should be replaced as '/'. This is a fix for a bug
introduced in 899f988df871c4923af01508b7efd06169888b90.

Resolves #647.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [n/a] `@github/docs-content-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
