### PR TITLE
Avoid showing the alert option in the drop down

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [UNRELEASED]
 
+- Fix a bug where the _Alerts_ option would show in the results view even if there is no alerts table available. [#1038](https://github.com/github/vscode-codeql/pull/1038)
+
 ## 1.5.8 - 2 December 2021
 
 - Emit a more explicit error message when a user tries to add a database with an unzipped source folder to the workspace. [#1021](https://github.com/github/vscode-codeql/pull/1021)

--- a/extensions/ql-vscode/src/view/result-tables.tsx
+++ b/extensions/ql-vscode/src/view/result-tables.tsx
@@ -106,7 +106,9 @@ export class ResultTables
   }
 
   private getResultSetNames(): string[] {
-    return this.props.parsedResultSets.resultSetNames.concat([ALERTS_TABLE_NAME]);
+    return this.props.interpretation
+      ? this.props.parsedResultSets.resultSetNames.concat([ALERTS_TABLE_NAME])
+      : this.props.parsedResultSets.resultSetNames;
   }
 
   constructor(props: ResultTablesProps) {


### PR DESCRIPTION
Only show it when there really is an alert table to see.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [n/a] Issues have been created for any UI or other user-facing changes made by this pull request.
- [n/a] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
