### PR TITLE
Add query items immediately

### DIFF
--- a/extensions/ql-vscode/media/drive.svg
+++ b/extensions/ql-vscode/media/drive.svg
@@ -1,0 +1,7 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M15.5 12.1952C15.5 12.9126 14.9137 13.4996 14.1957 13.4996H1.80435C1.08696 13.4996 0.5 12.9126 0.5 12.1952L0.5 9.80435C0.5 9.08696 1.08696 8.5 1.80435 8.5H14.1956C14.9137 8.5 15.5 9.08696 15.5 9.80435L15.5 12.1952Z" stroke="#959DA5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M2.45654 11.5H13.5435" stroke="#959DA5" stroke-linecap="round" stroke-linejoin="round"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M13.5 9.5C13.224 9.5 13 9.725 13 10C13 10.275 13.224 10.5 13.5 10.5C13.776 10.5 14 10.275 14 10C14 9.725 13.776 9.5 13.5 9.5" fill="#959DA5"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M11.5 9.5C11.224 9.5 11 9.725 11 10C11 10.275 11.224 10.5 11.5 10.5C11.776 10.5 12 10.275 12 10C12 9.725 11.776 9.5 11.5 9.5" fill="#959DA5"/>
+<path d="M15.5 9.81464L13.8728 2.76261C13.6922 2.06804 12.9572 1.5 12.2391 1.5H3.76087C3.04348 1.5 2.30848 2.06804 2.12783 2.76261L0.5 9.8" stroke="#959DA5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -59,10 +59,10 @@ import { InterfaceManager } from './interface';
 import { WebviewReveal } from './interface-utils';
 import { ideServerLogger, logger, queryServerLogger } from './logging';
 import { QueryHistoryManager } from './query-history';
-import { CompletedQuery } from './query-results';
+import { FullCompletedQueryInfo, FullQueryInfo } from './query-results';
 import * as qsClient from './queryserver-client';
 import { displayQuickQuery } from './quick-query';
-import { compileAndRunQueryAgainstDatabase, tmpDirDisposal } from './run-queries';
+import { compileAndRunQueryAgainstDatabase, createInitialQueryInfo, tmpDirDisposal } from './run-queries';
 import { QLTestAdapterFactory } from './test-adapter';
 import { TestUIService } from './test-ui';
 import { CompareInterfaceManager } from './compare/compare-interface';
