### PR TITLE
Add setting to enable/disable Quick Eval codelens

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [UNRELEASED]
 
+- Add a setting to enable/disable the Quick Evaluation CodeLens. [#1052](https://github.com/github/vscode-codeql/pull/1052)
 - Avoid creating a third column when opening the results view. The results view will always open to the right of the active editor, unless the active editor is in the rightmost editor column. In that case open in the leftmost column. [#1037](https://github.com/github/vscode-codeql/pull/1037)
 - Add a CodeLens to make the Quick Evaluation command more accessible. Click the `Quick Evaluation` prompt above a predicate definition in the editor to evaluate that predicate on its own. [#1035](https://github.com/github/vscode-codeql/pull/1035)
 - Fix a bug where the _Alerts_ option would show in the results view even if there is no alerts table available. [#1038](https://github.com/github/vscode-codeql/pull/1038)

--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,9 +2,8 @@
 
 ## [UNRELEASED]
 
-- Add a setting to enable/disable the Quick Evaluation CodeLens. [#1052](https://github.com/github/vscode-codeql/pull/1052)
 - Avoid creating a third column when opening the results view. The results view will always open to the right of the active editor, unless the active editor is in the rightmost editor column. In that case open in the leftmost column. [#1037](https://github.com/github/vscode-codeql/pull/1037)
-- Add a CodeLens to make the Quick Evaluation command more accessible. Click the `Quick Evaluation` prompt above a predicate definition in the editor to evaluate that predicate on its own. [#1035](https://github.com/github/vscode-codeql/pull/1035)
+- Add a CodeLens to make the Quick Evaluation command more accessible. Click the `Quick Evaluation` prompt above a predicate definition in the editor to evaluate that predicate on its own. You can enable/disable this in the `codeQL.runningQueries.quickEvalCodelens` setting. [#1035](https://github.com/github/vscode-codeql/pull/1035) & [#1052](https://github.com/github/vscode-codeql/pull/1052)
 - Fix a bug where the _Alerts_ option would show in the results view even if there is no alerts table available. [#1038](https://github.com/github/vscode-codeql/pull/1038)
 
 ## 1.5.8 - 2 December 2021

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -206,6 +206,11 @@
           "default": null,
           "description": "Path to a directory where the CodeQL extension should store query server logs. If empty, the extension stores logs in a temporary workspace folder and deletes the contents after each run."
         },
+        "codeQL.runningQueries.quickEvalCodelens": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable the 'Quick Evaluation' CodeLens."
+        },
         "codeQL.resultsDisplay.pageSize": {
           "type": "integer",
           "default": 200,

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -275,6 +275,16 @@ export class CliConfigListener extends ConfigListener implements CliConfig {
   }
 }
 
+/**
+ * Whether to enable CodeLens for the 'Quick Evaluation' command.
+ */
+const QUICK_EVAL_CODELENS_SETTING = new Setting('quickEvalCodelens', RUNNING_QUERIES_SETTING);
+
+export function isQuickEvalCodelensEnabled() {
+  return QUICK_EVAL_CODELENS_SETTING.getValue<boolean>();
+}
+
+
 // Enable experimental features
 
 /**

--- a/extensions/ql-vscode/src/quickEvalCodeLensProvider.ts
+++ b/extensions/ql-vscode/src/quickEvalCodeLensProvider.ts
@@ -1,43 +1,46 @@
 import {
   CodeLensProvider,
   TextDocument,
-  CodeLens, 
+  CodeLens,
   Command,
   Range
 } from 'vscode';
-  
+import { isQuickEvalCodelensEnabled } from './config';
+
 class QuickEvalCodeLensProvider implements CodeLensProvider {
   async provideCodeLenses(document: TextDocument): Promise<CodeLens[]> {
 
     const codeLenses: CodeLens[] = [];
 
-    for (let index = 0; index < document.lineCount; index++) {
-      const textLine = document.lineAt(index);
+    if (isQuickEvalCodelensEnabled()) {
+      for (let index = 0; index < document.lineCount; index++) {
+        const textLine = document.lineAt(index);
 
-      // Match a predicate signature, including predicate name, parameter list, and opening brace.
-      // This currently does not match predicates that span multiple lines.
-      const regex = new RegExp(/(\w+)\s*\([^()]*\)\s*\{/);
+        // Match a predicate signature, including predicate name, parameter list, and opening brace.
+        // This currently does not match predicates that span multiple lines.
+        const regex = new RegExp(/(\w+)\s*\([^()]*\)\s*\{/);
 
-      const matches = textLine.text.match(regex);
+        const matches = textLine.text.match(regex);
 
-      // Make sure that a code lens is not generated for any predicate that is commented out.
-      if (matches && !(/^\s*\/\//).test(textLine.text)) {
-        const range: Range = new Range(
-          textLine.range.start.line, matches.index!,
-          textLine.range.end.line, matches.index! + 1
-        );
+        // Make sure that a code lens is not generated for any predicate that is commented out.
+        if (matches && !(/^\s*\/\//).test(textLine.text)) {
+          const range: Range = new Range(
+            textLine.range.start.line, matches.index!,
+            textLine.range.end.line, matches.index! + 1
+          );
 
-        const command: Command = {
-          command: 'codeQL.codeLensQuickEval',
-          title: `Quick Evaluation: ${matches[1]}`,
-          arguments: [document.uri, range]
-        };
-        const codeLens = new CodeLens(range, command);
-        codeLenses.push(codeLens);
+          const command: Command = {
+            command: 'codeQL.codeLensQuickEval',
+            title: `Quick Evaluation: ${matches[1]}`,
+            arguments: [document.uri, range]
+          };
+          const codeLens = new CodeLens(range, command);
+          codeLenses.push(codeLens);
+        }
       }
     }
     return codeLenses;
   }
 }
-  
+
 export default QuickEvalCodeLensProvider;


### PR DESCRIPTION
Fixes https://github.com/github/vscode-codeql/issues/1051.

I've added a setting (and played around with it a bit to make sure it works ✔️)
![image](https://user-images.githubusercontent.com/42641846/146374657-3577dc10-0a49-4278-9c99-a7c917975677.png)


## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ n/a?] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
