### PR TITLE
Add a `codeql` task provider

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Emit a more explicit error message when a user tries to add a database with an unzipped source folder to the workspace. [#1021](https://github.com/github/vscode-codeql/pull/1021)
 - Ensure `src.zip` archives are used as the canonical source instead of `src` folders when importing databases. [#1025](https://github.com/github/vscode-codeql/pull/1025)
+- Add a CodeQL task provider. You can now run certain CodeQL CLI commands from the VS Code _Run Tasks_ menu. [#1014](https://github.com/github/vscode-codeql/pull/1014)
 
 ## 1.5.7 - 23 November 2021
 

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -986,7 +986,14 @@
           },
           "commandArgs": {
             "type": "array",
-            "description": "Additional command options."
+            "description": "Additional command arguments."
+          },
+          "prompts": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            },
+            "description": "A list of prompts to display to the user."
           }
         }
       }

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -972,6 +972,24 @@
         "view": "codeQLDatabases",
         "contents": "Add a CodeQL database:\n[From a folder](command:codeQLDatabases.chooseDatabaseFolder)\n[From an archive](command:codeQLDatabases.chooseDatabaseArchive)\n[From a URL (as a zip file)](command:codeQLDatabases.chooseDatabaseInternet)\n[From LGTM](command:codeQLDatabases.chooseDatabaseLgtm)"
       }
