### PR TITLE
Remove `token` for running a remote query

### DIFF
--- a/extensions/ql-vscode/src/authentication.ts
+++ b/extensions/ql-vscode/src/authentication.ts
@@ -7,16 +7,11 @@ const GITHUB_AUTH_PROVIDER_ID = 'github';
 // https://docs.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps
 const SCOPES = ['repo'];
 
-interface OctokitAndToken {
-  octokit: Octokit.Octokit;
-  token: string;
-}
-
 /** 
  * Handles authentication to GitHub, using the VS Code [authentication API](https://code.visualstudio.com/api/references/vscode-api#authentication).
  */
 export class Credentials {
-  private octokitAndToken: OctokitAndToken | undefined;
+  private octokit: Octokit.Octokit | undefined;
 
   // Explicitly make the constructor private, so that we can't accidentally call the constructor from outside the class
   // without also initializing the class.
@@ -26,20 +21,17 @@ export class Credentials {
   static async initialize(context: vscode.ExtensionContext): Promise<Credentials> {
     const c = new Credentials();
     c.registerListeners(context);
-    c.octokitAndToken = await c.createOctokit(false);
+    c.octokit = await c.createOctokit(false);
     return c;
   }
 
-  private async createOctokit(createIfNone: boolean): Promise<OctokitAndToken | undefined> {
+  private async createOctokit(createIfNone: boolean): Promise<Octokit.Octokit | undefined> {
     const session = await vscode.authentication.getSession(GITHUB_AUTH_PROVIDER_ID, SCOPES, { createIfNone });
 
     if (session) {
-      return {
-        octokit: new Octokit.Octokit({
-          auth: session.accessToken
-        }),
-        token: session.accessToken
-      };
+      return new Octokit.Octokit({
+        auth: session.accessToken
+      });
     } else {
       return undefined;
     }
@@ -49,33 +41,22 @@ export class Credentials {
     // Sessions are changed when a user logs in or logs out.
     context.subscriptions.push(vscode.authentication.onDidChangeSessions(async e => {
       if (e.provider.id === GITHUB_AUTH_PROVIDER_ID) {
-        this.octokitAndToken = await this.createOctokit(false);
+        this.octokit = await this.createOctokit(false);
       }
     }));
   }
 
   async getOctokit(): Promise<Octokit.Octokit> {
-    if (this.octokitAndToken) {
-      return this.octokitAndToken.octokit;
+    if (this.octokit) {
+      return this.octokit;
     }
 
-    this.octokitAndToken = await this.createOctokit(true);
+    this.octokit = await this.createOctokit(true);
     // octokit shouldn't be undefined, since we've set "createIfNone: true".
     // The following block is mainly here to prevent a compiler error.
-    if (!this.octokitAndToken) {
+    if (!this.octokit) {
       throw new Error('Did not initialize Octokit.');
     }
-    return this.octokitAndToken.octokit;
-  }
-
-  async getToken(): Promise<string> {
-    if (this.octokitAndToken) {
-      return this.octokitAndToken.token;
-    }
-    this.octokitAndToken = await this.createOctokit(true);
-    if (!this.octokitAndToken) {
-      throw new Error('Did not initialize Octokit.');
-    }
-    return this.octokitAndToken.token;
+    return this.octokit;
   }
 }

--- a/extensions/ql-vscode/src/run-remote-query.ts
+++ b/extensions/ql-vscode/src/run-remote-query.ts
@@ -112,7 +112,6 @@ export async function runRemoteQuery(cliServer: cli.CodeQLCliServer, credentials
 
 async function runRemoteQueriesApiRequest(credentials: Credentials, ref: string, language: string, repositories: string[], query: string) {
   const octokit = await credentials.getOctokit();
-  const token = await credentials.getToken();
 
   try {
     await octokit.request(
@@ -125,7 +124,6 @@ async function runRemoteQueriesApiRequest(credentials: Credentials, ref: string,
           language: language,
           repositories: repositories,
           query: query,
-          token: token,
         }
       }
     );


### PR DESCRIPTION
[internal feature]

The API for remote querying has changed (see linked issue), so we no longer need to provide a token in the Octokit request 🙂 This is a partial revert of [this commit](https://github.com/github/vscode-codeql/pull/882/commits/3c678ca39f90a429999e4a197c2ccc64f2718c00#diff-39def7429bdcd0a61f1dab2ef3277a28e1f8ff7186cced600a49b10c8b9d8276).

## Checklist

N/A, no user-facing changes

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
