### PR TITLE
Add helper command for working on the Remote Queries Results view

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -291,7 +291,7 @@
       },
       {
         "command": "codeQL.showFakeRemoteQueryResults",
-        "title": "[Internal] CodeQL: Show fake remote query results"
+        "title": "CodeQL: [Internal] Show fake remote query results"
       },
       {
         "command": "codeQL.runQueries",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -291,7 +291,7 @@
       },
       {
         "command": "codeQL.showFakeRemoteQueryResults",
-        "title": "CodeQL: Show fake remote query results"
+        "title": "[Internal] CodeQL: Show fake remote query results"
       },
       {
         "command": "codeQL.runQueries",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -290,6 +290,10 @@
         "title": "CodeQL: Run Remote Query"
       },
       {
+        "command": "codeQL.showFakeRemoteQueryResults",
+        "title": "CodeQL: Show fake remote query results"
+      },
+      {
         "command": "codeQL.runQueries",
         "title": "CodeQL: Run Queries in Selected Files"
       },
@@ -750,6 +754,10 @@
         {
           "command": "codeQL.runRemoteQuery",
           "when": "config.codeQL.canary && editorLangId == ql && resourceExtname == .ql"
+        },
+        {
+          "command": "codeQL.showFakeRemoteQueryResults",
+          "when": "config.codeQL.canary"
         },
         {
           "command": "codeQL.runQueries",

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -81,6 +81,8 @@ import { Credentials } from './authentication';
 import { RemoteQueriesManager } from './remote-queries/remote-queries-manager';
 import { RemoteQuery } from './remote-queries/remote-query';
 import { URLSearchParams } from 'url';
+import { RemoteQueriesInterfaceManager } from './remote-queries/remote-queries-interface';
+import { sampleRemoteQuery, sampleRemoteQueryResult } from './remote-queries/sample-data';
 
 /**
  * extension.ts
@@ -810,6 +812,12 @@ async function activateWithInstalledDistribution(
       query: RemoteQuery,
       token: CancellationToken) => {
       await rqm.monitorRemoteQuery(query, token);
+    }));
+
+  ctx.subscriptions.push(
+    commandRunner('codeQL.showFakeRemoteQueryResults', async () => {
+      const rqim = new RemoteQueriesInterfaceManager(ctx, logger);
+      await rqim.showResults(sampleRemoteQuery, sampleRemoteQueryResult);
     }));
 
   ctx.subscriptions.push(

--- a/extensions/ql-vscode/src/remote-queries/sample-data.ts
+++ b/extensions/ql-vscode/src/remote-queries/sample-data.ts
@@ -3,7 +3,7 @@ import { RemoteQueryResult } from './remote-query-result';
 
 export const sampleRemoteQuery: RemoteQuery = {
   queryName: 'Inefficient regular expression',
-  queryFilePath: '/Users/charisk/dev/vscode-codeql-starter/ql/javascript/ql/src/Performance/ReDoS.ql',
+  queryFilePath: '/Users/foo/dev/vscode-codeql-starter/ql/javascript/ql/src/Performance/ReDoS.ql',
   queryText: '/**\n * @name Inefficient regular expression\n * @description A regular expression that requires exponential time to match certain inputs\n *              can be a performance bottleneck, and may be vulnerable to denial-of-service\n *              attacks.\n * @kind problem\n * @problem.severity error\n * @security-severity 7.5\n * @precision high\n * @id js/redos\n * @tags security\n *       external/cwe/cwe-1333\n *       external/cwe/cwe-730\n *       external/cwe/cwe-400\n */\n\nimport javascript\nimport semmle.javascript.security.performance.ReDoSUtil\nimport semmle.javascript.security.performance.ExponentialBackTracking\n\nfrom RegExpTerm t, string pump, State s, string prefixMsg\nwhere hasReDoSResult(t, pump, s, prefixMsg)\nselect t,\n  "This part of the regular expression may cause exponential backtracking on strings " + prefixMsg +\n    "containing many repetitions of \'" + pump + "\'."\n',
   controllerRepository: {
     owner: 'big-corp',

--- a/extensions/ql-vscode/src/remote-queries/sample-data.ts
+++ b/extensions/ql-vscode/src/remote-queries/sample-data.ts
@@ -1,0 +1,86 @@
+import { RemoteQuery } from './remote-query';
+import { RemoteQueryResult } from './remote-query-result';
+
+export const sampleRemoteQuery: RemoteQuery = {
+  queryName: 'Inefficient regular expression',
+  queryFilePath: '/Users/charisk/dev/vscode-codeql-starter/ql/javascript/ql/src/Performance/ReDoS.ql',
+  queryText: '/**\n * @name Inefficient regular expression\n * @description A regular expression that requires exponential time to match certain inputs\n *              can be a performance bottleneck, and may be vulnerable to denial-of-service\n *              attacks.\n * @kind problem\n * @problem.severity error\n * @security-severity 7.5\n * @precision high\n * @id js/redos\n * @tags security\n *       external/cwe/cwe-1333\n *       external/cwe/cwe-730\n *       external/cwe/cwe-400\n */\n\nimport javascript\nimport semmle.javascript.security.performance.ReDoSUtil\nimport semmle.javascript.security.performance.ExponentialBackTracking\n\nfrom RegExpTerm t, string pump, State s, string prefixMsg\nwhere hasReDoSResult(t, pump, s, prefixMsg)\nselect t,\n  "This part of the regular expression may cause exponential backtracking on strings " + prefixMsg +\n    "containing many repetitions of \'" + pump + "\'."\n',
+  controllerRepository: {
+    owner: 'big-corp',
+    name: 'controller-repo'
+  },
+  repositories: [
+    {
+      owner: 'big-corp',
+      name: 'repo1'
+    },
+    {
+      owner: 'big-corp',
+      name: 'repo2'
+    },
+    {
+      owner: 'big-corp',
+      name: 'repo3'
+    },
+    {
+      owner: 'big-corp',
+      name: 'repo4'
+    },
+    {
+      owner: 'big-corp',
+      name: 'repo5'
+    }
+  ],
+  executionStartTime: new Date('2022-01-06T17:02:15.026Z'),
+  actionsWorkflowRunId: 1662757118
+};
+
+export const sampleRemoteQueryResult: RemoteQueryResult = {
+  executionEndTime: new Date('2022-01-06T17:04:37.026Z'),
+  allResultsDownloadLink: {
+    id: '137697018',
+    urlPath: '/repos/big-corp/controller-repo/actions/artifacts/137697018'
+  },
+  analysisResults: [
+    {
+      nwo: 'big-corp/repo1',
+      resultCount: 85,
+      fileSizeInBytes: 14123,
+      downloadLink: {
+        id: '137697017',
+        urlPath: '/repos/big-corp/controller-repo/actions/artifacts/137697017',
+        innerFilePath: 'results.sarif'
+      }
+    },
+    {
+      nwo: 'big-corp/repo2',
+      resultCount: 20,
+      fileSizeInBytes: 8698,
+      downloadLink: {
+        id: '137697018',
+        urlPath: '/repos/big-corp/controller-repo/actions/artifacts/137697018',
+        innerFilePath: 'results.sarif'
+      }
+    },
+    {
+      nwo: 'big-corp/repo3',
+      resultCount: 8,
+      fileSizeInBytes: 4123,
+      downloadLink: {
+        id: '137697019',
+        urlPath: '/repos/big-corp/controller-repo/actions/artifacts/137697019',
+        innerFilePath: 'results.sarif'
+      }
+    },
+    {
+      nwo: 'big-corp/repo4',
+      resultCount: 3,
+      fileSizeInBytes: 3313,
+      downloadLink: {
+        id: '137697020',
+        urlPath: '/repos/big-corp/controller-repo/actions/artifacts/137697020',
+        innerFilePath: 'results.sarif'
+      }
+    }
+  ]
+};


### PR DESCRIPTION
Adds a helper command that shows the Remote Queries Results view using mocked data instead of having to execute a query and wait for the results.

I found having this sort of thing helpful when working on the view so I thought we might want to check it in. If we don't want a command showing up even in canary, we could check in only the sample data and some commented out code. 

## Checklist
I believe the following isn't applicable:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] If this pull request makes user-facing changes that require documentation changes, the `ready-for-doc-review` label has been added to this pull request or the corresponding issue.
