### PR TITLE
Shorten error messages displayed in popups

### DIFF
--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -11,6 +11,7 @@ import {
 } from 'vscode';
 import { CodeQLCliServer } from './cli';
 import { logger } from './logging';
+import { shortenErrorMessage } from './pure/helpers-pure';
 
 /**
  * Show an error message and log it to the console
@@ -29,8 +30,9 @@ export async function showAndLogErrorMessage(message: string, {
   items = [] as string[],
   fullMessage = undefined as (string | undefined)
 } = {}): Promise<string | undefined> {
-  return internalShowAndLog(message, items, outputLogger, Window.showErrorMessage, fullMessage);
+  return internalShowAndLog(shortenErrorMessage(message), items, outputLogger, Window.showErrorMessage, fullMessage);
 }
+
 /**
  * Show a warning message and log it to the console
  *

--- a/extensions/ql-vscode/src/interface.ts
+++ b/extensions/ql-vscode/src/interface.ts
@@ -634,7 +634,7 @@ export class InterfaceManager extends DisposableObject {
         // If interpretation fails, accept the error and continue
         // trying to render uninterpreted results anyway.
         showAndLogErrorMessage(
-          `Exception during results interpretation: ${e.message}. Will show raw results instead.`
+          `${e.message.trim()}\nWill show raw results instead.`
         );
       }
     }

--- a/extensions/ql-vscode/src/pure/helpers-pure.ts
+++ b/extensions/ql-vscode/src/pure/helpers-pure.ts
@@ -29,3 +29,28 @@ export const asyncFilter = async function <T>(arr: T[], predicate: (arg0: T) => 
   const results = await Promise.all(arr.map(predicate));
   return arr.filter((_, index) => results[index]);
 };
+
+/**
+ * Creates a succint version of an error message, e.g. for displaying in a pop-up.
+ * @param errorMessage The error message to shorten.
+ * @return A shortened version of the error message.
+ */
+export function shortenErrorMessage(errorMessage: string): string {
+  // Filter out lines corresponding to Java stack traces.
+  const stackTraceLine = /\r?\n\s*(com|org|net)\..*\.java:[0-9]+\)(?=\r?\n)/g;
+  let succintMessage = errorMessage.toString().replace(stackTraceLine, '');
+
+  // Filter out lines corresponding to log lines.
+  const logLine = /\r?\n\[[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9] [0-9][0-9]:[0-9][0-9]:[0-9][0-9]\].*/g;
+  succintMessage = succintMessage.replace(logLine, '');
+
+  // Trim indentation at the start of lines.
+  const indentedLine = /(\r?\n)\s+/g;
+  succintMessage = succintMessage.replace(indentedLine, '$1').trim();
+
+  // Remove duplicated lines.
+  const duplicatedLine = /(\r?\n.*)\1/g;
+  succintMessage = succintMessage.replace(duplicatedLine, '$1');
+
+  return succintMessage;
+}

