### PR TITLE
Update CLI version for integration tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -151,7 +151,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        version: ['v2.2.6', 'v2.3.3', 'v2.4.6', 'v2.5.9', 'v2.6.0', 'nightly']
+        version: ['v2.2.6', 'v2.3.3', 'v2.4.6', 'v2.5.9', 'v2.6.1', 'nightly']
     env:
       CLI_VERSION: ${{ matrix.version }}
       NIGHTLY_URL: ${{ needs.find-nightly.outputs.url }}

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/queries.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/queries.test.ts
@@ -150,7 +150,7 @@ describe('Queries', function() {
       fs.readFileSync(qlpackFile, 'utf8')
     );
     // Should have chosen the js libraries
-    expect(qlpackContents.libraryPathDependencies[0]).to.eq('codeql-javascript');
+    expect(qlpackContents.libraryPathDependencies[0]).to.include('javascript');
   });
 
   it('should avoid creating a quick query', async () => {

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/run-cli.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/run-cli.test.ts
@@ -46,12 +46,12 @@ describe('Use cli', function() {
   it('should resolve query packs', async function() {
     skipIfNoCodeQL(this);
     const qlpacks = await cli.resolveQlpacks(getOnDiskWorkspaceFolders());
-    // should have a bunch of qlpacks. just check that a few known ones exist
-    expect(qlpacks['codeql-cpp']).not.to.be.undefined;
-    expect(qlpacks['codeql-csharp']).not.to.be.undefined;
-    expect(qlpacks['codeql-java']).not.to.be.undefined;
-    expect(qlpacks['codeql-javascript']).not.to.be.undefined;
-    expect(qlpacks['codeql-python']).not.to.be.undefined;
+    // Depending on the version of the CLI, the qlpacks may have different names
+    // (e.g. "codeql/javascript-all" vs "codeql-javascript"),
+    // so we just check that the expected languages are included.
+    for (const expectedLanguage of ['cpp', 'csharp', 'go', 'java', 'javascript', 'python']) {
+      expect((Object.keys(qlpacks)).includes(expectedLanguage));
+    }
   });
 
   it('should resolve languages', async function() {

--- a/extensions/ql-vscode/src/vscode-tests/ensureCli.ts
+++ b/extensions/ql-vscode/src/vscode-tests/ensureCli.ts
@@ -44,7 +44,7 @@ const _10MB = _1MB * 10;
 
 // CLI version to test. Hard code the latest as default. And be sure
 // to update the env if it is not otherwise set.
-const CLI_VERSION = process.env.CLI_VERSION || 'v2.5.9';
+const CLI_VERSION = process.env.CLI_VERSION || 'v2.6.1';
 process.env.CLI_VERSION = CLI_VERSION;
 
 // Base dir where CLIs will be downloaded into


### PR DESCRIPTION
[CodeQL CLI 2.6.1 is](https://github.com/github/codeql-cli-binaries/releases/tag/v2.6.1) released! 🚢 

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
