### PR TITLE
Get database sha from result index

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/gh-actions-api-client.ts
+++ b/extensions/ql-vscode/src/remote-queries/gh-actions-api-client.ts
@@ -12,6 +12,7 @@ import { RemoteQueryFailureIndexItem, RemoteQueryResultIndex, RemoteQuerySuccess
 interface ApiSuccessIndexItem {
   nwo: string;
   id: string;
+  sha?: string;
   results_count: number;
   bqrs_file_size: number;
   sarif_file_size?: number;
@@ -51,6 +52,7 @@ export async function getRemoteQueryIndex(
       id: item.id.toString(),
       artifactId: artifactId,
       nwo: item.nwo,
+      sha: item.sha,
       resultCount: item.results_count,
       bqrsFileSize: item.bqrs_file_size,
       sarifFileSize: item.sarif_file_size

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
@@ -319,6 +319,7 @@ export class RemoteQueriesInterfaceManager {
 
     return sortedAnalysisSummaries.map((analysisResult) => ({
       nwo: analysisResult.nwo,
+      databaseSha: analysisResult.databaseSha,
       resultCount: analysisResult.resultCount,
       downloadLink: analysisResult.downloadLink,
       fileSize: this.formatFileSize(analysisResult.fileSizeInBytes)

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
@@ -181,6 +181,7 @@ export class RemoteQueriesManager extends DisposableObject {
       .slice(0, autoDownloadMaxCount)
       .map(a => ({
         nwo: a.nwo,
+        databaseSha: a.databaseSha,
         resultCount: a.resultCount,
         downloadLink: a.downloadLink,
         fileSize: String(a.fileSizeInBytes)
@@ -196,6 +197,7 @@ export class RemoteQueriesManager extends DisposableObject {
 
     const analysisSummaries = resultIndex.successes.map(item => ({
       nwo: item.nwo,
+      databaseSha: item.sha || 'HEAD',
       resultCount: item.resultCount,
       fileSizeInBytes: item.sarifFileSize ? item.sarifFileSize : item.bqrsFileSize,
       downloadLink: {

--- a/extensions/ql-vscode/src/remote-queries/remote-query-result-index.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-query-result-index.ts
@@ -8,6 +8,7 @@ export interface RemoteQuerySuccessIndexItem {
   id: string;
   artifactId: number;
   nwo: string;
+  sha?: string;
   resultCount: number;
   bqrsFileSize: number;
   sarifFileSize?: number;

--- a/extensions/ql-vscode/src/remote-queries/remote-query-result.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-query-result.ts
@@ -10,6 +10,7 @@ export interface RemoteQueryResult {
 
 export interface AnalysisSummary {
   nwo: string,
+  databaseSha: string,
   resultCount: number,
   downloadLink: DownloadLink,
   fileSizeInBytes: number

--- a/extensions/ql-vscode/src/remote-queries/sample-data.ts
+++ b/extensions/ql-vscode/src/remote-queries/sample-data.ts
@@ -43,6 +43,7 @@ export const sampleRemoteQueryResult: RemoteQueryResult = {
   analysisSummaries: [
     {
       nwo: 'big-corp/repo1',
+      databaseSha: '1234567890',
       resultCount: 85,
       fileSizeInBytes: 14123,
       downloadLink: {
@@ -54,6 +55,7 @@ export const sampleRemoteQueryResult: RemoteQueryResult = {
     },
     {
       nwo: 'big-corp/repo2',
+      databaseSha: '1234567890',
       resultCount: 20,
       fileSizeInBytes: 8698,
       downloadLink: {
@@ -65,6 +67,7 @@ export const sampleRemoteQueryResult: RemoteQueryResult = {
     },
     {
       nwo: 'big-corp/repo3',
+      databaseSha: '1234567890',
       resultCount: 8,
       fileSizeInBytes: 4123,
       downloadLink: {
@@ -76,6 +79,7 @@ export const sampleRemoteQueryResult: RemoteQueryResult = {
     },
     {
       nwo: 'big-corp/repo4',
+      databaseSha: '1234567890',
       resultCount: 3,
       fileSizeInBytes: 3313,
       downloadLink: {

--- a/extensions/ql-vscode/src/remote-queries/shared/remote-query-result.ts
+++ b/extensions/ql-vscode/src/remote-queries/shared/remote-query-result.ts
@@ -19,6 +19,7 @@ export interface RemoteQueryResult {
 
 export interface AnalysisSummary {
   nwo: string,
+  databaseSha: string,
   resultCount: number,
   downloadLink: DownloadLink,
   fileSize: string,


### PR DESCRIPTION
We want to be able to link from remote query results to the exact file that's being analysed (i.e. the correct GitHub URL for the repository + the exact commit SHA that the database was built from).

https://github.com/dsp-testing/qc-run2/pull/639 adds this to the result index, and this PR reads the SHA and adds it to the `AnalysisSummary`. (If no SHA is found, we use `HEAD` as a fall back) 

We don't use the SHA anywhere yet, but we'll need it in the webview soon. (I "tested" the change by setting some breakpoints and checking the variables, but there's no visible change 🤷🏽 ) 

## Checklist

N/A - internal only 🤫 

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
