### PR TITLE
Remove use of all-results artifact

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/gh-actions-api-client.ts
+++ b/extensions/ql-vscode/src/remote-queries/gh-actions-api-client.ts
@@ -34,8 +34,6 @@ export async function getRemoteQueryIndex(
   const resultIndexArtifactId = getArtifactIDfromName('result-index', workflowUri, artifactList);
   const resultIndexItems = await getResultIndexItems(credentials, owner, repoName, resultIndexArtifactId);
 
-  const allResultsArtifactId = getArtifactIDfromName('all-results', workflowUri, artifactList);
-
   const items = resultIndexItems.map(item => {
     const artifactId = getArtifactIDfromName(item.id, workflowUri, artifactList);
 
@@ -50,9 +48,8 @@ export async function getRemoteQueryIndex(
   });
 
   return {
-    allResultsArtifactId,
     artifactsUrlPath,
-    items,
+    items
   };
 }
 

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
@@ -80,7 +80,6 @@ export class RemoteQueriesInterfaceManager {
       totalResultCount: totalResultCount,
       executionTimestamp: this.formatDate(query.executionStartTime),
       executionDuration: executionDuration,
-      downloadLink: queryResult.allResultsDownloadLink,
       analysisSummaries: analysisSummaries
     };
   }

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
@@ -123,11 +123,7 @@ export class RemoteQueriesManager {
 
     return {
       executionEndTime,
-      analysisSummaries,
-      allResultsDownloadLink: {
-        id: resultIndex.allResultsArtifactId.toString(),
-        urlPath: `${resultIndex.artifactsUrlPath}/${resultIndex.allResultsArtifactId}`
-      }
+      analysisSummaries
     };
   }
 }

--- a/extensions/ql-vscode/src/remote-queries/remote-query-result-index.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-query-result-index.ts
@@ -1,6 +1,5 @@
 export interface RemoteQueryResultIndex {
   artifactsUrlPath: string;
-  allResultsArtifactId: number;
   items: RemoteQueryResultIndexItem[];
 }
 

--- a/extensions/ql-vscode/src/remote-queries/remote-query-result.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-query-result.ts
@@ -3,7 +3,6 @@ import { DownloadLink } from './download-link';
 export interface RemoteQueryResult {
   executionEndTime: Date;
   analysisSummaries: AnalysisSummary[];
-  allResultsDownloadLink: DownloadLink;
 }
 
 export interface AnalysisSummary {

--- a/extensions/ql-vscode/src/remote-queries/sample-data.ts
+++ b/extensions/ql-vscode/src/remote-queries/sample-data.ts
@@ -38,10 +38,6 @@ export const sampleRemoteQuery: RemoteQuery = {
 
 export const sampleRemoteQueryResult: RemoteQueryResult = {
   executionEndTime: new Date('2022-01-06T17:04:37.026Z'),
-  allResultsDownloadLink: {
-    id: '137697018',
-    urlPath: '/repos/big-corp/controller-repo/actions/artifacts/137697018'
-  },
   analysisSummaries: [
     {
       nwo: 'big-corp/repo1',

--- a/extensions/ql-vscode/src/remote-queries/shared/remote-query-result.ts
+++ b/extensions/ql-vscode/src/remote-queries/shared/remote-query-result.ts
@@ -10,7 +10,6 @@ export interface RemoteQueryResult {
   totalResultCount: number;
   executionTimestamp: string;
   executionDuration: string;
-  downloadLink: DownloadLink;
   analysisSummaries: AnalysisSummary[]
 }
 

--- a/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
@@ -30,10 +30,6 @@ const emptyQueryResult: RemoteQueryResult = {
   totalResultCount: 0,
   executionTimestamp: '',
   executionDuration: '',
-  downloadLink: {
-    id: '',
-    urlPath: '',
-  },
   analysisSummaries: []
 };
 


### PR DESCRIPTION
The all-results artifact is currently checked and a download link is created for it but it's not actually used anywhere, so I've removed it completely.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
