### PR TITLE
Results view: Don't reopen webview if it's already visible

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [UNRELEASED]
 
+- Fix a bug where the results view moved column even when it was already visible. [#1070](https://github.com/github/vscode-codeql/pull/1070)
+
 ## 1.5.9 - 17 December 2021
 
 - Avoid creating a third column when opening the results view. The results view will always open to the right of the active editor, unless the active editor is in the rightmost editor column. In that case open in the leftmost column. [#1037](https://github.com/github/vscode-codeql/pull/1037)

--- a/extensions/ql-vscode/src/interface.ts
+++ b/extensions/ql-vscode/src/interface.ts
@@ -379,27 +379,29 @@ export class InterfaceManager extends DisposableObject {
 
     const panel = this.getPanel();
     await this.waitForPanelLoaded();
-    if (forceReveal === WebviewReveal.Forced) {
-      panel.reveal(undefined, true);
-    } else if (!panel.visible) {
-      // The results panel exists, (`.getPanel()` guarantees it) but
-      // is not visible; it's in a not-currently-viewed tab. Show a
-      // more asynchronous message to not so abruptly interrupt
-      // user's workflow by immediately revealing the panel.
-      const showButton = 'View Results';
-      const queryName = results.queryName;
-      const resultPromise = vscode.window.showInformationMessage(
-        `Finished running query ${queryName.length > 0 ? ` "${queryName}"` : ''
-        }.`,
-        showButton
-      );
-      // Address this click asynchronously so we still update the
-      // query history immediately.
-      void resultPromise.then((result) => {
-        if (result === showButton) {
-          panel.reveal();
-        }
-      });
+    if (!panel.visible) {
+      if (forceReveal === WebviewReveal.Forced) {
+        panel.reveal(undefined, true);
+      } else {
+        // The results panel exists, (`.getPanel()` guarantees it) but
+        // is not visible; it's in a not-currently-viewed tab. Show a
+        // more asynchronous message to not so abruptly interrupt
+        // user's workflow by immediately revealing the panel.
+        const showButton = 'View Results';
+        const queryName = results.queryName;
+        const resultPromise = vscode.window.showInformationMessage(
+          `Finished running query ${queryName.length > 0 ? ` "${queryName}"` : ''
+          }.`,
+          showButton
+        );
+        // Address this click asynchronously so we still update the
+        // query history immediately.
+        void resultPromise.then((result) => {
+          if (result === showButton) {
+            panel.reveal();
+          }
+        });
+      }
     }
 
     // Note that the resultSetSchemas will return offsets for the default (unsorted) page,


### PR DESCRIPTION
A user reported a bug where the results view is opened in the active editor, even if the results view is already visible in a different column:
<details><summary> 🖱️  Expand for example GIF</summary>
<p>

![34F3083B-05A6-46EF-8954-6D74615756E0](https://user-images.githubusercontent.com/42641846/148392949-579caa5c-0073-4d49-9f9c-4f209128f882.GIF)

</p>
</details> 

This PR fixes that behaviour. I.e. when there's already a results view visible (not necessarily active), we display the results in that panel. 

### Notes

A slight weirdness we could still find is that if the results view is open in a tab somewhere, but not visible, it can still move to a different place. I don't think this is a problem, but I can open an issue if it is!

<details><summary>🖱 Expand for details</summary>
<p>

In this case, the results view is open on the right, but it isn't currently visible. Since the right-hand side is the active editor, the new results open on the left. (So the results view moves column.)

![8003AFBE-3E96-4AB6-9083-33C1FB4D622A](https://user-images.githubusercontent.com/42641846/148393924-95994178-935a-436b-bcda-b25eabaee6f1.GIF)


</p>
</details> 



## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [n/a] Issues have been created for any UI or other user-facing changes made by this pull request.
- [n/a] If this pull request makes user-facing changes that require documentation changes, the `ready-for-doc-review` label has been added to this pull request or the corresponding issue.
