### PR TITLE
Store remote query artifacts in global storage

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -814,7 +814,7 @@ async function activateWithInstalledDistribution(
   );
 
   void logger.log('Initializing remote queries interface.');
-  const rqm = new RemoteQueriesManager(ctx, cliServer, logger);
+  const rqm = new RemoteQueriesManager(ctx, cliServer, queryStorageDir, logger);
 
   registerRemoteQueryTextProvider();
 
@@ -861,7 +861,7 @@ async function activateWithInstalledDistribution(
 
   ctx.subscriptions.push(
     commandRunner('codeQL.showFakeRemoteQueryResults', async () => {
-      const analysisResultsManager = new AnalysesResultsManager(ctx, logger);
+      const analysisResultsManager = new AnalysesResultsManager(ctx, queryStorageDir, logger);
       const rqim = new RemoteQueriesInterfaceManager(ctx, logger, analysisResultsManager);
       await rqim.showResults(sampleData.sampleRemoteQuery, sampleData.sampleRemoteQueryResult);
 

--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -545,3 +545,16 @@ export async function tryGetQueryMetadata(cliServer: CodeQLCliServer, queryPath:
     return;
   }
 }
+
+/**
+ * Creates a file in the query directory that indicates when this query was created.
+ * This is important for keeping track of when queries should be removed.
+ *
+ * @param queryPath The directory that will containt all files relevant to a query result.
+ * It does not need to exist.
+ */
+export async function createTimestampFile(storagePath: string) {
+  const timestampPath = path.join(storagePath, 'timestamp');
+  await fs.ensureDir(storagePath);
+  await fs.writeFile(timestampPath, Date.now().toString(), 'utf8');
+}

--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -303,7 +303,7 @@ export class QueryHistoryManager extends DisposableObject {
         } else {
           this.treeDataProvider.setCurrentItem(ev.selection[0]);
         }
-        this.updateCompareWith(ev.selection);
+        this.updateCompareWith([...ev.selection]);
       })
     );
 
