### PR TITLE
Add link to workflow run logs from results view

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
@@ -77,6 +77,7 @@ export class RemoteQueriesInterfaceManager {
       queryFileName: queryFileName,
       queryFilePath: query.queryFilePath,
       queryText: query.queryText,
+      workflowRunUrl: `https://github.com/${query.controllerRepository.owner}/${query.controllerRepository.name}/actions/runs/${query.actionsWorkflowRunId}`,
       totalRepositoryCount: query.repositories.length,
       affectedRepositoryCount: affectedRepositories.length,
       totalResultCount: totalResultCount,

--- a/extensions/ql-vscode/src/remote-queries/shared/remote-query-result.ts
+++ b/extensions/ql-vscode/src/remote-queries/shared/remote-query-result.ts
@@ -6,12 +6,13 @@ export interface RemoteQueryResult {
   queryFileName: string;
   queryFilePath: string;
   queryText: string;
+  workflowRunUrl: string;
   totalRepositoryCount: number;
   affectedRepositoryCount: number;
   totalResultCount: number;
   executionTimestamp: string;
   executionDuration: string;
-  analysisSummaries: AnalysisSummary[],
+  analysisSummaries: AnalysisSummary[];
   analysisFailures: AnalysisFailure[];
 }
 

--- a/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
@@ -16,7 +16,7 @@ import DownloadButton from './DownloadButton';
 import { AnalysisResults } from '../shared/analysis-result';
 import DownloadSpinner from './DownloadSpinner';
 import CollapsibleItem from './CollapsibleItem';
-import { AlertIcon, CodeSquareIcon, FileCodeIcon, FileSymlinkFileIcon, RepoIcon } from '@primer/octicons-react';
+import { AlertIcon, CodeSquareIcon, FileCodeIcon, FileSymlinkFileIcon, RepoIcon, TerminalIcon } from '@primer/octicons-react';
 
 const numOfReposInContractedMode = 10;
 
@@ -25,6 +25,7 @@ const emptyQueryResult: RemoteQueryResult = {
   queryFileName: '',
   queryFilePath: '',
   queryText: '',
+  workflowRunUrl: '',
   totalRepositoryCount: 0,
   affectedRepositoryCount: 0,
   totalResultCount: 0,
@@ -84,10 +85,16 @@ const QueryInfo = (queryResult: RemoteQueryResult) => (
         {queryResult.queryFileName}
       </a>
     </span>
-    <span>
+    <span className="vscode-codeql__query-file">
       <CodeSquareIcon size={16} />
       <a className="vscode-codeql__query-file-link" href="#" onClick={() => openQueryTextVirtualFile(queryResult)}>
-        query
+        Query
+      </a>
+    </span>
+    <span>
+      <TerminalIcon size={16} />
+      <a className="vscode-codeql__query-file-link" href={queryResult.workflowRunUrl}>
+        Logs
       </a>
     </span>
   </>

--- a/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
@@ -79,21 +79,21 @@ const QueryInfo = (queryResult: RemoteQueryResult) => (
     {queryResult.totalResultCount} results from running against {queryResult.totalRepositoryCount} repositories
     ({queryResult.executionDuration}), {queryResult.executionTimestamp}
     <VerticalSpace size={1} />
-    <span className="vscode-codeql__query-file">
-      <FileCodeIcon size={16} />
-      <a className="vscode-codeql__query-file-link" href="#" onClick={() => openQueryFile(queryResult)}>
+    <span>
+      <a className="vscode-codeql__query-info-link" href="#" onClick={() => openQueryFile(queryResult)}>
+        <span> <FileCodeIcon size={16} /> </span>
         {queryResult.queryFileName}
       </a>
     </span>
-    <span className="vscode-codeql__query-file">
-      <CodeSquareIcon size={16} />
-      <a className="vscode-codeql__query-file-link" href="#" onClick={() => openQueryTextVirtualFile(queryResult)}>
+    <span>
+      <a className="vscode-codeql__query-info-link" href="#" onClick={() => openQueryTextVirtualFile(queryResult)}>
+        <span> <CodeSquareIcon size={16} /> </span>
         Query
       </a>
     </span>
     <span>
-      <TerminalIcon size={16} />
-      <a className="vscode-codeql__query-file-link" href={queryResult.workflowRunUrl}>
+      <a className="vscode-codeql__query-info-link" href={queryResult.workflowRunUrl}>
+        <span> <TerminalIcon size={16} /> </span>
         Logs
       </a>
     </span>

--- a/extensions/ql-vscode/src/remote-queries/view/remoteQueries.css
+++ b/extensions/ql-vscode/src/remote-queries/view/remoteQueries.css
@@ -1,14 +1,10 @@
-.vscode-codeql__query-file {
-  padding-right: 1em;
-}
-
-.vscode-codeql__query-file-link {
+.vscode-codeql__query-info-link {
   text-decoration: none;
-  padding-left: 0.3em;
+  padding-right: 1em;
   color: var(--vscode-editor-foreground);
 }
 
-.vscode-codeql__query-file-link:hover {
+.vscode-codeql__query-info-link:hover {
   color: var(--vscode-editor-foreground);
 }
 


### PR DESCRIPTION
Adds a link to the GitHub Actions logs in the results view! (In line with our design mockups—see internal linked issue)

🖼️ 👀 

![image](https://user-images.githubusercontent.com/42641846/155382011-04193d2a-1fe9-4bb8-89bd-cf46cb011e9b.png)

## Checklist

N/A - internal! 💅🏽 

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
