### PR TITLE
New command to add database source folder to workspace

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [UNRELEASED]
 
+- Adds the _Add Database Source to Workspace_ command to the right-click context menu in the databases view. This lets users re-add a database's source folder to the workspace and browse the source code. [#891](https://github.com/github/vscode-codeql/pull/891)
+
 ## 1.5.1 - 23 June 2021
 
 No user facing changes.

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -346,6 +346,10 @@
         "title": "Show Database Directory"
       },
       {
+        "command": "codeQLDatabases.addDatabaseSource",
+        "title": "Add Database Source to Workspace"
+      },
+      {
         "command": "codeQL.chooseDatabaseFolder",
         "title": "CodeQL: Choose Database from Folder"
       },
@@ -585,6 +589,11 @@
           "when": "view == codeQLDatabases"
         },
         {
+          "command": "codeQLDatabases.addDatabaseSource",
+          "group": "9_qlCommands",
+          "when": "view == codeQLDatabases"
+        },
+        {
           "command": "codeQLQueryHistory.openQuery",
           "group": "9_qlCommands",
           "when": "view == codeQLQueryHistory"
@@ -705,6 +714,10 @@
         },
         {
           "command": "codeQLDatabases.openDatabaseFolder",
+          "when": "false"
+        },
+        {
+          "command": "codeQLDatabases.addDatabaseSource",
           "when": "false"
         },
         {

--- a/extensions/ql-vscode/src/databases-ui.ts
+++ b/extensions/ql-vscode/src/databases-ui.ts
@@ -350,6 +350,12 @@ export class DatabaseUI extends DisposableObject {
     );
     this.push(
       commandRunner(
+        'codeQLDatabases.addDatabaseSource',
+        this.handleAddSource
+      )
+    );
+    this.push(
+      commandRunner(
         'codeQLDatabases.removeOrphanedDatabases',
         this.handleRemoveOrphanedDatabases
       )
@@ -629,6 +635,25 @@ export class DatabaseUI extends DisposableObject {
       );
     } else {
       await env.openExternal(databaseItem.databaseUri);
+    }
+  };
+
+  /**
+   * Adds the source folder of a CodeQL database to the workspace.
+   * When a database is first added in the "Databases" view, its source folder is added to the workspace.
+   * If the source folder is removed from the workspace for some reason, we want to be able to re-add it if need be.
+   */
+  private handleAddSource = async (
+    databaseItem: DatabaseItem,
+    multiSelect: DatabaseItem[] | undefined
+  ): Promise<void> => {
+    if (multiSelect?.length) {
+      // TODO: This multiselect part doesn't work yet. Only the first databases is re-added.
+      await Promise.all(
+        multiSelect.map((dbItem) => this.databaseManager.addDatabaseSourceArchiveFolder(dbItem))
+      );
+    } else {
+      await this.databaseManager.addDatabaseSourceArchiveFolder(databaseItem);
     }
   };
 

--- a/extensions/ql-vscode/src/databases-ui.ts
+++ b/extensions/ql-vscode/src/databases-ui.ts
@@ -648,10 +648,9 @@ export class DatabaseUI extends DisposableObject {
     multiSelect: DatabaseItem[] | undefined
   ): Promise<void> => {
     if (multiSelect?.length) {
-      // TODO: This multiselect part doesn't work yet. Only the first databases is re-added.
-      await Promise.all(
-        multiSelect.map((dbItem) => this.databaseManager.addDatabaseSourceArchiveFolder(dbItem))
-      );
+      for (const dbItem of multiSelect) {
+        await this.databaseManager.addDatabaseSourceArchiveFolder(dbItem);
+      }
     } else {
       await this.databaseManager.addDatabaseSourceArchiveFolder(databaseItem);
     }

--- a/extensions/ql-vscode/src/databases.ts
+++ b/extensions/ql-vscode/src/databases.ts
@@ -587,7 +587,7 @@ export class DatabaseManager extends DisposableObject {
     }));
   }
 
-  private async addDatabaseSourceArchiveFolder(item: DatabaseItem) {
+  public async addDatabaseSourceArchiveFolder(item: DatabaseItem) {
     // The folder may already be in workspace state from a previous
     // session. If not, add it.
     const index = this.getDatabaseWorkspaceFolderIndex(item);


### PR DESCRIPTION
Will fix #798.

As described in the linked issue, we don't have an easy way of re-adding a database's source folder to the workspace. This PR adds a new command (in the Databases View) that lets you re-add a source folder.

(We also considered re-adding source folders automatically, similar to how the `codeQLDatabases.removeOrphanedDatabases` command is run, but I'm now wondering if that'll be annoying to users. They may have deliberately removed a source folder from their workspace, and don't want it included automatically 🤔 I'm open to suggestions though!)

PS: In the process, I found a small bug in how we upgrade databases. (Opened an issue here #890, but haven't worked out how to fix that yet! 😅)

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
   - I don't think a docs change is necessary, since the docs don't describe database commands in detail anyway. [We just say](https://codeql.github.com/docs/codeql-for-visual-studio-code/analyzing-your-projects) the following, which is still valid 🙂 
     > To see the menu options for interacting with a database, right-click an entry in the list. You can select multiple databases using Ctrl/Cmd+click.