@@ -430,7 +430,7 @@ async function activateWithInstalledDistribution(
   void logger.log('Initializing query history manager.');
   const queryHistoryConfigurationListener = new QueryHistoryConfigListener();
   ctx.subscriptions.push(queryHistoryConfigurationListener);
-  const showResults = async (item: CompletedQuery) =>
+  const showResults = async (item: FullCompletedQueryInfo) =>
     showResultsForCompletedQuery(item, WebviewReveal.Forced);
 
   const qhm = new QueryHistoryManager(
@@ -438,7 +438,7 @@ async function activateWithInstalledDistribution(
     ctx.extensionPath,
     queryHistoryConfigurationListener,
     showResults,
-    async (from: CompletedQuery, to: CompletedQuery) =>
+    async (from: FullCompletedQueryInfo, to: FullCompletedQueryInfo) =>
       showResultsForComparison(from, to),
   );
   ctx.subscriptions.push(qhm);
@@ -460,8 +460,8 @@ async function activateWithInstalledDistribution(
   archiveFilesystemProvider.activate(ctx);
 
   async function showResultsForComparison(
-    from: CompletedQuery,
-    to: CompletedQuery
+    from: FullCompletedQueryInfo,
+    to: FullCompletedQueryInfo
   ): Promise<void> {
     try {
       await cmpm.showResults(from, to);
@@ -471,7 +471,7 @@ async function activateWithInstalledDistribution(
   }
 
   async function showResultsForCompletedQuery(
-    query: CompletedQuery,
+    query: FullCompletedQueryInfo,
     forceReveal: WebviewReveal
   ): Promise<void> {
     await intm.showResults(query, forceReveal, false);
@@ -491,22 +491,35 @@ async function activateWithInstalledDistribution(
       if (databaseItem === undefined) {
         throw new Error('Can\'t run query without a selected database');
       }
-      const info = await compileAndRunQueryAgainstDatabase(
-        cliServer,
-        qs,
-        databaseItem,
-        quickEval,
-        selectedQuery,
-        progress,
-        token,
-        undefined,
-        range
-      );
-      const item = qhm.buildCompletedQuery(info);
-      await showResultsForCompletedQuery(item, WebviewReveal.NotForced);
-      // Note we must update the query history view after showing results as the
-      // display and sorting might depend on the number of results
-      await qhm.addCompletedQuery(item);
+      const databaseInfo = {
+        name: databaseItem.name,
+        databaseUri: databaseItem.databaseUri.toString(),
+      };
+
+      const initialInfo = await createInitialQueryInfo(selectedQuery, databaseInfo, quickEval, range);
+      const item = new FullQueryInfo(initialInfo, queryHistoryConfigurationListener);
+      qhm.addCompletedQuery(item);
+      await qhm.refreshTreeView(item);
+
+      try {
+        const info = await compileAndRunQueryAgainstDatabase(
+          cliServer,
+          qs,
+          databaseItem,
+          initialInfo,
+          progress,
+          token,
+        );
+        item.completeThisQuery(info);
+        await showResultsForCompletedQuery(item as FullCompletedQueryInfo, WebviewReveal.NotForced);
+        // Note we must update the query history view after showing results as the
+        // display and sorting might depend on the number of results
+      } catch (e) {
+        item.failureReason = e.message;
+        throw e;
+      } finally {
+        await qhm.refreshTreeView(item);
+      }
     }
   }
 
@@ -1017,7 +1030,7 @@ const checkForUpdatesCommand = 'codeQL.checkForUpdatesToCLI';
 
 /**
  * This text provider lets us open readonly files in the editor.
- * 
+ *
  * TODO: Consolidate this with the 'codeql' text provider in query-history.ts.
  */
 function registerRemoteQueryTextProvider() {

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
@@ -56,7 +56,7 @@ export class RemoteQueriesInterfaceManager {
   /**
    * Builds up a model tailored to the view based on the query and result domain entities.
    * The data is cleaned up, sorted where necessary, and transformed to a format that
-   * the view model can use. 
+   * the view model can use.
    * @param query Information about the query that was run.
    * @param queryResult The result of the query.
    * @returns A fully created view model.
@@ -125,10 +125,12 @@ export class RemoteQueriesInterfaceManager {
         scriptPathOnDisk,
         [baseStylesheetUriOnDisk, stylesheetPathOnDisk]
       );
-      panel.webview.onDidReceiveMessage(
-        async (e) => this.handleMsgFromView(e),
-        undefined,
-        ctx.subscriptions
+      ctx.subscriptions.push(
+        panel.webview.onDidReceiveMessage(
+          async (e) => this.handleMsgFromView(e),
+          undefined,
+          ctx.subscriptions
+        )
       );
     }
     return this.panel;

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/queries.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/queries.test.ts
@@ -11,7 +11,7 @@ import { DatabaseItem, DatabaseManager } from '../../databases';
 import { CodeQLExtensionInterface } from '../../extension';
 import { dbLoc, storagePath } from './global.helper';
 import { importArchiveDatabase } from '../../databaseFetcher';
-import { compileAndRunQueryAgainstDatabase } from '../../run-queries';
+import { compileAndRunQueryAgainstDatabase, createInitialQueryInfo } from '../../run-queries';
 import { CodeQLCliServer } from '../../cli';
 import { QueryServerClient } from '../../queryserver-client';
 import { skipIfNoCodeQL } from '../ensureCli';
@@ -96,15 +96,12 @@ describe('Queries', function() {
         cli,
         qs,
         dbItem,
-        false,
-        Uri.file(queryPath),
+        await mockInitialQueryInfo(queryPath),
         progress,
         token
       );
 
       // just check that the query was successful
-      expect(result.database.name).to.eq('db');
-      expect(result.options.queryText).to.eq(fs.readFileSync(queryPath, 'utf8'));
       expect(result.result.resultType).to.eq(QueryResultType.SUCCESS);
     } catch (e) {
       console.error('Test Failed');
@@ -121,15 +118,13 @@ describe('Queries', function() {
         cli,
         qs,
         dbItem,
-        false,
-        Uri.file(queryPath),
+        await mockInitialQueryInfo(queryPath),
         progress,
         token
       );
 
       // this message would indicate that the databases were not properly reregistered
       expect(result.result.message).not.to.eq('No result from server');
-      expect(result.options.queryText).to.eq(fs.readFileSync(queryPath, 'utf8'));
       expect(result.result.resultType).to.eq(QueryResultType.SUCCESS);
     } catch (e) {
       console.error('Test Failed');
@@ -173,5 +168,16 @@ describe('Queries', function() {
     } catch (e) {
       // ignore
     }
+  }
+
+  async function mockInitialQueryInfo(queryPath: string) {
+    return await createInitialQueryInfo(
+      Uri.file(queryPath),
+      {
+        name: dbItem.name,
+        databaseUri: dbItem.databaseUri.toString(),
+      },
+      false
+    );
   }
 });

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
@@ -6,8 +6,11 @@ import * as sinon from 'sinon';
 import * as chaiAsPromised from 'chai-as-promised';
 import { logger } from '../../logging';
 import { QueryHistoryManager, HistoryTreeDataProvider } from '../../query-history';
-import { CompletedQuery } from '../../query-results';
-import { QueryInfo } from '../../run-queries';
+import { QueryEvaluatonInfo, QueryWithResults } from '../../run-queries';
+import { QueryHistoryConfigListener } from '../../config';
+import * as messages from '../../pure/messages';
+import { QueryServerClient } from '../../queryserver-client';
+import { FullQueryInfo, InitialQueryInfo } from '../../query-results';
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;
@@ -15,10 +18,14 @@ const assert = chai.assert;
 
 
 describe('query-history', () => {
+  let configListener: QueryHistoryConfigListener;
   let showTextDocumentSpy: sinon.SinonStub;
   let showInformationMessageSpy: sinon.SinonStub;
   let executeCommandSpy: sinon.SinonStub;
   let showQuickPickSpy: sinon.SinonStub;
+  let queryHistoryManager: QueryHistoryManager | undefined;
+  let selectedCallback: sinon.SinonStub;
+  let doCompareCallback: sinon.SinonStub;
 
   let tryOpenExternalFile: Function;
   let sandbox: sinon.SinonSandbox;
@@ -38,9 +45,16 @@ describe('query-history', () => {
     executeCommandSpy = sandbox.stub(vscode.commands, 'executeCommand');
     sandbox.stub(logger, 'log');
     tryOpenExternalFile = (QueryHistoryManager.prototype as any).tryOpenExternalFile;
+    configListener = new QueryHistoryConfigListener();
+    selectedCallback = sandbox.stub();
+    doCompareCallback = sandbox.stub();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    if (queryHistoryManager) {
+      queryHistoryManager.dispose();
+      queryHistoryManager = undefined;
+    }
     sandbox.restore();
   });
 
@@ -85,24 +99,24 @@ describe('query-history', () => {
     });
   });
 
+  let allHistory: FullQueryInfo[];
+
+  beforeEach(() => {
+    allHistory = [
+      createMockFullQueryInfo('a', createMockQueryWithResults(true)),
+      createMockFullQueryInfo('b', createMockQueryWithResults(true)),
+      createMockFullQueryInfo('a', createMockQueryWithResults(false)),
+      createMockFullQueryInfo('a', createMockQueryWithResults(true)),
+    ];
+  });
+
   describe('findOtherQueryToCompare', () => {
-    let allHistory: { database: { name: string }; didRunSuccessfully: boolean }[];
-
-    beforeEach(() => {
-      allHistory = [
-        { didRunSuccessfully: true, database: { name: 'a' } },
-        { didRunSuccessfully: true, database: { name: 'b' } },
-        { didRunSuccessfully: false, database: { name: 'a' } },
-        { didRunSuccessfully: true, database: { name: 'a' } },
-      ];
-    });
-
     it('should find the second query to compare when one is selected', async () => {
       const thisQuery = allHistory[3];
-      const queryHistory = createMockQueryHistory(allHistory);
+      queryHistoryManager = await createMockQueryHistory(allHistory);
       showQuickPickSpy.returns({ query: allHistory[0] });
 
-      const otherQuery = await queryHistory.findOtherQueryToCompare(thisQuery, []);
+      const otherQuery = await (queryHistoryManager as any).findOtherQueryToCompare(thisQuery, []);
       expect(otherQuery).to.eq(allHistory[0]);
 
       // only called with first item, other items filtered out
@@ -112,9 +126,9 @@ describe('query-history', () => {
 
     it('should handle cancelling out of the quick select', async () => {
       const thisQuery = allHistory[3];
-      const queryHistory = createMockQueryHistory(allHistory);
+      queryHistoryManager = await createMockQueryHistory(allHistory);
 
-      const otherQuery = await queryHistory.findOtherQueryToCompare(thisQuery, []);
+      const otherQuery = await (queryHistoryManager as any).findOtherQueryToCompare(thisQuery, []);
       expect(otherQuery).to.be.undefined;
 
       // only called with first item, other items filtered out
@@ -124,20 +138,20 @@ describe('query-history', () => {
 
     it('should compare against 2 queries', async () => {
       const thisQuery = allHistory[3];
-      const queryHistory = createMockQueryHistory(allHistory);
+      queryHistoryManager = await createMockQueryHistory(allHistory);
 
-      const otherQuery = await queryHistory.findOtherQueryToCompare(thisQuery, [thisQuery, allHistory[0]]);
+      const otherQuery = await (queryHistoryManager as any).findOtherQueryToCompare(thisQuery, [thisQuery, allHistory[0]]);
       expect(otherQuery).to.eq(allHistory[0]);
       expect(showQuickPickSpy).not.to.have.been.called;
     });
 
     it('should throw an error when a query is not successful', async () => {
       const thisQuery = allHistory[3];
-      const queryHistory = createMockQueryHistory(allHistory);
-      allHistory[0].didRunSuccessfully = false;
+      queryHistoryManager = await createMockQueryHistory(allHistory);
+      allHistory[0] = createMockFullQueryInfo('a', createMockQueryWithResults(false));
 
       try {
-        await queryHistory.findOtherQueryToCompare(thisQuery, [thisQuery, allHistory[0]]);
+        await (queryHistoryManager as any).findOtherQueryToCompare(thisQuery, [thisQuery, allHistory[0]]);
         assert(false, 'Should have thrown');
       } catch (e) {
         expect(e.message).to.eq('Please select a successful query.');
@@ -145,12 +159,12 @@ describe('query-history', () => {
     });
 
     it('should throw an error when a databases are not the same', async () => {
-      const thisQuery = allHistory[3];
-      const queryHistory = createMockQueryHistory(allHistory);
-      allHistory[0].database.name = 'c';
+      queryHistoryManager = await createMockQueryHistory(allHistory);
 
       try {
-        await queryHistory.findOtherQueryToCompare(thisQuery, [thisQuery, allHistory[0]]);
+        // allHistory[0] is database a
+        // allHistory[1] is database b
+        await (queryHistoryManager as any).findOtherQueryToCompare(allHistory[0], [allHistory[0], allHistory[1]]);
         assert(false, 'Should have thrown');
       } catch (e) {
         expect(e.message).to.eq('Query databases must be the same.');
@@ -159,10 +173,10 @@ describe('query-history', () => {
 
     it('should throw an error when more than 2 queries selected', async () => {
       const thisQuery = allHistory[3];
-      const queryHistory = createMockQueryHistory(allHistory);
+      queryHistoryManager = await createMockQueryHistory(allHistory);
 
       try {
-        await queryHistory.findOtherQueryToCompare(thisQuery, [thisQuery, allHistory[0], allHistory[1]]);
+        await (queryHistoryManager as any).findOtherQueryToCompare(thisQuery, [thisQuery, allHistory[0], allHistory[1]]);
         assert(false, 'Should have thrown');
       } catch (e) {
         expect(e.message).to.eq('Please select no more than 2 queries.');
@@ -170,39 +184,116 @@ describe('query-history', () => {
     });
   });
 
+  describe('handleItemClicked', () => {
+    it('should call the selectedCallback when an item is clicked', async () => {
+      queryHistoryManager = await createMockQueryHistory(allHistory);
+      await queryHistoryManager.handleItemClicked(allHistory[0], [allHistory[0]]);
+      expect(selectedCallback).to.have.been.calledOnceWith(allHistory[0]);
+      expect(queryHistoryManager.treeDataProvider.getCurrent()).to.eq(allHistory[0]);
+    });
+
+    it('should do nothing if there is a multi-selection', async () => {
+      queryHistoryManager = await createMockQueryHistory(allHistory);
+      await queryHistoryManager.handleItemClicked(allHistory[0], [allHistory[0], allHistory[1]]);
+      expect(selectedCallback).not.to.have.been.called;
+      expect(queryHistoryManager.treeDataProvider.getCurrent()).to.be.undefined;
+    });
+
+    it('should throw if there is no selection', async () => {
+      queryHistoryManager = await createMockQueryHistory(allHistory);
+      try {
+        await queryHistoryManager.handleItemClicked(undefined!, []);
+        expect(true).to.be.false;
+      } catch (e) {
+        expect(selectedCallback).not.to.have.been.called;
+        expect(e.message).to.contain('No query selected');
+      }
+    });
+  });
+
+  it('should remove an item and not select a new one', async function() {
+    queryHistoryManager = await createMockQueryHistory(allHistory);
+    // deleting the first item when a different item is selected
+    // will not change the selection
+    const toDelete = allHistory[1];
+    const selected = allHistory[3];
+    // avoid triggering the callback by setting the field directly
+    (queryHistoryManager.treeDataProvider as any).current = selected;
+    await queryHistoryManager.handleRemoveHistoryItem(toDelete, [toDelete]);
+
+    expect(toDelete.completedQuery!.dispose).to.have.been.calledOnce;
+    expect(queryHistoryManager.treeDataProvider.getCurrent()).to.eq(selected);
+    expect(allHistory).not.to.contain(toDelete);
+
+    // the current item should have been re-selected
+    expect(selectedCallback).to.have.been.calledOnceWith(selected);
+  });
+
+  it('should remove an item and select a new one', async () => {
+    queryHistoryManager = await createMockQueryHistory(allHistory);
+
+    // deleting the selected item automatically selects next item
+    const toDelete = allHistory[1];
+    const newSelected = allHistory[2];
+    // avoid triggering the callback by setting the field directly
+    (queryHistoryManager.treeDataProvider as any).current = toDelete;
+    await queryHistoryManager.handleRemoveHistoryItem(toDelete, [toDelete]);
+
+    expect(toDelete.completedQuery!.dispose).to.have.been.calledOnce;
+    expect(queryHistoryManager.treeDataProvider.getCurrent()).to.eq(newSelected);
+    expect(allHistory).not.to.contain(toDelete);
+
+    // the current item should have been selected
+    expect(selectedCallback).to.have.been.calledOnceWith(newSelected);
+  });
+
+  describe('Compare callback', () => {
+    it('should call the compare callback', async () => {
+      queryHistoryManager = await createMockQueryHistory(allHistory);
+      await queryHistoryManager.handleCompareWith(allHistory[0], [allHistory[0], allHistory[3]]);
+      expect(doCompareCallback).to.have.been.calledOnceWith(allHistory[0], allHistory[3]);
+    });
+
+    it('should avoid calling the compare callback when only one item is selected', async () => {
+      queryHistoryManager = await createMockQueryHistory(allHistory);
+      await queryHistoryManager.handleCompareWith(allHistory[0], [allHistory[0]]);
+      expect(doCompareCallback).not.to.have.been.called;
+    });
+  });
+
   describe('updateCompareWith', () => {
-    it('should update compareWithItem when there is a single item', () => {
-      const queryHistory = createMockQueryHistory([]);
-      queryHistory.updateCompareWith(['a']);
-      expect(queryHistory.compareWithItem).to.be.eq('a');
+    it('should update compareWithItem when there is a single item', async () => {
+      queryHistoryManager = await createMockQueryHistory([]);
+      (queryHistoryManager as any).updateCompareWith(['a']);
+      expect(queryHistoryManager.compareWithItem).to.be.eq('a');
     });
 
-    it('should delete compareWithItem when there are 0 items', () => {
-      const queryHistory = createMockQueryHistory([]);
-      queryHistory.compareWithItem = 'a';
-      queryHistory.updateCompareWith([]);
-      expect(queryHistory.compareWithItem).to.be.undefined;
+    it('should delete compareWithItem when there are 0 items', async () => {
+      queryHistoryManager = await createMockQueryHistory([]);
+      queryHistoryManager.compareWithItem = allHistory[0];
+      (queryHistoryManager as any).updateCompareWith([]);
+      expect(queryHistoryManager.compareWithItem).to.be.undefined;
     });
 
-    it('should delete compareWithItem when there are more than 2 items', () => {
-      const queryHistory = createMockQueryHistory([]);
-      queryHistory.compareWithItem = 'a';
-      queryHistory.updateCompareWith(['a', 'b', 'c']);
-      expect(queryHistory.compareWithItem).to.be.undefined;
+    it('should delete compareWithItem when there are more than 2 items', async () => {
+      queryHistoryManager = await createMockQueryHistory(allHistory);
+      queryHistoryManager.compareWithItem = allHistory[0];
+      (queryHistoryManager as any).updateCompareWith([allHistory[0], allHistory[1], allHistory[2]]);
+      expect(queryHistoryManager.compareWithItem).to.be.undefined;
     });
 
-    it('should delete compareWithItem when there are 2 items and disjoint from compareWithItem', () => {
-      const queryHistory = createMockQueryHistory([]);
-      queryHistory.compareWithItem = 'a';
-      queryHistory.updateCompareWith(['b', 'c']);
-      expect(queryHistory.compareWithItem).to.be.undefined;
+    it('should delete compareWithItem when there are 2 items and disjoint from compareWithItem', async () => {
+      queryHistoryManager = await createMockQueryHistory([]);
+      queryHistoryManager.compareWithItem = allHistory[0];
+      (queryHistoryManager as any).updateCompareWith([allHistory[1], allHistory[2]]);
+      expect(queryHistoryManager.compareWithItem).to.be.undefined;
     });
 
-    it('should do nothing when compareWithItem exists and exactly 2 items', () => {
-      const queryHistory = createMockQueryHistory([]);
-      queryHistory.compareWithItem = 'a';
-      queryHistory.updateCompareWith(['a', 'b']);
-      expect(queryHistory.compareWithItem).to.be.eq('a');
+    it('should do nothing when compareWithItem exists and exactly 2 items', async () => {
+      queryHistoryManager = await createMockQueryHistory([]);
+      queryHistoryManager.compareWithItem = allHistory[0];
+      (queryHistoryManager as any).updateCompareWith([allHistory[0], allHistory[1]]);
+      expect(queryHistoryManager.compareWithItem).to.be.eq(allHistory[0]);
     });
   });
 
@@ -212,70 +303,107 @@ describe('query-history', () => {
       historyTreeDataProvider = new HistoryTreeDataProvider(vscode.Uri.file('/a/b/c').fsPath);
     });
 
+    afterEach(() => {
+      historyTreeDataProvider.dispose();
+    });
+
+
     it('should get a tree item with raw results', async () => {
-      const mockQuery = {
-        query: {
-          hasInterpretedResults: () => Promise.resolve(false)
-        } as QueryInfo,
-        didRunSuccessfully: true,
-        toString: () => 'mock label'
-      } as CompletedQuery;
+      const mockQuery = createMockFullQueryInfo('a', createMockQueryWithResults(true, /* raw results */ false));
       const treeItem = await historyTreeDataProvider.getTreeItem(mockQuery);
       expect(treeItem.command).to.deep.eq({
         title: 'Query History Item',
         command: 'codeQLQueryHistory.itemClicked',
         arguments: [mockQuery],
       });
-      expect(treeItem.label).to.eq('mock label');
+      expect(treeItem.label).to.contain('hucairz');
       expect(treeItem.contextValue).to.eq('rawResultsItem');
-      expect(treeItem.iconPath).to.be.undefined;
+      expect(treeItem.iconPath).to.deep.eq({
+        id: 'check', color: undefined
+      });
     });
 
     it('should get a tree item with interpreted results', async () => {
-      const mockQuery = {
-        query: {
-          // as above, except for this line
-          hasInterpretedResults: () => Promise.resolve(true)
-        } as QueryInfo,
-        didRunSuccessfully: true,
-        toString: () => 'mock label'
-      } as CompletedQuery;
+      const mockQuery = createMockFullQueryInfo('a', createMockQueryWithResults(true, /* interpreted results */ true));
       const treeItem = await historyTreeDataProvider.getTreeItem(mockQuery);
       expect(treeItem.contextValue).to.eq('interpretedResultsItem');
+      expect(treeItem.iconPath).to.deep.eq({
+        id: 'check', color: undefined
+      });
     });
 
     it('should get a tree item that did not complete successfully', async () => {
-      const mockQuery = {
-        query: {
-          hasInterpretedResults: () => Promise.resolve(true)
-        } as QueryInfo,
-        // as above, except for this line
-        didRunSuccessfully: false,
-        toString: () => 'mock label'
-      } as CompletedQuery;
+      const mockQuery = createMockFullQueryInfo('a', createMockQueryWithResults(false), false);
       const treeItem = await historyTreeDataProvider.getTreeItem(mockQuery);
       expect(treeItem.iconPath).to.eq(vscode.Uri.file('/a/b/c/media/red-x.svg').fsPath);
     });
 
+    it('should get a tree item that failed before creating any results', async () => {
+      const mockQuery = createMockFullQueryInfo('a', undefined, true);
+      const treeItem = await historyTreeDataProvider.getTreeItem(mockQuery);
+      expect(treeItem.iconPath).to.eq(vscode.Uri.file('/a/b/c/media/red-x.svg').fsPath);
+    });
+
+    it('should get a tree item that is in progress', async () => {
+      const mockQuery = createMockFullQueryInfo('a');
+      const treeItem = await historyTreeDataProvider.getTreeItem(mockQuery);
+      expect(treeItem.iconPath).to.deep.eq({
+        id: 'search-refresh', color: undefined
+      });
+    });
+
     it('should get children', () => {
-      const mockQuery = {
-        databaseName: 'abc'
-      } as CompletedQuery;
+      const mockQuery = createMockFullQueryInfo();
       historyTreeDataProvider.allHistory.push(mockQuery);
       expect(historyTreeDataProvider.getChildren()).to.deep.eq([mockQuery]);
       expect(historyTreeDataProvider.getChildren(mockQuery)).to.deep.eq([]);
     });
   });
-});
 
