### PR TITLE
Avoid uninteresting user facing errors

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add clearer error message when running a query using a missing or invalid qlpack. [#702](https://github.com/github/vscode-codeql/pull/702)
 - Add clearer error message when trying to run a command from the query history view if no item in the history is selected. [#702](https://github.com/github/vscode-codeql/pull/702)
 - Fix a bug where it is not possible to download some database archives. This fix specifically addresses large archives and archives whose central directories do not align with file headers. [#700](https://github.com/github/vscode-codeql/pull/700)
+- Avoid error dialogs when QL test discovery or database cleanup encounters a missing directory. [#706](https://github.com/github/vscode-codeql/pull/706)
 
 ## 1.3.7 - 24 November 2020
 

--- a/extensions/ql-vscode/src/databases-ui.ts
+++ b/extensions/ql-vscode/src/databases-ui.ts
@@ -378,7 +378,17 @@ export class DatabaseUI extends DisposableObject {
 
   handleRemoveOrphanedDatabases = async (): Promise<void> => {
     logger.log('Removing orphaned databases from workspace storage.');
-    let dbDirs =
+    let dbDirs = undefined;
+
+    if (
+      !(await fs.pathExists(this.storagePath) ||
+        !(await fs.stat(this.storagePath)).isDirectory())
+    ) {
+      // ignore a missing or invalid storage directory.
+      return;
+    }
+
+    dbDirs =
       // read directory
       (await fs.readdir(this.storagePath, { withFileTypes: true }))
         // remove non-directories

--- a/extensions/ql-vscode/src/databases-ui.ts
+++ b/extensions/ql-vscode/src/databases-ui.ts
@@ -384,7 +384,7 @@ export class DatabaseUI extends DisposableObject {
       !(await fs.pathExists(this.storagePath) ||
         !(await fs.stat(this.storagePath)).isDirectory())
     ) {
-      // ignore a missing or invalid storage directory.
+      logger.log('Missing or invalid storage directory. Not trying to remove orphaned databases.');
       return;
     }
 

--- a/extensions/ql-vscode/src/discovery.ts
+++ b/extensions/ql-vscode/src/discovery.ts
@@ -1,5 +1,5 @@
 import { DisposableObject } from './vscode-utils/disposable-object';
-import { showAndLogErrorMessage } from './helpers';
+import { logger } from './logging';
 
 /**
  * Base class for "discovery" operations, which scan the file system to find specific kinds of
@@ -62,7 +62,7 @@ export abstract class Discovery<T> extends DisposableObject {
     });
 
     discoveryPromise.catch(err => {
-      showAndLogErrorMessage(`${this.name} failed. Reason: ${err.message}`);
+      logger.log(`${this.name} failed. Reason: ${err.message}`);
     });
 
     discoveryPromise.finally(() => {

--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -123,15 +123,16 @@ export function commandRunner(
     try {
       return await task(...args);
     } catch (e) {
+      const errorMessage = `${e.message || e} (${commandId})`;
       if (e instanceof UserCancellationException) {
         // User has cancelled this action manually
         if (e.silent) {
-          logger.log(e.message);
+          logger.log(errorMessage);
         } else {
-          showAndLogWarningMessage(e.message);
+          showAndLogWarningMessage(errorMessage);
         }
       } else {
-        showAndLogErrorMessage(e.message || e);
+        showAndLogErrorMessage(errorMessage);
       }
       return undefined;
     }
@@ -161,15 +162,16 @@ export function commandRunnerWithProgress<R>(
     try {
       return await withProgress(progressOptionsWithDefaults, task, ...args);
     } catch (e) {
+      const errorMessage = `${e.message || e} (${commandId})`;
       if (e instanceof UserCancellationException) {
         // User has cancelled this action manually
         if (e.silent) {
-          logger.log(e.message);
+          logger.log(errorMessage);
         } else {
-          showAndLogWarningMessage(e.message);
+          showAndLogWarningMessage(errorMessage);
         }
       } else {
-        showAndLogErrorMessage(e.message || e);
+        showAndLogErrorMessage(errorMessage);
       }
       return undefined;
     }


### PR DESCRIPTION
This change avoids popping up error messages in two cases:

1. When doing test discovery, do not run discovery on non-existant
   directories. Also, if there is an error, print to the log, and do not
   pop up an error window. The reason is that test discovery is a
   background operation and these should not normally cause pop-ups.
2. When looking for orphaned databases, don't pop up an error if the
   storagePath can't be found. This is normal when working in a new,
   single root workspace.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Fixes #695

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [n/a] `@github/docs-content-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
