### PR TITLE
Fix syntax in CodeQL code scanning workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [main]
   schedule:
-    - cron: '0 0 * * 0'
+    - cron: '21 17 * * 0'
 
 jobs:
   codeql:
@@ -14,8 +14,8 @@ jobs:
 
     permissions:
       contents: read
-      security_events: write
-      pull_requests: read
+      security-events: write
+      pull-requests: read
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
The code scanning workflow has been failing with a syntax error, e.g. see https://github.com/github/vscode-codeql/actions/runs/786489168. Changed `_` to `-` to match the docs: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions.
The workflow is now green ✔️ though it returns the [warning](https://github.com/github/vscode-codeql/actions/runs/792817144) `Did not find any lines of code in database.` I'm not sure if the warning is directly related to this PR, or a separate bug 🤔 

PS: I also changed the cron to run at a less common time. Actions tends to be overloaded at the start of each hour, so we can save resources a bit by shifting the time 🙂 (I have no strong preference btw, 17:21 on Sundays seemed arbitrary enough!)

## Checklist

- [n/a] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [n/a] Issues have been created for any UI or other user-facing changes made by this pull request.
- [n/a] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
