### PR TITLE
Update docs team ping in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,4 +9,4 @@ Replace this with a description of the changes your pull request makes.
 
 - [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
 - [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
-- [ ] `@github/docs-content-dsp` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
+- [ ] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.


### PR DESCRIPTION
The docs team has been through a slight restructuring. The DSP subteam still technically exists, but we have an automated "first responder" process to pick up team pings to `@github/docs-content-codeql` instead, so I'd like to change the template! 

## Checklist

- _N/A_ [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- _N/A_ Issues have been created for any UI or other user-facing changes made by this pull request.
- _N/A_ `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
