### PR TITLE
Running remote queries: Save repo lists in VS Code config

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -233,6 +233,19 @@
           "default": false,
           "scope": "application",
           "description": "Specifies whether or not to write telemetry events to the extension log."
+        },
+        "codeQL.remoteRepositoryLists": {
+          "type": "object",
+          "patternProperties": {
+            ".*": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "default": null,
+          "markdownDescription": "[For internal use only] Lists of GitHub repositories that you want to query remotely. This should be a JSON object where each key is a user-specified name for this repository list, and the value is an array of GitHub repositories (of the form `<owner>/<repo>`)."
         }
       }
     },

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -291,3 +291,17 @@ export function isCanary() {
  * Avoids caching in the AST viewer if the user is also a canary user.
  */
 export const NO_CACHE_AST_VIEWER = new Setting('disableCache', AST_VIEWER_SETTING);
+
+/*
+ * Lists of GitHub repositories that you want to query remotely via the "Run Remote query" command.
+ * Note: This command is only available for internal users.
+ * 
+ * This setting should be a JSON object where each key is a user-specified name (string),
+ * and the value is an array of GitHub repositories (of the form `<owner>/<repo>`).
+ */
+
+const REMOTE_REPO_LISTS = new Setting('remoteRepositoryLists', ROOT_SETTING);
+
+export function getRemoteRepositoryLists(): Record<string, string[]> | undefined {
+  return REMOTE_REPO_LISTS.getValue<Record<string, string[]>>() || undefined;
+}

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -292,14 +292,13 @@ export function isCanary() {
  */
 export const NO_CACHE_AST_VIEWER = new Setting('disableCache', AST_VIEWER_SETTING);
 
-/*
+/**
  * Lists of GitHub repositories that you want to query remotely via the "Run Remote query" command.
  * Note: This command is only available for internal users.
  * 
  * This setting should be a JSON object where each key is a user-specified name (string),
  * and the value is an array of GitHub repositories (of the form `<owner>/<repo>`).
  */
-
 const REMOTE_REPO_LISTS = new Setting('remoteRepositoryLists', ROOT_SETTING);
 
 export function getRemoteRepositoryLists(): Record<string, string[]> | undefined {

--- a/extensions/ql-vscode/src/run-remote-query.ts
+++ b/extensions/ql-vscode/src/run-remote-query.ts
@@ -78,7 +78,12 @@ async function getRepositories(): Promise<string[] | undefined> {
     }
   } else {
     void logger.log('No repository lists defined. Displaying text input box.');
-    const repoRegex = /^(?:[a-zA-Z0-9]+-?)*[a-zA-Z0-9]\/[a-zA-Z0-9-_]+$/;
+    /**
+     * This regex matches strings of the form `owner/repo` where:
+     * - `owner` is made up of alphanumeric characters or single hyphens, starting and ending in an alphanumeric character
+     * - `repo` is made up of alphanumeric characters, hyphens, or underscores
+     */
+    const repoRegex = /^(?:[a-zA-Z0-9]+-)*[a-zA-Z0-9]+\/[a-zA-Z0-9-_]+$/;
     const remoteRepo = await window.showInputBox({
       title: 'Enter a GitHub repository in the format <owner>/<repo> (e.g. github/codeql)',
       placeHolder: '<owner>/<repo>',

--- a/extensions/ql-vscode/src/run-remote-query.ts
+++ b/extensions/ql-vscode/src/run-remote-query.ts
@@ -69,7 +69,7 @@ async function getRepositories(): Promise<string[] | undefined> {
         placeHolder: 'Select a repository list. You can define repository lists in the `codeQL.remoteRepositoryLists` setting.',
         ignoreFocusOut: true,
       });
-    if (quickpick && quickpick.repoList.length > 0) {
+    if (quickpick?.repoList.length) {
       void logger.log(`Selected repositories: ${quickpick.repoList}`);
       return quickpick.repoList;
     } else {
@@ -78,6 +78,7 @@ async function getRepositories(): Promise<string[] | undefined> {
     }
   } else {
     void logger.log('No repository lists defined. Displaying text input box.');
+    const repoRegex = /^(?:[a-zA-Z0-9]+-?)*[a-zA-Z0-9]\/[a-zA-Z0-9-_]+$/;
     const remoteRepo = await window.showInputBox({
       title: 'Enter a GitHub repository in the format <owner>/<repo> (e.g. github/codeql)',
       placeHolder: '<owner>/<repo>',
@@ -86,6 +87,9 @@ async function getRepositories(): Promise<string[] | undefined> {
     });
     if (!remoteRepo) {
       void showAndLogErrorMessage('No repositories entered.');
+      return;
+    } else if (!repoRegex.test(remoteRepo)) { // Check if user entered invalid input
+      void showAndLogErrorMessage('Invalid repository format. Must be in the format <owner>/<repo> (e.g. github/codeql)');
       return;
     }
     void logger.log(`Entered repository: ${remoteRepo}`);

--- a/extensions/ql-vscode/src/run-remote-query.ts
+++ b/extensions/ql-vscode/src/run-remote-query.ts
@@ -77,8 +77,19 @@ async function getRepositories(): Promise<string[] | undefined> {
       return;
     }
   } else {
-    void showAndLogErrorMessage('No repository lists defined. You can define repository lists in the `codeQL.remoteRepositoryLists` setting.');
-    return;
+    void logger.log('No repository lists defined. Displaying text input box.');
+    const remoteRepo = await window.showInputBox({
+      title: 'Enter a GitHub repository in the format <owner>/<repo> (e.g. github/codeql)',
+      placeHolder: '<owner>/<repo>',
+      prompt: 'Tip: you can save frequently used repositories in the `codeql.remoteRepositoryLists` setting',
+      ignoreFocusOut: true,
+    });
+    if (!remoteRepo) {
+      void showAndLogErrorMessage('No repositories entered.');
+      return;
+    }
+    void logger.log(`Entered repository: ${remoteRepo}`);
+    return [remoteRepo];
   }
 }
 


### PR DESCRIPTION
This PR tweaks how you run remote queries 😎 
Previously, each query needed a `.repositories` file that listed which repositories you wanted to analyze.

Now, you can save pre-defined "repository lists" in your VS Code settings, and choose one of those when you run a remote query. 

New flow:
1. If you still have a `.repositories` file, we use the information from there to run your remote query.
2. Otherwise, if you have saved repository lists in your VS Code settings, you can select one of those to run against.
3. If not, you can enter a single repo in a text input box and we run against that.

The `getRepositories` function should give an error if you end up with an empty string/array/object. It doesn't check if your repositories are valid, but the API call itself gives an error in that case (e.g. ❌ `"HttpError: Repository 'xxx' not found"`).


Question:
- Since this isn't a secret, is it okay for this internal setting to be visible in the Settings UI? (@jf205?)
![image](https://user-images.githubusercontent.com/42641846/129059011-71b4ce55-d9bc-4f66-bfa5-eb19ac3d2bad.png)
  I could hide it completely by omitting the [package.json](https://github.com/github/vscode-codeql/pull/918/files#diff-be4c5a31505df7de81fa4900e84e66c04d1a6bca9b3da50f8061d2cb2bfbbde1) change, but that would remove the validation (that the setting has the correct "shape", i.e. an object where the values are arrays of strings)

## Checklist

N/A: this is part of an internal-only feature (see linked issue for more context/details).

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
