### PR TITLE
Integrate evaluator structured logging per query server instance

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -209,6 +209,24 @@
           "default": null,
           "description": "Path to a directory where the CodeQL extension should store query server logs. If empty, the extension stores logs in a temporary workspace folder and deletes the contents after each run."
         },
+        "codeQL.runningQueries.structuredEvaluatorLog": {
+          "type": [
+            "string",
+            null
+          ],
+          "default": "structured-evaluator-log.json",
+          "description": "Path to a file where the evaluator should store structured evaluator logs. If empty, the query server stores the logs in a default location and overwrites them after each query server run."
+        },
+        "codeQL.runningQueries.structuredEvaluatorLog.minify": {
+          "type": "boolean",
+          "default": false,
+          "description": "Minifies the JSON output of structured evaluator logs, removing all whitespace except a single newline between event objects. If not passed, logs are not minified."
+        },
+        "codeQL.runningQueries.structuredEvaluatorLog.verbosity": {
+          "type": "integer",
+          "default": 1,
+          "description": "Specifies the verbosity of the structured evaluator logs, from 1 (least verbose) to 5 (most verbose). If not passed or empty, verbosity is set to 1. "
+        },
         "codeQL.runningQueries.quickEvalCodelens": {
           "type": "boolean",
           "default": true,

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -209,24 +209,6 @@
           "default": null,
           "description": "Path to a directory where the CodeQL extension should store query server logs. If empty, the extension stores logs in a temporary workspace folder and deletes the contents after each run."
         },
