### PR TITLE
Re-enable the queries cli test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,12 +124,11 @@ jobs:
         version: ['v2.2.6', 'v2.3.3', 'v2.4.0']
     env:
       CLI_VERSION: ${{ matrix.version }}
+      QL_PATH: '${{ github.workspace }}/codeql'
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
 
       - uses: actions/setup-node@v1
         with:
@@ -146,6 +145,12 @@ jobs:
         run: |
           npm run build
         shell: bash
+
+      - name: Checkout QL
+        uses: actions/checkout@v2
+        with:
+          repository: github/codeql
+          path: codeql
 
       - name: Run CLI tests (Linux)
         working-directory: extensions/ql-vscode

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,7 +124,7 @@ jobs:
         version: ['v2.2.6', 'v2.3.3', 'v2.4.0']
     env:
       CLI_VERSION: ${{ matrix.version }}
-      QL_PATH: '${{ github.workspace }}/codeql'
+      TEST_CODEQL_PATH: '${{ github.workspace }}/codeql'
 
     steps:
       - name: Checkout

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -86,7 +86,7 @@
       "args": [
         "--extensionDevelopmentPath=${workspaceRoot}/extensions/ql-vscode",
         "--extensionTestsPath=${workspaceRoot}/extensions/ql-vscode/out/vscode-tests/cli-integration/index",
-        "${workspaceRoot}/extensions/ql-vscode/test/data"
+        "${workspaceRoot}/extensions/ql-vscode/src/vscode-tests/cli-integration/data",
       ],
       "stopOnEntry": false,
       "sourceMaps": true,

--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -144,10 +144,15 @@ export class CodeQLCliServer implements Disposable {
   /** Path to current codeQL executable, or undefined if not running yet. */
   codeQlPath: string | undefined;
 
+  /**
+   * When set to true, ignore some modal popups and assume user has clicked "yes".
+   */
+  public quiet = false;
+
   constructor(
     private distributionProvider: DistributionProvider,
     private cliConfig: CliConfig,
-    private logger: Logger,
+    private logger: Logger
   ) {
     this.commandQueue = [];
     this.commandInProcess = false;

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -124,6 +124,7 @@ export interface CodeQLExtensionInterface {
   readonly distributionManager: DistributionManager;
   readonly databaseManager: DatabaseManager;
   readonly databaseUI: DatabaseUI;
+  readonly dispose: () => void;
 }
 
 /**
@@ -679,7 +680,10 @@ async function activateWithInstalledDistribution(
     qs,
     distributionManager,
     databaseManager: dbm,
-    databaseUI
+    databaseUI,
+    dispose: () => {
+      ctx.subscriptions.forEach(d => d.dispose());
+    }
   };
 }
 

--- a/extensions/ql-vscode/src/queryserver-client.ts
+++ b/extensions/ql-vscode/src/queryserver-client.ts
@@ -62,7 +62,12 @@ export class QueryServerClient extends DisposableObject {
   withProgressReporting: WithProgressReporting;
   public activeQueryName: string | undefined;
 
-  constructor(readonly config: QueryServerConfig, readonly cliServer: cli.CodeQLCliServer, readonly opts: ServerOpts, withProgressReporting: WithProgressReporting) {
+  constructor(
+    readonly config: QueryServerConfig,
+    readonly cliServer: cli.CodeQLCliServer,
+    readonly opts: ServerOpts,
+    withProgressReporting: WithProgressReporting
+  ) {
     super();
     // When the query server configuration changes, restart the query server.
     if (config.onDidChangeConfiguration !== undefined) {

--- a/extensions/ql-vscode/src/upgrades.ts
+++ b/extensions/ql-vscode/src/upgrades.ts
@@ -82,6 +82,13 @@ async function checkAndConfirmDatabaseUpgrade(
   }
 
   logger.log(descriptionMessage);
+
+
+  // If the quiet flag is set, do the upgrade without a popup.
+  if (qs.cliServer.quiet) {
+    return params;
+  }
+
   // Ask the user to confirm the upgrade.
 
   const showLogItem: vscode.MessageItem = { title: 'No, Show Changes', isCloseAffordance: true };

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/data/qlpack.yml
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/data/qlpack.yml
@@ -1,2 +1,3 @@
 name: integration-test-queries-javascript
 version: 0.0.0
+libraryPathDependencies: codeql-javascript

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/databases.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/databases.test.ts
@@ -2,8 +2,7 @@ import * as sinon from 'sinon';
 import * as path from 'path';
 import { fail } from 'assert';
 import { expect } from 'chai';
-import { extensions, CancellationToken, Uri } from 'vscode';
-import * as vscode from 'vscode';
+import { extensions, CancellationToken, Uri, window } from 'vscode';
 
 import { CodeQLExtensionInterface } from '../../extension';
 import { DatabaseManager } from '../../databases';
@@ -37,7 +36,7 @@ describe('Databases', function() {
       // the uri.fsPath function on windows returns a lowercase drive letter
       // so, force the storage path string to be lowercase, too.
       progressCallback = sandbox.spy();
-      inputBoxStub = sandbox.stub(vscode.window, 'showInputBox');
+      inputBoxStub = sandbox.stub(window, 'showInputBox');
     } catch (e) {
       fail(e);
     }
@@ -45,7 +44,7 @@ describe('Databases', function() {
 
   afterEach(() => {
     try {
-      databaseManager.dispose();
+      // dispose();
       sandbox.restore();
     } catch (e) {
       fail(e);

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/global.helper.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/global.helper.ts
@@ -44,11 +44,12 @@ export default function(mocha: /*Mocha*/ any) {
     }
   },
 
