### PR TITLE
Add polyfill for path to fix a bug that prevented the results view from being loaded

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [UNRELEASED]
 
+- Fix a bug that prevented the results view from being loaded. [#842](https://github.com/github/vscode-codeql/pull/842)
+
 ## 1.4.6 - 21 April 2021
 
 - Avoid showing an error popup when running a query with `@kind table` metadata. [#814](https://github.com/github/vscode-codeql/pull/814)

--- a/extensions/ql-vscode/gulpfile.ts/webpack.config.ts
+++ b/extensions/ql-vscode/gulpfile.ts/webpack.config.ts
@@ -15,7 +15,7 @@ export const config: webpack.Configuration = {
   resolve: {
     extensions: ['.js', '.ts', '.tsx', '.json'],
     fallback: {
-      path: false
+      path: require.resolve('path-browserify')
     }
   },
   module: {

--- a/extensions/ql-vscode/package-lock.json
+++ b/extensions/ql-vscode/package-lock.json
@@ -16,6 +16,7 @@
         "js-yaml": "^3.14.0",
         "minimist": "~1.2.5",
         "node-fetch": "~2.6.0",
+        "path-browserify": "^1.0.1",
         "react": "^16.8.6",
         "react-dom": "^16.8.6",
         "semver": "~7.3.2",
@@ -2006,7 +2007,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -6632,7 +6632,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.2",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -7760,6 +7759,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
     },
     "node_modules/path-dirname": {
       "version": "1.0.2",
@@ -17713,6 +17717,11 @@
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
+    },
+    "path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
     },
     "path-dirname": {
       "version": "1.0.2",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -853,6 +853,7 @@
     "js-yaml": "^3.14.0",
     "minimist": "~1.2.5",
     "node-fetch": "~2.6.0",
+    "path-browserify": "^1.0.1",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "semver": "~7.3.2",


### PR DESCRIPTION
Webpack >v5 doesn't include polyfills for core modules from Node.js by default. Since we use `path` in the results table UI, we need to include our own polyfill. This PR adds `path-browserify` to the distributed extension.

As future work, we could move SARIF location rendering into the core extension so we don't need to use `path.basename` in the UI. This would allow us to remove the polyfill.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.