-function createMockQueryHistory(allHistory: Record<string, unknown>[]) {
-  return {
-    assertSingleQuery: (QueryHistoryManager.prototype as any).assertSingleQuery,
-    findOtherQueryToCompare: (QueryHistoryManager.prototype as any).findOtherQueryToCompare,
-    treeDataProvider: {
-      allHistory
-    },
-    updateCompareWith: (QueryHistoryManager.prototype as any).updateCompareWith,
-    compareWithItem: undefined as undefined | string,
-  };
-}
+  function createMockFullQueryInfo(dbName = 'a', queryWitbResults?: QueryWithResults, isFail = false): FullQueryInfo {
+    const fqi = new FullQueryInfo(
+      {
+        databaseInfo: { name: dbName },
+        start: new Date(),
+        queryPath: 'hucairz'
+      } as InitialQueryInfo,
+      configListener
+    );
+
+    if (queryWitbResults) {
+      fqi.completeThisQuery(queryWitbResults);
+    }
+    if (isFail) {
+      fqi.failureReason = 'failure reason';
+    }
+    return fqi;
+  }
+
+  function createMockQueryWithResults(didRunSuccessfully = true, hasInterpretedResults = true): QueryWithResults {
+    return {
+      query: {
+        hasInterpretedResults: () => Promise.resolve(hasInterpretedResults)
+      } as QueryEvaluatonInfo,
+      result: {
+        resultType: didRunSuccessfully
+          ? messages.QueryResultType.SUCCESS
+          : messages.QueryResultType.OTHER_ERROR
+      } as messages.EvaluationResult,
+      dispose: sandbox.spy(),
+    };
+  }
+
+  async function createMockQueryHistory(allHistory: FullQueryInfo[]) {
+    const qhm = new QueryHistoryManager(
+      {} as QueryServerClient,
+      'xxx',
+      configListener,
+      selectedCallback,
+      doCompareCallback
+    );
+    (qhm.treeDataProvider as any).history = allHistory;
+    await vscode.workspace.saveAll();
+
+    return qhm;
+  }
+});

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/run-queries.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/run-queries.test.ts
@@ -5,7 +5,7 @@ import 'sinon-chai';
 import * as sinon from 'sinon';
 import * as chaiAsPromised from 'chai-as-promised';
 
