### PR TITLE
Add "pack install" and "pack download" commands

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [UNRELEASED]
 
 - Fix a bug where the results view moved column even when it was already visible. [#1070](https://github.com/github/vscode-codeql/pull/1070)
-- Add packaging-related commands. _CodeQL: Download Packs_ downloads packs from the package registry, and _CodeQL: Install Packs_ installs dependencies for packs in your workspace. [#1076](https://github.com/github/vscode-codeql/pull/1076)
+- Add packaging-related commands. _CodeQL: Download Packs_ downloads query packs from the package registry that can be run locally, and _CodeQL: Install Pack Dependencies_ installs dependencies for packs in your workspace. [#1076](https://github.com/github/vscode-codeql/pull/1076)
 
 ## 1.5.9 - 17 December 2021
 

--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [UNRELEASED]
 
 - Fix a bug where the results view moved column even when it was already visible. [#1070](https://github.com/github/vscode-codeql/pull/1070)
+- Add packaging-related commands. _CodeQL: Download Packs_ downloads packs from the package registry, and _CodeQL: Install Packs_ installs dependencies for packs in your workspace. [#1076](https://github.com/github/vscode-codeql/pull/1076)
 
 ## 1.5.9 - 17 December 2021
 

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -374,8 +374,8 @@
         "title": "CodeQL: Clear Cache"
       },
       {
-        "command": "codeQL.installPacks",
-        "title": "CodeQL: Install Packs"
+        "command": "codeQL.installPackDependencies",
+        "title": "CodeQL: Install Pack Dependencies"
       },
       {
         "command": "codeQL.downloadPacks",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -374,6 +374,14 @@
         "title": "CodeQL: Clear Cache"
       },
       {
+        "command": "codeQL.installPacks",
+        "title": "CodeQL: Install Packs"
+      },
+      {
+        "command": "codeQL.downloadPacks",
+        "title": "CodeQL: Download Packs"
+      },
+      {
         "command": "codeQLDatabases.setCurrentDatabase",
         "title": "Set Current Database"
       },

--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -1199,6 +1199,11 @@ export class CliVersionConstraint {
    */
   public static CLI_VERSION_WITH_OLD_EVAL_STATS = new SemVer('2.7.4');
 
+  /**
+   * CLI version where packaging was introduced.
+   */
+  public static CLI_VERSION_WITH_PACKAGING = new SemVer('2.6.0');
+
   constructor(private readonly cli: CodeQLCliServer) {
     /**/
   }
@@ -1249,5 +1254,9 @@ export class CliVersionConstraint {
 
   async supportsOldEvalStats() {
     return this.isVersionAtLeast(CliVersionConstraint.CLI_VERSION_WITH_OLD_EVAL_STATS);
+  }
+
+  async supportsPackaging() {
+    return this.isVersionAtLeast(CliVersionConstraint.CLI_VERSION_WITH_PACKAGING);
   }
 }

--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -847,10 +847,10 @@ export class CodeQLCliServer implements Disposable {
 
   /**
    * Downloads a specified pack.
-   * @param pack The `<package-scope/name[@version]>` of the pack to download.
+   * @param packs The `<package-scope/name[@version]>` of the packs to download.
    */
-  async packDownload(pack: string) {
-    return this.runJsonCodeQlCliCommand(['pack', 'download'], [pack], 'Downloading packs');
+  async packDownload(packs: string[]) {
+    return this.runJsonCodeQlCliCommand(['pack', 'download'], packs, 'Downloading packs');
   }
 
   async packInstall(dir: string) {

--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -845,6 +845,14 @@ export class CodeQLCliServer implements Disposable {
     );
   }
 
+  /**
+   * Downloads a specified pack.
+   * @param pack The `<package-scope/name[@version]>` of the pack to download.
+   */
+  async packDownload(pack: string) {
+    return this.runJsonCodeQlCliCommand(['pack', 'download'], [pack], 'Downloading packs');
+  }
+
   async packInstall(dir: string) {
     return this.runJsonCodeQlCliCommand(['pack', 'install'], [dir], 'Installing pack dependencies');
   }

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -83,7 +83,7 @@ import { RemoteQuery } from './remote-queries/remote-query';
 import { URLSearchParams } from 'url';
 import { RemoteQueriesInterfaceManager } from './remote-queries/remote-queries-interface';
 import { sampleRemoteQuery, sampleRemoteQueryResult } from './remote-queries/sample-data';
-import { handleDownloadPacks, handleInstallPacks } from './packaging';
+import { handleDownloadPacks, handleInstallPackDependencies } from './packaging';
 
 /**
  * extension.ts
@@ -924,12 +924,12 @@ async function activateWithInstalledDistribution(
     }));
 
   ctx.subscriptions.push(
-    commandRunnerWithProgress('codeQL.installPacks', async (
+    commandRunnerWithProgress('codeQL.installPackDependencies', async (
       progress: ProgressCallback
     ) =>
-      await handleInstallPacks(cliServer, progress),
+      await handleInstallPackDependencies(cliServer, progress),
       {
-        title: 'Installing packs',
+        title: 'Installing pack dependencies',
       }
     ));
 

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -83,6 +83,7 @@ import { RemoteQuery } from './remote-queries/remote-query';
 import { URLSearchParams } from 'url';
 import { RemoteQueriesInterfaceManager } from './remote-queries/remote-queries-interface';
 import { sampleRemoteQuery, sampleRemoteQueryResult } from './remote-queries/sample-data';
+import { handleDownloadPacks, handleInstallPacks } from './packaging';
 
 /**
  * extension.ts
@@ -921,6 +922,26 @@ async function activateWithInstalledDistribution(
         void helpers.showAndLogInformationMessage(`Authenticated to GitHub as user: ${userInfo.data.login}`);
       }
     }));
+
+  ctx.subscriptions.push(
+    commandRunnerWithProgress('codeQL.installPacks', async (
+      progress: ProgressCallback
+    ) =>
+      await handleInstallPacks(cliServer, progress),
+      {
+        title: 'Installing packs',
+      }
+    ));
+
+  ctx.subscriptions.push(
+    commandRunnerWithProgress('codeQL.downloadPacks', async (
+      progress: ProgressCallback
+    ) =>
+      await handleDownloadPacks(cliServer, progress),
+      {
+        title: 'Downloading packs',
+      }
+    ));
 
   commands.registerCommand('codeQL.showLogs', () => {
     logger.show();

--- a/extensions/ql-vscode/src/packaging.ts
+++ b/extensions/ql-vscode/src/packaging.ts
@@ -1,4 +1,4 @@
-import { CodeQLCliServer } from './cli';
+import { CliVersionConstraint, CodeQLCliServer } from './cli';
 import {
   getOnDiskWorkspaceFolders,
   showAndLogErrorMessage,
@@ -30,6 +30,10 @@ export async function handleDownloadPacks(
   cliServer: CodeQLCliServer,
   progress: ProgressCallback,
 ): Promise<void> {
+  if (!(await cliServer.cliConstraints.supportsPackaging())) {
+    throw new Error(`Packaging commands are not supported by this version of CodeQL. Please upgrade to v${CliVersionConstraint.CLI_VERSION_WITH_PACKAGING
+      } or later.`);
+  }
   progress({
     message: 'Choose packs to download',
     step: 1,
@@ -87,6 +91,10 @@ export async function handleInstallPacks(
   cliServer: CodeQLCliServer,
   progress: ProgressCallback,
 ): Promise<void> {
+  if (!(await cliServer.cliConstraints.supportsPackaging())) {
+    throw new Error(`Packaging commands are not supported by this version of CodeQL. Please upgrade to v${CliVersionConstraint.CLI_VERSION_WITH_PACKAGING
+      } or later.`);
+  }
   progress({
     message: 'Choose packs to install',
     step: 1,

--- a/extensions/ql-vscode/src/packaging.ts
+++ b/extensions/ql-vscode/src/packaging.ts
@@ -37,7 +37,7 @@ export async function handleDownloadPacks(
     maxStep: 2,
   });
   let packsToDownload: string[] = [];
-  const queryPackOption = 'Download core query packs';
+  const queryPackOption = 'Download all core query packs';
   const customPackOption = 'Download custom specified pack';
   const quickpick = await window.showQuickPick(
     [queryPackOption, customPackOption],
@@ -57,7 +57,7 @@ export async function handleDownloadPacks(
       throw new UserCancellationException('No pack specified.');
     }
   }
-  if (packsToDownload && packsToDownload.length > 0) {
+  if (packsToDownload?.length > 0) {
     progress({
       message: 'Downloading packs. This may take a few minutes.',
       step: 2,

--- a/extensions/ql-vscode/src/packaging.ts
+++ b/extensions/ql-vscode/src/packaging.ts
@@ -3,7 +3,6 @@ import {
   getOnDiskWorkspaceFolders,
   showAndLogErrorMessage,
   showAndLogInformationMessage,
-  showAndLogWarningMessage,
 } from './helpers';
 import { QuickPickItem, window } from 'vscode';
 import { ProgressCallback, UserCancellationException } from './commandRunner';
@@ -123,8 +122,8 @@ export async function handleInstallPacks(
     }
     if (failedPacks.length > 0) {
       void logger.log(`Errors:\n${errors.join('\n')}`);
-      void showAndLogWarningMessage(
-        `Unable to install some packs: ${failedPacks.join(', ')}. See logs for more details.`
+      throw new Error(
+        `Unable to install packs: ${failedPacks.join(', ')}. See logs for more details.`
       );
     } else {
       void showAndLogInformationMessage('Finished installing packs.');

--- a/extensions/ql-vscode/src/packaging.ts
+++ b/extensions/ql-vscode/src/packaging.ts
@@ -123,7 +123,7 @@ export async function handleInstallPacks(
     if (failedPacks.length > 0) {
       void logger.log(`Errors:\n${errors.join('\n')}`);
       throw new Error(
-        `Unable to install packs: ${failedPacks.join(', ')}. See logs for more details.`
+        `Unable to install packs: ${failedPacks.join(', ')}. See log for more details.`
       );
     } else {
       void showAndLogInformationMessage('Finished installing packs.');

--- a/extensions/ql-vscode/src/packaging.ts
+++ b/extensions/ql-vscode/src/packaging.ts
@@ -71,7 +71,7 @@ export async function handleDownloadPacks(
       void showAndLogInformationMessage('Finished downloading packs.');
     } catch (error) {
       void showAndLogErrorMessage(
-        'Unable to download all packs. See logs for more details.'
+        'Unable to download all packs. See log for more details.'
       );
     }
   }
@@ -87,7 +87,7 @@ interface QLPackQuickPickItem extends QuickPickItem {
  * @param cliServer The CLI server.
  * @param progress A progress callback.
  */
-export async function handleInstallPacks(
+export async function handleInstallPackDependencies(
   cliServer: CodeQLCliServer,
   progress: ProgressCallback,
 ): Promise<void> {
@@ -96,7 +96,7 @@ export async function handleInstallPacks(
       } or later.`);
   }
   progress({
-    message: 'Choose packs to install',
+    message: 'Choose packs to install dependencies for',
     step: 1,
     maxStep: 2,
   });
@@ -106,13 +106,13 @@ export async function handleInstallPacks(
     packRootDir: value,
   }));
   const packsToInstall = await window.showQuickPick(quickPickItems, {
-    placeHolder: 'Select packs to install',
+    placeHolder: 'Select packs to install dependencies for',
     canPickMany: true,
     ignoreFocusOut: true,
   });
   if (packsToInstall && packsToInstall.length > 0) {
     progress({
-      message: 'Installing packs. This may take a few minutes.',
+      message: 'Installing dependencies. This may take a few minutes.',
       step: 2,
       maxStep: 2,
     });
@@ -131,10 +131,10 @@ export async function handleInstallPacks(
     if (failedPacks.length > 0) {
       void logger.log(`Errors:\n${errors.join('\n')}`);
       throw new Error(
-        `Unable to install packs: ${failedPacks.join(', ')}. See log for more details.`
+        `Unable to install pack dependencies for: ${failedPacks.join(', ')}. See log for more details.`
       );
     } else {
-      void showAndLogInformationMessage('Finished installing packs.');
+      void showAndLogInformationMessage('Finished installing pack dependencies.');
     }
   } else {
     throw new UserCancellationException('No packs selected.');

--- a/extensions/ql-vscode/src/packaging.ts
+++ b/extensions/ql-vscode/src/packaging.ts
@@ -1,0 +1,144 @@
+import { CodeQLCliServer } from './cli';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import {
+  getOnDiskWorkspaceFolders,
+  showAndLogErrorMessage,
+  showAndLogInformationMessage,
+} from './helpers';
+import { window } from 'vscode';
+import { ProgressCallback } from './commandRunner';
+
+const CORE_PACKS = [
+  'codeql/cpp-all',
+  'codeql/csharp-all',
+  'codeql/go-all',
+  'codeql/java-all',
+  'codeql/javascript-all',
+  'codeql/python-all',
+  'codeql/ruby-all',
+];
+
+/**
+ * Lists all workspace folders that contain a qlpack.yml file.
+ *
+ * Note: This currently only finds packs at the root of a workspace folder.
+ * TODO: Add support for packs in subfolders.
+ */
+function getWorkspacePacks(): string[] {
+  const packs: string[] = [];
+  const workspaceFolders = getOnDiskWorkspaceFolders();
+  for (const folder of workspaceFolders) {
+    const qlpackYml = path.join(folder, 'qlpack.yml');
+    if (fs.pathExistsSync(qlpackYml)) {
+      packs.push(folder);
+    }
+  }
+  return packs;
+}
+
+/**
+ * Prompts user to choose packs to download, and downloads them.
+ *
+ * @param cliServer The CLI server.
+ * @param progress A progress callback.
+ */
+export async function handleDownloadPacks(
+  cliServer: CodeQLCliServer,
+  progress: ProgressCallback,
+): Promise<void> {
+  progress({
+    message: 'Choose packs to download',
+    step: 1,
+    maxStep: 2,
+  });
+  let packsToDownload: string[] = [];
+  const corePackOption = 'Download core CodeQL packs';
+  const customPackOption = 'Download custom specified pack';
+  const quickpick = await window.showQuickPick(
+    [corePackOption, customPackOption],
+    { ignoreFocusOut: true }
+  );
+  if (quickpick === corePackOption) {
+    packsToDownload = CORE_PACKS;
+  } else if (quickpick === customPackOption) {
+    const customPack = await window.showInputBox({
+      prompt:
+        'Enter the <package-scope/name[@version]> of the pack to download',
+      ignoreFocusOut: true,
+    });
+    if (customPack) {
+      packsToDownload.push(customPack);
+    } else {
+      void showAndLogErrorMessage('No pack specified.');
+    }
+  }
+  if (packsToDownload && packsToDownload.length > 0) {
+    progress({
+      message: `Downloading ${packsToDownload.join(', ')}`,
+      step: 2,
+      maxStep: 2,
+    });
+    for (const pack of packsToDownload) {
+      try {
+        await cliServer.packDownload(pack);
+      } catch (error) {
+        void showAndLogErrorMessage(`Unable to download pack ${pack}. See logs for more details.`);
+      }
+    }
+    void showAndLogInformationMessage('Finished downloading packs.');
+  }
+}
+
+/**
+ * Prompts user to choose packs to install, and installs them.
+ *
+ * @param cliServer The CLI server.
+ * @param progress A progress callback.
+ */
+export async function handleInstallPacks(
+  cliServer: CodeQLCliServer,
+  progress: ProgressCallback,
+): Promise<void> {
+  progress({
+    message: 'Choose packs to install',
+    step: 1,
+    maxStep: 2,
+  });
+  let packsToInstall: string[] = [];
+  const workspacePackOption = 'Install workspace packs';
+  const customPackOption = 'Install custom specified pack';
+  const quickpick = await window.showQuickPick(
+    [workspacePackOption, customPackOption],
+    { ignoreFocusOut: true }
+  );
+  if (quickpick === workspacePackOption) {
+    packsToInstall = getWorkspacePacks();
+  } else if (quickpick === customPackOption) {
+    const customPack = await window.showInputBox({
+      prompt:
+        'Enter the root directory of the pack to install (as an absolute path)',
+      ignoreFocusOut: true,
+    });
+    if (customPack) {
+      packsToInstall.push(customPack);
+    } else {
+      void showAndLogErrorMessage('No pack specified.');
+    }
+  }
+  if (packsToInstall && packsToInstall.length > 0) {
+    progress({
+      message: `Installing ${packsToInstall.join(', ')}`,
+      step: 2,
+      maxStep: 2,
+    });
+    for (const pack of packsToInstall) {
+      try {
+        await cliServer.packInstall(pack);
+      } catch (error) {
+        void showAndLogErrorMessage(`Unable to install pack ${pack}. See logs for more details.`);
+      }
+    }
+    void showAndLogInformationMessage('Finished installing packs.');
+  }
+}

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/data-invalid-pack/qlpack.yml
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/data-invalid-pack/qlpack.yml
@@ -1,0 +1,4 @@
+name: foo/bar
+version: 0.0.0
+dependencies:
+  foo/baz: '*'

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/packaging.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/packaging.test.ts
@@ -101,9 +101,9 @@ describe('Packaging commands', function() {
       },
     ]);
 
-    await mod.handleInstallPacks(cli, progress);
+    await mod.handleInstallPackDependencies(cli, progress);
     expect(showAndLogInformationMessageSpy.firstCall.args[0]).to.contain(
-      'Finished installing packs.'
+      'Finished installing pack dependencies.'
     );
   });
 
@@ -118,11 +118,11 @@ describe('Packaging commands', function() {
 
     try {
       // expect this to throw an error
-      await mod.handleInstallPacks(cli, progress);
+      await mod.handleInstallPackDependencies(cli, progress);
       // This line should not be reached
       expect(true).to.be.false;
     } catch (error) {
-      expect(error.message).to.contain('Unable to install packs:');
+      expect(error.message).to.contain('Unable to install pack dependencies');
     }
   });
 });

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/packaging.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/packaging.test.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 
 import * as pq from 'proxyquire';
 
-import { CodeQLCliServer } from '../../cli';
+import { CliVersionConstraint, CodeQLCliServer } from '../../cli';
 import { CodeQLExtensionInterface } from '../../extension';
 import { expect } from 'chai';
 
@@ -40,7 +40,11 @@ describe('Packaging commands', function() {
         'Extension not initialized. Make sure cli is downloaded and installed properly.'
       );
     }
-
+    if (!(await cli.cliConstraints.supportsPackaging())) {
+      console.log(`Packaging commands are not supported on CodeQL CLI v${CliVersionConstraint.CLI_VERSION_WITH_PACKAGING
+        }. Skipping this test.`);
+      this.skip();
+    }
     progress = sandbox.spy();
     quickPickSpy = sandbox.stub(window, 'showQuickPick');
     inputBoxSpy = sandbox.stub(window, 'showInputBox');

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/packaging.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/packaging.test.ts
@@ -47,7 +47,7 @@ describe('Packaging commands', function() {
     showAndLogErrorMessageSpy = sandbox.stub();
     showAndLogInformationMessageSpy = sandbox.stub();
     mod = proxyquire('../../packaging', {
-      '../helpers': {
+      './helpers': {
         showAndLogErrorMessage: showAndLogErrorMessageSpy,
         showAndLogInformationMessage: showAndLogInformationMessageSpy,
       },

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/packaging.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/packaging.test.ts
@@ -1,0 +1,108 @@
+import * as sinon from 'sinon';
+import { extensions, window } from 'vscode';
+import 'mocha';
+import * as path from 'path';
+
+import * as pq from 'proxyquire';
+
+import { CodeQLCliServer } from '../../cli';
+import { CodeQLExtensionInterface } from '../../extension';
+import { expect } from 'chai';
+
+const proxyquire = pq.noPreserveCache();
+
+describe('Packaging commands', function() {
+  let sandbox: sinon.SinonSandbox;
+
+  // up to 3 minutes per test
+  this.timeout(3 * 60 * 1000);
+
+  let cli: CodeQLCliServer;
+  let progress: sinon.SinonSpy;
+  let quickPickSpy: sinon.SinonStub;
+  let inputBoxSpy: sinon.SinonStub;
+  let showAndLogErrorMessageSpy: sinon.SinonStub;
+  let showAndLogInformationMessageSpy: sinon.SinonStub;
+  let mod: any;
+
+  beforeEach(async function() {
+    sandbox = sinon.createSandbox();
+
+    const extension = await extensions
+      .getExtension<CodeQLExtensionInterface | Record<string, never>>(
+        'GitHub.vscode-codeql'
+      )!
+      .activate();
+    if ('cliServer' in extension) {
+      cli = extension.cliServer;
+    } else {
+      throw new Error(
+        'Extension not initialized. Make sure cli is downloaded and installed properly.'
+      );
+    }
+
+    progress = sandbox.spy();
+    quickPickSpy = sandbox.stub(window, 'showQuickPick');
+    inputBoxSpy = sandbox.stub(window, 'showInputBox');
+    showAndLogErrorMessageSpy = sandbox.stub();
+    showAndLogInformationMessageSpy = sandbox.stub();
+    mod = proxyquire('../../packaging', {
+      '../helpers': {
+        showAndLogErrorMessage: showAndLogErrorMessageSpy,
+        showAndLogInformationMessage: showAndLogInformationMessageSpy,
+      },
+    });
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should download all core query packs', async () => {
+    quickPickSpy.resolves('Download all core query packs');
+
+    await mod.handleDownloadPacks(cli, progress);
+    expect(showAndLogInformationMessageSpy.firstCall.args[0]).to.contain(
+      'Finished downloading packs.'
+    );
+  });
+
+  it('should download valid user-specified pack', async () => {
+    quickPickSpy.resolves('Download custom specified pack');
+    inputBoxSpy.resolves('codeql/csharp-solorigate-queries');
+
+    await mod.handleDownloadPacks(cli, progress);
+    expect(showAndLogInformationMessageSpy.firstCall.args[0]).to.contain(
+      'Finished downloading packs.'
+    );
+  });
+
+  it('should show error for invalid user-specified pack', async () => {
+    quickPickSpy.resolves('Download custom specified pack');
+    inputBoxSpy.resolves('foo/not-a-real-pack@0.0.1');
+
+    await mod.handleDownloadPacks(cli, progress);
+
+    expect(showAndLogErrorMessageSpy.firstCall.args[0]).to.contain(
+      'Unable to download all packs.'
+    );
+  });
+
+  it('should install selected workspace packs', async () => {
+    const rootDir = path.join(__dirname, '../../../src/vscode-tests/cli-integration/data');
+    quickPickSpy.resolves(
+      [
+        {
+          label: 'integration-test-queries-javascript',
+          packRootDir: [rootDir],
+        },
+      ]
+    );
+
+    await mod.handleInstallPacks(cli, progress);
+
+    expect(showAndLogInformationMessageSpy.firstCall.args[0]).to.contain(
+      'Finished installing packs.'
+    );
+  });
+});

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/packaging.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/packaging.test.ts
@@ -77,7 +77,7 @@ describe('Packaging commands', function() {
     );
   });
 
-  it('should show error for invalid user-specified pack', async () => {
+  it('should show error when downloading invalid user-specified pack', async () => {
     quickPickSpy.resolves('Download custom specified pack');
     inputBoxSpy.resolves('foo/not-a-real-pack@0.0.1');
 
@@ -88,7 +88,7 @@ describe('Packaging commands', function() {
     );
   });
 
-  it('should attempt to install selected workspace packs', async () => {
+  it('should install valid workspace pack', async () => {
     const rootDir = path.join(__dirname, '../../../src/vscode-tests/cli-integration/data');
     quickPickSpy.resolves([
       {
@@ -97,11 +97,26 @@ describe('Packaging commands', function() {
       },
     ]);
 
+    await mod.handleInstallPacks(cli, progress);
+    expect(showAndLogInformationMessageSpy.firstCall.args[0]).to.contain(
+      'Finished installing packs.'
+    );
+  });
+
+  it('should throw an error when installing invalid workspace pack', async () => {
+    const rootDir = path.join(__dirname, '../../../src/vscode-tests/cli-integration/data-invalid-pack');
+    quickPickSpy.resolves([
+      {
+        label: 'foo/bar',
+        packRootDir: [rootDir],
+      },
+    ]);
+
     try {
+      // expect this to throw an error
       await mod.handleInstallPacks(cli, progress);
-      expect(showAndLogInformationMessageSpy.firstCall.args[0]).to.contain(
-        'Finished installing packs.'
-      );
+      // This line should not be reached
+      expect(true).to.be.false;
     } catch (error) {
       expect(error.message).to.contain('Unable to install packs:');
     }

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/packaging.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/packaging.test.ts
@@ -88,21 +88,22 @@ describe('Packaging commands', function() {
     );
   });
 
-  it('should install selected workspace packs', async () => {
+  it('should attempt to install selected workspace packs', async () => {
     const rootDir = path.join(__dirname, '../../../src/vscode-tests/cli-integration/data');
-    quickPickSpy.resolves(
-      [
-        {
-          label: 'integration-test-queries-javascript',
-          packRootDir: [rootDir],
-        },
-      ]
-    );
+    quickPickSpy.resolves([
+      {
+        label: 'integration-test-queries-javascript',
+        packRootDir: [rootDir],
+      },
+    ]);
 
-    await mod.handleInstallPacks(cli, progress);
-
-    expect(showAndLogInformationMessageSpy.firstCall.args[0]).to.contain(
-      'Finished installing packs.'
-    );
+    try {
+      await mod.handleInstallPacks(cli, progress);
+      expect(showAndLogInformationMessageSpy.firstCall.args[0]).to.contain(
+        'Finished installing packs.'
+      );
+    } catch (error) {
+      expect(error.message).to.contain('Unable to install packs:');
+    }
   });
 });


### PR DESCRIPTION
Adds commands to install and download packs 📦 

For the "Download Packs" command, I've added a hard-coded option to download all core packs, and a custom option if users want to specify a custom pack. 

<details><summary>Expand for demo GIF</summary>
<p>

![2A0768B5-1B85-4653-9664-992D399DEBB8](https://user-images.githubusercontent.com/42641846/149368864-98a9ab8c-a028-4ff9-b724-442dc9dfa1b9.GIF)


</p>
</details> 

For "Install Packs", the user can select packs from their workspace

<details><summary>Expand for demo GIF</summary>
<p>

![9E18DA5E-DCBD-433E-AF25-F6563BADC1ED](https://user-images.githubusercontent.com/42641846/149555148-73315f30-8835-4a4a-a227-5db8078e3998.GIF)

</p>
</details> 

~PS: I will add a test for these commands 🧪 But I'd be grateful for a quick review first to see if this is a plausible way of doing things!~ 🙈 Done!

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request (internal issue)
- [x] ~If this pull request makes user-facing changes that require documentation changes, the `ready-for-doc-review` label has been added to this pull request or the corresponding issue.~ Docs PR: https://github.com/github/codeql/pull/7661
