### PR TITLE
Non destructive upgrades in vscode

### DIFF
--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -60,6 +60,7 @@ export interface DbInfo {
 export interface UpgradesInfo {
   scripts: string[];
   finalDbscheme: string;
+  matchesTarget?: boolean;
 }
 
 /**
@@ -652,9 +653,11 @@ export class CodeQLCliServer implements Disposable {
    * @param searchPath A list of directories to search for upgrade scripts.
    * @returns A list of database upgrade script directories
    */
-  resolveUpgrades(dbScheme: string, searchPath: string[]): Promise<UpgradesInfo> {
+  resolveUpgrades(dbScheme: string, searchPath: string[], targetDbScheme?: string): Promise<UpgradesInfo> {
     const args = ['--additional-packs', searchPath.join(path.delimiter), '--dbscheme', dbScheme];
-
+    if (targetDbScheme) {
+      args.push('--target-dbscheme', targetDbScheme);
+    }
     return this.runJsonCodeQlCliCommand<UpgradesInfo>(
       ['resolve', 'upgrades'],
       args,

--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -651,6 +651,7 @@ export class CodeQLCliServer implements Disposable {
    * Gets information necessary for upgrading a database.
    * @param dbScheme the path to the dbscheme of the database to be upgraded.
    * @param searchPath A list of directories to search for upgrade scripts.
+   * @param targetDbScheme The dbscheme to try to upgrade to.
    * @returns A list of database upgrade script directories
    */
   resolveUpgrades(dbScheme: string, searchPath: string[], targetDbScheme?: string): Promise<UpgradesInfo> {

--- a/extensions/ql-vscode/src/databases-ui.ts
+++ b/extensions/ql-vscode/src/databases-ui.ts
@@ -23,7 +23,6 @@ import {
   ProgressCallback,
 } from './commandRunner';
 import {
-  getOnDiskWorkspaceFolders,
   showAndLogErrorMessage,
   isLikelyDatabaseRoot,
   isLikelyDbLanguageFolder

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -369,7 +369,6 @@ async function activateWithInstalledDistribution(
   ctx.subscriptions.push(dbm);
   logger.log('Initializing database panel.');
   const databaseUI = new DatabaseUI(
-    cliServer,
     dbm,
     qs,
     getContextStoragePath(ctx),

--- a/extensions/ql-vscode/src/pure/messages.ts
+++ b/extensions/ql-vscode/src/pure/messages.ts
@@ -475,7 +475,7 @@ export interface CompileUpgradeResult {
   error?: string;
 }
 
-export interface CompiledUpgradeSequence {
+export interface CompileUpgradeSequenceResult {
   /**
    * The compiled upgrades as a single file.
    */
@@ -1006,7 +1006,7 @@ export const compileUpgrade = new rpc.RequestType<WithProgressId<CompileUpgradeP
 /**
  * Compile an upgrade script to upgrade a dataset.
  */
-export const compileUpgradeSequence = new rpc.RequestType<WithProgressId<CompileUpgradeSequenceParams>, CompiledUpgradeSequence, void, void>('compilation/compileUpgradeSequence');
+export const compileUpgradeSequence = new rpc.RequestType<WithProgressId<CompileUpgradeSequenceParams>, CompileUpgradeSequenceResult, void, void>('compilation/compileUpgradeSequence');
 
 /**
  * Clear the cache of a dataset

--- a/extensions/ql-vscode/src/pure/messages.ts
+++ b/extensions/ql-vscode/src/pure/messages.ts
@@ -425,14 +425,6 @@ export interface CompileUpgradeSequenceParams {
    * A directory to store parts of the compiled upgrade
    */
   upgradeTempDir: string;
-  /** 
-   * The first dbscheme in the sequence.
-   */
-  initialDbscheme: string;
-  /** 
-   * The last dbscheme in the sequence.
-   */
-  finalDbscheme: string;
 }
 
 /**
@@ -483,12 +475,17 @@ export interface CompileUpgradeResult {
   error?: string;
 }
 
-export interface SingleFileCompiledUpgradeResult extends CompileUpgradeResult {
+export interface CompiledUpgradeSequence {
   /**
-   * The compiled upgrade.
+   * The compiled upgrades as a single file.
    */
-  compiledUpgrades?: SingleFileCompiledUpgrade;
+  compiledUpgrades?: string;
+  /**
+   * Any errors that occurred when checking the scripts.
+   */
+  error?: string;
 }
+
 
 /**
  * A description of a upgrade process
@@ -528,7 +525,7 @@ export interface UpgradeDescription {
 }
 
 
-export type CompiledUpgrades = MultiFileCompiledUpgrades | SingleFileCompiledUpgrade
+export type CompiledUpgrades = MultiFileCompiledUpgrades | SingleFileCompiledUpgrades
 
 /**
  * The parts shared by all compiled upgrades
@@ -573,7 +570,7 @@ interface MultiFileCompiledUpgrades extends CompiledUpgradesBase {
  * A compiled upgrade.
  * The upgrade is in a single file.
  */
-export interface SingleFileCompiledUpgrade extends CompiledUpgradesBase {
+export interface SingleFileCompiledUpgrades extends CompiledUpgradesBase {
   /**
    * The steps in the upgrade path
    */
@@ -1009,8 +1006,7 @@ export const compileUpgrade = new rpc.RequestType<WithProgressId<CompileUpgradeP
 /**
  * Compile an upgrade script to upgrade a dataset.
  */
-export const compileUpgradeSequence = new rpc.RequestType<WithProgressId<CompileUpgradeSequenceParams>, SingleFileCompiledUpgradeResult, void, void>('compilation/compileUpgradeSequence');
-
+export const compileUpgradeSequence = new rpc.RequestType<WithProgressId<CompileUpgradeSequenceParams>, CompiledUpgradeSequence, void, void>('compilation/compileUpgradeSequence');
 
 /**
  * Clear the cache of a dataset

--- a/extensions/ql-vscode/src/pure/messages.ts
+++ b/extensions/ql-vscode/src/pure/messages.ts
@@ -414,6 +414,28 @@ export interface CompileUpgradeParams {
 }
 
 /**
+ * Parameters for compiling an upgrade.
+ */
+export interface CompileUpgradeSequenceParams {
+  /**
+   * The sequence of upogrades to compile
+   */
+  upgradePaths: string[];
+  /**
+   * A directory to store parts of the compiled upgrade
+   */
+  upgradeTempDir: string;
+  /** 
+   * The first dbscheme in the sequence.
+   */
+  initialDbscheme: string;
+  /** 
+   * The last dbscheme in the sequence.
+   */
+  finalDbscheme: string;
+}
+
+/**
  * Parameters describing an upgrade
  */
 export interface UpgradeParams {
@@ -460,6 +482,14 @@ export interface CompileUpgradeResult {
    */
   error?: string;
 }
+
+export interface SingleFileCompiledUpgradeResult extends CompileUpgradeResult {
+  /**
+   * The compiled upgrade.
+   */
+  compiledUpgrades?: SingleFileCompiledUpgrade;
+}
+
 /**
  * A description of a upgrade process
  */
@@ -696,6 +726,10 @@ export interface QueryToRun {
    * A uri pointing to the qlo to run.
    */
   qlo: string;
+  /**
+   * A uri pointing to the compiled upgrade file.
+   */
+  compiledUpgrade?: string;
   /**
    * The path where we should save this queries results
    */
@@ -972,6 +1006,10 @@ export const checkUpgrade = new rpc.RequestType<WithProgressId<UpgradeParams>, C
  * Compile an upgrade script to upgrade a dataset.
  */
 export const compileUpgrade = new rpc.RequestType<WithProgressId<CompileUpgradeParams>, CompileUpgradeResult, void, void>('compilation/compileUpgrade');
+/**
+ * Compile an upgrade script to upgrade a dataset.
+ */
+export const compileUpgradeSequence = new rpc.RequestType<WithProgressId<CompileUpgradeSequenceParams>, SingleFileCompiledUpgradeResult, void, void>('compilation/compileUpgradeSequence');
 
 
 /**

--- a/extensions/ql-vscode/src/pure/messages.ts
+++ b/extensions/ql-vscode/src/pure/messages.ts
@@ -418,7 +418,7 @@ export interface CompileUpgradeParams {
  */
 export interface CompileUpgradeSequenceParams {
   /**
-   * The sequence of upogrades to compile
+   * The sequence of upgrades to compile
    */
   upgradePaths: string[];
   /**

--- a/extensions/ql-vscode/src/run-queries.ts
+++ b/extensions/ql-vscode/src/run-queries.ts
@@ -17,7 +17,6 @@ import * as config from './config';
 import { DatabaseItem } from './databases';
 import { getOnDiskWorkspaceFolders, showAndLogErrorMessage } from './helpers';
 import { ProgressCallback, UserCancellationException } from './commandRunner';
-import * as helpers from './helpers';
 import { DatabaseInfo, QueryMetadata, ResultsPaths } from './pure/interface-types';
 import { logger } from './logging';
 import * as messages from './pure/messages';
@@ -331,7 +330,7 @@ async function checkDbschemeCompatibility(
 }
 
 function reportNoUpgradePath(query: QueryInfo) {
-  throw new Error(`Query ${query.program.queryPath} expects database scheme ${query.queryDbscheme}, but the current database has a different scheme, and no database upgrades are available. The current database scheme may be newer than the CodeQL query libraries in your workspace. Please try using a newer version of the query libraries.`);
+  throw new Error(`Query ${query.program.queryPath} expects database scheme ${query.queryDbscheme}, but the current database has a different scheme, and no database upgrades are available. The current database scheme may be newer than the CodeQL query libraries in your workspace.\n\nPlease try using a newer version of the query libraries.`);
 }
 
 /**
@@ -344,7 +343,7 @@ async function compileNonDestructiveUpgrade(
   progress: ProgressCallback,
   token: CancellationToken,
 ): Promise<string> {
-  const searchPath = helpers.getOnDiskWorkspaceFolders();
+  const searchPath = getOnDiskWorkspaceFolders();
 
   if (!query.dbItem?.contents?.dbSchemeUri) {
     throw new Error('Database is invalid, and cannot be upgraded.');
@@ -577,7 +576,7 @@ export async function compileAndRunQueryAgainstDatabase(
       if (result.resultType !== messages.QueryResultType.SUCCESS) {
         const message = result.message || 'Failed to run query';
         logger.log(message);
-        helpers.showAndLogErrorMessage(message);
+        showAndLogErrorMessage(message);
       }
       return {
         query,

--- a/extensions/ql-vscode/src/run-queries.ts
+++ b/extensions/ql-vscode/src/run-queries.ts
@@ -354,7 +354,7 @@ async function compileNonDestructiveUpgrade(
   if (!matchesTarget) {
     reportNoUpgradePath(query);
   }
-  const result = await compileDatabaseUpgradeSequence(qs, query.dbItem, query.queryDbscheme, scripts, upgradeTemp, progress, token);
+  const result = await compileDatabaseUpgradeSequence(qs, query.dbItem, scripts, upgradeTemp, progress, token);
   if (result.compiledUpgrades === undefined) {
     const error = result.error || '[no error message available]';
     throw new Error(error);
@@ -362,7 +362,7 @@ async function compileNonDestructiveUpgrade(
   // We can upgrade to the actual target
   query.program.dbschemePath = query.queryDbscheme;
   // We are new enough that we will always support single file upgrades.
-  return result.compiledUpgrades.compiledUpgradeFile!;
+  return result.compiledUpgrades;
 
 }
 

--- a/extensions/ql-vscode/src/run-queries.ts
+++ b/extensions/ql-vscode/src/run-queries.ts
@@ -1,7 +1,7 @@
 import * as crypto from 'crypto';
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import * as tmp from 'tmp';
+import * as tmp from 'tmp-promise';
 import {
   CancellationToken,
   ConfigurationTarget,
@@ -338,7 +338,7 @@ function reportNoUpgradePath(query: QueryInfo) {
  */
 async function compileNonDestructiveUpgrade(
   qs: qsClient.QueryServerClient,
-  upgradeTemp: tmp.DirResult,
+  upgradeTemp: tmp.DirectoryResult,
   query: QueryInfo,
   progress: ProgressCallback,
   token: CancellationToken,
@@ -552,7 +552,7 @@ export async function compileAndRunQueryAgainstDatabase(
 
   const query = new QueryInfo(qlProgram, db, packConfig.dbscheme, quickEvalPosition, metadata, templates);
 
-  const upgradeDir = tmp.dirSync({ dir: upgradesTmpDir.name });
+  const upgradeDir = await tmp.dir({ dir: upgradesTmpDir.name });
   try {
     let upgradeQlo;
     if (await hasNondestructiveUpgradeCapabilities(qs)) {
@@ -615,7 +615,7 @@ export async function compileAndRunQueryAgainstDatabase(
       return createSyntheticResult(query, db, historyItemOptions, 'Query had compilation errors', messages.QueryResultType.OTHER_ERROR);
     }
   } finally {
-    upgradeDir.removeCallback();
+    upgradeDir.cleanup();
   }
 }
 

--- a/extensions/ql-vscode/src/upgrades.ts
+++ b/extensions/ql-vscode/src/upgrades.ts
@@ -39,12 +39,12 @@ export async function compileDatabaseUpgradeSequence(qs: qsClient.QueryServerCli
   resolvedSequence: string[],
   currentUpgradeTmp: tmp.DirResult,
   progress: ProgressCallback,
-  token: vscode.CancellationToken): Promise<messages.CompiledUpgradeSequence> {
+  token: vscode.CancellationToken): Promise<messages.CompileUpgradeSequenceResult> {
   if (db.contents === undefined || db.contents.dbSchemeUri === undefined) {
     throw new Error('Database is invalid, and cannot be upgraded.');
   }
-  if (!hasNondestructiveUpgradeCapabilities(qs)) {
-    throw new Error('The version of codeql is to old to run non-destructive upgrades.');
+  if (!await hasNondestructiveUpgradeCapabilities(qs)) {
+    throw new Error('The version of codeql is too old to run non-destructive upgrades.');
   }
   // If possible just compile the upgrade sequence
   return await qs.sendRequest(messages.compileUpgradeSequence, {

--- a/extensions/ql-vscode/src/upgrades.ts
+++ b/extensions/ql-vscode/src/upgrades.ts
@@ -22,13 +22,13 @@ const MAX_UPGRADE_MESSAGE_LINES = 10;
  * Check that we support non-destructive upgrades.
  * 
  * This requires 3 features. The ability to compile an upgrade sequence; The ability to 
- * run a non-desturcitve upgrades as a query; the ability to specify a target when 
+ * run a non-destructive upgrades as a query; the ability to specify a target when 
  * resolving upgrades.
  */
 export async function hasNondestructiveUpgradeCapabilities(qs: qsClient.QueryServerClient): Promise<boolean> {
   // TODO change to actual version when known
   // Note it is probably something 2.4.something
-  return semver.gte(await qs.cliServer.getVersion(), '2.3.2');
+  return semver.gte(await qs.cliServer.getVersion(), '2.4.1');
 }
 
 

--- a/extensions/ql-vscode/src/upgrades.ts
+++ b/extensions/ql-vscode/src/upgrades.ts
@@ -99,6 +99,7 @@ async function compileDatabaseUpgrade(
 async function checkAndConfirmDatabaseUpgrade(
   compiled: messages.CompiledUpgrades,
   db: DatabaseItem,
+  quiet: boolean
 ): Promise<void> {
 
   let descriptionMessage = '';
@@ -109,6 +110,11 @@ async function checkAndConfirmDatabaseUpgrade(
   }
   logger.log(descriptionMessage);
 
+
+  // If the quiet flag is set, do the upgrade without a popup.
+  if (quiet) {
+    return;
+  }
 
   // Ask the user to confirm the upgrade.
 
@@ -198,11 +204,7 @@ export async function upgradeDatabaseExplicit(
       return;
     }
 
-
-    // If the quiet flag is set, do the upgrade without a popup.
-    if (!qs.cliServer.quiet) {
-      await checkAndConfirmDatabaseUpgrade(compileUpgradeResult.compiledUpgrades, db);
-    }
+    await checkAndConfirmDatabaseUpgrade(compileUpgradeResult.compiledUpgrades, db, qs.cliServer.quiet);
 
     try {
       qs.logger.log('Running the following database upgrade:');

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/databases-ui.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/databases-ui.test.ts
@@ -68,7 +68,6 @@ describe('databases-ui', () => {
     const db5 = createDatabase(storageDir, 'db2-notimported-with-codeql-database.yml', 'cpp', 'codeql-database.yml');
 
     const databaseUI = new DatabaseUI(
-      {} as any,
       {
         databaseItems: [
           { databaseUri: Uri.file(db1) }


### PR DESCRIPTION
This depends on a rebased copy of #639 and also on some unreleased cli features and shouldn't be merged until we know which version they will be released in.

This PR makes us use silent non-destructive upgrades. It also refactors the current upgrade mechanism in places so we have slightly fewer code paths.

There are a few identation changes so you may want to add `?w=1` to the url when reviewing to ignore those changes.