### PR TITLE
Calculate databasesUnderTest with a loop

### DIFF
--- a/extensions/ql-vscode/src/test-adapter.ts
+++ b/extensions/ql-vscode/src/test-adapter.ts
@@ -190,8 +190,15 @@ export class QLTestAdapter extends DisposableObject implements TestAdapter {
     this._testStates.fire({ type: 'started', tests: tests } as TestRunStartedEvent);
 
     const currentDatabaseUri = this.databaseManager.currentDatabaseItem?.databaseUri;
-    const databasesUnderTest = this.databaseManager.databaseItems
-      .filter(database => tests.find(testPath => database.isAffectedByTest(testPath)));
+    const databasesUnderTest: DatabaseItem[] = [];
+    for (const database of this.databaseManager.databaseItems) {
+      for (const test of tests) {
+        if (await database.isAffectedByTest(test)) {
+          databasesUnderTest.push(database);
+          break;
+        }
+      }
+    }
 
     await this.removeDatabasesBeforeTests(databasesUnderTest, token);
     try {


### PR DESCRIPTION
Closes https://github.com/github/vscode-codeql/issues/910

Currently QLTestAdapter.run() calculates the databases affected by a set of tests (those databases will be deleted and then reopened after test completion) using a nested filter-find expression. Which does not work because the predicate is an async function, so the expression is testing the truthiness of a Promise instead of the async result.

This commit fixes the problem by implementing the same check with a loop so that we can invoke the async predicate using await.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
