### PR TITLE
Minor refactoring to support downloading GitHub databases

### DIFF
--- a/extensions/ql-vscode/src/databaseFetcher.ts
+++ b/extensions/ql-vscode/src/databaseFetcher.ts
@@ -90,7 +90,7 @@ export async function promptImportLgtmDatabase(
   }
 
   if (looksLikeLgtmUrl(lgtmUrl)) {
-    const databaseUrl = await convertToDatabaseUrl(lgtmUrl, progress);
+    const databaseUrl = await convertLgtmUrlToDatabaseUrl(lgtmUrl, progress);
     if (databaseUrl) {
       const item = await databaseArchiveFetcher(
         databaseUrl,
@@ -446,7 +446,7 @@ function extractProjectSlug(lgtmUrl: string): string | undefined {
 }
 
 // exported for testing
-export async function convertToDatabaseUrl(
+export async function convertLgtmUrlToDatabaseUrl(
   lgtmUrl: string,
   progress: ProgressCallback) {
   try {

--- a/extensions/ql-vscode/src/databaseFetcher.ts
+++ b/extensions/ql-vscode/src/databaseFetcher.ts
@@ -467,7 +467,9 @@ export async function convertLgtmUrlToDatabaseUrl(
       }
     }
 
-    const language = await promptForLanguage(projectJson, progress);
+    const languages = projectJson?.languages?.map((lang: { language: string }) => lang.language) || [];
+
+    const language = await promptForLanguage(languages, progress);
     if (!language) {
       return;
     }
@@ -495,7 +497,7 @@ async function downloadLgtmProjectMetadata(lgtmUrl: string): Promise<any> {
 }
 
 async function promptForLanguage(
-  projectJson: any,
+  languages: string[],
   progress: ProgressCallback
 ): Promise<string | undefined> {
   progress({
@@ -503,17 +505,19 @@ async function promptForLanguage(
     step: 2,
     maxStep: 2
   });
-  if (!projectJson?.languages?.length) {
+  if (!languages.length) {
     return;
   }
-  if (projectJson.languages.length === 1) {
-    return projectJson.languages[0].language;
+  if (languages.length === 1) {
+    return languages[0];
   }
 
   return await window.showQuickPick(
-    projectJson.languages.map((lang: { language: string }) => lang.language), {
-    placeHolder: 'Select the database language to download:'
-  }
+    languages,
+    {
+      placeHolder: 'Select the database language to download:',
+      ignoreFocusOut: true,
+    }
   );
 }
 

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/databaseFetcher.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/databaseFetcher.test.ts
@@ -9,7 +9,7 @@ import * as chai from 'chai';
 import { window } from 'vscode';
 
 import {
-  convertToDatabaseUrl,
+  convertLgtmUrlToDatabaseUrl,
   looksLikeLgtmUrl,
   findDirWithFile,
 } from '../../databaseFetcher';
@@ -17,11 +17,11 @@ import { ProgressCallback } from '../../commandRunner';
 chai.use(chaiAsPromised);
 const expect = chai.expect;
 
-describe('databaseFetcher', function () {
+describe('databaseFetcher', function() {
   // These tests make API calls and may need extra time to complete.
   this.timeout(10000);
 
-  describe('convertToDatabaseUrl', () => {
+  describe('convertLgtmUrlToDatabaseUrl', () => {
     let sandbox: sinon.SinonSandbox;
     let quickPickSpy: sinon.SinonStub;
     let progressSpy: ProgressCallback;
@@ -39,7 +39,7 @@ describe('databaseFetcher', function () {
     it('should convert a project url to a database url', async () => {
       quickPickSpy.resolves('javascript');
       const lgtmUrl = 'https://lgtm.com/projects/g/github/codeql';
-      const dbUrl = await convertToDatabaseUrl(lgtmUrl, progressSpy);
+      const dbUrl = await convertLgtmUrlToDatabaseUrl(lgtmUrl, progressSpy);
 
       expect(dbUrl).to.equal(
         'https://lgtm.com/api/v1.0/snapshots/1506465042581/javascript'
@@ -52,7 +52,7 @@ describe('databaseFetcher', function () {
       quickPickSpy.resolves('python');
       const lgtmUrl =
         'https://lgtm.com/projects/g/github/codeql/subpage/subpage2?query=xxx';
-      const dbUrl = await convertToDatabaseUrl(lgtmUrl, progressSpy);
+      const dbUrl = await convertLgtmUrlToDatabaseUrl(lgtmUrl, progressSpy);
 
       expect(dbUrl).to.equal(
         'https://lgtm.com/api/v1.0/snapshots/1506465042581/python'
@@ -64,7 +64,7 @@ describe('databaseFetcher', function () {
       quickPickSpy.resolves('python');
       const lgtmUrl =
         'g/github/codeql';
-      const dbUrl = await convertToDatabaseUrl(lgtmUrl, progressSpy);
+      const dbUrl = await convertLgtmUrlToDatabaseUrl(lgtmUrl, progressSpy);
 
       expect(dbUrl).to.equal(
         'https://lgtm.com/api/v1.0/snapshots/1506465042581/python'
@@ -75,7 +75,7 @@ describe('databaseFetcher', function () {
     it('should fail on a nonexistent project', async () => {
       quickPickSpy.resolves('javascript');
       const lgtmUrl = 'https://lgtm.com/projects/g/github/hucairz';
-      await expect(convertToDatabaseUrl(lgtmUrl, progressSpy)).to.rejectedWith(/Invalid LGTM URL/);
+      await expect(convertLgtmUrlToDatabaseUrl(lgtmUrl, progressSpy)).to.rejectedWith(/Invalid LGTM URL/);
       expect(progressSpy).to.have.callCount(0);
     });
   });


### PR DESCRIPTION
Two small things I wanted to separate out from the main work for https://github.com/github/vscode-codeql/issues/1123:
- Rename `convertToDatabaseUrl` to `convertLgtmUrlToDatabaseUrl` (so we have space for a `convertGitHubUrlToDatabaseUrl` function in future)
- Make `promptForLanguage` accept a general array of languages instead of LGTM-specific metadata

cc @robertbrignull 

## Checklist

N/A - this is prep work for https://github.com/github/vscode-codeql/issues/1123.

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