-        "codeQL.runningQueries.structuredEvaluatorLog": {
-          "type": [
-            "string",
-            null
-          ],
-          "default": "structured-evaluator-log.json",
-          "description": "Path to a file where the evaluator should store structured evaluator logs. If empty, the query server stores the logs in a default location and overwrites them after each query server run."
-        },
-        "codeQL.runningQueries.structuredEvaluatorLog.minify": {
-          "type": "boolean",
-          "default": false,
-          "description": "Minifies the JSON output of structured evaluator logs, removing all whitespace except a single newline between event objects. If not passed, logs are not minified."
-        },
-        "codeQL.runningQueries.structuredEvaluatorLog.verbosity": {
-          "type": "integer",
-          "default": 1,
-          "description": "Specifies the verbosity of the structured evaluator logs, from 1 (least verbose) to 5 (most verbose)."
-        },
         "codeQL.runningQueries.quickEvalCodelens": {
           "type": "boolean",
           "default": true,

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -225,6 +225,8 @@
         "codeQL.runningQueries.structuredEvaluatorLog.verbosity": {
           "type": "integer",
           "default": 1,
+          "minimum": 1,
+          "maximum": 5,
           "description": "Specifies the verbosity of the structured evaluator logs, from 1 (least verbose) to 5 (most verbose). If not passed or empty, verbosity is set to 1. "
         },
         "codeQL.runningQueries.quickEvalCodelens": {

--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -1205,11 +1205,10 @@ export class CliVersionConstraint {
   public static CLI_VERSION_WITH_PACKAGING = new SemVer('2.6.0');
 
   /**
-   * TODO(angelapwen): This is not quite accurate as the evaluator log options
-   * in the CLI have not yet been released. Update when released. 
-   * CLI version where the `--evaluator-log` and related options to the query server were introduced.
+   * CLI version where the `--evaluator-log` and related options to the query server were introduced,
+   * on a per-query server basis. 
    */
-   public static CLI_VERSION_WITH_STRUCTURED_EVAL_LOG = new SemVer('2.8.1');
+   public static CLI_VERSION_WITH_STRUCTURED_EVAL_LOG = new SemVer('2.8.2');
 
   constructor(private readonly cli: CodeQLCliServer) {
     /**/

--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -1204,6 +1204,13 @@ export class CliVersionConstraint {
    */
   public static CLI_VERSION_WITH_PACKAGING = new SemVer('2.6.0');
 
+  /**
+   * TODO(angelapwen): This is not quite accurate as the evaluator log options
+   * in the CLI have not yet been released. Update when released. 
+   * CLI version where the `--evaluator-log` and related options to the query server were introduced.
+   */
+   public static CLI_VERSION_WITH_STRUCTURED_EVAL_LOG = new SemVer('2.8.1');
+
   constructor(private readonly cli: CodeQLCliServer) {
     /**/
   }
@@ -1258,5 +1265,9 @@ export class CliVersionConstraint {
 
   async supportsPackaging() {
     return this.isVersionAtLeast(CliVersionConstraint.CLI_VERSION_WITH_PACKAGING);
+  }
+
+  async supportsStructuredEvalLog() {
+    return this.isVersionAtLeast(CliVersionConstraint.CLI_VERSION_WITH_STRUCTURED_EVAL_LOG);
   }
 }

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -93,8 +93,16 @@ export const AUTOSAVE_SETTING = new Setting('autoSave', RUNNING_QUERIES_SETTING)
 export const PAGE_SIZE = new Setting('pageSize', RESULTS_DISPLAY_SETTING);
 const CUSTOM_LOG_DIRECTORY_SETTING = new Setting('customLogDirectory', RUNNING_QUERIES_SETTING);
 
+const STRUCTURED_EVAL_LOG_SETTING = new Setting('structuredEvaluatorLog', RUNNING_QUERIES_SETTING);
+const STRUCTURED_EVAL_LOG_MINIFY_SETTING = new Setting('minify', STRUCTURED_EVAL_LOG_SETTING);
+const STRUCTURED_EVAL_LOG_VERBOSITY_SETTING = new Setting('verbosity', STRUCTURED_EVAL_LOG_SETTING);
+
 /** When these settings change, the running query server should be restarted. */
-const QUERY_SERVER_RESTARTING_SETTINGS = [NUMBER_OF_THREADS_SETTING, SAVE_CACHE_SETTING, CACHE_SIZE_SETTING, MEMORY_SETTING, DEBUG_SETTING, CUSTOM_LOG_DIRECTORY_SETTING];
+const QUERY_SERVER_RESTARTING_SETTINGS = [
+  NUMBER_OF_THREADS_SETTING, SAVE_CACHE_SETTING, CACHE_SIZE_SETTING, MEMORY_SETTING, 
+  DEBUG_SETTING, CUSTOM_LOG_DIRECTORY_SETTING, STRUCTURED_EVAL_LOG_SETTING, 
+  STRUCTURED_EVAL_LOG_MINIFY_SETTING, STRUCTURED_EVAL_LOG_VERBOSITY_SETTING
+];
 
 export interface QueryServerConfig {
   codeQlPath: string;
@@ -105,6 +113,9 @@ export interface QueryServerConfig {
   queryMemoryMb?: number;
   timeoutSecs: number;
   customLogDirectory?: string;
+  structuredEvalLogFile?: string;
+  structuredEvalLogMinify: boolean;
+  structuredEvalLogVerbosity: number;
   onDidChangeConfiguration?: Event<void>;
 }
 
@@ -207,6 +218,18 @@ export class QueryServerConfigListener extends ConfigListener implements QuerySe
 
   public get customLogDirectory(): string | undefined {
     return CUSTOM_LOG_DIRECTORY_SETTING.getValue<string>() || undefined;
+  }
+
+  public get structuredEvalLogFile(): string | undefined {
+    return STRUCTURED_EVAL_LOG_SETTING.getValue<string>() || undefined;
+  }
+
+  public get structuredEvalLogMinify(): boolean {
+    return STRUCTURED_EVAL_LOG_MINIFY_SETTING.getValue<boolean>();
+  }
+
+  public get structuredEvalLogVerbosity(): number {
+    return STRUCTURED_EVAL_LOG_VERBOSITY_SETTING.getValue<number>();
   }
 
   public get numThreads(): number {

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -93,15 +93,10 @@ export const AUTOSAVE_SETTING = new Setting('autoSave', RUNNING_QUERIES_SETTING)
 export const PAGE_SIZE = new Setting('pageSize', RESULTS_DISPLAY_SETTING);
 const CUSTOM_LOG_DIRECTORY_SETTING = new Setting('customLogDirectory', RUNNING_QUERIES_SETTING);
 
-const STRUCTURED_EVAL_LOG_SETTING = new Setting('structuredEvaluatorLog', RUNNING_QUERIES_SETTING);
-const STRUCTURED_EVAL_LOG_MINIFY_SETTING = new Setting('minify', STRUCTURED_EVAL_LOG_SETTING);
-const STRUCTURED_EVAL_LOG_VERBOSITY_SETTING = new Setting('verbosity', STRUCTURED_EVAL_LOG_SETTING);
-
 /** When these settings change, the running query server should be restarted. */
 const QUERY_SERVER_RESTARTING_SETTINGS = [
   NUMBER_OF_THREADS_SETTING, SAVE_CACHE_SETTING, CACHE_SIZE_SETTING, MEMORY_SETTING, 
-  DEBUG_SETTING, CUSTOM_LOG_DIRECTORY_SETTING, STRUCTURED_EVAL_LOG_SETTING, 
-  STRUCTURED_EVAL_LOG_MINIFY_SETTING, STRUCTURED_EVAL_LOG_VERBOSITY_SETTING
+  DEBUG_SETTING, CUSTOM_LOG_DIRECTORY_SETTING, 
 ];
 
 export interface QueryServerConfig {
@@ -113,9 +108,6 @@ export interface QueryServerConfig {
   queryMemoryMb?: number;
   timeoutSecs: number;
   customLogDirectory?: string;
-  structuredEvalLogFile?: string;
-  structuredEvalLogMinify: boolean;
-  structuredEvalLogVerbosity: number;
   onDidChangeConfiguration?: Event<void>;
 }
 
@@ -218,25 +210,6 @@ export class QueryServerConfigListener extends ConfigListener implements QuerySe
 
   public get customLogDirectory(): string | undefined {
     return CUSTOM_LOG_DIRECTORY_SETTING.getValue<string>() || undefined;
-  }
-
-  public get structuredEvalLogFile(): string | undefined {
-    return STRUCTURED_EVAL_LOG_SETTING.getValue<string>() || undefined;
-  }
-
-  public get structuredEvalLogMinify(): boolean {
-    return STRUCTURED_EVAL_LOG_MINIFY_SETTING.getValue<boolean>();
-  }
-
-  public get structuredEvalLogVerbosity(): number {
-    const verbosity = STRUCTURED_EVAL_LOG_VERBOSITY_SETTING.getValue<number>();
-
-    if (verbosity < 1 || verbosity > 5 || typeof (verbosity) !== 'number') {
-      void logger.log(`Ignoring value '${verbosity}' for setting ${STRUCTURED_EVAL_LOG_VERBOSITY_SETTING.qualifiedName}; falling back to default value of 1`);
-      return 1;
-    }
-
-    return verbosity;
   }
 
   public get numThreads(): number {

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -229,7 +229,14 @@ export class QueryServerConfigListener extends ConfigListener implements QuerySe
   }
 
   public get structuredEvalLogVerbosity(): number {
-    return STRUCTURED_EVAL_LOG_VERBOSITY_SETTING.getValue<number>();
+    const verbosity = STRUCTURED_EVAL_LOG_VERBOSITY_SETTING.getValue<number>();
+
+    if (verbosity < 1 || verbosity > 5 || typeof (verbosity) !== 'number') {
+      void logger.log(`Ignoring value '${verbosity}' for setting ${STRUCTURED_EVAL_LOG_VERBOSITY_SETTING.qualifiedName}; falling back to default value of 1`);
+      return 1;
+    }
+
+    return verbosity;
   }
 
   public get numThreads(): number {

--- a/extensions/ql-vscode/src/queryserver-client.ts
+++ b/extensions/ql-vscode/src/queryserver-client.ts
@@ -169,6 +169,21 @@ export class QueryServerClient extends DisposableObject {
 
     if (await this.cliServer.cliConstraints.supportsOldEvalStats()) {
       args.push('--old-eval-stats');
+    } 
+
+    if (this.config.structuredEvalLogFile) {
+      args.push('--evaluator-log');
+      args.push(this.config.structuredEvalLogFile);
+
+      if (this.config.structuredEvalLogMinify) {
+        args.push('--evaluator-log-minify');
+      }
+
+      // 1 is default behavior in query server if argument is not passed.
+      if (this.config.structuredEvalLogVerbosity > 1) {
+        args.push('--evaluator-log-level');
+        args.push(this.config.structuredEvalLogVerbosity.toString());
+      }
     }
 
     if (this.config.debug) {

--- a/extensions/ql-vscode/src/queryserver-client.ts
+++ b/extensions/ql-vscode/src/queryserver-client.ts
@@ -172,19 +172,13 @@ export class QueryServerClient extends DisposableObject {
     }
 
     if (await this.cliServer.cliConstraints.supportsStructuredEvalLog()) {
-      if (this.config.structuredEvalLogFile) {
-        args.push('--evaluator-log');
-        args.push(this.config.structuredEvalLogFile);
+      args.push('--evaluator-log');
+      args.push(`${this.opts.contextStoragePath}/structured-evaluator-log.json`);
   
-        if (this.config.structuredEvalLogMinify) {
-          args.push('--evaluator-log-minify');
-        }
-        // 1 is default behavior in query server if argument is not passed.
-        if (this.config.structuredEvalLogVerbosity > 1) {
-          args.push('--evaluator-log-level');
-          args.push(this.config.structuredEvalLogVerbosity.toString());
-        }
-      }
+      // We hard-code the verbosity level to 5 and minify to false. 
+      // This will be the behavior of the per-query structured logging in the CLI after 2.8.3.
+      args.push('--evaluator-log-level');
+      args.push('5');
     }
 
     if (this.config.debug) {

--- a/extensions/ql-vscode/src/queryserver-client.ts
+++ b/extensions/ql-vscode/src/queryserver-client.ts
@@ -169,20 +169,21 @@ export class QueryServerClient extends DisposableObject {
 
     if (await this.cliServer.cliConstraints.supportsOldEvalStats()) {
       args.push('--old-eval-stats');
-    } 
+    }
 
-    if (this.config.structuredEvalLogFile) {
-      args.push('--evaluator-log');
-      args.push(this.config.structuredEvalLogFile);
-
-      if (this.config.structuredEvalLogMinify) {
-        args.push('--evaluator-log-minify');
-      }
-
-      // 1 is default behavior in query server if argument is not passed.
-      if (this.config.structuredEvalLogVerbosity > 1) {
-        args.push('--evaluator-log-level');
-        args.push(this.config.structuredEvalLogVerbosity.toString());
+    if (await this.cliServer.cliConstraints.supportsStructuredEvalLog()) {
+      if (this.config.structuredEvalLogFile) {
+        args.push('--evaluator-log');
+        args.push(this.config.structuredEvalLogFile);
+  
+        if (this.config.structuredEvalLogMinify) {
+          args.push('--evaluator-log-minify');
+        }
+        // 1 is default behavior in query server if argument is not passed.
+        if (this.config.structuredEvalLogVerbosity > 1) {
+          args.push('--evaluator-log-level');
+          args.push(this.config.structuredEvalLogVerbosity.toString());
+        }
       }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

This pull request is intended to ensure the query server runs correctly with structured evaluator logging enabled. It does not alert the user to the generated structured logfile, but a user could manually find it amongst other query artifacts. All structured logs related to all queries in a single query server instance will be output to a single file within `structured-evaluator-log.json` in the storage path that includes other query artifacts. The logs will not be minified for now, and will be set to the highest verbosity, as these are the use cases we expect from most of our users. 

Because we do not expose any configurations or indications to the user that we are integrating structured logging with this change, I have not updated the CHANGELOG. That said, we are now writing an extra file to user's disk so I am open to adding the change too. 

### Testing
This change has been tested locally against the current version of the CLI that will be included into 2.8.2, and does produce the structured evaluator logfile as intended. It continues to pass all existing CLI integration tests. 

### Expected future work 
Note that this change is intended to work with the current version of the query server (ie. will be released in 2.8.2), which will print all structured logs related to all queries in a single query server instance to a single file. When the changes to the query server allow for individual queries to have structured logs in separate files (expected in 2.8.3) the changes to the extension should include:

-  creating a directory for all the structured evaluator logfiles (perhaps making this configurable similar to the existing log directory?)
-  passing unique logfile names for each query to the query server
- changing the feature to be flagged under 2.8.3 

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
