### PR TITLE
[Internal only] Support running queries with ML models from CodeQL packs

### DIFF
--- a/extensions/ql-vscode/package-lock.json
+++ b/extensions/ql-vscode/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "vscode-codeql",
-      "version": "1.5.7",
+      "version": "1.5.8",
       "license": "MIT",
       "dependencies": {
         "@octokit/rest": "^18.5.6",

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -333,3 +333,15 @@ export function getRemoteControllerRepo(): string | undefined {
 export async function setRemoteControllerRepo(repo: string | undefined) {
   await REMOTE_CONTROLLER_REPO.updateValue(repo, ConfigurationTarget.Global);
 }
+
+/**
+ * Whether to insecurely load ML models from CodeQL packs.
+ *
+ * This setting is for internal users only.
+ */
+const SHOULD_INSECURELY_LOAD_MODELS_FROM_PACKS =
+  new Setting('shouldInsecurelyLoadModelsFromPacks', RUNNING_QUERIES_SETTING);
+
+export function shouldInsecurelyLoadMlModelsFromPacks(): boolean {
+  return SHOULD_INSECURELY_LOAD_MODELS_FROM_PACKS.getValue<boolean>();
+}

--- a/extensions/ql-vscode/src/pure/messages.ts
+++ b/extensions/ql-vscode/src/pure/messages.ts
@@ -711,6 +711,11 @@ export interface EvaluateQueriesParams {
 
 export type TemplateDefinitions = { [key: string]: TemplateSource }
 
+export interface MlModel {
+  /** A URI pointing to the root directory of the model. */
+  uri: string;
+}
+
 /**
  * A single query that should be run
  */
@@ -744,6 +749,11 @@ export interface QueryToRun {
    * map should be set to the empty set or give an error.
    */
   allowUnknownTemplates: boolean;
+  /**
+   * The list of ML models that should be made available
+   * when evaluating the query.
+   */
+  availableMlModels?: MlModel[];
 }
 
 /**

--- a/extensions/ql-vscode/src/run-queries.ts
+++ b/extensions/ql-vscode/src/run-queries.ts
@@ -95,7 +95,7 @@ export class QueryInfo {
 
     const callbackId = qs.registerCallback(res => { result = res; });
 
-    const availableMlModelUris: messages.MlModel[] = availableMlModels.map(model => ({ uri: Uri.file(model.path).toString() }));
+    const availableMlModelUris: messages.MlModel[] = availableMlModels.map(model => ({ uri: Uri.file(model.path).toString(true) }));
 
     const queryToRun: messages.QueryToRun = {
       resultsPath: this.resultsPaths.resultsPath,
@@ -630,7 +630,6 @@ export async function compileAndRunQueryAgainstDatabase(
     } catch (e) {
       const message = `Couldn't resolve available ML models for ${qlProgram.queryPath}. Running the ` +
         `query without any ML models: ${e}.`;
-      void logger.log(message);
       void showAndLogErrorMessage(message);
     }
   }

--- a/extensions/ql-vscode/src/run-queries.ts
+++ b/extensions/ql-vscode/src/run-queries.ts
@@ -622,6 +622,7 @@ export async function compileAndRunQueryAgainstDatabase(
   // work with hidden settings, so we manually check that the workspace is trusted before looking at
   // whether the `shouldInsecurelyLoadMlModelsFromPacks` setting is enabled.
   if (workspace.isTrusted &&
+    config.isCanary() &&
     config.shouldInsecurelyLoadMlModelsFromPacks() &&
     await cliServer.cliConstraints.supportsResolveMlModels()) {
     try {

--- a/extensions/ql-vscode/src/run-queries.ts
+++ b/extensions/ql-vscode/src/run-queries.ts
@@ -86,6 +86,7 @@ export class QueryInfo {
   async run(
     qs: qsClient.QueryServerClient,
     upgradeQlo: string | undefined,
+    availableMlModels: cli.MlModelInfo[],
     progress: ProgressCallback,
     token: CancellationToken,
   ): Promise<messages.EvaluationResult> {
@@ -93,12 +94,15 @@ export class QueryInfo {
 
     const callbackId = qs.registerCallback(res => { result = res; });
 
+    const availableMlModelUris: messages.MlModel[] = availableMlModels.map(model => ({ uri: Uri.file(model.path).toString() }));
+
     const queryToRun: messages.QueryToRun = {
       resultsPath: this.resultsPaths.resultsPath,
       qlo: Uri.file(this.compiledQueryPath).toString(),
       compiledUpgrade: upgradeQlo && Uri.file(upgradeQlo).toString(),
       allowUnknownTemplates: true,
       templateValues: this.templates,
+      availableMlModels: availableMlModelUris,
       id: callbackId,
       timeoutSecs: qs.config.timeoutSecs,
     };
@@ -612,6 +616,18 @@ export async function compileAndRunQueryAgainstDatabase(
     void logger.log(`Couldn't resolve metadata for ${qlProgram.queryPath}: ${e}`);
   }
 
+  let availableMlModels: cli.MlModelInfo[] = [];
+  if (await cliServer.cliConstraints.supportsResolveMlModels()) {
+    try {
+      availableMlModels = (await cliServer.resolveMlModels(diskWorkspaceFolders)).models;
+      void logger.log(`Found available ML models at the following paths: ${availableMlModels.map(x => `'${x.path}'`).join(', ')}.`);
+    } catch (e) {
+      const message = `Couldn't resolve available ML models for ${qlProgram.queryPath}: ${e}`;
+      void logger.log(message);
+      void showAndLogErrorMessage(message);
+    }
+  }
+
   const query = new QueryInfo(qlProgram, db, packConfig.dbscheme, quickEvalPosition, metadata, templates);
 
   const upgradeDir = await tmp.dir({ dir: upgradesTmpDir.name, unsafeCleanup: true });
@@ -634,7 +650,7 @@ export async function compileAndRunQueryAgainstDatabase(
     }
 
     if (errors.length === 0) {
-      const result = await query.run(qs, upgradeQlo, progress, token);
+      const result = await query.run(qs, upgradeQlo, availableMlModels, progress, token);
       if (result.resultType !== messages.QueryResultType.SUCCESS) {
         const message = result.message || 'Failed to run query';
         void logger.log(message);


### PR DESCRIPTION
This functionality is for internal users only.  Do not use this functionality if you are not a GitHub employee.

This PR allows internal users to run queries that invoke ML models from CodeQL packs.  When a hidden setting is enabled, ML models are resolved using the CLI command `codeql resolve ml-models`.  To help prevent unintentional use of this functionality, we only respect the hidden setting if the workspace is trusted.

Available ML models are passed to the `availableMlModels` property of the `QueryToRun` object as part of the `evaluation/runQueries` queryserver message.  This makes them available for use in CodeQL queries.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