-import { QueryInfo } from '../../run-queries';
+import { QueryEvaluatonInfo } from '../../run-queries';
 import { QlProgram, Severity, compileQuery } from '../../pure/messages';
 import { DatabaseItem } from '../../databases';
 
@@ -13,7 +13,7 @@ chai.use(chaiAsPromised);
 const expect = chai.expect;
 
 describe('run-queries', () => {
-  it('should create a QueryInfo', () => {
+  it('should create a QueryEvaluatonInfo', () => {
     const info = createMockQueryInfo();
 
     const queryID = info.queryID;
@@ -85,7 +85,7 @@ describe('run-queries', () => {
   });
 
   function createMockQueryInfo() {
-    return new QueryInfo(
+    return new QueryEvaluatonInfo(
       'my-program' as unknown as QlProgram,
       {
         contents: {


### PR DESCRIPTION
This is a large commit and includes all the changes to add query
history items immediately. This also includes some smaller related 
changes that were hit while cleaning this area up.

The major part of this change is a refactoring of what we store in
the query history list. Previously, the `CompletedQuery` was stored.
Previously, objects of this type include all information about a query that was run
including:

- Its source file and text range (if a quick eval)
- Its database
- Its label
- The query results itself
- Metrics about the query run
- Metadata about the query itself

Now, the item stored is called a `FullQueryInfo`, which has two
properties:

- InitialQueryInfo: all the data about the query that we know _before_
  the query completes, eg- its source file and text range, database, and
  label
- CompletedQueryInfo: all the data about the query that we can only
  learn _after_ the query completes. This is an optional property.

There is also a `failureReason` property, which is an optional string
describing why the query failed.


There is also a `FullCompletedQueryInfo` type, which only exists to 
help with stronger typing. It is a `FullQueryInfo` with a non-optional
`CompletedQueryInfo`.

Most of the changes are around changing how the query history accesses
its history list.

There are some other smaller changes included here:

- New icon for completed query (previously, completed queries had no
  icons).
- New spinning icon for in progress queries.
- Better error handling in the logger to handle log messages when the
  extension is shutting down. This mostly helps clean up the output
  during tests.
- Add more disposables to subscriptions to be disposed of when the
  extension shuts down.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Replace this with a description of the changes your pull request makes.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
