### PR TITLE
Run PR checks on "ready_for_review"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,7 @@ name: Build Extension
 on:
   workflow_dispatch:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches:
       - main


### PR DESCRIPTION
By default, the [`pull_request`](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request) event means "`opened`, `synchronize`, or `reopened`". Also adding `ready_for_review`, so that the check runs when we take a PR out of draft state. Hopefully this will help us kick off PR checks on version bump PRs (e.g. https://github.com/github/vscode-codeql/pull/887) more effectively 😃 


## Checklist
n/a 

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
