### PR TITLE
Actions: Add permissions block to code scanning workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,6 +11,12 @@ on:
 jobs:
   codeql:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      security_events: write
+      pull_requests: read
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
Only adds permissions to the code scanning workflow. We should add to other workflows, but they require more complex permissions and I need to think about what to give them.