### PR TITLE
Rename analysis result to analysis summary

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
@@ -260,15 +260,15 @@ export class RemoteQueriesInterfaceManager {
 
   /**
    * Builds up a list of analysis summaries, in a data structure tailored to the view.
-   * @param analysisResults The summary of a specific analysis.
+   * @param analysisSummaries The summaries of a specific analyses.
    * @returns A fully created view model.
    */
-  private buildAnalysisSummaries(analysisResults: AnalysisSummary[]): AnalysisResultViewModel[] {
-    const filteredAnalysisResults = analysisResults.filter(r => r.resultCount > 0);
+  private buildAnalysisSummaries(analysisSummaries: AnalysisSummary[]): AnalysisResultViewModel[] {
+    const filteredAnalysisSummaries = analysisSummaries.filter(r => r.resultCount > 0);
 
-    const sortedAnalysisResults = filteredAnalysisResults.sort((a, b) => b.resultCount - a.resultCount);
+    const sortedAnalysisSummaries = filteredAnalysisSummaries.sort((a, b) => b.resultCount - a.resultCount);
 
-    return sortedAnalysisResults.map((analysisResult) => ({
+    return sortedAnalysisSummaries.map((analysisResult) => ({
       nwo: analysisResult.nwo,
       resultCount: analysisResult.resultCount,
       downloadLink: analysisResult.downloadLink,

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
@@ -63,10 +63,10 @@ export class RemoteQueriesInterfaceManager {
    */
   private buildViewModel(query: RemoteQuery, queryResult: RemoteQueryResult): RemoteQueryResultViewModel {
     const queryFileName = path.basename(query.queryFilePath);
-    const totalResultCount = queryResult.analysisSummary.reduce((acc, cur) => acc + cur.resultCount, 0);
+    const totalResultCount = queryResult.analysisSummaries.reduce((acc, cur) => acc + cur.resultCount, 0);
     const executionDuration = this.getDuration(queryResult.executionEndTime, query.executionStartTime);
-    const analysisSummaries = this.buildAnalysisSummaries(queryResult.analysisSummary);
-    const affectedRepositories = queryResult.analysisSummary.filter(r => r.resultCount > 0);
+    const analysisSummaries = this.buildAnalysisSummaries(queryResult.analysisSummaries);
+    const affectedRepositories = queryResult.analysisSummaries.filter(r => r.resultCount > 0);
 
     return {
       queryTitle: query.queryName,

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
@@ -19,10 +19,10 @@ import {
 import { Logger } from '../logging';
 import { getHtmlForWebview } from '../interface-utils';
 import { assertNever } from '../pure/helpers-pure';
-import { AnalysisResult, RemoteQueryResult } from './remote-query-result';
+import { AnalysisSummary, RemoteQueryResult } from './remote-query-result';
 import { RemoteQuery } from './remote-query';
 import { RemoteQueryResult as RemoteQueryResultViewModel } from './shared/remote-query-result';
-import { AnalysisResult as AnalysisResultViewModel } from './shared/remote-query-result';
+import { AnalysisSummary as AnalysisResultViewModel } from './shared/remote-query-result';
 import { downloadArtifactFromLink } from './gh-actions-api-client';
 import { Credentials } from '../authentication';
 import { showAndLogWarningMessage, showInformationMessageWithAction } from '../helpers';
@@ -63,10 +63,10 @@ export class RemoteQueriesInterfaceManager {
    */
   private buildViewModel(query: RemoteQuery, queryResult: RemoteQueryResult): RemoteQueryResultViewModel {
     const queryFileName = path.basename(query.queryFilePath);
-    const totalResultCount = queryResult.analysisResults.reduce((acc, cur) => acc + cur.resultCount, 0);
+    const totalResultCount = queryResult.analysisSummary.reduce((acc, cur) => acc + cur.resultCount, 0);
     const executionDuration = this.getDuration(queryResult.executionEndTime, query.executionStartTime);
-    const analysisResults = this.buildAnalysisResults(queryResult.analysisResults);
-    const affectedRepositories = queryResult.analysisResults.filter(r => r.resultCount > 0);
+    const analysisSummaries = this.buildAnalysisSummaries(queryResult.analysisSummary);
+    const affectedRepositories = queryResult.analysisSummary.filter(r => r.resultCount > 0);
 
     return {
       queryTitle: query.queryName,
@@ -79,7 +79,7 @@ export class RemoteQueriesInterfaceManager {
       executionTimestamp: this.formatDate(query.executionStartTime),
       executionDuration: executionDuration,
       downloadLink: queryResult.allResultsDownloadLink,
-      results: analysisResults
+      analysisSummaries: analysisSummaries
     };
   }
 
@@ -259,11 +259,11 @@ export class RemoteQueriesInterfaceManager {
   }
 
   /**
-   * Builds up a list of analysis results, in a data structure tailored to the view.
-   * @param analysisResults The results of a specific analysis.
+   * Builds up a list of analysis summaries, in a data structure tailored to the view.
+   * @param analysisResults The summary of a specific analysis.
    * @returns A fully created view model.
    */
-  private buildAnalysisResults(analysisResults: AnalysisResult[]): AnalysisResultViewModel[] {
+  private buildAnalysisSummaries(analysisResults: AnalysisSummary[]): AnalysisResultViewModel[] {
     const filteredAnalysisResults = analysisResults.filter(r => r.resultCount > 0);
 
     const sortedAnalysisResults = filteredAnalysisResults.sort((a, b) => b.resultCount - a.resultCount);

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
@@ -62,7 +62,7 @@ export class RemoteQueriesManager {
 
       const queryResult = this.mapQueryResult(executionEndTime, resultIndex);
 
-      const totalResultCount = queryResult.analysisSummary.reduce((acc, cur) => acc + cur.resultCount, 0);
+      const totalResultCount = queryResult.analysisSummaries.reduce((acc, cur) => acc + cur.resultCount, 0);
       const message = `Query "${query.queryName}" run on ${query.repositories.length} repositories and returned ${totalResultCount} results`;
 
       const shouldOpenView = await showInformationMessageWithAction(message, 'View');
@@ -92,7 +92,7 @@ export class RemoteQueriesManager {
 
     return {
       executionEndTime,
-      analysisSummary: analysisResults,
+      analysisSummaries: analysisResults,
       allResultsDownloadLink: {
         id: resultIndex.allResultsArtifactId.toString(),
         urlPath: `${resultIndex.artifactsUrlPath}/${resultIndex.allResultsArtifactId}`

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
@@ -79,7 +79,7 @@ export class RemoteQueriesManager {
   }
 
   private mapQueryResult(executionEndTime: Date, resultIndex: RemoteQueryResultIndex): RemoteQueryResult {
-    const analysisResults = resultIndex.items.map(item => ({
+    const analysisSummaries = resultIndex.items.map(item => ({
       nwo: item.nwo,
       resultCount: item.resultCount,
       fileSizeInBytes: item.sarifFileSize ? item.sarifFileSize : item.bqrsFileSize,
@@ -92,7 +92,7 @@ export class RemoteQueriesManager {
 
     return {
       executionEndTime,
-      analysisSummaries: analysisResults,
+      analysisSummaries,
       allResultsDownloadLink: {
         id: resultIndex.allResultsArtifactId.toString(),
         urlPath: `${resultIndex.artifactsUrlPath}/${resultIndex.allResultsArtifactId}`

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
@@ -62,7 +62,7 @@ export class RemoteQueriesManager {
 
       const queryResult = this.mapQueryResult(executionEndTime, resultIndex);
 
-      const totalResultCount = queryResult.analysisResults.reduce((acc, cur) => acc + cur.resultCount, 0);
+      const totalResultCount = queryResult.analysisSummary.reduce((acc, cur) => acc + cur.resultCount, 0);
       const message = `Query "${query.queryName}" run on ${query.repositories.length} repositories and returned ${totalResultCount} results`;
 
       const shouldOpenView = await showInformationMessageWithAction(message, 'View');
@@ -92,7 +92,7 @@ export class RemoteQueriesManager {
 
     return {
       executionEndTime,
-      analysisResults,
+      analysisSummary: analysisResults,
       allResultsDownloadLink: {
         id: resultIndex.allResultsArtifactId.toString(),
         urlPath: `${resultIndex.artifactsUrlPath}/${resultIndex.allResultsArtifactId}`

--- a/extensions/ql-vscode/src/remote-queries/remote-query-result.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-query-result.ts
@@ -2,11 +2,11 @@ import { DownloadLink } from './download-link';
 
 export interface RemoteQueryResult {
   executionEndTime: Date;
-  analysisResults: AnalysisResult[];
+  analysisSummary: AnalysisSummary[];
   allResultsDownloadLink: DownloadLink;
 }
 
-export interface AnalysisResult {
+export interface AnalysisSummary {
   nwo: string,
   resultCount: number,
   downloadLink: DownloadLink,

--- a/extensions/ql-vscode/src/remote-queries/remote-query-result.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-query-result.ts
@@ -2,7 +2,7 @@ import { DownloadLink } from './download-link';
 
 export interface RemoteQueryResult {
   executionEndTime: Date;
-  analysisSummary: AnalysisSummary[];
+  analysisSummaries: AnalysisSummary[];
   allResultsDownloadLink: DownloadLink;
 }
 

--- a/extensions/ql-vscode/src/remote-queries/sample-data.ts
+++ b/extensions/ql-vscode/src/remote-queries/sample-data.ts
@@ -41,7 +41,7 @@ export const sampleRemoteQueryResult: RemoteQueryResult = {
     id: '137697018',
     urlPath: '/repos/big-corp/controller-repo/actions/artifacts/137697018'
   },
-  analysisSummary: [
+  analysisSummaries: [
     {
       nwo: 'big-corp/repo1',
       resultCount: 85,

--- a/extensions/ql-vscode/src/remote-queries/sample-data.ts
+++ b/extensions/ql-vscode/src/remote-queries/sample-data.ts
@@ -41,7 +41,7 @@ export const sampleRemoteQueryResult: RemoteQueryResult = {
     id: '137697018',
     urlPath: '/repos/big-corp/controller-repo/actions/artifacts/137697018'
   },
-  analysisResults: [
+  analysisSummary: [
     {
       nwo: 'big-corp/repo1',
       resultCount: 85,

--- a/extensions/ql-vscode/src/remote-queries/shared/remote-query-result.ts
+++ b/extensions/ql-vscode/src/remote-queries/shared/remote-query-result.ts
@@ -11,10 +11,10 @@ export interface RemoteQueryResult {
   executionTimestamp: string;
   executionDuration: string;
   downloadLink: DownloadLink;
-  results: AnalysisResult[]
+  analysisSummaries: AnalysisSummary[]
 }
 
-export interface AnalysisResult {
+export interface AnalysisSummary {
   nwo: string,
   resultCount: number,
   downloadLink: DownloadLink,

--- a/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useEffect, useState } from 'react';
 import * as Rdom from 'react-dom';
 import { SetRemoteQueryResultMessage } from '../../pure/interface-types';
-import { AnalysisResult, RemoteQueryResult } from '../shared/remote-query-result';
+import { AnalysisSummary, RemoteQueryResult } from '../shared/remote-query-result';
 import * as octicons from '../../view/octicons';
 
 import { vscode } from '../../view/vscode-api';
@@ -24,7 +24,7 @@ const emptyQueryResult: RemoteQueryResult = {
     id: '',
     urlPath: '',
   },
-  results: []
+  analysisSummaries: []
 };
 
 const download = (link: DownloadLink) => {
@@ -34,7 +34,7 @@ const download = (link: DownloadLink) => {
   });
 };
 
-const AnalysisResultItem = (props: AnalysisResult) => (
+const AnalysisSummaryItem = (props: AnalysisSummary) => (
   <span>
     <span className="vscode-codeql__analysis-item">{octicons.repo}</span>
     <span className="vscode-codeql__analysis-item">{props.nwo}</span>
@@ -90,7 +90,7 @@ export function RemoteQueries(): JSX.Element {
   }
 
   const [repoListExpanded, setRepoListExpanded] = useState(false);
-  const numOfReposToShow = repoListExpanded ? queryResult.results.length : numOfReposInContractedMode;
+  const numOfReposToShow = repoListExpanded ? queryResult.analysisSummaries.length : numOfReposInContractedMode;
 
   const openQueryFile = () => {
     vscode.postMessage({
@@ -133,15 +133,15 @@ export function RemoteQueries(): JSX.Element {
           : <SummaryWithResults {...queryResult} />
       }
 
-      <ul className="vscode-codeql__results-list">
-        {queryResult.results.slice(0, numOfReposToShow).map((result, i) =>
-          <li key={result.nwo} className="vscode-codeql__results-list-item">
-            <AnalysisResultItem {...result} />
+      <ul className="vscode-codeql__analysis-summaries-list">
+        {queryResult.analysisSummaries.slice(0, numOfReposToShow).map((summary, i) =>
+          <li key={summary.nwo} className="vscode-codeql__analysis-summaries-list-item">
+            <AnalysisSummaryItem {...summary} />
           </li>
         )}
       </ul>
       {
-        queryResult.results.length > numOfReposInContractedMode &&
+        queryResult.analysisSummaries.length > numOfReposInContractedMode &&
         <button className="vscode-codeql__expand-button" onClick={() => setRepoListExpanded(!repoListExpanded)}>
           {repoListExpanded ? (<span>View less</span>) : (<span>View all</span>)}
         </button>

--- a/extensions/ql-vscode/src/remote-queries/view/remoteQueries.css
+++ b/extensions/ql-vscode/src/remote-queries/view/remoteQueries.css
@@ -67,13 +67,13 @@
   vertical-align: middle;
 }
 
-.vscode-codeql__results-list {
+.vscode-codeql__analysis-summaries-list {
   list-style-type: none;
   margin: 0;
   padding: 0.5em 0 0 0;
 }
 
-.vscode-codeql__results-list-item {
+.vscode-codeql__analysis-summaries-list-item {
   margin-top: 0.5em;
 }
 


### PR DESCRIPTION
Currently the term "analysis result" is used to refer to the summary of an analysis outcome. However, the term "result" means something else in terms of an analysis - it means an actual result of the query. 

I've renamed analysis result to analysis summary in order to avoid confusion.

## Checklist
N/A 
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] If this pull request makes user-facing changes that require documentation changes, the `ready-for-doc-review` label has been added to this pull request or the corresponding issue.
