### PR TITLE
Add support for (de-)registering databases with the query server

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [UNRELEASED]
 
+- Ensure databases are unlocked when removing them from the workspace. This will ensure that queries can be run on a database from the command line after being removed. Requires CodeQL CLI 2.4.1 or later. [#681](https://github.com/github/vscode-codeql/pull/681)
 - Fix bug when removing databases where sometimes the source folder would not be removed from the workspace or the database files would not be removed from the workspace storage location. [#692](https://github.com/github/vscode-codeql/pull/692)
 
 ## 1.3.7 - 24 November 2020

--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [UNRELEASED]
 
-- Ensure databases are unlocked when removing them from the workspace. This will ensure that queries can be run on a database from the command line after being removed. Requires CodeQL CLI 2.4.1 or later. [#681](https://github.com/github/vscode-codeql/pull/681)
+- Ensure databases are unlocked when removing them from the workspace. This will ensure that after a database is removed from VS Code, queries can be run on it from the command line without restarting VS Code. Requires CodeQL CLI 2.4.1 or later. [#681](https://github.com/github/vscode-codeql/pull/681)
 - Fix bug when removing databases where sometimes the source folder would not be removed from the workspace or the database files would not be removed from the workspace storage location. [#692](https://github.com/github/vscode-codeql/pull/692)
 
 ## 1.3.7 - 24 November 2020

--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -133,7 +133,7 @@ export class CodeQLCliServer implements Disposable {
   nullBuffer: Buffer;
 
   /** Version of current cli, lazily computed by the `getVersion()` method */
-  _version: SemVer | undefined;
+  private _version: SemVer | undefined;
 
   /** Path to current codeQL executable, or undefined if not running yet. */
   codeQlPath: string | undefined;
@@ -699,7 +699,7 @@ export class CodeQLCliServer implements Disposable {
     );
   }
 
-  private async getVersion() {
+  public async getVersion() {
     if (!this._version) {
       this._version = await this.refreshVersion();
     }

--- a/extensions/ql-vscode/src/databases-ui.ts
+++ b/extensions/ql-vscode/src/databases-ui.ts
@@ -603,7 +603,7 @@ export class DatabaseUI extends DisposableObject {
     multiSelect: DatabaseItem[] | undefined
   ): Promise<void> => {
     if (multiSelect?.length) {
-      Promise.all(multiSelect.map((dbItem) =>
+      await Promise.all(multiSelect.map((dbItem) =>
         this.databaseManager.removeDatabaseItem(progress, token, dbItem)
       ));
     } else {

--- a/extensions/ql-vscode/src/databases.ts
+++ b/extensions/ql-vscode/src/databases.ts
@@ -622,7 +622,7 @@ export class DatabaseManager extends DisposableObject {
             const databaseItem = await this.createDatabaseItemFromPersistedState(progress, token, database);
             try {
               await databaseItem.refresh();
-              await this.registerDatabases(progress, token, databaseItem);
+              await this.registerDatabase(progress, token, databaseItem);
               if (currentDatabaseUri === database.uri) {
                 this.setCurrentDatabaseItem(databaseItem, true);
               }
@@ -697,7 +697,7 @@ export class DatabaseManager extends DisposableObject {
     // Database items reconstituted from persisted state
     // will not have their contents yet.
     if (item.contents?.datasetUri) {
-      await this.registerDatabases(progress, token, item);
+      await this.registerDatabase(progress, token, item);
     }
     // note that we use undefined as the item in order to reset the entire tree
     this._onDidChangeDatabaseItem.fire({
@@ -748,7 +748,7 @@ export class DatabaseManager extends DisposableObject {
     }
 
     // Remove this database item from the allow-list
-    await this.deregisterDatabases(progress, token, item);
+    await this.deregisterDatabase(progress, token, item);
 
     // note that we use undefined as the item in order to reset the entire tree
     this._onDidChangeDatabaseItem.fire({
@@ -757,12 +757,12 @@ export class DatabaseManager extends DisposableObject {
     });
   }
 
-  private async deregisterDatabases(
+  private async deregisterDatabase(
     progress: ProgressCallback,
     token: vscode.CancellationToken,
     dbItem: DatabaseItem,
   ) {
-    if (dbItem.contents) {
+    if (dbItem.contents && (await this.qs.supportsDatabaseRegistration())) {
       const databases: Dataset[] = [{
         dbDir: dbItem.contents.datasetUri.fsPath,
         workingSet: 'default'
@@ -771,12 +771,12 @@ export class DatabaseManager extends DisposableObject {
     }
   }
 
-  private async registerDatabases(
+  private async registerDatabase(
     progress: ProgressCallback,
     token: vscode.CancellationToken,
     dbItem: DatabaseItem,
   ) {
-    if (dbItem.contents) {
+    if (dbItem.contents && (await this.qs.supportsDatabaseRegistration())) {
       const databases: Dataset[] = [{
         dbDir: dbItem.contents.datasetUri.fsPath,
         workingSet: 'default'

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -339,7 +339,7 @@ async function activateWithInstalledDistribution(
   await qs.startQueryServer();
 
   logger.log('Initializing database manager.');
-  const dbm = new DatabaseManager(ctx, qlConfigurationListener, logger);
+  const dbm = new DatabaseManager(ctx, qs, logger);
   ctx.subscriptions.push(dbm);
   logger.log('Initializing database panel.');
   const databaseUI = new DatabaseUI(

--- a/extensions/ql-vscode/src/pure/messages.ts
+++ b/extensions/ql-vscode/src/pure/messages.ts
@@ -837,7 +837,6 @@ export interface RunUpgradeParams {
   toRun: CompiledUpgrades;
 }
 
-
 /**
  * The result of running an upgrade
  */
@@ -857,6 +856,21 @@ export interface RunUpgradeResult {
   finalSha: string;
 }
 
+export interface RegisterDatabaseParams {
+  databases: Dataset[];
+}
+
+export interface DeregisterDatabaseParams {
+  databases: Dataset[];
+}
+
+export type RegisterDatabaseResult = {
+  registeredDatabases: Dataset[];
+};
+
+export type DeregisterDatabaseResult = {
+  registeredDatabases: Dataset[];
+};
 
 /**
  * Type for any action that could have progress messages.
@@ -933,6 +947,20 @@ export const runQueries = new rpc.RequestType<WithProgressId<EvaluateQueriesPara
  * Run upgrades on a dataset
  */
 export const runUpgrade = new rpc.RequestType<WithProgressId<RunUpgradeParams>, RunUpgradeResult, void, void>('evaluation/runUpgrade');
+
+export const registerDatabases = new rpc.RequestType<
+  WithProgressId<RegisterDatabaseParams>,
+  RegisterDatabaseResult,
+  void,
+  void
+>('evaluation/registerDatabases');
+
+export const deregisterDatabases = new rpc.RequestType<
+  WithProgressId<DeregisterDatabaseParams>,
+  DeregisterDatabaseResult,
+  void,
+  void
+>('evaluation/deregisterDatabases');
 
 /**
  * Request returned to the client to notify completion of a query.

--- a/extensions/ql-vscode/src/pure/messages.ts
+++ b/extensions/ql-vscode/src/pure/messages.ts
@@ -856,19 +856,19 @@ export interface RunUpgradeResult {
   finalSha: string;
 }
 
-export interface RegisterDatabaseParams {
+export interface RegisterDatabasesParams {
   databases: Dataset[];
 }
 
-export interface DeregisterDatabaseParams {
+export interface DeregisterDatabasesParams {
   databases: Dataset[];
 }
 
-export type RegisterDatabaseResult = {
+export type RegisterDatabasesResult = {
   registeredDatabases: Dataset[];
 };
 
-export type DeregisterDatabaseResult = {
+export type DeregisterDatabasesResult = {
   registeredDatabases: Dataset[];
 };
 
@@ -949,15 +949,15 @@ export const runQueries = new rpc.RequestType<WithProgressId<EvaluateQueriesPara
 export const runUpgrade = new rpc.RequestType<WithProgressId<RunUpgradeParams>, RunUpgradeResult, void, void>('evaluation/runUpgrade');
 
 export const registerDatabases = new rpc.RequestType<
-  WithProgressId<RegisterDatabaseParams>,
-  RegisterDatabaseResult,
+  WithProgressId<RegisterDatabasesParams>,
+  RegisterDatabasesResult,
   void,
   void
 >('evaluation/registerDatabases');
 
 export const deregisterDatabases = new rpc.RequestType<
-  WithProgressId<DeregisterDatabaseParams>,
-  DeregisterDatabaseResult,
+  WithProgressId<DeregisterDatabasesParams>,
+  DeregisterDatabasesResult,
   void,
   void
 >('evaluation/deregisterDatabases');

--- a/extensions/ql-vscode/src/queryserver-client.ts
+++ b/extensions/ql-vscode/src/queryserver-client.ts
@@ -104,6 +104,10 @@ export class QueryServerClient extends DisposableObject {
   private async startQueryServerImpl(progressReporter: ProgressReporter): Promise<void> {
     const ramArgs = await this.cliServer.resolveRam(this.config.queryMemoryMb, progressReporter);
     const args = ['--threads', this.config.numThreads.toString()].concat(ramArgs);
+
+    // TODO: This should only be added after an appropriate version check
+    args.push('--require-db-registration');
+
     if (this.config.debug) {
       args.push('--debug', '--tuple-counting');
     }

--- a/extensions/ql-vscode/src/queryserver-client.ts
+++ b/extensions/ql-vscode/src/queryserver-client.ts
@@ -112,8 +112,9 @@ export class QueryServerClient extends DisposableObject {
     const ramArgs = await this.cliServer.resolveRam(this.config.queryMemoryMb, progressReporter);
     const args = ['--threads', this.config.numThreads.toString()].concat(ramArgs);
 
-    // TODO: This should only be added after an appropriate version check
-    args.push('--require-db-registration');
+    if (await this.supportsDatabaseRegistration()) {
+      args.push('--require-db-registration');
+    }
 
     if (this.config.debug) {
       args.push('--debug', '--tuple-counting');


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Sends commands to the query server to add and remove databases from the allow list. This feature will enable proper unlocking of databases when they are removed from vscode.

Fixes #572 
Fixes #333 
Fixes #249 

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] `@github/docs-content-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
