### PR TITLE
Remove .only from mocha test

### DIFF
--- a/extensions/ql-vscode/test/pure-tests/logging.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/logging.test.ts
@@ -12,7 +12,7 @@ const proxyquire = pq.noPreserveCache().noCallThru();
 chai.use(sinonChai);
 const expect = chai.expect;
 
-describe.only('OutputChannelLogger tests', function() {
+describe('OutputChannelLogger tests', function() {
   this.timeout(999999);
   let OutputChannelLogger;
   const tempFolders: Record<string, tmp.DirResult> = {};


### PR DESCRIPTION
I believe this was accidentally checked in with [this](https://github.com/github/vscode-codeql/commit/2579d12f24bdbd6365762be567890ef376f3c613) commit.

This is a very easy mistake to make, so we should look at blocking the PR when a .only is left in.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
