### PR TITLE
Bump test timeouts

### DIFF
--- a/extensions/ql-vscode/src/vscode-tests/minimal-workspace/config.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/minimal-workspace/config.test.ts
@@ -15,7 +15,10 @@ import {
 chai.use(chaiAsPromised);
 const expect = chai.expect;
 
-describe('config listeners', () => {
+describe('config listeners', function() {
+  // Because we are adding some extra waiting, need to bump the test timeouts.
+  this.timeout(5000);
+
   let sandbox: Sinon.SinonSandbox;
   beforeEach(() => {
     sandbox = Sinon.createSandbox();


### PR DESCRIPTION
Necessary because we just added some extra waiting
in order to ensure that config listeners have all
fired.