### PR TITLE
Update tsc to 4.5.5

### DIFF
--- a/extensions/ql-vscode/package-lock.json
+++ b/extensions/ql-vscode/package-lock.json
@@ -106,7 +106,7 @@
         "ts-loader": "^8.1.0",
         "ts-node": "^8.3.0",
         "ts-protoc-gen": "^0.9.0",
-        "typescript": "^4.3.2",
+        "typescript": "^4.5.5",
         "typescript-formatter": "^7.2.2",
         "vsce": "^1.65.0",
         "vscode-test": "^1.4.0",
@@ -12107,9 +12107,9 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
-      "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -23202,9 +23202,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
-      "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
     },
     "typescript-formatter": {

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1179,7 +1179,7 @@
     "ts-loader": "^8.1.0",
     "ts-node": "^8.3.0",
     "ts-protoc-gen": "^0.9.0",
-    "typescript": "^4.3.2",
+    "typescript": "^4.5.5",
     "typescript-formatter": "^7.2.2",
     "vsce": "^1.65.0",
     "vscode-test": "^1.4.0",

--- a/extensions/ql-vscode/src/cli-version.ts
+++ b/extensions/ql-vscode/src/cli-version.ts
@@ -1,6 +1,7 @@
 import * as semver from 'semver';
 import { runCodeQlCliCommand } from './cli';
 import { Logger } from './logging';
+import { getErrorMessage } from './pure/helpers-pure';
 
 /**
  * Get the version of a CodeQL CLI.
@@ -18,7 +19,7 @@ export async function getCodeQlCliVersion(codeQlPath: string, logger: Logger): P
   } catch (e) {
     // Failed to run the version command. This might happen if the cli version is _really_ old, or it is corrupted.
     // Either way, we can't determine compatibility.
-    void logger.log(`Failed to run 'codeql version'. Reason: ${e.message}`);
+    void logger.log(`Failed to run 'codeql version'. Reason: ${getErrorMessage(e)}`);
     return undefined;
   }
 }

--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -13,7 +13,7 @@ import { CancellationToken, Disposable, Uri } from 'vscode';
 import { BQRSInfo, DecodedBqrsChunk } from './pure/bqrs-cli-types';
 import { CliConfig } from './config';
 import { DistributionProvider, FindDistributionResultKind } from './distribution';
-import { assertNever } from './pure/helpers-pure';
+import { assertNever, getErrorMessage, getErrorStack } from './pure/helpers-pure';
 import { QueryMetadata, SortDirection } from './pure/interface-types';
 import { Logger, ProgressReporter } from './logging';
 import { CompilationMessage } from './pure/messages';
@@ -346,7 +346,7 @@ export class CodeQLCliServer implements Disposable {
           stderrBuffers.length == 0
             ? new Error(`${description} failed: ${err}`)
             : new Error(`${description} failed: ${Buffer.concat(stderrBuffers).toString('utf8')}`);
-        newError.stack += (err.stack || '');
+        newError.stack += getErrorStack(err);
         throw newError;
       } finally {
         void this.logger.log(Buffer.concat(stderrBuffers).toString('utf8'));
@@ -448,7 +448,7 @@ export class CodeQLCliServer implements Disposable {
       try {
         yield JSON.parse(event) as EventType;
       } catch (err) {
-        throw new Error(`Parsing output of ${description} failed: ${err.stderr || err}`);
+        throw new Error(`Parsing output of ${description} failed: ${(err as any).stderr || getErrorMessage(err)}`);
       }
     }
   }
@@ -503,7 +503,7 @@ export class CodeQLCliServer implements Disposable {
     try {
       return JSON.parse(result) as OutputType;
     } catch (err) {
-      throw new Error(`Parsing output of ${description} failed: ${err.stderr || err}`);
+      throw new Error(`Parsing output of ${description} failed: ${(err as any).stderr || getErrorMessage(err)}`);
     }
   }
 
@@ -751,7 +751,7 @@ export class CodeQLCliServer implements Disposable {
       const dot = await this.readDotFiles(interpretedResultsPath);
       return dot;
     } catch (err) {
-      throw new Error(`Reading output of interpretation failed: ${err.stderr || err}`);
+      throw new Error(`Reading output of interpretation failed: ${getErrorMessage(err)}`);
     }
   }
 
@@ -1050,7 +1050,7 @@ export async function runCodeQlCliCommand(
     void logger.log('CLI command succeeded.');
     return result.stdout;
   } catch (err) {
-    throw new Error(`${description} failed: ${err.stderr || err}`);
+    throw new Error(`${description} failed: ${(err as any).stderr || getErrorMessage(err)}`);
   }
 }
 

--- a/extensions/ql-vscode/src/compare/compare-interface.ts
+++ b/extensions/ql-vscode/src/compare/compare-interface.ts
@@ -21,6 +21,7 @@ import { getHtmlForWebview, jumpToLocation } from '../interface-utils';
 import { transformBqrsResultSet, RawResultSet, BQRSInfo } from '../pure/bqrs-cli-types';
 import resultsDiff from './resultsDiff';
 import { CompletedLocalQueryInfo } from '../query-results';
+import { getErrorMessage } from '../pure/helpers-pure';
 
 interface ComparePair {
   from: CompletedLocalQueryInfo;
@@ -70,7 +71,7 @@ export class CompareInterfaceManager extends DisposableObject {
       try {
         rows = this.compareResults(fromResultSet, toResultSet);
       } catch (e) {
-        message = e.message;
+        message = getErrorMessage(e);
       }
 
       await this.postMessage({

--- a/extensions/ql-vscode/src/databaseFetcher.ts
+++ b/extensions/ql-vscode/src/databaseFetcher.ts
@@ -22,7 +22,7 @@ import {
 import { logger } from './logging';
 import { tmpDir } from './helpers';
 import { Credentials } from './authentication';
-import { REPO_REGEX } from './pure/helpers-pure';
+import { REPO_REGEX, getErrorMessage } from './pure/helpers-pure';
 
 /**
  * Prompts a user to fetch a database from a remote location. Database is assumed to be an archive file.
@@ -230,7 +230,7 @@ export async function importArchiveDatabase(
     }
     return item;
   } catch (e) {
-    if (e.message.includes('unexpected end of file')) {
+    if (getErrorMessage(e).includes('unexpected end of file')) {
       throw new Error('Database is corrupt or too large. Try unzipping outside of VS Code and importing the unzipped folder instead.');
     } else {
       // delegate
@@ -491,7 +491,7 @@ export async function convertGithubNwoToDatabaseUrl(
     return `https://api.github.com/repos/${owner}/${repo}/code-scanning/codeql/databases/${language}`;
 
   } catch (e) {
-    void logger.log(`Error: ${e.message}`);
+    void logger.log(`Error: ${getErrorMessage(e)}`);
     throw new Error(`Unable to get database for '${githubRepo}'`);
   }
 }
@@ -596,7 +596,7 @@ export async function convertLgtmUrlToDatabaseUrl(
       language,
     ].join('/')}`;
   } catch (e) {
-    void logger.log(`Error: ${e.message}`);
+    void logger.log(`Error: ${getErrorMessage(e)}`);
     throw new Error(`Invalid LGTM URL: ${lgtmUrl}`);
   }
 }

--- a/extensions/ql-vscode/src/databases-ui.ts
+++ b/extensions/ql-vscode/src/databases-ui.ts
@@ -38,7 +38,7 @@ import {
   promptImportLgtmDatabase,
 } from './databaseFetcher';
 import { CancellationToken } from 'vscode';
-import { asyncFilter } from './pure/helpers-pure';
+import { asyncFilter, getErrorMessage } from './pure/helpers-pure';
 import { Credentials } from './authentication';
 
 type ThemableIconPath = { light: string; dark: string } | string;
@@ -393,7 +393,7 @@ export class DatabaseUI extends DisposableObject {
     try {
       return await this.chooseAndSetDatabase(true, progress, token);
     } catch (e) {
-      void showAndLogErrorMessage(e.message);
+      void showAndLogErrorMessage(getErrorMessage(e));
       return undefined;
     }
   };
@@ -461,7 +461,7 @@ export class DatabaseUI extends DisposableObject {
     try {
       return await this.chooseAndSetDatabase(false, progress, token);
     } catch (e) {
-      void showAndLogErrorMessage(e.message);
+      void showAndLogErrorMessage(getErrorMessage(e));
       return undefined;
     }
   };
@@ -622,8 +622,7 @@ export class DatabaseUI extends DisposableObject {
     } catch (e) {
       // rethrow and let this be handled by default error handling.
       throw new Error(
-        `Could not set database to ${path.basename(uri.fsPath)}. Reason: ${e.message
-        }`
+        `Could not set database to ${path.basename(uri.fsPath)}. Reason: ${getErrorMessage(e)}`
       );
     }
   };

--- a/extensions/ql-vscode/src/databases.ts
+++ b/extensions/ql-vscode/src/databases.ts
@@ -19,6 +19,7 @@ import { DisposableObject } from './pure/disposable-object';
 import { Logger, logger } from './logging';
 import { registerDatabases, Dataset, deregisterDatabases } from './pure/messages';
 import { QueryServerClient } from './queryserver-client';
+import { getErrorMessage } from './pure/helpers-pure';
 
 /**
  * databases.ts
@@ -359,7 +360,7 @@ export class DatabaseItemImpl implements DatabaseItem {
       }
       catch (e) {
         this._contents = undefined;
-        this._error = e;
+        this._error = e instanceof Error ? e : new Error(String(e));
         throw e;
       }
     }
@@ -726,7 +727,7 @@ export class DatabaseManager extends DisposableObject {
           }
         } catch (e) {
           // database list had an unexpected type - nothing to be done?
-          void showAndLogErrorMessage(`Database list loading failed: ${e.message}`);
+          void showAndLogErrorMessage(`Database list loading failed: ${getErrorMessage(e)}`);
         }
       });
   }
@@ -841,7 +842,7 @@ export class DatabaseManager extends DisposableObject {
       void logger.log('Deleting database from filesystem.');
       fs.remove(item.databaseUri.fsPath).then(
         () => void logger.log(`Deleted '${item.databaseUri.fsPath}'`),
-        e => void logger.log(`Failed to delete '${item.databaseUri.fsPath}'. Reason: ${e.message}`));
+        e => void logger.log(`Failed to delete '${item.databaseUri.fsPath}'. Reason: ${getErrorMessage(e)}`));
     }
 
     // note that we use undefined as the item in order to reset the entire tree

--- a/extensions/ql-vscode/src/interface.ts
+++ b/extensions/ql-vscode/src/interface.ts
@@ -15,7 +15,7 @@ import * as cli from './cli';
 import { CodeQLCliServer } from './cli';
 import { DatabaseEventKind, DatabaseItem, DatabaseManager } from './databases';
 import { showAndLogErrorMessage, tmpDir } from './helpers';
-import { assertNever } from './pure/helpers-pure';
+import { assertNever, getErrorMessage, getErrorStack } from './pure/helpers-pure';
 import {
   FromResultsViewMsg,
   Interpretation,
@@ -353,8 +353,8 @@ export class InterfaceManager extends DisposableObject {
           assertNever(msg);
       }
     } catch (e) {
-      void showAndLogErrorMessage(e.message, {
-        fullMessage: e.stack
+      void showAndLogErrorMessage(getErrorMessage(e), {
+        fullMessage: getErrorStack(e)
       });
     }
   }
@@ -729,7 +729,7 @@ export class InterfaceManager extends DisposableObject {
         // If interpretation fails, accept the error and continue
         // trying to render uninterpreted results anyway.
         void showAndLogErrorMessage(
-          `Showing raw results instead of interpreted ones due to an error. ${e.message}`
+          `Showing raw results instead of interpreted ones due to an error. ${getErrorMessage(e)}`
         );
       }
     }
@@ -768,9 +768,8 @@ export class InterfaceManager extends DisposableObject {
     try {
       await this.showProblemResultsAsDiagnostics(interpretation, database);
     } catch (e) {
-      const msg = e instanceof Error ? e.message : e.toString();
       void this.logger.log(
-        `Exception while computing problem results as diagnostics: ${msg}`
+        `Exception while computing problem results as diagnostics: ${getErrorMessage(e)}`
       );
       this._diagnosticCollection.clear();
     }

--- a/extensions/ql-vscode/src/pure/helpers-pure.ts
+++ b/extensions/ql-vscode/src/pure/helpers-pure.ts
@@ -42,3 +42,15 @@ export const THREE_HOURS_IN_MS = 1000 * 60 * 60 * 3;
  * - `repo` is made up of alphanumeric characters, hyphens, or underscores
  */
 export const REPO_REGEX = /^(?:[a-zA-Z0-9]+-)*[a-zA-Z0-9]+\/[a-zA-Z0-9-_]+$/;
+
+export function getErrorMessage(e: any) {
+  return e instanceof Error ? e.message : String(e);
+}
+
+export function getErrorStack(e: any) {
+  return e instanceof Error ? e.stack ?? '' : '';
+}
+
+export function asError(e: any): Error {
+  return e instanceof Error ? e : new Error(String(e));
+}

--- a/extensions/ql-vscode/src/query-serialization.ts
+++ b/extensions/ql-vscode/src/query-serialization.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 
 import { QueryHistoryConfig } from './config';
 import { showAndLogErrorMessage } from './helpers';
-import { asyncFilter } from './pure/helpers-pure';
+import { asyncFilter, getErrorMessage, getErrorStack } from './pure/helpers-pure';
 import { CompletedQueryInfo, LocalQueryInfo, QueryHistoryInfo } from './query-results';
 import { QueryEvaluationInfo } from './run-queries';
 
@@ -64,7 +64,7 @@ export async function slurpQueryHistory(fsPath: string, config: QueryHistoryConf
     });
   } catch (e) {
     void showAndLogErrorMessage('Error loading query history.', {
-      fullMessage: ['Error loading query history.', e.stack].join('\n'),
+      fullMessage: ['Error loading query history.', getErrorStack(e)].join('\n'),
     });
     // since the query history is invalid, it should be deleted so this error does not happen on next startup.
     await fs.remove(fsPath);
@@ -94,6 +94,6 @@ export async function splatQueryHistory(queries: QueryHistoryInfo[], fsPath: str
     }, null, 2);
     await fs.writeFile(fsPath, data);
   } catch (e) {
-    throw new Error(`Error saving query history to ${fsPath}: ${e.message}`);
+    throw new Error(`Error saving query history to ${fsPath}: ${getErrorMessage(e)}`);
   }
 }

