### PR TITLE
Change public occurrences of "remote queries"

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -258,7 +258,7 @@
           "scope": "application",
           "description": "Specifies whether or not to write telemetry events to the extension log."
         },
-        "codeQL.remoteQueries.repositoryLists": {
+        "codeQL.variantAnalysis.repositoryLists": {
           "type": [
             "object",
             null
@@ -272,14 +272,14 @@
             }
           },
           "default": null,
-          "markdownDescription": "[For internal use only] Lists of GitHub repositories that you want to query remotely. This should be a JSON object where each key is a user-specified name for this repository list, and the value is an array of GitHub repositories (of the form `<owner>/<repo>`)."
+          "markdownDescription": "[For internal use only] Lists of GitHub repositories that you want to run variant analysis against. This should be a JSON object where each key is a user-specified name for this repository list, and the value is an array of GitHub repositories (of the form `<owner>/<repo>`)."
         },
-        "codeQL.remoteQueries.controllerRepo": {
+        "codeQL.variantAnalysis.controllerRepo": {
           "type": "string",
           "default": "",
           "pattern": "^$|^(?:[a-zA-Z0-9]+-)*[a-zA-Z0-9]+/[a-zA-Z0-9-_]+$",
           "patternErrorMessage": "Please enter a valid GitHub repository",
-          "markdownDescription": "[For internal use only] The name of the GitHub repository where you can view the progress and results of the \"Run Remote query\" command. The repository should be of the form `<owner>/<repo>`)."
+          "markdownDescription": "[For internal use only] The name of the GitHub repository where you can view the progress and results of the \"Run Variant Analysis\" command. The repository should be of the form `<owner>/<repo>`)."
         }
       }
     },
