### PR TITLE
Wait for document to be saved before running query

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [UNRELEASED]
 
+- Fix bug where a query is sometimes run before the file is saved. [#947](https://github.com/github/vscode-codeql/pull/947)
+
 ## 1.5.4 - 02 September 2021
 
 - Add support for filename pattern in history view. [#930](https://github.com/github/vscode-codeql/pull/930)

--- a/extensions/ql-vscode/src/run-queries.ts
+++ b/extensions/ql-vscode/src/run-queries.ts
@@ -524,7 +524,7 @@ export async function determineSelectedQuery(selectedResourceUri: Uri | undefine
   // then prompt the user to save it first.
   if (editor !== undefined && editor.document.uri.fsPath === queryPath) {
     if (await promptUserToSaveChanges(editor.document)) {
-      void editor.document.save();
+      await editor.document.save();
     }
   }
 


### PR DESCRIPTION
If `AUTOSAVE_SETTING` is `true` and I trigger the `Run Query` command, I occasionally see race conditions where the query is run before the file is saved, and I see results corresponding to the previous version of the query. I'm not sure how to test this and I haven't been able to reliably reproduce the problem (though it occurs often).

Intuitively, it seems like this change should fix it, since [`editor.document.save`](https://github.com/microsoft/vscode/blob/main/src/vs/vscode.d.ts#L143) returns a `Thenable`, which I think means it returns a promise or the function is async.

My javascript is very rusty, sorry if this is inaccurate!

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
