### PR TITLE
Create remote file links to GitHub URL

### DIFF
--- a/extensions/ql-vscode/src/pure/bqrs-utils.ts
+++ b/extensions/ql-vscode/src/pure/bqrs-utils.ts
@@ -101,7 +101,12 @@ export function tryGetRemoteLocation(
   if (loc === undefined) {
     return undefined;
   } else if (isWholeFileLoc(loc) || isLineColumnLoc(loc)) {
-    return fileLinkPrefix + loc.uri.replace(FILE_LOCATION_REGEX, '');
+    // Trim the location
+    // file:/home/runner/work/turboscan/turboscan/cmd/enumgenerator/main.go
+    const parts = loc.uri.split('/');
+    const trimmedLocation = parts.slice(6, parts.length).join('/');
+    return `${fileLinkPrefix}\\${trimmedLocation}`;
+
   } else if (isStringLoc(loc)) {
     const location = tryGetLocationFromString(loc);
     return location?.uri;

--- a/extensions/ql-vscode/src/pure/bqrs-utils.ts
+++ b/extensions/ql-vscode/src/pure/bqrs-utils.ts
@@ -93,3 +93,19 @@ export function isWholeFileLoc(loc: UrlValue): loc is WholeFileLocation {
 export function isStringLoc(loc: UrlValue): loc is string {
   return typeof loc === 'string';
 }
+
+export function tryGetRemoteLocation(
+  loc: UrlValue | undefined,
+  fileLinkPrefix: string
+): string | undefined {
+  if (loc === undefined) {
+    return undefined;
+  } else if (isWholeFileLoc(loc) || isLineColumnLoc(loc)) {
+    return fileLinkPrefix + loc.uri.replace(FILE_LOCATION_REGEX, '');
+  } else if (isStringLoc(loc)) {
+    const location = tryGetLocationFromString(loc);
+    return location?.uri;
+  } else {
+    return undefined;
+  }
+}

--- a/extensions/ql-vscode/src/pure/bqrs-utils.ts
+++ b/extensions/ql-vscode/src/pure/bqrs-utils.ts
@@ -107,12 +107,17 @@ export function tryGetRemoteLocation(
   // Remote locations have the following format:
   // file:/home/runner/work/<repo>/<repo/relative/path/to/file
   // So we need to drop the first 6 parts of the path.
+
+  // TODO: We can make this more robust to other path formats.
   const locationParts = resolvableLocation.uri.split('/');
   const trimmedLocation = locationParts.slice(6, locationParts.length).join('/');
 
-  return createRemoteFileRef(
+  const fileLink = {
     fileLinkPrefix,
-    trimmedLocation,
+    filePath: trimmedLocation,
+  };
+  return createRemoteFileRef(
+    fileLink,
     resolvableLocation.startLine,
     resolvableLocation.endLine);
 }

--- a/extensions/ql-vscode/src/pure/location-link-utils.ts
+++ b/extensions/ql-vscode/src/pure/location-link-utils.ts
@@ -1,0 +1,12 @@
+export function createRemoteFileRef(
+  filePrefix: string,
+  filePath: string,
+  startLine?: number,
+  endLine?: number
+): string {
+  if (startLine && endLine) {
+    return `${filePrefix}/${filePath}#L${startLine}-L${endLine}`;
+  } else {
+    return `${filePrefix}/${filePath}`;
+  }
+}

--- a/extensions/ql-vscode/src/pure/location-link-utils.ts
+++ b/extensions/ql-vscode/src/pure/location-link-utils.ts
@@ -1,12 +1,15 @@
+import { FileLink } from '../remote-queries/shared/analysis-result';
+
 export function createRemoteFileRef(
-  filePrefix: string,
-  filePath: string,
+  fileLink: FileLink,
   startLine?: number,
   endLine?: number
 ): string {
   if (startLine && endLine) {
-    return `${filePrefix}/${filePath}#L${startLine}-L${endLine}`;
+    return `${fileLink.fileLinkPrefix}/${fileLink.filePath}#L${startLine}-L${endLine}`;
+  } else if (startLine) {
+    return `${fileLink.fileLinkPrefix}/${fileLink.filePath}#L${startLine}`;
   } else {
-    return `${filePrefix}/${filePath}`;
+    return `${fileLink.fileLinkPrefix}/${fileLink.filePath}`;
   }
 }

--- a/extensions/ql-vscode/src/remote-queries/analyses-results-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/analyses-results-manager.ts
@@ -121,7 +121,7 @@ export class AnalysesResultsManager {
       throw new Error(`Could not download the analysis results for ${analysis.nwo}: ${e.message}`);
     }
 
-    const fileLinkPrefix = this.createFileLinkPrefix(analysis.nwo, analysis.databaseSha);
+    const fileLinkPrefix = this.createGitHubDotcomFileLinkPrefix(analysis.nwo, analysis.databaseSha);
 
     let newAnaysisResults: AnalysisResults;
     const fileExtension = path.extname(artifactPath);
@@ -169,7 +169,7 @@ export class AnalysesResultsManager {
     return this.internalGetAnalysesResults(analysis.downloadLink.queryId).some(x => x.nwo === analysis.nwo);
   }
 
-  private createFileLinkPrefix(nwo: string, sha: string): string {
+  private createGitHubDotcomFileLinkPrefix(nwo: string, sha: string): string {
     return `https://github.com/${nwo}/blob/${sha}`;
   }
 }

--- a/extensions/ql-vscode/src/remote-queries/analyses-results-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/analyses-results-manager.ts
@@ -133,7 +133,7 @@ export class AnalysesResultsManager {
         status: 'Completed'
       };
     } else if (fileExtension === '.bqrs') {
-      const queryResults = await this.readBqrsResults(artifactPath);
+      const queryResults = await this.readBqrsResults(artifactPath, fileLinkPrefix);
       newAnaysisResults = {
         ...analysisResults,
         rawResults: queryResults,
@@ -150,8 +150,8 @@ export class AnalysesResultsManager {
     void publishResults([...resultsForQuery]);
   }
 
-  private async readBqrsResults(filePath: string): Promise<AnalysisRawResults> {
-    return await extractRawResults(this.cliServer, this.logger, filePath);
+  private async readBqrsResults(filePath: string, fileLinkPrefix: string): Promise<AnalysisRawResults> {
+    return await extractRawResults(this.cliServer, this.logger, filePath, fileLinkPrefix);
   }
 
   private async readSarifResults(filePath: string, fileLinkPrefix: string): Promise<AnalysisAlert[]> {

--- a/extensions/ql-vscode/src/remote-queries/bqrs-processing.ts
+++ b/extensions/ql-vscode/src/remote-queries/bqrs-processing.ts
@@ -7,7 +7,8 @@ import { MAX_RAW_RESULTS } from './shared/result-limits';
 export async function extractRawResults(
   cliServer: CodeQLCliServer,
   logger: Logger,
-  filePath: string
+  filePath: string,
+  fileLinkPrefix: string,
 ): Promise<AnalysisRawResults> {
   const bqrsInfo = await cliServer.bqrsInfo(filePath);
   const resultSets = bqrsInfo['result-sets'];
@@ -30,5 +31,5 @@ export async function extractRawResults(
 
   const capped = !!chunk.next;
 
-  return { schema, resultSet, capped };
+  return { schema, resultSet, fileLinkPrefix, capped };
 }

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
@@ -319,7 +319,7 @@ export class RemoteQueriesInterfaceManager {
 
     return sortedAnalysisSummaries.map((analysisResult) => ({
       nwo: analysisResult.nwo,
-      databaseSha: analysisResult.databaseSha,
+      databaseSha: analysisResult.databaseSha || 'HEAD',
       resultCount: analysisResult.resultCount,
       downloadLink: analysisResult.downloadLink,
       fileSize: this.formatFileSize(analysisResult.fileSizeInBytes)

--- a/extensions/ql-vscode/src/remote-queries/shared/analysis-result.ts
+++ b/extensions/ql-vscode/src/remote-queries/shared/analysis-result.ts
@@ -10,8 +10,9 @@ export interface AnalysisResults {
 }
 
 export interface AnalysisRawResults {
-  schema: ResultSetSchema,
-  resultSet: RawResultSet,
+  schema: ResultSetSchema;
+  resultSet: RawResultSet;
+  fileLinkPrefix: string;
   capped: boolean;
 }
 

--- a/extensions/ql-vscode/src/remote-queries/shared/analysis-result.ts
+++ b/extensions/ql-vscode/src/remote-queries/shared/analysis-result.ts
@@ -19,10 +19,15 @@ export interface AnalysisAlert {
   message: AnalysisMessage;
   shortDescription: string;
   severity: ResultSeverity;
-  filePath: string;
+  fileLink: FileLink;
   codeSnippet: CodeSnippet;
   highlightedRegion?: HighlightedRegion;
   codeFlows: CodeFlow[];
+}
+
+export interface FileLink {
+  fileLinkPrefix: string;
+  filePath: string;
 }
 
 export interface CodeSnippet {
@@ -43,7 +48,7 @@ export interface CodeFlow {
 }
 
 export interface ThreadFlow {
-  filePath: string;
+  fileLink: FileLink;
   codeSnippet: CodeSnippet;
   highlightedRegion?: HighlightedRegion;
   message?: AnalysisMessage;
@@ -66,7 +71,7 @@ export interface AnalysisMessageLocationToken {
   t: 'location';
   text: string;
   location: {
-    filePath: string;
+    fileLink: FileLink;
     highlightedRegion?: HighlightedRegion;
   };
 }

--- a/extensions/ql-vscode/src/remote-queries/view/AnalysisAlertResult.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/AnalysisAlertResult.tsx
@@ -7,7 +7,7 @@ const AnalysisAlertResult = ({ alert }: { alert: AnalysisAlert }) => {
   const showPathsLink = alert.codeFlows.length > 0;
 
   return <FileCodeSnippet
-    filePath={alert.filePath}
+    fileLink={alert.fileLink}
     codeSnippet={alert.codeSnippet}
     highlightedRegion={alert.highlightedRegion}
     severity={alert.severity}

--- a/extensions/ql-vscode/src/remote-queries/view/CodePaths.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/CodePaths.tsx
@@ -71,7 +71,7 @@ const CodePath = ({
 
         <VerticalSpace size={2} />
         <FileCodeSnippet
-          filePath={threadFlow.filePath}
+          fileLink={threadFlow.fileLink}
           codeSnippet={threadFlow.codeSnippet}
           highlightedRegion={threadFlow.highlightedRegion}
           severity={severity}
@@ -82,7 +82,7 @@ const CodePath = ({
 };
 
 const getCodeFlowName = (codeFlow: CodeFlow) => {
-  const filePath = codeFlow.threadFlows[codeFlow.threadFlows.length - 1].filePath;
+  const filePath = codeFlow.threadFlows[codeFlow.threadFlows.length - 1].fileLink.filePath;
   return filePath.substring(filePath.lastIndexOf('/') + 1);
 };
 

--- a/extensions/ql-vscode/src/remote-queries/view/FileCodeSnippet.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/FileCodeSnippet.tsx
@@ -1,12 +1,20 @@
 import * as React from 'react';
 import styled from 'styled-components';
-import { CodeSnippet, HighlightedRegion, AnalysisMessage, ResultSeverity } from '../shared/analysis-result';
+import { CodeSnippet, FileLink, HighlightedRegion, AnalysisMessage, ResultSeverity } from '../shared/analysis-result';
 import { Box, Link } from '@primer/react';
 import VerticalSpace from './VerticalSpace';
 
 const borderColor = 'var(--vscode-editor-snippetFinalTabstopHighlightBorder)';
 const warningColor = '#966C23';
 const highlightColor = '#534425';
+
+const createFileLink = (fileLink: FileLink, startLine?: number, endLine?: number) => {
+  if (startLine && endLine) {
+    return `${fileLink.fileLinkPrefix}/${fileLink.filePath}#L${startLine}-L${endLine}`;
+  } else {
+    return `${fileLink.fileLinkPrefix}/${fileLink.filePath}`;
+  }
+};
 
 const getSeverityColor = (severity: ResultSeverity) => {
   switch (severity) {
@@ -106,7 +114,11 @@ const Message = ({
             case 'text':
               return <span key={`token-${index}`}>{token.text}</span>;
             case 'location':
-              return <Link key={`token-${index}`} href='TODO'>{token.text}</Link>;
+              return <Link
+                key={`token-${index}`}
+                href={createFileLink(token.location.fileLink, token.location.highlightedRegion?.startLine, token.location.highlightedRegion?.endLine)}>
+                {token.text}
+              </Link>;
             default:
               return <></>;
           }
@@ -165,14 +177,14 @@ const CodeLine = ({
 };
 
 const FileCodeSnippet = ({
-  filePath,
+  fileLink,
   codeSnippet,
   highlightedRegion,
   severity,
   message,
   messageChildren,
 }: {
-  filePath: string,
+  fileLink: FileLink,
   codeSnippet: CodeSnippet,
   highlightedRegion?: HighlightedRegion,
   severity?: ResultSeverity,
@@ -183,11 +195,12 @@ const FileCodeSnippet = ({
   const code = codeSnippet.text.split('\n');
 
   const startingLine = codeSnippet.startLine;
+  const endingLine = codeSnippet.endLine;
 
   return (
     <Container>
       <TitleContainer>
-        <Link>{filePath}</Link>
+        <Link href={createFileLink(fileLink, startingLine, endingLine)}>{fileLink.filePath}</Link>
       </TitleContainer>
       <CodeContainer>
         {code.map((line, index) => (

--- a/extensions/ql-vscode/src/remote-queries/view/FileCodeSnippet.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/FileCodeSnippet.tsx
@@ -3,18 +3,11 @@ import styled from 'styled-components';
 import { CodeSnippet, FileLink, HighlightedRegion, AnalysisMessage, ResultSeverity } from '../shared/analysis-result';
 import { Box, Link } from '@primer/react';
 import VerticalSpace from './VerticalSpace';
+import { createRemoteFileRef } from '../../pure/location-link-utils';
 
 const borderColor = 'var(--vscode-editor-snippetFinalTabstopHighlightBorder)';
 const warningColor = '#966C23';
 const highlightColor = '#534425';
-
-const createFileLink = (fileLink: FileLink, startLine?: number, endLine?: number) => {
-  if (startLine && endLine) {
-    return `${fileLink.fileLinkPrefix}/${fileLink.filePath}#L${startLine}-L${endLine}`;
-  } else {
-    return `${fileLink.fileLinkPrefix}/${fileLink.filePath}`;
-  }
-};
 
 const getSeverityColor = (severity: ResultSeverity) => {
   switch (severity) {
@@ -116,7 +109,11 @@ const Message = ({
             case 'location':
               return <Link
                 key={`token-${index}`}
-                href={createFileLink(token.location.fileLink, token.location.highlightedRegion?.startLine, token.location.highlightedRegion?.endLine)}>
+                href={createRemoteFileRef(
+                  token.location.fileLink.fileLinkPrefix,
+                  token.location.fileLink.filePath,
+                  token.location.highlightedRegion?.startLine,
+                  token.location.highlightedRegion?.endLine)}>
                 {token.text}
               </Link>;
             default:
@@ -197,10 +194,16 @@ const FileCodeSnippet = ({
   const startingLine = codeSnippet.startLine;
   const endingLine = codeSnippet.endLine;
 
+  const titleFileUri = createRemoteFileRef(
+    fileLink.fileLinkPrefix,
+    fileLink.filePath,
+    startingLine,
+    endingLine);
+
   return (
     <Container>
       <TitleContainer>
-        <Link href={createFileLink(fileLink, startingLine, endingLine)}>{fileLink.filePath}</Link>
+        <Link href={titleFileUri}>{fileLink.filePath}</Link>
       </TitleContainer>
       <CodeContainer>
         {code.map((line, index) => (

--- a/extensions/ql-vscode/src/remote-queries/view/FileCodeSnippet.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/FileCodeSnippet.tsx
@@ -110,8 +110,7 @@ const Message = ({
               return <Link
                 key={`token-${index}`}
                 href={createRemoteFileRef(
-                  token.location.fileLink.fileLinkPrefix,
-                  token.location.fileLink.filePath,
+                  token.location.fileLink,
                   token.location.highlightedRegion?.startLine,
                   token.location.highlightedRegion?.endLine)}>
                 {token.text}
@@ -195,8 +194,7 @@ const FileCodeSnippet = ({
   const endingLine = codeSnippet.endLine;
 
   const titleFileUri = createRemoteFileRef(
-    fileLink.fileLinkPrefix,
-    fileLink.filePath,
+    fileLink,
     startingLine,
     endingLine);
 

--- a/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
@@ -369,7 +369,7 @@ export function RemoteQueries(): JSX.Element {
     return <div>Waiting for results to load.</div>;
   }
 
-  const showAnalysesResults = false;
+  const showAnalysesResults = true;
 
   try {
     return <div>

--- a/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
@@ -304,7 +304,8 @@ const RepoAnalysisResults = (analysisResults: AnalysisResults) => {
       {analysisResults.rawResults &&
         <RawResultsTable
           schema={analysisResults.rawResults.schema}
-          results={analysisResults.rawResults.resultSet} />
+          results={analysisResults.rawResults.resultSet}
+          fileLinkPrefix={analysisResults.rawResults.fileLinkPrefix} />
       }
     </CollapsibleItem>
   );

--- a/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
@@ -273,7 +273,7 @@ const AnalysesResultsDescription = ({
   const showMaxResultsMessage = analysesResults.some(a => a.rawResults?.capped);
   const maxRawResultsMessage = <>
     <VerticalSpace size={1} />
-    Some repositories have more than {MAX_RAW_RESULTS} results. We will only show you up to
+    Some repositories have more than {MAX_RAW_RESULTS} results. We will only show you up to 
     {MAX_RAW_RESULTS} results for each repository.
   </>;
 
@@ -370,7 +370,7 @@ export function RemoteQueries(): JSX.Element {
     return <div>Waiting for results to load.</div>;
   }
 
-  const showAnalysesResults = true;
+  const showAnalysesResults = false;
 
   try {
     return <div>

--- a/extensions/ql-vscode/test/pure-tests/sarif-processing.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/sarif-processing.test.ts
@@ -378,12 +378,13 @@ describe('SARIF processing', () => {
   });
 
   describe('extractAnalysisAlerts', () => {
+    const fakefileLinkPrefix = 'https://example.com';
     it('should not return any results if no runs found in the SARIF', () => {
       const sarif = {
         // Runs are missing here.
       } as sarif.Log;
 
-      const result = extractAnalysisAlerts(sarif);
+      const result = extractAnalysisAlerts(sarif, fakefileLinkPrefix);
 
       expect(result).to.be.ok;
       expect(result.alerts.length).to.equal(0);
@@ -401,7 +402,7 @@ describe('SARIF processing', () => {
         ]
       } as sarif.Log;
 
-      const result = extractAnalysisAlerts(sarif);
+      const result = extractAnalysisAlerts(sarif, fakefileLinkPrefix);
 
       expect(result).to.be.ok;
       expect(result.alerts.length).to.equal(0);
@@ -411,7 +412,7 @@ describe('SARIF processing', () => {
       const sarif = buildValidSarifLog();
       sarif.runs![0]!.results![0]!.message.text = undefined;
 
-      const result = extractAnalysisAlerts(sarif);
+      const result = extractAnalysisAlerts(sarif, fakefileLinkPrefix);
 
       expect(result).to.be.ok;
       expect(result.errors.length).to.equal(1);
@@ -422,7 +423,7 @@ describe('SARIF processing', () => {
       const sarif = buildValidSarifLog();
       sarif.runs![0]!.results![0]!.locations![0]!.physicalLocation!.contextRegion = undefined;
 
-      const result = extractAnalysisAlerts(sarif);
+      const result = extractAnalysisAlerts(sarif, fakefileLinkPrefix);
 
       expect(result).to.be.ok;
       expect(result.errors.length).to.equal(1);
@@ -433,7 +434,7 @@ describe('SARIF processing', () => {
       const sarif = buildValidSarifLog();
       sarif.runs![0]!.results![0]!.locations![0]!.physicalLocation!.region = undefined;
 
-      const result = extractAnalysisAlerts(sarif);
+      const result = extractAnalysisAlerts(sarif, fakefileLinkPrefix);
 
       expect(result).to.be.ok;
       expect(result.alerts.length).to.equal(1);
@@ -443,7 +444,7 @@ describe('SARIF processing', () => {
       const sarif = buildValidSarifLog();
       sarif.runs![0]!.results![0]!.locations![0]!.physicalLocation!.artifactLocation = undefined;
 
-      const result = extractAnalysisAlerts(sarif);
+      const result = extractAnalysisAlerts(sarif, fakefileLinkPrefix);
 
       expect(result).to.be.ok;
       expect(result.errors.length).to.equal(1);
@@ -532,7 +533,7 @@ describe('SARIF processing', () => {
         ]
       } as sarif.Log;
 
-      const result = extractAnalysisAlerts(sarif);
+      const result = extractAnalysisAlerts(sarif, fakefileLinkPrefix);
       expect(result).to.be.ok;
       expect(result.errors.length).to.equal(0);
       expect(result.alerts.length).to.equal(3);
@@ -562,7 +563,7 @@ describe('SARIF processing', () => {
         }
       ];
 
-      const result = extractAnalysisAlerts(sarif);
+      const result = extractAnalysisAlerts(sarif, fakefileLinkPrefix);
 
       expect(result).to.be.ok;
       expect(result.errors.length).to.equal(0);
@@ -574,7 +575,10 @@ describe('SARIF processing', () => {
       expect(message.tokens[1].t).to.equal('location');
       expect(message.tokens[1].text).to.equal('absolute path');
       expect((message.tokens[1] as AnalysisMessageLocationToken).location).to.deep.equal({
-        filePath: 'npm-packages/meteor-installer/config.js',
+        fileLink: {
+          fileLinkPrefix: fakefileLinkPrefix,
+          filePath: 'npm-packages/meteor-installer/config.js',
+        },
         highlightedRegion: {
           startLine: 35,
           startColumn: 20,


### PR DESCRIPTION
Follow-up to #1205.

Creates a clickable link in the results view that links to the file location on GitHub. e.g.
![image](https://user-images.githubusercontent.com/42641846/158359163-8b589546-fff7-4c34-8568-224a0928aec7.png)
links to 
https://github.com/meteor/meteor/blob/HEAD/npm-packages/meteor-installer/install.js#L253-L257 (using the exact SHA instead of HEAD, when available).

## Checklist

N/A - still internal only 🗳️ 

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
