### PR TITLE
Implement download behaviour in remote queries view

### DIFF
--- a/extensions/ql-vscode/src/pure/interface-types.ts
+++ b/extensions/ql-vscode/src/pure/interface-types.ts
@@ -1,4 +1,5 @@
 import * as sarif from 'sarif';
+import { DownloadLink } from '../remote-queries/download-link';
 import { RemoteQueryResult } from '../remote-queries/shared/remote-query-result';
 import { RawResultSet, ResultRow, ResultSetSchema, Column, ResolvableLocationValue } from './bqrs-cli-types';
 
@@ -368,7 +369,8 @@ export interface ParsedResultSets {
 
 export type FromRemoteQueriesMessage =
   | RemoteQueryLoadedMessage
-  | RemoteQueryErrorMessage;
+  | RemoteQueryErrorMessage
+  | RemoteQueryDownloadLinkClickedMessage;
 
 export type ToRemoteQueriesMessage =
   | SetRemoteQueryResultMessage;
@@ -385,4 +387,9 @@ export interface SetRemoteQueryResultMessage {
 export interface RemoteQueryErrorMessage {
   t: 'remoteQueryError';
   error: string;
+}
+
+export interface RemoteQueryDownloadLinkClickedMessage {
+  t: 'remoteQueryDownloadLinkClicked';
+  downloadLink: DownloadLink;
 }

--- a/extensions/ql-vscode/src/remote-queries/download-link.ts
+++ b/extensions/ql-vscode/src/remote-queries/download-link.ts
@@ -3,13 +3,13 @@
  */
 export interface DownloadLink {
   /**
-   *  A unique id of the file/artifact being downloaded. 
+   *  A unique id of the artifact being downloaded. 
    */
   id: string;
 
   /**
    * The URL path to use against the GitHub API to download the
-   * linked file/artifact. 
+   * linked artifact. 
    */
   urlPath: string;
 

--- a/extensions/ql-vscode/src/remote-queries/download-link.ts
+++ b/extensions/ql-vscode/src/remote-queries/download-link.ts
@@ -1,0 +1,20 @@
+/**
+ * Represents a link to an item to be downloaded. 
+ */
+export interface DownloadLink {
+  /**
+   *  A unique id of the file/artifact being downloaded. 
+   */
+  id: string;
+
+  /**
+   * The URL path to use against the GitHub API to download the
+   * linked file/artifact. 
+   */
+  urlPath: string;
+
+  /**
+   * An optional path to follow inside the downloaded directory.
+   */
+  innerFilePath?: string;
+}

--- a/extensions/ql-vscode/src/remote-queries/download-link.ts
+++ b/extensions/ql-vscode/src/remote-queries/download-link.ts
@@ -1,5 +1,5 @@
 /**
- * Represents a link to an item to be downloaded. 
+ * Represents a link to an artifact to be downloaded. 
  */
 export interface DownloadLink {
   /**
@@ -14,7 +14,7 @@ export interface DownloadLink {
   urlPath: string;
 
   /**
-   * An optional path to follow inside the downloaded directory.
+   * An optional path to follow inside the downloaded archive containing the artifact.
    */
   innerFilePath?: string;
 }

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
@@ -56,7 +56,7 @@ export class RemoteQueriesManager {
     if (queryResult.status === 'CompletedSuccessfully') {
       const resultIndex = await getRemoteQueryIndex(credentials, query);
       if (!resultIndex) {
-        await showAndLogErrorMessage(`There was an issue retrieving the result for the query ${query.queryName}`);
+        void showAndLogErrorMessage(`There was an issue retrieving the result for the query ${query.queryName}`);
         return;
       }
 

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
@@ -5,11 +5,13 @@ import { ProgressCallback } from '../commandRunner';
 import { showAndLogErrorMessage, showInformationMessageWithAction } from '../helpers';
 import { Logger } from '../logging';
 import { runRemoteQuery } from './run-remote-query';
-import { getResultIndex, ResultIndexItem } from './gh-actions-api-client';
 import { RemoteQueriesInterfaceManager } from './remote-queries-interface';
 import { RemoteQuery } from './remote-query';
 import { RemoteQueriesMonitor } from './remote-queries-monitor';
+import { getRemoteQueryIndex } from './gh-actions-api-client';
+import { RemoteQueryResultIndex } from './remote-query-result-index';
 import { RemoteQueryResult } from './remote-query-result';
+import { DownloadLink } from './download-link';
 
 export class RemoteQueriesManager {
   private readonly remoteQueriesMonitor: RemoteQueriesMonitor;
@@ -52,14 +54,19 @@ export class RemoteQueriesManager {
     const executionEndTime = new Date();
 
     if (queryResult.status === 'CompletedSuccessfully') {
-      const resultIndexItems = await this.downloadResultIndex(credentials, query);
+      const resultIndex = await getRemoteQueryIndex(credentials, query);
+      if (!resultIndex) {
+        await showAndLogErrorMessage(`There was an issue retrieving the result for the query ${query.queryName}`);
+        return;
+      }
 
-      const totalResultCount = resultIndexItems.reduce((acc, cur) => acc + cur.results_count, 0);
+      const queryResult = this.mapQueryResult(executionEndTime, resultIndex);
+
+      const totalResultCount = queryResult.analysisResults.reduce((acc, cur) => acc + cur.resultCount, 0);
       const message = `Query "${query.queryName}" run on ${query.repositories.length} repositories and returned ${totalResultCount} results`;
 
       const shouldOpenView = await showInformationMessageWithAction(message, 'View');
       if (shouldOpenView) {
-        const queryResult = this.mapQueryResult(executionEndTime, resultIndexItems);
         const rqim = new RemoteQueriesInterfaceManager(this.ctx, this.logger);
         await rqim.showResults(query, queryResult);
       }
@@ -71,31 +78,25 @@ export class RemoteQueriesManager {
     }
   }
 
-  private async downloadResultIndex(credentials: Credentials, query: RemoteQuery) {
-    return await getResultIndex(
-      credentials,
-      query.controllerRepository.owner,
-      query.controllerRepository.name,
-      query.actionsWorkflowRunId);
-  }
-
-  private mapQueryResult(executionEndTime: Date, resultindexItems: ResultIndexItem[]): RemoteQueryResult {
-    // Example URIs are used for now, but a solution for downloading the results will soon be implemented.
-    const allResultsDownloadUri = 'www.example.com';
-    const analysisDownloadUri = 'www.example.com';
-
-    const analysisResults = resultindexItems.map(ri => ({
-      nwo: ri.nwo,
-      resultCount: ri.results_count,
-      downloadUri: analysisDownloadUri,
-      fileSizeInBytes: ri.sarif_file_size || ri.bqrs_file_size,
-    })
-    );
+  private mapQueryResult(executionEndTime: Date, resultIndex: RemoteQueryResultIndex): RemoteQueryResult {
+    const analysisResults = resultIndex.items.map(item => ({
+      nwo: item.nwo,
+      resultCount: item.resultCount,
+      fileSizeInBytes: item.sarifFileSize ? item.sarifFileSize : item.bqrsFileSize,
+      downloadLink: {
+        id: item.artifactId.toString(),
+        urlPath: `${resultIndex.artifactsUrlPath}/${item.artifactId}`,
+        innerFilePath: item.sarifFileSize ? 'results.sarif' : 'results.bqrs'
+      } as DownloadLink
+    }));
 
     return {
       executionEndTime,
       analysisResults,
-      allResultsDownloadUri,
+      allResultsDownloadLink: {
+        id: resultIndex.allResultsArtifactId.toString(),
+        urlPath: `${resultIndex.artifactsUrlPath}/${resultIndex.allResultsArtifactId}`
+      }
     };
   }
 }

--- a/extensions/ql-vscode/src/remote-queries/remote-query-result-index.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-query-result-index.ts
@@ -1,0 +1,14 @@
+export interface RemoteQueryResultIndex {
+  artifactsUrlPath: string;
+  allResultsArtifactId: number;
+  items: RemoteQueryResultIndexItem[];
+}
+
+export interface RemoteQueryResultIndexItem {
+  id: string;
+  artifactId: number;
+  nwo: string;
+  resultCount: number;
+  bqrsFileSize: number;
+  sarifFileSize?: number;
+}

--- a/extensions/ql-vscode/src/remote-queries/remote-query-result.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-query-result.ts
@@ -1,12 +1,14 @@
+import { DownloadLink } from './download-link';
+
 export interface RemoteQueryResult {
   executionEndTime: Date;
   analysisResults: AnalysisResult[];
-  allResultsDownloadUri: string;
+  allResultsDownloadLink: DownloadLink;
 }
 
 export interface AnalysisResult {
   nwo: string,
   resultCount: number,
-  downloadUri: string,
+  downloadLink: DownloadLink,
   fileSizeInBytes: number
 }

--- a/extensions/ql-vscode/src/remote-queries/shared/remote-query-result.ts
+++ b/extensions/ql-vscode/src/remote-queries/shared/remote-query-result.ts
@@ -1,3 +1,5 @@
+import { DownloadLink } from '../download-link';
+
 export interface RemoteQueryResult {
   queryTitle: string;
   queryFile: string;
@@ -6,13 +8,13 @@ export interface RemoteQueryResult {
   totalResultCount: number;
   executionTimestamp: string;
   executionDuration: string;
-  downloadLink: string;
+  downloadLink: DownloadLink;
   results: AnalysisResult[]
 }
 
 export interface AnalysisResult {
   nwo: string,
   resultCount: number,
-  downloadLink: string,
+  downloadLink: DownloadLink,
   fileSize: string,
 }

--- a/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
@@ -6,6 +6,7 @@ import { AnalysisResult, RemoteQueryResult } from '../shared/remote-query-result
 import * as octicons from '../../view/octicons';
 
 import { vscode } from '../../view/vscode-api';
+import { DownloadLink } from '../download-link';
 
 const numOfReposInContractedMode = 10;
 
@@ -17,8 +18,18 @@ const emptyQueryResult: RemoteQueryResult = {
   totalResultCount: 0,
   executionTimestamp: '',
   executionDuration: '',
-  downloadLink: '',
+  downloadLink: {
+    id: '',
+    urlPath: '',
+  },
   results: []
+};
+
+const download = (link: DownloadLink) => {
+  vscode.postMessage({
+    t: 'remoteQueryDownloadLinkClicked',
+    downloadLink: link
+  });
 };
 
 const AnalysisResultItem = (props: AnalysisResult) => (
@@ -31,7 +42,7 @@ const AnalysisResultItem = (props: AnalysisResult) => (
     <span className="vscode-codeql__analysis-item">
       <a
         className="vscode-codeql__download-link"
-        href={props.downloadLink}>
+        onClick={() => download(props.downloadLink)}>
         {octicons.download}{props.fileSize}
       </a>
     </span>
@@ -78,7 +89,8 @@ export function RemoteQueries(): JSX.Element {
 
       <div className="vscode-codeql__query-summary-container">
         <h2 className="vscode-codeql__query-summary-title">Repositories with results ({queryResult.affectedRepositoryCount}):</h2>
-        <a className="vscode-codeql__summary-download-link vscode-codeql__download-link" href={queryResult.downloadLink}>
+        <a className="vscode-codeql__summary-download-link vscode-codeql__download-link"
+          onClick={() => download(queryResult.downloadLink)}>
           {octicons.download}Download all
         </a>
       </div>

--- a/extensions/ql-vscode/src/remote-queries/view/remoteQueries.css
+++ b/extensions/ql-vscode/src/remote-queries/view/remoteQueries.css
@@ -11,6 +11,7 @@
   display: inline-block;
   font-size: x-small;
   text-decoration: none;
+  cursor: pointer;
 }
 
 .vscode-codeql__download-link svg {


### PR DESCRIPTION
Updates the download buttons in the remote queries view to download the results.

Once the file has been downloaded, a notification is shown

![image](https://user-images.githubusercontent.com/311693/145855111-033c04e4-bc98-4b80-94d5-07a89852cf44.png)

## Summary of changes
* Introduced the notion of a `DownloadLink` and used it in `RemoteQueryResult` entities and elsewhere.
* Introduced a `ResultIndex` entity that contains all the information we retrieve from the result-index file, as well as any other information needed from the workflow/API.
* Updated the actions API client to build up this new `ResultIndex` entity and also set DownloadLink information where appropriate.
* Updated the web view to send a message to the extension to initiate downloads.

Note that I think error handling in the API client can be improved, and I intend to do that in a separate PR.

## Checklist
N/A: Still an internal-only feature. No user-visible changes.

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
