### PR TITLE
Add feature to jump to the .ql file referenced by a .qlref

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Avoid showing an error popup when user runs a query without `@kind` metadata. [#801](https://github.com/github/vscode-codeql/pull/801)
 - Fix running of tests when the `ms-python` extension is installed. [#803](https://github.com/github/vscode-codeql/pull/803)
+- Add an option to jump from a .qlref file to the .ql file it references.
 
 ## 1.4.4 - 19 March 2021
 

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -34,6 +34,7 @@
     "onCommand:codeQLDatabases.chooseDatabaseLgtm",
     "onCommand:codeQL.setCurrentDatabase",
     "onCommand:codeQL.viewAst",
+    "onCommand:codeQL.openReferencedFile",
     "onCommand:codeQL.chooseDatabaseFolder",
     "onCommand:codeQL.chooseDatabaseArchive",
     "onCommand:codeQL.chooseDatabaseInternet",
@@ -228,6 +229,10 @@
       {
         "command": "codeQL.quickEval",
         "title": "CodeQL: Quick Evaluation"
+      },
+      {
+        "command": "codeQL.openReferencedFile",
+        "title": "CodeQL: Open Referenced File"
       },
       {
         "command": "codeQL.quickQuery",
@@ -619,6 +624,11 @@
           "command": "codeQL.runQueries",
           "group": "9_qlCommands",
           "when": "resourceScheme != codeql-zip-archive"
+        },
+        {
+          "command": "codeQL.openReferencedFile",
+          "group": "9_qlCommands",
+          "when": "resourceExtname == .qlref"
         }
       ],
       "commandPalette": [
@@ -633,6 +643,10 @@
         {
           "command": "codeQL.quickEval",
           "when": "editorLangId == ql"
+        },
+        {
+          "command": "codeQL.openReferencedFile",
+          "when": "resourceExtname == .qlref"
         },
         {
           "command": "codeQL.setCurrentDatabase",
@@ -771,6 +785,10 @@
         {
           "command": "codeQL.quickEval",
           "when": "editorLangId == ql"
+        },
+        {
+          "command": "codeQL.openReferencedFile",
+          "when": "resourceExtname == .qlref"
         }
       ]
     },

--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -151,7 +151,7 @@ export class CodeQLCliServer implements Disposable {
   /**
    * CLI version where the `codeql resolve qlref` command is available.
    */
-  private static CLI_VERSION_WITH_RESOLVE_QLREF = new SemVer('2.5.1');
+  public static CLI_VERSION_WITH_RESOLVE_QLREF = new SemVer('2.5.1');
 
   /** The process for the cli server, or undefined if one doesn't exist yet */
   process?: child_process.ChildProcessWithoutNullStreams;
@@ -937,11 +937,11 @@ class SplitBuffer {
 
   /**
    * A version of startsWith that isn't overriden by a broken version of ms-python.
-   * 
+   *
    * The definition comes from
    * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith
    * which is CC0/public domain
-   * 
+   *
    * See https://github.com/github/vscode-codeql/issues/802 for more context as to why we need it.
    */
   private static startsWith(s: string, searchString: string, position: number): boolean {

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -480,6 +480,23 @@ async function activateWithInstalledDistribution(
     }
   }
 
+  async function openReferencedFile(
+    selectedQuery: Uri
+  ): Promise<void> {
+    if (qs !== undefined) {
+      if (await cliServer.supportsResolveQlref()) {
+        const resolved = await cliServer.resolveQlref(selectedQuery.path);
+        const uri = Uri.file(resolved.resolvedPath);
+        await window.showTextDocument(uri, { preview: false });
+      } else {
+        helpers.showAndLogErrorMessage(
+          'Jumping from a .qlref file to the .ql file it references is not '
+          + 'supported with the CLI version you are running.\n'
+          + 'Please upgrade your CLI to use this feature.');
+      }
+    }
+  }
+
   ctx.subscriptions.push(tmpDirDisposal);
 
   logger.log('Initializing CodeQL language server.');
@@ -614,6 +631,12 @@ async function activateWithInstalledDistribution(
       {
         title: 'Run Quick Query'
       }
+    )
+  );
+  ctx.subscriptions.push(
+    commandRunner(
+      'codeQL.openReferencedFile',
+      openReferencedFile
     )
   );
 

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -492,7 +492,9 @@ async function activateWithInstalledDistribution(
         helpers.showAndLogErrorMessage(
           'Jumping from a .qlref file to the .ql file it references is not '
           + 'supported with the CLI version you are running.\n'
-          + 'Please upgrade your CLI to use this feature.');
+          + `Please upgrade your CLI to version ${
+          CodeQLCliServer.CLI_VERSION_WITH_RESOLVE_QLREF
+          } or later to use this feature.`);
       }
     }
   }


### PR DESCRIPTION
This PR adds an option to jump from a `.qlref` file to the `.ql` file it references. Note that it should not be merged yet, as it relies on a new CLI call `resolve qlref` which is not released yet.

Closes #654 