### PR TITLE
Add debug flag for query server

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,8 +16,9 @@
         "${workspaceRoot}/extensions/ql-vscode/out/**/*.js",
       ],
       "env": {
-        // uncomment to allow debugging the language server Java process from a remote java debugger
-        // "DEBUG_LANGUAGE_SERVER": "true"
+        // change to 'true' debug the IDE or Query servers
+        "IDE_SERVER_JAVA_DEBUG": "false",
+        "QUERY_SERVER_JAVA_DEBUG": "false",
       }
     },
     {

--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -907,3 +907,16 @@ async function logStream(stream: Readable, logger: Logger): Promise<void> {
     logger.log(line);
   }
 }
+
+
+export function shouldDebugIdeServer() {
+  return 'IDE_SERVER_JAVA_DEBUG' in process.env
+    && process.env.IDE_SERVER_JAVA_DEBUG !== '0'
+    && process.env.IDE_SERVER_JAVA_DEBUG?.toLocaleLowerCase() !== 'false';
+}
+
+export function shouldDebugQueryServer() {
+  return 'QUERY_SERVER_JAVA_DEBUG' in process.env
+    && process.env.QUERY_SERVER_JAVA_DEBUG !== '0'
+    && process.env.QUERY_SERVER_JAVA_DEBUG?.toLocaleLowerCase() !== 'false';
+}

--- a/extensions/ql-vscode/src/ide-server.ts
+++ b/extensions/ql-vscode/src/ide-server.ts
@@ -12,7 +12,7 @@ import { ideServerLogger } from './logging';
 export async function spawnIdeServer(config: QueryServerConfig): Promise<StreamInfo> {
   return window.withProgress({ title: 'CodeQL language server', location: ProgressLocation.Window }, async (progressReporter, _) => {
     const args = ['--check-errors', 'ON_CHANGE'];
-    if (shouldDebug()) {
+    if (cli.shouldDebugIdeServer()) {
       args.push('-J=-agentlib:jdwp=transport=dt_socket,address=localhost:9009,server=y,suspend=n,quiet=y');
     }
     const child = cli.spawnServer(
@@ -27,10 +27,4 @@ export async function spawnIdeServer(config: QueryServerConfig): Promise<StreamI
     );
     return { writer: child.stdin!, reader: child.stdout! };
   });
-}
-
-function shouldDebug() {
-  return 'DEBUG_LANGUAGE_SERVER' in process.env
-    && process.env.DEBUG_LANGUAGE_SERVER !== '0'
-    && process.env.DEBUG_LANGUAGE_SERVER?.toLocaleLowerCase() !== 'false';
 }

--- a/extensions/ql-vscode/src/queryserver-client.ts
+++ b/extensions/ql-vscode/src/queryserver-client.ts
@@ -107,6 +107,11 @@ export class QueryServerClient extends DisposableObject {
     if (this.config.debug) {
       args.push('--debug', '--tuple-counting');
     }
+
+    if (cli.shouldDebugQueryServer()) {
+      args.push('-J=-agentlib:jdwp=transport=dt_socket,address=localhost:9010,server=y,suspend=n,quiet=y');
+    }
+
     const child = cli.spawnServer(
       this.config.codeQlPath,
       'CodeQL query server',


### PR DESCRIPTION
And separate flag for IDE server. Setting these flags to `true` will
start the respective Java processes in debug mode so that they can
be attached to a debugger.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->


## Checklist

- [n/a] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [n/a] Issues have been created for any UI or other user-facing changes made by this pull request.
- [n/a] `@github/docs-content-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
