### PR TITLE
Forward all query metadata to the queryserver

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Avoid showing an error popup when user runs a query with `@kind table` metadata. [#814](https://github.com/github/vscode-codeql/pull/814)
 - Add an option to jump from a .qlref file to the .ql file it references. [#815](https://github.com/github/vscode-codeql/pull/815)
 - Avoid opening the results panel when a database is deleted. [#831](https://github.com/github/vscode-codeql/pull/831)
+- Forward all query metadata to the CLI when interpreting results. [#838](https://github.com/github/vscode-codeql/pull/838)
 
 ## 1.4.5 - 22 March 2021
 

--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -12,7 +12,6 @@ import { promisify } from 'util';
 import { CancellationToken, Disposable } from 'vscode';
 
 import { BQRSInfo, DecodedBqrsChunk } from './pure/bqrs-cli-types';
-import * as config from './config';
 import { CliConfig } from './config';
 import { DistributionProvider, FindDistributionResultKind } from './distribution';
 import { assertNever } from './pure/helpers-pure';
@@ -597,10 +596,10 @@ export class CodeQLCliServer implements Disposable {
 
   async runInterpretCommand(format: string, metadata: QueryMetadata, resultsPath: string, interpretedResultsPath: string, sourceInfo?: SourceInfo) {
     const args = [
-      `-t=kind=${metadata.kind}`,
-      `-t=id=${metadata.id}`,
       '--output', interpretedResultsPath,
       '--format', format,
+      // Forward all of the query metadata.
+      ...Object.entries(metadata).map(([key, value]) => `-t=${key}=${value}`)
     ];
     if (format == SARIF_FORMAT) {
       // TODO: This flag means that we don't group interpreted results
@@ -608,9 +607,6 @@ export class CodeQLCliServer implements Disposable {
       // interpretation with and without this flag, or do some
       // grouping client-side.
       args.push('--no-group-results');
-    }
-    if (config.isCanary() && metadata.scored !== undefined) {
-      args.push(`-t=scored=${metadata.scored}`);
     }
     if (sourceInfo !== undefined) {
       args.push(

--- a/extensions/ql-vscode/src/query-results.ts
+++ b/extensions/ql-vscode/src/query-results.ts
@@ -186,14 +186,13 @@ export function ensureMetadataIsComplete(metadata: QueryMetadata | undefined) {
   if (metadata === undefined) {
     throw new Error('Can\'t interpret results without query metadata');
   }
-  let { kind, id, scored } = metadata;
-  if (kind === undefined) {
+  if (metadata.kind === undefined) {
     throw new Error('Can\'t interpret results without query metadata including kind');
   }
-  if (id === undefined) {
+  if (metadata.id === undefined) {
     // Interpretation per se doesn't really require an id, but the
     // SARIF format does, so in the absence of one, we use a dummy id.
-    id = 'dummy-id';
+    metadata.id = 'dummy-id';
   }
-  return { kind, id, scored };
+  return metadata;
 }


### PR DESCRIPTION
This PR forwards all the query metadata to the queryserver.

Currently, only `@kind` and `@id` are forwarded for most users.  This results in metadata errors when running some queries, even if the queries being run had the correct metadata.  For example, the `@kind metric` query requires either the `@tags summary` metadata or the `@metricType` metadata key to be defined.  However the VS Code extension doesn't currently forward the `@tags` and `@metricType` properties, so the queryserver reports errors whenever a user tries to run these queries.

With this PR, we forward all the query metadata to the queryserver, so queries like these will no longer report metadata errors.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
