### PR TITLE
Fix AST Viewer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -151,7 +151,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        version: ['v2.2.6', 'v2.3.3', 'v2.4.6', 'v2.5.9', 'v2.6.1', 'nightly']
+        version: ['v2.3.3', 'v2.4.6', 'v2.5.9', 'v2.6.1', 'nightly']
     env:
       CLI_VERSION: ${{ matrix.version }}
       NIGHTLY_URL: ${{ needs.find-nightly.outputs.url }}

--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [UNRELEASED]
 
 - Fix bug where a query is sometimes run before the file is saved. [#947](https://github.com/github/vscode-codeql/pull/947)
+- Fix broken contextual queries, including _View AST_. [#949](https://github.com/github/vscode-codeql/pull/949)
 
 ## 1.5.4 - 02 September 2021
 

--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -423,6 +423,12 @@ const dbSchemeToLanguage = {
   'go.dbscheme': 'go'
 };
 
+export const languageToDbScheme = Object.entries(dbSchemeToLanguage).reduce((acc, [k, v]) => {
+  acc[v] = k;
+  return acc;
+}, {} as { [k: string]: string });
+
+
 /**
  * Returns the initial contents for an empty query, based on the language of the selected
  * databse.

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/run-cli.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/run-cli.test.ts
@@ -7,6 +7,8 @@ import { CodeQLCliServer, QueryInfoByLanguage } from '../../cli';
 import { CodeQLExtensionInterface } from '../../extension';
 import { skipIfNoCodeQL } from '../ensureCli';
 import { getOnDiskWorkspaceFolders } from '../../helpers';
+import { resolveQueries } from '../../contextual/queryResolver';
+import { KeyType } from '../../contextual/keyType';
 
 /**
  * Perform proper integration tests by running the CLI
@@ -67,5 +69,17 @@ describe('Use cli', function() {
     const queryPath = path.join(__dirname, 'data', 'simple-javascript-query.ql');
     const queryInfo: QueryInfoByLanguage = await cli.resolveQueryByLanguage(getOnDiskWorkspaceFolders(), Uri.file(queryPath));
     expect((Object.keys(queryInfo.byLanguage))[0]).to.eql('javascript');
+  });
+
+  it.only('should resolve printAST queries', async function() {
+    skipIfNoCodeQL(this);
+
+    const result = await resolveQueries(cli, {
+      dbschemePack: 'codeql/javascript-all',
+      dbschemePackIsLibraryPack: true,
+      queryPack: 'codeql/javascript-queries'
+    }, KeyType.PrintAstQuery);
+    expect(result.length).to.eq(1);
+    expect(result[0].endsWith('javascript/ql/src/printAst.ql')).to.be.true;
   });
 });

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/contextual/queryResolver.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/contextual/queryResolver.test.ts
@@ -30,19 +30,19 @@ describe('queryResolver', () => {
   });
 
   describe('resolveQueries', () => {
-
     it('should resolve a query', async () => {
       mockCli.resolveQueriesInSuite.returns(['a', 'b']);
       const result = await module.resolveQueries(mockCli, { dbschemePack: 'my-qlpack' }, KeyType.DefinitionQuery);
       expect(result).to.deep.equal(['a', 'b']);
       expect(writeFileSpy.getCall(0).args[0]).to.match(/.qls$/);
-      expect(yaml.safeLoad(writeFileSpy.getCall(0).args[1])).to.deep.equal({
-        qlpack: 'my-qlpack',
+      expect(yaml.safeLoad(writeFileSpy.getCall(0).args[1])).to.deep.equal([{
+        from: 'my-qlpack',
+        queries: '.',
         include: {
           kind: 'definitions',
           'tags contain': 'ide-contextual-queries/local-definitions'
         }
-      });
+      }]);
     });
 
     it('should resolve a query from the queries pack if this is an old CLI', async () => {

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/contextual/queryResolver.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/contextual/queryResolver.test.ts
@@ -52,13 +52,14 @@ describe('queryResolver', () => {
       const result = await module.resolveQueries(mockCli, { dbschemePackIsLibraryPack: true, dbschemePack: 'my-qlpack', queryPack: 'my-qlpack2' }, KeyType.DefinitionQuery);
       expect(result).to.deep.equal(['a', 'b']);
       expect(writeFileSpy.getCall(0).args[0]).to.match(/.qls$/);
-      expect(yaml.safeLoad(writeFileSpy.getCall(0).args[1])).to.deep.equal({
-        qlpack: 'my-qlpack2',
+      expect(yaml.safeLoad(writeFileSpy.getCall(0).args[1])).to.deep.equal([{
+        from: 'my-qlpack2',
+        queries: '.',
         include: {
           kind: 'definitions',
           'tags contain': 'ide-contextual-queries/local-definitions'
         }
-      });
+      }]);
     });
 
     it('should throw an error when there are no queries found', async () => {


### PR DESCRIPTION
The previous synthetic query suite was not finding the ast query because
the `qlpack` directive in a query suite only matches queries from the
default suite, which `printAST.ql` is not part of.

This changes to using `from` and `queries` directives.

Also, adds an integration test to ensure we find the queries using
different CLIs. However, this only tests using the latest `main` from
the codeql repository. I wonder if we should start testing using
different versions of the repo.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Replace this with a description of the changes your pull request makes.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
