### PR TITLE
Add extra delay in telemetry test

### DIFF
--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/telemetry.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/telemetry.test.ts
@@ -367,9 +367,8 @@ describe('telemetry reporting', function() {
     );
 
     // Need to wait some time since the onDidChangeConfiguration listeners fire
-    // asynchronously and we sometimes need to wait for them to complete in
-    // order to have as successful test.
-    await wait(50);
+    // asynchronously. Must ensure they to complete in order to have a successful test.
+    await wait(100);
   }
 
   async function wait(ms = 0) {


### PR DESCRIPTION
Some of our internal integration tests are failing occasionally. I
think extending the wait time here will fix.

## Checklist

- [n/a] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [n/a] Issues have been created for any UI or other user-facing changes made by this pull request.
- [n/a] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
