### PR TITLE
Add descriptive text and a link at top of query results

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add clearer error message when trying to run a command from the query history view if no item in the history is selected. [#702](https://github.com/github/vscode-codeql/pull/702)
 - Fix a bug where it is not possible to download some database archives. This fix specifically addresses large archives and archives whose central directories do not align with file headers. [#700](https://github.com/github/vscode-codeql/pull/700)
 - Avoid error dialogs when QL test discovery or database cleanup encounters a missing directory. [#706](https://github.com/github/vscode-codeql/pull/706)
+- Add descriptive text and a link in the results view. [#711](https://github.com/github/vscode-codeql/pull/711)
 
 ## 1.3.7 - 24 November 2020
 

--- a/extensions/ql-vscode/src/interface.ts
+++ b/extensions/ql-vscode/src/interface.ts
@@ -286,6 +286,9 @@ export class InterfaceManager extends DisposableObject {
           );
         }
         break;
+      case 'openFile':
+        await this.openFile(msg.filePath);
+        break;
       default:
         assertNever(msg);
     }
@@ -413,6 +416,8 @@ export class InterfaceManager extends DisposableObject {
       database: results.database,
       shouldKeepOldResultsWhileRendering,
       metadata: results.query.metadata,
+      queryName: results.toString(),
+      queryPath: results.query.program.queryPath
     });
   }
 
@@ -444,6 +449,8 @@ export class InterfaceManager extends DisposableObject {
       resultSetNames,
       pageSize: PAGE_SIZE.getValue(),
       numPages: numInterpretedPages(this._interpretation),
+      queryName: this._displayedQuery.toString(),
+      queryPath: this._displayedQuery.query.program.queryPath
     });
   }
 
@@ -454,6 +461,11 @@ export class InterfaceManager extends DisposableObject {
       PAGE_SIZE.getValue()
     );
     return schemas['result-sets'];
+  }
+
+  public async openFile(filePath: string) {
+    const textDocument = await vscode.workspace.openTextDocument(filePath);
+    await vscode.window.showTextDocument(textDocument, vscode.ViewColumn.One);
   }
 
   /**
@@ -517,6 +529,8 @@ export class InterfaceManager extends DisposableObject {
       database: results.database,
       shouldKeepOldResultsWhileRendering: false,
       metadata: results.query.metadata,
+      queryName: results.toString(),
+      queryPath: results.query.program.queryPath
     });
   }
 
@@ -534,8 +548,9 @@ export class InterfaceManager extends DisposableObject {
       sourceInfo
     );
     sarif.runs.forEach(run => {
-      if (run.results !== undefined)
+      if (run.results !== undefined) {
         sortInterpretedResults(run.results, sortState);
+      }
     });
 
     const numTotalResults = (() => {

--- a/extensions/ql-vscode/src/pure/interface-types.ts
+++ b/extensions/ql-vscode/src/pure/interface-types.ts
@@ -88,6 +88,8 @@ export interface SetStateMsg {
   interpretation: undefined | Interpretation;
   database: DatabaseInfo;
   metadata?: QueryMetadata;
+  queryName: string;
+  queryPath: string;
   /**
    * Whether to keep displaying the old results while rendering the new results.
    *
@@ -116,6 +118,8 @@ export interface ShowInterpretedPageMsg {
   numPages: number;
   pageSize: number;
   resultSetNames: string[];
+  queryName: string;
+  queryPath: string;
 }
 
 /** Advance to the next or previous path no in the path viewer */
@@ -153,7 +157,8 @@ export type FromResultsViewMsg =
   | ChangeRawResultsSortMsg
   | ChangeInterpretedResultsSortMsg
   | ResultViewLoaded
