### PR TITLE
Update the CLI versions to run integration tests against

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           LATEST=`gh api repos/dsp-testing/codeql-cli-nightlies/releases --jq '.[].tag_name' --method GET --raw-field 'per_page=1'`
           echo "::set-output name=nightly-url::https://github.com/dsp-testing/codeql-cli-nightlies/releases/download/$LATEST"
-    
+
   test:
     name: Test
     runs-on: ${{ matrix.os }}
@@ -151,7 +151,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        version: ['v2.2.6', 'v2.3.3', 'v2.4.6', 'v2.5.7', 'nightly']
+        version: ['v2.2.6', 'v2.3.3', 'v2.4.6', 'v2.5.8', 'nightly']
     env:
       CLI_VERSION: ${{ matrix.version }}
       NIGHTLY_URL: ${{ needs.find-nightly.outputs.url }}

--- a/extensions/ql-vscode/src/vscode-tests/ensureCli.ts
+++ b/extensions/ql-vscode/src/vscode-tests/ensureCli.ts
@@ -12,7 +12,7 @@ import { workspace } from 'vscode';
  *       version. Note that for now, we must maintain the default version by hand.
  *       This may be set to `nightly`, in which case the `NIGHTLY_URL` variable must
  *       also be set.
- * 
+ *
  *     - NIGHTLY_URL: The URL for a nightly release of the CodeQL CLI that will be
  *       used if `CLI_VERSION` is set to `nightly`.
  *
@@ -44,7 +44,7 @@ const _10MB = _1MB * 10;
 
 // CLI version to test. Hard code the latest as default. And be sure
 // to update the env if it is not otherwise set.
-const CLI_VERSION = process.env.CLI_VERSION || 'v2.5.5';
+const CLI_VERSION = process.env.CLI_VERSION || 'v2.5.8';
 process.env.CLI_VERSION = CLI_VERSION;
 
 // Base dir where CLIs will be downloaded into


### PR DESCRIPTION
Small change to ensure this extension tests against the most recent version of the CLI.