### PR TITLE
Add new endpoints of the query server protocol

### DIFF
--- a/extensions/ql-vscode/src/pure/messages.ts
+++ b/extensions/ql-vscode/src/pure/messages.ts
@@ -646,6 +646,31 @@ export interface ClearCacheParams {
    */
   dryRun: boolean;
 }
+
+/**
+ * Parameters to start a new structured log
+ */
+ export interface StartLogParams {
+  /**
+   * The dataset for which we want to start a new structured log
+   */
+  db: Dataset;
+  /**
+   * The path where we want to place the new structured log
+   */
+  logPath: string;
+}
+
+/**
+ * Parameters to terminate a structured log
+ */
+ export interface EndLogParams {
+  /**
+   * The dataset for which we want to terminated the log
+   */
+  db: Dataset;
+}
+
 /**
  * Parameters for trimming the cache of a dataset
  */
@@ -680,6 +705,26 @@ export interface ClearCacheResult {
    * deleted.
    */
   deletionMessage: string;
+}
+
+/**
+ * The result of starting a new structured log.
+ */
+export interface StartLogResult {
+  /**
+   * A user friendly message saying what happened.
+   */
+  successMessage: string;
+}
+
+/**
+ * The result of terminating a structured.
+ */
+export interface EndLogResult {
+  /**
+   * A user friendly message saying what happened.
+   */
+  successMessage: string;
 }
 
 /**
@@ -1017,6 +1062,16 @@ export const compileUpgrade = new rpc.RequestType<WithProgressId<CompileUpgradeP
  * Compile an upgrade script to upgrade a dataset.
  */
 export const compileUpgradeSequence = new rpc.RequestType<WithProgressId<CompileUpgradeSequenceParams>, CompileUpgradeSequenceResult, void, void>('compilation/compileUpgradeSequence');
+
+/**
+ * Start a new structured log in the evaluator, terminating the previous one if it exists
+ */
+ export const startLog = new rpc.RequestType<WithProgressId<StartLogParams>, StartLogResult, void, void>('evaluation/startLog');
+
+/**
+ * Terminate a structured log in the evaluator
+ */
+ export const endLog = new rpc.RequestType<WithProgressId<EndLogParams>, StartLogResult, void, void>('evaluation/endLog');
 
 /**
  * Clear the cache of a dataset


### PR DESCRIPTION
Adds in the interfaces and methods for calling two new (still unreleased) end-points for the query server in the VS code extension. I haven't called these anywhere yet nor added tests because (a) we haven't released a version of CodeQL with these in yet (b) we probably need to discuss a bit quite how/where we want to rotate the logs.

I have, however, tested this manually (with a query server built from a branch adding the endpoints in) by doing the most naive thing of adding in the calls at a suitable point in the `run` method of `run-queries.ts` and can confirm that they work.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
