### PR TITLE
Save query history across restarts

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix a bug where invoking _View AST_ from the file explorer would not view the selected file. Instead it would view the active editor. Also, prevent the _View AST_ from appearing if the current selection includes a directory or multiple files. [#1113](https://github.com/github/vscode-codeql/pull/1113)
 - Add query history items as soon as a query is run, including new icons for each history item. [#1094](https://github.com/github/vscode-codeql/pull/1094)
+- Save query history items across restarts. Items will be saved for 30 days and can be overwritten by setting the `codeQL.queryHistory.ttl` configuration setting. [???]
 
 ## 1.5.10 - 25 January 2022
 

--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Fix a bug where invoking _View AST_ from the file explorer would not view the selected file. Instead it would view the active editor. Also, prevent the _View AST_ from appearing if the current selection includes a directory or multiple files. [#1113](https://github.com/github/vscode-codeql/pull/1113)
 - Add query history items as soon as a query is run, including new icons for each history item. [#1094](https://github.com/github/vscode-codeql/pull/1094)
-- Save query history items across restarts. Items will be saved for 30 days and can be overwritten by setting the `codeQL.queryHistory.ttl` configuration setting. [???]
+- Save query history items across restarts. Items will be saved for 30 days and can be overwritten by setting the `codeQL.queryHistory.ttl` configuration setting. [#1130](https://github.com/github/vscode-codeql/pull/1130)
 
 ## 1.5.10 - 25 January 2022
 

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -224,6 +224,12 @@
           "default": "%q on %d - %s, %r result count [%t]",
           "markdownDescription": "Default string for how to label query history items.\n* %t is the time of the query\n* %q is the human-readable query name\n* %f is the query file name\n* %d is the database name\n* %r is the number of results\n* %s is a status string"
         },
+        "codeQL.queryHistory.ttl": {
+          "type": "number",
+          "default": 30,
+          "description": "Number of days to retain queries in the query history before being automatically deleted.",
+          "scope": "machine"
+        },
         "codeQL.runningTests.additionalTestArguments": {
           "scope": "window",
           "type": "array",

--- a/extensions/ql-vscode/src/contextual/locationFinder.ts
+++ b/extensions/ql-vscode/src/contextual/locationFinder.ts
@@ -28,6 +28,7 @@ export interface FullLocationLink extends LocationLink {
  * @param dbm The database manager
  * @param uriString The selected source file and location
  * @param keyType The contextual query type to run
+ * @param queryStorageDir The directory to store the query results
  * @param progress A progress callback
  * @param token A CancellationToken
  * @param filter A function that will filter extraneous results
@@ -38,7 +39,7 @@ export async function getLocationsForUriString(
   dbm: DatabaseManager,
   uriString: string,
   keyType: KeyType,
-  queryStorageLocation: string,
+  queryStorageDir: string,
   progress: ProgressCallback,
   token: CancellationToken,
   filter: (src: string, dest: string) => boolean
@@ -70,7 +71,7 @@ export async function getLocationsForUriString(
       qs,
       db,
       initialInfo,
-      queryStorageLocation,
+      queryStorageDir,
       progress,
       token,
       templates

--- a/extensions/ql-vscode/src/contextual/locationFinder.ts
+++ b/extensions/ql-vscode/src/contextual/locationFinder.ts
@@ -38,6 +38,7 @@ export async function getLocationsForUriString(
   dbm: DatabaseManager,
   uriString: string,
   keyType: KeyType,
+  queryStorageLocation: string,
   progress: ProgressCallback,
   token: CancellationToken,
   filter: (src: string, dest: string) => boolean
@@ -69,6 +70,7 @@ export async function getLocationsForUriString(
       qs,
       db,
       initialInfo,
+      queryStorageLocation,
       progress,
       token,
       templates

--- a/extensions/ql-vscode/src/contextual/templateProvider.ts
+++ b/extensions/ql-vscode/src/contextual/templateProvider.ts
@@ -42,7 +42,7 @@ export class TemplateQueryDefinitionProvider implements DefinitionProvider {
     private cli: CodeQLCliServer,
     private qs: QueryServerClient,
     private dbm: DatabaseManager,
-    private queryStorageLocation: string,
+    private queryStorageDir: string,
   ) {
     this.cache = new CachedOperation<LocationLink[]>(this.getDefinitions.bind(this));
   }
@@ -70,7 +70,7 @@ export class TemplateQueryDefinitionProvider implements DefinitionProvider {
         this.dbm,
         uriString,
         KeyType.DefinitionQuery,
-        this.queryStorageLocation,
+        this.queryStorageDir,
         progress,
         token,
         (src, _dest) => src === uriString
@@ -86,7 +86,7 @@ export class TemplateQueryReferenceProvider implements ReferenceProvider {
     private cli: CodeQLCliServer,
     private qs: QueryServerClient,
     private dbm: DatabaseManager,
-    private queryStorageLocation: string,
+    private queryStorageDir: string,
   ) {
     this.cache = new CachedOperation<FullLocationLink[]>(this.getReferences.bind(this));
   }
@@ -119,7 +119,7 @@ export class TemplateQueryReferenceProvider implements ReferenceProvider {
         this.dbm,
         uriString,
         KeyType.DefinitionQuery,
-        this.queryStorageLocation,
+        this.queryStorageDir,
         progress,
         token,
         (src, _dest) => src === uriString
@@ -140,7 +140,7 @@ export class TemplatePrintAstProvider {
     private cli: CodeQLCliServer,
     private qs: QueryServerClient,
     private dbm: DatabaseManager,
-    private queryStorageLocation: string,
+    private queryStorageDir: string,
   ) {
     this.cache = new CachedOperation<QueryWithDb>(this.getAst.bind(this));
   }
@@ -221,7 +221,7 @@ export class TemplatePrintAstProvider {
         this.qs,
         db,
         initialInfo,
-        this.queryStorageLocation,
+        this.queryStorageDir,
         progress,
         token,
         templates

--- a/extensions/ql-vscode/src/contextual/templateProvider.ts
+++ b/extensions/ql-vscode/src/contextual/templateProvider.ts
@@ -42,6 +42,7 @@ export class TemplateQueryDefinitionProvider implements DefinitionProvider {
     private cli: CodeQLCliServer,
     private qs: QueryServerClient,
     private dbm: DatabaseManager,
+    private queryStorageLocation: string,
   ) {
     this.cache = new CachedOperation<LocationLink[]>(this.getDefinitions.bind(this));
   }
@@ -69,6 +70,7 @@ export class TemplateQueryDefinitionProvider implements DefinitionProvider {
         this.dbm,
         uriString,
         KeyType.DefinitionQuery,
+        this.queryStorageLocation,
         progress,
         token,
         (src, _dest) => src === uriString
@@ -84,6 +86,7 @@ export class TemplateQueryReferenceProvider implements ReferenceProvider {
     private cli: CodeQLCliServer,
     private qs: QueryServerClient,
     private dbm: DatabaseManager,
+    private queryStorageLocation: string,
   ) {
     this.cache = new CachedOperation<FullLocationLink[]>(this.getReferences.bind(this));
   }
@@ -116,6 +119,7 @@ export class TemplateQueryReferenceProvider implements ReferenceProvider {
         this.dbm,
         uriString,
         KeyType.DefinitionQuery,
+        this.queryStorageLocation,
         progress,
         token,
         (src, _dest) => src === uriString
@@ -136,6 +140,7 @@ export class TemplatePrintAstProvider {
     private cli: CodeQLCliServer,
     private qs: QueryServerClient,
     private dbm: DatabaseManager,
+    private queryStorageLocation: string,
   ) {
     this.cache = new CachedOperation<QueryWithDb>(this.getAst.bind(this));
   }
@@ -216,6 +221,7 @@ export class TemplatePrintAstProvider {
         this.qs,
         db,
         initialInfo,
+        this.queryStorageLocation,
         progress,
         token,
         templates

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -436,13 +436,13 @@ async function activateWithInstalledDistribution(
   ctx.subscriptions.push(queryHistoryConfigurationListener);
   const showResults = async (item: FullCompletedQueryInfo) =>
     showResultsForCompletedQuery(item, WebviewReveal.Forced);
-  const queryStorageLocation = path.join(ctx.globalStorageUri.fsPath, 'queries');
-  await fs.ensureDir(queryStorageLocation);
+  const queryStorageDir = path.join(ctx.globalStorageUri.fsPath, 'queries');
+  await fs.ensureDir(queryStorageDir);
 
   const qhm = new QueryHistoryManager(
     qs,
     dbm,
-    queryStorageLocation,
+    queryStorageDir,
     ctx,
     queryHistoryConfigurationListener,
     showResults,
@@ -519,7 +519,7 @@ async function activateWithInstalledDistribution(
           qs,
           databaseItem,
           initialInfo,
-          queryStorageLocation,
+          queryStorageDir,
           progress,
           source.token,
         );
@@ -996,16 +996,16 @@ async function activateWithInstalledDistribution(
   void logger.log('Registering jump-to-definition handlers.');
   languages.registerDefinitionProvider(
     { scheme: archiveFilesystemProvider.zipArchiveScheme },
-    new TemplateQueryDefinitionProvider(cliServer, qs, dbm, queryStorageLocation)
+    new TemplateQueryDefinitionProvider(cliServer, qs, dbm, queryStorageDir)
   );
 
   languages.registerReferenceProvider(
     { scheme: archiveFilesystemProvider.zipArchiveScheme },
-    new TemplateQueryReferenceProvider(cliServer, qs, dbm, queryStorageLocation)
+    new TemplateQueryReferenceProvider(cliServer, qs, dbm, queryStorageDir)
   );
 
   const astViewer = new AstViewer();
-  const templateProvider = new TemplatePrintAstProvider(cliServer, qs, dbm, queryStorageLocation);
+  const templateProvider = new TemplatePrintAstProvider(cliServer, qs, dbm, queryStorageDir);
 
   ctx.subscriptions.push(astViewer);
   ctx.subscriptions.push(commandRunnerWithProgress('codeQL.viewAst', async (

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -19,6 +19,7 @@ import {
 } from 'vscode';
 import { LanguageClient } from 'vscode-languageclient';
 import * as os from 'os';
+import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as tmp from 'tmp-promise';
 import { testExplorerExtensionId, TestHub } from 'vscode-test-adapter-api';
@@ -435,16 +436,21 @@ async function activateWithInstalledDistribution(
   ctx.subscriptions.push(queryHistoryConfigurationListener);
   const showResults = async (item: FullCompletedQueryInfo) =>
     showResultsForCompletedQuery(item, WebviewReveal.Forced);
+  const queryStorageLocation = path.join(ctx.globalStorageUri.fsPath, 'queries');
+  await fs.ensureDir(queryStorageLocation);
 
   const qhm = new QueryHistoryManager(
     qs,
     dbm,
-    ctx.extensionPath,
+    queryStorageLocation,
+    ctx,
     queryHistoryConfigurationListener,
     showResults,
     async (from: FullCompletedQueryInfo, to: FullCompletedQueryInfo) =>
       showResultsForComparison(from, to),
   );
+  await qhm.readQueryHistory();
+
   ctx.subscriptions.push(qhm);
   void logger.log('Initializing results panel interface.');
   const intm = new InterfaceManager(ctx, dbm, cliServer, queryServerLogger);
@@ -513,10 +519,12 @@ async function activateWithInstalledDistribution(
           qs,
           databaseItem,
           initialInfo,
+          queryStorageLocation,
           progress,
           source.token,
         );
         item.completeThisQuery(completedQueryInfo);
+        await qhm.writeQueryHistory();
         await showResultsForCompletedQuery(item as FullCompletedQueryInfo, WebviewReveal.NotForced);
         // Note we must update the query history view after showing results as the
         // display and sorting might depend on the number of results
@@ -988,16 +996,16 @@ async function activateWithInstalledDistribution(
   void logger.log('Registering jump-to-definition handlers.');
   languages.registerDefinitionProvider(
     { scheme: archiveFilesystemProvider.zipArchiveScheme },
-    new TemplateQueryDefinitionProvider(cliServer, qs, dbm)
+    new TemplateQueryDefinitionProvider(cliServer, qs, dbm, queryStorageLocation)
   );
 
   languages.registerReferenceProvider(
     { scheme: archiveFilesystemProvider.zipArchiveScheme },
-    new TemplateQueryReferenceProvider(cliServer, qs, dbm)
+    new TemplateQueryReferenceProvider(cliServer, qs, dbm, queryStorageLocation)
   );
 
   const astViewer = new AstViewer();
-  const templateProvider = new TemplatePrintAstProvider(cliServer, qs, dbm);
+  const templateProvider = new TemplatePrintAstProvider(cliServer, qs, dbm, queryStorageLocation);
 
   ctx.subscriptions.push(astViewer);
   ctx.subscriptions.push(commandRunnerWithProgress('codeQL.viewAst', async (
@@ -1036,7 +1044,7 @@ async function activateWithInstalledDistribution(
 }
 
 function getContextStoragePath(ctx: ExtensionContext) {
-  return ctx.storagePath || ctx.globalStoragePath;
+  return ctx.storageUri?.fsPath || ctx.globalStorageUri.fsPath;
 }
 
 async function initializeLogging(ctx: ExtensionContext): Promise<void> {

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -439,6 +439,7 @@ async function activateWithInstalledDistribution(
   const queryStorageDir = path.join(ctx.globalStorageUri.fsPath, 'queries');
   await fs.ensureDir(queryStorageDir);
 
+  void logger.log('Initializing query history.');
   const qhm = new QueryHistoryManager(
     qs,
     dbm,

--- a/extensions/ql-vscode/src/query-history-scrubber.ts
+++ b/extensions/ql-vscode/src/query-history-scrubber.ts
@@ -1,0 +1,135 @@
+import * as fs from 'fs-extra';
+import * as os from 'os';
+import * as path from 'path';
+import { Disposable, ExtensionContext } from 'vscode';
+import { logger } from './logging';
+
+const LAST_SCRUB_TIME_KEY = 'lastScrubTime';
+
+type Counter = {
+  increment: () => void;
+};
+
+/**
+ * Registers an interval timer that will periodically check for queries old enought
+ * to be deleted.
+ *
+ * Note that this scrubber will clean all queries from all workspaces. It should not
+ * run too often and it should only run from one workspace at a time.
+ *
+ * Generally, `wakeInterval` should be significantly shorter than `throttleTime`.
+ *
+ * @param wakeInterval How often to check to see if the job should run.
+ * @param throttleTime How often to actually run the job.
+ * @param maxQueryTime The maximum age of a query before is ready for deletion.
+ * @param queryDirectory The directory containing all queries.
+ * @param ctx The extension context.
+ */
+export function registerQueryHistoryScubber(
+  wakeInterval: number,
+  throttleTime: number,
+  maxQueryTime: number,
+  queryDirectory: string,
+  ctx: ExtensionContext,
+
+  // optional counter to keep track of how many times the scrubber has run
+  counter?: Counter
+): Disposable {
+  const deregister = setInterval(scrubber, wakeInterval, throttleTime, maxQueryTime, queryDirectory, ctx, counter);
+
+  return {
+    dispose: () => {
+      clearInterval(deregister);
+    }
+  };
+}
+
+async function scrubber(
+  throttleTime: number,
+  maxQueryTime: number,
+  queryDirectory: string,
+  ctx: ExtensionContext,
+  counter?: Counter
+) {
+  const lastScrubTime = ctx.globalState.get<number>(LAST_SCRUB_TIME_KEY);
+  const now = Date.now();
+
+  // If we have never scrubbed before, or if the last scrub was more than `throttleTime` ago,
+  // then scrub again.
+  if (lastScrubTime === undefined || now - lastScrubTime >= throttleTime) {
+    await ctx.globalState.update(LAST_SCRUB_TIME_KEY, now);
+
+    let scrubCount = 0; // total number of directories deleted
+    try {
+      counter?.increment();
+      void logger.log('Scrubbing query directory. Removing old queries.');
+      if (!(await fs.pathExists(queryDirectory))) {
+        void logger.log(`Cannot scrub. Query directory does not exist: ${queryDirectory}`);
+        return;
+      }
+
+      const baseNames = await fs.readdir(queryDirectory);
+      const errors: string[] = [];
+      for (const baseName of baseNames) {
+        const dir = path.join(queryDirectory, baseName);
+        const scrubResult = await scrubDirectory(dir, now, maxQueryTime);
+        if (scrubResult.errorMsg) {
+          errors.push(scrubResult.errorMsg);
+        }
+        if (scrubResult.deleted) {
+          scrubCount++;
+        }
+      }
+
+      if (errors.length) {
+        throw new Error(os.EOL + errors.join(os.EOL));
+      }
+    } catch (e) {
+      void logger.log(`Error while scrubbing queries: ${e}`);
+    } finally {
+      void logger.log(`Scrubbed ${scrubCount} old queries.`);
+    }
+  }
+}
+
+async function scrubDirectory(dir: string, now: number, maxQueryTime: number): Promise<{
+  errorMsg?: string,
+  deleted: boolean
+}> {
+  const timestampFile = path.join(dir, 'timestamp');
+  try {
+    let deleted = true;
+    if (!(await fs.stat(dir)).isDirectory()) {
+      void logger.log(`  ${dir} is not a directory. Deleting.`);
+      await fs.remove(dir);
+    } else if (!(await fs.pathExists(timestampFile))) {
+      void logger.log(`  ${dir} has no timestamp file. Deleting.`);
+      await fs.remove(dir);
+    } else if (!(await fs.stat(timestampFile)).isFile()) {
+      void logger.log(`  ${timestampFile} is not a file. Deleting.`);
+      await fs.remove(dir);
+    } else {
+      const timestampText = await fs.readFile(timestampFile, 'utf8');
+      const timestamp = parseInt(timestampText, 10);
+
+      if (Number.isNaN(timestamp)) {
+        void logger.log(`  ${dir} has invalid timestamp '${timestampText}'. Deleting.`);
+        await fs.remove(dir);
+      } else if (now - timestamp > maxQueryTime) {
+        void logger.log(`  ${dir} is older than ${maxQueryTime / 1000} seconds. Deleting.`);
+        await fs.remove(dir);
+      } else {
+        void logger.log(`  ${dir} is not older than ${maxQueryTime / 1000} seconds. Keeping.`);
+        deleted = false;
+      }
+    }
+    return {
+      deleted
+    };
+  } catch (err) {
+    return {
+      errorMsg: `  Could not delete '${dir}': ${err}`,
+      deleted: false
+    };
+  }
+}

--- a/extensions/ql-vscode/src/query-history-scrubber.ts
+++ b/extensions/ql-vscode/src/query-history-scrubber.ts
@@ -35,7 +35,7 @@ export function registerQueryHistoryScubber(
   // optional counter to keep track of how many times the scrubber has run
   counter?: Counter
 ): Disposable {
-  const deregister = setInterval(scrubber, wakeInterval, throttleTime, maxQueryTime, queryDirectory, ctx, counter);
+  const deregister = setInterval(scrubQueries, wakeInterval, throttleTime, maxQueryTime, queryDirectory, ctx, counter);
 
   return {
     dispose: () => {
@@ -44,7 +44,7 @@ export function registerQueryHistoryScubber(
   };
 }
 
-async function scrubber(
+async function scrubQueries(
   throttleTime: number,
   maxQueryTime: number,
   queryDirectory: string,

--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -252,6 +252,7 @@ const DOUBLE_CLICK_TIME = 500;
 
 const NO_QUERY_SELECTED = 'No query selected. Select a query history item you have already run and try again.';
 
+const WORKSPACE_QUERY_HISTORY_FILE = 'workspace-query-history.json';
 export class QueryHistoryManager extends DisposableObject {
 
   treeDataProvider: HistoryTreeDataProvider;
@@ -275,7 +276,11 @@ export class QueryHistoryManager extends DisposableObject {
   ) {
     super();
 
-    this.queryMetadataStorageLocation = path.join((ctx.storageUri || ctx.globalStorageUri).fsPath, 'query-history.json');
+    // Note that we use workspace storage to hold the metadata for the query history.
+    // This is because the query history is specific to each workspace.
+    // For situations where `ctx.storageUri` is undefined (i.e., there is no workspace),
+    // we default to global storage.
+    this.queryMetadataStorageLocation = path.join((ctx.storageUri || ctx.globalStorageUri).fsPath, WORKSPACE_QUERY_HISTORY_FILE);
 
     this.treeDataProvider = this.push(new HistoryTreeDataProvider(
       ctx.extensionPath

--- a/extensions/ql-vscode/src/query-results.ts
+++ b/extensions/ql-vscode/src/query-results.ts
@@ -270,15 +270,16 @@ export class FullQueryInfo {
   constructor(
     public readonly initialInfo: InitialQueryInfo,
     config: QueryHistoryConfig,
-    private source?: CancellationTokenSource // used to cancel in progress queries
+    private cancellationSource?: CancellationTokenSource // used to cancel in progress queries
   ) {
     this.setConfig(config);
   }
 
   cancel() {
-    this.source?.cancel();
+    this.cancellationSource?.cancel();
     // query is no longer in progress, can delete the cancellation token source
-    delete this.source;
+    this.cancellationSource?.dispose();
+    delete this.cancellationSource;
   }
 
   get startTime() {
@@ -361,7 +362,10 @@ export class FullQueryInfo {
 
   completeThisQuery(info: QueryWithResults) {
     this.completedQuery = new CompletedQueryInfo(info);
-    delete this.source;
+
+    // dispose of the cancellation token source and also ensure the source is not serialized as JSON
+    this.cancellationSource?.dispose();
+    delete this.cancellationSource;
   }
 
   /**

--- a/extensions/ql-vscode/src/query-results.ts
+++ b/extensions/ql-vscode/src/query-results.ts
@@ -16,6 +16,7 @@ import {
 import { QueryHistoryConfig } from './config';
 import { DatabaseInfo } from './pure/interface-types';
 import { showAndLogErrorMessage } from './helpers';
+import { asyncFilter } from './pure/helpers-pure';
 
 /**
  * A description of the information about a query
@@ -190,9 +191,13 @@ export class FullQueryInfo {
 
   static async slurp(fsPath: string, config: QueryHistoryConfig): Promise<FullQueryInfo[]> {
     try {
+      if (!(await fs.pathExists(fsPath))) {
+        return [];
+      }
+
       const data = await fs.readFile(fsPath, 'utf8');
       const queries = JSON.parse(data);
-      return queries.map((q: FullQueryInfo) => {
+      const parsedQueries = queries.map((q: FullQueryInfo) => {
 
         // Need to explicitly set prototype since reading in from JSON will not
         // do this automatically. Note that we can't call the constructor here since
@@ -215,6 +220,14 @@ export class FullQueryInfo {
         }
         return q;
       });
+
+      // filter out queries that have been deleted on disk
+      // most likely another workspace has deleted them because the
+      // queries aged out.
+      return asyncFilter(parsedQueries, async (q) => {
+        const resultsPath = q.completedQuery?.query.resultsPaths.resultsPath;
+        return !!resultsPath && await fs.pathExists(resultsPath);
+      });
     } catch (e) {
       void showAndLogErrorMessage('Error loading query history.', {
         fullMessage: ['Error loading query history.', e.stack].join('\n'),
@@ -234,8 +247,12 @@ export class FullQueryInfo {
    */
   static async splat(queries: FullQueryInfo[], fsPath: string): Promise<void> {
     try {
-      const data = JSON.stringify(queries, null, 2);
-      await fs.mkdirp(path.dirname(fsPath));
+      if (!(await fs.pathExists(fsPath))) {
+        await fs.mkdir(path.dirname(fsPath), { recursive: true });
+      }
+      // remove incomplete queries since they cannot be recreated on restart
+      const filteredQueries = queries.filter(q => q.completedQuery !== undefined);
+      const data = JSON.stringify(filteredQueries, null, 2);
       await fs.writeFile(fsPath, data);
     } catch (e) {
       throw new Error(`Error saving query history to ${fsPath}: ${e.message}`);
@@ -253,13 +270,15 @@ export class FullQueryInfo {
   constructor(
     public readonly initialInfo: InitialQueryInfo,
     config: QueryHistoryConfig,
-    private readonly source?: CancellationTokenSource
+    private source?: CancellationTokenSource // used to cancel in progress queries
   ) {
     this.setConfig(config);
   }
 
   cancel() {
     this.source?.cancel();
+    // query is no longer in progress, can delete the cancellation token source
+    delete this.source;
   }
 
   get startTime() {
@@ -342,6 +361,7 @@ export class FullQueryInfo {
 
   completeThisQuery(info: QueryWithResults) {
     this.completedQuery = new CompletedQueryInfo(info);
+    delete this.source;
   }
 
   /**

--- a/extensions/ql-vscode/src/run-queries.ts
+++ b/extensions/ql-vscode/src/run-queries.ts
@@ -298,7 +298,7 @@ export class QueryEvaluationInfo {
     return this.csvPath;
   }
 
-  async cleanUp(): Promise<void> {
+  async deleteQuery(): Promise<void> {
     await fs.remove(this.querySaveDir);
   }
 }
@@ -598,7 +598,7 @@ export async function compileAndRunQueryAgainstDatabase(
   qs: qsClient.QueryServerClient,
   dbItem: DatabaseItem,
   initialInfo: InitialQueryInfo,
-  queryStorageLocation: string,
+  queryStorageDir: string,
   progress: ProgressCallback,
   token: CancellationToken,
   templates?: messages.TemplateDefinitions,
@@ -664,7 +664,7 @@ export async function compileAndRunQueryAgainstDatabase(
 
   const hasMetadataFile = (await dbItem.hasMetadataFile());
   const query = new QueryEvaluationInfo(
-    path.join(queryStorageLocation, initialInfo.id),
+    path.join(queryStorageDir, initialInfo.id),
     dbItem.databaseUri.fsPath,
     hasMetadataFile,
     packConfig.dbscheme,

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/queries.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/queries.test.ts
@@ -11,7 +11,7 @@ import { DatabaseItem, DatabaseManager } from '../../databases';
 import { CodeQLExtensionInterface } from '../../extension';
 import { dbLoc, storagePath } from './global.helper';
 import { importArchiveDatabase } from '../../databaseFetcher';
-import { compileAndRunQueryAgainstDatabase, createInitialQueryInfo } from '../../run-queries';
+import { compileAndRunQueryAgainstDatabase, createInitialQueryInfo, tmpDir } from '../../run-queries';
 import { CodeQLCliServer } from '../../cli';
 import { QueryServerClient } from '../../queryserver-client';
 import { skipIfNoCodeQL } from '../ensureCli';
@@ -97,6 +97,7 @@ describe('Queries', function() {
         qs,
         dbItem,
         await mockInitialQueryInfo(queryPath),
+        path.join(tmpDir.name, 'mock-storage-path'),
         progress,
         token
       );
@@ -119,6 +120,7 @@ describe('Queries', function() {
         qs,
         dbItem,
         await mockInitialQueryInfo(queryPath),
+        path.join(tmpDir.name, 'mock-storage-path'),
         progress,
         token
       );

--- a/extensions/ql-vscode/src/vscode-tests/minimal-workspace/activation.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/minimal-workspace/activation.test.ts
@@ -15,6 +15,9 @@ describe('launching with a minimal workspace', async () => {
     assert(ext);
   });
 
+  // Note, this test will only pass in pristine workspaces. This means that when run locally and you
+  // reuse an existing workspace that starts with an open ql file, this test will fail. There is
+  // no need to make any changes since this will still pass on CI.
   it('should not activate the extension at first', () => {
     assert(ext!.isActive === false);
   });

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
@@ -8,7 +8,8 @@ import * as sinon from 'sinon';
 
 import * as chaiAsPromised from 'chai-as-promised';
 import { logger } from '../../logging';
-import { QueryHistoryManager, HistoryTreeDataProvider, SortOrder, registerQueryHistoryScubber } from '../../query-history';
+import { QueryHistoryManager, HistoryTreeDataProvider, SortOrder } from '../../query-history';
+import { registerQueryHistoryScubber } from '../../query-history-scrubber';
 import { QueryEvaluationInfo, QueryWithResults, tmpDir } from '../../run-queries';
 import { QueryHistoryConfigListener } from '../../config';
 import * as messages from '../../pure/messages';

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/query-results.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/query-results.test.ts
@@ -6,13 +6,12 @@ import 'sinon-chai';
 import * as sinon from 'sinon';
 import * as chaiAsPromised from 'chai-as-promised';
 import { FullQueryInfo, InitialQueryInfo, interpretResults } from '../../query-results';
-import { queriesDir, QueryEvaluationInfo, QueryWithResults, tmpDir } from '../../run-queries';
+import { QueryEvaluationInfo, QueryWithResults, tmpDir } from '../../run-queries';
 import { QueryHistoryConfig } from '../../config';
 import { EvaluationResult, QueryResultType } from '../../pure/messages';
 import { DatabaseInfo, SortDirection, SortedResultSetInfo } from '../../pure/interface-types';
 import { CodeQLCliServer, SourceInfo } from '../../cli';
-import { env } from 'process';
-import { CancellationTokenSource, Uri } from 'vscode';
+import { CancellationTokenSource, Uri, env } from 'vscode';
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;
@@ -22,12 +21,15 @@ describe('query-results', () => {
   let onDidChangeQueryHistoryConfigurationSpy: sinon.SinonSpy;
   let mockConfig: QueryHistoryConfig;
   let sandbox: sinon.SinonSandbox;
+  let queryPath: string;
+  let cnt = 0;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
     disposeSpy = sandbox.spy();
     onDidChangeQueryHistoryConfigurationSpy = sandbox.spy();
     mockConfig = mockQueryHistoryConfig();
+    queryPath = path.join(Uri.file(tmpDir.name).fsPath, `query-${cnt++}`);
   });
 
   afterEach(() => {
@@ -40,6 +42,7 @@ describe('query-results', () => {
       const date = new Date('2022-01-01T00:00:00.000Z');
       const dateStr = date.toLocaleString(env.language);
       (fqi.initialInfo as any).start = date;
+
       expect(fqi.interpolate('xxx')).to.eq('xxx');
       expect(fqi.interpolate('%t %q %d %s %%')).to.eq(`${dateStr} hucairz a in progress %`);
       expect(fqi.interpolate('%t %q %d %s %%::%t %q %d %s %%')).to.eq(`${dateStr} hucairz a in progress %::${dateStr} hucairz a in progress %`);
@@ -51,7 +54,7 @@ describe('query-results', () => {
       // from the query path
       expect(fqi.getQueryName()).to.eq('hucairz');
 
-      fqi.completeThisQuery(createMockQueryWithResults());
+      fqi.completeThisQuery(createMockQueryWithResults(queryPath));
 
       // from the metadata
       expect(fqi.getQueryName()).to.eq('vwx');
@@ -92,7 +95,7 @@ describe('query-results', () => {
 
       // the %q from the config is now replaced by the name of the query
       // in the metadata
-      fqi.completeThisQuery(createMockQueryWithResults());
+      fqi.completeThisQuery(createMockQueryWithResults(queryPath));
       expect(fqi.label).to.eq('from config vwx');
 
       // replace the config with a user specified label
@@ -102,9 +105,10 @@ describe('query-results', () => {
     });
 
     it('should get the getResultsPath', () => {
-      const fqi = createMockFullQueryInfo('a', createMockQueryWithResults());
+      const query = createMockQueryWithResults(queryPath);
+      const fqi = createMockFullQueryInfo('a', query);
       const completedQuery = fqi.completedQuery!;
-      const expectedResultsPath = path.join(queriesDir, 'some-id/results.bqrs');
+      const expectedResultsPath = path.join(queryPath, 'results.bqrs');
 
       // from results path
       expect(completedQuery.getResultsPath('zxa', false)).to.eq(expectedResultsPath);
@@ -121,7 +125,7 @@ describe('query-results', () => {
     });
 
     it('should get the statusString', () => {
-      const fqi = createMockFullQueryInfo('a', createMockQueryWithResults(false));
+      const fqi = createMockFullQueryInfo('a', createMockQueryWithResults(queryPath, false));
       const completedQuery = fqi.completedQuery!;
 
       completedQuery.result.message = 'Tremendously';
@@ -146,7 +150,7 @@ describe('query-results', () => {
 
     it('should updateSortState', async () => {
       // setup
-      const fqi = createMockFullQueryInfo('a', createMockQueryWithResults());
+      const fqi = createMockFullQueryInfo('a', createMockQueryWithResults(queryPath));
       const completedQuery = fqi.completedQuery!;
 
       const spy = sandbox.spy();
@@ -162,8 +166,8 @@ describe('query-results', () => {
       await completedQuery.updateSortState(mockServer, 'a-result-set-name', sortState);
 
       // verify
-      const expectedResultsPath = path.join(queriesDir, 'some-id/results.bqrs');
-      const expectedSortedResultsPath = path.join(queriesDir, 'some-id/sortedResults-a-result-set-name.bqrs');
+      const expectedResultsPath = path.join(queryPath, 'results.bqrs');
+      const expectedSortedResultsPath = path.join(queryPath, 'sortedResults-a-result-set-name.bqrs');
       expect(spy).to.have.been.calledWith(
         expectedResultsPath,
         expectedSortedResultsPath,
@@ -248,12 +252,11 @@ describe('query-results', () => {
   });
 
   describe('splat and slurp', () => {
-    // TODO also add a test for round trip starting from file
     it('should splat and slurp query history', async () => {
-      const infoSuccessRaw = createMockFullQueryInfo('a', createMockQueryWithResults(false, false, '/a/b/c/a', false));
-      const infoSuccessInterpreted = createMockFullQueryInfo('b', createMockQueryWithResults(true, true, '/a/b/c/b', false));
+      const infoSuccessRaw = createMockFullQueryInfo('a', createMockQueryWithResults(`${queryPath}-a`, false, false, '/a/b/c/a', false));
+      const infoSuccessInterpreted = createMockFullQueryInfo('b', createMockQueryWithResults(`${queryPath}-b`, true, true, '/a/b/c/b', false));
       const infoEarlyFailure = createMockFullQueryInfo('c', undefined, true);
-      const infoLateFailure = createMockFullQueryInfo('d', createMockQueryWithResults(false, false, '/a/b/c/d', false));
+      const infoLateFailure = createMockFullQueryInfo('d', createMockQueryWithResults(`${queryPath}-c`, false, false, '/a/b/c/d', false));
       const infoInprogress = createMockFullQueryInfo('e');
       const allHistory = [
         infoSuccessRaw,
@@ -263,7 +266,16 @@ describe('query-results', () => {
         infoInprogress
       ];
 
-      const allHistoryPath = path.join(queriesDir, 'all-history.json');
+      // the expected results only contains the history with completed queries
+      const expectedHistory = [
+        infoSuccessRaw,
+        infoSuccessInterpreted,
+        infoLateFailure,
+      ];
+
+      const allHistoryPath = path.join(tmpDir.name, 'all-history.json');
+
+      // splat and slurp
       await FullQueryInfo.splat(allHistory, allHistoryPath);
       const allHistoryActual = await FullQueryInfo.slurp(allHistoryPath, mockConfig);
 
@@ -287,7 +299,7 @@ describe('query-results', () => {
           }
         }
       });
-      allHistory.forEach(info => {
+      expectedHistory.forEach(info => {
         if (info.completedQuery) {
           (info.completedQuery as any).dispose = undefined;
         }
@@ -295,16 +307,27 @@ describe('query-results', () => {
 
       // make the diffs somewhat sane by comparing each element directly
       for (let i = 0; i < allHistoryActual.length; i++) {
-        expect(allHistoryActual[i]).to.deep.eq(allHistory[i]);
+        expect(allHistoryActual[i]).to.deep.eq(expectedHistory[i]);
       }
-      expect(allHistoryActual.length).to.deep.eq(allHistory.length);
+      expect(allHistoryActual.length).to.deep.eq(expectedHistory.length);
     });
   });
 
+  function createMockQueryWithResults(
+    queryPath: string,
+    didRunSuccessfully = true,
+    hasInterpretedResults = true,
+    dbPath = '/a/b/c',
+    includeSpies = true
+  ): QueryWithResults {
+    // pretend that the results path exists
+    const resultsPath = path.join(queryPath, 'results.bqrs');
+    fs.mkdirpSync(queryPath);
+    fs.writeFileSync(resultsPath, '', 'utf8');
 
-  function createMockQueryWithResults(didRunSuccessfully = true, hasInterpretedResults = true, dbPath = '/a/b/c', includeSpies = true): QueryWithResults {
-    const query = new QueryEvaluationInfo('some-id',
-      Uri.file(dbPath).fsPath, // parse the Uri to make sure it is platform-independent
+    const query = new QueryEvaluationInfo(
+      queryPath,
+      Uri.file(dbPath).fsPath,
       true,
       'queryDbscheme',
       undefined,
@@ -361,6 +384,7 @@ describe('query-results', () => {
   function mockQueryHistoryConfig(): QueryHistoryConfig {
     return {
       onDidChangeConfiguration: onDidChangeQueryHistoryConfigurationSpy,
+      ttlInMillis: 999999,
       format: 'from config %q'
     };
   }

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/query-results.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/query-results.test.ts
@@ -273,7 +273,7 @@ describe('query-results', () => {
         infoLateFailure,
       ];
 
-      const allHistoryPath = path.join(tmpDir.name, 'all-history.json');
+      const allHistoryPath = path.join(tmpDir.name, 'workspace-query-history.json');
 
       // splat and slurp
       await FullQueryInfo.splat(allHistory, allHistoryPath);

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/query-results.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/query-results.test.ts
@@ -369,7 +369,9 @@ describe('query-results', () => {
         id: `some-id-${dbName}`,
       } as InitialQueryInfo,
       mockQueryHistoryConfig(),
-      {} as CancellationTokenSource
+      {
+        dispose: () => { /**/ },
+      } as CancellationTokenSource
     );
 
     if (queryWitbResults) {

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/run-queries.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/run-queries.test.ts
@@ -5,7 +5,7 @@ import 'sinon-chai';
 import * as sinon from 'sinon';
 import * as chaiAsPromised from 'chai-as-promised';
 
-import { QueryEvaluationInfo, queriesDir } from '../../run-queries';
+import { QueryEvaluationInfo } from '../../run-queries';
 import { Severity, compileQuery } from '../../pure/messages';
 import { Uri } from 'vscode';
 
@@ -14,13 +14,13 @@ const expect = chai.expect;
 
 describe('run-queries', () => {
   it('should create a QueryEvaluationInfo', () => {
-    const info = createMockQueryInfo();
+    const saveDir = 'query-save-dir';
+    const info = createMockQueryInfo(true, saveDir);
 
-    const queryId = info.id;
-    expect(info.compiledQueryPath).to.eq(path.join(queriesDir, queryId, 'compiledQuery.qlo'));
-    expect(info.dilPath).to.eq(path.join(queriesDir, queryId, 'results.dil'));
-    expect(info.resultsPaths.resultsPath).to.eq(path.join(queriesDir, queryId, 'results.bqrs'));
-    expect(info.resultsPaths.interpretedResultsPath).to.eq(path.join(queriesDir, queryId, 'interpretedResults.sarif'));
+    expect(info.compiledQueryPath).to.eq(path.join(saveDir, 'compiledQuery.qlo'));
+    expect(info.dilPath).to.eq(path.join(saveDir, 'results.dil'));
+    expect(info.resultsPaths.resultsPath).to.eq(path.join(saveDir, 'results.bqrs'));
+    expect(info.resultsPaths.interpretedResultsPath).to.eq(path.join(saveDir, 'interpretedResults.sarif'));
     expect(info.dbItemPath).to.eq(Uri.file('/abc').fsPath);
   });
 
@@ -90,9 +90,9 @@ describe('run-queries', () => {
   });
 
   let queryNum = 0;
-  function createMockQueryInfo(databaseHasMetadataFile = true) {
+  function createMockQueryInfo(databaseHasMetadataFile = true, saveDir = `save-dir${queryNum++}`) {
     return new QueryEvaluationInfo(
-      `save-dir${queryNum++}`,
+      saveDir,
       Uri.parse('file:///abc').fsPath,
       databaseHasMetadataFile,
       'my-scheme', // queryDbscheme,


### PR DESCRIPTION
Successfully completed queries will be stored on disk and available
across restarts.

- The query results are contained in global storage.
- Metadata and a summary about a query are stored in workspace storage.
- There is a job that runs every 2 hours to determine if any queries are
  old enough to be deleted.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
