### PR TITLE
Standardize integration test args in VSCode debugger

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -103,7 +103,8 @@
         "--disable-extension",
         "github.copilot",
         "${workspaceRoot}/extensions/ql-vscode/src/vscode-tests/cli-integration/data",
-        // Add a path to a checked out instance of the codeql repository so the libraries are
+        // Uncomment the last line and modify the path to a checked out 
+        // instance of the codeql repository so the libraries are
         // available in the workspace for the tests.
         // "${workspaceRoot}/../codeql"
       ],

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -59,7 +59,9 @@
       "runtimeExecutable": "${execPath}",
       "args": [
         "--extensionDevelopmentPath=${workspaceRoot}/extensions/ql-vscode",
-        "--extensionTestsPath=${workspaceRoot}/extensions/ql-vscode/out/vscode-tests/no-workspace/index"
+        "--extensionTestsPath=${workspaceRoot}/extensions/ql-vscode/out/vscode-tests/no-workspace/index",
+        "--disable-extensions",
+        "--disable-gpu"
       ],
       "stopOnEntry": false,
       "sourceMaps": true,
@@ -75,6 +77,8 @@
       "args": [
         "--extensionDevelopmentPath=${workspaceRoot}/extensions/ql-vscode",
         "--extensionTestsPath=${workspaceRoot}/extensions/ql-vscode/out/vscode-tests/minimal-workspace/index",
+        "--disable-extensions",
+        "--disable-gpu",
         "${workspaceRoot}/extensions/ql-vscode/test/data"
       ],
       "stopOnEntry": false,
@@ -91,6 +95,13 @@
       "args": [
         "--extensionDevelopmentPath=${workspaceRoot}/extensions/ql-vscode",
         "--extensionTestsPath=${workspaceRoot}/extensions/ql-vscode/out/vscode-tests/cli-integration/index",
+        "--disable-gpu",
+        "--disable-extension",
+        "eamodio.gitlens",
+        "--disable-extension",
+        "github.codespaces",
+        "--disable-extension",
+        "github.copilot",
         "${workspaceRoot}/extensions/ql-vscode/src/vscode-tests/cli-integration/data",
         // Add a path to a checked out instance of the codeql repository so the libraries are
         // available in the workspace for the tests.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

This change updates the `launch.json` arguments for the three integration test configurations to match the arguments used in https://github.com/github/vscode-codeql/blob/6bd7f0ae12d98752d87c97d07ad37761f4d61401/extensions/ql-vscode/src/vscode-tests/run-integration-tests.ts#L111-L144, which are much more recent. 

I have used the VSCode Debugger to test with these configurations locally and the tests work as expected. ✨ 

I also edited a comment in the `launch.json` file that was a bit difficult for me to understand initially. 

## Checklist

- [N/A] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [N/A] Issues have been created for any UI or other user-facing changes made by this pull request.
- [N/A] If this pull request makes user-facing changes that require documentation changes, the `ready-for-doc-review` label has been added to this pull request or the corresponding issue.
