### PR TITLE
Allow a custom branch name in settings file

### DIFF
--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -359,7 +359,7 @@ export async function setRemoteControllerRepo(repo: string | undefined) {
 }
 
 /**
- * The branch of "github/codeql-variant-analysis-action/" to use.
+ * The branch of "github/codeql-variant-analysis-action" to use with the "Run Variant Analysis" command.
  * Default value is "main".
  * Note: This command is only available for internal users.
  */
@@ -367,8 +367,4 @@ const ACTION_BRANCH = new Setting('actionBranch', REMOTE_QUERIES_SETTING);
 
 export function getActionBranch(): string {
   return ACTION_BRANCH.getValue<string>() || 'main';
-}
-
-export async function setActionBranch(branch: string | undefined) {
-  await ACTION_BRANCH.updateValue(branch, ConfigurationTarget.Global);
 }

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -357,3 +357,18 @@ export function getRemoteControllerRepo(): string | undefined {
 export async function setRemoteControllerRepo(repo: string | undefined) {
   await REMOTE_CONTROLLER_REPO.updateValue(repo, ConfigurationTarget.Global);
 }
+
+/**
+ * The branch of "github/codeql-variant-analysis-action/" to use.
+ * Default value is "main".
+ * Note: This command is only available for internal users.
+ */
+const ACTION_BRANCH = new Setting('actionBranch', REMOTE_QUERIES_SETTING);
+
+export function getActionBranch(): string {
+  return ACTION_BRANCH.getValue<string>() || 'main';
+}
+
+export async function setActionBranch(branch: string | undefined) {
+  await ACTION_BRANCH.updateValue(branch, ConfigurationTarget.Global);
+}

--- a/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
@@ -16,7 +16,7 @@ import {
 import { Credentials } from '../authentication';
 import * as cli from '../cli';
 import { logger } from '../logging';
-import { getRemoteControllerRepo, getRemoteRepositoryLists, setRemoteControllerRepo } from '../config';
+import { getActionBranch, getRemoteControllerRepo, getRemoteRepositoryLists, setRemoteControllerRepo } from '../config';
 import { ProgressCallback, UserCancellationException } from '../commandRunner';
 import { OctokitResponse } from '@octokit/types/dist-types';
 import { RemoteQuery } from './remote-query';
@@ -302,7 +302,8 @@ export async function runRemoteQuery(
       message: 'Sending request'
     });
 
-    const workflowRunId = await runRemoteQueriesApiRequest(credentials, 'main', language, repositories, owner, repo, base64Pack, dryRun);
+    const actionBranch = getActionBranch();
+    const workflowRunId = await runRemoteQueriesApiRequest(credentials, actionBranch, language, repositories, owner, repo, base64Pack, dryRun);
     const queryStartTime = Date.now();
     const queryMetadata = await tryGetQueryMetadata(cliServer, queryFile);
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

The variant analysis API endpoint accepts a parameter to control the branch of an action used as part of running the queries. This is for internal testing of changes. The option is not available to users who aren't github staff. But it is useful and it'll be more useful if we could set it from the preferences.

I tested it briefly and it seems to be working correctly and passing the value from the preferences file to the API method.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
  - No visible changes
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
  - No user-facing changes
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
  - Not required