-  | ChangePage;
+  | ChangePage
+  | OpenFileMsg;
 
 /**
  * Message from the results view to open a database source
@@ -165,6 +170,14 @@ export interface ViewSourceFileMsg {
   databaseUri: string;
 }
 
+/**
+ * Message from the results view to open a file in an editor.
+ */
+export interface OpenFileMsg {
+  t: 'openFile';
+  /* Full path to the file to open. */
+  filePath: string;
+}
 
 /**
  * Message from the results view to toggle the display of

--- a/extensions/ql-vscode/src/view/result-table-utils.tsx
+++ b/extensions/ql-vscode/src/view/result-table-utils.tsx
@@ -28,7 +28,8 @@ export interface ResultTableProps {
 }
 
 export const className = 'vscode-codeql__result-table';
-export const tableSelectionHeaderClassName = 'vscode-codeql__table-selection-header';
+export const tableHeaderClassName = 'vscode-codeql__table-selection-header';
+export const tableHeaderItemClassName = 'vscode-codeql__table-selection-header-item';
 export const alertExtrasClassName = `${className}-alert-extras`;
 export const toggleDiagnosticsClassName = `${className}-toggle-diagnostics`;
 export const evenRowClassName = 'vscode-codeql__result-table-row--even';
@@ -45,7 +46,9 @@ export function jumpToLocationHandler(
     jumpToLocation(loc, databaseUri);
     e.preventDefault();
     e.stopPropagation();
-    if (callback) callback();
+    if (callback) {
+      callback();
+    }
   };
 }
 
@@ -54,6 +57,13 @@ export function jumpToLocation(loc: ResolvableLocationValue, databaseUri: string
     t: 'viewSourceFile',
     loc,
     databaseUri
+  });
+}
+
+export function openFile(filePath: string): void {
+  vscode.postMessage({
+    t: 'openFile',
+    filePath
   });
 }
 

--- a/extensions/ql-vscode/src/view/results.tsx
+++ b/extensions/ql-vscode/src/view/results.tsx
@@ -11,7 +11,7 @@ import {
   QueryMetadata,
   ResultsPaths,
   ALERTS_TABLE_NAME,
-  ParsedResultSets
+  ParsedResultSets,
 } from '../pure/interface-types';
 import { EventHandlers as EventHandlerList } from './event-handler-list';
 import { ResultTables } from './result-tables';
@@ -37,6 +37,8 @@ interface ResultsInfo {
    */
   shouldKeepOldResultsWhileRendering: boolean;
   metadata?: QueryMetadata;
+  queryName: string;
+  queryPath: string;
 }
 
 interface Results {
@@ -96,6 +98,8 @@ class App extends React.Component<{}, ResultsViewState> {
           shouldKeepOldResultsWhileRendering:
             msg.shouldKeepOldResultsWhileRendering,
           metadata: msg.metadata,
+          queryName: msg.queryName,
+          queryPath: msg.queryPath,
         });
 
         this.loadResults();
@@ -127,6 +131,8 @@ class App extends React.Component<{}, ResultsViewState> {
           interpretation: msg.interpretation,
           shouldKeepOldResultsWhileRendering: true,
           metadata: msg.metadata,
+          queryName: msg.queryName,
+          queryPath: msg.queryPath,
         });
         this.loadResults();
         break;
@@ -280,6 +286,8 @@ class App extends React.Component<{}, ResultsViewState> {
             this.state.isExpectingResultsUpdate ||
             this.state.nextResultsInfo !== null
           }
+          queryName={displayedResults.resultsInfo.queryName}
+          queryPath={displayedResults.resultsInfo.queryPath}
         />
       );
     } else {

--- a/extensions/ql-vscode/src/view/resultsView.css
+++ b/extensions/ql-vscode/src/view/resultsView.css
@@ -8,13 +8,24 @@
   display: flex;
   padding: 0.5em 0;
   align-items: center;
+  justify-content: space-between;
+}
+
+.vscode-codeql__table-selection-pagination {
+  display: flex;
+  padding: 0.5em 0;
+  align-items: center;
+}
+
+.vscode-codeql__table-selection-header-item {
+  padding-left: 2em;
 }
 
 .vscode-codeql__table-selection-header select {
   border: 0;
 }
 
-.vscode-codeql__table-selection-header button {
+.vscode-codeql__table-selection-pagination button {
   padding: 0.3rem;
   margin: 0.2rem;
   border: 0;
@@ -25,11 +36,11 @@
   opacity: 0.8;
 }
 
-.vscode-codeql__table-selection-header button:hover {
+.vscode-codeql__table-selection-pagination button:hover {
   opacity: 1;
 }
 
-.vscode-codeql__table-selection-header input[type="number"] {
+.vscode-codeql__table-selection-pagination input[type="number"] {
   border-radius: 0;
   padding: 0.3rem;
   margin: 0.2rem;
@@ -183,10 +194,6 @@ td.vscode-codeql__path-index-cell {
 
 .octicon-light {
   opacity: 0.6;
-}
-
-.number-of-results {
-  padding-left: 3em;
 }
 
 .vscode-codeql__compare-header {


### PR DESCRIPTION
The descriptive text is the same as the label in the query history view.  The link opens the file that ran the query.

Here is a screenshot of a wide window:

<img width="920" alt="_Extension_Development_Host__-_CodeQL_Query_Results_—_vscode-codeql-starter__Workspace_" src="https://user-images.githubusercontent.com/363559/102390217-fac13400-3f88-11eb-9e72-1b75efe3aaf8.png">

And here is a narrow window:

<img width="637" alt="_Extension_Development_Host__-_CodeQL_Query_Results_—_vscode-codeql-starter__Workspace_" src="https://user-images.githubusercontent.com/363559/102390342-25ab8800-3f89-11eb-93f0-57b05ba2a8d1.png">


<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Fixes #634.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [n/a] `@github/docs-content-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