+    ],
+    "taskDefinitions": [
+      {
+        "type": "codeql",
+        "required": [
+          "command"
+        ],
+        "properties": {
+          "command": {
+            "type": "string",
+            "description": "The CodeQL CLI command to execute."
+          },
+          "commandArgs": {
+            "type": "array",
+            "description": "Additional command options."
+          }
+        }
+      }
     ]
   },
   "scripts": {

--- a/extensions/ql-vscode/src/codeql-task-provider.ts
+++ b/extensions/ql-vscode/src/codeql-task-provider.ts
@@ -37,7 +37,16 @@ export class CodeQLTaskProvider implements vscode.TaskProvider {
       return this.tasks;
     }
     // Hard-code examples for now. Not sure if we can do this in a better way.
-    const commands: string[] = ['resolve languages', 'version'];
+    const commands: string[] = [
+      'resolve languages',
+      'version',
+      'pack install',      // TODO: Specify which qlpack to install dependencies for.
+      'resolve queries',   // TODO: Specify which query, directory, or suite to resolve. Also specify search path/additional packs.
+      'resolve qlpacks',   // TODO: Specify a search path/additional packs.
+      // 'pack publish',     // Needs a PAT (from octokit?)
+      // 'pack download',    // Needs a PAT (from octokit?)
+      // 'database create'   // Needs additional args.
+    ];
     const commandArgs: string[][] = [[]];
 
     const tasks: vscode.Task[] | undefined = [];
@@ -73,6 +82,8 @@ class CodeQLTaskTerminal implements vscode.Pseudoterminal {
 
   private fileWatcher: vscode.FileSystemWatcher | undefined;
 
+  // TODO: Open the terminal (i.e. run the task) in an appropriate folder (e.g. the enclosing folder of the currently active editor).
+  // Currently, it is run from the first workspace folder (codeql-custom-queries-cpp in the starter workspace).
   constructor(private cliServer: CodeQLCliServer, private command: string, private commandArgs: string[]) {
   }
 

--- a/extensions/ql-vscode/src/codeql-task-provider.ts
+++ b/extensions/ql-vscode/src/codeql-task-provider.ts
@@ -1,0 +1,96 @@
+import * as vscode from 'vscode';
+import { CodeQLCliServer } from './cli';
+
+interface CodeQLTaskDefinition extends vscode.TaskDefinition {
+  /**
+   * The command to run.
+   */
+  command: string;
+
+  /**
+   * Additional command arguments.
+   */
+  commandArgs?: string[];
+}
+
+export class CodeQLTaskProvider implements vscode.TaskProvider {
+  static CodeQLType = 'codeql';
+  private tasks: vscode.Task[] | undefined;
+
+  constructor(private cliServer: CodeQLCliServer) { }
+
+  public provideTasks(): vscode.Task[] {
+    return this.getTasks();
+  }
+
+  public resolveTask(_task: vscode.Task): vscode.Task | undefined {
+    const command: string = _task.definition.command;
+    if (command) {
+      const definition: CodeQLTaskDefinition = <any>_task.definition;
+      return this.getTask(definition.command, definition.commandArgs ?? [], definition);
+    }
+    return undefined;
+  }
+
+  private getTasks(): vscode.Task[] {
+    if (this.tasks !== undefined) {
+      return this.tasks;
+    }
+    // Hard-code examples for now. Not sure if we can do this in a better way.
+    const commands: string[] = ['resolve languages', 'version'];
+    const commandArgs: string[][] = [[]];
+
+    const tasks: vscode.Task[] | undefined = [];
+    commands.forEach(command => {
+      commandArgs.forEach(commandArgsGroup => {
+        tasks.push(this.getTask(command, commandArgsGroup));
+      });
+    });
+    this.tasks = tasks;
+    return this.tasks;
+  }
+
+  private getTask(command: string, commandArgs: string[], definition?: CodeQLTaskDefinition): vscode.Task {
+    if (definition === undefined) {
+      definition = {
+        type: CodeQLTaskProvider.CodeQLType,
+        command,
+        commandArgs
+      };
+    }
+    return new vscode.Task(definition, vscode.TaskScope.Workspace, `${command} ${commandArgs.join(' ')}`,
+      CodeQLTaskProvider.CodeQLType, new vscode.CustomExecution(async (): Promise<vscode.Pseudoterminal> => {
+        return new CodeQLTaskTerminal(this.cliServer, command, commandArgs);
+      }));
+  }
+}
+
+class CodeQLTaskTerminal implements vscode.Pseudoterminal {
+  private writeEmitter = new vscode.EventEmitter<string>();
+  onDidWrite: vscode.Event<string> = this.writeEmitter.event;
+  private closeEmitter = new vscode.EventEmitter<number>();
+  onDidClose?: vscode.Event<number> = this.closeEmitter.event;
+
+  private fileWatcher: vscode.FileSystemWatcher | undefined;
+
+  constructor(private cliServer: CodeQLCliServer, private command: string, private commandArgs: string[]) {
+  }
+
+  async open(): Promise<void> {
+    await this.runCli([this.command], this.commandArgs);
+  }
+
+  close(): void {
+    // The terminal has been closed. Shutdown the build.
+    if (this.fileWatcher) {
+      this.fileWatcher.dispose();
+    }
+  }
+
+  private async runCli(command: string[], commandArgs: string[]): Promise<void> {
+    this.writeEmitter.fire('Running CodeQL task\r\n');
+    const output = await this.cliServer.runCodeQlCliCommand(command, commandArgs, '');
+    this.writeEmitter.fire(output);
+    this.closeEmitter.fire(0);
+  }
+}

--- a/extensions/ql-vscode/src/codeql-task-provider.ts
+++ b/extensions/ql-vscode/src/codeql-task-provider.ts
@@ -89,8 +89,12 @@ class CodeQLTaskTerminal implements vscode.Pseudoterminal {
 
   private async runCli(command: string[], commandArgs: string[]): Promise<void> {
     this.writeEmitter.fire('Running CodeQL task\r\n');
-    const output = await this.cliServer.runCodeQlCliCommand(command, commandArgs, '');
-    this.writeEmitter.fire(output);
+    try {
+      const output = await this.cliServer.runCodeQlCliCommand(command, commandArgs, '');
+      this.writeEmitter.fire(output);
+    } catch (e) {
+      this.writeEmitter.fire(`Error running CodeQL task: ${e}\r\n`);
+    }
     this.closeEmitter.fire(0);
   }
 }

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -11,7 +11,8 @@ import {
   window as Window,
   env,
   window,
-  QuickPickItem
+  QuickPickItem,
+  tasks
 } from 'vscode';
 import { LanguageClient } from 'vscode-languageclient';
 import * as os from 'os';
@@ -76,6 +77,7 @@ import { CodeQlStatusBarHandler } from './status-bar';
 import { Credentials } from './authentication';
 import { runRemoteQuery } from './remote-queries/run-remote-query';
 import { RemoteQueriesInterfaceManager } from './remote-queries/remote-queries-interface';
+import { CodeQLTaskProvider } from './codeql-task-provider';
 
 /**
  * extension.ts
@@ -384,6 +386,10 @@ async function activateWithInstalledDistribution(
 
   const statusBar = new CodeQlStatusBarHandler(cliServer, distributionConfigListener);
   ctx.subscriptions.push(statusBar);
+
+  void logger.log('Initializing CodeQL task provider...');
+  const taskProvider = tasks.registerTaskProvider(CodeQLTaskProvider.CodeQLType, new CodeQLTaskProvider(cliServer));
+  ctx.subscriptions.push(taskProvider);
 
   void logger.log('Initializing query server client.');
   const qs = new qsClient.QueryServerClient(


### PR DESCRIPTION
Adds a `codeql` task provider. The idea is that we can use this for packaging commands (and others). See internal issue for more context.

Currently, the available tasks are:
- `resolve qlpacks` in the workspace
- `pack download` (only for public packages for now)
- `pack install` (only works for qlpacks in the root of a workspace folder)

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
