### PR TITLE
Create remote file link for rendered results

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
@@ -302,7 +302,7 @@ export async function runRemoteQuery(
       message: 'Sending request'
     });
 
-    const workflowRunId = await runRemoteQueriesApiRequest(credentials, 'main', language, repositories, owner, repo, base64Pack, dryRun);
+    const workflowRunId = await runRemoteQueriesApiRequest(credentials, 'get-db-sha', language, repositories, owner, repo, base64Pack, dryRun);
     const queryStartTime = Date.now();
     const queryMetadata = await tryGetQueryMetadata(cliServer, queryFile);
 

--- a/extensions/ql-vscode/src/remote-queries/shared/analysis-result.ts
+++ b/extensions/ql-vscode/src/remote-queries/shared/analysis-result.ts
@@ -19,10 +19,15 @@ export interface AnalysisAlert {
   message: AnalysisMessage;
   shortDescription: string;
   severity: ResultSeverity;
-  filePath: string;
+  fileLink: FileLink;
   codeSnippet: CodeSnippet;
   highlightedRegion?: HighlightedRegion;
   codeFlows: CodeFlow[];
+}
+
+export interface FileLink {
+  fileLinkPrefix: string;
+  filePath: string;
 }
 
 export interface CodeSnippet {
@@ -43,7 +48,7 @@ export interface CodeFlow {
 }
 
 export interface ThreadFlow {
-  filePath: string;
+  fileLink: FileLink;
   codeSnippet: CodeSnippet;
   highlightedRegion?: HighlightedRegion;
   message?: AnalysisMessage;
@@ -66,7 +71,7 @@ export interface AnalysisMessageLocationToken {
   t: 'location';
   text: string;
   location: {
-    filePath: string;
+    fileLink: FileLink;
     highlightedRegion?: HighlightedRegion;
   };
 }

--- a/extensions/ql-vscode/src/remote-queries/view/AnalysisAlertResult.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/AnalysisAlertResult.tsx
@@ -7,7 +7,7 @@ const AnalysisAlertResult = ({ alert }: { alert: AnalysisAlert }) => {
   const showPathsLink = alert.codeFlows.length > 0;
 
   return <FileCodeSnippet
-    filePath={alert.filePath}
+    fileLink={alert.fileLink}
     codeSnippet={alert.codeSnippet}
     highlightedRegion={alert.highlightedRegion}
     severity={alert.severity}

--- a/extensions/ql-vscode/src/remote-queries/view/CodePaths.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/CodePaths.tsx
@@ -71,7 +71,7 @@ const CodePath = ({
 
         <VerticalSpace size={2} />
         <FileCodeSnippet
-          filePath={threadFlow.filePath}
+          fileLink={threadFlow.fileLink}
           codeSnippet={threadFlow.codeSnippet}
           highlightedRegion={threadFlow.highlightedRegion}
           severity={severity}
@@ -82,7 +82,7 @@ const CodePath = ({
 };
 
 const getCodeFlowName = (codeFlow: CodeFlow) => {
-  const filePath = codeFlow.threadFlows[codeFlow.threadFlows.length - 1].filePath;
+  const filePath = codeFlow.threadFlows[codeFlow.threadFlows.length - 1].fileLink.filePath;
   return filePath.substring(filePath.lastIndexOf('/') + 1);
 };
 

--- a/extensions/ql-vscode/src/remote-queries/view/FileCodeSnippet.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/FileCodeSnippet.tsx
@@ -1,12 +1,20 @@
 import * as React from 'react';
 import styled from 'styled-components';
-import { CodeSnippet, HighlightedRegion, AnalysisMessage, ResultSeverity } from '../shared/analysis-result';
+import { CodeSnippet, FileLink, HighlightedRegion, AnalysisMessage, ResultSeverity } from '../shared/analysis-result';
 import { Box, Link } from '@primer/react';
 import VerticalSpace from './VerticalSpace';
 
 const borderColor = 'var(--vscode-editor-snippetFinalTabstopHighlightBorder)';
 const warningColor = '#966C23';
 const highlightColor = '#534425';
+
+const createFileLink = (fileLink: FileLink, startLine?: number, endLine?: number) => {
+  if (startLine && endLine) {
+    return `${fileLink.fileLinkPrefix}/${fileLink.filePath}#L${startLine}-L${endLine}`;
+  } else {
+    return `${fileLink.fileLinkPrefix}/${fileLink.filePath}`;
+  }
+};
 
 const getSeverityColor = (severity: ResultSeverity) => {
   switch (severity) {
@@ -106,7 +114,11 @@ const Message = ({
             case 'text':
               return <span key={`token-${index}`}>{token.text}</span>;
             case 'location':
-              return <Link key={`token-${index}`} href='TODO'>{token.text}</Link>;
+              return <Link
+                key={`token-${index}`}
+                href={createFileLink(token.location.fileLink, token.location.highlightedRegion?.startLine, token.location.highlightedRegion?.endLine)}>
+                {token.text}
+              </Link>;
             default:
               return <></>;
           }
@@ -165,14 +177,14 @@ const CodeLine = ({
 };
 
 const FileCodeSnippet = ({
-  filePath,
+  fileLink,
   codeSnippet,
   highlightedRegion,
   severity,
   message,
   messageChildren,
 }: {
-  filePath: string,
+  fileLink: FileLink,
   codeSnippet: CodeSnippet,
   highlightedRegion?: HighlightedRegion,
   severity?: ResultSeverity,
@@ -183,11 +195,12 @@ const FileCodeSnippet = ({
   const code = codeSnippet.text.split('\n');
 
   const startingLine = codeSnippet.startLine;
+  const endingLine = codeSnippet.endLine;
 
   return (
     <Container>
       <TitleContainer>
-        <Link>{filePath}</Link>
+        <Link href={createFileLink(fileLink, startingLine, endingLine)}>{fileLink.filePath}</Link>
       </TitleContainer>
       <CodeContainer>
         {code.map((line, index) => (

--- a/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
@@ -369,7 +369,7 @@ export function RemoteQueries(): JSX.Element {
     return <div>Waiting for results to load.</div>;
   }
 
-  const showAnalysesResults = false;
+  const showAnalysesResults = true;
 
   try {
     return <div>


### PR DESCRIPTION
Follow-up to #1205.

Creates a clickable link in the results view that links to the file location on GitHub. e.g.
![image](https://user-images.githubusercontent.com/42641846/158359163-8b589546-fff7-4c34-8568-224a0928aec7.png)
links to 
https://github.com/meteor/meteor/blob/HEAD/npm-packages/meteor-installer/install.js#L253-L257 (using the exact SHA instead of HEAD, when available).

Only for rendered results (i.e. alerts) for now. Raw results in progress 🚧 

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
