### PR TITLE
Ensure src.zip is prioritized over src folder

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [UNRELEASED]
 
-- Emit a more explicit error message when a user tries to add a database with an unzipped source folder to the workspace. [1021](https://github.com/github/vscode-codeql/pull/1021)
+- Emit a more explicit error message when a user tries to add a database with an unzipped source folder to the workspace. [#1021](https://github.com/github/vscode-codeql/pull/1021)
+- Ensure `src.zip` archives are used as the canonical source instead of `src` folders when importing databases. [#1025](https://github.com/github/vscode-codeql/pull/1025)
 
 ## 1.5.7 - 23 November 2021
 

--- a/extensions/ql-vscode/src/databases.ts
+++ b/extensions/ql-vscode/src/databases.ts
@@ -121,20 +121,21 @@ async function findDataset(parentDirectory: string): Promise<vscode.Uri> {
   return vscode.Uri.file(dbAbsolutePath);
 }
 
-async function findSourceArchive(
+// exported for testing
+export async function findSourceArchive(
   databasePath: string, silent = false
 ): Promise<vscode.Uri | undefined> {
-
   const relativePaths = ['src', 'output/src_archive'];
 
   for (const relativePath of relativePaths) {
     const basePath = path.join(databasePath, relativePath);
     const zipPath = basePath + '.zip';
 
-    if (await fs.pathExists(basePath)) {
-      return vscode.Uri.file(basePath);
-    } else if (await fs.pathExists(zipPath)) {
+    // Prefer using a zip archive over a directory.
+    if (await fs.pathExists(zipPath)) {
       return encodeArchiveBasePath(zipPath);
+    } else if (await fs.pathExists(basePath)) {
+      return vscode.Uri.file(basePath);
     }
   }
   if (!silent) {
@@ -161,7 +162,6 @@ async function resolveDatabase(
     datasetUri,
     sourceArchiveUri
   };
-
 }
 
 /** Gets the relative paths of all `.dbscheme` files in the given directory. */


### PR DESCRIPTION
Fixes a bug where legacy databases with both unzipped and zipped sources
were incorrectly being loaded with the src folder.

Fixes #1020.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
