### PR TITLE
Fixed unique key warning

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
@@ -102,8 +102,8 @@ const Failures = (queryResult: RemoteQueryResult) => {
       <VerticalSpace size={3} />
       <Flash variant="danger">
         {queryResult.analysisFailures.map((f, i) => (
-          <>
-            <p className="vscode-codeql__analysis-failure" key={i}>
+          <div key={i}>
+            <p className="vscode-codeql__analysis-failure">
               <AlertIcon size={16} />
               <b>{f.nwo}: </b>
               {f.error}
@@ -111,7 +111,7 @@ const Failures = (queryResult: RemoteQueryResult) => {
             {
               i === queryResult.analysisFailures.length - 1 ? <></> : <VerticalSpace size={1} />
             }
-          </>
+          </div>
         ))}
       </Flash>
     </>


### PR DESCRIPTION
Quick PR to remove a warning generated by the new Failures component

```
Warning: Each child in a list should have a unique "key" prop.
Check the render method of `Failures`. See https://reactjs.org/link/warning-keys for more information.
    at Failures (https://file+.vscode-resource.vscode-webview.net/Users/charisk/dev/vscode-codeql/extensions/ql-vscode/out/remoteQueriesView.js:39823:21)
    at Fe (https://file+.vscode-resource.vscode-webview.net/Users/charisk/dev/vscode-codeql/extensions/ql-vscode/out/remoteQueriesView.js:39163:17294)
    at ThemeProvider (https://file+.vscode-resource.vscode-webview.net/Users/charisk/dev/vscode-codeql/extensions/ql-vscode/out/remoteQueriesView.js:4155:3)
    at div
    at RemoteQueries (https://file+.vscode-resource.vscode-webview.net/Users/charisk/dev/vscode-codeql/extensions/ql-vscode/out/remoteQueriesView.js:39921:90)
```

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
