### PR TITLE
Handle different dependencies in remote queries tests

### DIFF
--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/run-remote-query.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/run-remote-query.test.ts
@@ -115,7 +115,7 @@ describe('Remote queries', function() {
 
     // check dependencies.
     // 2.7.4 and earlier have ['javascript-all', 'javascript-upgrades']
-    // later only have ['javascript-all']. ensure this test can handle eitehr
+    // later only have ['javascript-all']. ensure this test can handle either
     expect(packNames.length).to.be.lessThan(3).and.greaterThan(0);
     expect(packNames[0]).to.deep.equal('javascript-all');
   });
@@ -176,7 +176,7 @@ describe('Remote queries', function() {
 
     // check dependencies.
     // 2.7.4 and earlier have ['javascript-all', 'javascript-upgrades']
-    // later only have ['javascript-all']. ensure this test can handle eitehr
+    // later only have ['javascript-all']. ensure this test can handle either
     expect(packNames.length).to.be.lessThan(3).and.greaterThan(0);
     expect(packNames[0]).to.deep.equal('javascript-all');
   });
@@ -236,7 +236,7 @@ describe('Remote queries', function() {
 
     // check dependencies.
     // 2.7.4 and earlier have ['javascript-all', 'javascript-upgrades']
-    // later only have ['javascript-all']. ensure this test can handle eitehr
+    // later only have ['javascript-all']. ensure this test can handle either
     expect(packNames.length).to.be.lessThan(3).and.greaterThan(0);
     expect(packNames[0]).to.deep.equal('javascript-all');
   });

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/run-remote-query.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/run-remote-query.test.ts
@@ -110,10 +110,14 @@ describe('Remote queries', function() {
     expect(fs.existsSync(path.join(compiledPackDir, 'not-in-pack.ql'))).to.be.false;
     verifyQlPack(path.join(compiledPackDir, 'qlpack.yml'), 'in-pack.ql', '0.0.0', await pathSerializationBroken());
 
-    // dependencies
     const libraryDir = path.join(compiledPackDir, '.codeql/libraries/codeql');
     const packNames = fs.readdirSync(libraryDir).sort();
-    expect(packNames).to.deep.equal(['javascript-all', 'javascript-upgrades']);
+
+    // check dependencies.
+    // 2.7.4 and earlier have ['javascript-all', 'javascript-upgrades']
+    // later only have ['javascript-all']. ensure this test can handle eitehr
+    expect(packNames.length).to.be.lessThan(3).and.greaterThan(0);
+    expect(packNames[0]).to.deep.equal('javascript-all');
   });
 
   it('should run a remote query that is not part of a qlpack', async () => {
@@ -166,11 +170,15 @@ describe('Remote queries', function() {
     expect(qlpackContents.version).to.equal('0.0.0');
     expect(qlpackContents.dependencies?.['codeql/javascript-all']).to.equal('*');
 
-    // dependencies
     const libraryDir = path.join(compiledPackDir, '.codeql/libraries/codeql');
     printDirectoryContents(libraryDir);
     const packNames = fs.readdirSync(libraryDir).sort();
-    expect(packNames).to.deep.equal(['javascript-all', 'javascript-upgrades']);
+
+    // check dependencies.
+    // 2.7.4 and earlier have ['javascript-all', 'javascript-upgrades']
+    // later only have ['javascript-all']. ensure this test can handle eitehr
+    expect(packNames.length).to.be.lessThan(3).and.greaterThan(0);
+    expect(packNames[0]).to.deep.equal('javascript-all');
   });
 
   it('should run a remote query that is nested inside a qlpack', async () => {
@@ -222,11 +230,15 @@ describe('Remote queries', function() {
     expect(qlpackContents.version).to.equal('0.0.0');
     expect(qlpackContents.dependencies?.['codeql/javascript-all']).to.equal('*');
 
-    // dependencies
     const libraryDir = path.join(compiledPackDir, '.codeql/libraries/codeql');
     printDirectoryContents(libraryDir);
     const packNames = fs.readdirSync(libraryDir).sort();
-    expect(packNames).to.deep.equal(['javascript-all', 'javascript-upgrades']);
+
+    // check dependencies.
+    // 2.7.4 and earlier have ['javascript-all', 'javascript-upgrades']
+    // later only have ['javascript-all']. ensure this test can handle eitehr
+    expect(packNames.length).to.be.lessThan(3).and.greaterThan(0);
+    expect(packNames[0]).to.deep.equal('javascript-all');
   });
 
   it('should cancel a run before uploading', async () => {


### PR DESCRIPTION
Starting in CLI 2.7.5, there will no longer be any
`codeql/javascript-upgrades` pack. Change the test so that it passes
using both old and new packs.


## Checklist

- [n/a] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [n/a] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