--- a/extensions/ql-vscode/src/pure/helpers-pure.ts
+++ b/extensions/ql-vscode/src/pure/helpers-pure.ts
@@ -49,7 +49,7 @@ export function shortenErrorMessage(errorMessage: string): string {
   succintMessage = succintMessage.replace(indentedLine, '$1').trim();
 
   // Remove duplicated lines.
-  const duplicatedLine = /(\r?\n.*)\1/g;
+  const duplicatedLine = /(\r?\n.*)\1+/g;
   succintMessage = succintMessage.replace(duplicatedLine, '$1');
 
   return succintMessage;

--- a/extensions/ql-vscode/test/pure-tests/helpers-pure.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/helpers-pure.test.ts
@@ -35,7 +35,7 @@ describe('helpers-pure', () => {
       runTest(input, expected);
     });
 
-    it('removes log lines lines', async () => {
+    it('removes log lines', async () => {
       const input = ['first line', '[2020-02-15 09:10:15] Some logging information', 'last line'];
       const expected = ['first line', 'last line'];
       runTest(input, expected);
@@ -47,9 +47,36 @@ describe('helpers-pure', () => {
       runTest(input, expected);
     });
 
-    it('removes duplicate lines', async () => {
+    it('removes one duplicate line', async () => {
       const input = ['first line', 'last line', 'last line'];
       const expected = ['first line', 'last line'];
+      runTest(input, expected);
+    });
+
+    it('removes several duplicate lines', async () => {
+      const input = ['first line', 'last line', 'last line', 'last line'];
+      const expected = ['first line', 'last line'];
+      runTest(input, expected);
+    });
+
+    it('shortens real example', async () => {
+      const input = ['Interpreting query results failed: A fatal error occurred: Could not process query metadata.',
+        'Error was: No query kind specified [NO_KIND_SPECIFIED]',
+        '[2021-03-18 23:43:25] Exception caught at top level: Could not process query metadata.',
+        '                      Error was: No query kind specified [NO_KIND_SPECIFIED]',
+        '                      com.semmle.cli2.bqrs.InterpretCommand.executeSubcommand(InterpretCommand.java:126)',
+        '                      com.semmle.cli2.picocli.SubcommandCommon.executeWithParent(SubcommandCommon.java:414)',
+        '                      com.semmle.cli2.execute.CliServerCommand.lambda$executeSubcommand$0(CliServerCommand.java:67)',
+        '                      com.semmle.cli2.picocli.SubcommandMaker.runMain(SubcommandMaker.java:201)',
+        '                      com.semmle.cli2.execute.CliServerCommand.executeSubcommand(CliServerCommand.java:67)',
+        '                      com.semmle.cli2.picocli.SubcommandCommon.call(SubcommandCommon.java:430)',
+        '                      com.semmle.cli2.picocli.SubcommandMaker.runMain(SubcommandMaker.java:201)',
+        '                      com.semmle.cli2.picocli.SubcommandMaker.runMain(SubcommandMaker.java:209)',
+        '                      com.semmle.cli2.CodeQL.main(CodeQL.java:93)',
+        'Will show raw results instead.'];
+      const expected = ['Interpreting query results failed: A fatal error occurred: Could not process query metadata.',
+        'Error was: No query kind specified [NO_KIND_SPECIFIED]',
+        'Will show raw results instead.'];
       runTest(input, expected);
     });
   });

--- a/extensions/ql-vscode/test/pure-tests/helpers-pure.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/helpers-pure.test.ts
@@ -1,6 +1,6 @@
 import { fail } from 'assert';
 import { expect } from 'chai';
-import { asyncFilter } from '../../src/pure/helpers-pure';
+import { asyncFilter, shortenErrorMessage } from '../../src/pure/helpers-pure';
 
 describe('helpers-pure', () => {
   it('should filter asynchronously', async () => {
@@ -18,5 +18,39 @@ describe('helpers-pure', () => {
     } catch (e) {
       expect(e.message).to.eq('opps');
     }
+  });
+
+  describe('error message shortener', () => {
+    const WINDOWS_LINE_END = '\r\n';
+    const LINUX_LINE_END = '\n';
+
+    function runTest(input: string[], expected: string[]) {
+      expect(shortenErrorMessage(input.join(WINDOWS_LINE_END)).split(WINDOWS_LINE_END)).eql(expected);
+      expect(shortenErrorMessage(input.join(LINUX_LINE_END)).split(LINUX_LINE_END)).eql(expected);
+    }
+
+    it('removes stack traces', async () => {
+      const input = ['first line', '    com.a.java.class.command(Class.java:65)', 'last line'];
+      const expected = ['first line', 'last line'];
+      runTest(input, expected);
+    });
+
+    it('removes log lines lines', async () => {
+      const input = ['first line', '[2020-02-15 09:10:15] Some logging information', 'last line'];
+      const expected = ['first line', 'last line'];
+      runTest(input, expected);
+    });
+
+    it('strips whitespace', async () => {
+      const input = ['    first line', '    last line'];
+      const expected = ['first line', 'last line'];
+      runTest(input, expected);
+    });
+
+    it('removes duplicate lines', async () => {
+      const input = ['first line', 'last line', 'last line'];
+      const expected = ['first line', 'last line'];
+      runTest(input, expected);
+    });
   });
 });


### PR DESCRIPTION
This addresses #724 by running a few regexes on error messages before they are displayed in pop-ups to try to shorten them by removing elements such as log lines and stack traces that will be too lengthy to show meaningfully in a popup.