@@ -929,14 +929,17 @@ the file in the file explorer and dragging it into the workspace.`
   private determineSelection(
     singleItem: FullQueryInfo,
     multiSelect: FullQueryInfo[]
-  ): { finalSingleItem: FullQueryInfo; finalMultiSelect: FullQueryInfo[] } {
+  ): {
+    finalSingleItem: FullQueryInfo;
+    finalMultiSelect: FullQueryInfo[]
+  } {
     if (!singleItem && !multiSelect?.[0]) {
       const selection = this.treeView.selection;
       const current = this.treeDataProvider.getCurrent();
       if (selection?.length) {
         return {
           finalSingleItem: selection[0],
-          finalMultiSelect: selection
+          finalMultiSelect: [...selection]
         };
       } else if (current) {
         return {

--- a/extensions/ql-vscode/src/remote-queries/analyses-results-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/analyses-results-manager.ts
@@ -8,8 +8,6 @@ import { AnalysisResults, QueryResult } from './shared/analysis-result';
 import { UserCancellationException } from '../commandRunner';
 import * as os from 'os';
 import { sarifParser } from '../sarif-parser';
-import { createTimestampFile } from '../helpers';
-import { nanoid } from 'nanoid';
 
 export class AnalysesResultsManager {
   // Store for the results of various analyses for a single remote query.
@@ -17,7 +15,7 @@ export class AnalysesResultsManager {
 
   constructor(
     private readonly ctx: ExtensionContext,
-    private readonly storagePath: string,
+    readonly storagePath: string,
     private readonly logger: Logger,
   ) {
     this.analysesResults = [];
@@ -81,20 +79,6 @@ export class AnalysesResultsManager {
     return [...this.analysesResults];
   }
 
-  /**
-   * Prepares a directory for storing analysis results for a single query run.
-   * This directory initially contains only a timestamp file, which will be
-   * used by the query history manager to determine when the directory
-   * should be deleted.
-   *
-   * @param queryName The name of the query that was run.
-   */
-  public async prepareDownloadDirectory(queryName: string): Promise<void> {
-    // Prepare the storage directory.
-    const artifactStorageDir = path.join(this.storagePath, `${queryName}-${nanoid()}`);
-    await createTimestampFile(artifactStorageDir);
-  }
-
   private async downloadSingleAnalysisResults(
     analysis: AnalysisSummary,
     credentials: Credentials,
@@ -111,7 +95,7 @@ export class AnalysesResultsManager {
 
     let artifactPath;
     try {
-      artifactPath = await downloadArtifactFromLink(credentials, analysis.downloadLink, this.storagePath);
+      artifactPath = await downloadArtifactFromLink(credentials, analysis.downloadLink);
     }
     catch (e) {
       throw new Error(`Could not download the analysis results for ${analysis.nwo}: ${e.message}`);

--- a/extensions/ql-vscode/src/remote-queries/analyses-results-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/analyses-results-manager.ts
@@ -95,7 +95,7 @@ export class AnalysesResultsManager {
 
     let artifactPath;
     try {
-      artifactPath = await downloadArtifactFromLink(credentials, analysis.downloadLink);
+      artifactPath = await downloadArtifactFromLink(credentials, this.storagePath, analysis.downloadLink);
     }
     catch (e) {
       throw new Error(`Could not download the analysis results for ${analysis.nwo}: ${e.message}`);

--- a/extensions/ql-vscode/src/remote-queries/download-link.ts
+++ b/extensions/ql-vscode/src/remote-queries/download-link.ts
@@ -1,15 +1,15 @@
 /**
- * Represents a link to an artifact to be downloaded. 
+ * Represents a link to an artifact to be downloaded.
  */
 export interface DownloadLink {
   /**
-   *  A unique id of the artifact being downloaded. 
+   *  A unique id of the artifact being downloaded.
    */
   id: string;
 
   /**
    * The URL path to use against the GitHub API to download the
-   * linked artifact. 
+   * linked artifact.
    */
   urlPath: string;
 
@@ -17,4 +17,9 @@ export interface DownloadLink {
    * An optional path to follow inside the downloaded archive containing the artifact.
    */
   innerFilePath?: string;
+
+  /**
+   * The full path to the directory where the artifacts for this link is stored.
+   */
+  artifactStorageDir: string;
 }

--- a/extensions/ql-vscode/src/remote-queries/download-link.ts
+++ b/extensions/ql-vscode/src/remote-queries/download-link.ts
@@ -19,7 +19,7 @@ export interface DownloadLink {
   innerFilePath?: string;
 
   /**
-   * The full path to the directory where the artifacts for this link is stored.
+   * A unique id of the remote query run. This is used to determine where to store artifacts and data from the run.
    */
-  artifactStorageDir: string;
+  queryId: string;
 }

--- a/extensions/ql-vscode/src/remote-queries/gh-actions-api-client.ts
+++ b/extensions/ql-vscode/src/remote-queries/gh-actions-api-client.ts
@@ -54,8 +54,7 @@ export async function getRemoteQueryIndex(
 
 export async function downloadArtifactFromLink(
   credentials: Credentials,
-  downloadLink: DownloadLink,
-  storagePath: string
+  downloadLink: DownloadLink
 ): Promise<string> {
 
   const octokit = await credentials.getOctokit();
@@ -63,16 +62,14 @@ export async function downloadArtifactFromLink(
   // Download the zipped artifact.
   const response = await octokit.request(`GET ${downloadLink.urlPath}/zip`, {});
 
-  const zipFilePath = path.join(storagePath, `${downloadLink.id}.zip`);
+  const zipFilePath = path.join(downloadLink.artifactStorageDir, `${downloadLink.id}.zip`);
   await saveFile(`${zipFilePath}`, response.data as ArrayBuffer);
 
   // Extract the zipped artifact.
-  const extractedPath = path.join(storagePath, downloadLink.id);
+  const extractedPath = path.join(downloadLink.artifactStorageDir, downloadLink.id);
   await unzipFile(zipFilePath, extractedPath);
 
-  return downloadLink.innerFilePath
-    ? path.join(extractedPath, downloadLink.innerFilePath)
-    : extractedPath;
+  return path.join(extractedPath, downloadLink.innerFilePath || '');
 }
 
 /**

--- a/extensions/ql-vscode/src/remote-queries/gh-actions-api-client.ts
+++ b/extensions/ql-vscode/src/remote-queries/gh-actions-api-client.ts
@@ -54,6 +54,7 @@ export async function getRemoteQueryIndex(
 
 export async function downloadArtifactFromLink(
   credentials: Credentials,
+  storagePath: string,
   downloadLink: DownloadLink
 ): Promise<string> {
 
@@ -62,11 +63,11 @@ export async function downloadArtifactFromLink(
   // Download the zipped artifact.
   const response = await octokit.request(`GET ${downloadLink.urlPath}/zip`, {});
 
-  const zipFilePath = path.join(downloadLink.artifactStorageDir, `${downloadLink.id}.zip`);
+  const zipFilePath = path.join(storagePath, downloadLink.queryId, `${downloadLink.id}.zip`);
   await saveFile(`${zipFilePath}`, response.data as ArrayBuffer);
 
   // Extract the zipped artifact.
-  const extractedPath = path.join(downloadLink.artifactStorageDir, downloadLink.id);
+  const extractedPath = path.join(storagePath, downloadLink.queryId, downloadLink.id);
   await unzipFile(zipFilePath, extractedPath);
 
   return path.join(extractedPath, downloadLink.innerFilePath || '');

--- a/extensions/ql-vscode/src/remote-queries/gh-actions-api-client.ts
+++ b/extensions/ql-vscode/src/remote-queries/gh-actions-api-client.ts
@@ -54,18 +54,20 @@ export async function getRemoteQueryIndex(
 
 export async function downloadArtifactFromLink(
   credentials: Credentials,
-  downloadLink: DownloadLink
+  downloadLink: DownloadLink,
+  storagePath: string
 ): Promise<string> {
+
   const octokit = await credentials.getOctokit();
 
   // Download the zipped artifact.
   const response = await octokit.request(`GET ${downloadLink.urlPath}/zip`, {});
 
-  const zipFilePath = path.join(tmpDir.name, `${downloadLink.id}.zip`);
+  const zipFilePath = path.join(storagePath, `${downloadLink.id}.zip`);
   await saveFile(`${zipFilePath}`, response.data as ArrayBuffer);
 
   // Extract the zipped artifact.
-  const extractedPath = path.join(tmpDir.name, downloadLink.id);
+  const extractedPath = path.join(storagePath, downloadLink.id);
   await unzipFile(zipFilePath, extractedPath);
 
   return downloadLink.innerFilePath

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
@@ -224,7 +224,7 @@ export class RemoteQueriesInterfaceManager {
 
   private async viewAnalysisResults(msg: RemoteQueryViewAnalysisResultsMessage): Promise<void> {
     const downloadLink = msg.analysisSummary.downloadLink;
-    const filePath = path.join(downloadLink.artifactStorageDir, downloadLink.id, downloadLink.innerFilePath || '');
+    const filePath = path.join(this.analysesResultsManager.storagePath, downloadLink.queryId, downloadLink.id, downloadLink.innerFilePath || '');
 
     const sarifViewerExtensionId = 'MS-SarifVSCode.sarif-viewer';
 

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
@@ -24,7 +24,7 @@ import { AnalysisSummary, RemoteQueryResult } from './remote-query-result';
 import { RemoteQuery } from './remote-query';
 import { RemoteQueryResult as RemoteQueryResultViewModel } from './shared/remote-query-result';
 import { AnalysisSummary as AnalysisResultViewModel } from './shared/remote-query-result';
-import { showAndLogWarningMessage, tmpDir } from '../helpers';
+import { showAndLogWarningMessage } from '../helpers';
 import { URLSearchParams } from 'url';
 import { SHOW_QUERY_TEXT_MSG } from '../query-history';
 import { AnalysesResultsManager } from './analyses-results-manager';
@@ -98,7 +98,7 @@ export class RemoteQueriesInterfaceManager {
           enableFindWidget: true,
           retainContextWhenHidden: true,
           localResourceRoots: [
-            Uri.file(tmpDir.name),
+            Uri.file(this.analysesResultsManager.storagePath),
             Uri.file(path.join(this.ctx.extensionPath, 'out')),
           ],
         }
@@ -224,7 +224,7 @@ export class RemoteQueriesInterfaceManager {
 
   private async viewAnalysisResults(msg: RemoteQueryViewAnalysisResultsMessage): Promise<void> {
     const downloadLink = msg.analysisSummary.downloadLink;
-    const filePath = path.join(tmpDir.name, downloadLink.id, downloadLink.innerFilePath || '');
+    const filePath = path.join(downloadLink.artifactStorageDir, downloadLink.id, downloadLink.innerFilePath || '');
 
     const sarifViewerExtensionId = 'MS-SarifVSCode.sarif-viewer';
 

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
@@ -25,9 +25,10 @@ export class RemoteQueriesManager {
   constructor(
     private readonly ctx: ExtensionContext,
     private readonly cliServer: CodeQLCliServer,
+    readonly storagePath: string,
     logger: Logger,
   ) {
-    this.analysesResultsManager = new AnalysesResultsManager(ctx, logger);
+    this.analysesResultsManager = new AnalysesResultsManager(ctx, storagePath, logger);
     this.interfaceManager = new RemoteQueriesInterfaceManager(ctx, logger, this.analysesResultsManager);
     this.remoteQueriesMonitor = new RemoteQueriesMonitor(ctx, logger);
   }
@@ -69,6 +70,7 @@ export class RemoteQueriesManager {
       }
 
       const queryResult = this.mapQueryResult(executionEndTime, resultIndex);
+      await this.analysesResultsManager.prepareDownloadDirectory(query.queryName);
 
       // Kick off auto-download of results.
       void commands.executeCommand('codeQL.autoDownloadRemoteQueryResults', queryResult);

--- a/extensions/ql-vscode/src/remote-queries/remote-query-result.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-query-result.ts
@@ -3,6 +3,7 @@ import { DownloadLink } from './download-link';
 export interface RemoteQueryResult {
   executionEndTime: Date;
   analysisSummaries: AnalysisSummary[];
+  artifactStorageDir: string;
 }
 
 export interface AnalysisSummary {

--- a/extensions/ql-vscode/src/remote-queries/remote-query-result.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-query-result.ts
@@ -3,7 +3,6 @@ import { DownloadLink } from './download-link';
 export interface RemoteQueryResult {
   executionEndTime: Date;
   analysisSummaries: AnalysisSummary[];
-  artifactStorageDir: string;
 }
 
 export interface AnalysisSummary {

--- a/extensions/ql-vscode/src/remote-queries/sample-data.ts
+++ b/extensions/ql-vscode/src/remote-queries/sample-data.ts
@@ -1,3 +1,5 @@
+import * as path from 'path';
+import { tmpDir } from '../helpers';
 import { RemoteQuery } from './remote-query';
 import { RemoteQueryResult } from './remote-query-result';
 import { AnalysisResults } from './shared/analysis-result';
@@ -38,6 +40,7 @@ export const sampleRemoteQuery: RemoteQuery = {
 
 export const sampleRemoteQueryResult: RemoteQueryResult = {
   executionEndTime: new Date('2022-01-06T17:04:37.026Z'),
+  artifactStorageDir: path.join(tmpDir.name, 'query.ql-123-xyz'),
   analysisSummaries: [
     {
       nwo: 'big-corp/repo1',
@@ -46,7 +49,8 @@ export const sampleRemoteQueryResult: RemoteQueryResult = {
       downloadLink: {
         id: '137697017',
         urlPath: '/repos/big-corp/controller-repo/actions/artifacts/137697017',
-        innerFilePath: 'results.sarif'
+        innerFilePath: 'results.sarif',
+        artifactStorageDir: path.join(tmpDir.name, 'query.ql-123-xyz')
       }
     },
     {
@@ -56,7 +60,8 @@ export const sampleRemoteQueryResult: RemoteQueryResult = {
       downloadLink: {
         id: '137697018',
         urlPath: '/repos/big-corp/controller-repo/actions/artifacts/137697018',
-        innerFilePath: 'results.sarif'
+        innerFilePath: 'results.sarif',
+        artifactStorageDir: path.join(tmpDir.name, 'query.ql-123-xyz')
       }
     },
     {
@@ -66,7 +71,8 @@ export const sampleRemoteQueryResult: RemoteQueryResult = {
       downloadLink: {
         id: '137697019',
         urlPath: '/repos/big-corp/controller-repo/actions/artifacts/137697019',
-        innerFilePath: 'results.sarif'
+        innerFilePath: 'results.sarif',
+        artifactStorageDir: path.join(tmpDir.name, 'query.ql-123-xyz')
       }
     },
     {
@@ -76,7 +82,8 @@ export const sampleRemoteQueryResult: RemoteQueryResult = {
       downloadLink: {
         id: '137697020',
         urlPath: '/repos/big-corp/controller-repo/actions/artifacts/137697020',
-        innerFilePath: 'results.sarif'
+        innerFilePath: 'results.sarif',
+        artifactStorageDir: path.join(tmpDir.name, 'query.ql-123-xyz')
       }
     }
   ]

--- a/extensions/ql-vscode/src/remote-queries/sample-data.ts
+++ b/extensions/ql-vscode/src/remote-queries/sample-data.ts
@@ -1,5 +1,3 @@
-import * as path from 'path';
-import { tmpDir } from '../helpers';
 import { RemoteQuery } from './remote-query';
 import { RemoteQueryResult } from './remote-query-result';
 import { AnalysisResults } from './shared/analysis-result';
@@ -40,7 +38,6 @@ export const sampleRemoteQuery: RemoteQuery = {
 
 export const sampleRemoteQueryResult: RemoteQueryResult = {
   executionEndTime: new Date('2022-01-06T17:04:37.026Z'),
-  artifactStorageDir: path.join(tmpDir.name, 'query.ql-123-xyz'),
   analysisSummaries: [
     {
       nwo: 'big-corp/repo1',
@@ -50,7 +47,7 @@ export const sampleRemoteQueryResult: RemoteQueryResult = {
         id: '137697017',
         urlPath: '/repos/big-corp/controller-repo/actions/artifacts/137697017',
         innerFilePath: 'results.sarif',
-        artifactStorageDir: path.join(tmpDir.name, 'query.ql-123-xyz')
+        queryId: 'query.ql-123-xyz'
       }
     },
     {
@@ -61,7 +58,7 @@ export const sampleRemoteQueryResult: RemoteQueryResult = {
         id: '137697018',
         urlPath: '/repos/big-corp/controller-repo/actions/artifacts/137697018',
         innerFilePath: 'results.sarif',
-        artifactStorageDir: path.join(tmpDir.name, 'query.ql-123-xyz')
+        queryId: 'query.ql-123-xyz'
       }
     },
     {
@@ -72,7 +69,7 @@ export const sampleRemoteQueryResult: RemoteQueryResult = {
         id: '137697019',
         urlPath: '/repos/big-corp/controller-repo/actions/artifacts/137697019',
         innerFilePath: 'results.sarif',
-        artifactStorageDir: path.join(tmpDir.name, 'query.ql-123-xyz')
+        queryId: 'query.ql-123-xyz'
       }
     },
     {
@@ -83,7 +80,7 @@ export const sampleRemoteQueryResult: RemoteQueryResult = {
         id: '137697020',
         urlPath: '/repos/big-corp/controller-repo/actions/artifacts/137697020',
         innerFilePath: 'results.sarif',
-        artifactStorageDir: path.join(tmpDir.name, 'query.ql-123-xyz')
+        queryId: 'query.ql-123-xyz'
       }
     }
   ]

--- a/extensions/ql-vscode/src/run-queries.ts
+++ b/extensions/ql-vscode/src/run-queries.ts
@@ -17,7 +17,7 @@ import { ErrorCodes, ResponseError } from 'vscode-languageclient';
 import * as cli from './cli';
 import * as config from './config';
 import { DatabaseItem, DatabaseManager } from './databases';
-import { getOnDiskWorkspaceFolders, showAndLogErrorMessage, tryGetQueryMetadata, upgradesTmpDir } from './helpers';
+import { createTimestampFile, getOnDiskWorkspaceFolders, showAndLogErrorMessage, tryGetQueryMetadata, upgradesTmpDir } from './helpers';
 import { ProgressCallback, UserCancellationException } from './commandRunner';
 import { DatabaseInfo, QueryMetadata } from './pure/interface-types';
 import { logger } from './logging';
@@ -99,9 +99,7 @@ export class QueryEvaluationInfo {
    * This is important for keeping track of when queries should be removed.
    */
   async createTimestampFile() {
-    const timestampPath = path.join(this.querySaveDir, 'timestamp');
-    await fs.ensureDir(this.querySaveDir);
-    await fs.writeFile(timestampPath, Date.now().toString(), 'utf8');
+    await createTimestampFile(this.querySaveDir);
   }
 
   async run(


### PR DESCRIPTION
This moves all artifacts downloaded for a remote query into the global
storage directory. Each remote query gets its own directory. The
parent directory is the shared query storage directory.

Each remote query directory also gets a timestamp file.

With these changes, remote queries will be persisted across restarts
and deleted automatically on the same schedule as local queries.

Note: This does _not_ add remote queries to the query history view yet.
This part of the feature is coming next.

## Checklist

- [n/a] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [n/a] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
