### PR TITLE
Minor webview fixes

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/view/FileCodeSnippet.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/FileCodeSnippet.tsx
@@ -206,13 +206,6 @@ const FileCodeSnippet = ({
       <CodeContainer>
         {code.map((line, index) => (
           <div key={index}>
-            {message && severity && <Message
-              message={message}
-              currentLineNumber={startingLine + index - 1}
-              highlightedRegion={highlightedRegion}
-              borderColor={getSeverityColor(severity)}>
-              {messageChildren}
-            </Message>}
             <Box display="flex">
               <Box
                 p={2}
@@ -238,6 +231,13 @@ const FileCodeSnippet = ({
                   highlightedRegion={highlightedRegion} />
               </Box>
             </Box>
+            {message && severity && <Message
+              message={message}
+              currentLineNumber={startingLine + index}
+              highlightedRegion={highlightedRegion}
+              borderColor={getSeverityColor(severity)}>
+              {messageChildren}
+            </Message>}
           </div>
         ))}
       </CodeContainer>

--- a/extensions/ql-vscode/src/remote-queries/view/FileCodeSnippet.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/FileCodeSnippet.tsx
@@ -208,7 +208,7 @@ const FileCodeSnippet = ({
           <div key={index}>
             {message && severity && <Message
               message={message}
-              currentLineNumber={startingLine + index}
+              currentLineNumber={startingLine + index - 1}
               highlightedRegion={highlightedRegion}
               borderColor={getSeverityColor(severity)}>
               {messageChildren}

--- a/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
@@ -260,7 +260,7 @@ const AnalysesResultsDescription = ({
   const showMaxResultsMessage = analysesResults.some(a => a.rawResults?.capped);
   const maxRawResultsMessage = <>
     <VerticalSpace size={1} />
-    Some repositories have more than {MAX_RAW_RESULTS} results. We will only show you up to 
+    Some repositories have more than {MAX_RAW_RESULTS} results. We will only show you up to&nbsp;
     {MAX_RAW_RESULTS} results for each repository.
   </>;
 


### PR DESCRIPTION
Puts the annotation for an alert below the highlighted line instead of above. (PS: I'm not sure if this is the right fix, but it _looks_ good at least 🤷🏽)
![image](https://user-images.githubusercontent.com/42641846/158790762-df565140-3be9-48f2-8b79-f7148a84c08c.png)

(Also converts a space to `&nbsp;` to stop an overenthusiastic linter from stripping it off the end of the line.) 

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
