### PR TITLE
Expand disk cache evaluator options

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [UNRELEASED]
 
+- Introduce evaluator options for saving intermediate results to the disk cache, and for limiting the size of this cache. [#593](https://github.com/github/vscode-codeql/pull/593)
 - Respect the `codeQL.runningQueries.numberOfThreads` setting when creating SARIF files during result interpretation. [#771](https://github.com/github/vscode-codeql/pull/771)
 - Allow using raw LGTM project slugs for fetching LGTM databases. [#769](https://github.com/github/vscode-codeql/pull/769)
 - Better error messages when BQRS interpretation fails to produce SARIF. [#770](https://github.com/github/vscode-codeql/pull/770)

--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [UNRELEASED]
 
-- Introduce evaluator options for saving intermediate results to the disk cache, and for limiting the size of this cache. [#593](https://github.com/github/vscode-codeql/pull/593)
+- Introduce evaluator options for saving intermediate results to the disk cache (`codeQL.runningQueries.saveCache`) and for limiting the size of this cache (`codeQL.runningQueries.cacheSize`). [#593](https://github.com/github/vscode-codeql/pull/593)
 - Respect the `codeQL.runningQueries.numberOfThreads` setting when creating SARIF files during result interpretation. [#771](https://github.com/github/vscode-codeql/pull/771)
 - Allow using raw LGTM project slugs for fetching LGTM databases. [#769](https://github.com/github/vscode-codeql/pull/769)
 - Better error messages when BQRS interpretation fails to produce SARIF. [#770](https://github.com/github/vscode-codeql/pull/770)

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -126,6 +126,7 @@
         "codeQL.runningQueries.saveCache": {
           "type": "boolean",
           "default": false,
+          "scope": "window",
           "description": "Aggressively save intermediate results to the disk cache. This may speed up subsequent queries if they are similar. Be aware that using this option will greatly increase disk usage and initial evaluation time."
         },
         "codeQL.runningQueries.cacheSize": {

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -126,7 +126,7 @@
         "codeQL.runningQueries.saveCache": {
           "type": "boolean",
           "default": false,
-          "description": "Aggressively save intermediate results to the disk cache. This advanced option is not recommended as it will greatly increase disk usage and evaluation time, but it may speed up subsequent queries if they are similar."
+          "description": "Aggressively save intermediate results to the disk cache. This may speed up subsequent queries if they are similar. Be aware that using this option will greatly increase disk usage and initial evaluation time."
         },
         "codeQL.runningQueries.cacheSize": {
           "type": [

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -123,6 +123,20 @@
           "maximum": 1024,
           "description": "Number of threads for running queries."
         },
+        "codeQL.runningQueries.saveCache": {
+          "type": "boolean",
+          "default": false,
+          "description": "Aggressively save intermediate results to the disk cache. This advanced option is not recommended as it will greatly increase disk usage and evaluation time, but it may speed up subsequent queries if they are similar."
+        },
+        "codeQL.runningQueries.cacheSize": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "default": null,
+          "minimum": 1024,
+          "description": "Maximum size of the disk cache (in MB). Leave blank to allow the evaluator to automatically adjust the size of the disk cache based on the size of the codebase and the complexity of the queries being executed."
+        },
         "codeQL.runningQueries.timeout": {
           "type": [
             "integer",

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -73,6 +73,8 @@ export interface DistributionConfig {
 
 const RUNNING_QUERIES_SETTING = new Setting('runningQueries', ROOT_SETTING);
 const NUMBER_OF_THREADS_SETTING = new Setting('numberOfThreads', RUNNING_QUERIES_SETTING);
+const SAVE_CACHE_SETTING = new Setting('saveCache', RUNNING_QUERIES_SETTING);
+const CACHE_SIZE_SETTING = new Setting('cacheSize', RUNNING_QUERIES_SETTING);
 const TIMEOUT_SETTING = new Setting('timeout', RUNNING_QUERIES_SETTING);
 const MEMORY_SETTING = new Setting('memory', RUNNING_QUERIES_SETTING);
 const DEBUG_SETTING = new Setting('debug', RUNNING_QUERIES_SETTING);
@@ -85,12 +87,14 @@ export const AUTOSAVE_SETTING = new Setting('autoSave', RUNNING_QUERIES_SETTING)
 export const PAGE_SIZE = new Setting('pageSize', RESULTS_DISPLAY_SETTING);
 
 /** When these settings change, the running query server should be restarted. */
-const QUERY_SERVER_RESTARTING_SETTINGS = [NUMBER_OF_THREADS_SETTING, MEMORY_SETTING, DEBUG_SETTING];
+const QUERY_SERVER_RESTARTING_SETTINGS = [NUMBER_OF_THREADS_SETTING, SAVE_CACHE_SETTING, CACHE_SIZE_SETTING, MEMORY_SETTING, DEBUG_SETTING];
 
 export interface QueryServerConfig {
   codeQlPath: string;
   debug: boolean;
   numThreads: number;
+  saveCache: boolean;
+  cacheSize: number;
   queryMemoryMb?: number;
   timeoutSecs: number;
   onDidChangeConfiguration?: Event<void>;
@@ -194,6 +198,14 @@ export class QueryServerConfigListener extends ConfigListener implements QuerySe
     return NUMBER_OF_THREADS_SETTING.getValue<number>();
   }
 
+  public get saveCache(): boolean {
+    return SAVE_CACHE_SETTING.getValue<boolean>();
+  }
+
+  public get cacheSize(): number {
+    return CACHE_SIZE_SETTING.getValue<number | null>() || 0;
+  }
+
   /** Gets the configured query timeout, in seconds. This looks up the setting at the time of access. */
   public get timeoutSecs(): number {
     return TIMEOUT_SETTING.getValue<number | null>() || 0;
@@ -235,7 +247,6 @@ export class CliConfigListener extends ConfigListener implements CliConfig {
   public get numberTestThreads(): number {
     return NUMBER_OF_TEST_THREADS_SETTING.getValue();
   }
-
 
   public get numberThreads(): number {
     return NUMBER_OF_THREADS_SETTING.getValue<number>();

--- a/extensions/ql-vscode/src/queryserver-client.ts
+++ b/extensions/ql-vscode/src/queryserver-client.ts
@@ -136,6 +136,15 @@ export class QueryServerClient extends DisposableObject {
     const ramArgs = await this.cliServer.resolveRam(this.config.queryMemoryMb, progressReporter);
     const args = ['--threads', this.config.numThreads.toString()].concat(ramArgs);
 
+    if (this.config.saveCache) {
+      args.push('--save-cache');
+    }
+
+    if (this.config.cacheSize > 0) {
+      args.push('--max-disk-cache');
+      args.push(this.config.cacheSize.toString());
+    }
+
     if (await this.supportsDatabaseRegistration()) {
       args.push('--require-db-registration');
     }

--- a/extensions/ql-vscode/src/vscode-tests/minimal-workspace/config.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/minimal-workspace/config.test.ts
@@ -65,6 +65,14 @@ describe('config listeners', function() {
         property: 'numThreads',
         values: [0, 1]
       }, {
+        name: 'codeQL.runningQueries.saveCache',
+        property: 'saveCache',
+        values: [false, true]
+      }, {
+        name: 'codeQL.runningQueries.cacheSize',
+        property: 'cacheSize',
+        values: [0, 1]
+      }, {
         name: 'codeQL.runningQueries.memory',
         property: 'queryMemoryMb',
         values: [0, 1]


### PR DESCRIPTION
This PR addresses #593 by expanding the options that can be passed to control how the evaluator handles the disk cache. In particular, it exposes to the user two settings - the first enables the saving of intermediate results to the cache, and the second allows limiting of the size of the cache. The default behaviour is unchanged from the current options - i.e. intermediate results are not saved to the disk cache, and the evaluator is allowed to choose its own limit on maximum cache size.