### PR TITLE
Allow exporting of results for non-alert queries

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [UNRELEASED]
 
 - Add support for filename pattern in history view. [#930](https://github.com/github/vscode-codeql/pull/930)
+- Add an option _Export Results (CSV)_ to export the results of a non-alert query. The existing options for alert queries have been renamed to _View Alerts_ to avoid confusion. [#929](https://github.com/github/vscode-codeql/pull/929)
 
 ## 1.5.3 - 18 August 2021
 

--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [UNRELEASED]
 
 - Add support for filename pattern in history view. [#930](https://github.com/github/vscode-codeql/pull/930)
-- Add an option _Export Results (CSV)_ to export the results of a non-alert query. The existing options for alert queries have been renamed to _View Alerts_ to avoid confusion. [#929](https://github.com/github/vscode-codeql/pull/929)
+- Add an option _View Results (CSV)_ to view the results of a non-alert query. The existing options for alert queries have been renamed to _View Alerts_ to avoid confusion. [#929](https://github.com/github/vscode-codeql/pull/929)
 
 ## 1.5.3 - 18 August 2021
 

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -462,15 +462,15 @@
         "title": "Show Query Text"
       },
       {
-        "command": "codeQLQueryHistory.exportCsvResults",
-        "title": "Export Results (CSV)"
+        "command": "codeQLQueryHistory.viewCsvResults",
+        "title": "View Results (CSV)"
       },
       {
-        "command": "codeQLQueryHistory.viewCsvResults",
+        "command": "codeQLQueryHistory.viewCsvAlerts",
         "title": "View Alerts (CSV)"
       },
       {
-        "command": "codeQLQueryHistory.viewSarifResults",
+        "command": "codeQLQueryHistory.viewSarifAlerts",
         "title": "View Alerts (SARIF)"
       },
       {
@@ -648,17 +648,17 @@
           "when": "view == codeQLQueryHistory"
         },
         {
-          "command": "codeQLQueryHistory.exportCsvResults",
+          "command": "codeQLQueryHistory.viewCsvResults",
           "group": "9_qlCommands",
           "when": "view == codeQLQueryHistory && viewItem != interpretedResultsItem"
         },
         {
-          "command": "codeQLQueryHistory.viewCsvResults",
+          "command": "codeQLQueryHistory.viewCsvAlerts",
           "group": "9_qlCommands",
           "when": "view == codeQLQueryHistory && viewItem == interpretedResultsItem"
         },
         {
-          "command": "codeQLQueryHistory.viewSarifResults",
+          "command": "codeQLQueryHistory.viewSarifAlerts",
           "group": "9_qlCommands",
           "when": "view == codeQLQueryHistory && viewItem == interpretedResultsItem"
         },
@@ -810,15 +810,15 @@
           "when": "false"
         },
         {
-          "command": "codeQLQueryHistory.exportCsvResults",
-          "when": "false"
-        },
-        {
           "command": "codeQLQueryHistory.viewCsvResults",
           "when": "false"
         },
         {
-          "command": "codeQLQueryHistory.viewSarifResults",
+          "command": "codeQLQueryHistory.viewCsvAlerts",
+          "when": "false"
+        },
+        {
+          "command": "codeQLQueryHistory.viewSarifAlerts",
           "when": "false"
         },
         {

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -462,12 +462,16 @@
         "title": "Show Query Text"
       },
       {
+        "command": "codeQLQueryHistory.exportCsvResults",
+        "title": "Export Results (CSV)"
+      },
+      {
         "command": "codeQLQueryHistory.viewCsvResults",
-        "title": "View Results (CSV)"
+        "title": "View Alerts (CSV)"
       },
       {
         "command": "codeQLQueryHistory.viewSarifResults",
-        "title": "View Results (SARIF)"
+        "title": "View Alerts (SARIF)"
       },
       {
         "command": "codeQLQueryHistory.viewDil",
@@ -644,6 +648,11 @@
           "when": "view == codeQLQueryHistory"
         },
         {
+          "command": "codeQLQueryHistory.exportCsvResults",
+          "group": "9_qlCommands",
+          "when": "view == codeQLQueryHistory && viewItem != interpretedResultsItem"
+        },
+        {
           "command": "codeQLQueryHistory.viewCsvResults",
           "group": "9_qlCommands",
           "when": "view == codeQLQueryHistory && viewItem == interpretedResultsItem"
@@ -798,6 +807,10 @@
         },
         {
           "command": "codeQLQueryHistory.showQueryText",
+          "when": "false"
+        },
+        {
+          "command": "codeQLQueryHistory.exportCsvResults",
           "when": "false"
         },
         {

--- a/extensions/ql-vscode/src/contextual/locationFinder.ts
+++ b/extensions/ql-vscode/src/contextual/locationFinder.ts
@@ -12,7 +12,7 @@ import { ProgressCallback } from '../commandRunner';
 import { KeyType } from './keyType';
 import { qlpackOfDatabase, resolveQueries } from './queryResolver';
 
-const SELECT_QUERY_NAME = '#select';
+export const SELECT_QUERY_NAME = '#select';
 export const TEMPLATE_NAME = 'selectedSourceFile';
 
 export interface FullLocationLink extends vscode.LocationLink {

--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -306,20 +306,20 @@ export class QueryHistoryManager extends DisposableObject {
     );
     this.push(
       commandRunner(
-        'codeQLQueryHistory.exportCsvResults',
-        this.handleExportCsvResults.bind(this)
-      )
-    );
-    this.push(
-      commandRunner(
         'codeQLQueryHistory.viewCsvResults',
         this.handleViewCsvResults.bind(this)
       )
     );
     this.push(
       commandRunner(
-        'codeQLQueryHistory.viewSarifResults',
-        this.handleViewSarifResults.bind(this)
+        'codeQLQueryHistory.viewCsvAlerts',
+        this.handleViewCsvAlerts.bind(this)
+      )
+    );
+    this.push(
+      commandRunner(
+        'codeQLQueryHistory.viewSarifAlerts',
+        this.handleViewSarifAlerts.bind(this)
       )
     );
     this.push(
@@ -556,7 +556,7 @@ export class QueryHistoryManager extends DisposableObject {
     await vscode.window.showTextDocument(doc, { preview: false });
   }
 
-  async handleViewSarifResults(
+  async handleViewSarifAlerts(
     singleItem: CompletedQuery,
     multiSelect: CompletedQuery[]
   ) {
@@ -577,33 +577,25 @@ export class QueryHistoryManager extends DisposableObject {
     }
   }
 
-  async handleExportCsvResults(
+  async handleViewCsvResults(
     singleItem: CompletedQuery,
     multiSelect: CompletedQuery[]
   ) {
     if (!this.assertSingleQuery(multiSelect)) {
       return;
     }
-
-    const saveLocation = await vscode.window.showSaveDialog({
-      title: 'CSV Results',
-      saveLabel: 'Export',
-      filters: {
-        'Comma-separated values': ['csv'],
-      }
-    });
-    if (!saveLocation) {
-      void showAndLogErrorMessage('No save location selected for CSV export!');
+    if (await singleItem.query.hasCsv()) {
+      void this.tryOpenExternalFile(singleItem.query.csvPath);
       return;
     }
-    await singleItem.query.exportCsvResults(this.qs, saveLocation.fsPath, () => {
+    await singleItem.query.exportCsvResults(this.qs, singleItem.query.csvPath, () => {
       void this.tryOpenExternalFile(
-        saveLocation.fsPath
+        singleItem.query.csvPath
       );
     });
   }
 
-  async handleViewCsvResults(
+  async handleViewCsvAlerts(
     singleItem: CompletedQuery,
     multiSelect: CompletedQuery[]
   ) {

--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -306,6 +306,12 @@ export class QueryHistoryManager extends DisposableObject {
     );
     this.push(
       commandRunner(
+        'codeQLQueryHistory.exportCsvResults',
+        this.handleExportCsvResults.bind(this)
+      )
+    );
+    this.push(
+      commandRunner(
         'codeQLQueryHistory.viewCsvResults',
         this.handleViewCsvResults.bind(this)
       )
@@ -569,6 +575,32 @@ export class QueryHistoryManager extends DisposableObject {
         `Query ${label} has no interpreted results.`
       );
     }
+  }
+
+  async handleExportCsvResults(
+    singleItem: CompletedQuery,
+    multiSelect: CompletedQuery[]
+  ) {
+    if (!this.assertSingleQuery(multiSelect)) {
+      return;
+    }
+
+    const saveLocation = await vscode.window.showSaveDialog({
+      title: 'CSV Results',
+      saveLabel: 'Export',
+      filters: {
+        'Comma-separated values': ['csv'],
+      }
+    });
+    if (!saveLocation) {
+      void showAndLogErrorMessage('No save location selected for CSV export!');
+      return;
+    }
+    await singleItem.query.exportCsvResults(this.qs, saveLocation.fsPath, () => {
+      void this.tryOpenExternalFile(
+        saveLocation.fsPath
+      );
+    });
   }
 
   async handleViewCsvResults(


### PR DESCRIPTION
Closes https://github.com/github/vscode-codeql/issues/832

This PR adds a new right click option in the Query History view called _Export Results (CSV)_ which will export the results of a non-alert query to a CSV file (as chosen in a save dialog displayed to the user).

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