--- a/extensions/ql-vscode/src/quick-query.ts
+++ b/extensions/ql-vscode/src/quick-query.ts
@@ -21,6 +21,7 @@ import {
   ProgressCallback,
   UserCancellationException
 } from './commandRunner';
+import { getErrorMessage } from './pure/helpers-pure';
 
 const QUICK_QUERIES_DIR_NAME = 'quick-queries';
 const QUICK_QUERY_QUERY_NAME = 'quick-query.ql';
@@ -132,7 +133,7 @@ export async function displayQuickQuery(
     await Window.showTextDocument(await workspace.openTextDocument(qlFile));
   } catch (e) {
     if (e instanceof ResponseError && e.code == ErrorCodes.RequestCancelled) {
-      throw new UserCancellationException(e.message);
+      throw new UserCancellationException(getErrorMessage(e));
     } else {
       throw e;
     }

--- a/extensions/ql-vscode/src/remote-queries/analyses-results-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/analyses-results-manager.ts
@@ -12,6 +12,7 @@ import { sarifParser } from '../sarif-parser';
 import { extractAnalysisAlerts } from './sarif-processing';
 import { CodeQLCliServer } from '../cli';
 import { extractRawResults } from './bqrs-processing';
+import { getErrorMessage } from '../pure/helpers-pure';
 
 export class AnalysesResultsManager {
   // Store for the results of various analyses for each remote query.
@@ -118,7 +119,7 @@ export class AnalysesResultsManager {
       artifactPath = await downloadArtifactFromLink(credentials, this.storagePath, analysis.downloadLink);
     }
     catch (e) {
-      throw new Error(`Could not download the analysis results for ${analysis.nwo}: ${e.message}`);
+      throw new Error(`Could not download the analysis results for ${analysis.nwo}: ${getErrorMessage(e)}`);
     }
 
     const fileLinkPrefix = this.createGitHubDotcomFileLinkPrefix(analysis.nwo, analysis.databaseSha);

--- a/extensions/ql-vscode/src/run-queries.ts
+++ b/extensions/ql-vscode/src/run-queries.ts
@@ -36,6 +36,7 @@ import { compileDatabaseUpgradeSequence, hasNondestructiveUpgradeCapabilities, u
 import { ensureMetadataIsComplete } from './query-results';
 import { SELECT_QUERY_NAME } from './contextual/locationFinder';
 import { DecodedBqrsChunk } from './pure/bqrs-cli-types';
+import { getErrorMessage } from './pure/helpers-pure';
 
 /**
  * run-queries.ts
@@ -790,7 +791,7 @@ export async function compileAndRunQueryAgainstDatabase(
       await upgradeDir?.cleanup();
     } catch (e) {
       void qs.logger.log(
-        `Could not clean up the upgrades dir. Reason: ${e.message || e}`,
+        `Could not clean up the upgrades dir. Reason: ${getErrorMessage(e)}`,
         { additionalLogLocation: query.logPath }
       );
     }

--- a/extensions/ql-vscode/src/sarif-parser.ts
+++ b/extensions/ql-vscode/src/sarif-parser.ts
@@ -4,17 +4,18 @@ import { parser } from 'stream-json';
 import { pick } from 'stream-json/filters/Pick';
 import Assembler = require('stream-json/Assembler');
 import { chain } from 'stream-chain';
+import { getErrorMessage } from './pure/helpers-pure';
 
-const DUMMY_TOOL : Sarif.Tool = {driver: {name: ''}};
+const DUMMY_TOOL: Sarif.Tool = { driver: { name: '' } };
 
-export async function sarifParser(interpretedResultsPath: string) : Promise<Sarif.Log> {
+export async function sarifParser(interpretedResultsPath: string): Promise<Sarif.Log> {
   try {
     // Parse the SARIF file into token streams, filtering out only the results array.
     const p = parser();
     const pipeline = chain([
       fs.createReadStream(interpretedResultsPath),
       p,
-      pick({filter: 'runs.0.results'})
+      pick({ filter: 'runs.0.results' })
     ]);
 
     // Creates JavaScript objects from the token stream
@@ -26,23 +27,23 @@ export async function sarifParser(interpretedResultsPath: string) : Promise<Sari
       pipeline.on('error', (error) => {
         reject(error);
       });
-      
+
       asm.on('done', (asm) => {
 
-        const log : Sarif.Log = {
-          version: '2.1.0', 
+        const log: Sarif.Log = {
+          version: '2.1.0',
           runs: [
-            { 
-              tool: DUMMY_TOOL, 
+            {
+              tool: DUMMY_TOOL,
               results: asm.current ?? []
             }
           ]
         };
-        
+
         resolve(log);
       });
     });
-  } catch (err) {
-    throw new Error(`Parsing output of interpretation failed: ${err.stderr || err}`);
+  } catch (e) {
+    throw new Error(`Parsing output of interpretation failed: ${(e as any).stderr || getErrorMessage(e)}`);
   }
 }

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/databases.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/databases.test.ts
@@ -18,7 +18,7 @@ describe('Databases', function() {
   this.timeout(60000);
 
   const LGTM_URL = 'https://lgtm.com/projects/g/aeisenberg/angular-bind-notifier/';
-  
+
   let databaseManager: DatabaseManager;
   let sandbox: sinon.SinonSandbox;
   let inputBoxStub: sinon.SinonStub;
@@ -40,7 +40,7 @@ describe('Databases', function() {
       progressCallback = sandbox.spy();
       inputBoxStub = sandbox.stub(window, 'showInputBox');
     } catch (e) {
-      fail(e);
+      fail(e as Error);
     }
   });
 
@@ -48,7 +48,7 @@ describe('Databases', function() {
     try {
       sandbox.restore();
     } catch (e) {
-      fail(e);
+      fail(e as Error);
     }
   });
 

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/packaging.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/packaging.test.ts
@@ -8,6 +8,7 @@ import * as pq from 'proxyquire';
 import { CliVersionConstraint, CodeQLCliServer } from '../../cli';
 import { CodeQLExtensionInterface } from '../../extension';
 import { expect } from 'chai';
+import { getErrorMessage } from '../../pure/helpers-pure';
 
 const proxyquire = pq.noPreserveCache();
 
@@ -121,8 +122,8 @@ describe('Packaging commands', function() {
       await mod.handleInstallPackDependencies(cli, progress);
       // This line should not be reached
       expect(true).to.be.false;
-    } catch (error) {
-      expect(error.message).to.contain('Unable to install pack dependencies');
+    } catch (e) {
+      expect(getErrorMessage(e)).to.contain('Unable to install pack dependencies');
     }
   });
 });

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/queries.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/queries.test.ts
@@ -78,7 +78,7 @@ describe('Queries', function() {
       }
       dbItem = maybeDbItem;
     } catch (e) {
-      fail(e);
+      fail(e as Error);
     }
   });
 
@@ -86,7 +86,7 @@ describe('Queries', function() {
     try {
       sandbox.restore();
     } catch (e) {
-      fail(e);
+      fail(e as Error);
     }
   });
 
@@ -107,7 +107,7 @@ describe('Queries', function() {
       expect(result.result.resultType).to.eq(QueryResultType.SUCCESS);
     } catch (e) {
       console.error('Test Failed');
-      fail(e);
+      fail(e as Error);
     }
   });
 
@@ -131,7 +131,7 @@ describe('Queries', function() {
       expect(result.result.resultType).to.eq(QueryResultType.SUCCESS);
     } catch (e) {
       console.error('Test Failed');
-      fail(e);
+      fail(e as Error);
     }
   });
 

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/query.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/query.test.ts
@@ -113,7 +113,7 @@ describe('using the query server', function() {
         throw new Error('Extension not initialized. Make sure cli is downloaded and installed properly.');
       }
     } catch (e) {
-      fail(e);
+      fail(e as Error);
     }
   });
 
@@ -163,7 +163,7 @@ describe('using the query server', function() {
         await compilationSucceeded.resolve();
       }
       catch (e) {
-        await compilationSucceeded.reject(e);
+        await compilationSucceeded.reject(e as Error);
       }
     });
 
@@ -190,7 +190,7 @@ describe('using the query server', function() {
         await qs.sendRequest(messages.runQueries, params, token, () => { /**/ });
       }
       catch (e) {
-        await evaluationSucceeded.reject(e);
+        await evaluationSucceeded.reject(e as Error);
       }
     });
 

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/contextual/queryResolver.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/contextual/queryResolver.test.ts
@@ -7,6 +7,7 @@ import * as chai from 'chai';
 import * as sinonChai from 'sinon-chai';
 import * as pq from 'proxyquire';
 import { KeyType } from '../../../contextual/keyType';
