### PR TITLE
Use codeQL.runningQueries.numberOfThreads to run interpretation

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [UNRELEASED]
 
+- Respect the `codeQL.runningQueries.numberOfThreads` setting when creating SARIF files during result interpretation. [#771](https://github.com/github/vscode-codeql/pull/771)
 - Allow using raw LGTM project slugs for fetching LGTM databases. [#769](https://github.com/github/vscode-codeql/pull/769)
 
 ## 1.4.3 - 22 February 2021

--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -597,6 +597,12 @@ export class CodeQLCliServer implements Disposable {
         '--source-location-prefix', sourceInfo.sourceLocationPrefix
       );
     }
+
+    args.push(
+      '--threads',
+      this.cliConfig.numberThreads.toString(),
+    );
+
     args.push(resultsPath);
     await this.runCodeQlCliCommand(['bqrs', 'interpret'], args, 'Interpreting query results');
 

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -104,10 +104,11 @@ export interface QueryHistoryConfig {
   onDidChangeConfiguration: Event<void>;
 }
 
-const CLI_SETTINGS = [NUMBER_OF_TEST_THREADS_SETTING];
+const CLI_SETTINGS = [NUMBER_OF_TEST_THREADS_SETTING, NUMBER_OF_THREADS_SETTING];
 
 export interface CliConfig {
   numberTestThreads: number;
+  numberThreads: number;
   onDidChangeConfiguration?: Event<void>;
 }
 
@@ -233,6 +234,11 @@ export class CliConfigListener extends ConfigListener implements CliConfig {
 
   public get numberTestThreads(): number {
     return NUMBER_OF_TEST_THREADS_SETTING.getValue();
+  }
+
+
+  public get numberThreads(): number {
+    return NUMBER_OF_THREADS_SETTING.getValue<number>();
   }
 
   protected handleDidChangeConfiguration(e: ConfigurationChangeEvent): void {

--- a/extensions/ql-vscode/src/vscode-tests/minimal-workspace/config.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/minimal-workspace/config.test.ts
@@ -41,6 +41,10 @@ describe('config listeners', function() {
     {
       clazz: CliConfigListener,
       settings: [{
+        name: 'codeQL.runningQueries.numberOfThreads',
+        property: 'numberThreads',
+        values: [0, 1]
+      }, {
         name: 'codeQL.runningTests.numberOfThreads',
         property: 'numberTestThreads',
         values: [1, 0]


### PR DESCRIPTION
When running `codeql bqrs interpret`, ensure the
`codeQL.runningQueries.numberOfThreads` setting is respected.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Fixes #764

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [n/a] `@github/docs-content-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
