### PR TITLE
Increase font size and add margins to empty query message

### DIFF
--- a/extensions/ql-vscode/src/view/result-table-utils.tsx
+++ b/extensions/ql-vscode/src/view/result-table-utils.tsx
@@ -142,7 +142,7 @@ export function nextSortDirection(direction: SortDirection | undefined, includeU
 }
 
 export function emptyQueryResultsMessage(): JSX.Element {
-  return <span>
+  return <div className='vscode-codeql__empty-query-message'><span>
     This query returned no results. If this isn&apos;t what you were expecting, and for effective query-writing tips, check out the <a href="https://codeql.github.com/docs/codeql-language-guides/">CodeQL language guides</a>.
-  </span>;
+  </span></div>;
 }

--- a/extensions/ql-vscode/src/view/result-table-utils.tsx
+++ b/extensions/ql-vscode/src/view/result-table-utils.tsx
@@ -143,6 +143,6 @@ export function nextSortDirection(direction: SortDirection | undefined, includeU
 
 export function emptyQueryResultsMessage(): JSX.Element {
   return <span>
-    This query returned no results. If this isn&apos;t what you&apos;re expecting, and for effective query-writing tips, check out the <a href="https://codeql.github.com/docs/codeql-language-guides/">CodeQL language guides</a>.
+    This query returned no results. If this isn&apos;t what you were expecting, and for effective query-writing tips, check out the <a href="https://codeql.github.com/docs/codeql-language-guides/">CodeQL language guides</a>.
   </span>;
 }

--- a/extensions/ql-vscode/src/view/resultsView.css
+++ b/extensions/ql-vscode/src/view/resultsView.css
@@ -221,3 +221,16 @@ td.vscode-codeql__path-index-cell {
 .vscode-codeql__compare-body > tbody {
   vertical-align: top;
 }
+
+.vscode-codeql__empty-query-message {
+  height: 300px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.vscode-codeql__empty-query-message > span {
+  max-width: 80%;
+  font-size: 14px;
+  text-align: center;
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Increased the empty query output message's font size and added margins around the message using flex-box centering.

Closes https://github.com/github/vscode-codeql/issues/869

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [n/a] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
