### PR TITLE
Offer option to rerun remote query on the subset of valid repositories

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -812,6 +812,10 @@ async function activateWithInstalledDistribution(
       }
     }));
 
+  commands.registerCommand('codeQL.showLogs', () => {
+    logger.show();
+  });
+
   void logger.log('Starting language server.');
   ctx.subscriptions.push(client.start());
 

--- a/extensions/ql-vscode/src/run-remote-query.ts
+++ b/extensions/ql-vscode/src/run-remote-query.ts
@@ -136,16 +136,16 @@ async function runRemoteQueriesApiRequest(credentials: Credentials, ref: string,
       const invalidRepos = error?.response?.data?.invalid_repos || [];
       const reposWithoutDbUploads = error?.response?.data?.repos_without_db_uploads || [];
       void logger.log('Unable to run query on all repositories');
-      void logger.log('invalidRepos = ' + JSON.stringify(invalidRepos));
-      void logger.log('reposWithoutDbUploads = ' + JSON.stringify(reposWithoutDbUploads));
+      void logger.log('Invalid repos: ' + invalidRepos.join(', '));
+      void logger.log('Repos without DB uploads: ' + reposWithoutDbUploads.join(', '));
 
       if (invalidRepos.length + reposWithoutDbUploads.length === repositories.length) {
         // Every repo is invalid in some way
-        void showAndLogErrorMessage('Unable to run query on the specified repositories.');
+        void showAndLogErrorMessage('Unable to run query on any of the specified repositories.');
         return;
       }
 
-      const popupMessage = 'Unable to run query on the specified repositories. See logs for more details.';
+      const popupMessage = 'Unable to run query on some of the specified repositories. See logs for more details.';
       const rerunQuery = await showInformationMessageWithAction(popupMessage, 'Rerun on the valid repositories only');
       if (rerunQuery) {
         const validRepositories = repositories.filter(r => !invalidRepos.includes(r) && !reposWithoutDbUploads.includes(r));

--- a/extensions/ql-vscode/src/run-remote-query.ts
+++ b/extensions/ql-vscode/src/run-remote-query.ts
@@ -135,9 +135,13 @@ async function runRemoteQueriesApiRequest(credentials: Credentials, ref: string,
     if (typeof error.message === 'string' && error.message.includes('Some repositories were invalid')) {
       const invalidRepos = error?.response?.data?.invalid_repos || [];
       const reposWithoutDbUploads = error?.response?.data?.repos_without_db_uploads || [];
-      void logger.log('Unable to run query on all repositories');
-      void logger.log('Invalid repos: ' + invalidRepos.join(', '));
-      void logger.log('Repos without DB uploads: ' + reposWithoutDbUploads.join(', '));
+      void logger.log('Unable to run query on some of the specified repositories');
+      if (invalidRepos.length > 0) {
+        void logger.log('Invalid repos: ' + invalidRepos.join(', '));
+      }
+      if (reposWithoutDbUploads.length > 0) {
+        void logger.log('Repos without DB uploads: ' + reposWithoutDbUploads.join(', '));
+      }
 
       if (invalidRepos.length + reposWithoutDbUploads.length === repositories.length) {
         // Every repo is invalid in some way
@@ -145,7 +149,7 @@ async function runRemoteQueriesApiRequest(credentials: Credentials, ref: string,
         return;
       }
 
-      const popupMessage = 'Unable to run query on some of the specified repositories. See logs for more details.';
+      const popupMessage = 'Unable to run query on some of the specified repositories. [See logs for more details](command:codeQL.showLogs)';
       const rerunQuery = await showInformationMessageWithAction(popupMessage, 'Rerun on the valid repositories only');
       if (rerunQuery) {
         const validRepositories = repositories.filter(r => !invalidRepos.includes(r) && !reposWithoutDbUploads.includes(r));

--- a/extensions/ql-vscode/src/run-remote-query.ts
+++ b/extensions/ql-vscode/src/run-remote-query.ts
@@ -39,7 +39,7 @@ async function getRepositories(): Promise<string[] | undefined> {
         ignoreFocusOut: true,
       });
     if (quickpick?.repoList.length) {
-      void logger.log(`Selected repositories: ${quickpick.repoList}`);
+      void logger.log(`Selected repositories: ${quickpick.repoList.join(', ')}`);
       return quickpick.repoList;
     } else {
       void showAndLogErrorMessage('No repositories selected.');

--- a/extensions/ql-vscode/src/run-remote-query.ts
+++ b/extensions/ql-vscode/src/run-remote-query.ts
@@ -137,10 +137,10 @@ async function runRemoteQueriesApiRequest(credentials: Credentials, ref: string,
       const reposWithoutDbUploads = error?.response?.data?.repos_without_db_uploads || [];
       void logger.log('Unable to run query on some of the specified repositories');
       if (invalidRepos.length > 0) {
-        void logger.log('Invalid repos: ' + invalidRepos.join(', '));
+        void logger.log(`Invalid repos: ${invalidRepos.join(', ')}`);
       }
       if (reposWithoutDbUploads.length > 0) {
-        void logger.log('Repos without DB uploads: ' + reposWithoutDbUploads.join(', '));
+        void logger.log(`Repos without DB uploads: ${reposWithoutDbUploads.join(', ')}`);
       }
 
       if (invalidRepos.length + reposWithoutDbUploads.length === repositories.length) {
@@ -149,11 +149,11 @@ async function runRemoteQueriesApiRequest(credentials: Credentials, ref: string,
         return;
       }
 
-      const popupMessage = 'Unable to run query on some of the specified repositories. [See logs for more details](command:codeQL.showLogs)';
+      const popupMessage = 'Unable to run query on some of the specified repositories. [See logs for more details](command:codeQL.showLogs).';
       const rerunQuery = await showInformationMessageWithAction(popupMessage, 'Rerun on the valid repositories only');
       if (rerunQuery) {
         const validRepositories = repositories.filter(r => !invalidRepos.includes(r) && !reposWithoutDbUploads.includes(r));
-        void logger.log('Rerunning query on set of valid repositories: ' + JSON.stringify(validRepositories));
+        void logger.log(`Rerunning query on set of valid repositories: ${JSON.stringify(validRepositories)}`);
         await runRemoteQueriesApiRequest(credentials, ref, language, validRepositories, query);
       }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Paired with @shati-patel to write this 🍐 

When a user tries to run a remote CodeQL query (Internal feature only) but it turns out that a subset of the repositories chosen are invalid, offer them the option to rerun their query but only on the subset of valid repositories. The full set of invalid repositories and reasons are included in the logs. It would be nice to also include this information in the popup message but we were struggling to find a convenient or good way to do this.

## Checklist

No changelog needed as this is an internal feature.

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
