### PR TITLE
Pass `--old-eval-stats` to query server

### DIFF
--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -169,7 +169,7 @@ export class CodeQLCliServer implements Disposable {
   /** Version of current cli, lazily computed by the `getVersion()` method */
   private _version: SemVer | undefined;
 
-  /** 
+  /**
    * The languages supported by the current version of the CLI, computed by `getSupportedLanguages()`.
    */
   private _supportedLanguages: string[] | undefined;
@@ -806,7 +806,7 @@ export class CodeQLCliServer implements Disposable {
   /**
    * Gets the list of available languages. Refines the result of `resolveLanguages()`, by excluding
    * extra things like "xml" and "properties".
-   * 
+   *
    * @returns An array of languages that are supported by the current version of the CodeQL CLI.
    */
   public async getSupportedLanguages(): Promise<string[]> {
@@ -1186,6 +1186,11 @@ export class CliVersionConstraint {
    */
   public static CLI_VERSION_WITH_RESOLVE_ML_MODELS = new SemVer('2.7.3');
 
+  /**
+   * CLI version where the `--old-eval-stats` option to the query server was introduced.
+   */
+  public static CLI_VERSION_WITH_OLD_EVAL_STATS = new SemVer('2.7.4');
+
   constructor(private readonly cli: CodeQLCliServer) {
     /**/
   }
@@ -1234,4 +1239,7 @@ export class CliVersionConstraint {
     return this.isVersionAtLeast(CliVersionConstraint.CLI_VERSION_WITH_RESOLVE_ML_MODELS);
   }
 
+  async supportsOldEvalStats() {
+    return this.isVersionAtLeast(CliVersionConstraint.CLI_VERSION_WITH_OLD_EVAL_STATS);
+  }
 }

--- a/extensions/ql-vscode/src/queryserver-client.ts
+++ b/extensions/ql-vscode/src/queryserver-client.ts
@@ -167,6 +167,10 @@ export class QueryServerClient extends DisposableObject {
       args.push('--require-db-registration');
     }
 
+    if (await this.cliServer.cliConstraints.supportsOldEvalStats()) {
+      args.push('--old-eval-stats');
+    }
+
     if (this.config.debug) {
       args.push('--debug', '--tuple-counting');
     }


### PR DESCRIPTION
This is in preparation of supporting structured query logs.
When passing this option, use the old format of query logs.
Later, when we want to add support for structured query
logs, we can add remove this option.

No changelog required since this is an internal change.

## Checklist

- [n/a] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [n/a] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
