### PR TITLE
Tests for run-remote-query

### DIFF
--- a/extensions/ql-vscode/src/run-remote-query.ts
+++ b/extensions/ql-vscode/src/run-remote-query.ts
@@ -23,7 +23,7 @@ interface RepoListQuickPickItem extends QuickPickItem {
 /**
  * Gets the repositories to run the query against.
  */
-async function getRepositories(): Promise<string[] | undefined> {
+export async function getRepositories(): Promise<string[] | undefined> {
   const repoLists = getRemoteRepositoryLists();
   if (repoLists && Object.keys(repoLists).length) {
     const quickPickItems = Object.entries(repoLists).map<RepoListQuickPickItem>(([key, value]) => (

--- a/extensions/ql-vscode/src/run-remote-query.ts
+++ b/extensions/ql-vscode/src/run-remote-query.ts
@@ -130,33 +130,38 @@ async function runRemoteQueriesApiRequest(credentials: Credentials, ref: string,
     void showAndLogInformationMessage(`Successfully scheduled runs. [Click here to see the progress](https://github.com/${OWNER}/${REPO}/actions).`);
 
   } catch (error) {
-    if (typeof error.message === 'string' && error.message.includes('Some repositories were invalid')) {
-      const invalidRepos = error?.response?.data?.invalid_repos || [];
-      const reposWithoutDbUploads = error?.response?.data?.repos_without_db_uploads || [];
-      void logger.log('Unable to run query on some of the specified repositories');
-      if (invalidRepos.length > 0) {
-        void logger.log(`Invalid repos: ${invalidRepos.join(', ')}`);
-      }
-      if (reposWithoutDbUploads.length > 0) {
-        void logger.log(`Repos without DB uploads: ${reposWithoutDbUploads.join(', ')}`);
-      }
-
-      if (invalidRepos.length + reposWithoutDbUploads.length === repositories.length) {
-        // Every repo is invalid in some way
-        void showAndLogErrorMessage('Unable to run query on any of the specified repositories.');
-        return;
-      }
-
-      const popupMessage = 'Unable to run query on some of the specified repositories. [See logs for more details](command:codeQL.showLogs).';
-      const rerunQuery = await showInformationMessageWithAction(popupMessage, 'Rerun on the valid repositories only');
-      if (rerunQuery) {
-        const validRepositories = repositories.filter(r => !invalidRepos.includes(r) && !reposWithoutDbUploads.includes(r));
-        void logger.log(`Rerunning query on set of valid repositories: ${JSON.stringify(validRepositories)}`);
-        await runRemoteQueriesApiRequest(credentials, ref, language, validRepositories, query);
-      }
-
-    } else {
-      void showAndLogErrorMessage(error);
-    }
+    await validateRepositories(error, credentials, ref, language, repositories, query);
   }
+}
+
+async function validateRepositories(error: any, credentials: Credentials, ref: string, language: string, repositories: string[], query: string) {
+  if (typeof error.message === 'string' && error.message.includes('Some repositories were invalid')) {
+    const invalidRepos = error?.response?.data?.invalid_repos || [];
+    const reposWithoutDbUploads = error?.response?.data?.repos_without_db_uploads || [];
+    void logger.log('Unable to run query on some of the specified repositories');
+    if (invalidRepos.length > 0) {
+      void logger.log(`Invalid repos: ${invalidRepos.join(', ')}`);
+    }
+    if (reposWithoutDbUploads.length > 0) {
+      void logger.log(`Repos without DB uploads: ${reposWithoutDbUploads.join(', ')}`);
+    }
+
+    if (invalidRepos.length + reposWithoutDbUploads.length === repositories.length) {
+      // Every repo is invalid in some way
+      void showAndLogErrorMessage('Unable to run query on any of the specified repositories.');
+      return;
+    }
+
+    const popupMessage = 'Unable to run query on some of the specified repositories. [See logs for more details](command:codeQL.showLogs).';
+    const rerunQuery = await showInformationMessageWithAction(popupMessage, 'Rerun on the valid repositories only');
+    if (rerunQuery) {
+      const validRepositories = repositories.filter(r => !invalidRepos.includes(r) && !reposWithoutDbUploads.includes(r));
+      void logger.log(`Rerunning query on set of valid repositories: ${JSON.stringify(validRepositories)}`);
+      await runRemoteQueriesApiRequest(credentials, ref, language, validRepositories, query);
+    }
+
+  } else {
+    void showAndLogErrorMessage(error);
+  }
+
 }

--- a/extensions/ql-vscode/src/run-remote-query.ts
+++ b/extensions/ql-vscode/src/run-remote-query.ts
@@ -134,7 +134,7 @@ async function runRemoteQueriesApiRequest(credentials: Credentials, ref: string,
   }
 }
 
-async function validateRepositories(error: any, credentials: Credentials, ref: string, language: string, repositories: string[], query: string) {
+export async function validateRepositories(error: any, credentials: Credentials, ref: string, language: string, repositories: string[], query: string) {
   if (typeof error.message === 'string' && error.message.includes('Some repositories were invalid')) {
     const invalidRepos = error?.response?.data?.invalid_repos || [];
     const reposWithoutDbUploads = error?.response?.data?.repos_without_db_uploads || [];

--- a/extensions/ql-vscode/src/run-remote-query.ts
+++ b/extensions/ql-vscode/src/run-remote-query.ts
@@ -130,11 +130,12 @@ async function runRemoteQueriesApiRequest(credentials: Credentials, ref: string,
     void showAndLogInformationMessage(`Successfully scheduled runs. [Click here to see the progress](https://github.com/${OWNER}/${REPO}/actions).`);
 
   } catch (error) {
-    await validateRepositories(error, credentials, ref, language, repositories, query);
+    await attemptRerun(error, credentials, ref, language, repositories, query);
   }
 }
 
-export async function validateRepositories(error: any, credentials: Credentials, ref: string, language: string, repositories: string[], query: string) {
+/** Attempts to rerun the query on only the valid repositories */
+export async function attemptRerun(error: any, credentials: Credentials, ref: string, language: string, repositories: string[], query: string) {
   if (typeof error.message === 'string' && error.message.includes('Some repositories were invalid')) {
     const invalidRepos = error?.response?.data?.invalid_repos || [];
     const reposWithoutDbUploads = error?.response?.data?.repos_without_db_uploads || [];

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/run-remote-query.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/run-remote-query.test.ts
@@ -1,0 +1,77 @@
+import 'vscode-test';
+import 'mocha';
+import * as chaiAsPromised from 'chai-as-promised';
+import * as sinon from 'sinon';
+import * as chai from 'chai';
+import { window } from 'vscode';
+import * as pq from 'proxyquire';
+
+const proxyquire = pq.noPreserveCache();
+chai.use(chaiAsPromised);
+const expect = chai.expect;
+
+describe('run-remote-query', function() {
+
+  describe('getRepositories', () => {
+    let sandbox: sinon.SinonSandbox;
+    let quickPickSpy: sinon.SinonStub;
+    let showInputBoxSpy: sinon.SinonStub;
+    let getRemoteRepositoryListsSpy: sinon.SinonStub;
+    let mod: any;
+    beforeEach(() => {
+      sandbox = sinon.createSandbox();
+      quickPickSpy = sandbox.stub(window, 'showQuickPick');
+      showInputBoxSpy = sandbox.stub(window, 'showInputBox');
+      getRemoteRepositoryListsSpy = sandbox.stub();
+      mod = proxyquire('../../run-remote-query', {
+        './config': {
+          getRemoteRepositoryLists: getRemoteRepositoryListsSpy
+        }
+      });
+
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('should return a repo list that you chose from your pre-defined config', async () => {
+      // fake return values
+      quickPickSpy.resolves(
+        { repoList: ['foo/bar', 'foo/baz'] }
+      );
+      getRemoteRepositoryListsSpy.returns(
+        {
+          'list1': ['foo/bar', 'foo/baz'],
+          'list2': [],
+        }
+      );
+
+      // make the function call
+      const repoList = await mod.getRepositories();
+
+      // Check that the return value is correct
+      expect(repoList).to.deep.eq(
+        ['foo/bar', 'foo/baz']
+      );
+    });
+
+    it('should show a textbox if you have no repo lists configured', async () => {
+      // fake return values
+      showInputBoxSpy.resolves('foo/bar');
+      getRemoteRepositoryListsSpy.returns({});
+
+      // make the function call
+      const repoList = await mod.getRepositories();
+
+      // Check that the return value is correct
+      expect(repoList).to.deep.equal(
+        ['foo/bar']
+      );
+    });
+  });
+
+  describe('runRemoteQuery', () => {
+    // TODO
+  });
+});

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/run-remote-query.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/run-remote-query.test.ts
@@ -105,7 +105,7 @@ describe('run-remote-query', function() {
 
   });
 
-  describe('validateRepositories', () => {
+  describe('attemptRerun', () => {
     let sandbox: sinon.SinonSandbox;
     let showAndLogErrorMessageSpy: sinon.SinonStub;
     let showInformationMessageWithActionSpy: sinon.SinonStub;
@@ -152,7 +152,7 @@ describe('run-remote-query', function() {
       const repositories = ['abc/def', 'ghi/jkl', 'mno/pqr', 'stu/vwx'];
 
       // make the function call
-      await mod.validateRepositories(error, credentials, ref, language, repositories, query);
+      await mod.attemptRerun(error, credentials, ref, language, repositories, query);
 
       // check logging output
       expect(logSpy.firstCall.args[0]).to.contain('Unable to run query');
@@ -168,7 +168,7 @@ describe('run-remote-query', function() {
       showInformationMessageWithActionSpy.resolves(true);
 
       // make the function call
-      await mod.validateRepositories(error, credentials, ref, language, repositories, query);
+      await mod.attemptRerun(error, credentials, ref, language, repositories, query);
 
       // check logging output
       expect(logSpy.firstCall.args[0]).to.contain('Unable to run query');

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/run-remote-query.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/run-remote-query.test.ts
@@ -71,6 +71,98 @@ describe('run-remote-query', function() {
     });
   });
 
+  describe('validateRepositories', () => {
+    let sandbox: sinon.SinonSandbox;
+    let showAndLogErrorMessageSpy: sinon.SinonStub;
+    let showInformationMessageWithActionSpy: sinon.SinonStub;
+    let mockRequest: sinon.SinonStub;
+    let logSpy: sinon.SinonStub;
+    let mod: any;
+
+    const error = {
+      message: 'Unable to run query on the specified repositories. Some repositories were invalid or don\'t have database uploads enabled.',
+      response: {
+        data: {
+          invalid_repos: ['abc/def', 'ghi/jkl'],
+          repos_without_db_uploads: ['mno/pqr', 'stu/vwx']
+        }
+      }
+    };
+    const ref = 'main';
+    const language = 'javascript';
+    const credentials = getMockCredentials(0);
+    const query = 'select 1';
+
+    beforeEach(() => {
+      sandbox = sinon.createSandbox();
+      logSpy = sandbox.stub();
+      showAndLogErrorMessageSpy = sandbox.stub();
+      showInformationMessageWithActionSpy = sandbox.stub();
+      mod = proxyquire('../../run-remote-query', {
+        './helpers': {
+          showAndLogErrorMessage: showAndLogErrorMessageSpy,
+          showInformationMessageWithAction: showInformationMessageWithActionSpy
+        },
+        './logging': {
+          'logger': {
+            log: logSpy
+          }
+        },
+      });
+    });
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('should return and log error if it can\'t run on any repos', async () => {
+      const repositories = ['abc/def', 'ghi/jkl', 'mno/pqr', 'stu/vwx'];
+
+      // make the function call
+      await mod.validateRepositories(error, credentials, ref, language, repositories, query);
+
+      // check logging output
+      expect(logSpy.firstCall.args[0]).to.contain('Unable to run query');
+      expect(logSpy.secondCall.args[0]).to.contain('Invalid repos: abc/def, ghi/jkl');
+      expect(logSpy.thirdCall.args[0]).to.contain('Repos without DB uploads: mno/pqr, stu/vwx');
+      expect(showAndLogErrorMessageSpy.firstCall.args[0]).to.contain('Unable to run query on any');
+    });
+
+    it('should list invalid repos and repos without DB uploads, and rerun on valid ones', async () => {
+      const repositories = ['foo/bar', 'abc/def', 'ghi/jkl', 'mno/pqr', 'foo/baz'];
+
+      // fake return values
+      showInformationMessageWithActionSpy.resolves(true);
+
+      // make the function call
+      await mod.validateRepositories(error, credentials, ref, language, repositories, query);
+
+      // check logging output
+      expect(logSpy.firstCall.args[0]).to.contain('Unable to run query');
+      expect(logSpy.secondCall.args[0]).to.contain('Invalid repos: abc/def, ghi/jkl');
+      expect(logSpy.thirdCall.args[0]).to.contain('Repos without DB uploads: mno/pqr');
+
+      // check that the correct information message is displayed
+      expect(showInformationMessageWithActionSpy.firstCall.args[0]).to.contain('Unable to run query on some');
+      expect(showInformationMessageWithActionSpy.firstCall.args[1]).to.contain('Rerun');
+
+      // check that API request is made again, with only valid repos
+      expect(logSpy.lastCall.args[0]).to.contain('valid repositories: ["foo/bar","foo/baz"]');
+      // test a few values in the octokit request
+      expect(mockRequest.firstCall.args[1].data.language).to.eq('javascript');
+      expect(mockRequest.firstCall.args[1].data.repositories).to.deep.eq(['foo/bar', 'foo/baz']);
+
+    });
+
+    function getMockCredentials(response: any) {
+      mockRequest = sinon.stub().resolves(response);
+      return {
+        getOctokit: () => ({
+          request: mockRequest
+        })
+      };
+    }
+  });
+
   describe('runRemoteQuery', () => {
     // TODO
   });


### PR DESCRIPTION
First pass at adding tests:

- Tests for `getRepositories` ✔️ 
- Tests for ~`validateRepositories`~ `attemptRerun` ✔️ 
- Tests for `runRemoteQuery`: still TODO (I can follow-up in separate PR)

There's still more to test, but (to avoid this PR getting too big) it's probably helpful to get this reviewed and merged so far...

I've tried testing the main interesting cases for `getRepositories` and `attemptRerun`. Is there anything else that would be helpful to test? (Or not test? 🙃) 

## Checklist

N/A

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
