### PR TITLE
Update Primer React to v35

### DIFF
--- a/extensions/ql-vscode/package-lock.json
+++ b/extensions/ql-vscode/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@octokit/rest": "^18.5.6",
         "@primer/octicons-react": "^16.3.0",
-        "@primer/react": "^35.0.0-rc.c106d292",
+        "@primer/react": "^35.0.0",
         "child-process-promise": "^2.2.1",
         "classnames": "~2.2.6",
         "d3": "^6.3.1",
@@ -668,9 +668,9 @@
       "integrity": "sha512-+Gwo89YK1OFi6oubTlah/zPxxzMNaMLy+inECAYI646KIFdzzhAsKWb3z5tSOu5Ff7no4isRV64rWfMSKLZclw=="
     },
     "node_modules/@primer/react": {
-      "version": "35.0.0-rc.c106d292",
-      "resolved": "https://registry.npmjs.org/@primer/react/-/react-35.0.0-rc.c106d292.tgz",
-      "integrity": "sha512-4CyB2OvwMOt1ZULbOUD6Nz7LnE433OT/h6hJDld/IE4klGAtF1HxDVUG7PfbGmlpw87I79WGjvH2+qx6EIhtZA==",
+      "version": "35.0.0",
+      "resolved": "https://registry.npmjs.org/@primer/react/-/react-35.0.0.tgz",
+      "integrity": "sha512-pjraRDHoT6Lwmto31ZN+WrtNCDA6lieOhr+4XC1z8wuq/JSGJVB3gHePi2/yIZldy2WoK55O1lsyp8llUiakog==",
       "dependencies": {
         "@primer/behaviors": "1.1.0",
         "@primer/octicons-react": "16.1.1",
@@ -13790,9 +13790,9 @@
       "integrity": "sha512-+Gwo89YK1OFi6oubTlah/zPxxzMNaMLy+inECAYI646KIFdzzhAsKWb3z5tSOu5Ff7no4isRV64rWfMSKLZclw=="
     },
     "@primer/react": {
-      "version": "35.0.0-rc.c106d292",
-      "resolved": "https://registry.npmjs.org/@primer/react/-/react-35.0.0-rc.c106d292.tgz",
-      "integrity": "sha512-4CyB2OvwMOt1ZULbOUD6Nz7LnE433OT/h6hJDld/IE4klGAtF1HxDVUG7PfbGmlpw87I79WGjvH2+qx6EIhtZA==",
+      "version": "35.0.0",
+      "resolved": "https://registry.npmjs.org/@primer/react/-/react-35.0.0.tgz",
+      "integrity": "sha512-pjraRDHoT6Lwmto31ZN+WrtNCDA6lieOhr+4XC1z8wuq/JSGJVB3gHePi2/yIZldy2WoK55O1lsyp8llUiakog==",
       "requires": {
         "@primer/behaviors": "1.1.0",
         "@primer/octicons-react": "16.1.1",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1065,7 +1065,7 @@
   "dependencies": {
     "@octokit/rest": "^18.5.6",
     "@primer/octicons-react": "^16.3.0",
-    "@primer/react": "^35.0.0-rc.c106d292",
+    "@primer/react": "^35.0.0",
     "child-process-promise": "^2.2.1",
     "classnames": "~2.2.6",
     "d3": "^6.3.1",


### PR DESCRIPTION
Update `@primer/react` to latest stable version.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
