### PR TITLE
Add test for `resolveQueryByLanguage`

### DIFF
--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/data/simple-javascript-query.ql
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/data/simple-javascript-query.ql
@@ -1,0 +1,3 @@
+import javascript
+
+select 1

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/data/simple-query.ql
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/data/simple-query.ql
@@ -1,3 +1,5 @@
+import javascript
+
 predicate edges(int i, int j) {
   i = 1 and j = 2 or i = 2 and j = 3
 }

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/data/simple-query.ql
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/data/simple-query.ql
@@ -1,5 +1,3 @@
-import javascript
-
 predicate edges(int i, int j) {
   i = 1 and j = 2 or i = 2 and j = 3
 }

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/run-cli.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/run-cli.test.ts
@@ -64,7 +64,7 @@ describe('Use cli', function() {
 
   it('should resolve query by language', async function() {
     skipIfNoCodeQL(this);
-    const queryPath = path.join(__dirname, 'data', 'simple-query.ql');
+    const queryPath = path.join(__dirname, 'data', 'simple-javascript-query.ql');
     const queryInfo: QueryInfoByLanguage = await cli.resolveQueryByLanguage(getOnDiskWorkspaceFolders(), Uri.file(queryPath));
     expect((Object.keys(queryInfo.byLanguage))[0]).to.eql('javascript');
   });

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/run-cli.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/run-cli.test.ts
@@ -1,8 +1,9 @@
 import { expect } from 'chai';
-import { extensions } from 'vscode';
+import { extensions, Uri } from 'vscode';
+import * as path from 'path';
 import { SemVer } from 'semver';
 
-import { CodeQLCliServer } from '../../cli';
+import { CodeQLCliServer, QueryInfoByLanguage } from '../../cli';
 import { CodeQLExtensionInterface } from '../../extension';
 import { skipIfNoCodeQL } from '../ensureCli';
 import { getOnDiskWorkspaceFolders } from '../../helpers';
@@ -59,5 +60,12 @@ describe('Use cli', function() {
     for (const expectedLanguage of ['cpp', 'csharp', 'go', 'java', 'javascript', 'python']) {
       expect(languages).to.have.property(expectedLanguage).that.is.not.undefined;
     }
+  });
+
+  it('should resolve query by language', async function() {
+    skipIfNoCodeQL(this);
+    const queryPath = path.join(__dirname, 'data', 'simple-query.ql');
+    const queryInfo: QueryInfoByLanguage = await cli.resolveQueryByLanguage(getOnDiskWorkspaceFolders(), Uri.file(queryPath));
+    expect((Object.keys(queryInfo.byLanguage))[0]).to.eql('javascript');
   });
 });


### PR DESCRIPTION
Adding another test! (follow-up to https://github.com/github/vscode-codeql/pull/937).

- Added a new query `simple-javascript-query.ql` with an import statement 
- Added test to check that the language resolves to `'javascript'`

## Checklist

N/A - not user-facing

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
