### PR TITLE
Use variable for highlighting code

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/view/FileCodeSnippet.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/FileCodeSnippet.tsx
@@ -7,7 +7,7 @@ import { createRemoteFileRef } from '../../pure/location-link-utils';
 
 const borderColor = 'var(--vscode-editor-snippetFinalTabstopHighlightBorder)';
 const warningColor = '#966C23';
-const highlightColor = '#534425';
+const highlightColor = 'var(--vscode-editor-findMatchHighlightBackground)';
 
 const getSeverityColor = (severity: ResultSeverity) => {
   switch (severity) {


### PR DESCRIPTION
Code highlighting looked funny in light mode 🙈  
![image](https://user-images.githubusercontent.com/42641846/158657485-bcbd4336-c6f2-4003-b818-b57a97b7cb13.png)


I've used a variable instead, so it currently looks like this in dark/light mode:
![image](https://user-images.githubusercontent.com/42641846/158657323-dc071ffb-3f38-4e16-ad85-a0e0de33b57c.png)
or 
![image](https://user-images.githubusercontent.com/42641846/158657347-69bb349b-fe12-4377-9589-a06b7d986326.png)

My choice of `--vscode-editor-findMatchHighlightBackground` was fairly random, but it looks plausible 😅 

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
