### PR TITLE
Split download actions in remote queries view

### DIFF
--- a/extensions/ql-vscode/src/pure/interface-types.ts
+++ b/extensions/ql-vscode/src/pure/interface-types.ts
@@ -377,7 +377,8 @@ export type FromRemoteQueriesMessage =
   | RemoteQueryErrorMessage
   | OpenFileMsg
   | OpenVirtualFileMsg
-  | RemoteQueryDownloadLinkClickedMessage;
+  | RemoteQueryDownloadAnalysisResultsMessage
+  | RemoteQueryDownloadAllAnalysesResultsMessage;
 
 export type ToRemoteQueriesMessage =
   | SetRemoteQueryResultMessage;
@@ -396,7 +397,13 @@ export interface RemoteQueryErrorMessage {
   error: string;
 }
 
-export interface RemoteQueryDownloadLinkClickedMessage {
-  t: 'remoteQueryDownloadLinkClicked';
+export interface RemoteQueryDownloadAnalysisResultsMessage {
+  t: 'remoteQueryDownloadAnalysisResults';
+  nwo: string
+  downloadLink: DownloadLink;
+}
+
+export interface RemoteQueryDownloadAllAnalysesResultsMessage {
+  t: 'remoteQueryDownloadAllAnalysesResults';
   downloadLink: DownloadLink;
 }

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
@@ -14,7 +14,6 @@ import { tmpDir } from '../run-queries';
 import {
   ToRemoteQueriesMessage,
   FromRemoteQueriesMessage,
-  RemoteQueryDownloadLinkClickedMessage,
 } from '../pure/interface-types';
 import { Logger } from '../logging';
 import { getHtmlForWebview } from '../interface-utils';
@@ -28,6 +27,7 @@ import { Credentials } from '../authentication';
 import { showAndLogWarningMessage, showInformationMessageWithAction } from '../helpers';
 import { URLSearchParams } from 'url';
 import { SHOW_QUERY_TEXT_MSG } from '../query-history';
+import { DownloadLink } from './download-link';
 
 export class RemoteQueriesInterfaceManager {
   private panel: WebviewPanel | undefined;
@@ -189,18 +189,21 @@ export class RemoteQueriesInterfaceManager {
       case 'openVirtualFile':
         await this.openVirtualFile(msg.queryText);
         break;
-      case 'remoteQueryDownloadLinkClicked':
-        await this.handleDownloadLinkClicked(msg);
+      case 'remoteQueryDownloadAnalysisResults':
+        await this.handleDownloadLinkClicked(msg.downloadLink);
+        break;
+      case 'remoteQueryDownloadAllAnalysesResults':
+        await this.handleDownloadLinkClicked(msg.downloadLink);
         break;
       default:
         assertNever(msg);
     }
   }
 
-  private async handleDownloadLinkClicked(msg: RemoteQueryDownloadLinkClickedMessage): Promise<void> {
+  private async handleDownloadLinkClicked(downloadLink: DownloadLink): Promise<void> {
     const credentials = await Credentials.initialize(this.ctx);
 
-    const filePath = await downloadArtifactFromLink(credentials, msg.downloadLink);
+    const filePath = await downloadArtifactFromLink(credentials, downloadLink);
     const isDir = (await fs.stat(filePath)).isDirectory();
     const message = `Result file saved at ${filePath}`;
     if (isDir) {

--- a/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
@@ -33,9 +33,17 @@ const emptyQueryResult: RemoteQueryResult = {
   analysisSummaries: []
 };
 
-const download = (link: DownloadLink) => {
+const downloadAnalysisResults = (nwo: string, link: DownloadLink) => {
   vscode.postMessage({
-    t: 'remoteQueryDownloadLinkClicked',
+    t: 'remoteQueryDownloadAnalysisResults',
+    nwo,
+    downloadLink: link
+  });
+};
+
+const downloadAllAnalysesResults = (link: DownloadLink) => {
+  vscode.postMessage({
+    t: 'remoteQueryDownloadAllAnalysesResults',
     downloadLink: link
   });
 };
@@ -76,7 +84,9 @@ const QueryInfo = (queryResult: RemoteQueryResult) => (
 const SummaryTitleWithResults = (queryResult: RemoteQueryResult) => (
   <div className="vscode-codeql__query-summary-container">
     <SectionTitle text={`Repositories with results (${queryResult.affectedRepositoryCount}):`} />
-    <DownloadButton text="Download all" onClick={() => download(queryResult.downloadLink)} />
+    <DownloadButton
+      text="Download all"
+      onClick={() => downloadAllAnalysesResults(queryResult.downloadLink)} />
   </div>
 );
 
@@ -92,7 +102,9 @@ const SummaryItem = (props: AnalysisSummary) => (
     <span className="vscode-codeql__analysis-item">{props.nwo}</span>
     <span className="vscode-codeql__analysis-item"><Badge text={props.resultCount.toString()} /></span>
     <span className="vscode-codeql__analysis-item">
-      <DownloadButton text={props.fileSize} onClick={() => download(props.downloadLink)} />
+      <DownloadButton
+        text={props.fileSize}
+        onClick={() => downloadAnalysisResults(props.nwo, props.downloadLink)} />
     </span>
   </span>
 );


### PR DESCRIPTION
We currently have a single action to download a results artifact which means that we lose some context about what we're downloading when we reach the extension code. In order to keep that context and make it easier to track which results have been downloaded, I split the action into two separate ones.

## Checklist
N/A
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] If this pull request makes user-facing changes that require documentation changes, the `ready-for-doc-review` label has been added to this pull request or the corresponding issue.
