### PR TITLE
Auto-download analyses results

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -779,7 +779,7 @@ async function activateWithInstalledDistribution(
   );
 
   void logger.log('Initializing remote queries interface.');
-  const rqm = new RemoteQueriesManager(ctx, logger, cliServer);
+  const rqm = new RemoteQueriesManager(ctx, cliServer, logger);
 
   registerRemoteQueryTextProvider();
 

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -80,6 +80,7 @@ import { CodeQlStatusBarHandler } from './status-bar';
 import { Credentials } from './authentication';
 import { RemoteQueriesManager } from './remote-queries/remote-queries-manager';
 import { RemoteQuery } from './remote-queries/remote-query';
+import { RemoteQueryResult } from './remote-queries/remote-query-result';
 import { URLSearchParams } from 'url';
 import { RemoteQueriesInterfaceManager } from './remote-queries/remote-queries-interface';
 import { sampleRemoteQuery, sampleRemoteQueryResult } from './remote-queries/sample-data';
@@ -814,6 +815,13 @@ async function activateWithInstalledDistribution(
       query: RemoteQuery,
       token: CancellationToken) => {
       await rqm.monitorRemoteQuery(query, token);
+    }));
+
+  ctx.subscriptions.push(
+    commandRunner('codeQL.autoDownloadRemoteQueryResults', async (
+      queryResult: RemoteQueryResult,
+      token: CancellationToken) => {
+      await rqm.autoDownloadRemoteQueryResults(queryResult, token);
     }));
 
   ctx.subscriptions.push(

--- a/extensions/ql-vscode/src/remote-queries/analyses-results-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/analyses-results-manager.ts
@@ -48,7 +48,7 @@ export class AnalysesResultsManager {
     const batchSize = 3;
 
     for (let i = 0; i < analysesToDownload.length; i += batchSize) {
-      if (token && token.isCancellationRequested) {
+      if (token?.isCancellationRequested) {
         throw new Error('Downloading of analyses results has been cancelled');
       }
 

--- a/extensions/ql-vscode/src/remote-queries/analyses-results-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/analyses-results-manager.ts
@@ -47,7 +47,7 @@ export class AnalysesResultsManager {
     void this.logger.log('Downloading and processing analyses results');
 
     const batchSize = 3;
-    const numOfBatches = Math.ceil(analysesToDownload.length / 3);
+    const numOfBatches = Math.ceil(analysesToDownload.length / batchSize);
 
     for (let i = 0; i < analysesToDownload.length; i += batchSize) {
       if (token?.isCancellationRequested) {
@@ -58,7 +58,7 @@ export class AnalysesResultsManager {
       const batchTasks = batch.map(analysis => this.downloadSingleAnalysisResults(analysis, credentials));
 
       const nwos = batch.map(a => a.nwo).join(', ');
-      void this.logger.log(`Downloading batch ${Math.floor(i / 3) + 1} of ${numOfBatches} (${nwos})`);
+      void this.logger.log(`Downloading batch ${Math.floor(i / batchSize) + 1} of ${numOfBatches} (${nwos})`);
 
       await Promise.all(batchTasks);
 

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
@@ -51,6 +51,8 @@ export class RemoteQueriesInterfaceManager {
       t: 'setRemoteQueryResult',
       queryResult: this.buildViewModel(query, queryResult)
     });
+
+    await this.setAnalysisResults(this.analysesResultsManager.getAnalysesResults());
   }
 
   /**
@@ -201,20 +203,25 @@ export class RemoteQueriesInterfaceManager {
   }
 
   private async downloadAnalysisResults(msg: RemoteQueryDownloadAnalysisResultsMessage): Promise<void> {
-    await this.analysesResultsManager.downloadAnalysisResults(msg.analysisSummary);
-    await this.setAnalysisResults(this.analysesResultsManager.getAnalysesResults());
+    await this.analysesResultsManager.downloadAnalysisResults(
+      msg.analysisSummary,
+      results => this.setAnalysisResults(results));
   }
 
   private async downloadAllAnalysesResults(msg: RemoteQueryDownloadAllAnalysesResultsMessage): Promise<void> {
-    await this.analysesResultsManager.downloadAllResults(msg.analysisSummaries);
-    await this.setAnalysisResults(this.analysesResultsManager.getAnalysesResults());
+    await this.analysesResultsManager.downloadAnalysesResults(
+      msg.analysisSummaries,
+      undefined,
+      results => this.setAnalysisResults(results));
   }
 
-  private async setAnalysisResults(analysesResults: AnalysisResults[]): Promise<void> {
-    await this.postMessage({
-      t: 'setAnalysesResults',
-      analysesResults: analysesResults
-    });
+  public async setAnalysisResults(analysesResults: AnalysisResults[]): Promise<void> {
+    if (this.panel?.active) {
+      await this.postMessage({
+        t: 'setAnalysesResults',
+        analysesResults: analysesResults
+      });
+    }
   }
 
   private postMessage(msg: ToRemoteQueriesMessage): Thenable<boolean> {

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
@@ -28,7 +28,7 @@ export class RemoteQueriesManager {
     private readonly cliServer: CodeQLCliServer
   ) {
     this.analysesResultsManager = new AnalysesResultsManager(ctx, logger);
-    this.interfaceManager = new RemoteQueriesInterfaceManager(this.ctx, this.logger, this.analysesResultsManager);
+    this.interfaceManager = new RemoteQueriesInterfaceManager(ctx, logger, this.analysesResultsManager);
     this.remoteQueriesMonitor = new RemoteQueriesMonitor(ctx, logger);
   }
 

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
@@ -24,8 +24,8 @@ export class RemoteQueriesManager {
 
   constructor(
     private readonly ctx: ExtensionContext,
-    private readonly logger: Logger,
-    private readonly cliServer: CodeQLCliServer
+    private readonly cliServer: CodeQLCliServer,
+    logger: Logger,
   ) {
     this.analysesResultsManager = new AnalysesResultsManager(ctx, logger);
     this.interfaceManager = new RemoteQueriesInterfaceManager(ctx, logger, this.analysesResultsManager);

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
@@ -100,7 +100,7 @@ export class RemoteQueriesManager {
         nwo: a.nwo,
         resultCount: a.resultCount,
         downloadLink: a.downloadLink,
-        fileSize: a.fileSizeInBytes.toString()
+        fileSize: String(a.fileSizeInBytes)
       }));
 
     await this.analysesResultsManager.downloadAnalysesResults(


### PR DESCRIPTION
Kick off auto-downloading of analyses results once a remote query has completed successfully.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
