### PR TITLE
[do not merge] Remove `--old-eval-stats` argument

### DIFF
--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -1186,11 +1186,6 @@ export class CliVersionConstraint {
    */
   public static CLI_VERSION_WITH_RESOLVE_ML_MODELS = new SemVer('2.7.3');
 
-  /**
-   * CLI version where the `--old-eval-stats` option to the query server was introduced.
-   */
-  public static CLI_VERSION_WITH_OLD_EVAL_STATS = new SemVer('2.7.4');
-
   constructor(private readonly cli: CodeQLCliServer) {
     /**/
   }
@@ -1237,9 +1232,5 @@ export class CliVersionConstraint {
 
   async supportsResolveMlModels() {
     return this.isVersionAtLeast(CliVersionConstraint.CLI_VERSION_WITH_RESOLVE_ML_MODELS);
-  }
-
-  async supportsOldEvalStats() {
-    return this.isVersionAtLeast(CliVersionConstraint.CLI_VERSION_WITH_OLD_EVAL_STATS);
   }
 }

--- a/extensions/ql-vscode/src/queryserver-client.ts
+++ b/extensions/ql-vscode/src/queryserver-client.ts
@@ -167,10 +167,6 @@ export class QueryServerClient extends DisposableObject {
       args.push('--require-db-registration');
     }
 
-    if (await this.cliServer.cliConstraints.supportsOldEvalStats()) {
-      args.push('--old-eval-stats');
-    }
-
     if (this.config.debug) {
       args.push('--debug', '--tuple-counting');
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

This pull request essentially reverts the changes in https://github.com/github/vscode-codeql/pull/1036 — we had added the `--old-eval-stats` argument so that we still supported the scrapeable evaluator logs while the structured logs are being developed and observed. 

We are now beginning work on supporting structured logging in the extension. The first step of this work is to ensure that the query server continues to run without error with structured logging rather than scrapeable evaluator logging. Opening this PR to check integration tests in CI, but will not merge until structured logs are surfaced in the extension.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] If this pull request makes user-facing changes that require documentation changes, the `ready-for-doc-review` label has been added to this pull request or the corresponding issue.