+import { getErrorMessage } from '../../../pure/helpers-pure';
 
 const proxyquire = pq.noPreserveCache().noCallThru();
 chai.use(chaiAsPromised);
@@ -70,7 +71,7 @@ describe('queryResolver', () => {
         // should reject
         expect(true).to.be.false;
       } catch (e) {
-        expect(e.message).to.eq(
+        expect(getErrorMessage(e)).to.eq(
           'Couldn\'t find any queries tagged ide-contextual-queries/local-definitions in any of the following packs: my-qlpack.'
         );
       }

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
@@ -19,6 +19,7 @@ import { DatabaseManager } from '../../databases';
 import * as tmp from 'tmp-promise';
 import { ONE_DAY_IN_MS, ONE_HOUR_IN_MS, TWO_HOURS_IN_MS, THREE_HOURS_IN_MS } from '../../pure/helpers-pure';
 import { tmpDir } from '../../helpers';
+import { getErrorMessage } from '../../pure/helpers-pure';
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;
@@ -162,7 +163,7 @@ describe('query-history', () => {
         await (queryHistoryManager as any).findOtherQueryToCompare(thisQuery, [thisQuery, allHistory[0]]);
         assert(false, 'Should have thrown');
       } catch (e) {
-        expect(e.message).to.eq('Please select a successful query.');
+        expect(getErrorMessage(e)).to.eq('Please select a successful query.');
       }
     });
 
@@ -175,7 +176,7 @@ describe('query-history', () => {
         await (queryHistoryManager as any).findOtherQueryToCompare(allHistory[0], [allHistory[0], allHistory[1]]);
         assert(false, 'Should have thrown');
       } catch (e) {
-        expect(e.message).to.eq('Query databases must be the same.');
+        expect(getErrorMessage(e)).to.eq('Query databases must be the same.');
       }
     });
 
