### PR TITLE
Update ECMAScript version to be the same across the codebase

### DIFF
--- a/extensions/ql-vscode/gulpfile.ts/tsconfig.json
+++ b/extensions/ql-vscode/gulpfile.ts/tsconfig.json
@@ -5,7 +5,7 @@
     "strict": true,
     "module": "commonjs",
     "target": "es2017",
-    "lib": ["es6"],
+    "lib": ["ES2021"],
     "moduleResolution": "node",
     "sourceMap": true,
     "rootDir": ".",

--- a/extensions/ql-vscode/src/compare/view/tsconfig.json
+++ b/extensions/ql-vscode/src/compare/view/tsconfig.json
@@ -4,10 +4,7 @@
     "moduleResolution": "node",
     "target": "es6",
     "outDir": "out",
-    "lib": [
-      "es6",
-      "dom"
-    ],
+    "lib": ["ES2021", "dom"],
     "jsx": "react",
     "sourceMap": true,
     "rootDir": "..",
@@ -17,7 +14,5 @@
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true
   },
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"]
 }

--- a/extensions/ql-vscode/src/remote-queries/view/tsconfig.json
+++ b/extensions/ql-vscode/src/remote-queries/view/tsconfig.json
@@ -4,7 +4,7 @@
     "moduleResolution": "node",
     "target": "es6",
     "outDir": "out",
-    "lib": ["es6", "dom"],
+    "lib": ["ES2021", "dom"],
     "jsx": "react",
     "sourceMap": true,
     "rootDir": "..",

--- a/extensions/ql-vscode/src/view/tsconfig.json
+++ b/extensions/ql-vscode/src/view/tsconfig.json
@@ -4,10 +4,7 @@
     "moduleResolution": "node",
     "target": "es6",
     "outDir": "out",
-    "lib": [
-      "es6",
-      "dom"
-    ],
+    "lib": ["ES2021", "dom"],
     "jsx": "react",
     "sourceMap": true,
     "rootDir": "..",
@@ -17,7 +14,5 @@
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true
   },
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
In a [previous PR](https://github.com/github/vscode-codeql/pull/1166), the lib version was changed to `ES2021` but only in the root level .tsconfig file. This PR updates all other .tsconfig files for consistency.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
