### PR TITLE
Add full screen modal component

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/view/FullScreenModal.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/FullScreenModal.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import styled from 'styled-components';
+import { XCircleIcon } from '@primer/octicons-react';
+
+const Container = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+  opacity: 1;
+  background-color: var(--vscode-editor-background);
+  z-index: 5000;
+  padding-top: 1em;
+`;
+
+const CloseButton = styled.button`
+  position: absolute;
+  top: 1em;
+  right: 1em;
+  background-color: var(--vscode-editor-background);
+  border: none;
+`;
+
+const FullScreenModal = ({
+  setOpen,
+  containerElementId,
+  children
+}: {
+  setOpen: (open: boolean) => void;
+  containerElementId: string;
+  children: React.ReactNode
+}) => {
+  const containerElement = document.getElementById(containerElementId);
+  if (!containerElement) {
+    throw Error(`Could not find container element. Id: ${containerElementId}`);
+  }
+
+  return ReactDOM.createPortal(
+    <>
+      <Container>
+        <CloseButton onClick={() => setOpen(false)}>
+          <XCircleIcon size={24} />
+        </CloseButton>
+        {children}
+      </Container>
+    </>,
+    containerElement
+  );
+};
+
+export default FullScreenModal;


### PR DESCRIPTION
Adds a new full screen modal component that will be used to show code paths for path queries.

It uses React Portals to break out of the DOM tree. See https://reactjs.org/docs/portals.html

The component isn't currently in use as we don't have code paths yet, but you can see it in action on [this branch](https://github.com/github/vscode-codeql/tree/charisk/use-full-screen-modal). Usage commit [here](https://github.com/github/vscode-codeql/commit/5f475f5472a1cd0de1c3cf5a13c68f9a2e8eecf2).

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
