### PR TITLE
Tidy up language dropdown

### DIFF
--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -415,7 +415,7 @@ export class CachedOperation<U> {
  * @see cli.CliVersionConstraint.supportsLanguageName
  * @see cli.CodeQLCliServer.resolveDatabase
  */
-const dbSchemeToLanguage = {
+export const dbSchemeToLanguage = {
   'semmlecode.javascript.dbscheme': 'javascript',
   'semmlecode.cpp.dbscheme': 'cpp',
   'semmlecode.dbscheme': 'java',
@@ -498,14 +498,12 @@ export async function findLanguage(
   }
 
   // will be undefined if user cancels the quick pick.
-  return await askForLanguage(false);
+  return await askForLanguage(cliServer, false);
 }
 
-export const supportedLanguages = Object.values(dbSchemeToLanguage).sort();
-
-export async function askForLanguage(throwOnEmpty = true): Promise<string | undefined> {
+export async function askForLanguage(cliServer: CodeQLCliServer, throwOnEmpty = true): Promise<string | undefined> {
   const language = await Window.showQuickPick(
-    supportedLanguages,
+    await cliServer.getSupportedLanguages(),
     { placeHolder: 'Select target language for your query', ignoreFocusOut: true }
   );
   if (!language) {

--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -421,7 +421,8 @@ const dbSchemeToLanguage = {
   'semmlecode.dbscheme': 'java',
   'semmlecode.python.dbscheme': 'python',
   'semmlecode.csharp.dbscheme': 'csharp',
-  'go.dbscheme': 'go'
+  'go.dbscheme': 'go',
+  'ruby.dbscheme': 'ruby'
 };
 
 export const languageToDbScheme = Object.entries(dbSchemeToLanguage).reduce((acc, [k, v]) => {
@@ -500,7 +501,7 @@ export async function findLanguage(
   return await askForLanguage(false);
 }
 
-export const supportedLanguages = ['cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby'];
+export const supportedLanguages = Object.values(dbSchemeToLanguage).sort();
 
 export async function askForLanguage(throwOnEmpty = true): Promise<string | undefined> {
   const language = await Window.showQuickPick(

--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -497,14 +497,14 @@ export async function findLanguage(
   }
 
   // will be undefined if user cancels the quick pick.
-  return await askForLanguage(cliServer, false);
+  return await askForLanguage(false);
 }
 
+export const supportedLanguages = ['cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby'];
 
-export async function askForLanguage(cliServer: CodeQLCliServer, throwOnEmpty = true): Promise<string | undefined> {
-  const availableLanguages = Object.keys(await cliServer.resolveLanguages()).sort();
+export async function askForLanguage(throwOnEmpty = true): Promise<string | undefined> {
   const language = await Window.showQuickPick(
-    availableLanguages,
+    supportedLanguages,
     { placeHolder: 'Select target language for your query', ignoreFocusOut: true }
   );
   if (!language) {

--- a/extensions/ql-vscode/src/run-remote-query.ts
+++ b/extensions/ql-vscode/src/run-remote-query.ts
@@ -134,7 +134,7 @@ async function generateQueryPack(cliServer: cli.CodeQLCliServer, queryFile: stri
 
   } else {
     // open popup to ask for language if not already hardcoded
-    language = fallbackLanguage || await askForLanguage();
+    language = fallbackLanguage || await askForLanguage(cliServer);
 
     // copy only the query file to the query pack directory
     // and generate a synthetic query pack

--- a/extensions/ql-vscode/src/run-remote-query.ts
+++ b/extensions/ql-vscode/src/run-remote-query.ts
@@ -134,7 +134,7 @@ async function generateQueryPack(cliServer: cli.CodeQLCliServer, queryFile: stri
 
   } else {
     // open popup to ask for language if not already hardcoded
-    language = fallbackLanguage || await askForLanguage(cliServer);
+    language = fallbackLanguage || await askForLanguage();
 
     // copy only the query file to the query pack directory
     // and generate a synthetic query pack

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/run-cli.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/run-cli.test.ts
@@ -6,7 +6,7 @@ import { SemVer } from 'semver';
 import { CodeQLCliServer, QueryInfoByLanguage } from '../../cli';
 import { CodeQLExtensionInterface } from '../../extension';
 import { skipIfNoCodeQL } from '../ensureCli';
-import { getOnDiskWorkspaceFolders, getQlPackForDbscheme, languageToDbScheme } from '../../helpers';
+import { getOnDiskWorkspaceFolders, getQlPackForDbscheme, languageToDbScheme, supportedLanguages } from '../../helpers';
 import { resolveQueries } from '../../contextual/queryResolver';
 import { KeyType } from '../../contextual/keyType';
 
@@ -14,8 +14,6 @@ import { KeyType } from '../../contextual/keyType';
  * Perform proper integration tests by running the CLI
  */
 describe('Use cli', function() {
-  const supportedLanguages = ['cpp', 'csharp', 'go', 'java', 'javascript', 'python'];
-
   this.timeout(60000);
 
   let cli: CodeQLCliServer;


### PR DESCRIPTION
The language dropdown for remote queries included some extra stuff like `xml`:

![image](https://user-images.githubusercontent.com/42641846/141145964-183bb14d-9807-4926-8aea-c8591f27805f.png)

That list came from a call to `codeql resolve languages`, which I've now replaced with a hard-coded list of languages. (We already had a hard-coded list of supported languages, so I didn't feel too bad about reusing that one 🙃 )

## Checklist

N/A: this is only relevant for remote queries, which is still an internal-only feature.

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
