### PR TITLE
Fix recommended extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,7 @@
   // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
   // List of extensions which should be recommended for users of this workspace.
   "recommendations": [
-    "eamodio.tsl-problem-matcher",
+    "amodio.tsl-problem-matcher",
     "dbaeumer.vscode-eslint",
     "eternalphane.tsfmt-vscode"
   ],


### PR DESCRIPTION
We recommend an extension that can't be found, apparently 🙃 I've been getting this warning:
![image](https://user-images.githubusercontent.com/42641846/139445826-a89f603b-e778-487d-8cb0-e8cabf63898b.png)

According to the VS Code marketplace, the correct ID for this extension is: `amodio.tsl-problem-matcher` 
https://marketplace.visualstudio.com/items?itemName=amodio.tsl-problem-matcher

## Checklist


N/A
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
