### PR TITLE
Rename ColumnValue to CellValue

### DIFF
--- a/extensions/ql-vscode/src/pure/bqrs-cli-types.ts
+++ b/extensions/ql-vscode/src/pure/bqrs-cli-types.ts
@@ -79,11 +79,11 @@ export interface WholeFileLocation {
 
 export type ResolvableLocationValue = WholeFileLocation | LineColumnLocation;
 
-export type UrlValue = ResolvableLocationValue  | string;
+export type UrlValue = ResolvableLocationValue | string;
 
-export type ColumnValue = EntityValue | number | string | boolean;
+export type CellValue = EntityValue | number | string | boolean;
 
-export type ResultRow = ColumnValue[];
+export type ResultRow = CellValue[];
 
 export interface RawResultSet {
   readonly schema: ResultSetSchema;
@@ -104,6 +104,6 @@ export function transformBqrsResultSet(
 }
 
 export interface DecodedBqrsChunk {
-  tuples: ColumnValue[][];
+  tuples: CellValue[][];
   next?: number;
 }

--- a/extensions/ql-vscode/src/view/RawTableValue.tsx
+++ b/extensions/ql-vscode/src/view/RawTableValue.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 
 import { renderLocation } from './result-table-utils';
-import { ColumnValue } from '../pure/bqrs-cli-types';
+import { CellValue } from '../pure/bqrs-cli-types';
 
 interface Props {
-  value: ColumnValue;
+  value: CellValue;
   databaseUri: string;
 }
 

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/query.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/query.test.ts
@@ -8,7 +8,7 @@ import { CancellationTokenSource } from 'vscode-jsonrpc';
 import * as messages from '../../pure/messages';
 import * as qsClient from '../../queryserver-client';
 import * as cli from '../../cli';
-import { ColumnValue } from '../../pure/bqrs-cli-types';
+import { CellValue } from '../../pure/bqrs-cli-types';
 import { extensions } from 'vscode';
 import { CodeQLExtensionInterface } from '../../extension';
 import { fail } from 'assert';
@@ -53,7 +53,7 @@ class Checkpoint<T> {
 }
 
 type ResultSets = {
-  [name: string]: ColumnValue[][];
+  [name: string]: CellValue[][];
 }
 
 type QueryTestCase = {


### PR DESCRIPTION
`ColumnValue` seems to represent the value of a specific cell in a column, so to me it seems that `CellValue` is a better name for it.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
