### PR TITLE
Preemptively add a version number to the query history json file

### DIFF
--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/query-results.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/query-results.test.ts
@@ -18,7 +18,7 @@ import { slurpQueryHistory, splatQueryHistory } from '../../query-serialization'
 chai.use(chaiAsPromised);
 const expect = chai.expect;
 
-describe.only('query-results', () => {
+describe('query-results', () => {
   let disposeSpy: sinon.SinonSpy;
   let onDidChangeQueryHistoryConfigurationSpy: sinon.SinonSpy;
   let mockConfig: QueryHistoryConfig;

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/query-results.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/query-results.test.ts
@@ -18,7 +18,7 @@ import { slurpQueryHistory, splatQueryHistory } from '../../query-serialization'
 chai.use(chaiAsPromised);
 const expect = chai.expect;
 
-describe('query-results', () => {
+describe.only('query-results', () => {
   let disposeSpy: sinon.SinonSpy;
   let onDidChangeQueryHistoryConfigurationSpy: sinon.SinonSpy;
   let mockConfig: QueryHistoryConfig;
@@ -254,20 +254,30 @@ describe('query-results', () => {
   });
 
   describe('splat and slurp', () => {
-    it('should splat and slurp query history', async () => {
-      const infoSuccessRaw = createMockFullQueryInfo('a', createMockQueryWithResults(`${queryPath}-a`, false, false, '/a/b/c/a', false));
-      const infoSuccessInterpreted = createMockFullQueryInfo('b', createMockQueryWithResults(`${queryPath}-b`, true, true, '/a/b/c/b', false));
-      const infoEarlyFailure = createMockFullQueryInfo('c', undefined, true);
-      const infoLateFailure = createMockFullQueryInfo('d', createMockQueryWithResults(`${queryPath}-c`, false, false, '/a/b/c/d', false));
-      const infoInprogress = createMockFullQueryInfo('e');
-      const allHistory = [
+
+    let infoSuccessRaw: LocalQueryInfo;
+    let infoSuccessInterpreted: LocalQueryInfo;
+    let infoEarlyFailure: LocalQueryInfo;
+    let infoLateFailure: LocalQueryInfo;
+    let infoInprogress: LocalQueryInfo;
+    let allHistory: LocalQueryInfo[];
+
+    beforeEach(() => {
+      infoSuccessRaw = createMockFullQueryInfo('a', createMockQueryWithResults(`${queryPath}-a`, false, false, '/a/b/c/a', false));
+      infoSuccessInterpreted = createMockFullQueryInfo('b', createMockQueryWithResults(`${queryPath}-b`, true, true, '/a/b/c/b', false));
+      infoEarlyFailure = createMockFullQueryInfo('c', undefined, true);
+      infoLateFailure = createMockFullQueryInfo('d', createMockQueryWithResults(`${queryPath}-c`, false, false, '/a/b/c/d', false));
+      infoInprogress = createMockFullQueryInfo('e');
+      allHistory = [
         infoSuccessRaw,
         infoSuccessInterpreted,
         infoEarlyFailure,
         infoLateFailure,
         infoInprogress
       ];
+    });
 
+    it('should splat and slurp query history', async () => {
       // the expected results only contains the history with completed queries
       const expectedHistory = [
         infoSuccessRaw,
@@ -312,6 +322,18 @@ describe('query-results', () => {
         expect(allHistoryActual[i]).to.deep.eq(expectedHistory[i]);
       }
       expect(allHistoryActual.length).to.deep.eq(expectedHistory.length);
+    });
+
+    it('should handle an invalid query history version', async () => {
+      const badPath = path.join(tmpDir.name, 'bad-query-history.json');
+      fs.writeFileSync(badPath, JSON.stringify({
+        version: 2,
+        queries: allHistory
+      }), 'utf8');
+
+      const allHistoryActual = await slurpQueryHistory(badPath, mockConfig);
+      // version number is invalid. Should return an empty array.
+      expect(allHistoryActual).to.deep.eq([]);
     });
   });
 


### PR DESCRIPTION
Since we are now storing query history on disk, we will need to handle
situations where versions change. For now, there is only version 1. In
the future, we may need to make breaking changes to this format and we
need the flexibility to detect and possibly handle different versions.

In this case, users don't often downgrade their vscode versions, so
most likely, we only need to be forward compatible. Ie- we need to
handle moving from v1 to v2, but not the other way around.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

## Checklist

- [n/a] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
