### PR TITLE
Tidy and add tests for `resolveLanguages` commands

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -73,7 +73,7 @@ import {
 import { CodeQlStatusBarHandler } from './status-bar';
 
 import { Credentials } from './authentication';
-import { runRemoteQuery, findLanguage } from './run-remote-query';
+import { runRemoteQuery } from './run-remote-query';
 
 /**
  * extension.ts
@@ -576,7 +576,7 @@ async function activateWithInstalledDistribution(
           return;
         }
         // If possible, only show databases with the right language (otherwise show all databases).
-        const queryLanguage = await findLanguage(cliServer, uri);
+        const queryLanguage = await helpers.findLanguage(cliServer, uri);
         if (queryLanguage) {
           filteredDBs = dbm.databaseItems.filter(db => db.language === queryLanguage);
           if (filteredDBs.length === 0) {

--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -424,3 +424,34 @@ export async function isLikelyDatabaseRoot(maybeRoot: string) {
 export function isLikelyDbLanguageFolder(dbPath: string) {
   return !!path.basename(dbPath).startsWith('db-');
 }
+
+/**
+ * Finds the language that a query targets.
+ * If it can't be autodetected, prompt the user to specify the language manually.
+ */
+export async function findLanguage(
+  cliServer: CodeQLCliServer,
+  queryUri: Uri | undefined
+): Promise<string | undefined> {
+  const uri = queryUri || Window.activeTextEditor?.document.uri;
+  if (uri !== undefined) {
+    try {
+      const queryInfo = await cliServer.resolveQueryByLanguage(getOnDiskWorkspaceFolders(), uri);
+      const language = (Object.keys(queryInfo.byLanguage))[0];
+      void logger.log(`Detected query language: ${language}`);
+      return language;
+    } catch (e) {
+      void logger.log('Could not autodetect query language. Select language manually.');
+    }
+  }
+  const availableLanguages = Object.keys(await cliServer.resolveLanguages());
+  const language = await Window.showQuickPick(
+    availableLanguages,
+    { placeHolder: 'Select target language for your query', ignoreFocusOut: true }
+  );
+  if (!language) {
+    // This only happens if the user cancels the quick pick.
+    void showAndLogErrorMessage('Language not found. Language must be specified manually.');
+  }
+  return language;
+}

--- a/extensions/ql-vscode/src/run-remote-query.ts
+++ b/extensions/ql-vscode/src/run-remote-query.ts
@@ -1,7 +1,7 @@
 import { QuickPickItem, Uri, window } from 'vscode';
 import * as yaml from 'js-yaml';
 import * as fs from 'fs-extra';
-import { getOnDiskWorkspaceFolders, showAndLogErrorMessage, showAndLogInformationMessage } from './helpers';
+import { findLanguage, showAndLogErrorMessage, showAndLogInformationMessage } from './helpers';
 import { Credentials } from './authentication';
 import * as cli from './cli';
 import { logger } from './logging';
@@ -15,37 +15,6 @@ interface Config {
 // Test "controller" repository and workflow.
 const OWNER = 'dsp-testing';
 const REPO = 'qc-controller';
-
-/**
- * Finds the language that a query targets.
- * If it can't be autodetected, prompt the user to specify the language manually.
- */
-export async function findLanguage(
-  cliServer: cli.CodeQLCliServer,
-  queryUri: Uri | undefined
-): Promise<string | undefined> {
-  const uri = queryUri || window.activeTextEditor?.document.uri;
-  if (uri !== undefined) {
-    try {
-      const queryInfo = await cliServer.resolveQueryByLanguage(getOnDiskWorkspaceFolders(), uri);
-      const language = (Object.keys(queryInfo.byLanguage))[0];
-      void logger.log(`Detected query language: ${language}`);
-      return language;
-    } catch (e) {
-      void logger.log('Could not autodetect query language. Select language manually.');
-    }
-  }
-  const availableLanguages = Object.keys(await cliServer.resolveLanguages());
-  const language = await window.showQuickPick(
-    availableLanguages,
-    { placeHolder: 'Select target language for your query', ignoreFocusOut: true }
-  );
-  if (!language) {
-    // This only happens if the user cancels the quick pick.
-    void showAndLogErrorMessage('Language not found. Language must be specified manually.');
-  }
-  return language;
-}
 
 interface RepoListQuickPickItem extends QuickPickItem {
   repoList: string[];

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/run-cli.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/run-cli.test.ts
@@ -52,4 +52,15 @@ describe('Use cli', function() {
     expect(qlpacks['codeql-javascript']).not.to.be.undefined;
     expect(qlpacks['codeql-python']).not.to.be.undefined;
   });
+
+  it('should resolve languages', async function() {
+    skipIfNoCodeQL(this);
+    const languages = await cli.resolveLanguages();
+    // should have a bunch of languages. just check that a few known ones exist
+    expect(languages['cpp']).not.to.be.undefined;
+    expect(languages['csharp']).not.to.be.undefined;
+    expect(languages['java']).not.to.be.undefined;
+    expect(languages['javascript']).not.to.be.undefined;
+    expect(languages['python']).not.to.be.undefined;
+  });
 });

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/run-cli.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/run-cli.test.ts
@@ -56,11 +56,8 @@ describe('Use cli', function() {
   it('should resolve languages', async function() {
     skipIfNoCodeQL(this);
     const languages = await cli.resolveLanguages();
-    // should have a bunch of languages. just check that a few known ones exist
-    expect(languages['cpp']).not.to.be.undefined;
-    expect(languages['csharp']).not.to.be.undefined;
-    expect(languages['java']).not.to.be.undefined;
-    expect(languages['javascript']).not.to.be.undefined;
-    expect(languages['python']).not.to.be.undefined;
+    for (const expectedLanguage of ['cpp', 'csharp', 'go', 'java', 'javascript', 'python']) {
+      expect(languages).to.have.property(expectedLanguage).that.is.not.undefined;
+    }
   });
 });


### PR DESCRIPTION
First stage of tidying up and adding tests. See https://github.com/github/vscode-codeql/pull/915#pullrequestreview-720517460 and the linked (internal) issue.

- I've moved `findLanguage` out of "run-remote-query" and into a more general place ("helpers"), since it's used in a few functions and this seemed like a more logical place
- Added a test for `resolveLanguages` (basically copied from the `resolveQlpacks` test above 😅) 

I haven't yet added a test for the other functions from https://github.com/github/vscode-codeql/pull/915, since they require a bit more setup. Stay tuned for a follow-up PR 😎 

## Checklist

_N/A: no user-facing changes_

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
