### PR TITLE
Make error messages clearer for some common problems

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Fix bug when removing databases where sometimes the source folder would not be removed from the workspace or the database files would not be removed from the workspace storage location. [#692](https://github.com/github/vscode-codeql/pull/692)
 - Query results with no string representation will now be displayed with placeholder text in query results. Previously, they were omitted. [#694](https://github.com/github/vscode-codeql/pull/694)
 - Add a label for the language of a database in the databases view. This will only take effect for new databases created with the CodeQL CLI v2.4.1 or later. [#697](https://github.com/github/vscode-codeql/pull/697)
+- Add clearer error message when running a query using a missing or invalid qlpack. [#702](https://github.com/github/vscode-codeql/pull/702)
+- Add clearer error message when trying to run a command from the query history view if no item in the history is selected. [#702](https://github.com/github/vscode-codeql/pull/702)
 
 ## 1.3.7 - 24 November 2020
 

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -304,7 +304,7 @@
       },
       {
         "command": "codeQLQueryHistory.openQuery",
-        "title": "Open Query",
+        "title": "Open the query that produced these results",
         "icon": {
           "light": "media/light/edit.svg",
           "dark": "media/dark/edit.svg"

--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -172,6 +172,7 @@ class HistoryTreeDataProvider extends DisposableObject implements QueryHistoryDa
  */
 const DOUBLE_CLICK_TIME = 500;
 
+const NO_QUERY_SELECTED = 'No query selected. Select a query history item you have already run and try again.';
 export class QueryHistoryManager extends DisposableObject {
   treeDataProvider: HistoryTreeDataProvider;
   treeView: vscode.TreeView<CompletedQuery>;
@@ -310,6 +311,10 @@ export class QueryHistoryManager extends DisposableObject {
       return;
     }
 
+    if (!finalSingleItem) {
+      throw new Error(NO_QUERY_SELECTED);
+    }
+
     const textDocument = await vscode.workspace.openTextDocument(
       vscode.Uri.file(finalSingleItem.query.program.queryPath)
     );
@@ -398,6 +403,11 @@ export class QueryHistoryManager extends DisposableObject {
     if (!this.assertSingleQuery(finalMultiSelect)) {
       return;
     }
+
+    if (!finalSingleItem) {
+      throw new Error(NO_QUERY_SELECTED);
+    }
+
     this.treeDataProvider.setCurrentItem(finalSingleItem);
 
     const now = new Date();
@@ -438,6 +448,10 @@ export class QueryHistoryManager extends DisposableObject {
   ) {
     if (!this.assertSingleQuery(multiSelect)) {
       return;
+    }
+
+    if (!singleItem) {
+      throw new Error(NO_QUERY_SELECTED);
     }
 
     const queryName = singleItem.queryName.endsWith('.ql')

--- a/extensions/ql-vscode/src/run-queries.ts
+++ b/extensions/ql-vscode/src/run-queries.ts
@@ -345,7 +345,7 @@ async function promptUserToSaveChanges(document: TextDocument): Promise<boolean>
     else {
       const yesItem = { title: 'Yes', isCloseAffordance: false };
       const alwaysItem = { title: 'Always Save', isCloseAffordance: false };
-      const noItem = { title: 'No (run anyway)', isCloseAffordance: false };
+      const noItem = { title: 'No (run version on disk)', isCloseAffordance: false };
       const cancelItem = { title: 'Cancel', isCloseAffordance: true };
       const message = 'Query file has unsaved changes. Save now?';
       const chosenItem = await window.showInformationMessage(
@@ -477,6 +477,10 @@ export async function compileAndRunQueryAgainstDatabase(
   const diskWorkspaceFolders = helpers.getOnDiskWorkspaceFolders();
   // Figure out the library path for the query.
   const packConfig = await cliServer.resolveLibraryPath(diskWorkspaceFolders, queryPath);
+
+  if (!packConfig.dbscheme) {
+    throw new Error('Could not find a database scheme for this query. Please check that you have a valid qlpack.yml file for this query, which refers to a database scheme either in the `dbscheme` field or through one of its dependencies.');
+  }
 
   // Check whether the query has an entirely different schema from the
   // database. (Queries that merely need the database to be upgraded


### PR DESCRIPTION
1. Clicking on query history menu items when nothing is selected. Error
   message is clearer. It would be better to disable when nothing is
   selected, but waiting on
   https://github.com/microsoft/vscode/issues/99767 to be released.
2. Trying to run query with a missing or invalid qlpack has better
   message.
3. Better hover text for "Open query".

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [n/a] Issues have been created for any UI or other user-facing changes made by this pull request.
- [n/a] `@github/docs-content-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
