### PR TITLE
Update to VS Code 1.59.0

### DIFF
--- a/extensions/ql-vscode/package-lock.json
+++ b/extensions/ql-vscode/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "vscode-codeql",
-      "version": "1.5.10",
+      "version": "1.5.11",
       "license": "MIT",
       "dependencies": {
         "@octokit/rest": "^18.5.6",
@@ -64,7 +64,7 @@
         "@types/through2": "^2.0.36",
         "@types/tmp": "^0.1.0",
         "@types/unzipper": "~0.10.1",
-        "@types/vscode": "^1.57.0",
+        "@types/vscode": "^1.59.0",
         "@types/webpack": "^4.32.1",
         "@types/xml2js": "~0.4.4",
         "@typescript-eslint/eslint-plugin": "^4.26.0",
@@ -105,7 +105,7 @@
         "webpack-cli": "^4.6.0"
       },
       "engines": {
-        "vscode": "^1.57.0"
+        "vscode": "^1.59.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -975,9 +975,9 @@
       }
     },
     "node_modules/@types/vscode": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.57.0.tgz",
-      "integrity": "sha512-FeznBFtIDCWRluojTsi9c3LLcCHOXP5etQfBK42+ixo1CoEAchkw39tuui9zomjZuKfUVL33KZUDIwHZ/xvOkQ==",
+      "version": "1.59.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.59.0.tgz",
+      "integrity": "sha512-Zg38rusx2nU6gy6QdF7v4iqgxNfxzlBlDhrRCjOiPQp+sfaNrp3f9J6OHIhpGNN1oOAca4+9Hq0+8u3jwzPMlQ==",
       "dev": true
     },
     "node_modules/@types/webpack": {
@@ -12788,9 +12788,9 @@
       }
     },
     "@types/vscode": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.57.0.tgz",
-      "integrity": "sha512-FeznBFtIDCWRluojTsi9c3LLcCHOXP5etQfBK42+ixo1CoEAchkw39tuui9zomjZuKfUVL33KZUDIwHZ/xvOkQ==",
+      "version": "1.59.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.59.0.tgz",
+      "integrity": "sha512-Zg38rusx2nU6gy6QdF7v4iqgxNfxzlBlDhrRCjOiPQp+sfaNrp3f9J6OHIhpGNN1oOAca4+9Hq0+8u3jwzPMlQ==",
       "dev": true
     },
     "@types/webpack": {

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/github/vscode-codeql"
   },
   "engines": {
-    "vscode": "^1.57.0"
+    "vscode": "^1.59.0"
   },
   "categories": [
     "Programming Languages"
@@ -1057,7 +1057,7 @@
     "@types/through2": "^2.0.36",
     "@types/tmp": "^0.1.0",
     "@types/unzipper": "~0.10.1",
-    "@types/vscode": "^1.57.0",
+    "@types/vscode": "^1.59.0",
     "@types/webpack": "^4.32.1",
     "@types/xml2js": "~0.4.4",
     "@typescript-eslint/eslint-plugin": "^4.26.0",

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/helpers.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/helpers.test.ts
@@ -192,6 +192,9 @@ describe('helpers', () => {
   }
 
   class MockMemento implements Memento {
+    keys(): readonly string[] {
+      throw new Error('Method not implemented.');
+    }
     map = new Map<any, any>();
 
     /**


### PR DESCRIPTION
First step towards #1085. The native VS Code testing API is only available from v1.59.0 onwards, so I've upgraded here.

Minor impact: the only noticeable change was that the `Memento` class (which we use in tests) needed an extra method.

## Checklist

n/a

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