@@ -297,8 +297,8 @@
         "title": "CodeQL: Run Query on Multiple Databases"
       },
       {
-        "command": "codeQL.runRemoteQuery",
-        "title": "CodeQL: Run Remote Query"
+        "command": "codeQL.runVariantAnalysis",
+        "title": "CodeQL: Run Variant Analysis"
       },
       {
         "command": "codeQL.runQueries",
@@ -542,7 +542,7 @@
       },
       {
         "command": "codeQLQueryHistory.openOnGithub",
-        "title": "Open Remote Query on GitHub"
+        "title": "Open Variant Analysis on GitHub"
       },
       {
         "command": "codeQLQueryResults.nextPathStep",
@@ -798,7 +798,7 @@
           "when": "resourceLangId == ql && resourceExtname == .ql"
         },
         {
-          "command": "codeQL.runRemoteQuery",
+          "command": "codeQL.runVariantAnalysis",
           "when": "config.codeQL.canary && editorLangId == ql && resourceExtname == .ql"
         },
         {
@@ -976,7 +976,7 @@
           "when": "editorLangId == ql && resourceExtname == .ql"
         },
         {
-          "command": "codeQL.runRemoteQuery",
+          "command": "codeQL.runVariantAnalysis",
           "when": "config.codeQL.canary && editorLangId == ql && resourceExtname == .ql"
         },
         {

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -323,7 +323,7 @@ export function isCanary() {
 export const NO_CACHE_AST_VIEWER = new Setting('disableCache', AST_VIEWER_SETTING);
 
 // Settings for remote queries
-const REMOTE_QUERIES_SETTING = new Setting('remoteQueries', ROOT_SETTING);
+const REMOTE_QUERIES_SETTING = new Setting('variantAnalysis', ROOT_SETTING);
 
 /**
  * Lists of GitHub repositories that you want to query remotely via the "Run Variant Analysis" command.

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -326,7 +326,7 @@ export const NO_CACHE_AST_VIEWER = new Setting('disableCache', AST_VIEWER_SETTIN
 const REMOTE_QUERIES_SETTING = new Setting('remoteQueries', ROOT_SETTING);
 
 /**
- * Lists of GitHub repositories that you want to query remotely via the "Run Remote query" command.
+ * Lists of GitHub repositories that you want to query remotely via the "Run Variant Analysis" command.
  * Note: This command is only available for internal users.
  *
  * This setting should be a JSON object where each key is a user-specified name (string),
@@ -343,7 +343,7 @@ export async function setRemoteRepositoryLists(lists: Record<string, string[]> |
 }
 
 /**
- * The name of the "controller" repository that you want to use with the "Run Remote query" command.
+ * The name of the "controller" repository that you want to use with the "Run Variant Analysis" command.
  * Note: This command is only available for internal users.
  *
  * This setting should be a GitHub repository of the form `<owner>/<repo>`.

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -844,9 +844,9 @@ async function activateWithInstalledDistribution(
 
   registerRemoteQueryTextProvider();
 
-  // The "runRemoteQuery" command is internal-only.
+  // The "runVariantAnalysis" command is internal-only.
   ctx.subscriptions.push(
-    commandRunnerWithProgress('codeQL.runRemoteQuery', async (
+    commandRunnerWithProgress('codeQL.runVariantAnalysis', async (
       progress: ProgressCallback,
       token: CancellationToken,
       uri: Uri | undefined
@@ -866,7 +866,7 @@ async function activateWithInstalledDistribution(
         throw new Error('Remote queries require the CodeQL Canary version to run.');
       }
     }, {
-      title: 'Run Remote Query',
+      title: 'Run Variant Analysis',
       cancellable: true
     })
   );

--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -577,7 +577,7 @@ export class QueryHistoryManager extends DisposableObject {
         this.treeDataProvider.remove(item);
         void logger.log(`Deleted ${item.label}.`);
         if (item.status === QueryStatus.InProgress) {
-          void logger.log('The remote query is still running on GitHub Actions. To cancel there, you must go to the query run in your browser.');
+          void logger.log('The variant analysis is still running on GitHub Actions. To cancel there, you must go to the workflow run in your browser.');
         }
 
         this._onDidRemoveQueryItem.fire(item);

--- a/extensions/ql-vscode/src/remote-queries/gh-actions-api-client.ts
+++ b/extensions/ql-vscode/src/remote-queries/gh-actions-api-client.ts
@@ -267,18 +267,18 @@ function getWorkflowError(conclusion: string | null): string {
   }
 
   if (conclusion === 'cancelled') {
-    return 'The remote query execution was cancelled.';
+    return 'Variant analysis execution was cancelled.';
   }
 
   if (conclusion === 'timed_out') {
-    return 'The remote query execution timed out.';
+    return 'Variant analysis execution timed out.';
   }
 
   if (conclusion === 'failure') {
     // TODO: Get the actual error from the workflow or potentially
     // from an artifact from the action itself.
-    return 'The remote query execution has failed.';
+    return 'Variant analysis execution has failed.';
   }
 
-  return `Unexpected query execution conclusion: ${conclusion}`;
+  return `Unexpected variant analysis execution conclusion: ${conclusion}`;
 }

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
@@ -91,7 +91,7 @@ export class RemoteQueriesInterfaceManager {
       const { ctx } = this;
       const panel = (this.panel = Window.createWebviewPanel(
         'remoteQueriesView',
-        'Remote Query Results',
+        'CodeQL Query Results',
         { viewColumn: ViewColumn.Active, preserveFocus: true },
         {
           enableScripts: true,

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
@@ -186,7 +186,7 @@ export class RemoteQueriesInterfaceManager {
         break;
       case 'remoteQueryError':
         void this.logger.log(
-          `Remote query error: ${msg.error}`
+          `Variant analysis error: ${msg.error}`
         );
         break;
       case 'openFile':

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
@@ -157,11 +157,11 @@ export class RemoteQueriesManager extends DisposableObject {
     } else if (queryWorkflowResult.status === 'CompletedUnsuccessfully') {
       queryItem.failureReason = queryWorkflowResult.error;
       queryItem.status = QueryStatus.Failed;
-      void showAndLogErrorMessage(`Remote query execution failed. Error: ${queryWorkflowResult.error}`);
+      void showAndLogErrorMessage(`Variant analysis execution failed. Error: ${queryWorkflowResult.error}`);
     } else if (queryWorkflowResult.status === 'Cancelled') {
       queryItem.failureReason = 'Cancelled';
       queryItem.status = QueryStatus.Failed;
-      void showAndLogErrorMessage('Remote query monitoring was cancelled');
+      void showAndLogErrorMessage('Variant analysis monitoring was cancelled');
     } else if (queryWorkflowResult.status === 'InProgress') {
       // Should not get here. Only including this to ensure `assertNever` uses proper type checking.
       void showAndLogErrorMessage(`Unexpected status: ${queryWorkflowResult.status}`);

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-monitor.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-monitor.ts
@@ -49,7 +49,7 @@ export class RemoteQueriesMonitor {
       attemptCount++;
     }
 
-    void this.logger.log('Remote query monitoring timed out after 2 days');
+    void this.logger.log('Variant analysis monitoring timed out after 2 days');
     return { status: 'Cancelled' };
   }
 

--- a/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
@@ -65,7 +65,7 @@ export async function getRepositories(): Promise<string[] | undefined> {
     const quickpick = await window.showQuickPick<RepoListQuickPickItem>(
       quickPickItems,
       {
-        placeHolder: 'Select a repository list. You can define repository lists in the `codeQL.remoteQueries.repositoryLists` setting.',
+        placeHolder: 'Select a repository list. You can define repository lists in the `codeQL.variantAnalysis.repositoryLists` setting.',
         ignoreFocusOut: true,
       });
     if (quickpick?.repoList.length) {
@@ -80,7 +80,7 @@ export async function getRepositories(): Promise<string[] | undefined> {
     const remoteRepo = await window.showInputBox({
       title: 'Enter a GitHub repository in the format <owner>/<repo> (e.g. github/codeql)',
       placeHolder: '<owner>/<repo>',
-      prompt: 'Tip: you can save frequently used repositories in the `codeQL.remoteQueries.repositoryLists` setting',
+      prompt: 'Tip: you can save frequently used repositories in the `codeQL.variantAnalysis.repositoryLists` setting',
       ignoreFocusOut: true,
     });
     if (!remoteRepo) {

--- a/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
@@ -430,7 +430,7 @@ async function ensureNameAndSuite(queryPackDir: string, packRelativePath: string
   qlpack.name = QUERY_PACK_NAME;
 
   qlpack.defaultSuite = [{
-    description: 'Query suite for remote query'
+    description: 'Query suite for variant analysis'
   }, {
     query: packRelativePath.replace(/\\/g, '/')
   }];

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/run-remote-query.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/run-remote-query.test.ts
@@ -279,7 +279,7 @@ describe('Remote queries', function() {
       },
       library: false,
       defaultSuite: [{
-        description: 'Query suite for remote query'
+        description: 'Query suite for variant analysis'
       }, {
         query: queryPath
       }]


### PR DESCRIPTION
Renames "remote queries" to "variant analysis" (see internal issue).

I've covered any user-facing messages/settings/commands but I've deliberately left most internal things unchanged, like the file structure, names of types, tests etc

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
