### PR TITLE
Results View: Fix display of booleans

### DIFF
--- a/extensions/ql-vscode/src/view/RawTableValue.tsx
+++ b/extensions/ql-vscode/src/view/RawTableValue.tsx
@@ -15,7 +15,7 @@ export default function RawTableValue(props: Props): JSX.Element {
     || typeof v === 'number'
     || typeof v === 'boolean'
   ) {
-    return <span>{v}</span>;
+    return <span>{v.toString()}</span>;
   }
 
   return renderLocation(v.url, v.label, props.databaseUri);


### PR DESCRIPTION
React nodes containing booleans aren't rendered. We want a node with a string. 

I don't why this has only just stopped working but this seems to fix the problem.