### PR TITLE
Download and process analyses results

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -84,6 +84,7 @@ import { URLSearchParams } from 'url';
 import { RemoteQueriesInterfaceManager } from './remote-queries/remote-queries-interface';
 import { sampleRemoteQuery, sampleRemoteQueryResult } from './remote-queries/sample-data';
 import { handleDownloadPacks, handleInstallPackDependencies } from './packaging';
+import { AnalysesResultsManager } from './remote-queries/analyses-results-manager';
 
 /**
  * extension.ts
@@ -817,7 +818,8 @@ async function activateWithInstalledDistribution(
 
   ctx.subscriptions.push(
     commandRunner('codeQL.showFakeRemoteQueryResults', async () => {
-      const rqim = new RemoteQueriesInterfaceManager(ctx, logger);
+      const analysisResultsManager = new AnalysesResultsManager(ctx, logger);
+      const rqim = new RemoteQueriesInterfaceManager(ctx, logger, analysisResultsManager);
       await rqim.showResults(sampleRemoteQuery, sampleRemoteQueryResult);
     }));
 

--- a/extensions/ql-vscode/src/pure/interface-types.ts
+++ b/extensions/ql-vscode/src/pure/interface-types.ts
@@ -1,6 +1,6 @@
 import * as sarif from 'sarif';
-import { DownloadLink } from '../remote-queries/download-link';
-import { RemoteQueryResult } from '../remote-queries/shared/remote-query-result';
+import { AnalysisResults } from '../remote-queries/shared/analysis-result';
+import { AnalysisSummary, RemoteQueryResult } from '../remote-queries/shared/remote-query-result';
 import { RawResultSet, ResultRow, ResultSetSchema, Column, ResolvableLocationValue } from './bqrs-cli-types';
 
 /**
@@ -381,7 +381,8 @@ export type FromRemoteQueriesMessage =
   | RemoteQueryDownloadAllAnalysesResultsMessage;
 
 export type ToRemoteQueriesMessage =
-  | SetRemoteQueryResultMessage;
+  | SetRemoteQueryResultMessage
+  | SetAnalysesResultsMessage;
 
 export interface RemoteQueryLoadedMessage {
   t: 'remoteQueryLoaded';
@@ -392,6 +393,11 @@ export interface SetRemoteQueryResultMessage {
   queryResult: RemoteQueryResult
 }
 
+export interface SetAnalysesResultsMessage {
+  t: 'setAnalysesResults';
+  analysesResults: AnalysisResults[];
+}
+
 export interface RemoteQueryErrorMessage {
   t: 'remoteQueryError';
   error: string;
@@ -399,11 +405,10 @@ export interface RemoteQueryErrorMessage {
 
 export interface RemoteQueryDownloadAnalysisResultsMessage {
   t: 'remoteQueryDownloadAnalysisResults';
-  nwo: string
-  downloadLink: DownloadLink;
+  analysisSummary: AnalysisSummary
 }
 
 export interface RemoteQueryDownloadAllAnalysesResultsMessage {
   t: 'remoteQueryDownloadAllAnalysesResults';
-  downloadLink: DownloadLink;
+  analysisSummaries: AnalysisSummary[];
 }

--- a/extensions/ql-vscode/src/remote-queries/analyses-results-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/analyses-results-manager.ts
@@ -1,0 +1,90 @@
+import { ExtensionContext } from 'vscode';
+import { Credentials } from '../authentication';
+import { Logger } from '../logging';
+import { downloadArtifactFromLink } from './gh-actions-api-client';
+import { DownloadLink } from './download-link';
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import { AnalysisSummary } from './shared/remote-query-result';
+import * as sarif from 'sarif';
+import { AnalysisResults, QueryResult } from './shared/analysis-result';
+
+export class AnalysesResultsManager {
+  // Store for the results of various analyses for a single remote query.
+  private readonly analysesResults: { [key: string]: QueryResult[] };
+
+  constructor(
+    private readonly ctx: ExtensionContext,
+    private readonly logger: Logger,
+  ) {
+    this.analysesResults = {};
+  }
+
+  public async downloadAnalysisResults(
+    analysisSummary: AnalysisSummary,
+  ): Promise<void> {
+    const credentials = await Credentials.initialize(this.ctx);
+
+    void this.logger.log(`Downloading and processing results for ${analysisSummary.nwo}`);
+
+    const queryResults = await this.downloadSingleAnalysisResults(
+      analysisSummary.downloadLink,
+      credentials);
+
+    this.analysesResults[analysisSummary.nwo] = queryResults;
+  }
+
+  public async downloadAllResults(
+    analysisSummaries: AnalysisSummary[],
+  ): Promise<void> {
+    const credentials = await Credentials.initialize(this.ctx);
+
+    void this.logger.log('Downloading and processing all results');
+
+    for (const analysis of analysisSummaries) {
+      const queryResults = await this.downloadSingleAnalysisResults(analysis.downloadLink, credentials);
+      this.analysesResults[analysis.nwo] = queryResults;
+    }
+  }
+
+  public getFlattenedAnalysesResults(): AnalysisResults[] {
+    return Object.entries(this.analysesResults).map(([nwo, results]) => ({ nwo, results }));
+  }
+
+  private async downloadSingleAnalysisResults(
+    downloadLink: DownloadLink,
+    credentials: Credentials
+  ): Promise<QueryResult[]> {
+    const artifactPath = await downloadArtifactFromLink(credentials, downloadLink);
+
+    if (path.extname(artifactPath) === '.sarif') {
+      return await this.readResults(artifactPath);
+    } else {
+      // Non-problem or problem-path queries are not currently fully supported.
+      return [];
+    }
+  }
+
+  private async readResults(filePath: string): Promise<QueryResult[]> {
+    const queryResults: QueryResult[] = [];
+
+    const sarifContents = await fs.readFile(filePath, 'utf8');
+    const sarifLog = JSON.parse(sarifContents) as sarif.Log;
+
+    // Read the sarif file and extract information that we want to display
+    // in the UI. For now we're only getting the message texts but we'll gradually
+    // extract more information based on the UX we want to build. 
+
+    sarifLog.runs?.forEach(run => {
+      run?.results?.forEach(result => {
+        if (result?.message?.text) {
+          queryResults.push({
+            message: result.message.text
+          });
+        }
+      });
+    });
+
+    return queryResults;
+  }
+}

--- a/extensions/ql-vscode/src/remote-queries/analyses-results-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/analyses-results-manager.ts
@@ -62,7 +62,7 @@ export class AnalysesResultsManager {
       const queryResults = await this.readResults(artifactPath);
       analysisResults = { nwo: analysis.nwo, results: queryResults };
     } else {
-      void this.logger.log('Non-problem or problem-path queries are not currently fully supported.');
+      void this.logger.log('Cannot download results. Only alert and path queries are fully supported.');
       analysisResults = { nwo: analysis.nwo, results: [] };
     }
 

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
@@ -202,12 +202,12 @@ export class RemoteQueriesInterfaceManager {
 
   private async downloadAnalysisResults(msg: RemoteQueryDownloadAnalysisResultsMessage): Promise<void> {
     await this.analysesResultsManager.downloadAnalysisResults(msg.analysisSummary);
-    await this.setAnalysisResults(this.analysesResultsManager.getFlattenedAnalysesResults());
+    await this.setAnalysisResults(this.analysesResultsManager.getAnalysesResults());
   }
 
   private async downloadAllAnalysesResults(msg: RemoteQueryDownloadAllAnalysesResultsMessage): Promise<void> {
     await this.analysesResultsManager.downloadAllResults(msg.analysisSummaries);
-    await this.setAnalysisResults(this.analysesResultsManager.getFlattenedAnalysesResults());
+    await this.setAnalysisResults(this.analysesResultsManager.getAnalysesResults());
   }
 
   private async setAnalysisResults(analysesResults: AnalysisResults[]): Promise<void> {

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
@@ -12,15 +12,18 @@ import { getRemoteQueryIndex } from './gh-actions-api-client';
 import { RemoteQueryResultIndex } from './remote-query-result-index';
 import { RemoteQueryResult } from './remote-query-result';
 import { DownloadLink } from './download-link';
+import { AnalysesResultsManager } from './analyses-results-manager';
 
 export class RemoteQueriesManager {
   private readonly remoteQueriesMonitor: RemoteQueriesMonitor;
+  private readonly analysesResultsManager: AnalysesResultsManager;
 
   constructor(
     private readonly ctx: ExtensionContext,
     private readonly logger: Logger,
     private readonly cliServer: CodeQLCliServer
   ) {
+    this.analysesResultsManager = new AnalysesResultsManager(ctx, logger);
     this.remoteQueriesMonitor = new RemoteQueriesMonitor(ctx, logger);
   }
 
@@ -67,7 +70,7 @@ export class RemoteQueriesManager {
 
       const shouldOpenView = await showInformationMessageWithAction(message, 'View');
       if (shouldOpenView) {
-        const rqim = new RemoteQueriesInterfaceManager(this.ctx, this.logger);
+        const rqim = new RemoteQueriesInterfaceManager(this.ctx, this.logger, this.analysesResultsManager);
         await rqim.showResults(query, queryResult);
       }
     } else if (queryResult.status === 'CompletedUnsuccessfully') {

--- a/extensions/ql-vscode/src/remote-queries/shared/analysis-result.ts
+++ b/extensions/ql-vscode/src/remote-queries/shared/analysis-result.ts
@@ -1,0 +1,8 @@
+export interface AnalysisResults {
+  nwo: string;
+  results: QueryResult[];
+}
+
+export interface QueryResult {
+  message?: string;
+}


### PR DESCRIPTION
Adds logic to download analyses results, do some minimal processing and make them available to the web view.

Note that this solution doesn't work well with running multiple queries but I'm hoping to address that once we have some notion of query history.

Also it does not support bqrs files as there is some Product/UX work that needs to happen.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
