### PR TITLE
Add a language label next to databases in the UI

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Ensure databases are unlocked when removing them from the workspace. This will ensure that after a database is removed from VS Code, queries can be run on it from the command line without restarting VS Code. Requires CodeQL CLI 2.4.1 or later. [#681](https://github.com/github/vscode-codeql/pull/681)
 - Fix bug when removing databases where sometimes the source folder would not be removed from the workspace or the database files would not be removed from the workspace storage location. [#692](https://github.com/github/vscode-codeql/pull/692)
 - Query results with no string representation will now be displayed with placeholder text in query results. Previously, they were omitted. [#694](https://github.com/github/vscode-codeql/pull/694)
+- Add a label for the language of a database in the databases view. This will only take effect for new databases created with the CodeQL CLI v2.4.1 or later. [#697](https://github.com/github/vscode-codeql/pull/697)
 
 ## 1.3.7 - 24 November 2020
 

--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -50,6 +50,7 @@ export interface DbInfo {
   sourceArchiveRoot: string;
   datasetFolder: string;
   logsFolder: string;
+  primaryLanguage: string;
 }
 
 /**

--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -125,7 +125,7 @@ export class CodeQLCliServer implements Disposable {
   private static CLI_VERSION_WITH_DECOMPILE_KIND_DIL = new SemVer('2.3.0');
 
   /**
-   * CLI version where --kind=DIL was introduced
+   * CLI version where languages are exposed during a `codeql resolve database` command.
    */
   private static CLI_VERSION_WITH_LANGUAGE = new SemVer('2.4.1');
 
@@ -716,7 +716,7 @@ export class CodeQLCliServer implements Disposable {
     return (await this.getVersion()).compare(CodeQLCliServer.CLI_VERSION_WITH_DECOMPILE_KIND_DIL) >= 0;
   }
 
-  public async supportsLangaugeName() {
+  public async supportsLanguageName() {
     return (await this.getVersion()).compare(CodeQLCliServer.CLI_VERSION_WITH_LANGUAGE) >= 0;
   }
 

--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -50,7 +50,7 @@ export interface DbInfo {
   sourceArchiveRoot: string;
   datasetFolder: string;
   logsFolder: string;
-  primaryLanguage: string;
+  languages: string[];
 }
 
 /**
@@ -123,6 +123,11 @@ export class CodeQLCliServer implements Disposable {
    * CLI version where --kind=DIL was introduced
    */
   private static CLI_VERSION_WITH_DECOMPILE_KIND_DIL = new SemVer('2.3.0');
+
+  /**
+   * CLI version where --kind=DIL was introduced
+   */
+  private static CLI_VERSION_WITH_LANGUAGE = new SemVer('2.4.1');
 
   /** The process for the cli server, or undefined if one doesn't exist yet */
   process?: child_process.ChildProcessWithoutNullStreams;
@@ -690,7 +695,7 @@ export class CodeQLCliServer implements Disposable {
   }
 
   async generateDil(qloFile: string, outFile: string): Promise<void> {
-    const extraArgs = (await this.getVersion()).compare(CodeQLCliServer.CLI_VERSION_WITH_DECOMPILE_KIND_DIL) >= 0
+    const extraArgs = await this.supportsDecompileDil()
       ? ['--kind', 'dil', '-o', outFile, qloFile]
       : ['-o', outFile, qloFile];
     await this.runCodeQlCliCommand(
@@ -705,6 +710,14 @@ export class CodeQLCliServer implements Disposable {
       this._version = await this.refreshVersion();
     }
     return this._version;
+  }
+
+  private async supportsDecompileDil() {
+    return (await this.getVersion()).compare(CodeQLCliServer.CLI_VERSION_WITH_DECOMPILE_KIND_DIL) >= 0;
+  }
+
+  public async supportsLangaugeName() {
+    return (await this.getVersion()).compare(CodeQLCliServer.CLI_VERSION_WITH_LANGUAGE) >= 0;
   }
 
   private async refreshVersion() {

--- a/extensions/ql-vscode/src/contextual/queryResolver.ts
+++ b/extensions/ql-vscode/src/contextual/queryResolver.ts
@@ -16,8 +16,7 @@ export async function qlpackOfDatabase(cli: CodeQLCliServer, db: DatabaseItem): 
   if (db.contents === undefined)
     return undefined;
   const datasetPath = db.contents.datasetUri.fsPath;
-  const { qlpack } = await helpers.resolveDatasetFolder(cli, datasetPath);
-  return qlpack;
+  return await helpers.getQlPackForDbscheme(cli, datasetPath);
 }
 
 

--- a/extensions/ql-vscode/src/databases-ui.ts
+++ b/extensions/ql-vscode/src/databases-ui.ts
@@ -18,15 +18,15 @@ import {
   DatabaseItem,
   DatabaseManager,
   getUpgradesDirectories,
-  isLikelyDatabaseRoot,
-  isLikelyDbLanguageFolder,
 } from './databases';
 import {
   commandRunner,
   commandRunnerWithProgress,
   getOnDiskWorkspaceFolders,
   ProgressCallback,
-  showAndLogErrorMessage
+  showAndLogErrorMessage,
+  isLikelyDatabaseRoot,
+  isLikelyDbLanguageFolder
 } from './helpers';
 import { logger } from './logging';
 import { clearCacheInDatabase } from './run-queries';
@@ -143,6 +143,7 @@ class DatabaseTreeDataProvider extends DisposableObject
       );
     }
     item.tooltip = element.databaseUri.fsPath;
+    item.description = element.language;
     return item;
   }
 

--- a/extensions/ql-vscode/src/databases.ts
+++ b/extensions/ql-vscode/src/databases.ts
@@ -831,8 +831,10 @@ export class DatabaseManager extends DisposableObject {
   }
 
   private async getPrimaryLanguage(dbPath: string) {
-    if (!(await this.cli.supportsLangaugeName())) {
-      // return undefined so that we continually recalculate until the cli version is bumped
+    if (!(await this.cli.supportsLanguageName())) {
+      // return undefined so that we recalculate on restart until the cli is at a version that
+      // supports this feature. This recalculation is cheap since we avoid calling into the cli
+      // unless we know it can return the langauges property.
       return undefined;
     }
     const dbInfo = await this.cli.resolveDatabase(dbPath);

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -339,7 +339,7 @@ async function activateWithInstalledDistribution(
   await qs.startQueryServer();
 
   logger.log('Initializing database manager.');
-  const dbm = new DatabaseManager(ctx, qs, logger);
+  const dbm = new DatabaseManager(ctx, qs, cliServer, logger);
   ctx.subscriptions.push(dbm);
   logger.log('Initializing database panel.');
   const databaseUI = new DatabaseUI(

--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -464,6 +464,16 @@ export class CachedOperation<U> {
  * The following functions al heuristically determine metadata about databases.
  */
 
+/**
+ * Note that this heuristic is only being used for backwards compatibility with
+ * CLI versions before the langauge name was introduced to dbInfo. Implementations
+ * that do not require backwards compatibility should call
+ * `cli.CodeQLCliServer.resolveDatabase` and use the first entry in the
+ * `languages` property.
+ *
+ * @see cli.CodeQLCliServer.supportsLangaugeName
+ * @see cli.CodeQLCliServer.resolveDatabase
+ */
 const dbSchemeToLanguage = {
   'semmlecode.javascript.dbscheme': 'javascript',
   'semmlecode.cpp.dbscheme': 'cpp',
@@ -496,6 +506,12 @@ export function getInitialQueryContents(language: string, dbscheme: string) {
     : 'select ""';
 }
 
+/**
+ * Heuristically determines if the directory passed in corresponds
+ * to a database root.
+ *
+ * @param maybeRoot
+ */
 export async function isLikelyDatabaseRoot(maybeRoot: string) {
   const [a, b, c] = (await Promise.all([
     // databases can have either .dbinfo or codeql-database.yml.
@@ -511,17 +527,4 @@ export async function isLikelyDatabaseRoot(maybeRoot: string) {
 
 export function isLikelyDbLanguageFolder(dbPath: string) {
   return !!path.basename(dbPath).startsWith('db-');
-}
-
-export async function getPrimaryLanguage(root: string) {
-  try {
-    const metadataFile = path.join(root, 'codeql-database.yml');
-    if (await fs.pathExists(metadataFile)) {
-      const metadata = yaml.safeLoad(await fs.readFile(metadataFile, 'utf8')) as { primaryLanguage: string | undefined };
-      return metadata.primaryLanguage || '';
-    }
-  } catch (e) {
-    // could not determine language
-  }
-  return '';
 }

--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -466,12 +466,12 @@ export class CachedOperation<U> {
 
 /**
  * Note that this heuristic is only being used for backwards compatibility with
- * CLI versions before the langauge name was introduced to dbInfo. Implementations
+ * CLI versions before the langauge name was introduced to dbInfo. Features
  * that do not require backwards compatibility should call
  * `cli.CodeQLCliServer.resolveDatabase` and use the first entry in the
  * `languages` property.
  *
- * @see cli.CodeQLCliServer.supportsLangaugeName
+ * @see cli.CodeQLCliServer.supportsLanguageName
  * @see cli.CodeQLCliServer.resolveDatabase
  */
 const dbSchemeToLanguage = {
@@ -487,7 +487,7 @@ const dbSchemeToLanguage = {
  * Returns the initial contents for an empty query, based on the language of the selected
  * databse.
  *
- * First try to get the contents text based on language. if that fails, try to get based on
+ * First try to use the given language name. If that doesn't exist, try to infer it based on
  * dbscheme. Otherwise return no import statement.
  *
  * @param language the database language or empty string if unknown

--- a/extensions/ql-vscode/src/pure/helpers-pure.ts
+++ b/extensions/ql-vscode/src/pure/helpers-pure.ts
@@ -2,7 +2,7 @@
  * helpers-pure.ts
  * ------------
  *
- * Helper functions that don't depend on vscode and therefore can be used by the front-end and pure unit tests.
+ * Helper functions that don't depend on vscode or the CLI and therefore can be used by the front-end and pure unit tests.
  */
 
 /**

--- a/extensions/ql-vscode/src/quick-query.ts
+++ b/extensions/ql-vscode/src/quick-query.ts
@@ -5,8 +5,16 @@ import { CancellationToken, ExtensionContext, window as Window, workspace, Uri }
 import { ErrorCodes, ResponseError } from 'vscode-languageclient';
 import { CodeQLCliServer } from './cli';
 import { DatabaseUI } from './databases-ui';
-import * as helpers from './helpers';
 import { logger } from './logging';
+import {
+  getInitialQueryContents,
+  getPrimaryDbscheme,
+  getQlPackForDbscheme,
+  ProgressCallback,
+  showAndLogErrorMessage,
+  showBinaryChoiceDialog,
+  UserCancellationException
+} from './helpers';
 
 const QUICK_QUERIES_DIR_NAME = 'quick-queries';
 const QUICK_QUERY_QUERY_NAME = 'quick-query.ql';
@@ -14,21 +22,6 @@ const QUICK_QUERY_WORKSPACE_FOLDER_NAME = 'Quick Queries';
 
 export function isQuickQueryPath(queryPath: string): boolean {
   return path.basename(queryPath) === QUICK_QUERY_QUERY_NAME;
-}
-
-/**
- * `getBaseText` heuristically returns an appropriate import statement
- * prelude based on the filename of the dbscheme file given. TODO: add
- * a 'default import' field to the qlpack itself, and use that.
- */
-function getBaseText(dbschemeBase: string) {
-  if (dbschemeBase == 'semmlecode.javascript.dbscheme') return 'import javascript\n\nselect ""';
-  if (dbschemeBase == 'semmlecode.cpp.dbscheme') return 'import cpp\n\nselect ""';
-  if (dbschemeBase == 'semmlecode.dbscheme') return 'import java\n\nselect ""';
-  if (dbschemeBase == 'semmlecode.python.dbscheme') return 'import python\n\nselect ""';
-  if (dbschemeBase == 'semmlecode.csharp.dbscheme') return 'import csharp\n\nselect ""';
-  if (dbschemeBase == 'go.dbscheme') return 'import go\n\nselect ""';
-  return 'select ""';
 }
 
 function getQuickQueriesDir(ctx: ExtensionContext): string {
@@ -51,7 +44,7 @@ export async function displayQuickQuery(
   ctx: ExtensionContext,
   cliServer: CodeQLCliServer,
   databaseUI: DatabaseUI,
-  progress: helpers.ProgressCallback,
+  progress: ProgressCallback,
   token: CancellationToken
 ) {
 
@@ -85,7 +78,7 @@ export async function displayQuickQuery(
     // being undefined) just let the user know that they're in for a
     // restart.
     if (workspace.workspaceFile === undefined) {
-      const makeMultiRoot = await helpers.showBinaryChoiceDialog('Quick query requires multiple folders in the workspace. Reload workspace as multi-folder workspace?');
+      const makeMultiRoot = await showBinaryChoiceDialog('Quick query requires multiple folders in the workspace. Reload workspace as multi-folder workspace?');
       if (makeMultiRoot) {
         updateQuickQueryDir(queriesDir, workspaceFolders.length, 0);
       }
@@ -105,7 +98,9 @@ export async function displayQuickQuery(
     }
 
     const datasetFolder = await dbItem.getDatasetFolder(cliServer);
-    const { qlpack, dbscheme } = await helpers.resolveDatasetFolder(cliServer, datasetFolder);
+    const dbscheme = await getPrimaryDbscheme(datasetFolder);
+    const qlpack = await getQlPackForDbscheme(cliServer, dbscheme);
+
     const quickQueryQlpackYaml: any = {
       name: 'quick-query',
       version: '1.0.0',
@@ -114,21 +109,21 @@ export async function displayQuickQuery(
 
     const qlFile = path.join(queriesDir, QUICK_QUERY_QUERY_NAME);
     const qlPackFile = path.join(queriesDir, 'qlpack.yml');
-    await fs.writeFile(qlFile, getBaseText(path.basename(dbscheme)), 'utf8');
+    await fs.writeFile(qlFile, getInitialQueryContents(dbItem.language, dbscheme), 'utf8');
     await fs.writeFile(qlPackFile, yaml.safeDump(quickQueryQlpackYaml), 'utf8');
     Window.showTextDocument(await workspace.openTextDocument(qlFile));
   }
 
   // TODO: clean up error handling for top-level commands like this
   catch (e) {
-    if (e instanceof helpers.UserCancellationException) {
+    if (e instanceof UserCancellationException) {
       logger.log(e.message);
     }
     else if (e instanceof ResponseError && e.code == ErrorCodes.RequestCancelled) {
       logger.log(e.message);
     }
     else if (e instanceof Error)
-      helpers.showAndLogErrorMessage(e.message);
+      showAndLogErrorMessage(e.message);
     else
       throw e;
   }

--- a/extensions/ql-vscode/src/vscode-tests/minimal-workspace/databases.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/minimal-workspace/databases.test.ts
@@ -71,7 +71,7 @@ describe('databases', () => {
         supportsDatabaseRegistration: supportsDatabaseRegistrationSpy
       } as unknown as QueryServerClient,
       {
-        supportsLangaugeName: supportsLanguageNameSpy,
+        supportsLanguageName: supportsLanguageNameSpy,
         resolveDatabase: resolveDatabaseSpy
       } as unknown as CodeQLCliServer,
       {} as Logger,

--- a/extensions/ql-vscode/src/vscode-tests/minimal-workspace/databases.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/minimal-workspace/databases.test.ts
@@ -12,20 +12,20 @@ import {
   DatabaseManager,
   DatabaseItemImpl,
   DatabaseContents,
-  isLikelyDbLanguageFolder,
   FullDatabaseOptions
 } from '../../databases';
 import { Logger } from '../../logging';
 import { encodeArchiveBasePath, encodeSourceArchiveUri } from '../../archive-filesystem-provider';
 import { QueryServerClient } from '../../queryserver-client';
-import { ProgressCallback } from '../../helpers';
 import { registerDatabases } from '../../pure/messages';
+import { isLikelyDbLanguageFolder, ProgressCallback } from '../../helpers';
 
 describe('databases', () => {
 
   const MOCK_DB_OPTIONS: FullDatabaseOptions = {
     dateAdded: 123,
-    ignoreSourceArchive: false
+    ignoreSourceArchive: false,
+    language: ''
   };
 
   let databaseManager: DatabaseManager;

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/contextual/queryResolver.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/contextual/queryResolver.test.ts
@@ -16,7 +16,7 @@ const expect = chai.expect;
 describe('queryResolver', () => {
   let module: Record<string, Function>;
   let writeFileSpy: sinon.SinonSpy;
-  let resolveDatasetFolderSpy: sinon.SinonStub;
+  let getQlPackForDbschemeSpy: sinon.SinonStub;
   let mockCli: Record<string, sinon.SinonStub>;
   beforeEach(() => {
     mockCli = {
@@ -60,7 +60,7 @@ describe('queryResolver', () => {
 
   describe('qlpackOfDatabase', () => {
     it('should get the qlpack of a database', async () => {
-      resolveDatasetFolderSpy.returns({ qlpack: 'my-qlpack' });
+      getQlPackForDbschemeSpy.resolves('my-qlpack');
       const db = {
         contents: {
           datasetUri: {
@@ -70,20 +70,20 @@ describe('queryResolver', () => {
       };
       const result = await module.qlpackOfDatabase(mockCli, db);
       expect(result).to.eq('my-qlpack');
-      expect(resolveDatasetFolderSpy).to.have.been.calledWith(mockCli, '/path/to/database');
+      expect(getQlPackForDbschemeSpy).to.have.been.calledWith(mockCli, '/path/to/database');
     });
   });
 
   function createModule() {
     writeFileSpy = sinon.spy();
-    resolveDatasetFolderSpy = sinon.stub();
+    getQlPackForDbschemeSpy = sinon.stub();
     return proxyquire('../../../contextual/queryResolver', {
       'fs-extra': {
         writeFile: writeFileSpy
       },
 
       '../helpers': {
-        resolveDatasetFolder: resolveDatasetFolderSpy,
+        getQlPackForDbscheme: getQlPackForDbschemeSpy,
         getOnDiskWorkspaceFolders: () => ({}),
         showAndLogErrorMessage: () => ({})
       }

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/helpers.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/helpers.test.ts
@@ -6,7 +6,7 @@ import * as tmp from 'tmp';
 import * as path from 'path';
 import * as fs from 'fs-extra';
 
-import { getInitialQueryContents, getPrimaryLanguage, InvocationRateLimiter } from '../../helpers';
+import { getInitialQueryContents, InvocationRateLimiter, isLikelyDbLanguageFolder } from '../../helpers';
 
 describe('Invocation rate limiter', () => {
   // 1 January 2020
@@ -105,14 +105,6 @@ describe('codeql-database.yml tests', () => {
     dir.removeCallback();
   });
 
-  it('should get the language of a database', async () => {
-    expect(await getPrimaryLanguage(dir.name)).to.eq('cpp');
-  });
-
-  it('should get the language of a database when langauge is not known', async () => {
-    expect(await getPrimaryLanguage('xxx')).to.eq('');
-  });
-
   it('should get initial query contents when language is known', () => {
     expect(getInitialQueryContents('cpp', 'hucairz')).to.eq('import cpp\n\nselect ""');
   });
@@ -124,6 +116,11 @@ describe('codeql-database.yml tests', () => {
   it('should get initial query contents when nothing is known', () => {
     expect(getInitialQueryContents('', 'hucairz')).to.eq('select ""');
   });
+});
+
+it('should find likely db language folders', () => {
+  expect(isLikelyDbLanguageFolder('db-javascript')).to.be.true;
+  expect(isLikelyDbLanguageFolder('dbnot-a-db')).to.be.false;
 });
 
 class MockExtensionContext implements ExtensionContext {


### PR DESCRIPTION
This change will only work on databases created by cli >= 2.4.1. In that
version, a new `primaryLanguage` field in the `codeql-database.yml`
file. We use this property as the language.

This change also includes a refactoring of the logic around extracting
database information heuristically based on file location. As much
as possible, it is extracted to the `helpers` module. Also, the
initial quick query text is generated based on the language (if known)
otherwise it falls back to the old style of generation.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Fixes #321

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [n/a] `@github/docs-content-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
