### PR TITLE
Limit error messages shown in popups to 2 lines

### DIFF
--- a/extensions/ql-vscode/src/databases-ui.ts
+++ b/extensions/ql-vscode/src/databases-ui.ts
@@ -423,9 +423,9 @@ export class DatabaseUI extends DisposableObject {
     if (failures.length) {
       const dirname = path.dirname(failures[0]);
       showAndLogErrorMessage(
-        `Failed to delete unused databases:\n  ${
-        failures.join('\n  ')
-        }\n. To delete unused databases, please remove them manually from the storage folder ${dirname}.`
+        `Failed to delete unused databases (${
+        failures.join(', ')
+        }).\nTo delete unused databases, please remove them manually from the storage folder ${dirname}.`
       );
     }
   };

--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -29,8 +29,13 @@ export async function showAndLogErrorMessage(message: string, {
   items = [] as string[],
   fullMessage = undefined as (string | undefined)
 } = {}): Promise<string | undefined> {
-  return internalShowAndLog(message, items, outputLogger, Window.showErrorMessage, fullMessage);
+  return internalShowAndLog(dropLinesExceptInitial(message), items, outputLogger, Window.showErrorMessage, fullMessage);
 }
+
+function dropLinesExceptInitial(message: string, n = 2) {
+  return message.toString().split(/\r?\n/).slice(0, n).join('\n');
+}
+
 /**
  * Show a warning message and log it to the console
  *

--- a/extensions/ql-vscode/src/interface.ts
+++ b/extensions/ql-vscode/src/interface.ts
@@ -634,7 +634,7 @@ export class InterfaceManager extends DisposableObject {
         // If interpretation fails, accept the error and continue
         // trying to render uninterpreted results anyway.
         showAndLogErrorMessage(
-          `Exception during results interpretation: ${e.message}. Will show raw results instead.`
+          `Showing raw results instead of interpreted ones due to an error. ${e.message}`
         );
       }
     }

--- a/extensions/ql-vscode/src/run-queries.ts
+++ b/extensions/ql-vscode/src/run-queries.ts
@@ -640,8 +640,11 @@ export async function compileAndRunQueryAgainstDatabase(
         formattedMessages.push(formatted);
         qs.logger.log(formatted);
       }
-      if (quickEval && formattedMessages.length <= 3) {
-        showAndLogErrorMessage('Quick evaluation compilation failed: \n' + formattedMessages.join('\n'));
+      if (quickEval && formattedMessages.length <= 2) {
+        // If there are more than 2 error messages, they will not be displayed well in a popup
+        // and will be trimmed by the function displaying the error popup. Accordingly, we only
+        // try to show the errors if there are 2 or less, otherwise we direct the user to the log.
+        showAndLogErrorMessage('Quick evaluation compilation failed: ' + formattedMessages.join('\n'));
       } else {
         showAndLogErrorMessage((quickEval ? 'Quick evaluation' : 'Query') + compilationFailedErrorTail);
       }


### PR DESCRIPTION
Addresses #724 by limiting error messages in popups to 2 lines. Note that this required changing around a couple of error messages that were likely to be more than 2 lines but we wanted to show all of to ensure that they do not get trimmed.