### PR TITLE
Fix highlight region end column calculation

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/sarif-processing.ts
+++ b/extensions/ql-vscode/src/remote-queries/sarif-processing.ts
@@ -169,7 +169,10 @@ function getHighlightedRegion(region: sarif.Region): HighlightedRegion {
     startLine,
     startColumn,
     endLine,
-    endColumn
+
+    // parseSarifRegion currently shifts the end column by 1 to account 
+    // for the way vscode counts columns so we need to shift it back.
+    endColumn: endColumn + 1
   };
 }
 

--- a/extensions/ql-vscode/test/pure-tests/sarif-processing.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/sarif-processing.test.ts
@@ -579,7 +579,7 @@ describe('SARIF processing', () => {
           startLine: 35,
           startColumn: 20,
           endLine: 35,
-          endColumn: 59
+          endColumn: 60
         }
       });
       expect(message.tokens[2].t).to.equal('text');


### PR DESCRIPTION
In a recent PR we took advantage of the `parseSarifRegion()` from `sarif-utils.ts` for remote queries. However, `parseSarifRegion` assumes the region will be used by VS Code tooling (the editor) so it offsets it by 1. This made highlights in the remote queries view miss out on the last character.

Ideally we should be updating `parseSarifRegion` to be more generic but that would have been a slightly bigger change than I would have liked right now.

## Checklist
N/A:

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
