### PR TITLE
New setting to specify number of paths per alert

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add support for filename pattern in history view. [#930](https://github.com/github/vscode-codeql/pull/930)
 - Add an option _View Results (CSV)_ to view the results of a non-alert query. The existing options for alert queries have been renamed to _View Alerts_ to avoid confusion. [#929](https://github.com/github/vscode-codeql/pull/929)
+- Allow users to specify the number of paths to display for each alert. [#931](https://github.com/github/vscode-codeql/pull/931)
 
 ## 1.5.3 - 18 August 2021
 

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -180,6 +180,11 @@
           "default": false,
           "description": "Enable debug logging and tuple counting when running CodeQL queries. This information is useful for debugging query performance."
         },
+        "codeQL.runningQueries.maxPaths": {
+          "type": "integer",
+          "default": 4,
+          "markdownDescription": "Max number of paths to display for each alert found by a path query (`@kind path-problem`)."
+        },
         "codeQL.runningQueries.autoSave": {
           "type": "boolean",
           "default": false,

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -183,6 +183,8 @@
         "codeQL.runningQueries.maxPaths": {
           "type": "integer",
           "default": 4,
+          "minimum": 1,
+          "maximum": 256,
           "markdownDescription": "Max number of paths to display for each alert found by a path query (`@kind path-problem`)."
         },
         "codeQL.runningQueries.autoSave": {

--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -649,6 +649,11 @@ export class CodeQLCliServer implements Disposable {
       this.cliConfig.numberThreads.toString(),
     );
 
+    args.push(
+      '--max-paths',
+      this.cliConfig.maxPaths.toString(),
+    );
+
     args.push(resultsPath);
     await this.runCodeQlCliCommand(['bqrs', 'interpret'], args, 'Interpreting query results');
   }

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -79,6 +79,7 @@ const CACHE_SIZE_SETTING = new Setting('cacheSize', RUNNING_QUERIES_SETTING);
 const TIMEOUT_SETTING = new Setting('timeout', RUNNING_QUERIES_SETTING);
 const MEMORY_SETTING = new Setting('memory', RUNNING_QUERIES_SETTING);
 const DEBUG_SETTING = new Setting('debug', RUNNING_QUERIES_SETTING);
+const MAX_PATHS = new Setting('maxPaths', RUNNING_QUERIES_SETTING);
 const RUNNING_TESTS_SETTING = new Setting('runningTests', ROOT_SETTING);
 const RESULTS_DISPLAY_SETTING = new Setting('resultsDisplay', ROOT_SETTING);
 
@@ -112,12 +113,13 @@ export interface QueryHistoryConfig {
   onDidChangeConfiguration: Event<void>;
 }
 
-const CLI_SETTINGS = [ADDITIONAL_TEST_ARGUMENTS_SETTING, NUMBER_OF_TEST_THREADS_SETTING, NUMBER_OF_THREADS_SETTING];
+const CLI_SETTINGS = [ADDITIONAL_TEST_ARGUMENTS_SETTING, NUMBER_OF_TEST_THREADS_SETTING, NUMBER_OF_THREADS_SETTING, MAX_PATHS];
 
 export interface CliConfig {
   additionalTestArguments: string[];
   numberTestThreads: number;
   numberThreads: number;
+  maxPaths: number;
   onDidChangeConfiguration?: Event<void>;
 }
 
@@ -262,6 +264,10 @@ export class CliConfigListener extends ConfigListener implements CliConfig {
 
   public get numberThreads(): number {
     return NUMBER_OF_THREADS_SETTING.getValue<number>();
+  }
+
+  public get maxPaths(): number {
+    return MAX_PATHS.getValue<number>();
   }
 
   protected handleDidChangeConfiguration(e: ConfigurationChangeEvent): void {

--- a/extensions/ql-vscode/src/vscode-tests/minimal-workspace/config.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/minimal-workspace/config.test.ts
@@ -48,6 +48,10 @@ describe('config listeners', function() {
         name: 'codeQL.runningTests.numberOfThreads',
         property: 'numberTestThreads',
         values: [1, 0]
+      }, {
+        name: 'codeQL.runningQueries.maxPaths',
+        property: 'maxPaths',
+        values: [0, 1]
       }]
     },
     {


### PR DESCRIPTION
Will fix #919 .

Added a new setting `codeQL.runningQueries.maxPaths` that lets you configure how many paths to display 🙂 I tested this with a few databases/queries (e.g. [this one](https://lgtm.com/projects/g/codefollower/Tomcat-Research/alerts/?mode=list&id=java%2Fcommand-line-injection%2Cjava%2Fxss))


## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] ~`@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.~ No docs updates needed.
