### PR TITLE
Add support for filename pattern in history view

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [UNRELEASED]
 
+- Adjust test log output to display diffs only when comparing failed test results with expected test results. [#920](https://github.com/github/vscode-codeql/pull/920)
+- Add support for filename pattern in history view. [#930](https://github.com/github/vscode-codeql/pull/930)
+
 ## 1.5.3 - 18 August 2021
 
 - Add a command _CodeQL: Run Query on Multiple Databases_, which lets users select multiple databases to run a query on. [#898](https://github.com/github/vscode-codeql/pull/898)

--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## [UNRELEASED]
 
-- Adjust test log output to display diffs only when comparing failed test results with expected test results. [#920](https://github.com/github/vscode-codeql/pull/920)
 - Add support for filename pattern in history view. [#930](https://github.com/github/vscode-codeql/pull/930)
 
 ## 1.5.3 - 18 August 2021

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -206,7 +206,7 @@
         "codeQL.queryHistory.format": {
           "type": "string",
           "default": "%q on %d - %s, %r result count [%t]",
-          "description": "Default string for how to label query history items. %t is the time of the query, %q is the query name, %d is the database name, %r is the number of results, and %s is a status string."
+          "markdownDescription": "Default string for how to label query history items.\n* %t is the time of the query\n* %q is the human-readable query name\n*%f is the query file name\n* %d is the database name\n* %r is the number of results\n* %s is a status string"
         },
         "codeQL.runningTests.additionalTestArguments": {
           "scope": "window",

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/query-results.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/query-results.test.ts
@@ -54,6 +54,23 @@ describe('CompletedQuery', () => {
     expect(completedQuery.queryName).to.eq('Quick evaluation of yz:1');
   });
 
+  it('should get the query file name', () => {
+    const completedQuery = mockCompletedQuery();
+
+    // from the query path
+    expect(completedQuery.queryFileName).to.eq('stu');
+
+    // from quick eval position
+    (completedQuery.query as any).quickEvalPosition = {
+      line: 1,
+      endLine: 2,
+      fileName: '/home/users/yz'
+    };
+    expect(completedQuery.queryFileName).to.eq('yz:1-2');
+    (completedQuery.query as any).quickEvalPosition.endLine = 1;
+    expect(completedQuery.queryFileName).to.eq('yz:1');
+  });
+
   it('should get the label', () => {
     const completedQuery = mockCompletedQuery();
     expect(completedQuery.getLabel()).to.eq('ghi');


### PR DESCRIPTION
Allow users to see the filename in the query history view instead of the name from the metadata. Introduce the `%f` pattern in the history view, supporting full queries as well as quick eval queries. 

![Screenshot 2021-08-19 at 12 38 59](https://user-images.githubusercontent.com/316929/130055065-d9a17607-64a0-4fcd-96a3-691ae0661f85.png)

Reformatted the description of the format preference to better see the available patterns.
![Screenshot 2021-08-19 at 12 40 43](https://user-images.githubusercontent.com/316929/130055312-be764ba7-4448-41b5-9b2b-bb5bf62d0eda.png)

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
