### PR TITLE
Expose Remote Query language

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
@@ -77,6 +77,7 @@ export class RemoteQueriesInterfaceManager {
       queryFileName: queryFileName,
       queryFilePath: query.queryFilePath,
       queryText: query.queryText,
+      language: query.language,
       workflowRunUrl: `https://github.com/${query.controllerRepository.owner}/${query.controllerRepository.name}/actions/runs/${query.actionsWorkflowRunId}`,
       totalRepositoryCount: query.repositories.length,
       affectedRepositoryCount: affectedRepositories.length,

--- a/extensions/ql-vscode/src/remote-queries/remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-query.ts
@@ -4,6 +4,7 @@ export interface RemoteQuery {
   queryName: string;
   queryFilePath: string;
   queryText: string;
+  language: string;
   controllerRepository: Repository;
   repositories: Repository[];
   executionStartTime: number; // Use number here since it needs to be serialized and desserialized.

--- a/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
@@ -314,7 +314,15 @@ export async function runRemoteQuery(
         return;
       }
 
-      const remoteQuery = await buildRemoteQueryEntity(repositories, queryFile, queryMetadata, owner, repo, queryStartTime, workflowRunId);
+      const remoteQuery = await buildRemoteQueryEntity(
+        repositories,
+        queryFile,
+        queryMetadata,
+        owner,
+        repo,
+        queryStartTime,
+        workflowRunId,
+        language);
 
       // don't return the path because it has been deleted
       return { query: remoteQuery };
@@ -437,7 +445,8 @@ async function buildRemoteQueryEntity(
   controllerRepoOwner: string,
   controllerRepoName: string,
   queryStartTime: number,
-  workflowRunId: number
+  workflowRunId: number,
+  language: string
 ): Promise<RemoteQuery> {
   // The query name is either the name as specified in the query metadata, or the file name.
   const queryName = queryMetadata?.name ?? path.basename(queryFilePath);
@@ -453,6 +462,7 @@ async function buildRemoteQueryEntity(
     queryName,
     queryFilePath,
     queryText,
+    language,
     controllerRepository: {
       owner: controllerRepoOwner,
       name: controllerRepoName,

--- a/extensions/ql-vscode/src/remote-queries/sample-data.ts
+++ b/extensions/ql-vscode/src/remote-queries/sample-data.ts
@@ -6,6 +6,7 @@ export const sampleRemoteQuery: RemoteQuery = {
   queryName: 'Inefficient regular expression',
   queryFilePath: '/Users/foo/dev/vscode-codeql-starter/ql/javascript/ql/src/Performance/ReDoS.ql',
   queryText: '/**\n * @name Inefficient regular expression\n * @description A regular expression that requires exponential time to match certain inputs\n *              can be a performance bottleneck, and may be vulnerable to denial-of-service\n *              attacks.\n * @kind problem\n * @problem.severity error\n * @security-severity 7.5\n * @precision high\n * @id js/redos\n * @tags security\n *       external/cwe/cwe-1333\n *       external/cwe/cwe-730\n *       external/cwe/cwe-400\n */\n\nimport javascript\nimport semmle.javascript.security.performance.ReDoSUtil\nimport semmle.javascript.security.performance.ExponentialBackTracking\n\nfrom RegExpTerm t, string pump, State s, string prefixMsg\nwhere hasReDoSResult(t, pump, s, prefixMsg)\nselect t,\n  "This part of the regular expression may cause exponential backtracking on strings " + prefixMsg +\n    "containing many repetitions of \'" + pump + "\'."\n',
+  language: 'javascript',
   controllerRepository: {
     owner: 'big-corp',
     name: 'controller-repo'

--- a/extensions/ql-vscode/src/remote-queries/shared/remote-query-result.ts
+++ b/extensions/ql-vscode/src/remote-queries/shared/remote-query-result.ts
@@ -6,6 +6,7 @@ export interface RemoteQueryResult {
   queryFileName: string;
   queryFilePath: string;
   queryText: string;
+  language: string;
   workflowRunUrl: string;
   totalRepositoryCount: number;
   affectedRepositoryCount: number;

--- a/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
@@ -25,6 +25,7 @@ const emptyQueryResult: RemoteQueryResult = {
   queryFileName: '',
   queryFilePath: '',
   queryText: '',
+  language: '',
   workflowRunUrl: '',
   totalRepositoryCount: 0,
   affectedRepositoryCount: 0,


### PR DESCRIPTION
Expose the language we're querying against so that it can be used for syntax highlighting configuration.

Note that the new information isn't actually used anywhere yet. It will be used in future PR.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
