### PR TITLE
Add link to language guides for empty query results

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [UNRELEASED]
 
 - Display CodeQL CLI version being downloaded during an upgrade. [#862](https://github.com/github/vscode-codeql/pull/862)
+- Display a helpful message and link to documentation when a query produces no results. [#866](https://github.com/github/vscode-codeql/pull/866)
 
 ## 1.4.8 - 05 May 2021
 

--- a/extensions/ql-vscode/src/view/alert-table.tsx
+++ b/extensions/ql-vscode/src/view/alert-table.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import * as Sarif from 'sarif';
 import * as Keys from '../pure/result-keys';
 import * as octicons from './octicons';
-import { className, renderLocation, ResultTableProps, zebraStripe, selectableZebraStripe, jumpToLocation, nextSortDirection } from './result-table-utils';
+import { className, renderLocation, ResultTableProps, zebraStripe, selectableZebraStripe, jumpToLocation, nextSortDirection, emptyQueryResultsMessage } from './result-table-utils';
 import { onNavigation, NavigationEvent } from './results';
 import { PathTableResultSet } from '../pure/interface-types';
 import {
@@ -79,7 +79,7 @@ export class PathTable extends React.Component<PathTableProps, PathTableState> {
     if (this.props.nonemptyRawResults) {
       return <span>No Alerts. See <a href='#' onClick={this.props.showRawResults}>raw results</a>.</span>;
     } else {
-      return <span>No Alerts</span>;
+      return emptyQueryResultsMessage();
     }
   }
 

--- a/extensions/ql-vscode/src/view/raw-results-table.tsx
+++ b/extensions/ql-vscode/src/view/raw-results-table.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ResultTableProps, className } from './result-table-utils';
+import { ResultTableProps, className, emptyQueryResultsMessage } from './result-table-utils';
 import { RAW_RESULTS_LIMIT, RawResultsSortState } from '../pure/interface-types';
 import { RawTableResultSet } from '../pure/interface-types';
 import RawTableHeader from './RawTableHeader';
@@ -21,6 +21,10 @@ export class RawTable extends React.Component<RawTableProps, {}> {
     const { resultSet, databaseUri } = this.props;
 
     let dataRows = resultSet.rows;
+    if (dataRows.length === 0) {
+      return emptyQueryResultsMessage();
+    }
+
     let numTruncatedResults = 0;
     if (dataRows.length > RAW_RESULTS_LIMIT) {
       numTruncatedResults = dataRows.length - RAW_RESULTS_LIMIT;

--- a/extensions/ql-vscode/src/view/result-table-utils.tsx
+++ b/extensions/ql-vscode/src/view/result-table-utils.tsx
@@ -140,3 +140,9 @@ export function nextSortDirection(direction: SortDirection | undefined, includeU
       return assertNever(direction);
   }
 }
+
+export function emptyQueryResultsMessage(): JSX.Element {
+  return <span>
+    This query returned no results. If this isn&apos;t what you&apos;re expecting, and for effective query-writing tips, check out the <a href="https://codeql.github.com/docs/codeql-language-guides/">CodeQL language guides</a>.
+  </span>;
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Empty table when no query results are returned is replaced by a message with documentation to the [CodeQL Language Guides](https://codeql.github.com/docs/codeql-language-guides/).

Fixes https://github.com/github/vscode-codeql/issues/551.

Please let me know if this warrants a change to the changelogs and if I should cc `@github/docs-content-codeql`.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [n/a] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
