### PR TITLE
Prepare for release v1.3.5

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CodeQL for Visual Studio Code: Changelog
 
-## [UNRELEASED]
+## 1.3.5 - 27 October 2020
+
+- Fix a bug where archived source folders for databases were not showing any contents.
 
 ## 1.3.4 - 22 October 2020
 


### PR DESCRIPTION
Adds a missing entry to the changelog.