### PR TITLE
Remote queries: Open query file/text from webview

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -12,7 +12,9 @@ import {
   env,
   window,
   QuickPickItem,
-  Range
+  Range,
+  workspace,
+  ProviderResult
 } from 'vscode';
 import { LanguageClient } from 'vscode-languageclient';
 import * as os from 'os';
@@ -78,6 +80,7 @@ import { CodeQlStatusBarHandler } from './status-bar';
 import { Credentials } from './authentication';
 import { RemoteQueriesManager } from './remote-queries/remote-queries-manager';
 import { RemoteQuery } from './remote-queries/remote-query';
+import { URLSearchParams } from 'url';
 
 /**
  * extension.ts
@@ -773,6 +776,8 @@ async function activateWithInstalledDistribution(
   void logger.log('Initializing remote queries interface.');
   const rqm = new RemoteQueriesManager(ctx, logger, cliServer);
 
+  registerTextProvider();
+
   // The "runRemoteQuery" command is internal-only.
   ctx.subscriptions.push(
     commandRunnerWithProgress('codeQL.runRemoteQuery', async (
@@ -980,3 +985,20 @@ async function initializeLogging(ctx: ExtensionContext): Promise<void> {
 }
 
 const checkForUpdatesCommand = 'codeQL.checkForUpdatesToCLI';
+
+/**
+ * This text provider lets us open readonly files in the editor.
+ * 
+ * TODO: Consolidate this with the 'codeql' text provider in query-history.ts.
+ */
+function registerTextProvider() {
+  workspace.registerTextDocumentContentProvider('remote-query', {
+    provideTextDocumentContent(
+      uri: Uri
+    ): ProviderResult<string> {
+      const params = new URLSearchParams(uri.query);
+
+      return params.get('queryText');
+    },
+  });
+}

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -776,7 +776,7 @@ async function activateWithInstalledDistribution(
   void logger.log('Initializing remote queries interface.');
   const rqm = new RemoteQueriesManager(ctx, logger, cliServer);
 
-  registerTextProvider();
+  registerRemoteQueryTextProvider();
 
   // The "runRemoteQuery" command is internal-only.
   ctx.subscriptions.push(
@@ -991,7 +991,7 @@ const checkForUpdatesCommand = 'codeQL.checkForUpdatesToCLI';
  * 
  * TODO: Consolidate this with the 'codeql' text provider in query-history.ts.
  */
-function registerTextProvider() {
+function registerRemoteQueryTextProvider() {
   workspace.registerTextDocumentContentProvider('remote-query', {
     provideTextDocumentContent(
       uri: Uri

--- a/extensions/ql-vscode/src/pure/interface-types.ts
+++ b/extensions/ql-vscode/src/pure/interface-types.ts
@@ -368,7 +368,8 @@ export interface ParsedResultSets {
 
 export type FromRemoteQueriesMessage =
   | RemoteQueryLoadedMessage
-  | RemoteQueryErrorMessage;
+  | RemoteQueryErrorMessage
+  | OpenFileMsg;
 
 export type ToRemoteQueriesMessage =
   | SetRemoteQueryResultMessage;

--- a/extensions/ql-vscode/src/pure/interface-types.ts
+++ b/extensions/ql-vscode/src/pure/interface-types.ts
@@ -181,6 +181,11 @@ export interface OpenFileMsg {
   filePath: string;
 }
 
+export interface OpenVirtualFileMsg {
+  t: 'openVirtualFile';
+  queryText: string;
+}
+
 /**
  * Message from the results view to toggle the display of
  * query diagnostics.
@@ -369,7 +374,8 @@ export interface ParsedResultSets {
 export type FromRemoteQueriesMessage =
   | RemoteQueryLoadedMessage
   | RemoteQueryErrorMessage
-  | OpenFileMsg;
+  | OpenFileMsg
+  | OpenVirtualFileMsg;
 
 export type ToRemoteQueriesMessage =
   | SetRemoteQueryResultMessage;

--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -32,7 +32,7 @@ export type QueryHistoryItemOptions = {
   isQuickQuery?: boolean;
 };
 
-const SHOW_QUERY_TEXT_MSG = `\
+export const SHOW_QUERY_TEXT_MSG = `\
 ////////////////////////////////////////////////////////////////////////////////////
 // This is the text of the entire query file when it was executed for this query  //
 // run. The text or dependent libraries may have changed since then.              //

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
@@ -4,6 +4,7 @@ import {
   window as Window,
   ViewColumn,
   Uri,
+  workspace,
 } from 'vscode';
 import * as path from 'path';
 
@@ -62,6 +63,8 @@ export class RemoteQueriesInterfaceManager {
     return {
       queryTitle: query.queryName,
       queryFile: queryFile,
+      queryPath: query.queryFilePath,
+      queryTextTmpFile: query.queryTextTmpFile,
       totalRepositoryCount: query.repositories.length,
       affectedRepositoryCount: affectedRepositories.length,
       totalResultCount: totalResultCount,
@@ -129,6 +132,11 @@ export class RemoteQueriesInterfaceManager {
     });
   }
 
+  public async openFile(filePath: string) {
+    const textDocument = await workspace.openTextDocument(filePath);
+    await Window.showTextDocument(textDocument, ViewColumn.One);
+  }
+
   private async handleMsgFromView(
     msg: FromRemoteQueriesMessage
   ): Promise<void> {
@@ -142,6 +150,9 @@ export class RemoteQueriesInterfaceManager {
         void this.logger.log(
           `Remote query error: ${msg.error}`
         );
+        break;
+      case 'openFile':
+        await this.openFile(msg.filePath);
         break;
       default:
         assertNever(msg);

--- a/extensions/ql-vscode/src/remote-queries/remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-query.ts
@@ -3,7 +3,7 @@ import { Repository } from './repository';
 export interface RemoteQuery {
   queryName: string;
   queryFilePath: string;
-  queryTextTmpFile: string;
+  queryTextTmpFilePath: string;
   controllerRepository: Repository;
   repositories: Repository[];
   executionStartTime: Date;

--- a/extensions/ql-vscode/src/remote-queries/remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-query.ts
@@ -3,7 +3,7 @@ import { Repository } from './repository';
 export interface RemoteQuery {
   queryName: string;
   queryFilePath: string;
-  queryTextTmpFilePath: string;
+  queryText: string;
   controllerRepository: Repository;
   repositories: Repository[];
   executionStartTime: Date;

--- a/extensions/ql-vscode/src/remote-queries/remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-query.ts
@@ -3,6 +3,7 @@ import { Repository } from './repository';
 export interface RemoteQuery {
   queryName: string;
   queryFilePath: string;
+  queryTextTmpFile: string;
   controllerRepository: Repository;
   repositories: Repository[];
   executionStartTime: Date;

--- a/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
@@ -467,9 +467,13 @@ function buildRemoteQueryEntity(
     return { owner: owner, name: repo };
   });
 
+  // TODO: Get query text from query file and save it in a temporary .ql file. 
+  const queryTextTmpFile = '';
+
   return {
     queryName,
     queryFilePath,
+    queryTextTmpFile,
     controllerRepository: {
       owner: controllerRepoOwner,
       name: controllerRepoName,

--- a/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
@@ -468,12 +468,12 @@ function buildRemoteQueryEntity(
   });
 
   // TODO: Get query text from query file and save it in a temporary .ql file. 
-  const queryTextTmpFile = '';
+  const queryTextTmpFilePath = '';
 
   return {
     queryName,
     queryFilePath,
-    queryTextTmpFile,
+    queryTextTmpFilePath,
     controllerRepository: {
       owner: controllerRepoOwner,
       name: controllerRepoName,

--- a/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
@@ -467,26 +467,12 @@ async function buildRemoteQueryEntity(
     return { owner: owner, name: repo };
   });
 
-  // Get the query text from query file and save it in a temporary .ql file. 
-  const queryTextTmpFilePath = path.join(tmpDir.name, `tmp-${queryName}`);
   const queryText = await fs.readFile(queryFilePath, 'utf8');
-  await fs.writeFile(
-    queryTextTmpFilePath, `\
-////////////////////////////////////////////////////////////////////////////////////
-// This is the text of the entire query file when it was executed for this query  //
-// run. The text or dependent libraries may have changed since then.              //
-//                                                                                //
-// To make changes to the query and the dependent libraries, save this file in a  //
-// suitable, permanent location.                                                  //
-////////////////////////////////////////////////////////////////////////////////////
-
-${queryText}`
-  );
 
   return {
     queryName,
     queryFilePath,
-    queryTextTmpFilePath,
+    queryText,
     controllerRepository: {
       owner: controllerRepoOwner,
       name: controllerRepoName,

--- a/extensions/ql-vscode/src/remote-queries/shared/remote-query-result.ts
+++ b/extensions/ql-vscode/src/remote-queries/shared/remote-query-result.ts
@@ -2,7 +2,7 @@ export interface RemoteQueryResult {
   queryTitle: string;
   queryFileName: string;
   queryFilePath: string;
-  queryTextTmpFilePath: string;
+  queryText: string;
   totalRepositoryCount: number;
   affectedRepositoryCount: number;
   totalResultCount: number;

--- a/extensions/ql-vscode/src/remote-queries/shared/remote-query-result.ts
+++ b/extensions/ql-vscode/src/remote-queries/shared/remote-query-result.ts
@@ -1,8 +1,8 @@
 export interface RemoteQueryResult {
   queryTitle: string;
-  queryFile: string;
-  queryPath: string;
-  queryTextTmpFile: string;
+  queryFileName: string;
+  queryFilePath: string;
+  queryTextTmpFilePath: string;
   totalRepositoryCount: number;
   affectedRepositoryCount: number;
   totalResultCount: number;

--- a/extensions/ql-vscode/src/remote-queries/shared/remote-query-result.ts
+++ b/extensions/ql-vscode/src/remote-queries/shared/remote-query-result.ts
@@ -1,6 +1,8 @@
 export interface RemoteQueryResult {
   queryTitle: string;
   queryFile: string;
+  queryPath: string;
+  queryTextTmpFile: string;
   totalRepositoryCount: number;
   affectedRepositoryCount: number;
   totalResultCount: number;

--- a/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
@@ -12,6 +12,8 @@ const numOfReposInContractedMode = 10;
 const emptyQueryResult: RemoteQueryResult = {
   queryTitle: '',
   queryFile: '',
+  queryPath: '',
+  queryTextTmpFile: '',
   totalRepositoryCount: 0,
   affectedRepositoryCount: 0,
   totalResultCount: 0,
@@ -37,6 +39,13 @@ const AnalysisResultItem = (props: AnalysisResult) => (
     </span>
   </span>
 );
+
+function openFile(filePath: string): void {
+  vscode.postMessage({
+    t: 'openFile',
+    filePath
+  });
+}
 
 export function RemoteQueries(): JSX.Element {
   const [queryResult, setQueryResult] = useState<RemoteQueryResult>(emptyQueryResult);
@@ -64,6 +73,14 @@ export function RemoteQueries(): JSX.Element {
   const numOfReposToShow = repoListExpanded ? queryResult.results.length : numOfReposInContractedMode;
 
   try {
+    const openQueryFile = () => {
+      openFile(queryResult.queryPath);
+    };
+
+    const openQueryTextTmpFile = () => {
+      openFile(queryResult.queryTextTmpFile);
+    };
+
     return <div className="vscode-codeql__remote-queries-view">
       <h1 className="vscode-codeql__query-title">{queryResult.queryTitle}</h1>
 
@@ -72,8 +89,16 @@ export function RemoteQueries(): JSX.Element {
         ({queryResult.executionDuration}), {queryResult.executionTimestamp}
       </p>
       <p className="vscode-codeql__paragraph">
-        <span className="vscode-codeql__query-file">{octicons.file} <span>{queryResult.queryFile}</span></span>
-        <span>{octicons.codeSquare} <span>query</span></span>
+        <span className="vscode-codeql__query-file">{octicons.file}
+          <a className="vscode-codeql__query-file-link" href="#" onClick={openQueryFile}>
+            {queryResult.queryFile}
+          </a>
+        </span>
+        <span>{octicons.codeSquare}
+          <a className="vscode-codeql__query-file-link" href="#" onClick={openQueryTextTmpFile}>
+            query
+          </a>
+        </span>
       </p>
 
       <div className="vscode-codeql__query-summary-container">

--- a/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
@@ -65,21 +65,21 @@ export function RemoteQueries(): JSX.Element {
   const [repoListExpanded, setRepoListExpanded] = useState(false);
   const numOfReposToShow = repoListExpanded ? queryResult.results.length : numOfReposInContractedMode;
 
+  const openQueryFile = () => {
+    vscode.postMessage({
+      t: 'openFile',
+      filePath: queryResult.queryFilePath
+    });
+  };
+
+  const openQueryTextVirtualFile = () => {
+    vscode.postMessage({
+      t: 'openVirtualFile',
+      queryText: queryResult.queryText
+    });
+  };
+
   try {
-    const openQueryFile = () => {
-      vscode.postMessage({
-        t: 'openFile',
-        filePath: queryResult.queryFilePath
-      });
-    };
-
-    const openQueryTextTmpFile = () => {
-      vscode.postMessage({
-        t: 'openVirtualFile',
-        queryText: queryResult.queryText
-      });
-    };
-
     return <div className="vscode-codeql__remote-queries-view">
       <h1 className="vscode-codeql__query-title">{queryResult.queryTitle}</h1>
 
@@ -94,7 +94,7 @@ export function RemoteQueries(): JSX.Element {
           </a>
         </span>
         <span>{octicons.codeSquare}
-          <a className="vscode-codeql__query-file-link" href="#" onClick={openQueryTextTmpFile}>
+          <a className="vscode-codeql__query-file-link" href="#" onClick={openQueryTextVirtualFile}>
             query
           </a>
         </span>

--- a/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
@@ -13,7 +13,7 @@ const emptyQueryResult: RemoteQueryResult = {
   queryTitle: '',
   queryFileName: '',
   queryFilePath: '',
-  queryTextTmpFilePath: '',
+  queryText: '',
   totalRepositoryCount: 0,
   affectedRepositoryCount: 0,
   totalResultCount: 0,
@@ -39,13 +39,6 @@ const AnalysisResultItem = (props: AnalysisResult) => (
     </span>
   </span>
 );
-
-function openFile(filePath: string): void {
-  vscode.postMessage({
-    t: 'openFile',
-    filePath
-  });
-}
 
 export function RemoteQueries(): JSX.Element {
   const [queryResult, setQueryResult] = useState<RemoteQueryResult>(emptyQueryResult);
@@ -74,11 +67,17 @@ export function RemoteQueries(): JSX.Element {
 
   try {
     const openQueryFile = () => {
-      openFile(queryResult.queryFilePath);
+      vscode.postMessage({
+        t: 'openFile',
+        filePath: queryResult.queryFilePath
+      });
     };
 
     const openQueryTextTmpFile = () => {
-      openFile(queryResult.queryTextTmpFilePath);
+      vscode.postMessage({
+        t: 'openVirtualFile',
+        queryText: queryResult.queryText
+      });
     };
 
     return <div className="vscode-codeql__remote-queries-view">

--- a/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
@@ -11,9 +11,9 @@ const numOfReposInContractedMode = 10;
 
 const emptyQueryResult: RemoteQueryResult = {
   queryTitle: '',
-  queryFile: '',
-  queryPath: '',
-  queryTextTmpFile: '',
+  queryFileName: '',
+  queryFilePath: '',
+  queryTextTmpFilePath: '',
   totalRepositoryCount: 0,
   affectedRepositoryCount: 0,
   totalResultCount: 0,
@@ -74,11 +74,11 @@ export function RemoteQueries(): JSX.Element {
 
   try {
     const openQueryFile = () => {
-      openFile(queryResult.queryPath);
+      openFile(queryResult.queryFilePath);
     };
 
     const openQueryTextTmpFile = () => {
-      openFile(queryResult.queryTextTmpFile);
+      openFile(queryResult.queryTextTmpFilePath);
     };
 
     return <div className="vscode-codeql__remote-queries-view">
@@ -91,7 +91,7 @@ export function RemoteQueries(): JSX.Element {
       <p className="vscode-codeql__paragraph">
         <span className="vscode-codeql__query-file">{octicons.file}
           <a className="vscode-codeql__query-file-link" href="#" onClick={openQueryFile}>
-            {queryResult.queryFile}
+            {queryResult.queryFileName}
           </a>
         </span>
         <span>{octicons.codeSquare}

--- a/extensions/ql-vscode/src/remote-queries/view/remoteQueries.css
+++ b/extensions/ql-vscode/src/remote-queries/view/remoteQueries.css
@@ -39,6 +39,11 @@
   padding-right: 1em;
 }
 
+.vscode-codeql__query-file-link {
+  text-decoration: none;
+  padding-left: 0.3em;
+}
+
 .vscode-codeql__query-summary-container {
   padding-top: 1.5em;
 }

--- a/extensions/ql-vscode/src/remote-queries/view/remoteQueries.css
+++ b/extensions/ql-vscode/src/remote-queries/view/remoteQueries.css
@@ -42,6 +42,11 @@
 .vscode-codeql__query-file-link {
   text-decoration: none;
   padding-left: 0.3em;
+  color: var(--vscode-editor-foreground);
+}
+
+.vscode-codeql__query-file-link:hover {
+  color: var(--vscode-editor-foreground);
 }
 
 .vscode-codeql__query-summary-container {


### PR DESCRIPTION
Adds some interaction to these buttons in the remote queries webview:

![image](https://user-images.githubusercontent.com/42641846/145982184-a0bb515a-6854-417a-84c6-c244c7bf33b8.png)

- The first one opens the query file that was run, if it exists (similar to what we do in the local results view). 
- The second one opens the exact query text that was run (in a virtual "read-only" file).

### Follow up

- Consolidate the `remote-query` and `codeql` text providers.
- Once #1037 is merged, extract that behaviour so it is used wherever we are opening editors.

## Checklist

N/A: Still an internal-only feature. No user-visible changes.

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
