### PR TITLE
Configure correct TypeScript version to use in VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,7 +22,8 @@
     "common/temp": true,
     "**/.vscode-test": true
   },
-  "typescript.tsdk": "./common/temp/node_modules/typescript/lib", // we want to use the TS server from our node_modules folder to control its version
+  "typescript.tsdk": "./extensions/ql-vscode/node_modules/typescript/lib", // we want to use the TS server from our node_modules folder to control its version
+  "typescript.enablePromptUseWorkspaceTsdk": true,
   "eslint.validate": [
     "javascript",
     "javascriptreact",


### PR DESCRIPTION
VS Code v1.60.0 uses TypeScript 4.4.2 by default, which gives a number of new errors (e.g. [in `catch` clauses](https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#use-unknown-catch-variables)). I had to change the `"typescript.tsdk"` setting to get VS Code to use the workspace version (TypeScript 4.3.2) instead. (I'm not sure if the setting was working previously: I didn't have a `common/temp` folder 🤔)
Also added `"typescript.enablePromptUseWorkspaceTsdk": true` to prompt users to choose the workspace version too. 

I tested this in a fresh codespace, which seemed to work. We'll probably want to upgrade to 4.4 at some point but, either way, I think this change is helpful to make sure we're all using the same workspace version 🙂 

## Checklist

N/A

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
