### PR TITLE
Rename analysis alert results

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/analyses-results-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/analyses-results-manager.ts
@@ -101,7 +101,7 @@ export class AnalysesResultsManager {
     const analysisResults: AnalysisResults = {
       nwo: analysis.nwo,
       status: 'InProgress',
-      alertResults: []
+      interpretedResults: []
     };
     const queryId = analysis.downloadLink.queryId;
     const resultsForQuery = this.internalGetAnalysesResults(queryId);
@@ -123,7 +123,7 @@ export class AnalysesResultsManager {
       const queryResults = await this.readResults(artifactPath);
       newAnaysisResults = {
         ...analysisResults,
-        alertResults: queryResults,
+        interpretedResults: queryResults,
         status: 'Completed'
       };
     } else {

--- a/extensions/ql-vscode/src/remote-queries/analyses-results-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/analyses-results-manager.ts
@@ -101,7 +101,7 @@ export class AnalysesResultsManager {
     const analysisResults: AnalysisResults = {
       nwo: analysis.nwo,
       status: 'InProgress',
-      results: []
+      alertResults: []
     };
     const queryId = analysis.downloadLink.queryId;
     const resultsForQuery = this.internalGetAnalysesResults(queryId);
@@ -123,7 +123,7 @@ export class AnalysesResultsManager {
       const queryResults = await this.readResults(artifactPath);
       newAnaysisResults = {
         ...analysisResults,
-        results: queryResults,
+        alertResults: queryResults,
         status: 'Completed'
       };
     } else {

--- a/extensions/ql-vscode/src/remote-queries/sample-data.ts
+++ b/extensions/ql-vscode/src/remote-queries/sample-data.ts
@@ -99,7 +99,7 @@ export const sampleRemoteQueryResult: RemoteQueryResult = {
 };
 
 
-const createAnalysisResults = (n: number) => Array(n).fill(
+const createAnalysisAlertResults = (n: number) => Array(n).fill(
   {
     message: 'This shell command depends on an uncontrolled [absolute path](1).',
     shortDescription: 'Shell command built from environment values',
@@ -317,18 +317,18 @@ export const sampleAnalysesResultsStage1: AnalysisResults[] = [
   {
     nwo: 'big-corp/repo1',
     status: 'InProgress',
-    results: []
+    alertResults: []
   },
   {
     nwo: 'big-corp/repo2',
     status: 'InProgress',
-    results: []
+    alertResults: []
 
   },
   {
     nwo: 'big-corp/repo3',
     status: 'InProgress',
-    results: []
+    alertResults: []
   },
   // No entries for repo4
 ];
@@ -337,22 +337,22 @@ export const sampleAnalysesResultsStage2: AnalysisResults[] = [
   {
     nwo: 'big-corp/repo1',
     status: 'Completed',
-    results: createAnalysisResults(85)
+    alertResults: createAnalysisAlertResults(85)
   },
   {
     nwo: 'big-corp/repo2',
     status: 'Completed',
-    results: createAnalysisResults(20)
+    alertResults: createAnalysisAlertResults(20)
   },
   {
     nwo: 'big-corp/repo3',
     status: 'InProgress',
-    results: []
+    alertResults: []
   },
   {
     nwo: 'big-corp/repo4',
     status: 'InProgress',
-    results: []
+    alertResults: []
   },
 ];
 
@@ -360,22 +360,22 @@ export const sampleAnalysesResultsStage3: AnalysisResults[] = [
   {
     nwo: 'big-corp/repo1',
     status: 'Completed',
-    results: createAnalysisResults(85)
+    alertResults: createAnalysisAlertResults(85)
   },
   {
     nwo: 'big-corp/repo2',
     status: 'Completed',
-    results: createAnalysisResults(20)
+    alertResults: createAnalysisAlertResults(20)
   },
   {
     nwo: 'big-corp/repo3',
     status: 'Completed',
-    results: createAnalysisResults(8)
+    alertResults: createAnalysisAlertResults(8)
   },
   {
     nwo: 'big-corp/repo4',
     status: 'Completed',
-    results: createAnalysisResults(3)
+    alertResults: createAnalysisAlertResults(3)
   },
 ];
 
@@ -383,21 +383,21 @@ export const sampleAnalysesResultsWithFailure: AnalysisResults[] = [
   {
     nwo: 'big-corp/repo1',
     status: 'Completed',
-    results: createAnalysisResults(85)
+    alertResults: createAnalysisAlertResults(85)
   },
   {
     nwo: 'big-corp/repo2',
     status: 'Completed',
-    results: createAnalysisResults(20)
+    alertResults: createAnalysisAlertResults(20)
   },
   {
     nwo: 'big-corp/repo3',
     status: 'Failed',
-    results: []
+    alertResults: []
   },
   {
     nwo: 'big-corp/repo4',
     status: 'Completed',
-    results: createAnalysisResults(3)
+    alertResults: createAnalysisAlertResults(3)
   },
 ];

--- a/extensions/ql-vscode/src/remote-queries/sample-data.ts
+++ b/extensions/ql-vscode/src/remote-queries/sample-data.ts
@@ -99,7 +99,7 @@ export const sampleRemoteQueryResult: RemoteQueryResult = {
 };
 
 
-const createAnalysisAlertResults = (n: number) => Array(n).fill(
+const createAnalysisInterpretedResults = (n: number) => Array(n).fill(
   {
     message: 'This shell command depends on an uncontrolled [absolute path](1).',
     shortDescription: 'Shell command built from environment values',
@@ -317,18 +317,18 @@ export const sampleAnalysesResultsStage1: AnalysisResults[] = [
   {
     nwo: 'big-corp/repo1',
     status: 'InProgress',
-    alertResults: []
+    interpretedResults: []
   },
   {
     nwo: 'big-corp/repo2',
     status: 'InProgress',
-    alertResults: []
+    interpretedResults: []
 
   },
   {
     nwo: 'big-corp/repo3',
     status: 'InProgress',
-    alertResults: []
+    interpretedResults: []
   },
   // No entries for repo4
 ];
@@ -337,22 +337,22 @@ export const sampleAnalysesResultsStage2: AnalysisResults[] = [
   {
     nwo: 'big-corp/repo1',
     status: 'Completed',
-    alertResults: createAnalysisAlertResults(85)
+    interpretedResults: createAnalysisInterpretedResults(85)
   },
   {
     nwo: 'big-corp/repo2',
     status: 'Completed',
-    alertResults: createAnalysisAlertResults(20)
+    interpretedResults: createAnalysisInterpretedResults(20)
   },
   {
     nwo: 'big-corp/repo3',
     status: 'InProgress',
-    alertResults: []
+    interpretedResults: []
   },
   {
     nwo: 'big-corp/repo4',
     status: 'InProgress',
-    alertResults: []
+    interpretedResults: []
   },
 ];
 
@@ -360,22 +360,22 @@ export const sampleAnalysesResultsStage3: AnalysisResults[] = [
   {
     nwo: 'big-corp/repo1',
     status: 'Completed',
-    alertResults: createAnalysisAlertResults(85)
+    interpretedResults: createAnalysisInterpretedResults(85)
   },
   {
     nwo: 'big-corp/repo2',
     status: 'Completed',
-    alertResults: createAnalysisAlertResults(20)
+    interpretedResults: createAnalysisInterpretedResults(20)
   },
   {
     nwo: 'big-corp/repo3',
     status: 'Completed',
-    alertResults: createAnalysisAlertResults(8)
+    interpretedResults: createAnalysisInterpretedResults(8)
   },
   {
     nwo: 'big-corp/repo4',
     status: 'Completed',
-    alertResults: createAnalysisAlertResults(3)
+    interpretedResults: createAnalysisInterpretedResults(3)
   },
 ];
 
@@ -383,21 +383,21 @@ export const sampleAnalysesResultsWithFailure: AnalysisResults[] = [
   {
     nwo: 'big-corp/repo1',
     status: 'Completed',
-    alertResults: createAnalysisAlertResults(85)
+    interpretedResults: createAnalysisInterpretedResults(85)
   },
   {
     nwo: 'big-corp/repo2',
     status: 'Completed',
-    alertResults: createAnalysisAlertResults(20)
+    interpretedResults: createAnalysisInterpretedResults(20)
   },
   {
     nwo: 'big-corp/repo3',
     status: 'Failed',
-    alertResults: []
+    interpretedResults: []
   },
   {
     nwo: 'big-corp/repo4',
     status: 'Completed',
-    alertResults: createAnalysisAlertResults(3)
+    interpretedResults: createAnalysisInterpretedResults(3)
   },
 ];

--- a/extensions/ql-vscode/src/remote-queries/shared/analysis-result.ts
+++ b/extensions/ql-vscode/src/remote-queries/shared/analysis-result.ts
@@ -3,7 +3,7 @@ export type AnalysisResultStatus = 'InProgress' | 'Completed' | 'Failed';
 export interface AnalysisResults {
   nwo: string;
   status: AnalysisResultStatus;
-  results: AnalysisAlert[];
+  alertResults: AnalysisAlert[];
 }
 
 export interface AnalysisAlert {

--- a/extensions/ql-vscode/src/remote-queries/shared/analysis-result.ts
+++ b/extensions/ql-vscode/src/remote-queries/shared/analysis-result.ts
@@ -3,7 +3,7 @@ export type AnalysisResultStatus = 'InProgress' | 'Completed' | 'Failed';
 export interface AnalysisResults {
   nwo: string;
   status: AnalysisResultStatus;
-  alertResults: AnalysisAlert[];
+  interpretedResults: AnalysisAlert[];
 }
 
 export interface AnalysisAlert {

--- a/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
@@ -73,7 +73,7 @@ const openQueryTextVirtualFile = (queryResult: RemoteQueryResult) => {
 };
 
 const sumAnalysesResults = (analysesResults: AnalysisResults[]) =>
-  analysesResults.reduce((acc, curr) => acc + curr.alertResults.length, 0);
+  analysesResults.reduce((acc, curr) => acc + curr.interpretedResults.length, 0);
 
 const QueryInfo = (queryResult: RemoteQueryResult) => (
   <>
@@ -264,13 +264,13 @@ const AnalysesResultsDescription = ({ totalAnalysesResults, totalResults }: { to
 const RepoAnalysisResults = (analysisResults: AnalysisResults) => {
   const title = <>
     {analysisResults.nwo}
-    <Badge text={analysisResults.alertResults.length.toString()} />
+    <Badge text={analysisResults.interpretedResults.length.toString()} />
   </>;
 
   return (
     <CollapsibleItem title={title}>
       <ul className="vscode-codeql__flat-list" >
-        {analysisResults.alertResults.map((r, i) =>
+        {analysisResults.interpretedResults.map((r, i) =>
           <li key={i}>
             <AnalysisAlertResult alert={r} />
             <VerticalSpace size={2} />
@@ -297,7 +297,7 @@ const AnalysesResults = ({ analysesResults, totalResults }: { analysesResults: A
         totalAnalysesResults={totalAnalysesResults}
         totalResults={totalResults} />
       <ul className="vscode-codeql__flat-list">
-        {analysesResults.filter(a => a.alertResults.length > 0).map(r =>
+        {analysesResults.filter(a => a.interpretedResults.length > 0).map(r =>
           <li key={r.nwo} className="vscode-codeql__analyses-results-list-item">
             <RepoAnalysisResults {...r} />
           </li>)}

--- a/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
@@ -73,7 +73,7 @@ const openQueryTextVirtualFile = (queryResult: RemoteQueryResult) => {
 };
 
 const sumAnalysesResults = (analysesResults: AnalysisResults[]) =>
-  analysesResults.reduce((acc, curr) => acc + curr.results.length, 0);
+  analysesResults.reduce((acc, curr) => acc + curr.alertResults.length, 0);
 
 const QueryInfo = (queryResult: RemoteQueryResult) => (
   <>
@@ -264,13 +264,13 @@ const AnalysesResultsDescription = ({ totalAnalysesResults, totalResults }: { to
 const RepoAnalysisResults = (analysisResults: AnalysisResults) => {
   const title = <>
     {analysisResults.nwo}
-    <Badge text={analysisResults.results.length.toString()} />
+    <Badge text={analysisResults.alertResults.length.toString()} />
   </>;
 
   return (
     <CollapsibleItem title={title}>
       <ul className="vscode-codeql__flat-list" >
-        {analysisResults.results.map((r, i) =>
+        {analysisResults.alertResults.map((r, i) =>
           <li key={i}>
             <AnalysisAlertResult alert={r} />
             <VerticalSpace size={2} />
@@ -297,7 +297,7 @@ const AnalysesResults = ({ analysesResults, totalResults }: { analysesResults: A
         totalAnalysesResults={totalAnalysesResults}
         totalResults={totalResults} />
       <ul className="vscode-codeql__flat-list">
-        {analysesResults.filter(a => a.results.length > 0).map(r =>
+        {analysesResults.filter(a => a.alertResults.length > 0).map(r =>
           <li key={r.nwo} className="vscode-codeql__analyses-results-list-item">
             <RepoAnalysisResults {...r} />
           </li>)}

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-query-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-query-history.test.ts
@@ -211,14 +211,14 @@ describe('Remote queries and query history manager', function() {
       expect(publisher.getCall(0).args[0][0]).to.include({
         nwo: 'github/vscode-codeql',
         status: 'InProgress',
-        // alertResults: ... avoid checking the alertResults object since it is complex
+        // interpretedResults: ... avoid checking the interpretedResults object since it is complex
       });
 
       // second time, it has the path to the sarif file.
       expect(publisher.getCall(1).args[0][0]).to.include({
         nwo: 'github/vscode-codeql',
         status: 'Completed',
-        // alertResults: ... avoid checking the alertResults object since it is complex
+        // interpretedResults: ... avoid checking the interpretedResults object since it is complex
       });
       expect(publisher).to.have.been.calledTwice;
 
@@ -226,7 +226,7 @@ describe('Remote queries and query history manager', function() {
       expect(arm.getAnalysesResults(rawQueryHistory[0].queryId)[0]).to.include({
         nwo: 'github/vscode-codeql',
         status: 'Completed',
-        // alertResults: ... avoid checking the alertResults object since it is complex
+        // interpretedResults: ... avoid checking the interpretedResults object since it is complex
       });
       publisher.resetHistory();
 
@@ -242,7 +242,7 @@ describe('Remote queries and query history manager', function() {
       await arm.downloadAnalysesResults(analysisSummaries, undefined, publisher);
 
       const trimmed = publisher.getCalls().map(call => call.args[0]).map(args => {
-        args.forEach((analysisResult: any) => delete analysisResult.alertResults);
+        args.forEach((analysisResult: any) => delete analysisResult.interpretedResults);
         return args;
       });
 

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-query-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-query-history.test.ts
@@ -211,14 +211,14 @@ describe('Remote queries and query history manager', function() {
       expect(publisher.getCall(0).args[0][0]).to.include({
         nwo: 'github/vscode-codeql',
         status: 'InProgress',
-        // results: ... avoid checking the results object since it is complex
+        // alertResults: ... avoid checking the alertResults object since it is complex
       });
 
       // second time, it has the path to the sarif file.
       expect(publisher.getCall(1).args[0][0]).to.include({
         nwo: 'github/vscode-codeql',
         status: 'Completed',
-        // results: ... avoid checking the results object since it is complex
+        // alertResults: ... avoid checking the alertResults object since it is complex
       });
       expect(publisher).to.have.been.calledTwice;
 
@@ -226,7 +226,7 @@ describe('Remote queries and query history manager', function() {
       expect(arm.getAnalysesResults(rawQueryHistory[0].queryId)[0]).to.include({
         nwo: 'github/vscode-codeql',
         status: 'Completed',
-        // results: ... avoid checking the results object since it is complex
+        // alertResults: ... avoid checking the alertResults object since it is complex
       });
       publisher.resetHistory();
 
@@ -242,7 +242,7 @@ describe('Remote queries and query history manager', function() {
       await arm.downloadAnalysesResults(analysisSummaries, undefined, publisher);
 
       const trimmed = publisher.getCalls().map(call => call.args[0]).map(args => {
-        args.forEach((analysisResult: any) => delete analysisResult.results);
+        args.forEach((analysisResult: any) => delete analysisResult.alertResults);
         return args;
       });
 


### PR DESCRIPTION
We will soon be introducing support for non-alert results, so I've renamed `results` to `alertResults` to disambiguate between the two.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
