### PR TITLE
Wait a few seconds before monitoring remote query run

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/remote-queries-monitor.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-monitor.ts
@@ -29,10 +29,9 @@ export class RemoteQueriesMonitor {
 
     let attemptCount = 0;
 
-    // Wait a bit before starting to monitor the workflow run.
-    await this.sleep(RemoteQueriesMonitor.sleepTime);
-
     while (attemptCount <= RemoteQueriesMonitor.maxAttemptCount) {
+      await this.sleep(RemoteQueriesMonitor.sleepTime);
+
       if (cancellationToken && cancellationToken.isCancellationRequested) {
         return { status: 'Cancelled' };
       }
@@ -47,7 +46,6 @@ export class RemoteQueriesMonitor {
         return workflowStatus;
       }
 
-      await this.sleep(RemoteQueriesMonitor.sleepTime);
       attemptCount++;
     }
 

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-monitor.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-monitor.ts
@@ -29,6 +29,9 @@ export class RemoteQueriesMonitor {
 
     let attemptCount = 0;
 
+    // Wait a bit before starting to monitor the workflow run.
+    await this.sleep(RemoteQueriesMonitor.sleepTime);
+
     while (attemptCount <= RemoteQueriesMonitor.maxAttemptCount) {
       if (cancellationToken && cancellationToken.isCancellationRequested) {
         return { status: 'Cancelled' };


### PR DESCRIPTION
We sometimes get an error where the extension successfully schedules a remote query run but then fails with an `HttpError: Not Found` error when it checks the workflow status. Waiting a few seconds before starting to check the status might help 🤞🏽 

See internal linked issue for more info!

## Checklist

n/a, internal feature

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] If this pull request makes user-facing changes that require documentation changes, the `ready-for-doc-review` label has been added to this pull request or the corresponding issue.
