### PR TITLE
Fix type for "remote repo list" setting

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -235,7 +235,10 @@
           "description": "Specifies whether or not to write telemetry events to the extension log."
         },
         "codeQL.remoteRepositoryLists": {
-          "type": "object",
+          "type": [
+            "object",
+            null
+          ],
           "patternProperties": {
             ".*": {
               "type": "array",


### PR DESCRIPTION
Tiny follow-up to #918. The setting I added was being autofilled in a weird way:

![24C31004-BFA8-4E3D-8526-A3A070B372E5](https://user-images.githubusercontent.com/42641846/129893785-aeb328f2-0365-41c8-9919-58b36fafc802.GIF)

Allowing it to have type `null` seems to fix this 🙂