@@ -187,7 +188,7 @@ describe('query-history', () => {
         await (queryHistoryManager as any).findOtherQueryToCompare(thisQuery, [thisQuery, allHistory[0], allHistory[1]]);
         assert(false, 'Should have thrown');
       } catch (e) {
-        expect(e.message).to.eq('Please select no more than 2 queries.');
+        expect(getErrorMessage(e)).to.eq('Please select no more than 2 queries.');
       }
     });
   });

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-query-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-query-history.test.ts
@@ -18,6 +18,7 @@ import { RemoteQueryResult } from '../../remote-queries/shared/remote-query-resu
 import { DisposableBucket } from '../disposable-bucket';
 import { testDisposeHandler } from '../test-dispose-handler';
 import { walkDirectory } from '../../helpers';
+import { getErrorMessage } from '../../pure/helpers-pure';
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;
@@ -291,7 +292,7 @@ describe('Remote queries and query history manager', function() {
         } as CancellationToken, publisher);
         expect.fail('Should have thrown');
       } catch (e) {
-        expect(e.message).to.contain('cancelled');
+        expect(getErrorMessage(e)).to.contain('cancelled');
       }
 
       expect(publisher).not.to.have.been.called;

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/telemetry.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/telemetry.test.ts
@@ -87,7 +87,7 @@ describe('telemetry reporting', function() {
       const reporter: any = telemetryListener._reporter;
       expect(reporter.userOptIn).to.eq(false); // disabled
     } catch (e) {
-      fail(e);
+      fail(e as Error);
     }
   });
 
