### PR TITLE
Deal with analysis messages that have links to locations

### DIFF
--- a/extensions/ql-vscode/src/pure/sarif-utils.ts
+++ b/extensions/ql-vscode/src/pure/sarif-utils.ts
@@ -148,7 +148,7 @@ export function parseSarifRegion(
   // We assume that the SARIF we're given always has startLine
   // This is not mandated by the SARIF spec, but should be true of
   // SARIF output by our own tools.
-  const startLine = region.startLine!;
+  const startLine = region.startLine ?? 1;
 
   // These defaults are from SARIF 2.1.0 spec, section 3.30.2, "Text Regions"
   // https://docs.oasis-open.org/sarif/sarif/v2.1.0/cs01/sarif-v2.1.0-cs01.html#_Ref493492556
@@ -160,7 +160,7 @@ export function parseSarifRegion(
   // length we don't know at this point in the code.
   //
   // It is off by one with respect to the way vscode counts columns in selections.
-  const endColumn = region.endColumn! - 1;
+  const endColumn = (region.endColumn ?? 1) - 1;
 
   return {
     startLine,

--- a/extensions/ql-vscode/src/pure/sarif-utils.ts
+++ b/extensions/ql-vscode/src/pure/sarif-utils.ts
@@ -145,9 +145,8 @@ export function parseSarifRegion(
   startColumn: number,
   endColumn: number
 } {
-  // We assume that the SARIF we're given always has startLine
-  // This is not mandated by the SARIF spec, but should be true of
-  // SARIF output by our own tools.
+  // The SARIF we're given should have a startLine, but we
+  // fall back to 1, just in case something has gone wrong.
   const startLine = region.startLine ?? 1;
 
   // These defaults are from SARIF 2.1.0 spec, section 3.30.2, "Text Regions"
@@ -155,9 +154,10 @@ export function parseSarifRegion(
   const endLine = region.endLine === undefined ? startLine : region.endLine;
   const startColumn = region.startColumn === undefined ? 1 : region.startColumn;
 
-  // We also assume that our tools will always supply `endColumn` field, which is
-  // fortunate, since the SARIF spec says that it defaults to the end of the line, whose
-  // length we don't know at this point in the code.
+  // Our tools should always supply `endColumn` field, which is fortunate, since 
+  // the SARIF spec says that it defaults to the end of the line, whose
+  // length we don't know at this point in the code. We fall back to 1,
+  // just in case something has gone wrong.
   //
   // It is off by one with respect to the way vscode counts columns in selections.
   const endColumn = (region.endColumn ?? 1) - 1;

--- a/extensions/ql-vscode/src/pure/sarif-utils.ts
+++ b/extensions/ql-vscode/src/pure/sarif-utils.ts
@@ -127,33 +127,47 @@ export function parseSarifLocation(
       userVisibleFile
     } as ParsedSarifLocation;
   } else {
-    const region = physicalLocation.region;
-    // We assume that the SARIF we're given always has startLine
-    // This is not mandated by the SARIF spec, but should be true of
-    // SARIF output by our own tools.
-    const startLine = region.startLine!;
-
-    // These defaults are from SARIF 2.1.0 spec, section 3.30.2, "Text Regions"
-    // https://docs.oasis-open.org/sarif/sarif/v2.1.0/cs01/sarif-v2.1.0-cs01.html#_Ref493492556
-    const endLine = region.endLine === undefined ? startLine : region.endLine;
-    const startColumn = region.startColumn === undefined ? 1 : region.startColumn;
-
-    // We also assume that our tools will always supply `endColumn` field, which is
-    // fortunate, since the SARIF spec says that it defaults to the end of the line, whose
-    // length we don't know at this point in the code.
-    //
-    // It is off by one with respect to the way vscode counts columns in selections.
-    const endColumn = region.endColumn! - 1;
+    const region = parseSarifRegion(physicalLocation.region);
 
     return {
       uri: effectiveLocation,
       userVisibleFile,
-      startLine,
-      startColumn,
-      endLine,
-      endColumn,
+      ...region
     };
   }
+}
+
+export function parseSarifRegion(
+  region: Sarif.Region
+): {
+  startLine: number,
+  endLine: number,
+  startColumn: number,
+  endColumn: number
+} {
+  // We assume that the SARIF we're given always has startLine
+  // This is not mandated by the SARIF spec, but should be true of
+  // SARIF output by our own tools.
+  const startLine = region.startLine!;
+
+  // These defaults are from SARIF 2.1.0 spec, section 3.30.2, "Text Regions"
+  // https://docs.oasis-open.org/sarif/sarif/v2.1.0/cs01/sarif-v2.1.0-cs01.html#_Ref493492556
+  const endLine = region.endLine === undefined ? startLine : region.endLine;
+  const startColumn = region.startColumn === undefined ? 1 : region.startColumn;
+
+  // We also assume that our tools will always supply `endColumn` field, which is
+  // fortunate, since the SARIF spec says that it defaults to the end of the line, whose
+  // length we don't know at this point in the code.
+  //
+  // It is off by one with respect to the way vscode counts columns in selections.
+  const endColumn = region.endColumn! - 1;
+
+  return {
+    startLine,
+    startColumn,
+    endLine,
+    endColumn
+  };
 }
 
 export function isNoLocation(loc: ParsedSarifLocation): loc is NoLocation {

--- a/extensions/ql-vscode/src/remote-queries/sample-data.ts
+++ b/extensions/ql-vscode/src/remote-queries/sample-data.ts
@@ -101,7 +101,35 @@ export const sampleRemoteQueryResult: RemoteQueryResult = {
 
 const createAnalysisResults = (n: number) => Array(n).fill(
   {
-    message: 'This shell command depends on an uncontrolled [absolute path](1).',
+    message: {
+      tokens: [
+        {
+          t: 'text',
+          text: 'This shell command depends on an uncontrolled '
+        },
+        {
+          t: 'location',
+          text: 'absolute path',
+          location: {
+            filePath: 'npm-packages/meteor-installer/config.js',
+            codeSnippet: {
+              startLine: 33,
+              endLine: 37,
+              text: '\nconst meteorLocalFolder = \'.meteor\';\nconst meteorPath = path.resolve(rootPath, meteorLocalFolder);\n\nmodule.exports = {\n'
+            },
+            highlightedRegion: {
+              startLine: 35,
+              startColumn: 20,
+              endColumn: 61
+            }
+          }
+        },
+        {
+          t: 'text',
+          text: '.'
+        }
+      ]
+    },
     shortDescription: 'Shell command built from environment values',
     severity: 'Error',
     filePath: 'npm-packages/meteor-installer/config.js',

--- a/extensions/ql-vscode/src/remote-queries/sarif-processing.ts
+++ b/extensions/ql-vscode/src/remote-queries/sarif-processing.ts
@@ -24,8 +24,8 @@ export function extractAnalysisAlerts(
   const errors: string[] = [];
 
   try {
-    for (const run of sarifLog.runs!) {
-      for (const result of run.results!) {
+    for (const run of sarifLog.runs ?? []) {
+      for (const result of run.results ?? []) {
         try {
           alerts.push(...extractResultAlerts(run, result));
         } catch (e) {
@@ -53,7 +53,7 @@ function extractResultAlerts(
   const codeFlows = getCodeFlows(result);
   const shortDescription = getShortDescription(rule, message!);
 
-  for (const location of result.locations!) {
+  for (const location of result.locations ?? []) {
     const physicalLocation = location.physicalLocation!;
     const filePath = physicalLocation.artifactLocation!.uri!;
     const codeSnippet = getCodeSnippet(physicalLocation.contextRegion!);

--- a/extensions/ql-vscode/src/remote-queries/sarif-processing.ts
+++ b/extensions/ql-vscode/src/remote-queries/sarif-processing.ts
@@ -289,7 +289,7 @@ function extractCodeFlows(
           if (!location?.location) {
             errors.push('No location found in a SARIF thread flow');
           }
-          const { processedLocation, errors: locationErrors } = extractLocation(location!.location!);
+          const { processedLocation, errors: locationErrors } = extractLocation(location.location!);
           if (locationErrors.length > 0) {
             errors.push(...locationErrors);
             continue;

--- a/extensions/ql-vscode/src/remote-queries/sarif-processing.ts
+++ b/extensions/ql-vscode/src/remote-queries/sarif-processing.ts
@@ -23,19 +23,15 @@ export function extractAnalysisAlerts(
   const alerts: AnalysisAlert[] = [];
   const errors: string[] = [];
 
-  try {
-    for (const run of sarifLog.runs ?? []) {
-      for (const result of run.results ?? []) {
-        try {
-          alerts.push(...extractResultAlerts(run, result));
-        } catch (e) {
-          errors.push(`Error when processing SARIF result: ${e}`);
-          continue;
-        }
+  for (const run of sarifLog.runs ?? []) {
+    for (const result of run.results ?? []) {
+      try {
+        alerts.push(...extractResultAlerts(run, result));
+      } catch (e) {
+        errors.push(`Error when processing SARIF result: ${e}`);
+        continue;
       }
     }
-  } catch (e) {
-    errors.push(`Error when processing SARIF run: ${e}`);
   }
 
   return { alerts, errors };

--- a/extensions/ql-vscode/src/remote-queries/shared/analysis-result.ts
+++ b/extensions/ql-vscode/src/remote-queries/shared/analysis-result.ts
@@ -25,7 +25,7 @@ export interface CodeSnippet {
 export interface HighlightedRegion {
   startLine: number;
   startColumn: number;
-  endLine: number | undefined;
+  endLine: number;
   endColumn: number;
 }
 
@@ -36,7 +36,7 @@ export interface CodeFlow {
 export interface ThreadFlow {
   filePath: string;
   codeSnippet: CodeSnippet;
-  highlightedRegion: HighlightedRegion;
+  highlightedRegion?: HighlightedRegion;
   message?: AnalysisMessage;
 }
 
@@ -56,14 +56,10 @@ export interface AnalysisMessageTextToken {
 export interface AnalysisMessageLocationToken {
   t: 'location';
   text: string;
-  location: Location;
-}
-
-export interface Location {
-  message?: string;
-  filePath: string;
-  codeSnippet: CodeSnippet;
-  highlightedRegion?: HighlightedRegion;
+  location: {
+    filePath: string;
+    highlightedRegion?: HighlightedRegion;
+  };
 }
 
 export type ResultSeverity = 'Recommendation' | 'Warning' | 'Error';

--- a/extensions/ql-vscode/src/remote-queries/shared/analysis-result.ts
+++ b/extensions/ql-vscode/src/remote-queries/shared/analysis-result.ts
@@ -7,12 +7,12 @@ export interface AnalysisResults {
 }
 
 export interface AnalysisAlert {
-  message: string;
+  message: AnalysisMessage;
   shortDescription: string;
   severity: ResultSeverity;
   filePath: string;
   codeSnippet: CodeSnippet;
-  highlightedRegion: HighlightedRegion;
+  highlightedRegion?: HighlightedRegion;
   codeFlows: CodeFlow[];
 }
 
@@ -37,7 +37,33 @@ export interface ThreadFlow {
   filePath: string;
   codeSnippet: CodeSnippet;
   highlightedRegion: HighlightedRegion;
+  message?: AnalysisMessage;
+}
+
+export interface AnalysisMessage {
+  tokens: AnalysisMessageToken[]
+}
+
+export type AnalysisMessageToken =
+  | AnalysisMessageTextToken
+  | AnalysisMessageLocationToken;
+
+export interface AnalysisMessageTextToken {
+  t: 'text';
+  text: string;
+}
+
+export interface AnalysisMessageLocationToken {
+  t: 'location';
+  text: string;
+  location: Location;
+}
+
+export interface Location {
   message?: string;
+  filePath: string;
+  codeSnippet: CodeSnippet;
+  highlightedRegion?: HighlightedRegion;
 }
 
 export type ResultSeverity = 'Recommendation' | 'Warning' | 'Error';

--- a/extensions/ql-vscode/src/remote-queries/view/CodePaths.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/CodePaths.tsx
@@ -3,7 +3,7 @@ import { ActionList, ActionMenu, Box, Button, Label, Link, Overlay } from '@prim
 import * as React from 'react';
 import { useRef, useState } from 'react';
 import styled from 'styled-components';
-import { CodeFlow, ResultSeverity } from '../shared/analysis-result';
+import { CodeFlow, AnalysisMessage, ResultSeverity } from '../shared/analysis-result';
 import FileCodeSnippet from './FileCodeSnippet';
 import SectionTitle from './SectionTitle';
 import VerticalSpace from './VerticalSpace';
@@ -45,7 +45,7 @@ const CodePath = ({
   severity
 }: {
   codeFlow: CodeFlow;
-  message: string;
+  message: AnalysisMessage;
   severity: ResultSeverity;
 }) => {
   return <>
@@ -122,7 +122,7 @@ const CodePaths = ({
 }: {
   codeFlows: CodeFlow[],
   ruleDescription: string,
-  message: string,
+  message: AnalysisMessage,
   severity: ResultSeverity
 }) => {
   const [isOpen, setIsOpen] = useState(false);

--- a/extensions/ql-vscode/src/remote-queries/view/FileCodeSnippet.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/FileCodeSnippet.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import styled from 'styled-components';
-import { CodeSnippet, HighlightedRegion, ResultSeverity } from '../shared/analysis-result';
+import { CodeSnippet, HighlightedRegion, AnalysisMessage, ResultSeverity } from '../shared/analysis-result';
 import { Box, Link } from '@primer/react';
 import VerticalSpace from './VerticalSpace';
 
@@ -75,19 +75,19 @@ const HighlightedLine = ({ text }: { text: string }) => {
 };
 
 const Message = ({
-  messageText,
+  message,
   currentLineNumber,
   highlightedRegion,
   borderColor,
   children
 }: {
-  messageText: string,
+  message: AnalysisMessage,
   currentLineNumber: number,
-  highlightedRegion: HighlightedRegion,
+  highlightedRegion?: HighlightedRegion,
   borderColor: string,
   children: React.ReactNode
 }) => {
-  if (highlightedRegion.startLine !== currentLineNumber) {
+  if (!highlightedRegion || highlightedRegion.startLine !== currentLineNumber) {
     return <></>;
   }
 
@@ -101,7 +101,16 @@ const Message = ({
       paddingTop="1em"
       paddingBottom="1em">
       <MessageText>
-        {messageText}
+        {message.tokens.map((token, index) => {
+          switch (token.t) {
+            case 'text':
+              return <span key={`token-${index}`}>{token.text}</span>;
+            case 'location':
+              return <Link key={`token-${index}`} href='TODO'>{token.text}</Link>;
+            default:
+              return <></>;
+          }
+        })}
         {children && <>
           <VerticalSpace size={2} />
           {children}
@@ -120,9 +129,9 @@ const CodeLine = ({
 }: {
   line: string,
   lineNumber: number,
-  highlightedRegion: HighlightedRegion
+  highlightedRegion?: HighlightedRegion
 }) => {
-  if (!shouldHighlightLine(lineNumber, highlightedRegion)) {
+  if (!highlightedRegion || !shouldHighlightLine(lineNumber, highlightedRegion)) {
     return <PlainLine text={line} />;
   }
 
@@ -165,9 +174,9 @@ const FileCodeSnippet = ({
 }: {
   filePath: string,
   codeSnippet: CodeSnippet,
-  highlightedRegion: HighlightedRegion,
+  highlightedRegion?: HighlightedRegion,
   severity?: ResultSeverity,
-  message?: string,
+  message?: AnalysisMessage,
   messageChildren?: React.ReactNode,
 }) => {
 
@@ -184,7 +193,7 @@ const FileCodeSnippet = ({
         {code.map((line, index) => (
           <div key={index}>
             {message && severity && <Message
-              messageText={message}
+              message={message}
               currentLineNumber={startingLine + index}
               highlightedRegion={highlightedRegion}
               borderColor={getSeverityColor(severity)}>

--- a/extensions/ql-vscode/test/pure-tests/sarif-processing.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/sarif-processing.test.ts
@@ -378,7 +378,7 @@ describe('SARIF processing', () => {
   });
 
   describe('extractAnalysisAlerts', () => {
-    it('should return an error if no runs found in the SARIF', () => {
+    it('should not return any results if no runs found in the SARIF', () => {
       const sarif = {
         // Runs are missing here.
       } as sarif.Log;
@@ -386,11 +386,10 @@ describe('SARIF processing', () => {
       const result = extractAnalysisAlerts(sarif);
 
       expect(result).to.be.ok;
-      expect(result.errors.length).to.equal(1);
-      expectSarifRunParsingError(result.errors[0]);
+      expect(result.alerts.length).to.equal(0);
     });
 
-    it('should return errors for runs that have no results', () => {
+    it('should not return any results for runs that have no results', () => {
       const sarif = {
         runs: [
           {
@@ -405,8 +404,7 @@ describe('SARIF processing', () => {
       const result = extractAnalysisAlerts(sarif);
 
       expect(result).to.be.ok;
-      expect(result.errors.length).to.equal(1);
-      expectSarifRunParsingError(result.errors[0]);
+      expect(result.alerts.length).to.equal(0);
     });
 
     it('should return errors for results that have no message', () => {
@@ -588,10 +586,6 @@ describe('SARIF processing', () => {
       expect(message.tokens[2].text).to.equal('.');
     });
   });
-
-  function expectSarifRunParsingError(msg: string) {
-    expect(msg.startsWith('Error when processing SARIF run')).to.be.true;
-  }
 
   function expectResultParsingError(msg: string) {
     expect(msg.startsWith('Error when processing SARIF result')).to.be.true;


### PR DESCRIPTION
Analysis messages can have tokens in them that need to be replaced to link to locations. This PR adds support for rendering these messages properly. Note that the link to the location isn't populated yet - once we have support for that we'll be able to take advantage of it here.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
