### PR TITLE
Fix ast view and command registration

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 ## [UNRELEASED]
 
+- Fix a bug where invoking _View AST_ from the file explorer would not view the selected file. Instead it would view the active editor. Also, prevent the _View AST_ from appearing if the current selection includes a directory or multiple files. [#1113](https://github.com/github/vscode-codeql/pull/1113)
+
 ## 1.5.10 - 25 January 2022
 
 - Fix a bug where the results view moved column even when it was already visible. [#1070](https://github.com/github/vscode-codeql/pull/1070)
 - Add packaging-related commands. _CodeQL: Download Packs_ downloads query packs from the package registry that can be run locally, and _CodeQL: Install Pack Dependencies_ installs dependencies for packs in your workspace. [#1076](https://github.com/github/vscode-codeql/pull/1076)
 - Add query history items as soon as a query is run, including new icons for each history item. [#1094](https://github.com/github/vscode-codeql/pull/1094)
-- Fix a bug where invoking _View AST_ from the file explorer would not view the selected file. Instead it would view the active editor. [#1113](https://github.com/github/vscode-codeql/pull/1113)
 
 ## 1.5.9 - 17 December 2021
 

--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix a bug where the results view moved column even when it was already visible. [#1070](https://github.com/github/vscode-codeql/pull/1070)
 - Add packaging-related commands. _CodeQL: Download Packs_ downloads query packs from the package registry that can be run locally, and _CodeQL: Install Pack Dependencies_ installs dependencies for packs in your workspace. [#1076](https://github.com/github/vscode-codeql/pull/1076)
 - Add query history items as soon as a query is run, including new icons for each history item. [#1094](https://github.com/github/vscode-codeql/pull/1094)
+- Fix a bug where invoking _View AST_ from the file explorer would not view the selected file. Instead it would view the active editor. [#1113](https://github.com/github/vscode-codeql/pull/1113)
 
 ## 1.5.9 - 17 December 2021
 

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -731,7 +731,7 @@
         {
           "command": "codeQL.viewAst",
           "group": "9_qlCommands",
-          "when": "resourceScheme == codeql-zip-archive"
+          "when": "resourceScheme == codeql-zip-archive && !explorerResourceIsFolder && !listMultiSelection"
         },
         {
           "command": "codeQL.runQueries",

--- a/extensions/ql-vscode/src/contextual/templateProvider.ts
+++ b/extensions/ql-vscode/src/contextual/templateProvider.ts
@@ -10,6 +10,7 @@ import {
   TextDocument,
   Uri
 } from 'vscode';
+import * as path from 'path';
 
 import { decodeSourceArchiveUri, encodeArchiveBasePath, zipArchiveScheme } from '../archive-filesystem-provider';
 import { CodeQLCliServer } from '../cli';
@@ -142,19 +143,19 @@ export class TemplatePrintAstProvider {
   async provideAst(
     progress: ProgressCallback,
     token: CancellationToken,
-    document?: TextDocument
+    fileUri?: Uri
   ): Promise<AstBuilder | undefined> {
-    if (!document) {
+    if (!fileUri) {
       throw new Error('Cannot view the AST. Please select a valid source file inside a CodeQL database.');
     }
     const { query, dbUri } = this.shouldCache()
-      ? await this.cache.get(document.uri.toString(), progress, token)
-      : await this.getAst(document.uri.toString(), progress, token);
+      ? await this.cache.get(fileUri.toString(), progress, token)
+      : await this.getAst(fileUri.toString(), progress, token);
 
     return new AstBuilder(
       query, this.cli,
       this.dbm.findDatabaseItem(dbUri)!,
-      document.fileName
+      path.basename(fileUri.fsPath),
     );
   }
 

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -968,9 +968,11 @@ async function activateWithInstalledDistribution(
       }
     ));
 
-  commands.registerCommand('codeQL.showLogs', () => {
-    logger.show();
-  });
+  ctx.subscriptions.push(
+    commandRunner('codeQL.showLogs', async () => {
+      logger.show();
+    })
+  );
 
   void logger.log('Starting language server.');
   ctx.subscriptions.push(client.start());
@@ -993,12 +995,14 @@ async function activateWithInstalledDistribution(
   ctx.subscriptions.push(astViewer);
   ctx.subscriptions.push(commandRunnerWithProgress('codeQL.viewAst', async (
     progress: ProgressCallback,
-    token: CancellationToken
+    token: CancellationToken,
+    selectedFile: Uri,
   ) => {
+
     const ast = await templateProvider.provideAst(
       progress,
       token,
-      window.activeTextEditor?.document,
+      selectedFile ?? window.activeTextEditor?.document.uri,
     );
     if (ast) {
       astViewer.updateRoots(await ast.getRoots(), ast.db, ast.fileName);

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -996,9 +996,8 @@ async function activateWithInstalledDistribution(
   ctx.subscriptions.push(commandRunnerWithProgress('codeQL.viewAst', async (
     progress: ProgressCallback,
     token: CancellationToken,
-    selectedFile: Uri,
+    selectedFile: Uri
   ) => {
-
     const ast = await templateProvider.provideAst(
       progress,
       token,


### PR DESCRIPTION
Two small bugs:

1. The AST view command was viewing the wrong ast when the command was
   selected from the context menu. It was always selecting the active
   editor instead of the item selected in the file menu.
2. The `codeql.showLogs` command was not being registered properly.
   With this change, there is uniform error handling, telemetry,
   and disposal.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
