### PR TITLE
Remove feature flag for loading ML models from packs

### DIFF
--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -343,15 +343,3 @@ export function getRemoteControllerRepo(): string | undefined {
 export async function setRemoteControllerRepo(repo: string | undefined) {
   await REMOTE_CONTROLLER_REPO.updateValue(repo, ConfigurationTarget.Global);
 }
-
-/**
- * Whether to insecurely load ML models from CodeQL packs.
- *
- * This setting is for internal users only.
- */
-const SHOULD_INSECURELY_LOAD_MODELS_FROM_PACKS =
-  new Setting('shouldInsecurelyLoadModelsFromPacks', RUNNING_QUERIES_SETTING);
-
-export function shouldInsecurelyLoadMlModelsFromPacks(): boolean {
-  return SHOULD_INSECURELY_LOAD_MODELS_FROM_PACKS.getValue<boolean>();
-}

--- a/extensions/ql-vscode/src/run-queries.ts
+++ b/extensions/ql-vscode/src/run-queries.ts
@@ -10,8 +10,7 @@ import {
   TextDocument,
   TextEditor,
   Uri,
-  window,
-  workspace
+  window
 } from 'vscode';
 import { ErrorCodes, ResponseError } from 'vscode-languageclient';
 
@@ -632,13 +631,7 @@ export async function compileAndRunQueryAgainstDatabase(
   const metadata = await tryGetQueryMetadata(cliServer, qlProgram.queryPath);
 
   let availableMlModels: cli.MlModelInfo[] = [];
-  // The `capabilities.untrustedWorkspaces.restrictedConfigurations` entry in package.json doesn't
-  // work with hidden settings, so we manually check that the workspace is trusted before looking at
-  // whether the `shouldInsecurelyLoadMlModelsFromPacks` setting is enabled.
-  if (workspace.isTrusted &&
-    config.isCanary() &&
-    config.shouldInsecurelyLoadMlModelsFromPacks() &&
-    await cliServer.cliConstraints.supportsResolveMlModels()) {
+  if (await cliServer.cliConstraints.supportsResolveMlModels()) {
     try {
       availableMlModels = (await cliServer.resolveMlModels(diskWorkspaceFolders)).models;
       void logger.log(`Found available ML models at the following paths: ${availableMlModels.map(x => `'${x.path}'`).join(', ')}.`);


### PR DESCRIPTION
This functionality is now ready for use by all users, and should be enabled for everyone. I don't think now is the right time to advertise it though, so haven't added a changelog note.

**Removal of `workspace.isTrusted` guard**

The restriction to trusted workspaces only was only necessary to confirm secure usage of the `shouldInsecurelyLoadMlModelsFromPacks` setting (see the comment). This setting has now been removed, and the security mechanisms built into `codeql resolve ml-models` mean that we don't need or want to restrict loading ML models to trusted workspaces.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
