### PR TITLE
Add command to open remote query on github

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -545,6 +545,10 @@
         "title": "Compare Results"
       },
       {
+        "command": "codeQLQueryHistory.openOnGithub",
+        "title": "Open Remote Query on GitHub"
+      },
+      {
         "command": "codeQLQueryResults.nextPathStep",
         "title": "CodeQL: Show Next Step on Path"
       },
@@ -734,7 +738,12 @@
         {
           "command": "codeQLQueryHistory.cancel",
           "group": "9_qlCommands",
-          "when": "viewItem == inProgressResultsItem"
+          "when": "viewItem == inProgressResultsItem || viewItem == inProgressRemoteResultsItem"
+        },
+        {
+          "command": "codeQLQueryHistory.openOnGithub",
+          "group": "9_qlCommands",
+          "when": "viewItem == remoteResultsItem || viewItem == inProgressRemoteResultsItem"
         },
         {
           "command": "codeQLTests.showOutputDifferences",
@@ -902,6 +911,10 @@
         },
         {
           "command": "codeQLQueryHistory.cancel",
+          "when": "false"
+        },
+        {
+          "command": "codeQLQueryHistory.openOnGithub",
           "when": "false"
         },
         {


### PR DESCRIPTION
Command is available for remote queries that are in progress or
completed.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

## Checklist

- [n/a] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
