### PR TITLE
Use correct primer icon in results view

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
@@ -16,7 +16,7 @@ import DownloadButton from './DownloadButton';
 import { AnalysisResults } from '../shared/analysis-result';
 import DownloadSpinner from './DownloadSpinner';
 import CollapsibleItem from './CollapsibleItem';
-import { CodeSquareIcon, FileIcon, FileSymlinkFileIcon, RepoIcon } from '@primer/octicons-react';
+import { CodeSquareIcon, FileCodeIcon, FileSymlinkFileIcon, RepoIcon } from '@primer/octicons-react';
 
 const numOfReposInContractedMode = 10;
 
@@ -78,7 +78,7 @@ const QueryInfo = (queryResult: RemoteQueryResult) => (
     ({queryResult.executionDuration}), {queryResult.executionTimestamp}
     <VerticalSpace size={1} />
     <span className="vscode-codeql__query-file">
-      <FileIcon size={16} />
+      <FileCodeIcon size={16} />
       <a className="vscode-codeql__query-file-link" href="#" onClick={() => openQueryFile(queryResult)}>
         {queryResult.queryFileName}
       </a>


### PR DESCRIPTION
Minor: Our design mockups use the "[file-code](https://primer.style/octicons/file-code-16)" icon instead of the "[file](https://primer.style/octicons/file-16)" icon: 

![image](https://user-images.githubusercontent.com/42641846/155121834-fe952c8d-3dc4-4e8f-92d1-fc6777d3eeba.png)

## Checklist

N/A 🎨 

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