+  // Set the CLI version here before activation to ensure we don't accidentally try to download a cli
   async () => {
-    // Set the CLI version here before activation to ensure we don't accidentally try to download a cli
     await workspace.getConfiguration().update('codeQL.cli.executablePath', process.env.CLI_PATH, ConfigurationTarget.Global);
   },
 
+  // Create the temp directory to be used as extension local storage.
   () => {
     const dir = tmp.dirSync();
     storagePath = fs.realpathSync(dir.name);
@@ -61,7 +62,10 @@ export default function(mocha: /*Mocha*/ any) {
 
 
 
-  mocha.globalTeardown(() => {
-    removeStorage?.();
-  });
+  mocha.globalTeardown([
+    // ensure temp directory is cleaned up.
+    () => {
+      removeStorage?.();
+    }
+  ]);
 }

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/global.helper.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/global.helper.ts
@@ -4,7 +4,8 @@ import * as fs from 'fs-extra';
 import fetch from 'node-fetch';
 
 import { fail } from 'assert';
-import { ConfigurationTarget, workspace } from 'vscode';
+import { ConfigurationTarget, extensions, workspace } from 'vscode';
+import { CodeQLExtensionInterface } from '../../extension';
 
 // This file contains helpers shared between actual tests.
 
@@ -21,48 +22,57 @@ export default function(mocha: /*Mocha*/ any) {
   // create an extension storage location
   let removeStorage: tmp.DirResult['removeCallback'] | undefined;
 
-  // ensure the test database is downloaded
-  mocha.globalSetup([async () => {
-    fs.mkdirpSync(path.dirname(dbLoc));
-    if (!fs.existsSync(dbLoc)) {
-      try {
-        await new Promise((resolve, reject) => {
-          fetch(DB_URL).then(response => {
-            const dest = fs.createWriteStream(dbLoc);
-            response.body.pipe(dest);
+  mocha.globalSetup([
+    // ensure the test database is downloaded
+    async () => {
+      fs.mkdirpSync(path.dirname(dbLoc));
+      if (!fs.existsSync(dbLoc)) {
+        try {
+          await new Promise((resolve, reject) => {
+            fetch(DB_URL).then(response => {
+              const dest = fs.createWriteStream(dbLoc);
+              response.body.pipe(dest);
 
-            response.body.on('error', reject);
-            dest.on('error', reject);
-            dest.on('close', () => {
-              resolve(dbLoc);
+              response.body.on('error', reject);
+              dest.on('error', reject);
+              dest.on('close', () => {
+                resolve(dbLoc);
+              });
             });
           });
-        });
-      } catch (e) {
-        fail('Failed to download test database: ' + e);
+        } catch (e) {
+          fail('Failed to download test database: ' + e);
+        }
       }
+    },
+
+    // Set the CLI version here before activation to ensure we don't accidentally try to download a cli
+    async () => {
+      await workspace.getConfiguration().update('codeQL.cli.executablePath', process.env.CLI_PATH, ConfigurationTarget.Global);
+    },
+
+    // Create the temp directory to be used as extension local storage.
+    () => {
+      const dir = tmp.dirSync();
+      storagePath = fs.realpathSync(dir.name);
+      if (storagePath.substring(0, 2).match(/[A-Z]:/)) {
+        storagePath = storagePath.substring(0, 1).toLocaleLowerCase() + storagePath.substring(1);
+      }
+
+      removeStorage = dir.removeCallback;
     }
-  },
-
-  // Set the CLI version here before activation to ensure we don't accidentally try to download a cli
-  async () => {
-    await workspace.getConfiguration().update('codeQL.cli.executablePath', process.env.CLI_PATH, ConfigurationTarget.Global);
-  },
-
-  // Create the temp directory to be used as extension local storage.
-  () => {
-    const dir = tmp.dirSync();
-    storagePath = fs.realpathSync(dir.name);
-    if (storagePath.substring(0, 2).match(/[A-Z]:/)) {
-      storagePath = storagePath.substring(0, 1).toLocaleLowerCase() + storagePath.substring(1);
-    }
-
-    removeStorage = dir.removeCallback;
-  }]);
-
-
+  ]);
 
   mocha.globalTeardown([
+    // ensure etension is cleaned up.
+    async () => {
+      const extension = await extensions.getExtension<CodeQLExtensionInterface | {}>('GitHub.vscode-codeql')!.activate();
+      // This shuts down the extension and can only be run after all tests have completed.
+      // If this is not called, then the test process will hang.
+      if ('dispose' in extension) {
+        extension.dispose();
+      }
+    },
     // ensure temp directory is cleaned up.
     () => {
       removeStorage?.();

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/queries.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/queries.test.ts
@@ -18,9 +18,7 @@ import { QueryServerClient } from '../../queryserver-client';
 /**
  * Integration tests for queries
  */
-// TODO: Not currently able to run this because we do not have access to the javascript qlpack.
-// Need to download ql libraries separately.
-xdescribe('Queries', function() {
+describe.only('Queries', function() {
   this.timeout(20000);
 
   let dbItem: DatabaseItem;
@@ -40,6 +38,7 @@ xdescribe('Queries', function() {
         databaseManager = extension.databaseManager;
         cli = extension.cliServer;
         qs = extension.qs;
+        cli.quiet = true;
       } else {
         throw new Error('Extension not initialized. Make sure cli is downloaded and installed properly.');
       }

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/queries.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/queries.test.ts
@@ -13,13 +13,18 @@ import { importArchiveDatabase } from '../../databaseFetcher';
 import { compileAndRunQueryAgainstDatabase } from '../../run-queries';
 import { CodeQLCliServer } from '../../cli';
 import { QueryServerClient } from '../../queryserver-client';
+import { skipIfNoCodeQL } from '../ensureCli';
 
 
 /**
  * Integration tests for queries
  */
-describe.only('Queries', function() {
+describe('Queries', function() {
   this.timeout(20000);
+
+  before(function() {
+    skipIfNoCodeQL(this);
+  });
 
   let dbItem: DatabaseItem;
   let databaseManager: DatabaseManager;
@@ -67,8 +72,6 @@ describe.only('Queries', function() {
 
   afterEach(() => {
     try {
-      databaseManager?.dispose();
-      qs?.dispose();
       sandbox.restore();
     } catch (e) {
       fail(e);

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/run-cli.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/run-cli.test.ts
@@ -4,7 +4,8 @@ import { SemVer } from 'semver';
 
 import { CodeQLCliServer } from '../../cli';
 import { CodeQLExtensionInterface } from '../../extension';
-
+import { skipIfNoCodeQL } from '../ensureCli';
+import { getOnDiskWorkspaceFolders } from '../../helpers';
 
 /**
  * Perform proper integration tests by running the CLI
@@ -23,10 +24,6 @@ describe('Use cli', function() {
     }
   });
 
-  afterEach(() => {
-    cli.dispose();
-  });
-
   it('should have the correct version of the cli', async () => {
     expect(
       (await cli.getVersion()).toString()
@@ -41,5 +38,16 @@ describe('Use cli', function() {
       '-J-Xmx4096M',
       '--off-heap-ram=4096'
     ]);
+  });
+
+  it.only('should resolve query packs', async function() {
+    skipIfNoCodeQL(this);
+    const qlpacks = await cli.resolveQlpacks(getOnDiskWorkspaceFolders());
+    // should have a bunch of qlpacks. just check that a few known ones exist
+    expect(qlpacks['codeql-cpp']).not.to.be.undefined;
+    expect(qlpacks['codeql-csharp']).not.to.be.undefined;
+    expect(qlpacks['codeql-java']).not.to.be.undefined;
+    expect(qlpacks['codeql-javascript']).not.to.be.undefined;
+    expect(qlpacks['codeql-python']).not.to.be.undefined;
   });
 });

--- a/extensions/ql-vscode/src/vscode-tests/run-integration-tests.ts
+++ b/extensions/ql-vscode/src/vscode-tests/run-integration-tests.ts
@@ -122,9 +122,10 @@ function getLaunchArgs(dir: TestDir) {
       ];
 
     case TestDir.CliIntegration:
+      // CLI integration tests requires a multi-root workspace so that the data and the QL sources are accessible.
       return [
         path.resolve(__dirname, '../../test/data'),
-        process.env.QL_PATH!
+        process.env.TEST_CODEQL_PATH!
       ];
 
     default:

--- a/extensions/ql-vscode/src/vscode-tests/run-integration-tests.ts
+++ b/extensions/ql-vscode/src/vscode-tests/run-integration-tests.ts
@@ -88,13 +88,15 @@ async function main() {
 
     console.log(`Running integration tests in these directories: ${dirs}`);
     for (const dir of dirs) {
+      const launchArgs = getLaunchArgs(dir as TestDir);
       console.log(`Next integration test dir: ${dir}`);
+      console.log(`Launch args: ${launchArgs}`);
       await runTestsWithRetryOnSegfault({
         version: VSCODE_VERSION,
         vscodeExecutablePath,
         extensionDevelopmentPath,
         extensionTestsPath: path.resolve(__dirname, dir, 'index'),
-        launchArgs: getLaunchArgs(dir as TestDir)
+        launchArgs
       }, 3);
     }
   } catch (err) {
@@ -120,7 +122,10 @@ function getLaunchArgs(dir: TestDir) {
       ];
 
     case TestDir.CliIntegration:
-      break;
+      return [
+        path.resolve(__dirname, '../../test/data'),
+        process.env.QL_PATH!
+      ];
 
     default:
       assertNever(dir);


### PR DESCRIPTION
* Requires that QL_PATH environment variable is set and points to a
  checkout of github/codeql
* Adds the `quiet` flag to the cli. When set, this flag will prevent
  some modal dialogs from disrupting the flow. Currently, we only ensure
  that the upgrades dialog is avoided.
* Update the main.yml workflow to checkout the codeql repo

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Added a second commit, which does the following:

Move query.test.ts to the cli integration tests

* Now query.test.ts runs on multiple cli versions
* Removed most `dispose` calls in cli tests because each test shares the
  same instance of the extension and all of its properties. So, we
  shouldn't be disposing until the last test completes. It's likely that
  we will need to be more careful about cleaning up state between test
  runs, but we haven't hit that yet and this can happen in a later
  commit.

## Checklist

- [n/a] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [n/a] Issues have been created for any UI or other user-facing changes made by this pull request.
- [n/a] `@github/docs-content-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
