### PR TITLE
Autodetect what language a query is for

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [UNRELEASED]
 
 - Add a command _CodeQL: Run Query on Multiple Databases_, which lets users select multiple databases to run a query on. [#898](https://github.com/github/vscode-codeql/pull/898)
+- Autodetect what language a query targets. This refines the _CodeQL: Run Query on Multiple Databases_ command to only show relevant databases. [#915](https://github.com/github/vscode-codeql/pull/915)
 
 ## 1.5.2 - 13 July 2021
 

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -570,11 +570,15 @@ async function activateWithInstalledDistribution(
         token: CancellationToken,
         uri: Uri | undefined
       ) => {
+        let filteredDBs = dbm.databaseItems;
+        // If possible, only show databases with the right language (otherwise show all databases).
         const queryLanguage = await findLanguage(cliServer, uri);
-        const filteredDBs = dbm.databaseItems.filter(db => db.language === queryLanguage);
-        if (filteredDBs.length === 0) {
-          void helpers.showAndLogErrorMessage(`No databases found for language ${queryLanguage}`);
-          return;
+        if (queryLanguage) {
+          filteredDBs = dbm.databaseItems.filter(db => db.language === queryLanguage);
+          if (filteredDBs.length === 0) {
+            void helpers.showAndLogErrorMessage(`No databases found for language ${queryLanguage}. Please add a suitable database to your workspace.`);
+            return;
+          }
         }
         const quickPickItems = filteredDBs.map<DatabaseQuickPickItem>(dbItem => (
           {
@@ -588,7 +592,7 @@ async function activateWithInstalledDistribution(
          */
         const quickpick = await window.showQuickPick<DatabaseQuickPickItem>(
           quickPickItems,
-          { canPickMany: true }
+          { canPickMany: true, ignoreFocusOut: true }
         );
         if (quickpick !== undefined) {
           // Collect all skipped databases and display them at the end (instead of popping up individual errors)

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -571,6 +571,10 @@ async function activateWithInstalledDistribution(
         uri: Uri | undefined
       ) => {
         let filteredDBs = dbm.databaseItems;
+        if (filteredDBs.length === 0) {
+          void helpers.showAndLogErrorMessage('No databases found. Please add a suitable database to your workspace.');
+          return;
+        }
         // If possible, only show databases with the right language (otherwise show all databases).
         const queryLanguage = await findLanguage(cliServer, uri);
         if (queryLanguage) {

--- a/extensions/ql-vscode/src/run-remote-query.ts
+++ b/extensions/ql-vscode/src/run-remote-query.ts
@@ -71,7 +71,7 @@ export async function runRemoteQuery(cliServer: cli.CodeQLCliServer, credentials
   const repositories = config.repositories;
 
   if (!language) {
-    return;
+    return; // No error message needed, since `findlanguage` already displays one.
   }
 
   try {


### PR DESCRIPTION
Adds a `findLanguage` function that uses `codeql resolve queries --format bylanguage` to detect a query's language. This might not work for some queries, so I've added a manual selection as a fallback.

This is used in two places:
- When running a query on multiple databases (we now only show the databases that correspond to the query language)
- When running a remote query (we can now autodetect a language when it isn't specified in the `.repositories` config. This config file is going to be replaced by a different UI soon.)

Question: Does this need tests? I wasn't sure where/how to go about that!

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
   - Only the "multiple DBs" part is user-facing for now
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request. 
   - No docs update required (beyond pending update from https://github.com/github/codeql/pull/6322)
