### PR TITLE
Expose remote query submission result

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/remote-query-submission-result.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-query-submission-result.ts
@@ -1,0 +1,6 @@
+import { RemoteQuery } from './remote-query';
+
+export interface RemoteQuerySubmissionResult {
+  queryDirPath?: string;
+  query?: RemoteQuery;
+}

--- a/extensions/ql-vscode/src/remote-queries/remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-query.ts
@@ -1,0 +1,10 @@
+import { Repository } from './repository';
+
+export interface RemoteQuery {
+  queryName: string;
+  queryFilePath: string;
+  controllerRepository: Repository;
+  repositories: Repository[];
+  executionStartTime: Date;
+  actionsWorkflowRunId: number;
+}

--- a/extensions/ql-vscode/src/remote-queries/repository.ts
+++ b/extensions/ql-vscode/src/remote-queries/repository.ts
@@ -1,0 +1,4 @@
+export interface Repository {
+  owner: string;
+  name: string;
+}

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/run-remote-query.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/run-remote-query.test.ts
@@ -68,7 +68,9 @@ describe('Remote queries', function() {
   it('should run a remote query that is part of a qlpack', async () => {
     const fileUri = getFile('data-remote-qlpack/in-pack.ql');
 
-    const queryPackRootDir = (await runRemoteQuery(cli, credentials, fileUri, true, progress, token))!;
+    const querySubmissionResult = await runRemoteQuery(cli, credentials, fileUri, true, progress, token);
+    expect(querySubmissionResult).to.be.ok;
+    const queryPackRootDir = querySubmissionResult!.queryDirPath!;
     printDirectoryContents(queryPackRootDir);
 
     // to retrieve the list of repositories
@@ -117,7 +119,9 @@ describe('Remote queries', function() {
   it('should run a remote query that is not part of a qlpack', async () => {
     const fileUri = getFile('data-remote-no-qlpack/in-pack.ql');
 
-    const queryPackRootDir = (await runRemoteQuery(cli, credentials, fileUri, true, progress, token))!;
+    const querySubmissionResult = await runRemoteQuery(cli, credentials, fileUri, true, progress, token);
+    expect(querySubmissionResult).to.be.ok;
+    const queryPackRootDir = querySubmissionResult!.queryDirPath!;
 
     // to retrieve the list of repositories
     // and a second time to ask for the language
@@ -172,7 +176,9 @@ describe('Remote queries', function() {
   it('should run a remote query that is nested inside a qlpack', async () => {
     const fileUri = getFile('data-remote-qlpack-nested/subfolder/in-pack.ql');
 
-    const queryPackRootDir = (await runRemoteQuery(cli, credentials, fileUri, true, progress, token))!;
+    const querySubmissionResult = await runRemoteQuery(cli, credentials, fileUri, true, progress, token);
+    expect(querySubmissionResult).to.be.ok;
+    const queryPackRootDir = querySubmissionResult!.queryDirPath!;
 
     // to retrieve the list of repositories
     expect(showQuickPickSpy).to.have.been.calledOnce;


### PR DESCRIPTION
Small refactor to expose the result of a remote query submission. 

The remote query details will be used in future PRs.