### PR TITLE
Update Docs ping in issue template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,4 +9,4 @@ Replace this with a description of the changes your pull request makes.
 
 - [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
 - [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
-- [ ] `@github/docs-content-codeql` has been cc'd in all issues for UI or other user-facing changes made by this pull request.
+- [ ] The `ready-for-doc-review` label has been added to all issues for UI or other user-facing changes made by this pull request.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,4 +9,4 @@ Replace this with a description of the changes your pull request makes.
 
 - [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
 - [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
-- [ ] The `ready-for-doc-review` label has been added to all issues for UI or other user-facing changes made by this pull request.
+- [ ] If this pull request makes user-facing changes that require documentation changes, the `ready-for-doc-review` label has been added to this pull request or the corresponding issue.


### PR DESCRIPTION
Update this repository's pull request template prompting the user to add the `ready-for-doc-review` label whenever the proposed changes touch upon the UI or introduce any user-facing elements.
The Docs Content team uses an automation which looks for this label to facilitate pings to the appropriate group of writers. This makes the old `@github/docs-content-codeql` team obsolete.

## Checklist

- [x] Add a `ready-for-doc-review` label to this repository. I can't do this myself, because I don't have the necessary access level: https://github.com/github/vscode-codeql/issues/1062