### PR TITLE
Log most expensive predicates and timings to query server window

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Fix a bug where queries took a long time to run if there are no folders in the workspace. [#1157](https://github.com/github/vscode-codeql/pull/1157)
 - [BREAKING CHANGE] The `codeQL.runningQueries.customLogDirectory` setting is deprecated and no longer has any function. Instead, all query log files will be stored in the query history directory, next to the query results. [#1178](https://github.com/github/vscode-codeql/pull/1178)
 - Add a _Open query directory_ command for query items. This command opens the directory containing all artifacts for a query. [#1179](https://github.com/github/vscode-codeql/pull/1179)
-- Add options to display evaluator logs for a given query run. Some information that was previously found in the query server output may now be found here. [#1186](https://github.com/github/vscode-codeql/pull/1186)
+- Add options to display evaluator logs for a given query run. Some information that was previously found in the query server output may now be found here. Summaries are logged to the Query Server Output window at the end of the run. [#1186](https://github.com/github/vscode-codeql/pull/1186)
 
 ## 1.5.11 - 10 February 2022
 

--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix a bug where queries took a long time to run if there are no folders in the workspace. [#1157](https://github.com/github/vscode-codeql/pull/1157)
 - [BREAKING CHANGE] The `codeQL.runningQueries.customLogDirectory` setting is deprecated and no longer has any function. Instead, all query log files will be stored in the query history directory, next to the query results. [#1178](https://github.com/github/vscode-codeql/pull/1178)
 - Add a _Open query directory_ command for query items. This command opens the directory containing all artifacts for a query. [#1179](https://github.com/github/vscode-codeql/pull/1179)
+- Add options to display evaluator logs for a given query run. Some information that was previously found in the query server output may now be found here. [#1186](https://github.com/github/vscode-codeql/pull/1186)
 
 ## 1.5.11 - 10 February 2022
 

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -513,6 +513,14 @@
         "title": "Open query directory"
       },
       {
+        "command": "codeQLQueryHistory.showEvalLog",
+        "title": "Show Evaluator Log (Raw)"
+      },
+      {
+        "command": "codeQLQueryHistory.showEvalLogSummary",
+        "title": "Show Evaluator Log (Summary)"
+      },
+      {
         "command": "codeQLQueryHistory.cancel",
         "title": "Cancel"
       },
@@ -707,6 +715,16 @@
           "when": "view == codeQLQueryHistory && !hasRemoteServer"
         },
         {
+          "command": "codeQLQueryHistory.showEvalLog",
+          "group": "9_qlCommands",
+          "when": "viewItem == rawResultsItem || viewItem == interpretedResultsItem || viewItem == cancelledResultsItem"
+        },
+        {
+          "command": "codeQLQueryHistory.showEvalLogSummary",
+          "group": "9_qlCommands",
+          "when": "viewItem == rawResultsItem || viewItem == interpretedResultsItem || viewItem == cancelledResultsItem"
+        },
+        {
           "command": "codeQLQueryHistory.showQueryText",
           "group": "9_qlCommands",
           "when": "view == codeQLQueryHistory"
@@ -894,6 +912,14 @@
         },
         {
           "command": "codeQLQueryHistory.showQueryLog",
+          "when": "false"
+        },
+        {
+          "command": "codeQLQueryHistory.showEvalLog",
+          "when": "false"
+        },
+        {
+          "command": "codeQLQueryHistory.showEvalLogSummary",
           "when": "false"
         },
         {

--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -666,6 +666,23 @@ export class CodeQLCliServer implements Disposable {
   }
 
   /**
+  * Generate a summary of an evaluation log.
+  * @param inputPath The path of an evaluation event log.
+  * @param outputPath The path to write a human-readable summary of it to.
+  */
+   async generateLogSummary(
+    inputPath: string,
+    outputPath: string,
+  ): Promise<string> {
+    const subcommandArgs = [
+      '--format=text',
+      inputPath,
+      outputPath
+    ];
+    return await this.runCodeQlCliCommand(['generate', 'log-summary'], subcommandArgs, 'Generating log summary');
+  }
+
+  /**
   * Gets the results from a bqrs.
   * @param bqrsPath The path to the bqrs.
   * @param resultSet The result set to get.
@@ -1256,6 +1273,11 @@ export class CliVersionConstraint {
    */
   public static CLI_VERSION_WITH_STRUCTURED_EVAL_LOG = new SemVer('2.8.2');
 
+   /**
+    * CLI version that supports rotating structured logs to produce one per query.
+    */
+    public static CLI_VERSION_WITH_PER_QUERY_EVAL_LOG = new SemVer('2.8.4');
+
   constructor(private readonly cli: CodeQLCliServer) {
     /**/
   }
@@ -1314,5 +1336,9 @@ export class CliVersionConstraint {
 
   async supportsStructuredEvalLog() {
     return this.isVersionAtLeast(CliVersionConstraint.CLI_VERSION_WITH_STRUCTURED_EVAL_LOG);
+  }
+
+  async supportsPerQueryEvalLog() {
+    return this.isVersionAtLeast(CliVersionConstraint.CLI_VERSION_WITH_PER_QUERY_EVAL_LOG);
   }
 }

--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -1268,15 +1268,9 @@ export class CliVersionConstraint {
   public static CLI_VERSION_WITH_PACKAGING = new SemVer('2.6.0');
 
   /**
-   * CLI version where the `--evaluator-log` and related options to the query server were introduced,
-   * on a per-query server basis.
-   */
-  public static CLI_VERSION_WITH_STRUCTURED_EVAL_LOG = new SemVer('2.8.2');
-
-   /**
-    * CLI version that supports rotating structured logs to produce one per query.
-    */
-    public static CLI_VERSION_WITH_PER_QUERY_EVAL_LOG = new SemVer('2.8.4');
+  * CLI version that supports rotating structured logs to produce one per query.
+  */
+  public static CLI_VERSION_WITH_PER_QUERY_EVAL_LOG = new SemVer('2.8.4');
 
   constructor(private readonly cli: CodeQLCliServer) {
     /**/
@@ -1332,10 +1326,6 @@ export class CliVersionConstraint {
 
   async supportsPackaging() {
     return this.isVersionAtLeast(CliVersionConstraint.CLI_VERSION_WITH_PACKAGING);
-  }
-
-  async supportsStructuredEvalLog() {
-    return this.isVersionAtLeast(CliVersionConstraint.CLI_VERSION_WITH_STRUCTURED_EVAL_LOG);
   }
 
   async supportsPerQueryEvalLog() {

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -537,6 +537,8 @@ async function activateWithInstalledDistribution(
           queryStorageDir,
           progress,
           source.token,
+          undefined,
+          item,
         );
         item.completeThisQuery(completedQueryInfo);
         await showResultsForCompletedQuery(item as CompletedLocalQueryInfo, WebviewReveal.NotForced);

--- a/extensions/ql-vscode/src/pure/messages.ts
+++ b/extensions/ql-vscode/src/pure/messages.ts
@@ -646,6 +646,35 @@ export interface ClearCacheParams {
    */
   dryRun: boolean;
 }
+
+/**
+ * Parameters to start a new structured log
+ */
+ export interface StartLogParams {
+  /**
+   * The dataset for which we want to start a new structured log
+   */
+  db: Dataset;
+  /**
+   * The path where we want to place the new structured log
+   */
+  logPath: string;
+}
+
+/**
+ * Parameters to terminate a structured log
+ */
+ export interface EndLogParams {
+  /**
+   * The dataset for which we want to terminated the log
+   */
+  db: Dataset;
+  /**
+   * The path of the log to terminate, will be a no-op if we aren't logging here
+   */
+  logPath: string;
+}
+
 /**
  * Parameters for trimming the cache of a dataset
  */
@@ -680,6 +709,26 @@ export interface ClearCacheResult {
    * deleted.
    */
   deletionMessage: string;
+}
+
+/**
+ * The result of starting a new structured log.
+ */
+export interface StartLogResult {
+  /**
+   * A user friendly message saying what happened.
+   */
+  outcomeMessage: string;
+}
+
+/**
+ * The result of terminating a structured.
+ */
+export interface EndLogResult {
+  /**
+   * A user friendly message saying what happened.
+   */
+  outcomeMessage: string;
 }
 
 /**
@@ -1017,6 +1066,16 @@ export const compileUpgrade = new rpc.RequestType<WithProgressId<CompileUpgradeP
  * Compile an upgrade script to upgrade a dataset.
  */
 export const compileUpgradeSequence = new rpc.RequestType<WithProgressId<CompileUpgradeSequenceParams>, CompileUpgradeSequenceResult, void, void>('compilation/compileUpgradeSequence');
+
+/**
+ * Start a new structured log in the evaluator, terminating the previous one if it exists
+ */
+ export const startLog = new rpc.RequestType<WithProgressId<StartLogParams>, StartLogResult, void, void>('evaluation/startLog');
+
+/**
+ * Terminate a structured log in the evaluator. Is a no-op if we aren't logging to the given location
+ */
+ export const endLog = new rpc.RequestType<WithProgressId<EndLogParams>, EndLogResult, void, void>('evaluation/endLog');
 
 /**
  * Clear the cache of a dataset

--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -34,7 +34,6 @@ import { DatabaseManager } from './databases';
 import { registerQueryHistoryScubber } from './query-history-scrubber';
 import { QueryStatus } from './query-status';
 import { slurpQueryHistory, splatQueryHistory } from './query-serialization';
-import * as fs from 'fs-extra';
 import { CliVersionConstraint } from './cli';
 
 /**
@@ -784,10 +783,7 @@ export class QueryHistoryManager extends DisposableObject {
       return;
     }
 
-    if (finalSingleItem.evalLogLocation) {
-      if (!fs.existsSync(finalSingleItem.evalLogSummaryLocation)) {
-        await this.qs.cliServer.generateLogSummary(finalSingleItem.evalLogLocation, finalSingleItem.evalLogSummaryLocation);
-      }
+    if (finalSingleItem.evalLogSummaryLocation) {
       await this.tryOpenExternalFile(finalSingleItem.evalLogSummaryLocation);
     } else {
       this.warnNoEvalLog();

--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -759,13 +759,15 @@ export class QueryHistoryManager extends DisposableObject {
     singleItem: QueryHistoryInfo,
     multiSelect: QueryHistoryInfo[]
   ) {
-    // Local queries only
-    if (!this.assertSingleQuery(multiSelect) || singleItem?.t !== 'local') {
+    const { finalSingleItem, finalMultiSelect } = this.determineSelection(singleItem, multiSelect);
+
+    // Only applicable to an individual local query
+    if (!this.assertSingleQuery(finalMultiSelect) || !finalSingleItem || finalSingleItem.t !== 'local') {
       return;
     }
 
-    if (singleItem.evalLogLocation) {
-      await this.tryOpenExternalFile(singleItem.evalLogLocation);
+    if (finalSingleItem.evalLogLocation) {
+      await this.tryOpenExternalFile(finalSingleItem.evalLogLocation);
     } else {
       this.warnNoEvalLog();
     }
@@ -775,17 +777,18 @@ export class QueryHistoryManager extends DisposableObject {
     singleItem: QueryHistoryInfo,
     multiSelect: QueryHistoryInfo[]
   ) {
-    // Local queries only
-    if (!this.assertSingleQuery(multiSelect) || singleItem?.t !== 'local') {
+    const { finalSingleItem, finalMultiSelect } = this.determineSelection(singleItem, multiSelect);
+
+    // Only applicable to an individual local query
+    if (!this.assertSingleQuery(finalMultiSelect) || !finalSingleItem || finalSingleItem.t !== 'local') {
       return;
     }
 
-    if (singleItem.evalLogLocation) {
-      const summaryLocation = singleItem.evalLogLocation + '.summary';
-      if (!fs.existsSync(summaryLocation)) {
-        await this.qs.cliServer.generateLogSummary(singleItem.evalLogLocation, summaryLocation);
+    if (finalSingleItem.evalLogLocation) {
+      if (!fs.existsSync(finalSingleItem.evalLogSummaryLocation)) {
+        await this.qs.cliServer.generateLogSummary(finalSingleItem.evalLogLocation, finalSingleItem.evalLogSummaryLocation);
       }
-      await this.tryOpenExternalFile(summaryLocation);
+      await this.tryOpenExternalFile(finalSingleItem.evalLogSummaryLocation);
     } else {
       this.warnNoEvalLog();
     }

--- a/extensions/ql-vscode/src/query-results.ts
+++ b/extensions/ql-vscode/src/query-results.ts
@@ -312,6 +312,14 @@ export class LocalQueryInfo {
     }
   }
 
+  /**
+   * Return the location of a query's evaluator log summary. This file may not exist yet,
+   * in which case it can be created by invoking `codeql generate log-summary`.
+   */
+  get evalLogSummaryLocation(): string {
+    return this.evalLogLocation + '.summary';
+  }
+
   get completed(): boolean {
     return !!this.completedQuery;
   }

--- a/extensions/ql-vscode/src/query-results.ts
+++ b/extensions/ql-vscode/src/query-results.ts
@@ -216,6 +216,7 @@ export class LocalQueryInfo {
 
   public failureReason: string | undefined;
   public completedQuery: CompletedQueryInfo | undefined;
+  public evalLogLocation: string | undefined;
   private config: QueryHistoryConfig | undefined;
 
   /**

--- a/extensions/ql-vscode/src/queryserver-client.ts
+++ b/extensions/ql-vscode/src/queryserver-client.ts
@@ -259,10 +259,10 @@ export function findQueryLogFile(resultPath: string): string {
   return path.join(resultPath, 'query.log');
 }
 
-export function findQueryStructLogFile(resultPath: string): string {
+export function findQueryEvalLogFile(resultPath: string): string {
   return path.join(resultPath, 'evaluator-log.jsonl');
 }
 
-export function findQueryStructLogSummaryFile(resultPath: string): string {
+export function findQueryEvalLogSummaryFile(resultPath: string): string {
   return path.join(resultPath, 'evaluator-log.jsonl.summary');
 }

--- a/extensions/ql-vscode/src/queryserver-client.ts
+++ b/extensions/ql-vscode/src/queryserver-client.ts
@@ -1,6 +1,5 @@
 import * as cp from 'child_process';
 import * as path from 'path';
-import * as fs from 'fs-extra';
 
 import { DisposableObject } from './pure/disposable-object';
 import { Disposable, CancellationToken, commands } from 'vscode';

--- a/extensions/ql-vscode/src/queryserver-client.ts
+++ b/extensions/ql-vscode/src/queryserver-client.ts
@@ -150,19 +150,6 @@ export class QueryServerClient extends DisposableObject {
       args.push('--old-eval-stats');
     }
 
-    if (await this.cliServer.cliConstraints.supportsStructuredEvalLog()) {
-      const structuredLogFile = `${this.opts.contextStoragePath}/structured-evaluator-log.json`;
-      await fs.ensureFile(structuredLogFile);
-
-      args.push('--evaluator-log');
-      args.push(structuredLogFile);
-
-      // We hard-code the verbosity level to 5 and minify to false.
-      // This will be the behavior of the per-query structured logging in the CLI after 2.8.3.
-      args.push('--evaluator-log-level');
-      args.push('5');
-    }
-
     if (this.config.debug) {
       args.push('--debug', '--tuple-counting');
     }

--- a/extensions/ql-vscode/src/queryserver-client.ts
+++ b/extensions/ql-vscode/src/queryserver-client.ts
@@ -262,3 +262,7 @@ export function findQueryLogFile(resultPath: string): string {
 export function findQueryStructLogFile(resultPath: string): string {
   return path.join(resultPath, 'evaluator-log.jsonl');
 }
+
+export function findQueryStructLogSummaryFile(resultPath: string): string {
+  return path.join(resultPath, 'evaluator-log.jsonl.summary');
+}

--- a/extensions/ql-vscode/src/queryserver-client.ts
+++ b/extensions/ql-vscode/src/queryserver-client.ts
@@ -146,7 +146,7 @@ export class QueryServerClient extends DisposableObject {
       args.push('--require-db-registration');
     }
 
-    if (await this.cliServer.cliConstraints.supportsOldEvalStats()) {
+    if (await this.cliServer.cliConstraints.supportsOldEvalStats() && !(await this.cliServer.cliConstraints.supportsPerQueryEvalLog())) {
       args.push('--old-eval-stats');
     }
 
@@ -257,4 +257,8 @@ export class QueryServerClient extends DisposableObject {
 
 export function findQueryLogFile(resultPath: string): string {
   return path.join(resultPath, 'query.log');
+}
+
+export function findQueryStructLogFile(resultPath: string): string {
+  return path.join(resultPath, 'evaluator-log.jsonl');
 }

--- a/extensions/ql-vscode/src/run-queries.ts
+++ b/extensions/ql-vscode/src/run-queries.ts
@@ -675,7 +675,7 @@ export async function compileAndRunQueryAgainstDatabase(
   progress: ProgressCallback,
   token: CancellationToken,
   templates?: messages.TemplateDefinitions,
-  queryInfo?: LocalQueryInfo,
+  queryInfo?: LocalQueryInfo, // May be omitted for queries not initiated by the user. If omitted we won't create a structured log for the query.
 ): Promise<QueryWithResults> {
   if (!dbItem.contents || !dbItem.contents.dbSchemeUri) {
     throw new Error(`Database ${dbItem.databaseUri} does not have a CodeQL database scheme.`);

--- a/extensions/ql-vscode/src/run-queries.ts
+++ b/extensions/ql-vscode/src/run-queries.ts
@@ -98,6 +98,10 @@ export class QueryEvaluationInfo {
     return qsClient.findQueryStructLogFile(this.querySaveDir);
   }
 
+  get structLogSummaryPath() {
+    return qsClient.findQueryStructLogSummaryFile(this.querySaveDir);
+  }
+
   get resultsPaths() {
     return {
       resultsPath: path.join(this.querySaveDir, 'results.bqrs'),
@@ -187,7 +191,12 @@ export class QueryEvaluationInfo {
           db: dataset,
           logPath: this.structLogPath,
         });
-        queryInfo.evalLogLocation = this.structLogPath;
+        if (this.hasStructLog()) {
+          queryInfo.evalLogLocation = this.structLogPath;
+          await qs.cliServer.generateLogSummary(this.structLogPath, this.structLogSummaryPath);
+        } else {
+          void showAndLogWarningMessage(`Failed to write structured log to ${this.structLogPath}.`);
+        }
       }
     }
     return result || {
@@ -281,6 +290,13 @@ export class QueryEvaluationInfo {
    */
   async hasCsv(): Promise<boolean> {
     return fs.pathExists(this.csvPath);
+  }
+
+  /**
+   * Holds if this query already has a completed structured log
+   */
+  async hasStructLog(): Promise<boolean> {
+    return fs.pathExists(this.structLogPath);
   }
 
   /**


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

I have made a few additions ✨ to a work in progress PR to add per-query structured evaluator logs that cannot be merged yet. Changes include:
- generating evaluator summary logs as soon as the raw logs are written rather than only when the user clicks "Show Evaluator Log (Summary)" so that
- the most expensive predicates and timing summary from the end of the summary file can be printed to the query server output window where our users expect it
- renames all instances where we call the logs "structured" to "eval" or "evaluator" log to match naming across the repository
- deprecates structured logging for a single query server instance as this is no longer necessary (rolls back #1151)

<img width="1485" alt="query-server-view" src="https://user-images.githubusercontent.com/39155301/158889443-f3ad97bc-3279-4886-a8fc-e44af3e54f10.png">

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
