### PR TITLE
Update progress bar for "install pack dependencies"

### DIFF
--- a/extensions/ql-vscode/src/packaging.ts
+++ b/extensions/ql-vscode/src/packaging.ts
@@ -110,15 +110,19 @@ export async function handleInstallPackDependencies(
     canPickMany: true,
     ignoreFocusOut: true,
   });
-  if (packsToInstall && packsToInstall.length > 0) {
-    progress({
-      message: 'Installing dependencies. This may take a few minutes.',
-      step: 2,
-      maxStep: 2,
-    });
+  const numberOfPacks = packsToInstall?.length || 0;
+  if (packsToInstall && numberOfPacks > 0) {
     const failedPacks = [];
     const errors = [];
+    // Start at 1 because we already have the first step
+    let count = 1;
     for (const pack of packsToInstall) {
+      count++;
+      progress({
+        message: `Installing dependencies for ${pack.label}`,
+        step: count,
+        maxStep: numberOfPacks + 1,
+      });
       try {
         for (const dir of pack.packRootDir) {
           await cliServer.packInstall(dir);


### PR DESCRIPTION
As @adityasharad suggested in https://github.com/github/vscode-codeql/pull/1076#discussion_r787067110, we can have more granular progress tracking by counting how many packs to install 📦 

This sort of works, except we can't set the `maxStep` until after the user has selected the packs... So for the first step ([here](https://github.com/shati-patel/vscode-codeql/blob/d534f88fad43410f07b8ed651726f31d4d55649d/extensions/ql-vscode/src/packaging.ts#L98-L102)) I just stuck with "2" as the max number of steps, which means that the first step takes up a disproportionate amount of space in the progress bar. This looks a bit odd, but I don't think it's a big problem 😅 

## Checklist

n/a - just a follow-up to #1076!

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] If this pull request makes user-facing changes that require documentation changes, the `ready-for-doc-review` label has been added to this pull request or the corresponding issue.
