### PR TITLE
Run CodeQL analysis with latest CLI to opt into ML-powered queries beta

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,6 +26,9 @@ jobs:
         with:
             languages: javascript
             config-file: ./.github/codeql/codeql-config.yml
+            # We require at least CodeQL CLI v2.7.6 to opt into the ML-powered queries beta. This
+            # can be removed once CodeQL Bundle v2.7.6 ships in the Actions VM images.
+            tools: latest
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@main


### PR DESCRIPTION
We need to run the CodeQL analysis with at least CodeQL CLI v2.7.6 to opt into the ML-powered queries beta. This CLI hasn't yet made it into the Actions VM images, so we add `tools: latest` to download the CodeQL Bundle v2.7.6 from `github/codeql-action`. Once CodeQL Bundle v2.7.6 ships in the Actions VM images, we will then be able to remove `tools: latest`.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
