### PR TITLE
Allow multiple analyses for same repo to be downloaded

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/analyses-results-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/analyses-results-manager.ts
@@ -10,15 +10,16 @@ import * as os from 'os';
 import { sarifParser } from '../sarif-parser';
 
 export class AnalysesResultsManager {
-  // Store for the results of various analyses for a single remote query.
-  private readonly analysesResults: AnalysisResults[];
+  // Store for the results of various analyses for each remote query.
+  // The key is the queryId and is also the name of the directory where results are stored.
+  private readonly analysesResults: Map<string, AnalysisResults[]>;
 
   constructor(
     private readonly ctx: ExtensionContext,
     readonly storagePath: string,
     private readonly logger: Logger,
   ) {
-    this.analysesResults = [];
+    this.analysesResults = new Map();
   }
 
   public async downloadAnalysisResults(
@@ -78,8 +79,12 @@ export class AnalysesResultsManager {
     }
   }
 
-  public getAnalysesResults(): AnalysisResults[] {
-    return [...this.analysesResults];
+  public getAnalysesResults(queryId: string): AnalysisResults[] {
+    return [...(this.analysesResults.get(queryId) || [])];
+  }
+
+  public removeAnalysesResults(queryId: string) {
+    this.analysesResults.delete(queryId);
   }
 
   private async downloadSingleAnalysisResults(
@@ -92,9 +97,11 @@ export class AnalysesResultsManager {
       status: 'InProgress',
       results: []
     };
-
-    this.analysesResults.push(analysisResults);
-    void publishResults(this.analysesResults);
+    const queryId = analysis.downloadLink.queryId;
+    const resultsForQuery = this.analysesResults.get(queryId) || [];
+    resultsForQuery.push(analysisResults);
+    this.analysesResults.set(queryId, resultsForQuery);
+    void publishResults(resultsForQuery);
 
     let artifactPath;
     try {
@@ -113,7 +120,7 @@ export class AnalysesResultsManager {
       analysisResults.status = 'Failed';
     }
 
-    void publishResults(this.analysesResults);
+    void publishResults(resultsForQuery);
   }
 
   private async readResults(filePath: string): Promise<QueryResult[]> {
@@ -139,6 +146,6 @@ export class AnalysesResultsManager {
   }
 
   private isAnalysisDownloaded(analysis: AnalysisSummary): boolean {
-    return this.analysesResults.some(x => x.nwo === analysis.nwo);
+    return (this.analysesResults.get(analysis.downloadLink.queryId) || []).some(x => x.nwo === analysis.nwo);
   }
 }

--- a/extensions/ql-vscode/src/remote-queries/analyses-results-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/analyses-results-manager.ts
@@ -80,7 +80,11 @@ export class AnalysesResultsManager {
   }
 
   public getAnalysesResults(queryId: string): AnalysisResults[] {
-    return [...(this.analysesResults.get(queryId) || [])];
+    return [...this.internalGetAnalysesResults(queryId)];
+  }
+
+  private internalGetAnalysesResults(queryId: string): AnalysisResults[] {
+    return this.analysesResults.get(queryId) || [];
   }
 
   public removeAnalysesResults(queryId: string) {
@@ -98,7 +102,7 @@ export class AnalysesResultsManager {
       results: []
     };
     const queryId = analysis.downloadLink.queryId;
-    const resultsForQuery = this.analysesResults.get(queryId) || [];
+    const resultsForQuery = this.internalGetAnalysesResults(queryId);
     resultsForQuery.push(analysisResults);
     this.analysesResults.set(queryId, resultsForQuery);
     void publishResults(resultsForQuery);
@@ -146,6 +150,6 @@ export class AnalysesResultsManager {
   }
 
   private isAnalysisDownloaded(analysis: AnalysisSummary): boolean {
-    return (this.analysesResults.get(analysis.downloadLink.queryId) || []).some(x => x.nwo === analysis.nwo);
+    return this.internalGetAnalysesResults(analysis.downloadLink.queryId).some(x => x.nwo === analysis.nwo);
   }
 }

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
@@ -54,7 +54,7 @@ export class RemoteQueriesInterfaceManager {
       queryResult: this.buildViewModel(query, queryResult)
     });
 
-    await this.setAnalysisResults(this.analysesResultsManager.getAnalysesResults());
+    await this.setAnalysisResults(this.analysesResultsManager.getAnalysesResults(queryResult.queryId));
   }
 
   /**

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
@@ -67,6 +67,7 @@ export class RemoteQueriesManager extends DisposableObject {
 
   private async handleRemoveQueryItem(queryItem: QueryHistoryInfo) {
     if (queryItem?.t === 'remote') {
+      this.analysesResultsManager.removeAnalysesResults(queryItem.queryId);
       await this.removeStorageDirectory(queryItem);
     }
   }
@@ -211,7 +212,8 @@ export class RemoteQueriesManager extends DisposableObject {
     return {
       executionEndTime,
       analysisSummaries,
-      analysisFailures
+      analysisFailures,
+      queryId
     };
   }
 

--- a/extensions/ql-vscode/src/remote-queries/remote-query-result.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-query-result.ts
@@ -5,6 +5,7 @@ export interface RemoteQueryResult {
   executionEndTime: number; // Can't use a Date here since it needs to be serialized and desserialized.
   analysisSummaries: AnalysisSummary[];
   analysisFailures: AnalysisFailure[];
+  queryId: string;
 }
 
 export interface AnalysisSummary {

--- a/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
@@ -302,6 +302,7 @@ export async function runRemoteQuery(
       message: 'Sending request'
     });
 
+    // TODO When https://github.com/dsp-testing/qc-run2/pull/567 is merged, we can change the branch back to `main`.
     const workflowRunId = await runRemoteQueriesApiRequest(credentials, 'better-errors', language, repositories, owner, repo, base64Pack, dryRun);
     const queryStartTime = Date.now();
     const queryMetadata = await tryGetQueryMetadata(cliServer, queryFile);

--- a/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
@@ -302,7 +302,7 @@ export async function runRemoteQuery(
       message: 'Sending request'
     });
 
-    const workflowRunId = await runRemoteQueriesApiRequest(credentials, 'main', language, repositories, owner, repo, base64Pack, dryRun);
+    const workflowRunId = await runRemoteQueriesApiRequest(credentials, 'better-errors', language, repositories, owner, repo, base64Pack, dryRun);
     const queryStartTime = Date.now();
     const queryMetadata = await tryGetQueryMetadata(cliServer, queryFile);
 

--- a/extensions/ql-vscode/src/remote-queries/sample-data.ts
+++ b/extensions/ql-vscode/src/remote-queries/sample-data.ts
@@ -37,6 +37,7 @@ export const sampleRemoteQuery: RemoteQuery = {
 };
 
 export const sampleRemoteQueryResult: RemoteQueryResult = {
+  queryId: 'query123',
   executionEndTime: new Date('2022-01-06T17:04:37.026Z').getTime(),
   analysisSummaries: [
     {


### PR DESCRIPTION
Removes the limitation specified in #1089 where analyses for the same
repo and different queries will overwrite each other.

This PR does not save analysis results across restarts. After restarting, results will need to be re-downloaded. That is what I will work on next.

## Checklist

- [n/a] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
