### PR TITLE
Display analysis failures (for remote queries) in results view

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/gh-actions-api-client.ts
+++ b/extensions/ql-vscode/src/remote-queries/gh-actions-api-client.ts
@@ -12,9 +12,10 @@ import { RemoteQueryResultIndex, RemoteQueryResultIndexItem } from './remote-que
 interface ApiResultIndexItem {
   nwo: string;
   id: string;
-  results_count: number;
-  bqrs_file_size: number;
+  results_count?: number;
+  bqrs_file_size?: number;
   sarif_file_size?: number;
+  error?: string;
 }
 
 export async function getRemoteQueryIndex(
@@ -34,7 +35,8 @@ export async function getRemoteQueryIndex(
   const resultIndexItems = await getResultIndexItems(credentials, owner, repoName, resultIndexArtifactId);
 
   const items = resultIndexItems.map(item => {
-    const artifactId = getArtifactIDfromName(item.id, workflowUri, artifactList);
+    // We only need the artifact for non-error items.
+    const artifactId = item.error ? undefined : getArtifactIDfromName(item.id, workflowUri, artifactList);
 
     return {
       id: item.id.toString(),
@@ -43,6 +45,7 @@ export async function getRemoteQueryIndex(
       resultCount: item.results_count,
       bqrsFileSize: item.bqrs_file_size,
       sarifFileSize: item.sarif_file_size,
+      error: item.error
     } as RemoteQueryResultIndexItem;
   });
 

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
@@ -82,7 +82,8 @@ export class RemoteQueriesInterfaceManager {
       totalResultCount: totalResultCount,
       executionTimestamp: this.formatDate(query.executionStartTime),
       executionDuration: executionDuration,
-      analysisSummaries: analysisSummaries
+      analysisSummaries: analysisSummaries,
+      analysisFailures: queryResult.analysisFailures,
     };
   }
 

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
@@ -13,7 +13,7 @@ import { RemoteQueriesInterfaceManager } from './remote-queries-interface';
 import { RemoteQuery } from './remote-query';
 import { RemoteQueriesMonitor } from './remote-queries-monitor';
 import { getRemoteQueryIndex } from './gh-actions-api-client';
-import { RemoteQueryFailureIndexItem, RemoteQueryResultIndex, RemoteQuerySuccessIndexItem } from './remote-query-result-index';
+import { RemoteQueryResultIndex } from './remote-query-result-index';
 import { RemoteQueryResult } from './remote-query-result';
 import { DownloadLink } from './download-link';
 import { AnalysesResultsManager } from './analyses-results-manager';
@@ -129,9 +129,7 @@ export class RemoteQueriesManager {
 
   private mapQueryResult(executionEndTime: Date, resultIndex: RemoteQueryResultIndex, queryId: string): RemoteQueryResult {
 
-    const successes = resultIndex.items.filter(item => !item.error) as RemoteQuerySuccessIndexItem[];
-    const failures = resultIndex.items.filter(item => item.error) as RemoteQueryFailureIndexItem[];
-    const analysisSummaries = successes.map(item => ({
+    const analysisSummaries = resultIndex.successes.map(item => ({
       nwo: item.nwo,
       resultCount: item.resultCount,
       fileSizeInBytes: item.sarifFileSize ? item.sarifFileSize : item.bqrsFileSize,
@@ -142,7 +140,7 @@ export class RemoteQueriesManager {
         queryId,
       } as DownloadLink
     }));
-    const analysisFailures = failures.map(item => ({
+    const analysisFailures = resultIndex.failures.map(item => ({
       nwo: item.nwo,
       error: item.error
     }));

--- a/extensions/ql-vscode/src/remote-queries/remote-query-result-index.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-query-result-index.ts
@@ -1,6 +1,7 @@
 export interface RemoteQueryResultIndex {
   artifactsUrlPath: string;
-  items: RemoteQueryResultIndexItem[];
+  successes: RemoteQuerySuccessIndexItem[];
+  failures: RemoteQueryFailureIndexItem[];
 }
 
 export interface RemoteQuerySuccessIndexItem {
@@ -18,5 +19,3 @@ export interface RemoteQueryFailureIndexItem {
   nwo: string;
   error: string;
 }
-
-export type RemoteQueryResultIndexItem = RemoteQuerySuccessIndexItem & RemoteQueryFailureIndexItem;

--- a/extensions/ql-vscode/src/remote-queries/remote-query-result-index.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-query-result-index.ts
@@ -3,7 +3,7 @@ export interface RemoteQueryResultIndex {
   items: RemoteQueryResultIndexItem[];
 }
 
-export interface RemoteQueryResultIndexItem {
+export interface RemoteQuerySuccessIndexItem {
   id: string;
   artifactId: number;
   nwo: string;
@@ -11,3 +11,12 @@ export interface RemoteQueryResultIndexItem {
   bqrsFileSize: number;
   sarifFileSize?: number;
 }
+
+export interface RemoteQueryFailureIndexItem {
+  id: string;
+  artifactId: number;
+  nwo: string;
+  error: string;
+}
+
+export type RemoteQueryResultIndexItem = RemoteQuerySuccessIndexItem & RemoteQueryFailureIndexItem;

--- a/extensions/ql-vscode/src/remote-queries/remote-query-result.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-query-result.ts
@@ -1,8 +1,10 @@
 import { DownloadLink } from './download-link';
+import { AnalysisFailure } from './shared/analysis-failure';
 
 export interface RemoteQueryResult {
   executionEndTime: Date;
   analysisSummaries: AnalysisSummary[];
+  analysisFailures: AnalysisFailure[];
 }
 
 export interface AnalysisSummary {

--- a/extensions/ql-vscode/src/remote-queries/sample-data.ts
+++ b/extensions/ql-vscode/src/remote-queries/sample-data.ts
@@ -88,7 +88,11 @@ export const sampleRemoteQueryResult: RemoteQueryResult = {
     {
       nwo: 'big-corp/repo5',
       error: 'Error message'
-    }
+    },
+    {
+      nwo: 'big-corp/repo6',
+      error: 'Error message'
+    },
   ]
 };
 

--- a/extensions/ql-vscode/src/remote-queries/sample-data.ts
+++ b/extensions/ql-vscode/src/remote-queries/sample-data.ts
@@ -83,6 +83,12 @@ export const sampleRemoteQueryResult: RemoteQueryResult = {
         queryId: 'query.ql-123-xyz'
       }
     }
+  ],
+  analysisFailures: [
+    {
+      nwo: 'big-corp/repo5',
+      error: 'Error message'
+    }
   ]
 };
 

--- a/extensions/ql-vscode/src/remote-queries/shared/analysis-failure.ts
+++ b/extensions/ql-vscode/src/remote-queries/shared/analysis-failure.ts
@@ -1,0 +1,4 @@
+export interface AnalysisFailure {
+  nwo: string,
+  error: string
+}

--- a/extensions/ql-vscode/src/remote-queries/shared/remote-query-result.ts
+++ b/extensions/ql-vscode/src/remote-queries/shared/remote-query-result.ts
@@ -1,4 +1,5 @@
 import { DownloadLink } from '../download-link';
+import { AnalysisFailure } from './analysis-failure';
 
 export interface RemoteQueryResult {
   queryTitle: string;
@@ -10,7 +11,8 @@ export interface RemoteQueryResult {
   totalResultCount: number;
   executionTimestamp: string;
   executionDuration: string;
-  analysisSummaries: AnalysisSummary[]
+  analysisSummaries: AnalysisSummary[],
+  analysisFailures: AnalysisFailure[];
 }
 
 export interface AnalysisSummary {

--- a/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
@@ -100,15 +100,7 @@ const Failures = (queryResult: RemoteQueryResult) => {
   return (
     <>
       <VerticalSpace size={3} />
-      <Flash
-        variant="danger"
-        // Currently only works for dark mode (potential bug with Flash component)
-        // https://primer.style/react/Flash
-        sx={{
-          backgroundColor: '#3B2229',
-          color: '#ADBAC7',
-        }}
-      >
+      <Flash variant="danger">
         {queryResult.analysisFailures.map((f, i) => (
           <>
             <p className="vscode-codeql__analysis-failure" key={i}>
@@ -328,7 +320,7 @@ export function RemoteQueries(): JSX.Element {
 
   try {
     return <div>
-      <ThemeProvider>
+      <ThemeProvider colorMode="auto">
         <ViewTitle>{queryResult.queryTitle}</ViewTitle>
         <QueryInfo {...queryResult} />
         <Failures {...queryResult} />

--- a/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useEffect, useState } from 'react';
 import * as Rdom from 'react-dom';
-import { ThemeProvider } from '@primer/react';
+import { Flash, ThemeProvider } from '@primer/react';
 import { ToRemoteQueriesMessage } from '../../pure/interface-types';
 import { AnalysisSummary, RemoteQueryResult } from '../shared/remote-query-result';
 
@@ -16,7 +16,7 @@ import DownloadButton from './DownloadButton';
 import { AnalysisResults } from '../shared/analysis-result';
 import DownloadSpinner from './DownloadSpinner';
 import CollapsibleItem from './CollapsibleItem';
-import { CodeSquareIcon, FileCodeIcon, FileSymlinkFileIcon, RepoIcon } from '@primer/octicons-react';
+import { AlertIcon, CodeSquareIcon, FileCodeIcon, FileSymlinkFileIcon, RepoIcon } from '@primer/octicons-react';
 
 const numOfReposInContractedMode = 10;
 
@@ -30,7 +30,8 @@ const emptyQueryResult: RemoteQueryResult = {
   totalResultCount: 0,
   executionTimestamp: '',
   executionDuration: '',
-  analysisSummaries: []
+  analysisSummaries: [],
+  analysisFailures: [],
 };
 
 const downloadAnalysisResults = (analysisSummary: AnalysisSummary) => {
@@ -91,6 +92,39 @@ const QueryInfo = (queryResult: RemoteQueryResult) => (
     </span>
   </>
 );
+
+const Failures = (queryResult: RemoteQueryResult) => {
+  if (queryResult.analysisFailures.length === 0) {
+    return <></>;
+  }
+  return (
+    <>
+      <VerticalSpace size={3} />
+      <Flash
+        variant="danger"
+        // Currently only works for dark mode (potential bug with Flash component)
+        // https://primer.style/react/Flash
+        sx={{
+          backgroundColor: '#3B2229',
+          color: '#ADBAC7',
+        }}
+      >
+        {queryResult.analysisFailures.map((f, i) => (
+          <>
+            <p className="vscode-codeql__analysis-failure" key={i}>
+              <AlertIcon size={16} />
+              <b>{f.nwo}: </b>
+              {f.error}
+            </p>
+            {
+              i === queryResult.analysisFailures.length - 1 ? <></> : <VerticalSpace size={1} />
+            }
+          </>
+        ))}
+      </Flash>
+    </>
+  );
+};
 
 const SummaryTitleWithResults = ({
   queryResult,
@@ -297,6 +331,7 @@ export function RemoteQueries(): JSX.Element {
       <ThemeProvider>
         <ViewTitle>{queryResult.queryTitle}</ViewTitle>
         <QueryInfo {...queryResult} />
+        <Failures {...queryResult} />
         <Summary queryResult={queryResult} analysesResults={analysesResults} />
         {showAnalysesResults && <AnalysesResults analysesResults={analysesResults} totalResults={queryResult.totalResultCount} />}
       </ThemeProvider>

--- a/extensions/ql-vscode/src/remote-queries/view/remoteQueries.css
+++ b/extensions/ql-vscode/src/remote-queries/view/remoteQueries.css
@@ -57,4 +57,5 @@
   margin: 0;
   font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas,
     Liberation Mono, monospace;
+  color: var(--vscode-editor-foreground);
 }

--- a/extensions/ql-vscode/src/remote-queries/view/remoteQueries.css
+++ b/extensions/ql-vscode/src/remote-queries/view/remoteQueries.css
@@ -52,3 +52,9 @@
 .vscode-codeql__analysis-result-file-link {
   vertical-align: middle;
 }
+
+.vscode-codeql__analysis-failure {
+  margin: 0;
+  font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas,
+    Liberation Mono, monospace;
+}


### PR DESCRIPTION
VS Code now reads error messages (for failed analysis runs) from the result index and displays those errors in the results view:

![image](https://user-images.githubusercontent.com/42641846/154977398-cc15c51b-fe1d-4ad6-9087-6ceecc23298d.png)

See linked issue + PR.

## Checklist

N/A: internal only! 🚪 

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
