### PR TITLE
Make sure extension dependencies are installed

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -19,7 +19,8 @@
     "Programming Languages"
   ],
   "extensionDependencies": [
-    "hbenl.vscode-test-explorer"
+    "hbenl.vscode-test-explorer",
+    "ms-vscode.test-adapter-converter"
   ],
   "capabilities": {
     "untrustedWorkspaces": {

--- a/extensions/ql-vscode/src/vscode-tests/run-integration-tests.ts
+++ b/extensions/ql-vscode/src/vscode-tests/run-integration-tests.ts
@@ -80,10 +80,19 @@ async function main() {
     if (dirs.includes(TestDir.CliIntegration)) {
       console.log('Installing required extensions');
       const cliPath = resolveCliPathFromVSCodeExecutablePath(vscodeExecutablePath);
-      cp.spawnSync(cliPath, ['--install-extension', 'hbenl.vscode-test-explorer'], {
-        encoding: 'utf-8',
-        stdio: 'inherit'
-      });
+      cp.spawnSync(
+        cliPath,
+        [
+          '--install-extension',
+          'hbenl.vscode-test-explorer',
+          '--install-extension',
+          'ms-vscode.test-adapter-converter',
+        ],
+        {
+          encoding: 'utf-8',
+          stdio: 'inherit',
+        }
+      );
     }
 
     console.log(`Running integration tests in these directories: ${dirs}`);


### PR DESCRIPTION
The CodeQL extension depends on `hbenl.vscode-test-explorer`, which in turn depends on `ms-vscode.test-adapter-converter`.

The former gets installed automatically, but there's a manual step for the latter:
![image](https://user-images.githubusercontent.com/42641846/150157059-0ad9f09d-3d23-4fdd-a4f7-3f4679b6d593.png)

VS Code does prompt you to install, but if you cancel or miss that notification (easily done!), it's hard to get to a usable state from there.

If we directly depend on `ms-vscode.test-adapter-converter`, it should get installed properly. Thanks to @KarlFuhlbrugge for helping to test!

PS: The [`hbenl.vscode-test-explorer`](https://marketplace.visualstudio.com/items?itemName=hbenl.vscode-test-explorer) is deprecated, so eventually we should move to the VS Code native testing UI. But hopefully this fixes things in the meantime!

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] If this pull request makes user-facing changes that require documentation changes, the `ready-for-doc-review` label has been added to this pull request or the corresponding issue.
