### PR TITLE
Prevent CodeQL tests from interfering with loaded testproj databases

### DIFF
--- a/extensions/ql-vscode/src/databaseFetcher.ts
+++ b/extensions/ql-vscode/src/databaseFetcher.ts
@@ -10,7 +10,7 @@ import {
 import * as fs from 'fs-extra';
 import * as path from 'path';
 
-import { DatabaseManager, DatabaseItem } from './databases';
+import { DatabaseManager, DatabaseItem, getStorageFolder } from './databases';
 import {
   showAndLogInformationMessage,
 } from './helpers';
@@ -199,33 +199,6 @@ async function databaseArchiveFetcher(
   } else {
     throw new Error('Database not found in archive.');
   }
-}
-
-async function getStorageFolder(storagePath: string, urlStr: string) {
-  // we need to generate a folder name for the unzipped archive,
-  // this needs to be human readable since we may use this name as the initial
-  // name for the database
-  const url = Uri.parse(urlStr);
-  // MacOS has a max filename length of 255
-  // and remove a few extra chars in case we need to add a counter at the end.
-  let lastName = path.basename(url.path).substring(0, 250);
-  if (lastName.endsWith('.zip')) {
-    lastName = lastName.substring(0, lastName.length - 4);
-  }
-
-  const realpath = await fs.realpath(storagePath);
-  let folderName = path.join(realpath, lastName);
-
-  // avoid overwriting existing folders
-  let counter = 0;
-  while (await fs.pathExists(folderName)) {
-    counter++;
-    folderName = path.join(realpath, `${lastName}-${counter}`);
-    if (counter > 100) {
-      throw new Error('Could not find a unique name for downloaded database.');
-    }
-  }
-  return folderName;
 }
 
 function validateHttpsUrl(databaseUrl: string) {


### PR DESCRIPTION
This PR is work-in-progress for #768, and I would like to get some early feedback on how any aspect of this PR can be improved.

Here is the general plan:

- [x] Always copy database directories to extension-controlled location before loading
- [ ] Re-copy and re-register the database after each test run

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