@@ -98,7 +98,7 @@ describe('telemetry reporting', function() {
 
       expect(telemetryListener._reporter).to.be.undefined;
     } catch (e) {
-      fail(e);
+      fail(e as Error);
     }
   });
 

--- a/extensions/ql-vscode/test/pure-tests/helpers-pure.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/helpers-pure.test.ts
@@ -1,7 +1,7 @@
 import { fail } from 'assert';
 import { expect } from 'chai';
 
-import { asyncFilter } from '../../src/pure/helpers-pure';
+import { asyncFilter, getErrorMessage } from '../../src/pure/helpers-pure';
 
 describe('helpers-pure', () => {
   it('should filter asynchronously', async () => {
@@ -17,7 +17,7 @@ describe('helpers-pure', () => {
       await asyncFilter([1, 2, 3], rejects);
       fail('Should have thrown');
     } catch (e) {
-      expect(e.message).to.eq('opps');
+      expect(getErrorMessage(e)).to.eq('opps');
     }
   });
 });


### PR DESCRIPTION
The default version of tsc in vscode is now 4.5.4. This version
has changed the type of the variable in the catch block.
Previously, it was `any`. Now it is `unknown`.

This change updates vscode so that it can build with 4.5.4.

Previously, this had been a bit of a pain since sometimes running
a compile task in vscode will use the global default version of
tsc.

This is also a chance to try out the new dependency review workflow.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
