### PR TITLE
Avoid testing for the correct CLI_VERSION if CLI_PATH is set

### DIFF
--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/run-cli.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/run-cli.test.ts
@@ -29,7 +29,7 @@ describe('Use cli', function() {
     }
   });
 
-  if (process.env.CLI_VERSION !== 'nightly') {
+  if (process.env.CLI_VERSION && process.env.CLI_VERSION !== 'nightly') {
     it('should have the correct version of the cli', async () => {
       expect(
         (await cli.getVersion()).toString()

--- a/extensions/ql-vscode/src/vscode-tests/ensureCli.ts
+++ b/extensions/ql-vscode/src/vscode-tests/ensureCli.ts
@@ -61,6 +61,9 @@ export async function ensureCli(useCli: boolean) {
     if ('CLI_PATH' in process.env) {
       const executablePath = process.env.CLI_PATH;
       console.log(`Using existing CLI at ${executablePath}`);
+
+      // The CLI_VERSION env variable is not used when the CLI_PATH is set.
+      delete process.env.CLI_VERSION;
       return;
     }
 


### PR DESCRIPTION
This should fix the failing CLI integration tests.