### PR TITLE
Add command to run queries on multiple databases

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [UNRELEASED]
 
+- Add a command _CodeQL: Run Query on Multiple Databases_, which lets users select multiple databases to run a query on. [#898](https://github.com/github/vscode-codeql/pull/898)
+
 ## 1.5.2 - 13 July 2021
 
 - Add the _Add Database Source to Workspace_ command to the right-click context menu in the databases view. This lets users re-add a database's source folder to the workspace and browse the source code. [#891](https://github.com/github/vscode-codeql/pull/891)

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -246,6 +246,10 @@
         "title": "CodeQL: Run Query"
       },
       {
+        "command": "codeQL.runQueryOnMultipleDatabases",
+        "title": "CodeQL: Run Query on Multiple Databases"
+      },
+      {
         "command": "codeQL.runRemoteQuery",
         "title": "CodeQL: Run Remote Query"
       },
@@ -681,6 +685,10 @@
           "when": "resourceLangId == ql && resourceExtname == .ql"
         },
         {
+          "command": "codeQL.runQueryOnMultipleDatabases",
+          "when": "resourceLangId == ql && resourceExtname == .ql"
+        },
+        {
           "command": "codeQL.runRemoteQuery",
           "when": "config.codeQL.canary && editorLangId == ql && resourceExtname == .ql"
         },
@@ -828,6 +836,10 @@
       "editor/context": [
         {
           "command": "codeQL.runQuery",
+          "when": "editorLangId == ql && resourceExtname == .ql"
+        },
+        {
+          "command": "codeQL.runQueryOnMultipleDatabases",
           "when": "editorLangId == ql && resourceExtname == .ql"
         },
         {

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -472,7 +472,9 @@ async function activateWithInstalledDistribution(
   ): Promise<void> {
     if (qs !== undefined) {
       const dbItem = databaseQuickPick !== undefined
+        // database selected from multi-database quick pick
         ? databaseQuickPick
+        // database currently selected in Databases UI
         : await databaseUI.getDatabaseItem(progress, token);
       if (dbItem === undefined) {
         throw new Error('Can\'t run query without a selected database');
@@ -587,7 +589,12 @@ async function activateWithInstalledDistribution(
         );
         if (quickpick !== undefined) {
           for (const item of quickpick) {
-            await compileAndRunQuery(false, uri, progress, token, item.databaseItem);
+            try {
+              await compileAndRunQuery(false, uri, progress, token, item.databaseItem);
+            } catch (error) {
+              // Skip databases that are incompatible with the query, e.g. using a different language.
+              void helpers.showAndLogErrorMessage(`Skipped database '${item.label}'. ${error}`);
+            }
           }
         } else {
           void helpers.showAndLogErrorMessage('No databases selected.');

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -472,14 +472,14 @@ async function activateWithInstalledDistribution(
   ): Promise<void> {
     if (qs !== undefined) {
       // If no databaseItem is specified, use the database currently selected in the Databases UI
-      const dbItem = databaseItem || await databaseUI.getDatabaseItem(progress, token);
-      if (dbItem === undefined) {
+      databaseItem = databaseItem || await databaseUI.getDatabaseItem(progress, token);
+      if (databaseItem === undefined) {
         throw new Error('Can\'t run query without a selected database');
       }
       const info = await compileAndRunQueryAgainstDatabase(
         cliServer,
         qs,
-        dbItem,
+        databaseItem,
         quickEval,
         selectedQuery,
         progress,

--- a/extensions/ql-vscode/src/run-queries.ts
+++ b/extensions/ql-vscode/src/run-queries.ts
@@ -563,7 +563,7 @@ export async function compileAndRunQueryAgainstDatabase(
   const dbSchemaName = path.basename(db.contents.dbSchemeUri.fsPath);
   if (querySchemaName != dbSchemaName) {
     void logger.log(`Query schema was ${querySchemaName}, but database schema was ${dbSchemaName}.`);
-    throw new Error(`The query ${path.basename(queryPath)} cannot be run against the selected database: their target languages are different. Please select a different database and try again.`);
+    throw new Error(`The query ${path.basename(queryPath)} cannot be run against the selected database (${db.name}): their target languages are different. Please select a different database and try again.`);
   }
 
   const qlProgram: messages.QlProgram = {


### PR DESCRIPTION
Will fix #569.

First pass at adding a new command "CodeQL: Run Query on Multiple Databases", that lets you select multiple databases from a quick pick menu and run a query over all of them. This currently loops over all selected databases and displays results and query history runs for each database separately. If a database is incompatible, we display an error message and skip to the next database.

This might need some design input if we want to do anything fancy with results display 😅 

<details><summary>Expand for a (somewhat grainy) demo</summary>

  ![multi-db demo](https://user-images.githubusercontent.com/42641846/124298131-ce02f180-db53-11eb-996a-9909ae09bcb1.GIF)

</details>

**Notes**
- Would this be useful in its current form? (I was mainly experimenting, so suggestions are welcome 🙂)
- The database quick pick currently lists _all_ databases that are in your Databases UI, including those with the wrong language. I couldn't see an obvious way to filter them...

## Checklist


- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] ~`@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.~ Opened an internal docs issue! 
