### PR TITLE
Use the ast edge label when building the ast node label

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Whenever the extension restarts, orphaned databases will be cleaned up. These are databases whose files are located inside of the extension's storage area, but are not imported into the workspace.
 - After renaming a database, the database list is re-sorted. [#685](https://github.com/github/vscode-codeql/pull/685)
 - Add a `codeQl.resultsDisplay.pageSize` setting to configure the number of results displayed in a single results view page. Increase the default page size from 100 to 200. [#686](https://github.com/github/vscode-codeql/pull/686)
+- Update the AST Viewer to include edge labels (if available) in addition to the target node labels. So far, only C/C++ databases take advantage of this change. [#688](https://github.com/github/vscode-codeql/pull/688)
 
 ## 1.3.6 - 4 November 2020
 

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/contextual/astBuilder.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/contextual/astBuilder.test.ts
@@ -65,6 +65,66 @@ describe('AstBuilder', () => {
     )).to.deep.eq(expectedRoots);
   });
 
+  it('should build an AST child without edge label', async () => {
+    // just test one of the children to make sure that the structure is right
+    // this label should only come from the node, not the edge
+    const astBuilder = createAstBuilder();
+    const roots = await astBuilder.getRoots();
+
+    expect(roots[0].children[0].parent).to.eq(roots[0]);
+    // break the recursion
+    (roots[0].children[0] as any).parent = undefined;
+    (roots[0].children[0] as any).children = undefined;
+
+    const child = {
+      children: undefined,
+      fileLocation: undefined,
+      id: 26359,
+      label: 'params',
+      location: {
+        endColumn: 22,
+        endLine: 19,
+        startColumn: 5,
+        startLine: 19,
+        uri: 'file:/opt/src/arch/sandbox/lib/interrupts.c'
+      },
+      order: 0,
+      parent: undefined
+    };
+
+    expect(roots[0].children[0]).to.deep.eq(child);
+  });
+
+  it('should build an AST child with edge label', async () => {
+    // just test one of the children to make sure that the structure is right
+    // this label should only come from both the node and the edge
+    const astBuilder = createAstBuilder();
+    const roots = await astBuilder.getRoots();
+
+    expect(roots[0].children[1].parent).to.eq(roots[0]);
+    // break the recursion
+    (roots[0].children[1] as any).parent = undefined;
+    (roots[0].children[1] as any).children = undefined;
+
+    const child = {
+      children: undefined,
+      fileLocation: undefined,
+      id: 26367,
+      label: 'body: [Block] { ... }',
+      location: {
+        endColumn: 1,
+        endLine: 22,
+        startColumn: 1,
+        startLine: 20,
+        uri: 'file:/opt/src/arch/sandbox/lib/interrupts.c'
+      },
+      order: 2,
+      parent: undefined
+    };
+
+    expect(roots[0].children[1]).to.deep.eq(child);
+  });
+
   it('should fail when graphProperties are not correct', async () => {
     overrides.graphProperties = {
       tuples: [

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/data/astBuilder.json
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/data/astBuilder.json
@@ -28,7 +28,7 @@
           }
         },
         "semmle.label",
-        ""
+        "params"
       ],
       [
         {
@@ -406,7 +406,7 @@
           }
         },
         "semmle.label",
-        "params"
+        "1234"
       ],
       [
         {


### PR DESCRIPTION
The C PrintAST library now includes the edge name in the AST Viewer
tree.

Resolves #687

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [n/a] `@github/docs-content-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
