### PR TITLE
Update CLI integration tests with latest version of CLI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -127,7 +127,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        version: ['v2.2.6', 'v2.3.3', 'v2.4.6', 'v2.5.6']
+        version: ['v2.2.6', 'v2.3.3', 'v2.4.6', 'v2.5.7']
     env:
       CLI_VERSION: ${{ matrix.version }}
       TEST_CODEQL_PATH: '${{ github.workspace }}/codeql'


### PR DESCRIPTION
CodeQL CLI v2.5.7 is now [released](https://github.com/github/codeql-cli-binaries/releases/tag/v2.5.7) 🎉

## Checklist

N/A - only affects tests 