### PR TITLE
Adjust test log output to display diffs only for failing test results

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add a command _CodeQL: Run Query on Multiple Databases_, which lets users select multiple databases to run a query on. [#898](https://github.com/github/vscode-codeql/pull/898)
 - Autodetect what language a query targets. This refines the _CodeQL: Run Query on Multiple Databases_ command to only show relevant databases. [#915](https://github.com/github/vscode-codeql/pull/915)
+- Adjust test log output to display diffs only when comparing failed test results with expected test results. [#920](https://github.com/github/vscode-codeql/pull/920)
 
 ## 1.5.2 - 13 July 2021
 

--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -123,6 +123,7 @@ export interface TestCompleted {
   expected: string;
   diff: string[] | undefined;
   failureDescription?: string;
+  failureStage?: string;
 }
 
 /**

--- a/extensions/ql-vscode/src/test-adapter.ts
+++ b/extensions/ql-vscode/src/test-adapter.ts
@@ -294,7 +294,9 @@ export class QLTestAdapter extends DisposableObject implements TestAdapter {
           : 'failed';
       let message: string | undefined;
       if (event.failureDescription || event.diff?.length) {
-        message = ['', `${state}: ${event.test}`, event.failureDescription || event.diff?.join('\n'), ''].join('\n');
+        message = event.failureStage === 'RESULT'
+          ? ['', `${state}: ${event.test}`, event.failureDescription || event.diff?.join('\n'), ''].join('\n')
+          : ['', `${event.failureStage?.toLowerCase()} error: ${event.test}`, event.failureDescription || `${event.messages[0].severity}: ${event.messages[0].message}`, ''].join('\n');
         void testLogger.log(message);
       }
       this._testStates.fire({

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/test-adapter.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/test-adapter.test.ts
@@ -96,7 +96,7 @@ describe('test-adapter', () => {
       type: 'test',
       state: 'errored',
       test: gPath,
-      message: `\nerrored: ${gPath}\npqr\nxyz\n`,
+      message: `\ncompilation error: ${gPath}\nERROR: abc\n`,
       decorations: [
         { line: 1, message: 'abc' }
       ]
@@ -149,14 +149,16 @@ describe('test-adapter', () => {
           pass: false,
           diff: ['pqr', 'xyz'],
           // a compile error
+          failureStage: 'COMPILATION',
           messages: [
-            { position: { line: 1 }, message: 'abc' }
+            { position: { line: 1 }, message: 'abc', severity: 'ERROR' }
           ]
         });
         yield Promise.resolve({
           test: Uri.parse('file:/ab/c/e/f/h.ql').fsPath,
           pass: false,
           diff: ['jkh', 'tuv'],
+          failureStage: 'RESULT',
           messages: []
         });
       })()


### PR DESCRIPTION
Adjusted test log output to display diffs only when comparing failed test results with expected test results. For example, compilation errors will no longer compare expected results with error logs.

Example compilation error log BEFORE change:
```
Compiling queries in <path-to-test>.
[1/1 comp 5s] FAILED(COMPILATION) <path-to-test>
0 tests passed; 1 tests failed:
  FAILED: <path-to-test>

errored: <path-to-test>
--- expected
+++ actual
@@ -1,1 +1,1 @@
-| main.go:15:41:15:52 | call to len |
+ERROR: Could not resolve predicate length/0 (<path-to-test>)
```

Same error AFTER change:
```
Compiling queries in <path-to-test>.
[1/1 comp 5.5s] FAILED(COMPILATION) <path-to-test>
0 tests passed; 1 tests failed:
  FAILED: <path-to-test>

compilation error: <path-to-test>
ERROR: Could not resolve predicate length/0
```

Closes https://github.com/github/vscode-codeql/issues/819.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [n/a] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
