### PR TITLE
Add option to specify a different "controller" repo

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -241,7 +241,7 @@
           "scope": "application",
           "description": "Specifies whether or not to write telemetry events to the extension log."
         },
-        "codeQL.remoteRepositoryLists": {
+        "codeQL.remoteQueries.repositoryLists": {
           "type": [
             "object",
             null

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -256,6 +256,13 @@
           },
           "default": null,
           "markdownDescription": "[For internal use only] Lists of GitHub repositories that you want to query remotely. This should be a JSON object where each key is a user-specified name for this repository list, and the value is an array of GitHub repositories (of the form `<owner>/<repo>`)."
+        },
+        "codeQL.remoteQueries.controllerRepo": {
+          "type": "string",
+          "default": "",
+          "pattern": "^$|^(?:[a-zA-Z0-9]+-)*[a-zA-Z0-9]+/[a-zA-Z0-9-_]+$",
+          "patternErrorMessage": "Please enter a valid GitHub repository",
+          "markdownDescription": "[For internal use only] The name of the GitHub repository where you can view the progress and results of the \"Run Remote query\" command. The repository should be of the form `<owner>/<repo>`)."
         }
       }
     },

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -313,3 +313,15 @@ const REMOTE_REPO_LISTS = new Setting('repositoryLists', REMOTE_QUERIES_SETTING)
 export function getRemoteRepositoryLists(): Record<string, string[]> | undefined {
   return REMOTE_REPO_LISTS.getValue<Record<string, string[]>>() || undefined;
 }
