### PR TITLE
Avoid recursive selection changes in ast viewer

### DIFF
--- a/extensions/ql-vscode/src/astViewer.ts
+++ b/extensions/ql-vscode/src/astViewer.ts
@@ -8,6 +8,7 @@ import {
   TreeItem,
   TreeView,
   TextEditorSelectionChangeEvent,
+  TextEditorSelectionChangeKind,
   Location,
   Range
 } from 'vscode';
@@ -33,7 +34,7 @@ export interface ChildAstItem extends AstItem {
   parent: ChildAstItem | AstItem;
 }
 
-class AstViewerDataProvider  extends DisposableObject implements TreeDataProvider<AstItem> {
+class AstViewerDataProvider extends DisposableObject implements TreeDataProvider<AstItem> {
 
   public roots: AstItem[] = [];
   public db: DatabaseItem | undefined;
@@ -47,9 +48,9 @@ class AstViewerDataProvider  extends DisposableObject implements TreeDataProvide
     super();
     this.push(
       commandRunner('codeQLAstViewer.gotoCode',
-      async (item: AstItem) => {
-        await showLocation(item.fileLocation);
-      })
+        async (item: AstItem) => {
+          await showLocation(item.fileLocation);
+        })
     );
   }
 
@@ -157,6 +158,11 @@ export class AstViewer extends DisposableObject {
           return candidate;
         }
       }
+      return;
+    }
+
+    // Avoid recursive tree-source code updates.
+    if (e.kind === TextEditorSelectionChangeKind.Command) {
       return;
     }
 


### PR DESCRIPTION
This will prevent selections jumping around when an ast entry is
selected and its child has the same source location as the current
selection.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Fixes #656.

## Checklist

- [n/a] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [n/a] `@github/docs-content-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
