### PR TITLE
Clear SARIF viewer before showing new results

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
@@ -239,6 +239,9 @@ export class RemoteQueriesInterfaceManager {
       await sarifExt.activate();
     }
 
+    // Clear any previous results before showing new results
+    await sarifExt.exports.closeAllLogs();
+
     await sarifExt.exports.openLogs([
       Uri.file(filePath),
     ]);


### PR DESCRIPTION
Clears any old results from the SARIF viewer before showing new ones (otherwise you get an increasing number of results piling up). See internal linked issue.

The [`closeAllLogs` API](https://github.com/microsoft/sarif-vscode-extension/blob/main/src/extension/index.ts#L82-L84) seems to Just Work ™ (tried locally)


## Checklist

N/A 👻

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
