### PR TITLE
Report description for test failure when possible

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add a configuration option to pass additional arguments to the CLI when running tests. [#785](https://github.com/github/vscode-codeql/pull/785)
 - Introduce option to view query results as CSV. [#784](https://github.com/github/vscode-codeql/pull/784)
 - Add some snippets for commonly used QL statements. [#780](https://github.com/github/vscode-codeql/pull/780)
+- More descriptive error messages on QL test failures. [#788](https://github.com/github/vscode-codeql/pull/788)
 
 ## 1.4.3 - 22 February 2021
 

--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -104,6 +104,7 @@ export interface TestCompleted {
   evaluationMs: number;
   expected: string;
   diff: string[] | undefined;
+  failureDescription?: string;
 }
 
 /**

--- a/extensions/ql-vscode/src/test-adapter.ts
+++ b/extensions/ql-vscode/src/test-adapter.ts
@@ -223,8 +223,8 @@ export class QLTestAdapter extends DisposableObject implements TestAdapter {
           ? 'errored'
           : 'failed';
       let message: string | undefined;
-      if (event.diff?.length) {
-        message = ['', `${state}: ${event.test}`, ...event.diff, ''].join('\n');
+      if (event.failureDescription || event.diff?.length) {
+        message = ['', `${state}: ${event.test}`, event.failureDescription || event.diff?.join('\n'), ''].join('\n');
         testLogger.log(message);
       }
       this._testStates.fire({


### PR DESCRIPTION
Addresses #774 by reading the `failureDescription` field for a test failure and when this is present reporting this instead of the diff. I believe this is the right choice since as I understand it when this field is present, the diff will not be useful as it means something went more catastrophically wrong (e.g. we couldn't find the expected output).