### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -1106,8 +1106,8 @@ class SplitBuffer {
     while (this.searchIndex <= (this.buffer.length - this.maxSeparatorLength)) {
       for (const separator of this.separators) {
         if (SplitBuffer.startsWith(this.buffer, separator, this.searchIndex)) {
-          const line = this.buffer.substr(0, this.searchIndex);
-          this.buffer = this.buffer.substr(this.searchIndex + separator.length);
+          const line = this.buffer.slice(0, this.searchIndex);
+          this.buffer = this.buffer.slice(this.searchIndex + separator.length);
           this.searchIndex = 0;
           return line;
         }

--- a/extensions/ql-vscode/src/test-adapter.ts
+++ b/extensions/ql-vscode/src/test-adapter.ts
@@ -76,7 +76,7 @@ export class QLTestAdapterFactory extends DisposableObject {
  * @param ext The new extension, including the `.`.
  */
 function changeExtension(p: string, ext: string): string {
-  return p.substr(0, p.length - path.extname(p).length) + ext;
+  return p.slice(0, -path.extname(p).length) + ext;
 }
 
 /**


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
