### PR TITLE
Specify custom directory for storing evaluation logs

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Display CodeQL CLI version being downloaded during an upgrade. [#862](https://github.com/github/vscode-codeql/pull/862)
 - Display a helpful message and link to documentation when a query produces no results. [#866](https://github.com/github/vscode-codeql/pull/866)
 - Refresh test databases automatically after a test run. [#868](https://github.com/github/vscode-codeql/pull/868)
+- Allow users to specify a custom directory for storing query server logs (`codeQL.runningQueries.customLogDirectory`). The extension will not delete these logs automatically. [#863](https://github.com/github/vscode-codeql/pull/863)
 
 ## 1.4.8 - 05 May 2021
 

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -179,6 +179,14 @@
           "default": 20,
           "description": "Max number of simultaneous queries to run using the 'CodeQL: Run Queries' command."
         },
+        "codeQL.runningQueries.customLogDirectory": {
+          "type": [
+            "string",
+            null
+          ],
+          "default": null,
+          "description": "Path to a directory where the CodeQL extension should store query server logs. If empty, the extension stores logs in a temporary workspace folder and deletes the contents after each run."
+        },
         "codeQL.resultsDisplay.pageSize": {
           "type": "integer",
           "default": 200,

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -87,9 +87,10 @@ export const NUMBER_OF_TEST_THREADS_SETTING = new Setting('numberOfThreads', RUN
 export const MAX_QUERIES = new Setting('maxQueries', RUNNING_QUERIES_SETTING);
 export const AUTOSAVE_SETTING = new Setting('autoSave', RUNNING_QUERIES_SETTING);
 export const PAGE_SIZE = new Setting('pageSize', RESULTS_DISPLAY_SETTING);
+const CUSTOM_LOG_DIRECTORY_SETTING = new Setting('customLogDirectory', RUNNING_QUERIES_SETTING);
 
 /** When these settings change, the running query server should be restarted. */
-const QUERY_SERVER_RESTARTING_SETTINGS = [NUMBER_OF_THREADS_SETTING, SAVE_CACHE_SETTING, CACHE_SIZE_SETTING, MEMORY_SETTING, DEBUG_SETTING];
+const QUERY_SERVER_RESTARTING_SETTINGS = [NUMBER_OF_THREADS_SETTING, SAVE_CACHE_SETTING, CACHE_SIZE_SETTING, MEMORY_SETTING, DEBUG_SETTING, CUSTOM_LOG_DIRECTORY_SETTING];
 
 export interface QueryServerConfig {
   codeQlPath: string;
@@ -99,6 +100,7 @@ export interface QueryServerConfig {
   cacheSize: number;
   queryMemoryMb?: number;
   timeoutSecs: number;
+  customLogDirectory?: string;
   onDidChangeConfiguration?: Event<void>;
 }
 
@@ -195,6 +197,10 @@ export class QueryServerConfigListener extends ConfigListener implements QuerySe
 
   public get codeQlPath(): string {
     return this._codeQlPath;
+  }
+
+  public get customLogDirectory(): string | undefined {
+    return CUSTOM_LOG_DIRECTORY_SETTING.getValue<string>() || undefined;
   }
 
   public get numThreads(): number {

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -155,7 +155,7 @@ export async function activate(ctx: ExtensionContext): Promise<CodeQLExtensionIn
   }
 
   const distributionConfigListener = new DistributionConfigListener();
-  initializeLogging(ctx);
+  await initializeLogging(ctx);
   await initializeTelemetry(extension, ctx);
   languageSupport.install();
 
@@ -767,10 +767,10 @@ function getContextStoragePath(ctx: ExtensionContext) {
   return ctx.storagePath || ctx.globalStoragePath;
 }
 
-function initializeLogging(ctx: ExtensionContext): void {
+async function initializeLogging(ctx: ExtensionContext): Promise<void> {
   const storagePath = getContextStoragePath(ctx);
-  logger.setLogStoragePath(storagePath, false);
-  ideServerLogger.setLogStoragePath(storagePath, false);
+  await logger.setLogStoragePath(storagePath, false);
+  await ideServerLogger.setLogStoragePath(storagePath, false);
   ctx.subscriptions.push(logger);
   ctx.subscriptions.push(queryServerLogger);
   ctx.subscriptions.push(ideServerLogger);

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -380,6 +380,7 @@ async function activateWithInstalledDistribution(
     cliServer,
     {
       logger: queryServerLogger,
+      contextStoragePath: getContextStoragePath(ctx),
     },
     (task) =>
       Window.withProgress(
@@ -768,9 +769,8 @@ function getContextStoragePath(ctx: ExtensionContext) {
 
 function initializeLogging(ctx: ExtensionContext): void {
   const storagePath = getContextStoragePath(ctx);
-  logger.init(storagePath);
-  queryServerLogger.init(storagePath);
-  ideServerLogger.init(storagePath);
+  logger.setLogStoragePath(storagePath, false);
+  ideServerLogger.setLogStoragePath(storagePath, false);
   ctx.subscriptions.push(logger);
   ctx.subscriptions.push(queryServerLogger);
   ctx.subscriptions.push(ideServerLogger);

--- a/extensions/ql-vscode/src/logging.ts
+++ b/extensions/ql-vscode/src/logging.ts
@@ -28,9 +28,16 @@ export interface Logger {
   removeAdditionalLogLocation(location: string | undefined): void;
 
   /**
-   * The base location location where all side log files are stored.
+   * The base location where all side log files are stored.
    */
   getBaseLocation(): string | undefined;
+
+  /**
+   * Sets the location where logs are stored.
+   * @param storagePath The path where logs are stored.
+   * @param isCustomLogDirectory Whether the logs are stored in a custom, user-specified directory.
+   */
+  setLogStoragePath(storagePath: string, isCustomLogDirectory: boolean): Promise<void>;
 }
 
 export type ProgressReporter = Progress<{ message: string }>;
@@ -49,14 +56,14 @@ export class OutputChannelLogger extends DisposableObject implements Logger {
     this.isCustomLogDirectory = false;
   }
 
-  setLogStoragePath(storagePath: string, isCustomLogDirectory: boolean): void {
+  async setLogStoragePath(storagePath: string, isCustomLogDirectory: boolean): Promise<void> {
     this.additionalLogLocationPath = path.join(storagePath, this.title);
 
     this.isCustomLogDirectory = isCustomLogDirectory;
 
     if (!this.isCustomLogDirectory) {
       // clear out any old state from previous runs
-      fs.remove(this.additionalLogLocationPath);
+      await fs.remove(this.additionalLogLocationPath);
     }
   }
 

--- a/extensions/ql-vscode/src/queryserver-client.ts
+++ b/extensions/ql-vscode/src/queryserver-client.ts
@@ -93,10 +93,12 @@ export class QueryServerClient extends DisposableObject {
     let storagePath = this.opts.contextStoragePath;
     let isCustomLogDirectory = false;
     if (this.config.customLogDirectory) {
-      if (fs.existsSync(this.config.customLogDirectory) && fs.statSync(this.config.customLogDirectory).isDirectory()) {
+      try {
+        fs.mkdirSync(this.config.customLogDirectory);
+        helpers.showAndLogInformationMessage(`Storing query server logs to user-specified directory: ${this.config.customLogDirectory}.`);
         storagePath = this.config.customLogDirectory;
         isCustomLogDirectory = true;
-      } else if (this.config.customLogDirectory) {
+      } catch (e) {
         helpers.showAndLogErrorMessage(`${this.config.customLogDirectory} is not a valid directory. Logs will be stored in a temporary workspace directory instead.`);
       }
     }

--- a/extensions/ql-vscode/test/pure-tests/logging.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/logging.test.ts
@@ -48,7 +48,7 @@ describe('OutputChannelLogger tests', () => {
   });
 
   it('should create a side log in the workspace area', async () => {
-    logger.setLogStoragePath(tempFolders.storagePath.name, false);
+    await logger.setLogStoragePath(tempFolders.storagePath.name, false);
 
     await logger.log('xxx', { additionalLogLocation: 'first' });
     await logger.log('yyy', { additionalLogLocation: 'second' });
@@ -65,7 +65,7 @@ describe('OutputChannelLogger tests', () => {
   });
 
   it('should delete side logs on dispose', async () => {
-    logger.setLogStoragePath(tempFolders.storagePath.name, false);
+    await logger.setLogStoragePath(tempFolders.storagePath.name, false);
     await logger.log('xxx', { additionalLogLocation: 'first' });
     await logger.log('yyy', { additionalLogLocation: 'second' });
 
@@ -80,7 +80,7 @@ describe('OutputChannelLogger tests', () => {
   });
 
   it('should not delete side logs on dispose in a custom directory', async () => {
-    logger.setLogStoragePath(tempFolders.storagePath.name, true);
+    await logger.setLogStoragePath(tempFolders.storagePath.name, true);
     await logger.log('xxx', { additionalLogLocation: 'first' });
     await logger.log('yyy', { additionalLogLocation: 'second' });
 
@@ -95,7 +95,7 @@ describe('OutputChannelLogger tests', () => {
   });
 
   it('should remove an additional log location', async () => {
-    logger.setLogStoragePath(tempFolders.storagePath.name, false);
+    await logger.setLogStoragePath(tempFolders.storagePath.name, false);
     await logger.log('xxx', { additionalLogLocation: 'first' });
     await logger.log('yyy', { additionalLogLocation: 'second' });
 
@@ -110,7 +110,7 @@ describe('OutputChannelLogger tests', () => {
   });
 
   it('should not remove an additional log location in a custom directory', async () => {
-    logger.setLogStoragePath(tempFolders.storagePath.name, true);
+    await logger.setLogStoragePath(tempFolders.storagePath.name, true);
     await logger.log('xxx', { additionalLogLocation: 'first' });
     await logger.log('yyy', { additionalLogLocation: 'second' });
 
@@ -126,17 +126,17 @@ describe('OutputChannelLogger tests', () => {
 
   it('should delete an existing folder when setting the log storage path', async () => {
     fs.createFileSync(path.join(tempFolders.storagePath.name, 'test-logger', 'xxx'));
-    logger.setLogStoragePath(tempFolders.storagePath.name, false);
+    await logger.setLogStoragePath(tempFolders.storagePath.name, false);
     // should be empty dir
 
+    await waitABit();
     const testLoggerFolder = path.join(tempFolders.storagePath.name, 'test-logger');
-    // TODO: Why does this test pass? I'd expect the length to be 0 if it's correctly deleted the existing folder.
-    expect(fs.readdirSync(testLoggerFolder).length).to.equal(1);
+    expect(fs.existsSync(testLoggerFolder)).to.be.false;
   });
 
   it('should not delete an existing folder when setting the log storage path for a custom directory', async () => {
     fs.createFileSync(path.join(tempFolders.storagePath.name, 'test-logger', 'xxx'));
-    logger.setLogStoragePath(tempFolders.storagePath.name, true);
+    await logger.setLogStoragePath(tempFolders.storagePath.name, true);
     // should not be empty dir
 
     const testLoggerFolder = path.join(tempFolders.storagePath.name, 'test-logger');


### PR DESCRIPTION
Will fix https://github.com/github/vscode-codeql/issues/820.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
  - Docs-wise, we should probably mention this in https://codeql.github.com/docs/codeql-for-visual-studio-code/troubleshooting-codeql-for-visual-studio-code/. 
