### PR TITLE
Remote queries: Get query name from metadata (if possible)

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
@@ -8,11 +8,12 @@ import { Credentials } from '../authentication';
 import * as cli from '../cli';
 import { logger } from '../logging';
 import { getRemoteControllerRepo, getRemoteRepositoryLists, setRemoteControllerRepo } from '../config';
-import { tmpDir } from '../run-queries';
+import { getQueryMetadata, tmpDir } from '../run-queries';
 import { ProgressCallback, UserCancellationException } from '../commandRunner';
 import { OctokitResponse } from '@octokit/types/dist-types';
 import { RemoteQuery } from './remote-query';
 import { RemoteQuerySubmissionResult } from './remote-query-submission-result';
+import { QueryMetadata } from '../pure/interface-types';
 
 interface Config {
   repositories: string[];
@@ -323,6 +324,7 @@ export async function runRemoteQuery(
 
     const workflowRunId = await runRemoteQueriesApiRequest(credentials, ref, language, repositories, owner, repo, base64Pack, dryRun);
     const queryStartTime = new Date();
+    const queryMetadata = await getQueryMetadata(cliServer, queryFile);
 
     if (dryRun) {
       return { queryDirPath: remoteQueryDir.path };
@@ -331,7 +333,7 @@ export async function runRemoteQuery(
         return;
       }
 
-      const remoteQuery = await buildRemoteQueryEntity(repositories, queryFile, owner, repo, queryStartTime, workflowRunId);
+      const remoteQuery = await buildRemoteQueryEntity(repositories, queryFile, queryMetadata, owner, repo, queryStartTime, workflowRunId);
 
       // don't return the path because it has been deleted
       return { query: remoteQuery };
@@ -454,13 +456,14 @@ async function ensureNameAndSuite(queryPackDir: string, packRelativePath: string
 async function buildRemoteQueryEntity(
   repositories: string[],
   queryFilePath: string,
+  queryMetadata: QueryMetadata | undefined,
   controllerRepoOwner: string,
   controllerRepoName: string,
   queryStartTime: Date,
   workflowRunId: number
 ): Promise<RemoteQuery> {
-  // For now, just use the file name as the query name. 
-  const queryName = path.basename(queryFilePath);
+  // The query name is either the name as specified in the query metadata, or the file name. 
+  const queryName = queryMetadata?.name ?? path.basename(queryFilePath);
 
   const queryRepos = repositories.map(r => {
     const [owner, repo] = r.split('/');


### PR DESCRIPTION
In the remote queries webview, display the actual query name (from the metadata) if available. Otherwise, fall back to the file name: 

![image](https://user-images.githubusercontent.com/42641846/146040143-a9b79928-e982-46b5-9c24-7fee661415d9.png)

![image](https://user-images.githubusercontent.com/42641846/146040610-3ea6ba6a-bea7-465c-8c98-81d01376b8fd.png)

## Notes

I started from the existing [`getQueryName()`](https://github.com/github/vscode-codeql/blob/bf350779c9d1a722768ccbdc5d2da8418b5e6862/extensions/ql-vscode/src/query-results.ts#L158-L166) function, which does this exact thing for local queries. However, the types don't match up, so I couldn't work out how to re-use it directly 😕 

Instead, I separated out the code that gets query metadata, and re-used that for remote queries. Other suggestions are also welcome! 😇 

cc @charisk 

### Follow-up

- Add a test for the metadata function
- Restructure/rename the function to make things cleaner (see https://github.com/github/vscode-codeql/pull/1049#discussion_r769411121)

## Checklist

N/A - internal-only, no user-visible impact.

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
