### PR TITLE
Use SARIF viewer extension for analysis results

### DIFF
--- a/extensions/ql-vscode/src/pure/interface-types.ts
+++ b/extensions/ql-vscode/src/pure/interface-types.ts
@@ -378,7 +378,8 @@ export type FromRemoteQueriesMessage =
   | OpenFileMsg
   | OpenVirtualFileMsg
   | RemoteQueryDownloadAnalysisResultsMessage
-  | RemoteQueryDownloadAllAnalysesResultsMessage;
+  | RemoteQueryDownloadAllAnalysesResultsMessage
+  | RemoteQueryViewAnalysisResultsMessage;
 
 export type ToRemoteQueriesMessage =
   | SetRemoteQueryResultMessage
@@ -411,4 +412,9 @@ export interface RemoteQueryDownloadAnalysisResultsMessage {
 export interface RemoteQueryDownloadAllAnalysesResultsMessage {
   t: 'remoteQueryDownloadAllAnalysesResults';
   analysisSummaries: AnalysisSummary[];
+}
+
+export interface RemoteQueryViewAnalysisResultsMessage {
+  t: 'remoteQueryViewAnalysisResults';
+  analysisSummary: AnalysisSummary
 }

--- a/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
@@ -17,6 +17,7 @@ import DownloadButton from './DownloadButton';
 import { AnalysisResults } from '../shared/analysis-result';
 import DownloadSpinner from './DownloadSpinner';
 import CollapsibleItem from './CollapsibleItem';
+import { FileSymlinkFileIcon } from '@primer/octicons-react';
 
 const numOfReposInContractedMode = 10;
 
@@ -44,6 +45,13 @@ const downloadAllAnalysesResults = (query: RemoteQueryResult) => {
   vscode.postMessage({
     t: 'remoteQueryDownloadAllAnalysesResults',
     analysisSummaries: query.analysisSummaries
+  });
+};
+
+const viewAnalysisResults = (analysisSummary: AnalysisSummary) => {
+  vscode.postMessage({
+    t: 'remoteQueryViewAnalysisResults',
+    analysisSummary
   });
 };
 
@@ -110,7 +118,7 @@ const SummaryTitleNoResults = () => (
   </div>
 );
 
-const SummaryItemDownload = ({
+const SummaryItemDownloadAndView = ({
   analysisSummary,
   analysisResults
 }: {
@@ -130,7 +138,13 @@ const SummaryItemDownload = ({
     </>;
   }
 
-  return (<></>);
+  return <>
+    <HorizontalSpace size={2} />
+    <a className="vscode-codeql__analysis-result-file-link"
+      onClick={() => viewAnalysisResults(analysisSummary)} >
+      <FileSymlinkFileIcon size={16} />
+    </a>
+  </>;
 };
 
 const SummaryItem = ({
@@ -145,7 +159,7 @@ const SummaryItem = ({
     <span className="vscode-codeql__analysis-item">{analysisSummary.nwo}</span>
     <span className="vscode-codeql__analysis-item"><Badge text={analysisSummary.resultCount.toString()} /></span>
     <span className="vscode-codeql__analysis-item">
-      <SummaryItemDownload
+      <SummaryItemDownloadAndView
         analysisSummary={analysisSummary}
         analysisResults={analysisResults} />
     </span>

--- a/extensions/ql-vscode/src/remote-queries/view/remoteQueries.css
+++ b/extensions/ql-vscode/src/remote-queries/view/remoteQueries.css
@@ -60,3 +60,7 @@
   padding-top: 1em;
   font-size: x-small;
 }
+
+.vscode-codeql__analysis-result-file-link {
+  vertical-align: middle;
+}


### PR DESCRIPTION
Add a new button that lets users view the results of an analysis using the SARIF viewer extension.

This is a temporary solution until we have a proper way of rendering results. 

Co-authored with @rneatherway. 

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
