### PR TITLE
Docs: add clarification on directory for running tests via CLI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ You can use VS Code to debug the extension without explicitly installing it. Jus
 
 Unit tests and many integration tests do not require a copy of the CodeQL CLI.
 
-Outside of vscode, run:
+Outside of vscode, in the `extensions/ql-vscode` directory, run:
 
 ```shell
 npm run test && npm run integration


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

This PR adds a small clarification to the Contributing documentation. Previously it wasn't clear (to me ✨) which directory to run the commands for CLI testing from. 

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
