### PR TITLE
Disable codeql test commands from the command palette

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -355,11 +355,11 @@
       },
       {
         "command": "codeQLTests.showOutputDifferences",
-        "title": "CodeQL: Show Test Output Differences"
+        "title": "Show Test Output Differences"
       },
       {
         "command": "codeQLTests.acceptOutput",
-        "title": "CodeQL: Accept Test Output"
+        "title": "Accept Test Output"
       },
       {
         "command": "codeQLAstViewer.gotoCode",
@@ -627,6 +627,14 @@
         },
         {
           "command": "codeQLAstViewer.clear",
+          "when": "false"
+        },
+        {
+          "command": "codeQLTests.acceptOutput",
+          "when": "false"
+        },
+        {
+          "command": "codeQLTests.showOutputDifferences",
           "when": "false"
         }
       ],

--- a/extensions/ql-vscode/test/pure-tests/command-lint.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/command-lint.test.ts
@@ -32,7 +32,6 @@ describe('commands declared in package.json', function() {
     if (
       command.match(/^codeQL\./)
       || command.match(/^codeQLQueryResults\./)
-      || command.match(/^codeQLTests\./)
     ) {
       paletteCmds.add(command);
       expect(title).not.to.be.undefined;
@@ -42,6 +41,7 @@ describe('commands declared in package.json', function() {
       command.match(/^codeQLDatabases\./)
       || command.match(/^codeQLQueryHistory\./)
       || command.match(/^codeQLAstViewer\./)
+      || command.match(/^codeQLTests\./)
     ) {
       scopedCmds.add(command);
       expect(title).not.to.be.undefined;
@@ -68,8 +68,6 @@ describe('commands declared in package.json', function() {
     if (commandDecl.when === 'false')
       disabledInPalette.add(commandDecl.command);
   });
-
-
 
   it('should have commands appropriately prefixed', function() {
     paletteCmds.forEach(command => {


### PR DESCRIPTION
These commands are not applicable from the global context. They require
an argument to be passed in. So, they should be hidden in the command
palette.

Fixes #658.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

## Checklist

- [n/a] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [n/a] `@github/docs-content-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
