### PR TITLE
Fix missing call to showAndLogErrorMessage

### DIFF
--- a/extensions/ql-vscode/src/upgrades.ts
+++ b/extensions/ql-vscode/src/upgrades.ts
@@ -152,7 +152,7 @@ export async function upgradeDatabase(
 
   if (compileUpgradeResult.compiledUpgrades === undefined) {
     const error = compileUpgradeResult.error || '[no error message available]';
-    (`Compilation of database upgrades failed: ${error}`);
+    showAndLogErrorMessage(`Compilation of database upgrades failed: ${error}`);
     return;
   }
 


### PR DESCRIPTION
Tiny fix to ensure we display an error message if database upgrades can't be compiled.  

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] `@github/docs-content-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