+
+/**
+ * The name of the "controller" repository that you want to use with the "Run Remote query" command.
+ * Note: This command is only available for internal users.
+ *
+ * This setting should be a GitHub repository of the form `<owner>/<repo>`.
+ */
+const REMOTE_CONTROLLER_REPO = new Setting('controllerRepo', REMOTE_QUERIES_SETTING);
+
+export function getRemoteControllerRepo(): string | undefined {
+  return REMOTE_CONTROLLER_REPO.getValue<string>() || undefined;
+}

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -298,6 +298,9 @@ export function isCanary() {
  */
 export const NO_CACHE_AST_VIEWER = new Setting('disableCache', AST_VIEWER_SETTING);
 
+// Settings for remote queries
+const REMOTE_QUERIES_SETTING = new Setting('remoteQueries', ROOT_SETTING);
+
 /**
  * Lists of GitHub repositories that you want to query remotely via the "Run Remote query" command.
  * Note: This command is only available for internal users.
@@ -305,7 +308,7 @@ export const NO_CACHE_AST_VIEWER = new Setting('disableCache', AST_VIEWER_SETTIN
  * This setting should be a JSON object where each key is a user-specified name (string),
  * and the value is an array of GitHub repositories (of the form `<owner>/<repo>`).
  */
-const REMOTE_REPO_LISTS = new Setting('remoteRepositoryLists', ROOT_SETTING);
+const REMOTE_REPO_LISTS = new Setting('repositoryLists', REMOTE_QUERIES_SETTING);
 
 export function getRemoteRepositoryLists(): Record<string, string[]> | undefined {
   return REMOTE_REPO_LISTS.getValue<Record<string, string[]>>() || undefined;

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -325,3 +325,7 @@ const REMOTE_CONTROLLER_REPO = new Setting('controllerRepo', REMOTE_QUERIES_SETT
 export function getRemoteControllerRepo(): string | undefined {
   return REMOTE_CONTROLLER_REPO.getValue<string>() || undefined;
 }
+
+export async function setRemoteControllerRepo(repo: string | undefined) {
+  await REMOTE_CONTROLLER_REPO.updateValue(repo, ConfigurationTarget.Global);
+}

--- a/extensions/ql-vscode/src/run-remote-query.ts
+++ b/extensions/ql-vscode/src/run-remote-query.ts
@@ -108,8 +108,8 @@ export async function runRemoteQuery(cliServer: cli.CodeQLCliServer, credentials
   // If it doesn't exist, prompt the user to enter it, and save that value to the config.
   let controllerRepo: string | undefined;
   controllerRepo = getRemoteControllerRepo();
-  if (!controllerRepo) {
-    void logger.log('No controller repository defined.');
+  if (!controllerRepo || !REPO_REGEX.test(controllerRepo)) {
+    void logger.log(controllerRepo ? 'Invalid controller repository name.' : 'No controller repository defined.');
     controllerRepo = await window.showInputBox({
       title: 'Controller repository in which to display progress and results of remote queries',
       placeHolder: '<owner>/<repo>',

--- a/extensions/ql-vscode/src/run-remote-query.ts
+++ b/extensions/ql-vscode/src/run-remote-query.ts
@@ -35,7 +35,7 @@ export async function getRepositories(): Promise<string[] | undefined> {
     const quickpick = await window.showQuickPick<RepoListQuickPickItem>(
       quickPickItems,
       {
-        placeHolder: 'Select a repository list. You can define repository lists in the `codeQL.remoteRepositoryLists` setting.',
+        placeHolder: 'Select a repository list. You can define repository lists in the `codeQL.remoteQueries.repositoryLists` setting.',
         ignoreFocusOut: true,
       });
     if (quickpick?.repoList.length) {
@@ -56,7 +56,7 @@ export async function getRepositories(): Promise<string[] | undefined> {
     const remoteRepo = await window.showInputBox({
       title: 'Enter a GitHub repository in the format <owner>/<repo> (e.g. github/codeql)',
       placeHolder: '<owner>/<repo>',
-      prompt: 'Tip: you can save frequently used repositories in the `codeql.remoteRepositoryLists` setting',
+      prompt: 'Tip: you can save frequently used repositories in the `codeQL.remoteQueries.repositoryLists` setting',
       ignoreFocusOut: true,
     });
     if (!remoteRepo) {
@@ -85,7 +85,7 @@ export async function runRemoteQuery(cliServer: cli.CodeQLCliServer, credentials
   let repositories: string[] | undefined;
 
   // If the user has an explicit `.repositories` file, use that.
-  // Otherwise, prompt user to select repositories from the `codeQL.remoteRepositoryLists` setting.
+  // Otherwise, prompt user to select repositories from the `codeQL.remoteQueries.repositoryLists` setting.
   if (await fs.pathExists(repositoriesFile)) {
     void logger.log(`Found '${repositoriesFile}'. Using information from that file to run ${queryFile}.`);
 

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/run-remote-query.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/run-remote-query.test.ts
@@ -126,6 +126,8 @@ describe('run-remote-query', function() {
     const language = 'javascript';
     const credentials = getMockCredentials(0);
     const query = 'select 1';
+    const owner = 'owner';
+    const repo = 'repo';
 
     beforeEach(() => {
       sandbox = sinon.createSandbox();
@@ -152,7 +154,7 @@ describe('run-remote-query', function() {
       const repositories = ['abc/def', 'ghi/jkl', 'mno/pqr', 'stu/vwx'];
 
       // make the function call
-      await mod.attemptRerun(error, credentials, ref, language, repositories, query);
+      await mod.attemptRerun(error, credentials, ref, language, repositories, query, owner, repo);
 
       // check logging output
       expect(logSpy.firstCall.args[0]).to.contain('Unable to run query');
@@ -168,7 +170,7 @@ describe('run-remote-query', function() {
       showInformationMessageWithActionSpy.resolves(true);
 
       // make the function call
-      await mod.attemptRerun(error, credentials, ref, language, repositories, query);
+      await mod.attemptRerun(error, credentials, ref, language, repositories, query, owner, repo);
 
       // check logging output
       expect(logSpy.firstCall.args[0]).to.contain('Unable to run query');


### PR DESCRIPTION
[Internal use only]

Instead of hard-coding the controller repo for viewing remote queries, let users specify a custom one in the settings. This works because we can use a dynamic workflow instead of a workflow file checked in to a controller repo. (Currently behind a feature flag - see linked issue or let me know if you need access for reviewing!) If there's no repo defined in the config, prompt user to enter it in a textbox.

Note: Slightly tangential, but I also renamed the `remoteRepositoryLists` setting and grouped everything related to remote queries under a `codeQL.remoteQueries` category. I'll update the internal instructions with the renamed setting.

## Checklist

N/A - no user-facing changes

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
