### PR TITLE
Fix formatting for history format preference

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -213,7 +213,7 @@
         "codeQL.queryHistory.format": {
           "type": "string",
           "default": "%q on %d - %s, %r result count [%t]",
-          "markdownDescription": "Default string for how to label query history items.\n* %t is the time of the query\n* %q is the human-readable query name\n*%f is the query file name\n* %d is the database name\n* %r is the number of results\n* %s is a status string"
+          "markdownDescription": "Default string for how to label query history items.\n* %t is the time of the query\n* %q is the human-readable query name\n* %f is the query file name\n* %d is the database name\n* %r is the number of results\n* %s is a status string"
         },
         "codeQL.runningTests.additionalTestArguments": {
           "scope": "window",


### PR DESCRIPTION
There was a space missing for one of the items, making it not rendered correctly as list item

![Screenshot 2021-09-16 at 11 31 33](https://user-images.githubusercontent.com/316929/133588102-963c6f7f-6350-4991-973f-0e5f1911f95c.png)


- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
