### PR TITLE
Add command to copy version information

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,7 +10,12 @@ assignees: ''
 **Describe the bug**
 A clear and concise description of what the bug is.
 
-**To Reproduce**
+**Version**
+The CodeQL and VS Code version in which the bug occurs.
+<!-- To copy version information for the CodeQL extension, click "CodeQL CLI vX.X.X" in the status bar at the bottom of the screen. 
+To copy detailed version information for VS Code itself, see https://code.visualstudio.com/docs/supporting/FAQ#_how-do-i-find-the-version. -->
+
+**To reproduce**
 Steps to reproduce the behavior.
 
 **Expected behavior**

--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 - Copy version information to the clipboard when a user clicks the CodeQL section of the status bar. [#845](https://github.com/github/vscode-codeql/pull/845)
 - Ensure changes in directories that contain tests will be properly updated in the test explorer. [#846](https://github.com/github/vscode-codeql/pull/846)
-- Add a command to copy version information about the extension. [#845](https://github.com/github/vscode-codeql/pull/845)
-- Copy version information to the clipboard when a user clicks on the CodeQL section of the status bar. [#845](https://github.com/github/vscode-codeql/pull/845)
 
 ## 1.4.7 - 23 April 2021
 

--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## [UNRELEASED]
 
+- Copy version information to the clipboard when a user clicks the CodeQL section of the status bar. [#845](https://github.com/github/vscode-codeql/pull/845)
 - Ensure changes in directories that contain tests will be properly updated in the test explorer. [#846](https://github.com/github/vscode-codeql/pull/846)
+- Add a command to copy version information about the extension. [#845](https://github.com/github/vscode-codeql/pull/845)
+- Copy version information to the clipboard when a user clicks on the CodeQL section of the status bar. [#845](https://github.com/github/vscode-codeql/pull/845)
 
 ## 1.4.7 - 23 April 2021
 

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -243,6 +243,10 @@
         "title": "CodeQL: Open Documentation"
       },
       {
+        "command": "codeQL.copyVersion",
+        "title": "CodeQL: Copy Version Information"
+      },
+      {
         "command": "codeQLDatabases.chooseDatabaseFolder",
         "title": "Choose Database from Folder",
         "icon": {

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -13,6 +13,7 @@ import {
   window
 } from 'vscode';
 import { LanguageClient } from 'vscode-languageclient';
+import * as os from 'os';
 import * as path from 'path';
 import { testExplorerExtensionId, TestHub } from 'vscode-test-adapter-api';
 
@@ -699,6 +700,14 @@ async function activateWithInstalledDistribution(
   ctx.subscriptions.push(
     commandRunner('codeQL.openDocumentation', async () =>
       env.openExternal(Uri.parse('https://codeql.github.com/docs/'))));
+
+  ctx.subscriptions.push(
+    commandRunner('codeQL.copyVersion', async () => {
+      const text = `CodeQL extension version: ${extension?.packageJSON.version} \nCodeQL CLI version: ${await cliServer.getVersion()} \nPlatform: ${os.platform()} ${os.arch()}`;
+      env.clipboard.writeText(text);
+      helpers.showAndLogInformationMessage(text);
+    }));
+
 
   logger.log('Starting language server.');
   ctx.subscriptions.push(client.start());

--- a/extensions/ql-vscode/src/status-bar.ts
+++ b/extensions/ql-vscode/src/status-bar.ts
@@ -19,7 +19,7 @@ export class CodeQlStatusBarHandler extends DisposableObject {
     this.push(this.item);
     this.push(workspace.onDidChangeConfiguration(this.handleDidChangeConfiguration, this));
     this.push(distributionConfigListener.onDidChangeConfiguration(() => this.updateStatusItem()));
-    this.item.command = 'codeQL.openDocumentation';
+    this.item.command = 'codeQL.copyVersion';
     this.updateStatusItem();
   }
 
@@ -37,7 +37,7 @@ export class CodeQlStatusBarHandler extends DisposableObject {
 
   private async updateStatusItem() {
     const canary = CANARY_FEATURES.getValue() ? ' (Canary)' : '';
-    // since getting the verison may take a few seconds, initialize with some
+    // since getting the version may take a few seconds, initialize with some
     // meaningful text.
     this.item.text = `CodeQL${canary}`;
 


### PR DESCRIPTION
Fixes https://github.com/github/vscode-codeql/issues/795.
You can now access version information from the status bar or by running `CodeQL: Copy Version Information` from the Command Palette.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [n/a] ~`@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.~ This doesn't need docs: the note in the issue template should be enough.
