### PR TITLE
Remember remote queries across restarts

### DIFF
--- a/extensions/ql-vscode/src/query-results.ts
+++ b/extensions/ql-vscode/src/query-results.ts
@@ -291,7 +291,7 @@ export class LocalQueryInfo {
     }
   }
 
-  isCompleted(): boolean {
+  get completed(): boolean {
     return !!this.completedQuery;
   }
 

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
@@ -261,8 +261,8 @@ export class RemoteQueriesInterfaceManager {
     return this.getPanel().webview.postMessage(msg);
   }
 
-  private getDuration(startTime: Date, endTime: Date): string {
-    const diffInMs = startTime.getTime() - endTime.getTime();
+  private getDuration(startTime: number, endTime: number): string {
+    const diffInMs = startTime - endTime;
     return this.formatDuration(diffInMs);
   }
 
@@ -282,7 +282,8 @@ export class RemoteQueriesInterfaceManager {
     }
   }
 
-  private formatDate = (d: Date): string => {
+  private formatDate = (millis: number): string => {
+    const d = new Date(millis);
     const datePart = d.toLocaleDateString(undefined, { day: 'numeric', month: 'short' });
     const timePart = d.toLocaleTimeString(undefined, { hour: 'numeric', minute: 'numeric', hour12: true });
     return `${datePart} at ${timePart}`;

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
@@ -21,11 +21,14 @@ import { assertNever } from '../pure/helpers-pure';
 import { RemoteQueryHistoryItem } from './remote-query-history-item';
 import { QueryHistoryManager } from '../query-history';
 import { QueryStatus } from '../query-status';
+import { DisposableObject } from '../pure/disposable-object';
+import { QueryHistoryInfo } from '../query-results';
 
 const autoDownloadMaxSize = 300 * 1024;
 const autoDownloadMaxCount = 100;
 
-export class RemoteQueriesManager {
+const noop = () => { /* do nothing */ };
+export class RemoteQueriesManager extends DisposableObject {
   private readonly remoteQueriesMonitor: RemoteQueriesMonitor;
   private readonly analysesResultsManager: AnalysesResultsManager;
   private readonly interfaceManager: RemoteQueriesInterfaceManager;
@@ -37,9 +40,50 @@ export class RemoteQueriesManager {
     private readonly storagePath: string,
     logger: Logger,
   ) {
+    super();
     this.analysesResultsManager = new AnalysesResultsManager(ctx, storagePath, logger);
     this.interfaceManager = new RemoteQueriesInterfaceManager(ctx, logger, this.analysesResultsManager);
     this.remoteQueriesMonitor = new RemoteQueriesMonitor(ctx, logger);
+
+    // Handle events from the query history manager
+    this.push(this.qhm.onDidAddQueryItem(this.handleAddQueryItem.bind(this)));
+    this.push(this.qhm.onDidRemoveQueryItem(this.handleRemoveQueryItem.bind(this)));
+    this.push(this.qhm.onWillOpenQueryItem(this.handleOpenQueryItem.bind(this)));
+  }
+
+  private async handleAddQueryItem(queryItem: QueryHistoryInfo) {
+    if (queryItem?.t === 'remote') {
+      if (!(await this.queryHistoryItemExists(queryItem))) {
+        // In this case, the query was deleted from disk, most likely because it was purged
+        // by another workspace. We should remove it from the history manager.
+        await this.qhm.handleRemoveHistoryItem(queryItem);
+      } else if (queryItem.status === QueryStatus.InProgress) {
+        // In this case, last time we checked, the query was still in progress.
+        // We need to setup the monitor to check for completion.
+        await commands.executeCommand('codeQL.monitorRemoteQuery', queryItem);
+      }
+    }
+  }
+
+  private async handleRemoveQueryItem(queryItem: QueryHistoryInfo) {
+    if (queryItem?.t === 'remote') {
+      await this.removeStorageDirectory(queryItem);
+    }
+  }
+
+  private async handleOpenQueryItem(queryItem: QueryHistoryInfo) {
+    if (queryItem?.t === 'remote') {
+      try {
+        const remoteQueryResult = await this.retrieveJsonFile(queryItem, 'query-result.json') as RemoteQueryResult;
+        // open results in the background
+        void this.openResults(queryItem.remoteQuery, remoteQueryResult).then(
+          noop,
+          err => void showAndLogErrorMessage(err)
+        );
+      } catch (e) {
+        void showAndLogErrorMessage(`Could not open query results. ${e}`);
+      }
+    }
   }
 
   public async runRemoteQuery(
@@ -56,66 +100,74 @@ export class RemoteQueriesManager {
       progress,
       token);
 
-    if (querySubmission && querySubmission.query) {
-      void commands.executeCommand('codeQL.monitorRemoteQuery', querySubmission.query);
+    if (querySubmission?.query) {
+      const query = querySubmission.query;
+      const queryId = this.createQueryId(query.queryName);
+
+      const queryHistoryItem: RemoteQueryHistoryItem = {
+        t: 'remote',
+        status: QueryStatus.InProgress,
+        completed: false,
+        queryId,
+        label: query.queryName,
+        remoteQuery: query,
+      };
+      await this.prepareStorageDirectory(queryHistoryItem);
+      await this.storeJsonFile(queryHistoryItem, 'query.json', query);
+
+      this.qhm.addQuery(queryHistoryItem);
+      await this.qhm.refreshTreeView();
     }
   }
 
   public async monitorRemoteQuery(
-    query: RemoteQuery,
+    queryItem: RemoteQueryHistoryItem,
     cancellationToken: CancellationToken
   ): Promise<void> {
-    const queryId = this.createQueryId(query.queryName);
-    await this.prepareStorageDirectory(queryId);
-    await this.storeFile(queryId, 'query.json', query);
-
-    const queryHistoryItem = new RemoteQueryHistoryItem(query.queryName, queryId, this.storagePath);
-    this.qhm.addQuery(queryHistoryItem);
-
     const credentials = await Credentials.initialize(this.ctx);
 
-    const queryWorkflowResult = await this.remoteQueriesMonitor.monitorQuery(query, cancellationToken);
+    const queryWorkflowResult = await this.remoteQueriesMonitor.monitorQuery(queryItem.remoteQuery, cancellationToken);
 
-    const executionEndTime = new Date();
+    const executionEndTime = Date.now();
 
     if (queryWorkflowResult.status === 'CompletedSuccessfully') {
-      const resultIndex = await getRemoteQueryIndex(credentials, query);
+      const resultIndex = await getRemoteQueryIndex(credentials, queryItem.remoteQuery);
       if (!resultIndex) {
-        void showAndLogErrorMessage(`There was an issue retrieving the result for the query ${query.queryName}`);
+        void showAndLogErrorMessage(`There was an issue retrieving the result for the query ${queryItem.label}`);
         return;
       }
-      queryHistoryItem.completed = true;
-      queryHistoryItem.status = QueryStatus.Completed;
-      const queryResult = this.mapQueryResult(executionEndTime, resultIndex, queryId);
+      queryItem.completed = true;
+      queryItem.status = QueryStatus.Completed;
+      const queryResult = this.mapQueryResult(executionEndTime, resultIndex, queryItem.queryId);
 
-      await this.storeFile(queryId, 'query-result.json', queryResult);
+      await this.storeJsonFile(queryItem, 'query-result.json', queryResult);
 
       // Kick off auto-download of results in the background.
       void commands.executeCommand('codeQL.autoDownloadRemoteQueryResults', queryResult);
 
       // Ask if the user wants to open the results in the background.
-      void this.askToOpenResults(query, queryResult).then(
-        () => { /* do nothing */ },
+      void this.askToOpenResults(queryItem.remoteQuery, queryResult).then(
+        noop,
         err => {
           void showAndLogErrorMessage(err);
         }
       );
     } else if (queryWorkflowResult.status === 'CompletedUnsuccessfully') {
-      queryHistoryItem.failureReason = queryWorkflowResult.error;
-      queryHistoryItem.status = QueryStatus.Failed;
-      await showAndLogErrorMessage(`Remote query execution failed. Error: ${queryWorkflowResult.error}`);
+      queryItem.failureReason = queryWorkflowResult.error;
+      queryItem.status = QueryStatus.Failed;
+      void showAndLogErrorMessage(`Remote query execution failed. Error: ${queryWorkflowResult.error}`);
     } else if (queryWorkflowResult.status === 'Cancelled') {
-      queryHistoryItem.failureReason = 'Cancelled';
-      queryHistoryItem.status = QueryStatus.Failed;
-      await showAndLogErrorMessage('Remote query monitoring was cancelled');
+      queryItem.failureReason = 'Cancelled';
+      queryItem.status = QueryStatus.Failed;
+      void showAndLogErrorMessage('Remote query monitoring was cancelled');
     } else if (queryWorkflowResult.status === 'InProgress') {
-      // Should not get here
-      await showAndLogErrorMessage(`Unexpected status: ${queryWorkflowResult.status}`);
+      // Should not get here. Only including this to ensure `assertNever` uses proper type checking.
+      void showAndLogErrorMessage(`Unexpected status: ${queryWorkflowResult.status}`);
     } else {
       // Ensure all cases are covered
       assertNever(queryWorkflowResult.status);
     }
-    this.qhm.refreshTreeView();
+    await this.qhm.refreshTreeView();
   }
 
   public async autoDownloadRemoteQueryResults(
@@ -138,7 +190,7 @@ export class RemoteQueriesManager {
       results => this.interfaceManager.setAnalysisResults(results));
   }
 
-  private mapQueryResult(executionEndTime: Date, resultIndex: RemoteQueryResultIndex, queryId: string): RemoteQueryResult {
+  private mapQueryResult(executionEndTime: number, resultIndex: RemoteQueryResultIndex, queryId: string): RemoteQueryResult {
 
     const analysisSummaries = resultIndex.successes.map(item => ({
       nwo: item.nwo,
@@ -163,13 +215,17 @@ export class RemoteQueriesManager {
     };
   }
 
+  public async openResults(query: RemoteQuery, queryResult: RemoteQueryResult) {
+    await this.interfaceManager.showResults(query, queryResult);
+  }
+
   private async askToOpenResults(query: RemoteQuery, queryResult: RemoteQueryResult): Promise<void> {
     const totalResultCount = queryResult.analysisSummaries.reduce((acc, cur) => acc + cur.resultCount, 0);
     const message = `Query "${query.queryName}" run on ${query.repositories.length} repositories and returned ${totalResultCount} results`;
 
     const shouldOpenView = await showInformationMessageWithAction(message, 'View');
     if (shouldOpenView) {
-      await this.interfaceManager.showResults(query, queryResult);
+      await this.openResults(query, queryResult);
     }
   }
 
@@ -191,13 +247,27 @@ export class RemoteQueriesManager {
    *
    * @param queryName The name of the query that was run.
    */
-  private async prepareStorageDirectory(queryId: string): Promise<void> {
-    await createTimestampFile(path.join(this.storagePath, queryId));
+  private async prepareStorageDirectory(queryHistoryItem: RemoteQueryHistoryItem): Promise<void> {
+    await createTimestampFile(path.join(this.storagePath, queryHistoryItem.queryId));
   }
 
-  private async storeFile(queryId: string, fileName: string, obj: any): Promise<void> {
-    const filePath = path.join(this.storagePath, queryId, fileName);
+  private async storeJsonFile<T>(queryHistoryItem: RemoteQueryHistoryItem, fileName: string, obj: T): Promise<void> {
+    const filePath = path.join(this.storagePath, queryHistoryItem.queryId, fileName);
     await fs.writeFile(filePath, JSON.stringify(obj, null, 2), 'utf8');
   }
 
+  private async retrieveJsonFile<T>(queryHistoryItem: RemoteQueryHistoryItem, fileName: string): Promise<T> {
+    const filePath = path.join(this.storagePath, queryHistoryItem.queryId, fileName);
+    return JSON.parse(await fs.readFile(filePath, 'utf8'));
+  }
+
+  private async removeStorageDirectory(queryItem: RemoteQueryHistoryItem): Promise<void> {
+    const filePath = path.join(this.storagePath, queryItem.queryId);
+    await fs.remove(filePath);
+  }
+
+  private async queryHistoryItemExists(queryItem: RemoteQueryHistoryItem): Promise<boolean> {
+    const filePath = path.join(this.storagePath, queryItem.queryId);
+    return await fs.pathExists(filePath);
+  }
 }

--- a/extensions/ql-vscode/src/remote-queries/remote-query-history-item.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-query-history-item.ts
@@ -1,33 +1,15 @@
-import * as fs from 'fs-extra';
-import * as path from 'path';
-
 import { QueryStatus } from '../query-status';
+import { RemoteQuery } from './remote-query';
 
 /**
  * Information about a remote query.
  */
-export class RemoteQueryHistoryItem {
-  readonly t = 'remote';
-  failureReason: string | undefined;
+export interface RemoteQueryHistoryItem {
+  readonly t: 'remote';
+  failureReason?: string;
   status: QueryStatus;
-  completed = false;
-
-  constructor(
-    public label: string, // TODO, the query label should have interpolation like local queries
-    public readonly queryId: string,
-    private readonly storagePath: string,
-  ) {
-    this.status = QueryStatus.InProgress;
-  }
-
-  isCompleted(): boolean {
-    return this.completed;
-  }
-  async deleteQuery(): Promise<void> {
-    await fs.remove(this.querySaveDir);
-  }
-
-  get querySaveDir(): string {
-    return path.join(this.storagePath, this.queryId);
-  }
+  completed: boolean;
+  readonly queryId: string,
+  label: string, // TODO, the query label should have interpolation like local queries
+  remoteQuery: RemoteQuery,
 }

--- a/extensions/ql-vscode/src/remote-queries/remote-query-result.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-query-result.ts
@@ -2,7 +2,7 @@ import { DownloadLink } from './download-link';
 import { AnalysisFailure } from './shared/analysis-failure';
 
 export interface RemoteQueryResult {
-  executionEndTime: Date;
+  executionEndTime: number; // Can't use a Date here since it needs to be serialized and desserialized.
   analysisSummaries: AnalysisSummary[];
   analysisFailures: AnalysisFailure[];
 }

--- a/extensions/ql-vscode/src/remote-queries/remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-query.ts
@@ -6,6 +6,6 @@ export interface RemoteQuery {
   queryText: string;
   controllerRepository: Repository;
   repositories: Repository[];
-  executionStartTime: Date;
+  executionStartTime: number; // Use number here since it needs to be serialized and desserialized.
   actionsWorkflowRunId: number;
 }

--- a/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
@@ -303,7 +303,7 @@ export async function runRemoteQuery(
     });
 
     const workflowRunId = await runRemoteQueriesApiRequest(credentials, 'main', language, repositories, owner, repo, base64Pack, dryRun);
-    const queryStartTime = new Date();
+    const queryStartTime = Date.now();
     const queryMetadata = await tryGetQueryMetadata(cliServer, queryFile);
 
     if (dryRun) {
@@ -435,7 +435,7 @@ async function buildRemoteQueryEntity(
   queryMetadata: QueryMetadata | undefined,
   controllerRepoOwner: string,
   controllerRepoName: string,
-  queryStartTime: Date,
+  queryStartTime: number,
   workflowRunId: number
 ): Promise<RemoteQuery> {
   // The query name is either the name as specified in the query metadata, or the file name.

--- a/extensions/ql-vscode/src/remote-queries/sample-data.ts
+++ b/extensions/ql-vscode/src/remote-queries/sample-data.ts
@@ -32,12 +32,12 @@ export const sampleRemoteQuery: RemoteQuery = {
       name: 'repo5'
     }
   ],
-  executionStartTime: new Date('2022-01-06T17:02:15.026Z'),
+  executionStartTime: new Date('2022-01-06T17:02:15.026Z').getTime(),
   actionsWorkflowRunId: 1662757118
 };
 
 export const sampleRemoteQueryResult: RemoteQueryResult = {
-  executionEndTime: new Date('2022-01-06T17:04:37.026Z'),
+  executionEndTime: new Date('2022-01-06T17:04:37.026Z').getTime(),
   analysisSummaries: [
     {
       nwo: 'big-corp/repo1',

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
@@ -743,12 +743,12 @@ describe('query-history', () => {
         extensionPath: vscode.Uri.file('/x/y/z').fsPath,
       } as vscode.ExtensionContext,
       configListener,
-      selectedCallback,
       doCompareCallback
     );
+    qhm.onWillOpenQueryItem(selectedCallback);
     (qhm.treeDataProvider as any).history = [...allHistory];
     await vscode.workspace.saveAll();
-    qhm.refreshTreeView();
+    await qhm.refreshTreeView();
     return qhm;
   }
 });


### PR DESCRIPTION
Remote query items will be stored in query history and will remain
available across restarts.

When the extension is restarted, any `InProgress` remote queries will
be monitored until they complete.

When clicked on, a remote query is opened and its results can be
downloaded. The query text and the query file can be opened from the
history menu. A remote query can be deleted as well, which will purge
all results from global storage.

Limitations:

1. Labels are not editable
2. Running multiple queries that each run on the same repository
   will have conflicting results and there will be errors when trying
   to view the results of the second query. This limitation is not new,
   but it is easier to hit now. See #1089.

Both of these limitations will be addressed in future PRs.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

## Checklist

- [n/a] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [n/a] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
