### PR TITLE
Improve LGTM download messages

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Copy version information to the clipboard when a user clicks the CodeQL section of the status bar. [#845](https://github.com/github/vscode-codeql/pull/845)
 - Ensure changes in directories that contain tests will be properly updated in the test explorer. [#846](https://github.com/github/vscode-codeql/pull/846)
+- Remind users to choose a language when downloading a database from LGTM. [#852](https://github.com/github/vscode-codeql/pull/852)
 
 ## 1.4.7 - 23 April 2021
 

--- a/extensions/ql-vscode/src/databases-ui.ts
+++ b/extensions/ql-vscode/src/databases-ui.ts
@@ -108,7 +108,7 @@ class DatabaseTreeDataProvider extends DisposableObject
   }
 
   private handleDidChangeDatabaseItem = (event: DatabaseChangedEvent): void => {
-    // Note that events from the databse manager are instances of DatabaseChangedEvent
+    // Note that events from the database manager are instances of DatabaseChangedEvent
     // and events fired by the UI are instances of DatabaseItem
 
     // When event.item is undefined, then the entire tree is refreshed.
@@ -703,7 +703,7 @@ export class DatabaseUI extends DisposableObject {
    * 2. If the selected URI is a directory matching db-*, choose the containing directory
    * 3. choose the current directory
    *
-   * @param uri a URI that is a datbase folder or inside it
+   * @param uri a URI that is a database folder or inside it
    *
    * @return the actual database folder found by using the heuristics above.
    */

--- a/extensions/ql-vscode/src/databases-ui.ts
+++ b/extensions/ql-vscode/src/databases-ui.ts
@@ -295,7 +295,7 @@ export class DatabaseUI extends DisposableObject {
         'codeQLDatabases.chooseDatabaseLgtm',
         this.handleChooseDatabaseLgtm,
         {
-          title: 'Adding database from LGTM',
+          title: 'Adding database from LGTM. Choose a language from the dropdown, if available.',
         })
     );
     this.push(

--- a/extensions/ql-vscode/src/databases-ui.ts
+++ b/extensions/ql-vscode/src/databases-ui.ts
@@ -295,7 +295,7 @@ export class DatabaseUI extends DisposableObject {
         'codeQLDatabases.chooseDatabaseLgtm',
         this.handleChooseDatabaseLgtm,
         {
-          title: 'Adding database from LGTM. Choose a language from the dropdown, if available.',
+          title: 'Adding database from LGTM. Choose a language from the dropdown, if requested.',
         })
     );
     this.push(

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -682,7 +682,7 @@ async function activateWithInstalledDistribution(
     ) =>
       databaseUI.handleChooseDatabaseLgtm(progress, token),
       {
-        title: 'Adding database from LGTM',
+        title: 'Adding database from LGTM. Choose a language from the dropdown, if available.',
       })
   );
   ctx.subscriptions.push(

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -682,7 +682,7 @@ async function activateWithInstalledDistribution(
     ) =>
       databaseUI.handleChooseDatabaseLgtm(progress, token),
       {
-        title: 'Adding database from LGTM. Choose a language from the dropdown, if available.',
+        title: 'Adding database from LGTM. Choose a language from the dropdown, if requested.',
       })
   );
   ctx.subscriptions.push(

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -140,7 +140,7 @@ export interface CodeQLExtensionInterface {
 
 /**
  * Returns the CodeQLExtensionInterface, or an empty object if the interface is not
- * available afer activation is complete. This will happen if there is no cli
+ * available after activation is complete. This will happen if there is no cli
  * installed when the extension starts. Downloading and installing the cli
  * will happen at a later time.
  *


### PR DESCRIPTION
Fixes https://github.com/github/vscode-codeql/issues/813 (commit https://github.com/github/vscode-codeql/commit/6c8121202a5a0cd9c9756f40abca2efb1b9a5ee9). I've expanded the LGTM download message to prompt users to choose a language:

![image](https://user-images.githubusercontent.com/42641846/116404237-5b5d5900-a826-11eb-90ef-9a1a0825d3ca.png)

👆🏽 This doesn't apply to all databases, hence "if available". (I hope that's clear enough, but otherwise we can try to _only_ display this message for multi-language databases. I haven't looked at how to do this yet 🙇🏽‍♀️)

(https://github.com/github/vscode-codeql/commit/281084e780f04c8f66d23b3684fc07d5fcb16df0 fixes some minor typos.) 

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- n/a `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
