### PR TITLE
Move some database commands to overflow menu

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add clearer error message when trying to run a command from the query history view if no item in the history is selected. [#702](https://github.com/github/vscode-codeql/pull/702)
 - Fix a bug where it is not possible to download some database archives. This fix specifically addresses large archives and archives whose central directories do not align with file headers. [#700](https://github.com/github/vscode-codeql/pull/700)
 - Avoid error dialogs when QL test discovery or database cleanup encounters a missing directory. [#706](https://github.com/github/vscode-codeql/pull/706)
+- Move _Add Database_ commands from the navigation bar at the top of the Databases view and into the overflow menu. [#708](https://github.com/github/vscode-codeql/pull/708)
 
 ## 1.3.7 - 24 November 2020
 

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -196,7 +196,7 @@
       },
       {
         "command": "codeQLDatabases.chooseDatabaseFolder",
-        "title": "Choose Database from Folder",
+        "title": "Add Database from Folder",
         "icon": {
           "light": "media/light/folder-opened-plus.svg",
           "dark": "media/dark/folder-opened-plus.svg"
@@ -208,7 +208,7 @@
       },
       {
         "command": "codeQLDatabases.chooseDatabaseArchive",
-        "title": "Choose Database from Archive",
+        "title": "Add Database from Archive",
         "icon": {
           "light": "media/light/archive-plus.svg",
           "dark": "media/dark/archive-plus.svg"
@@ -216,7 +216,7 @@
       },
       {
         "command": "codeQLDatabases.chooseDatabaseInternet",
-        "title": "Download Database",
+        "title": "Add Database from Internet",
         "icon": {
           "light": "media/light/cloud-download.svg",
           "dark": "media/dark/cloud-download.svg"
@@ -224,7 +224,7 @@
       },
       {
         "command": "codeQLDatabases.chooseDatabaseLgtm",
-        "title": "Download from LGTM",
+        "title": "Add Database from LGTM",
         "icon": {
           "light": "media/light/lgtm-plus.svg",
           "dark": "media/dark/lgtm-plus.svg"
@@ -398,22 +398,22 @@
         {
           "command": "codeQLDatabases.chooseDatabaseFolder",
           "when": "view == codeQLDatabases",
-          "group": "navigation"
+          "group": "1_open@1"
         },
         {
           "command": "codeQLDatabases.chooseDatabaseArchive",
           "when": "view == codeQLDatabases",
-          "group": "navigation"
+          "group": "1_open@2"
         },
         {
           "command": "codeQLDatabases.chooseDatabaseInternet",
           "when": "view == codeQLDatabases",
-          "group": "navigation"
+          "group": "1_open@3"
         },
         {
           "command": "codeQLDatabases.chooseDatabaseLgtm",
           "when": "view == codeQLDatabases",
-          "group": "navigation"
+          "group": "1_open@4"
         },
         {
           "command": "codeQLQueryHistory.openQuery",


### PR DESCRIPTION
This commit moves the "Add *" and "Download *" database commands
from the buttons on top and into an overflow menu.

I believe this is easier to read since the icons were never fully
understandable and required hovering to read.

Also, renamed the commands to be more consistent. Now all begin
with "Add Database from".

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Simple PR to change the layout of the view commands. I didn't know this was possible until I saw it in another extension. Will look like this:

<img width="650" alt="_Extension_Development_Host__-_XXE_qlref_—_vscode-codeql-starter__Workspace_" src="https://user-images.githubusercontent.com/363559/102268223-e2411300-3ecf-11eb-9424-acc4e8b5e85f.png">

I'm open to better wording than "Download Database from Internet".

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [n/a] `@github/docs-content-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
