### PR TITLE
Update linting rules

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -126,7 +126,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        version: ['v2.2.6', 'v2.3.3', 'v2.4.5', 'v2.4.6', 'v2.5.5']
+        version: ['v2.2.6', 'v2.3.3', 'v2.4.6', 'v2.5.5']
     env:
       CLI_VERSION: ${{ matrix.version }}
       TEST_CODEQL_PATH: '${{ github.workspace }}/codeql'

--- a/extensions/ql-vscode/.eslintrc.js
+++ b/extensions/ql-vscode/.eslintrc.js
@@ -24,6 +24,7 @@ module.exports = {
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/no-non-null-assertion": "off",
     "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-floating-promises": [ "error", { ignoreVoid: true } ],
     "prefer-const": ["warn", { destructuring: "all" }],
     indent: "off",
     "@typescript-eslint/indent": "off",

--- a/extensions/ql-vscode/src/archive-filesystem-provider.ts
+++ b/extensions/ql-vscode/src/archive-filesystem-provider.ts
@@ -115,7 +115,7 @@ class InvalidSourceArchiveUriError extends Error {
 export function decodeSourceArchiveUri(uri: vscode.Uri): ZipFileReference {
   if (!uri.authority) {
     // Uri is malformed, but this is recoverable
-    logger.log(`Warning: ${new InvalidSourceArchiveUriError(uri).message}`);
+    void logger.log(`Warning: ${new InvalidSourceArchiveUriError(uri).message}`);
     return {
       pathWithinSourceArchive: '/',
       sourceArchiveZipPath: uri.path
@@ -141,7 +141,7 @@ function ensureFile(map: DirectoryHierarchyMap, file: string) {
   const dirname = path.dirname(file);
   if (dirname === '.') {
     const error = `Ill-formed path ${file} in zip archive (expected absolute path)`;
-    logger.log(error);
+    void logger.log(error);
     throw new Error(error);
   }
   ensureDir(map, dirname);

--- a/extensions/ql-vscode/src/cli-version.ts
+++ b/extensions/ql-vscode/src/cli-version.ts
@@ -18,7 +18,7 @@ export async function getCodeQlCliVersion(codeQlPath: string, logger: Logger): P
   } catch (e) {
     // Failed to run the version command. This might happen if the cli version is _really_ old, or it is corrupted.
     // Either way, we can't determine compatibility.
-    logger.log(`Failed to run 'codeql version'. Reason: ${e.message}`);
+    void logger.log(`Failed to run 'codeql version'. Reason: ${e.message}`);
     return undefined;
   }
 }

--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -183,15 +183,15 @@ export class CodeQLCliServer implements Disposable {
   killProcessIfRunning(): void {
     if (this.process) {
       // Tell the Java CLI server process to shut down.
-      this.logger.log('Sending shutdown request');
+      void this.logger.log('Sending shutdown request');
       try {
         this.process.stdin.write(JSON.stringify(['shutdown']), 'utf8');
         this.process.stdin.write(this.nullBuffer);
-        this.logger.log('Sent shutdown request');
+        void this.logger.log('Sent shutdown request');
       } catch (e) {
         // We are probably fine here, the process has already closed stdin.
-        this.logger.log(`Shutdown request failed: process stdin may have already closed. The error was ${e}`);
-        this.logger.log('Stopping the process anyway.');
+        void this.logger.log(`Shutdown request failed: process stdin may have already closed. The error was ${e}`);
+        void this.logger.log('Stopping the process anyway.');
       }
       // Close the stdin and stdout streams.
       // This is important on Windows where the child process may not die cleanly.
@@ -271,7 +271,7 @@ export class CodeQLCliServer implements Disposable {
       // Compute the full args array
       const args = command.concat(LOGGING_FLAGS).concat(commandArgs);
       const argsString = args.join(' ');
-      this.logger.log(`${description} using CodeQL CLI: ${argsString}...`);
+      void this.logger.log(`${description} using CodeQL CLI: ${argsString}...`);
       try {
         await new Promise<void>((resolve, reject) => {
           // Start listening to stdout
@@ -298,7 +298,7 @@ export class CodeQLCliServer implements Disposable {
         const fullBuffer = Buffer.concat(stdoutBuffers);
         // Make sure we remove the terminator;
         const data = fullBuffer.toString('utf8', 0, fullBuffer.length - 1);
-        this.logger.log('CLI command succeeded.');
+        void this.logger.log('CLI command succeeded.');
         return data;
       } catch (err) {
         // Kill the process if it isn't already dead.
@@ -311,7 +311,7 @@ export class CodeQLCliServer implements Disposable {
         newError.stack += (err.stack || '');
         throw newError;
       } finally {
-        this.logger.log(Buffer.concat(stderrBuffers).toString('utf8'));
+        void this.logger.log(Buffer.concat(stderrBuffers).toString('utf8'));
         // Remove the listeners we set up.
         process.stdout.removeAllListeners('data');
         process.stderr.removeAllListeners('data');
@@ -371,7 +371,7 @@ export class CodeQLCliServer implements Disposable {
       }
       if (logger !== undefined) {
         // The human-readable output goes to stderr.
-        logStream(child.stderr!, logger);
+        void logStream(child.stderr!, logger);
       }
 
       for await (const event of await splitStreamAtSeparators(child.stdout!, ['\0'])) {
@@ -813,7 +813,7 @@ export function spawnServer(
   if (progressReporter !== undefined) {
     progressReporter.report({ message: `Starting ${name}` });
   }
-  logger.log(`Starting ${name} using CodeQL CLI: ${base} ${argsString}`);
+  void logger.log(`Starting ${name} using CodeQL CLI: ${base} ${argsString}`);
   const child = child_process.spawn(base, args);
   if (!child || !child.pid) {
     throw new Error(`Failed to start ${name} using command ${base} ${argsString}.`);
@@ -829,7 +829,7 @@ export function spawnServer(
   if (progressReporter !== undefined) {
     progressReporter.report({ message: `Started ${name}` });
   }
-  logger.log(`${name} started on PID: ${child.pid}`);
+  void logger.log(`${name} started on PID: ${child.pid}`);
   return child;
 }
 
@@ -858,10 +858,10 @@ export async function runCodeQlCliCommand(
     if (progressReporter !== undefined) {
       progressReporter.report({ message: description });
     }
-    logger.log(`${description} using CodeQL CLI: ${codeQlPath} ${argsString}...`);
+    void logger.log(`${description} using CodeQL CLI: ${codeQlPath} ${argsString}...`);
     const result = await promisify(child_process.execFile)(codeQlPath, args);
-    logger.log(result.stderr);
-    logger.log('CLI command succeeded.');
+    void logger.log(result.stderr);
+    void logger.log('CLI command succeeded.');
     return result.stdout;
   } catch (err) {
     throw new Error(`${description} failed: ${err.stderr || err}`);
@@ -976,7 +976,7 @@ const lineEndings = ['\r\n', '\r', '\n'];
  */
 async function logStream(stream: Readable, logger: Logger): Promise<void> {
   for await (const line of await splitStreamAtSeparators(stream, lineEndings)) {
-    logger.log(line);
+    await logger.log(line);
   }
 }
 

--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -976,6 +976,7 @@ const lineEndings = ['\r\n', '\r', '\n'];
  */
 async function logStream(stream: Readable, logger: Logger): Promise<void> {
   for await (const line of await splitStreamAtSeparators(stream, lineEndings)) {
+    // Await the result of log here in order to ensure the logs are written in the correct order.
     await logger.log(line);
   }
 }

--- a/extensions/ql-vscode/src/commandRunner.ts
+++ b/extensions/ql-vscode/src/commandRunner.ts
@@ -126,16 +126,16 @@ export function commandRunner(
       if (e instanceof UserCancellationException) {
         // User has cancelled this action manually
         if (e.silent) {
-          logger.log(errorMessage);
+          void logger.log(errorMessage);
         } else {
-          showAndLogWarningMessage(errorMessage);
+          void showAndLogWarningMessage(errorMessage);
         }
       } else {
         // Include the full stack in the error log only.
         const fullMessage = e.stack
           ? `${errorMessage}\n${e.stack}`
           : errorMessage;
-        showAndLogErrorMessage(errorMessage, {
+        void showAndLogErrorMessage(errorMessage, {
           fullMessage
         });
       }
@@ -177,16 +177,16 @@ export function commandRunnerWithProgress<R>(
       if (e instanceof UserCancellationException) {
         // User has cancelled this action manually
         if (e.silent) {
-          logger.log(errorMessage);
+          void logger.log(errorMessage);
         } else {
-          showAndLogWarningMessage(errorMessage);
+          void showAndLogWarningMessage(errorMessage);
         }
       } else {
         // Include the full stack in the error log only.
         const fullMessage = e.stack
           ? `${errorMessage}\n${e.stack}`
           : errorMessage;
-        showAndLogErrorMessage(errorMessage, {
+        void showAndLogErrorMessage(errorMessage, {
           fullMessage
         });
       }

--- a/extensions/ql-vscode/src/compare/compare-interface.ts
+++ b/extensions/ql-vscode/src/compare/compare-interface.ts
@@ -173,7 +173,7 @@ export class CompareInterfaceManager extends DisposableObject {
         break;
 
       case 'changeCompare':
-        this.changeTable(msg.newResultSetName);
+        await this.changeTable(msg.newResultSetName);
         break;
 
       case 'viewSourceFile':
@@ -267,11 +267,11 @@ export class CompareInterfaceManager extends DisposableObject {
     return resultsDiff(fromResults, toResults);
   }
 
-  private openQuery(kind: 'from' | 'to') {
+  private async openQuery(kind: 'from' | 'to') {
     const toOpen =
       kind === 'from' ? this.comparePair?.from : this.comparePair?.to;
     if (toOpen) {
-      this.showQueryResultsCallback(toOpen);
+      await this.showQueryResultsCallback(toOpen);
     }
   }
 }

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -226,7 +226,7 @@ export class QueryServerConfigListener extends ConfigListener implements QuerySe
       return undefined;
     }
     if (memory == 0 || typeof (memory) !== 'number') {
-      logger.log(`Ignoring value '${memory}' for setting ${MEMORY_SETTING.qualifiedName}`);
+      void logger.log(`Ignoring value '${memory}' for setting ${MEMORY_SETTING.qualifiedName}`);
       return undefined;
     }
     return memory;

--- a/extensions/ql-vscode/src/contextual/queryResolver.ts
+++ b/extensions/ql-vscode/src/contextual/queryResolver.ts
@@ -37,7 +37,7 @@ export async function resolveQueries(cli: CodeQLCliServer, qlpack: string, keyTy
 
   const queries = await cli.resolveQueriesInSuite(suiteFile, helpers.getOnDiskWorkspaceFolders());
   if (queries.length === 0) {
-    helpers.showAndLogErrorMessage(
+    void helpers.showAndLogErrorMessage(
       `No ${nameOfKeyType(keyType)} queries (tagged "${tagOfKeyType(keyType)}") could be found in the current library path. \
       Try upgrading the CodeQL libraries. If that doesn't work, then ${nameOfKeyType(keyType)} queries are not yet available \
       for this language.`

--- a/extensions/ql-vscode/src/databaseFetcher.ts
+++ b/extensions/ql-vscode/src/databaseFetcher.ts
@@ -51,8 +51,8 @@ export async function promptImportInternetDatabase(
   );
 
   if (item) {
-    commands.executeCommand('codeQLDatabases.focus');
-    showAndLogInformationMessage('Database downloaded and imported successfully.');
+    await commands.executeCommand('codeQLDatabases.focus');
+    void showAndLogInformationMessage('Database downloaded and imported successfully.');
   }
   return item;
 
@@ -91,8 +91,8 @@ export async function promptImportLgtmDatabase(
         token
       );
       if (item) {
-        commands.executeCommand('codeQLDatabases.focus');
-        showAndLogInformationMessage('Database downloaded and imported successfully.');
+        await commands.executeCommand('codeQLDatabases.focus');
+        void showAndLogInformationMessage('Database downloaded and imported successfully.');
       }
       return item;
     }
@@ -125,8 +125,8 @@ export async function importArchiveDatabase(
       token
     );
     if (item) {
-      commands.executeCommand('codeQLDatabases.focus');
-      showAndLogInformationMessage('Database unzipped and imported successfully.');
+      await commands.executeCommand('codeQLDatabases.focus');
+      void showAndLogInformationMessage('Database unzipped and imported successfully.');
     }
     return item;
   } catch (e) {
@@ -433,7 +433,7 @@ export async function convertToDatabaseUrl(lgtmUrl: string) {
       language,
     ].join('/')}`;
   } catch (e) {
-    logger.log(`Error: ${e.message}`);
+    void logger.log(`Error: ${e.message}`);
     throw new Error(`Invalid LGTM URL: ${lgtmUrl}`);
   }
 }

--- a/extensions/ql-vscode/src/databases-ui.ts
+++ b/extensions/ql-vscode/src/databases-ui.ts
@@ -234,7 +234,7 @@ export class DatabaseUI extends DisposableObject {
   }
 
   init() {
-    logger.log('Registering database panel commands.');
+    void logger.log('Registering database panel commands.');
     this.push(
       commandRunnerWithProgress(
         'codeQL.setCurrentDatabase',
@@ -369,20 +369,20 @@ export class DatabaseUI extends DisposableObject {
     try {
       return await this.chooseAndSetDatabase(true, progress, token);
     } catch (e) {
-      showAndLogErrorMessage(e.message);
+      void showAndLogErrorMessage(e.message);
       return undefined;
     }
   };
 
   handleRemoveOrphanedDatabases = async (): Promise<void> => {
-    logger.log('Removing orphaned databases from workspace storage.');
+    void logger.log('Removing orphaned databases from workspace storage.');
     let dbDirs = undefined;
 
     if (
       !(await fs.pathExists(this.storagePath)) ||
       !(await fs.stat(this.storagePath)).isDirectory()
     ) {
-      logger.log('Missing or invalid storage directory. Not trying to remove orphaned databases.');
+      void logger.log('Missing or invalid storage directory. Not trying to remove orphaned databases.');
       return;
     }
 
@@ -403,7 +403,7 @@ export class DatabaseUI extends DisposableObject {
     dbDirs = await asyncFilter(dbDirs, isLikelyDatabaseRoot);
 
     if (!dbDirs.length) {
-      logger.log('No orphaned databases found.');
+      void logger.log('No orphaned databases found.');
       return;
     }
 
@@ -412,8 +412,8 @@ export class DatabaseUI extends DisposableObject {
     await Promise.all(
       dbDirs.map(async dbDir => {
         try {
-          logger.log(`Deleting orphaned database '${dbDir}'.`);
-          await fs.rmdir(dbDir, { recursive: true } as any);  // typings doesn't recognize the options argument
+          void logger.log(`Deleting orphaned database '${dbDir}'.`);
+          await fs.remove(dbDir);
         } catch (e) {
           failures.push(`${path.basename(dbDir)}`);
         }
@@ -422,7 +422,7 @@ export class DatabaseUI extends DisposableObject {
 
     if (failures.length) {
       const dirname = path.dirname(failures[0]);
-      showAndLogErrorMessage(
+      void showAndLogErrorMessage(
         `Failed to delete unused databases (${
         failures.join(', ')
         }).\nTo delete unused databases, please remove them manually from the storage folder ${dirname}.`
@@ -438,7 +438,7 @@ export class DatabaseUI extends DisposableObject {
     try {
       return await this.chooseAndSetDatabase(false, progress, token);
     } catch (e) {
-      showAndLogErrorMessage(e.message);
+      void showAndLogErrorMessage(e.message);
       return undefined;
     }
   };
@@ -617,7 +617,7 @@ export class DatabaseUI extends DisposableObject {
     });
 
     if (newName) {
-      this.databaseManager.renameDatabaseItem(databaseItem, newName);
+      await this.databaseManager.renameDatabaseItem(databaseItem, newName);
     }
   };
 

--- a/extensions/ql-vscode/src/databases.ts
+++ b/extensions/ql-vscode/src/databases.ts
@@ -115,7 +115,7 @@ async function findDataset(parentDirectory: string): Promise<vscode.Uri> {
 
   const dbAbsolutePath = path.join(parentDirectory, dbRelativePaths[0]);
   if (dbRelativePaths.length > 1) {
-    showAndLogWarningMessage(`Found multiple dataset directories in database, using '${dbAbsolutePath}'.`);
+    void showAndLogWarningMessage(`Found multiple dataset directories in database, using '${dbAbsolutePath}'.`);
   }
 
   return vscode.Uri.file(dbAbsolutePath);
@@ -138,7 +138,7 @@ async function findSourceArchive(
     }
   }
   if (!silent) {
-    showAndLogInformationMessage(
+    void showAndLogInformationMessage(
       `Could not find source archive for database '${databasePath}'. Assuming paths are absolute.`
     );
   }
@@ -506,7 +506,7 @@ export class DatabaseItemImpl implements DatabaseItem {
 function eventFired<T>(event: vscode.Event<T>, timeoutMs = 1000): Promise<T | undefined> {
   return new Promise((res, _rej) => {
     const timeout = setTimeout(() => {
-      logger.log(`Waiting for event ${event} timed out after ${timeoutMs}ms`);
+      void logger.log(`Waiting for event ${event} timed out after ${timeoutMs}ms`);
       res(undefined);
       dispose();
     }, timeoutMs);
@@ -543,7 +543,7 @@ export class DatabaseManager extends DisposableObject {
     qs.onDidStartQueryServer(this.reregisterDatabases.bind(this));
 
     // Let this run async.
-    this.loadPersistedState();
+    void this.loadPersistedState();
   }
 
   public async openDatabase(
@@ -605,15 +605,15 @@ export class DatabaseManager extends DisposableObject {
       const end = (vscode.workspace.workspaceFolders || []).length;
       const uri = item.getSourceArchiveExplorerUri();
       if (uri === undefined) {
-        logger.log(`Couldn't obtain file explorer uri for ${item.name}`);
+        void logger.log(`Couldn't obtain file explorer uri for ${item.name}`);
       }
       else {
-        logger.log(`Adding workspace folder for ${item.name} source archive at index ${end}`);
+        void logger.log(`Adding workspace folder for ${item.name} source archive at index ${end}`);
         if ((vscode.workspace.workspaceFolders || []).length < 2) {
           // Adding this workspace folder makes the workspace
           // multi-root, which may surprise the user. Let them know
           // we're doing this.
-          vscode.window.showInformationMessage(`Adding workspace folder for source archive of database ${item.name}.`);
+          void vscode.window.showInformationMessage(`Adding workspace folder for source archive of database ${item.name}.`);
         }
         vscode.workspace.updateWorkspaceFolders(end, 0, {
           name: `[${item.name} source archive]`,
@@ -696,7 +696,7 @@ export class DatabaseManager extends DisposableObject {
               await databaseItem.refresh();
               await this.registerDatabase(progress, token, databaseItem);
               if (currentDatabaseUri === database.uri) {
-                this.setCurrentDatabaseItem(databaseItem, true);
+                await this.setCurrentDatabaseItem(databaseItem, true);
               }
             }
             catch (e) {
@@ -706,7 +706,7 @@ export class DatabaseManager extends DisposableObject {
           }
         } catch (e) {
           // database list had an unexpected type - nothing to be done?
-          showAndLogErrorMessage(`Database list loading failed: ${e.message}`);
+          void showAndLogErrorMessage(`Database list loading failed: ${e.message}`);
         }
       });
   }
@@ -807,16 +807,16 @@ export class DatabaseManager extends DisposableObject {
       folder => item.belongsToSourceArchiveExplorerUri(folder.uri)
     );
     if (folderIndex >= 0) {
-      logger.log(`Removing workspace folder at index ${folderIndex}`);
+      void logger.log(`Removing workspace folder at index ${folderIndex}`);
       vscode.workspace.updateWorkspaceFolders(folderIndex, 1);
     }
 
     // Delete folder from file system only if it is controlled by the extension
     if (this.isExtensionControlledLocation(item.databaseUri)) {
-      logger.log('Deleting database from filesystem.');
+      void logger.log('Deleting database from filesystem.');
       fs.remove(item.databaseUri.fsPath).then(
-        () => logger.log(`Deleted '${item.databaseUri.fsPath}'`),
-        e => logger.log(`Failed to delete '${item.databaseUri.fsPath}'. Reason: ${e.message}`));
+        () => void logger.log(`Deleted '${item.databaseUri.fsPath}'`),
+        e => void logger.log(`Failed to delete '${item.databaseUri.fsPath}'. Reason: ${e.message}`));
     }
 
     // Remove this database item from the allow-list
@@ -858,12 +858,12 @@ export class DatabaseManager extends DisposableObject {
   }
 
   private updatePersistedCurrentDatabaseItem(): void {
-    this.ctx.workspaceState.update(CURRENT_DB, this._currentDatabaseItem ?
+    void this.ctx.workspaceState.update(CURRENT_DB, this._currentDatabaseItem ?
       this._currentDatabaseItem.databaseUri.toString(true) : undefined);
   }
 
   private updatePersistedDatabaseList(): void {
-    this.ctx.workspaceState.update(DB_LIST, this._databaseItems.map(item => item.getPersistedState()));
+    void this.ctx.workspaceState.update(DB_LIST, this._databaseItems.map(item => item.getPersistedState()));
   }
 
   private isExtensionControlledLocation(uri: vscode.Uri) {

--- a/extensions/ql-vscode/src/databases.ts
+++ b/extensions/ql-vscode/src/databases.ts
@@ -763,7 +763,7 @@ export class DatabaseManager extends DisposableObject {
     item: DatabaseItem
   ) {
     this._databaseItems.push(item);
-    this.updatePersistedDatabaseList();
+    await this.updatePersistedDatabaseList();
 
     // Add this database item to the allow-list
     // Database items reconstituted from persisted state
@@ -780,7 +780,7 @@ export class DatabaseManager extends DisposableObject {
 
   public async renameDatabaseItem(item: DatabaseItem, newName: string) {
     item.name = newName;
-    this.updatePersistedDatabaseList();
+    await this.updatePersistedDatabaseList();
     this._onDidChangeDatabaseItem.fire({
       // pass undefined so that the entire tree is rebuilt in order to re-sort
       item: undefined,
@@ -800,7 +800,7 @@ export class DatabaseManager extends DisposableObject {
     if (index >= 0) {
       this._databaseItems.splice(index, 1);
     }
-    this.updatePersistedDatabaseList();
+    await this.updatePersistedDatabaseList();
 
     // Delete folder from workspace, if it is still there
     const folderIndex = (vscode.workspace.workspaceFolders || []).findIndex(
@@ -862,8 +862,8 @@ export class DatabaseManager extends DisposableObject {
       this._currentDatabaseItem.databaseUri.toString(true) : undefined);
   }
 
-  private updatePersistedDatabaseList(): void {
-    void this.ctx.workspaceState.update(DB_LIST, this._databaseItems.map(item => item.getPersistedState()));
+  private async updatePersistedDatabaseList(): Promise<void> {
+    await this.ctx.workspaceState.update(DB_LIST, this._databaseItems.map(item => item.getPersistedState()));
   }
 
   private isExtensionControlledLocation(uri: vscode.Uri) {

--- a/extensions/ql-vscode/src/discovery.ts
+++ b/extensions/ql-vscode/src/discovery.ts
@@ -59,23 +59,23 @@ export abstract class Discovery<T> extends DisposableObject {
         this.discoveryInProgress = false;
         this.update(results);
       }
-    });
+    })
 
-    discoveryPromise.catch(err => {
-      logger.log(`${this.name} failed. Reason: ${err.message}`);
-    });
+      .catch(err => {
+        void logger.log(`${this.name} failed. Reason: ${err.message}`);
+      })
 
-    discoveryPromise.finally(() => {
-      if (this.retry) {
-        // Another refresh request came in while we were still running a previous discovery
-        // operation. Since the discovery results we just computed are now stale, we'll launch
-        // another discovery operation instead of updating.
-        // Note that by doing this inside of `finally`, we will relaunch discovery even if the
-        // initial discovery operation failed.
-        this.retry = false;
-        this.launchDiscovery();
-      }
-    });
+      .finally(() => {
+        if (this.retry) {
+          // Another refresh request came in while we were still running a previous discovery
+          // operation. Since the discovery results we just computed are now stale, we'll launch
+          // another discovery operation instead of updating.
+          // Note that by doing this inside of `finally`, we will relaunch discovery even if the
+          // initial discovery operation failed.
+          this.retry = false;
+          this.launchDiscovery();
+        }
+      });
   }
 
   /**

--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -77,7 +77,7 @@ async function internalShowAndLog(
   fullMessage?: string
 ): Promise<string | undefined> {
   const label = 'Show Log';
-  outputLogger.log(fullMessage || message);
+  void outputLogger.log(fullMessage || message);
   const result = await fn(message, label, ...items);
   if (result === label) {
     outputLogger.show();
@@ -259,11 +259,11 @@ export async function getQlPackForDbscheme(cliServer: CodeQLCliServer, dbschemeP
   const packs: { packDir: string | undefined; packName: string }[] =
     Object.entries(qlpacks).map(([packName, dirs]) => {
       if (dirs.length < 1) {
-        logger.log(`In getQlPackFor ${dbschemePath}, qlpack ${packName} has no directories`);
+        void logger.log(`In getQlPackFor ${dbschemePath}, qlpack ${packName} has no directories`);
         return { packName, packDir: undefined };
       }
       if (dirs.length > 1) {
-        logger.log(`In getQlPackFor ${dbschemePath}, qlpack ${packName} has more than one directory; arbitrarily choosing the first`);
+        void logger.log(`In getQlPackFor ${dbschemePath}, qlpack ${packName} has more than one directory; arbitrarily choosing the first`);
       }
       return {
         packName,
@@ -292,7 +292,7 @@ export async function getPrimaryDbscheme(datasetFolder: string): Promise<string>
   const dbscheme = dbschemes[0];
 
   if (dbschemes.length > 1) {
-    Window.showErrorMessage(`Found multiple dbschemes in ${datasetFolder} during quick query; arbitrarily choosing the first, ${dbscheme}, to decide what library to use.`);
+    void Window.showErrorMessage(`Found multiple dbschemes in ${datasetFolder} during quick query; arbitrarily choosing the first, ${dbscheme}, to decide what library to use.`);
   }
   return dbscheme;
 }

--- a/extensions/ql-vscode/src/interface-utils.ts
+++ b/extensions/ql-vscode/src/interface-utils.ts
@@ -224,14 +224,14 @@ export async function jumpToLocation(
     } catch (e) {
       if (e instanceof Error) {
         if (e.message.match(/File not found/)) {
-          Window.showErrorMessage(
+          void Window.showErrorMessage(
             'Original file of this result is not in the database\'s source archive.'
           );
         } else {
-          logger.log(`Unable to handleMsgFromView: ${e.message}`);
+          void logger.log(`Unable to handleMsgFromView: ${e.message}`);
         }
       } else {
-        logger.log(`Unable to handleMsgFromView: ${e}`);
+        void logger.log(`Unable to handleMsgFromView: ${e}`);
       }
     }
   }

--- a/extensions/ql-vscode/src/interface.ts
+++ b/extensions/ql-vscode/src/interface.ts
@@ -119,7 +119,7 @@ export class InterfaceManager extends DisposableObject {
         this.handleSelectionChange.bind(this)
       )
     );
-    logger.log('Registering path-step navigation commands.');
+    void logger.log('Registering path-step navigation commands.');
     this.push(
       commandRunner(
         'codeQLQueryResults.nextPathStep',
@@ -138,7 +138,7 @@ export class InterfaceManager extends DisposableObject {
         if (kind === DatabaseEventKind.Remove) {
           this._diagnosticCollection.clear();
           if (this.isShowingPanel()) {
-            this.postMessage({
+            void this.postMessage({
               t: 'untoggleShowProblems'
             });
           }
@@ -148,7 +148,7 @@ export class InterfaceManager extends DisposableObject {
   }
 
   async navigatePathStep(direction: number): Promise<void> {
-    this.postMessage({ t: 'navigatePath', direction });
+    await this.postMessage({ t: 'navigatePath', direction });
   }
 
   private isShowingPanel() {
@@ -207,14 +207,14 @@ export class InterfaceManager extends DisposableObject {
     sortState: InterpretedResultsSortState | undefined
   ): Promise<void> {
     if (this._displayedQuery === undefined) {
-      showAndLogErrorMessage(
+      void showAndLogErrorMessage(
         'Failed to sort results since evaluation info was unknown.'
       );
       return;
     }
     // Notify the webview that it should expect new results.
     await this.postMessage({ t: 'resultsUpdating' });
-    this._displayedQuery.updateInterpretedSortState(sortState);
+    await this._displayedQuery.updateInterpretedSortState(sortState);
     await this.showResults(this._displayedQuery, WebviewReveal.NotForced, true);
   }
 
@@ -223,7 +223,7 @@ export class InterfaceManager extends DisposableObject {
     sortState: RawResultsSortState | undefined
   ): Promise<void> {
     if (this._displayedQuery === undefined) {
-      showAndLogErrorMessage(
+      void showAndLogErrorMessage(
         'Failed to sort results since evaluation info was unknown.'
       );
       return;
@@ -301,7 +301,7 @@ export class InterfaceManager extends DisposableObject {
           assertNever(msg);
       }
     } catch (e) {
-      showAndLogErrorMessage(e.message, {
+      void showAndLogErrorMessage(e.message, {
         fullMessage: e.stack
       });
     }
@@ -372,7 +372,7 @@ export class InterfaceManager extends DisposableObject {
       );
       // Address this click asynchronously so we still update the
       // query history immediately.
-      resultPromise.then((result) => {
+      void resultPromise.then((result) => {
         if (result === showButton) {
           panel.reveal();
         }
@@ -556,7 +556,7 @@ export class InterfaceManager extends DisposableObject {
     sortState: InterpretedResultsSortState | undefined
   ): Promise<Interpretation | undefined> {
     if (!resultsPaths) {
-      this.logger.log('No results path. Cannot display interpreted results.');
+      void this.logger.log('No results path. Cannot display interpreted results.');
       return undefined;
     }
 
@@ -603,7 +603,7 @@ export class InterfaceManager extends DisposableObject {
       throw new Error('Tried to get interpreted results before interpretation finished');
     }
     if (this._interpretation.sarif.runs.length !== 1) {
-      this.logger.log(`Warning: SARIF file had ${this._interpretation.sarif.runs.length} runs, expected 1`);
+      void this.logger.log(`Warning: SARIF file had ${this._interpretation.sarif.runs.length} runs, expected 1`);
     }
     const interp = this._interpretation;
     return {
@@ -642,7 +642,7 @@ export class InterfaceManager extends DisposableObject {
       } catch (e) {
         // If interpretation fails, accept the error and continue
         // trying to render uninterpreted results anyway.
-        showAndLogErrorMessage(
+        void showAndLogErrorMessage(
           `Showing raw results instead of interpreted ones due to an error. ${e.message}`
         );
       }
@@ -683,7 +683,7 @@ export class InterfaceManager extends DisposableObject {
       await this.showProblemResultsAsDiagnostics(interpretation, database);
     } catch (e) {
       const msg = e instanceof Error ? e.message : e.toString();
-      this.logger.log(
+      void this.logger.log(
         `Exception while computing problem results as diagnostics: ${msg}`
       );
       this._diagnosticCollection.clear();
@@ -697,7 +697,7 @@ export class InterfaceManager extends DisposableObject {
     const { sarif, sourceLocationPrefix } = interpretation;
 
     if (!sarif.runs || !sarif.runs[0].results) {
-      this.logger.log(
+      void this.logger.log(
         'Didn\'t find a run in the sarif results. Error processing sarif?'
       );
       return;
@@ -708,11 +708,11 @@ export class InterfaceManager extends DisposableObject {
     for (const result of sarif.runs[0].results) {
       const message = result.message.text;
       if (message === undefined) {
-        this.logger.log('Sarif had result without plaintext message');
+        void this.logger.log('Sarif had result without plaintext message');
         continue;
       }
       if (!result.locations) {
-        this.logger.log('Sarif had result without location');
+        void this.logger.log('Sarif had result without location');
         continue;
       }
 
@@ -725,7 +725,7 @@ export class InterfaceManager extends DisposableObject {
       }
       const resultLocation = tryResolveLocation(sarifLoc, databaseItem);
       if (!resultLocation) {
-        this.logger.log('Sarif location was not resolvable ' + sarifLoc);
+        void this.logger.log('Sarif location was not resolvable ' + sarifLoc);
         continue;
       }
       const parsedMessage = parseSarifPlainTextMessage(message);

--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -249,7 +249,7 @@ export class QueryHistoryManager extends DisposableObject {
       })
     );
 
-    logger.log('Registering query history panel commands.');
+    void logger.log('Registering query history panel commands.');
     this.push(
       commandRunner(
         'codeQLQueryHistory.openQuery',
@@ -402,7 +402,7 @@ export class QueryHistoryManager extends DisposableObject {
     });
     const current = this.treeDataProvider.getCurrent();
     if (current !== undefined) {
-      this.treeView.reveal(current);
+      await this.treeView.reveal(current);
       await this.invokeCallbackOn(current);
     }
   }
@@ -470,10 +470,10 @@ export class QueryHistoryManager extends DisposableObject {
       const to = await this.findOtherQueryToCompare(from, multiSelect);
 
       if (from && to) {
-        this.doCompareCallback(from, to);
+        await this.doCompareCallback(from, to);
       }
     } catch (e) {
-      showAndLogErrorMessage(e.message);
+      void showAndLogErrorMessage(e.message);
     }
   }
 
@@ -520,7 +520,7 @@ export class QueryHistoryManager extends DisposableObject {
     if (singleItem.logFileLocation) {
       await this.tryOpenExternalFile(singleItem.logFileLocation);
     } else {
-      showAndLogWarningMessage('No log file available');
+      void showAndLogWarningMessage('No log file available');
     }
   }
 
@@ -565,7 +565,7 @@ export class QueryHistoryManager extends DisposableObject {
       );
     } else {
       const label = singleItem.getLabel();
-      showAndLogInformationMessage(
+      void showAndLogInformationMessage(
         `Query ${label} has no interpreted results.`
       );
     }
@@ -644,7 +644,7 @@ export class QueryHistoryManager extends DisposableObject {
         // We must fire the onDidChangeTreeData event to ensure the current element can be selected
         // using `reveal` if the tree view was not visible when the current element was added.
         this.treeDataProvider.refresh();
-        this.treeView.reveal(current);
+        void this.treeView.reveal(current);
       }
     }
   }
@@ -671,13 +671,13 @@ the file in the file explorer and dragging it into the workspace.`
           try {
             await vscode.commands.executeCommand('revealFileInOS', uri);
           } catch (e) {
-            showAndLogErrorMessage(e.message);
+            void showAndLogErrorMessage(e.message);
           }
         }
       } else {
-        showAndLogErrorMessage(`Could not open file ${fileLocation}`);
-        logger.log(e.message);
-        logger.log(e.stack);
+        void showAndLogErrorMessage(`Could not open file ${fileLocation}`);
+        void logger.log(e.message);
+        void logger.log(e.stack);
       }
     }
   }
@@ -729,7 +729,7 @@ the file in the file explorer and dragging it into the workspace.`
 
   private assertSingleQuery(multiSelect: CompletedQuery[] = [], message = 'Please select a single query.') {
     if (multiSelect.length > 1) {
-      showAndLogErrorMessage(
+      void showAndLogErrorMessage(
         message
       );
       return false;
@@ -797,4 +797,3 @@ the file in the file explorer and dragging it into the workspace.`
     this.treeDataProvider.refresh(completedQuery);
   }
 }
-

--- a/extensions/ql-vscode/src/queryserver-client.ts
+++ b/extensions/ql-vscode/src/queryserver-client.ts
@@ -30,7 +30,7 @@ class ServerProcess implements Disposable {
   }
 
   dispose(): void {
-    this.logger.log('Stopping query server...');
+    void this.logger.log('Stopping query server...');
     this.connection.dispose();
     this.child.stdin!.end();
     this.child.stderr!.destroy();
@@ -38,7 +38,7 @@ class ServerProcess implements Disposable {
 
     // On Windows, we usually have to terminate the process before closing its stdout.
     this.child.stdout!.destroy();
-    this.logger.log('Stopped query server.');
+    void this.logger.log('Stopped query server.');
   }
 }
 
@@ -97,11 +97,11 @@ export class QueryServerClient extends DisposableObject {
         if (!(await fs.pathExists(this.config.customLogDirectory))) {
           await fs.mkdir(this.config.customLogDirectory);
         }
-        this.logger.log(`Saving query server logs to user-specified directory: ${this.config.customLogDirectory}.`);
+        void this.logger.log(`Saving query server logs to user-specified directory: ${this.config.customLogDirectory}.`);
         storagePath = this.config.customLogDirectory;
         isCustomLogDirectory = true;
       } catch (e) {
-        helpers.showAndLogErrorMessage(`${this.config.customLogDirectory} is not a valid directory. Logs will be stored in a temporary workspace directory instead.`);
+        void helpers.showAndLogErrorMessage(`${this.config.customLogDirectory} is not a valid directory. Logs will be stored in a temporary workspace directory instead.`);
       }
     }
 
@@ -118,7 +118,7 @@ export class QueryServerClient extends DisposableObject {
     if (this.serverProcess !== undefined) {
       this.disposeAndStopTracking(this.serverProcess);
     } else {
-      this.logger.log('No server process to be stopped.');
+      void this.logger.log('No server process to be stopped.');
     }
   }
 
@@ -192,9 +192,8 @@ export class QueryServerClient extends DisposableObject {
     const connection = createMessageConnection(child.stdout, child.stdin);
     connection.onRequest(completeQuery, res => {
       if (!(res.runId in this.evaluationResultCallbacks)) {
-        this.logger.log(`No callback associated with run id ${res.runId}, continuing without executing any callback`);
-      }
-      else {
+        void this.logger.log(`No callback associated with run id ${res.runId}, continuing without executing any callback`);
+      } else {
         const baseLocation = this.logger.getBaseLocation();
         if (baseLocation && this.activeQueryName) {
           res.logFileLocation = path.join(baseLocation, this.activeQueryName);

--- a/extensions/ql-vscode/src/status-bar.ts
+++ b/extensions/ql-vscode/src/status-bar.ts
@@ -20,7 +20,7 @@ export class CodeQlStatusBarHandler extends DisposableObject {
     this.push(workspace.onDidChangeConfiguration(this.handleDidChangeConfiguration, this));
     this.push(distributionConfigListener.onDidChangeConfiguration(() => this.updateStatusItem()));
     this.item.command = 'codeQL.copyVersion';
-    this.updateStatusItem();
+    void this.updateStatusItem();
   }
 
   private handleDidChangeConfiguration(e: ConfigurationChangeEvent) {

--- a/extensions/ql-vscode/src/telemetry.ts
+++ b/extensions/ql-vscode/src/telemetry.ts
@@ -209,6 +209,8 @@ export let telemetryListener: TelemetryListener;
 
 export async function initializeTelemetry(extension: Extension<any>, ctx: ExtensionContext): Promise<void> {
   telemetryListener = new TelemetryListener(extension.id, extension.packageJSON.version, key, ctx);
-  await telemetryListener.initialize();
+  // do not await initialization, since doing so will sometimes cause a modal popup.
+  // this is a particular problem during integration tests, which will hang if a modal popup is displayed.
+  void telemetryListener.initialize();
   ctx.subscriptions.push(telemetryListener);
 }

--- a/extensions/ql-vscode/src/telemetry.ts
+++ b/extensions/ql-vscode/src/telemetry.ts
@@ -119,7 +119,7 @@ export class TelemetryListener extends ConfigListener {
         }
 
         if (LOG_TELEMETRY.getValue<boolean>()) {
-          logger.log(`Telemetry: ${JSON.stringify(envelope)}`);
+          void logger.log(`Telemetry: ${JSON.stringify(envelope)}`);
         }
         return true;
       });
@@ -128,7 +128,7 @@ export class TelemetryListener extends ConfigListener {
 
   dispose() {
     super.dispose();
-    this.reporter?.dispose();
+    void this.reporter?.dispose();
   }
 
   sendCommandUsage(name: string, executionTime: number, error?: Error) {
@@ -187,7 +187,7 @@ export class TelemetryListener extends ConfigListener {
 
   private disposeReporter() {
     if (this.reporter) {
-      this.reporter.dispose();
+      void this.reporter.dispose();
       this.reporter = undefined;
     }
   }
@@ -209,6 +209,6 @@ export let telemetryListener: TelemetryListener;
 
 export async function initializeTelemetry(extension: Extension<any>, ctx: ExtensionContext): Promise<void> {
   telemetryListener = new TelemetryListener(extension.id, extension.packageJSON.version, key, ctx);
-  telemetryListener.initialize();
+  await telemetryListener.initialize();
   ctx.subscriptions.push(telemetryListener);
 }

--- a/extensions/ql-vscode/src/test-adapter.ts
+++ b/extensions/ql-vscode/src/test-adapter.ts
@@ -218,7 +218,7 @@ export class QLTestAdapter extends DisposableObject implements TestAdapter {
         // This method is invoked from Test Explorer UI, and testing indicates that Test
         // Explorer UI swallows any thrown exception without reporting it to the user.
         // So we need to display the error message ourselves and then rethrow.
-        showAndLogErrorMessage(`Cannot remove database ${database.name}: ${e}`);
+        void showAndLogErrorMessage(`Cannot remove database ${database.name}: ${e}`);
         throw e;
       }
     }
@@ -242,7 +242,7 @@ export class QLTestAdapter extends DisposableObject implements TestAdapter {
           // This method is invoked from Test Explorer UI, and testing indicates that Test
           // Explorer UI swallows any thrown exception without reporting it to the user.
           // So we need to display the error message ourselves and then rethrow.
-          showAndLogWarningMessage(`Cannot reopen database ${uri}: ${e}`);
+          void showAndLogWarningMessage(`Cannot reopen database ${uri}: ${e}`);
           throw e;
         }
       }
@@ -268,7 +268,7 @@ export class QLTestAdapter extends DisposableObject implements TestAdapter {
 
   public cancel(): void {
     if (this.runningTask !== undefined) {
-      testLogger.log('Cancelling test run...');
+      void testLogger.log('Cancelling test run...');
       this.runningTask.cancel();
       this.clearTask();
     }
@@ -288,7 +288,7 @@ export class QLTestAdapter extends DisposableObject implements TestAdapter {
       let message: string | undefined;
       if (event.failureDescription || event.diff?.length) {
         message = ['', `${state}: ${event.test}`, event.failureDescription || event.diff?.join('\n'), ''].join('\n');
-        testLogger.log(message);
+        void testLogger.log(message);
       }
       this._testStates.fire({
         type: 'test',

--- a/extensions/ql-vscode/src/test-ui.ts
+++ b/extensions/ql-vscode/src/test-ui.ts
@@ -44,7 +44,7 @@ export class TestUIService extends UIService implements TestController {
   constructor(private readonly testHub: TestHub) {
     super();
 
-    logger.log('Registering CodeQL test panel commands.');
+    void logger.log('Registering CodeQL test panel commands.');
     this.registerCommand('codeQLTests.showOutputDifferences', this.showOutputDifferences);
     this.registerCommand('codeQLTests.acceptOutput', this.acceptOutput);
 
@@ -90,7 +90,7 @@ export class TestUIService extends UIService implements TestController {
       };
 
       if (!await fs.pathExists(expectedPath)) {
-        showAndLogWarningMessage(`'${path.basename(expectedPath)}' does not exist. Creating an empty file.`);
+        void showAndLogWarningMessage(`'${path.basename(expectedPath)}' does not exist. Creating an empty file.`);
         await fs.createFile(expectedPath);
       }
 

--- a/extensions/ql-vscode/src/upgrades.ts
+++ b/extensions/ql-vscode/src/upgrades.ts
@@ -103,7 +103,7 @@ async function checkAndConfirmDatabaseUpgrade(
     descriptionMessage += `Would perform upgrade: ${script.description}\n`;
     descriptionMessage += `\t-> Compatibility: ${script.compatibility}\n`;
   }
-  logger.log(descriptionMessage);
+  void logger.log(descriptionMessage);
 
 
   // If the quiet flag is set, do the upgrade without a popup.
@@ -187,35 +187,35 @@ export async function upgradeDatabaseExplicit(
       compileUpgradeResult = await compileDatabaseUpgrade(qs, db, finalDbscheme, scripts, currentUpgradeTmp, progress, token);
     }
     catch (e) {
-      showAndLogErrorMessage(`Compilation of database upgrades failed: ${e}`);
+      void showAndLogErrorMessage(`Compilation of database upgrades failed: ${e}`);
       return;
     }
     finally {
-      qs.logger.log('Done compiling database upgrade.');
+      void qs.logger.log('Done compiling database upgrade.');
     }
 
     if (!compileUpgradeResult.compiledUpgrades) {
       const error = compileUpgradeResult.error || '[no error message available]';
-      showAndLogErrorMessage(`Compilation of database upgrades failed: ${error}`);
+      void showAndLogErrorMessage(`Compilation of database upgrades failed: ${error}`);
       return;
     }
 
     await checkAndConfirmDatabaseUpgrade(compileUpgradeResult.compiledUpgrades, db, qs.cliServer.quiet);
 
     try {
-      qs.logger.log('Running the following database upgrade:');
+      void qs.logger.log('Running the following database upgrade:');
 
       getUpgradeDescriptions(compileUpgradeResult.compiledUpgrades).map(s => s.description).join('\n');
       return await runDatabaseUpgrade(qs, db, compileUpgradeResult.compiledUpgrades, progress, token);
     }
     catch (e) {
-      showAndLogErrorMessage(`Database upgrade failed: ${e}`);
+      void showAndLogErrorMessage(`Database upgrade failed: ${e}`);
       return;
     } finally {
-      qs.logger.log('Done running database upgrade.');
+      void qs.logger.log('Done running database upgrade.');
     }
   } finally {
-    currentUpgradeTmp.cleanup();
+    await currentUpgradeTmp.cleanup();
   }
 }
 

--- a/extensions/ql-vscode/src/view/results.tsx
+++ b/extensions/ql-vscode/src/view/results.tsx
@@ -102,7 +102,7 @@ class App extends React.Component<{}, ResultsViewState> {
           queryPath: msg.queryPath,
         });
 
-        this.loadResults();
+        void this.loadResults();
         break;
       case 'showInterpretedPage':
         this.updateStateWithNewResultsInfo({
@@ -134,7 +134,7 @@ class App extends React.Component<{}, ResultsViewState> {
           queryName: msg.queryName,
           queryPath: msg.queryPath,
         });
-        this.loadResults();
+        void this.loadResults();
         break;
       case 'resultsUpdating':
         this.setState({

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/global.helper.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/global.helper.ts
@@ -27,7 +27,7 @@ export default function(mocha: Mocha) {
       if (!fs.existsSync(dbLoc)) {
         try {
           await new Promise((resolve, reject) => {
-            fetch(DB_URL).then(response => {
+            return fetch(DB_URL).then(response => {
               const dest = fs.createWriteStream(dbLoc);
               response.body.pipe(dest);
 

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/query.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/query.test.ts
@@ -119,7 +119,7 @@ describe('using the query server', function() {
 
   it('should be able to start the query server', async function() {
     await qs.startQueryServer();
-    queryServerStarted.resolve();
+    await queryServerStarted.resolve();
   });
 
   for (const queryTestCase of queryTestCases) {
@@ -160,10 +160,10 @@ describe('using the query server', function() {
         };
         const result = await qs.sendRequest(messages.compileQuery, params, token, () => { /**/ });
         expect(result.messages!.length).to.equal(0);
-        compilationSucceeded.resolve();
+        await compilationSucceeded.resolve();
       }
       catch (e) {
-        compilationSucceeded.reject(e);
+        await compilationSucceeded.reject(e);
       }
     });
 
@@ -171,7 +171,7 @@ describe('using the query server', function() {
       try {
         await compilationSucceeded.done();
         const callbackId = qs.registerCallback(_res => {
-          evaluationSucceeded.resolve();
+          void evaluationSucceeded.resolve();
         });
         const queryToRun: messages.QueryToRun = {
           resultsPath: RESULTS_PATH,
@@ -190,7 +190,7 @@ describe('using the query server', function() {
         await qs.sendRequest(messages.runQueries, params, token, () => { /**/ });
       }
       catch (e) {
-        evaluationSucceeded.reject(e);
+        await evaluationSucceeded.reject(e);
       }
     });
 
@@ -203,7 +203,7 @@ describe('using the query server', function() {
         const decoded = await cliServer.bqrsDecode(RESULTS_PATH, resultSet.name);
         actualResultSets[resultSet.name] = decoded.tuples;
       }
-      parsedResults.resolve();
+      await parsedResults.resolve();
     });
 
     it(`should have correct results for query ${queryName}`, async function() {

--- a/extensions/ql-vscode/src/vscode-tests/ensureCli.ts
+++ b/extensions/ql-vscode/src/vscode-tests/ensureCli.ts
@@ -39,7 +39,7 @@ const _10MB = _1MB * 10;
 
 // CLI version to test. Hard code the latest as default. And be sure
 // to update the env if it is not otherwise set.
-const CLI_VERSION = process.env.CLI_VERSION || 'v2.4.2';
+const CLI_VERSION = process.env.CLI_VERSION || 'v2.5.5';
 process.env.CLI_VERSION = CLI_VERSION;
 
 // Base dir where CLIs will be downloaded into

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/contextual/astBuilder.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/contextual/astBuilder.test.ts
@@ -135,7 +135,7 @@ describe('AstBuilder', () => {
     };
 
     const astBuilder = createAstBuilder();
-    expect(astBuilder.getRoots()).to.be.rejectedWith('AST is invalid');
+    await expect(astBuilder.getRoots()).to.be.rejectedWith('AST is invalid');
   });
 
   function createAstBuilder() {

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/databaseFetcher.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/databaseFetcher.test.ts
@@ -69,7 +69,7 @@ describe('databaseFetcher', function() {
     it('should fail on a nonexistent project', async () => {
       quickPickSpy.resolves('javascript');
       const lgtmUrl = 'https://lgtm.com/projects/g/github/hucairz';
-      expect(convertToDatabaseUrl(lgtmUrl)).to.rejectedWith(/Invalid LGTM URL/);
+      await expect(convertToDatabaseUrl(lgtmUrl)).to.rejectedWith(/Invalid LGTM URL/);
     });
   });
 

--- a/extensions/ql-vscode/src/vscode-tests/run-integration-tests.ts
+++ b/extensions/ql-vscode/src/vscode-tests/run-integration-tests.ts
@@ -105,7 +105,7 @@ async function main() {
   }
 }
 
-main();
+void main();
 
 
 function getLaunchArgs(dir: TestDir) {

--- a/extensions/ql-vscode/src/vscode-tests/run-integration-tests.ts
+++ b/extensions/ql-vscode/src/vscode-tests/run-integration-tests.ts
@@ -128,6 +128,14 @@ function getLaunchArgs(dir: TestDir) {
       return [
         '--disable-gpu',
         path.resolve(__dirname, '../../test/data'),
+
+        // explicitly disable extensions that are known to interfere with the CLI integration tests
+        '--disable-extension',
+        'eamodio.gitlens',
+        '--disable-extension',
+        'github.codespaces',
+        '--disable-extension',
+        'github.copilot',
         process.env.TEST_CODEQL_PATH!
       ];
 


### PR DESCRIPTION
Add the `@typescript-eslint/no-floating-promises` rule with an allowance
for floating promises if `void` is used.

This increases safety and ensures that we are explicit when we avoid
awaiting a promise. I already caught a few bugish locations.

In general, we don't need to await the results of logging calls.

databases-ui, we were using a deprecated method for removing a
directory. `fs.rmdir` instead of `fs.remove`.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Replace this with a description of the changes your pull request makes.

## Checklist

- [n/a] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [n/a] Issues have been created for any UI or other user-facing changes made by this pull request.
- [n/a] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
