### PR TITLE
Add cancellation from query history view

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -668,7 +668,7 @@
         {
           "command": "codeQLQueryHistory.removeHistoryItem",
           "group": "9_qlCommands",
-          "when": "view == codeQLQueryHistory && viewItem != inProgressResultsItem"
+          "when": "viewItem == interpretedResultsItem || viewItem == rawResultsItem || viewItem == cancelledResultsItem"
         },
         {
           "command": "codeQLQueryHistory.setLabel",
@@ -678,12 +678,12 @@
         {
           "command": "codeQLQueryHistory.compareWith",
           "group": "9_qlCommands",
-          "when": "view == codeQLQueryHistory && (viewItem == rawResultsItem || viewItem == interpretedResultsItem)"
+          "when": "viewItem == rawResultsItem || viewItem == interpretedResultsItem"
         },
         {
           "command": "codeQLQueryHistory.showQueryLog",
           "group": "9_qlCommands",
-          "when": "view == codeQLQueryHistory && (viewItem == rawResultsItem || viewItem == interpretedResultsItem)"
+          "when": "viewItem == rawResultsItem || viewItem == interpretedResultsItem"
         },
         {
           "command": "codeQLQueryHistory.showQueryText",
@@ -693,37 +693,37 @@
         {
           "command": "codeQLQueryHistory.viewCsvResults",
           "group": "9_qlCommands",
-          "when": "view == codeQLQueryHistory && viewItem == rawResultsItem"
+          "when": "viewItem == rawResultsItem"
         },
         {
           "command": "codeQLQueryHistory.viewCsvAlerts",
           "group": "9_qlCommands",
-          "when": "view == codeQLQueryHistory && viewItem == interpretedResultsItem"
+          "when": "viewItem == interpretedResultsItem"
         },
         {
           "command": "codeQLQueryHistory.viewSarifAlerts",
           "group": "9_qlCommands",
-          "when": "view == codeQLQueryHistory && viewItem == interpretedResultsItem"
+          "when": "viewItem == interpretedResultsItem"
         },
         {
           "command": "codeQLQueryHistory.viewDil",
           "group": "9_qlCommands",
-          "when": "view == codeQLQueryHistory && (viewItem == rawResultsItem || viewItem == interpretedResultsItem)"
+          "when": "viewItem == rawResultsItem || viewItem == interpretedResultsItem"
         },
         {
           "command": "codeQLQueryHistory.cancel",
           "group": "9_qlCommands",
-          "when": "view == codeQLQueryHistory && viewItem == inProgressResultsItem"
+          "when": "viewItem == inProgressResultsItem"
         },
         {
           "command": "codeQLTests.showOutputDifferences",
           "group": "qltest@1",
-          "when": "view == test-explorer && viewItem == testWithSource"
+          "when": "viewItem == testWithSource"
         },
         {
           "command": "codeQLTests.acceptOutput",
           "group": "qltest@2",
-          "when": "view == test-explorer && viewItem == testWithSource"
+          "when": "viewItem == testWithSource"
         }
       ],
       "explorer/context": [

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -497,6 +497,10 @@
         "title": "Show Query Log"
       },
       {
+        "command": "codeQLQueryHistory.cancel",
+        "title": "Cancel"
+      },
+      {
         "command": "codeQLQueryHistory.showQueryText",
         "title": "Show Query Text"
       },
@@ -664,7 +668,7 @@
         {
           "command": "codeQLQueryHistory.removeHistoryItem",
           "group": "9_qlCommands",
-          "when": "view == codeQLQueryHistory"
+          "when": "view == codeQLQueryHistory && viewItem != inProgressResultsItem"
         },
         {
           "command": "codeQLQueryHistory.setLabel",
@@ -674,12 +678,12 @@
         {
           "command": "codeQLQueryHistory.compareWith",
           "group": "9_qlCommands",
-          "when": "view == codeQLQueryHistory"
+          "when": "view == codeQLQueryHistory && (viewItem == rawResultsItem || viewItem == interpretedResultsItem)"
         },
         {
           "command": "codeQLQueryHistory.showQueryLog",
           "group": "9_qlCommands",
-          "when": "view == codeQLQueryHistory"
+          "when": "view == codeQLQueryHistory && (viewItem == rawResultsItem || viewItem == interpretedResultsItem)"
         },
         {
           "command": "codeQLQueryHistory.showQueryText",
@@ -689,7 +693,7 @@
         {
           "command": "codeQLQueryHistory.viewCsvResults",
           "group": "9_qlCommands",
-          "when": "view == codeQLQueryHistory && viewItem != interpretedResultsItem"
+          "when": "view == codeQLQueryHistory && viewItem == rawResultsItem"
         },
         {
           "command": "codeQLQueryHistory.viewCsvAlerts",
@@ -704,12 +708,12 @@
         {
           "command": "codeQLQueryHistory.viewDil",
           "group": "9_qlCommands",
-          "when": "view == codeQLQueryHistory"
+          "when": "view == codeQLQueryHistory && (viewItem == rawResultsItem || viewItem == interpretedResultsItem)"
         },
         {
-          "command": "codeQL.previewQueryHelp",
+          "command": "codeQLQueryHistory.cancel",
           "group": "9_qlCommands",
-          "when": "view == codeQLQueryHistory && resourceScheme == .qhelp && isWorkspaceTrusted"
+          "when": "view == codeQLQueryHistory && viewItem == inProgressResultsItem"
         },
         {
           "command": "codeQLTests.showOutputDifferences",
@@ -860,6 +864,10 @@
         },
         {
           "command": "codeQLQueryHistory.showQueryLog",
+          "when": "false"
+        },
+        {
+          "command": "codeQLQueryHistory.cancel",
           "when": "false"
         },
         {

--- a/extensions/ql-vscode/src/query-results.ts
+++ b/extensions/ql-vscode/src/query-results.ts
@@ -1,4 +1,4 @@
-import { env } from 'vscode';
+import { CancellationTokenSource, env } from 'vscode';
 
 import { QueryWithResults, tmpDir, QueryEvaluationInfo } from './run-queries';
 import * as messages from './pure/messages';
@@ -180,8 +180,13 @@ export class FullQueryInfo {
   constructor(
     public readonly initialInfo: InitialQueryInfo,
     private readonly config: QueryHistoryConfig,
+    private readonly source: CancellationTokenSource
   ) {
     /**/
+  }
+
+  cancel() {
+    this.source.cancel();
   }
 
   get startTime() {

--- a/extensions/ql-vscode/src/run-queries.ts
+++ b/extensions/ql-vscode/src/run-queries.ts
@@ -695,7 +695,8 @@ let queryId = 0;
 export async function createInitialQueryInfo(
   selectedQueryUri: Uri | undefined,
   databaseInfo: DatabaseInfo,
-  isQuickEval: boolean, range?: Range
+  isQuickEval: boolean,
+  range?: Range
 ): Promise<InitialQueryInfo> {
   // Determine which query to run, based on the selection and the active editor.
   const { queryPath, quickEvalPosition, quickEvalText } = await determineSelectedQuery(selectedQueryUri, isQuickEval, range);

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
@@ -515,7 +515,8 @@ describe('query-history', () => {
         start: new Date(),
         queryPath: 'hucairz'
       } as InitialQueryInfo,
-      configListener
+      configListener,
+      {} as vscode.CancellationTokenSource
     );
 
     if (queryWitbResults) {

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/query-results.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/query-results.test.ts
@@ -12,6 +12,7 @@ import { EvaluationResult, QueryResultType } from '../../pure/messages';
 import { SortDirection, SortedResultSetInfo } from '../../pure/interface-types';
 import { CodeQLCliServer, SourceInfo } from '../../cli';
 import { env } from 'process';
+import { CancellationTokenSource } from 'vscode';
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;
@@ -266,7 +267,8 @@ describe('query-results', () => {
         start: new Date(),
         queryPath: 'path/to/hucairz'
       } as InitialQueryInfo,
-      mockQueryHistoryConfig()
+      mockQueryHistoryConfig(),
+      {} as CancellationTokenSource
     );
 
     if (queryWitbResults) {


### PR DESCRIPTION
And tweak the commands visible from the view.

No changelog entry needed since it is still part of the query history feature.

## Checklist

- [n/a] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
