### PR TITLE
Tidy up and add test for getting query metadata

### DIFF
--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -12,6 +12,7 @@ import {
 import { CodeQLCliServer, QlpacksInfo } from './cli';
 import { UserCancellationException } from './commandRunner';
 import { logger } from './logging';
+import { QueryMetadata } from './pure/interface-types';
 
 /**
  * Show an error message and log it to the console
@@ -515,4 +516,20 @@ export async function askForLanguage(cliServer: CodeQLCliServer, throwOnEmpty = 
     }
   }
   return language;
+}
+
+/**
+ * Gets metadata for a query, if it exists.
+ * @param cliServer The CLI server.
+ * @param queryPath The path to the query.
+ * @returns A promise that resolves to the query metadata, if available.
+ */
+export async function tryGetQueryMetadata(cliServer: CodeQLCliServer, queryPath: string): Promise<QueryMetadata | undefined> {
+  try {
+    return await cliServer.resolveMetadata(queryPath);
+  } catch (e) {
+    // Ignore errors and provide no metadata.
+    void logger.log(`Couldn't resolve metadata for ${queryPath}: ${e}`);
+    return;
+  }
 }

--- a/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
@@ -3,12 +3,20 @@ import * as path from 'path';
 import * as yaml from 'js-yaml';
 import * as fs from 'fs-extra';
 import * as tmp from 'tmp-promise';
-import { askForLanguage, findLanguage, getOnDiskWorkspaceFolders, showAndLogErrorMessage, showAndLogInformationMessage, showInformationMessageWithAction } from '../helpers';
+import {
+  askForLanguage,
+  findLanguage,
+  getOnDiskWorkspaceFolders,
+  showAndLogErrorMessage,
+  showAndLogInformationMessage,
+  showInformationMessageWithAction,
+  tryGetQueryMetadata
+} from '../helpers';
 import { Credentials } from '../authentication';
 import * as cli from '../cli';
 import { logger } from '../logging';
 import { getRemoteControllerRepo, getRemoteRepositoryLists, setRemoteControllerRepo } from '../config';
-import { getQueryMetadata, tmpDir } from '../run-queries';
+import { tmpDir } from '../run-queries';
 import { ProgressCallback, UserCancellationException } from '../commandRunner';
 import { OctokitResponse } from '@octokit/types/dist-types';
 import { RemoteQuery } from './remote-query';
@@ -324,7 +332,7 @@ export async function runRemoteQuery(
 
     const workflowRunId = await runRemoteQueriesApiRequest(credentials, ref, language, repositories, owner, repo, base64Pack, dryRun);
     const queryStartTime = new Date();
-    const queryMetadata = await getQueryMetadata(cliServer, queryFile);
+    const queryMetadata = await tryGetQueryMetadata(cliServer, queryFile);
 
     if (dryRun) {
       return { queryDirPath: remoteQueryDir.path };

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/data/simple-javascript-query.ql
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/data/simple-javascript-query.ql
@@ -1,3 +1,10 @@
+/**
+ * @name This is the name
+ * @kind problem
+ * @problem.severity warning
+ * @id javascript/example/test-query
+ */
+
 import javascript
 
 select 1

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/helpers.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/helpers.test.ts
@@ -1,0 +1,39 @@
+import * as path from 'path';
+import { extensions } from 'vscode';
+import 'mocha';
+
+import { CodeQLCliServer } from '../../cli';
+import { CodeQLExtensionInterface } from '../../extension';
+import { tryGetQueryMetadata } from '../../helpers';
+import { expect } from 'chai';
+
+describe('helpers (with CLI)', function() {
+  const baseDir = path.join(__dirname, '../../../src/vscode-tests/cli-integration');
+
+  // up to 3 minutes per test
+  this.timeout(3 * 60 * 1000);
+
+  let cli: CodeQLCliServer;
+
+  beforeEach(async () => {
+    const extension = await extensions.getExtension<CodeQLExtensionInterface | Record<string, never>>('GitHub.vscode-codeql')!.activate();
+    if ('cliServer' in extension) {
+      cli = extension.cliServer;
+    } else {
+      throw new Error('Extension not initialized. Make sure cli is downloaded and installed properly.');
+    }
+  });
+
+  it('should get query metadata if it exists', async () => {
+    // Query with empty metadata
+    const noMetadata = await tryGetQueryMetadata(cli, path.join(baseDir, 'data', 'simple-query.ql'));
+    // Query with metadata
+    const metadata = await tryGetQueryMetadata(cli, path.join(baseDir, 'data', 'simple-javascript-query.ql'));
+
+    expect(noMetadata).to.deep.equal({});
+
+    expect(metadata!.name).to.equal('This is the name');
+    expect(metadata!.kind).to.equal('problem');
+    expect(metadata!.id).to.equal('javascript/example/test-query');
+  });
+});

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/helpers.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/helpers.test.ts
@@ -24,16 +24,19 @@ describe('helpers (with CLI)', function() {
     }
   });
 
-  it('should get query metadata if it exists', async () => {
-    // Query with empty metadata
-    const noMetadata = await tryGetQueryMetadata(cli, path.join(baseDir, 'data', 'simple-query.ql'));
+  it('should get query metadata when available', async () => {
     // Query with metadata
     const metadata = await tryGetQueryMetadata(cli, path.join(baseDir, 'data', 'simple-javascript-query.ql'));
-
-    expect(noMetadata).to.deep.equal({});
 
     expect(metadata!.name).to.equal('This is the name');
     expect(metadata!.kind).to.equal('problem');
     expect(metadata!.id).to.equal('javascript/example/test-query');
+  });
+
+  it('should handle query with no metadata', async () => {
+    // Query with empty metadata
+    const noMetadata = await tryGetQueryMetadata(cli, path.join(baseDir, 'data', 'simple-query.ql'));
+
+    expect(noMetadata).to.deep.equal({});
   });
 });


### PR DESCRIPTION
Follow-up to #1049.
- Move the function to the general `helpers.ts` file
- Rename it to `tryGetQueryMetadata`
- Add a CLI integration test

## Checklist

N/A, no user-facing changes

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
