### PR TITLE
Add source map support and clean test dependencies

### DIFF
--- a/extensions/ql-vscode/package-lock.json
+++ b/extensions/ql-vscode/package-lock.json
@@ -101,6 +101,7 @@
         "proxyquire": "~2.1.3",
         "sinon": "~9.0.0",
         "sinon-chai": "~3.5.0",
+        "source-map-support": "^0.5.21",
         "style-loader": "~0.23.1",
         "through2": "^4.0.2",
         "ts-loader": "^8.1.0",
@@ -11237,9 +11238,9 @@
       }
     },
     "node_modules/source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -22861,9 +22862,9 @@
       }
     },
     "source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1202,6 +1202,7 @@
     "proxyquire": "~2.1.3",
     "sinon": "~9.0.0",
     "sinon-chai": "~3.5.0",
+    "source-map-support": "^0.5.21",
     "style-loader": "~0.23.1",
     "through2": "^4.0.2",
     "ts-loader": "^8.1.0",

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -1,3 +1,4 @@
+import 'source-map-support/register';
 import {
   CancellationToken,
   CancellationTokenSource,

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/helpers.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/helpers.test.ts
@@ -1,6 +1,5 @@
 import * as path from 'path';
 import { extensions } from 'vscode';
-import 'mocha';
 
 import { CodeQLCliServer } from '../../cli';
 import { CodeQLExtensionInterface } from '../../extension';

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/index.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/index.ts
@@ -1,7 +1,9 @@
+import 'source-map-support/register';
 import { runTestsInDirectory } from '../index-template';
 import 'mocha';
 import * as sinonChai from 'sinon-chai';
 import * as chai from 'chai';
+import 'chai/register-should';
 import * as chaiAsPromised from 'chai-as-promised';
 chai.use(chaiAsPromised);
 chai.use(sinonChai);

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/packaging.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/packaging.test.ts
@@ -1,6 +1,5 @@
 import * as sinon from 'sinon';
 import { extensions, window } from 'vscode';
-import 'mocha';
 import * as path from 'path';
 
 import * as pq from 'proxyquire';

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/queries.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/queries.test.ts
@@ -3,7 +3,6 @@ import { CancellationToken, commands, ExtensionContext, extensions, Uri } from '
 import * as sinon from 'sinon';
 import * as path from 'path';
 import * as fs from 'fs-extra';
-import 'mocha';
 import { expect } from 'chai';
 import * as yaml from 'js-yaml';
 

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/query.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/query.test.ts
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import * as fs from 'fs-extra';
-import 'mocha';
 import * as path from 'path';
 import * as tmp from 'tmp';
 import * as url from 'url';

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/run-remote-query.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/run-remote-query.test.ts
@@ -2,7 +2,6 @@ import { assert, expect } from 'chai';
 import * as path from 'path';
 import * as sinon from 'sinon';
 import { CancellationToken, extensions, QuickPickItem, Uri, window } from 'vscode';
-import 'mocha';
 import * as fs from 'fs-extra';
 import * as os from 'os';
 import * as yaml from 'js-yaml';

--- a/extensions/ql-vscode/src/vscode-tests/minimal-workspace/activation.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/minimal-workspace/activation.test.ts
@@ -1,12 +1,7 @@
 import * as assert from 'assert';
-import * as chai from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
-import 'mocha';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import * as determiningSelectedQueryTest from './determining-selected-query-test';
-
-chai.use(chaiAsPromised);
 
 describe('launching with a minimal workspace', async () => {
 

--- a/extensions/ql-vscode/src/vscode-tests/minimal-workspace/config.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/minimal-workspace/config.test.ts
@@ -1,9 +1,6 @@
 import 'vscode-test';
-import 'mocha';
-import * as chaiAsPromised from 'chai-as-promised';
-import 'sinon-chai';
 import * as Sinon from 'sinon';
-import * as chai from 'chai';
+import { expect } from 'chai';
 import { workspace } from 'vscode';
 
 import {
@@ -11,9 +8,6 @@ import {
   QueryHistoryConfigListener,
   QueryServerConfigListener
 } from '../../config';
-
-chai.use(chaiAsPromised);
-const expect = chai.expect;
 
 describe('config listeners', function() {
   // Because we are adding some extra waiting, need to bump the test timeouts.

--- a/extensions/ql-vscode/src/vscode-tests/minimal-workspace/databases.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/minimal-workspace/databases.test.ts
@@ -1,5 +1,4 @@
 import 'vscode-test';
-import 'mocha';
 import * as sinon from 'sinon';
 import * as tmp from 'tmp';
 import * as fs from 'fs-extra';

--- a/extensions/ql-vscode/src/vscode-tests/minimal-workspace/index.ts
+++ b/extensions/ql-vscode/src/vscode-tests/minimal-workspace/index.ts
@@ -1,11 +1,12 @@
+import 'source-map-support/register';
 import { runTestsInDirectory } from '../index-template';
 
 import * as sinonChai from 'sinon-chai';
 import * as chai from 'chai';
+import 'chai/register-should';
 import * as chaiAsPromised from 'chai-as-promised';
 chai.use(chaiAsPromised);
 chai.use(sinonChai);
-
 
 export function run(): Promise<void> {
   return runTestsInDirectory(__dirname);

--- a/extensions/ql-vscode/src/vscode-tests/minimal-workspace/qltest-discovery.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/minimal-workspace/qltest-discovery.test.ts
@@ -1,5 +1,4 @@
 import 'vscode-test';
-import 'mocha';
 import { Uri, WorkspaceFolder } from 'vscode';
 import { expect } from 'chai';
 import * as fs from 'fs-extra';

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/astViewer.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/astViewer.test.ts
@@ -1,6 +1,5 @@
 import * as fs from 'fs-extra';
-import * as chai from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import { expect } from 'chai';
 import * as sinon from 'sinon';
 import * as yaml from 'js-yaml';
 
@@ -8,11 +7,6 @@ import { AstViewer, AstItem } from '../../astViewer';
 import { commands, Range, Uri } from 'vscode';
 import { DatabaseItem } from '../../databases';
 import { testDisposeHandler } from '../test-dispose-handler';
-
-chai.use(chaiAsPromised);
-const expect = chai.expect;
-
-
 
 describe('AstViewer', () => {
   let astRoots: AstItem[];

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/contextual/astBuilder.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/contextual/astBuilder.test.ts
@@ -1,6 +1,5 @@
 import * as fs from 'fs-extra';
-import * as chai from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import { expect } from 'chai';
 import * as sinon from 'sinon';
 
 import AstBuilder from '../../../contextual/astBuilder';
@@ -8,9 +7,6 @@ import { QueryWithResults } from '../../../run-queries';
 import { CodeQLCliServer } from '../../../cli';
 import { DatabaseItem } from '../../../databases';
 import { Uri } from 'vscode';
-
-chai.use(chaiAsPromised);
-const expect = chai.expect;
 
 /**
  *

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/contextual/fileRangeFromURI.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/contextual/fileRangeFromURI.test.ts
@@ -1,5 +1,4 @@
 import 'vscode-test';
-import 'mocha';
 import { expect } from 'chai';
 import { Uri, Range } from 'vscode';
 

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/contextual/queryResolver.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/contextual/queryResolver.test.ts
@@ -1,18 +1,12 @@
 import 'vscode-test';
-import 'mocha';
 import * as yaml from 'js-yaml';
-import * as chaiAsPromised from 'chai-as-promised';
 import * as sinon from 'sinon';
-import * as chai from 'chai';
-import * as sinonChai from 'sinon-chai';
+import { expect } from 'chai';
 import * as pq from 'proxyquire';
 import { KeyType } from '../../../contextual/keyType';
 import { getErrorMessage } from '../../../pure/helpers-pure';
 
 const proxyquire = pq.noPreserveCache().noCallThru();
-chai.use(chaiAsPromised);
-chai.use(sinonChai);
-const expect = chai.expect;
 
 describe('queryResolver', () => {
   let module: Record<string, Function>;

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/databaseFetcher.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/databaseFetcher.test.ts
@@ -1,11 +1,9 @@
 import 'vscode-test';
-import 'mocha';
-import * as chaiAsPromised from 'chai-as-promised';
 import * as sinon from 'sinon';
 import * as path from 'path';
 import * as fs from 'fs-extra';
 import * as tmp from 'tmp';
-import * as chai from 'chai';
+import { expect } from 'chai';
 import { window } from 'vscode';
 
 import {
@@ -18,8 +16,6 @@ import { ProgressCallback } from '../../commandRunner';
 import * as pq from 'proxyquire';
 
 const proxyquire = pq.noPreserveCache();
-chai.use(chaiAsPromised);
-const expect = chai.expect;
 
 describe('databaseFetcher', function() {
   // These tests make API calls and may need extra time to complete.

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/databases-ui.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/databases-ui.test.ts
@@ -1,5 +1,4 @@
 import 'vscode-test';
-import 'mocha';
 import * as tmp from 'tmp';
 import * as path from 'path';
 import * as fs from 'fs-extra';

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/distribution.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/distribution.test.ts
@@ -1,18 +1,13 @@
-import * as chai from 'chai';
+import { expect } from 'chai';
 import * as path from 'path';
 import * as fetch from 'node-fetch';
-import 'chai/register-should';
 import * as semver from 'semver';
-import * as sinonChai from 'sinon-chai';
 import * as sinon from 'sinon';
 import * as pq from 'proxyquire';
-import 'mocha';
 
 import { GithubRelease, GithubReleaseAsset, ReleasesApiConsumer } from '../../distribution';
 
 const proxyquire = pq.noPreserveCache();
-chai.use(sinonChai);
-const expect = chai.expect;
 
 describe('Releases API consumer', () => {
   const owner = 'someowner';
@@ -95,7 +90,7 @@ describe('Releases API consumer', () => {
     it('fails if none of the releases are within the version range', async () => {
       const consumer = new MockReleasesApiConsumer(owner, repo);
 
-      await chai.expect(
+      await expect(
         consumer.getLatestRelease(new semver.Range('5.*.*'))
       ).to.be.rejectedWith(Error);
     });
@@ -114,7 +109,7 @@ describe('Releases API consumer', () => {
     it('fails if none of the releases pass the additional compatibility test', async () => {
       const consumer = new MockReleasesApiConsumer(owner, repo);
 
-      await chai.expect(consumer.getLatestRelease(
+      await expect(consumer.getLatestRelease(
         new semver.Range('2.*.*'),
         true,
         release => release.assets.some(asset => asset.name === 'otherExampleAsset.txt')

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/helpers.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/helpers.test.ts
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import 'mocha';
 import {
   EnvironmentVariableCollection,
   EnvironmentVariableMutator,

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/index.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/index.ts
@@ -1,4 +1,13 @@
+import 'source-map-support/register';
 import { runTestsInDirectory } from '../index-template';
+import * as sinonChai from 'sinon-chai';
+import * as chai from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
+import 'chai/register-should';
+
+chai.use(chaiAsPromised);
+chai.use(sinonChai);
+
 export function run(): Promise<void> {
   return runTestsInDirectory(__dirname);
 }

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
@@ -1,12 +1,9 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import * as chai from 'chai';
-import 'mocha';
-import 'sinon-chai';
+import { expect, assert } from 'chai';
 import * as vscode from 'vscode';
 import * as sinon from 'sinon';
 
-import * as chaiAsPromised from 'chai-as-promised';
 import { logger } from '../../logging';
 import { registerQueryHistoryScubber } from '../../query-history-scrubber';
 import { QueryHistoryManager, HistoryTreeDataProvider, SortOrder } from '../../query-history';
@@ -20,10 +17,6 @@ import * as tmp from 'tmp-promise';
 import { ONE_DAY_IN_MS, ONE_HOUR_IN_MS, TWO_HOURS_IN_MS, THREE_HOURS_IN_MS } from '../../pure/helpers-pure';
 import { tmpDir } from '../../helpers';
 import { getErrorMessage } from '../../pure/helpers-pure';
-
-chai.use(chaiAsPromised);
-const expect = chai.expect;
-const assert = chai.assert;
 
 describe('query-history', () => {
   const mockExtensionLocation = path.join(tmpDir.name, 'mock-extension-location');

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/query-results.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/query-results.test.ts
@@ -1,10 +1,7 @@
-import * as chai from 'chai';
+import { expect } from 'chai';
 import * as path from 'path';
 import * as fs from 'fs-extra';
-import 'mocha';
-import 'sinon-chai';
 import * as sinon from 'sinon';
-import * as chaiAsPromised from 'chai-as-promised';
 import { LocalQueryInfo, InitialQueryInfo, interpretResultsSarif } from '../../query-results';
 import { QueryEvaluationInfo, QueryWithResults } from '../../run-queries';
 import { QueryHistoryConfig } from '../../config';
@@ -14,9 +11,6 @@ import { CodeQLCliServer, SourceInfo } from '../../cli';
 import { CancellationTokenSource, Uri, env } from 'vscode';
 import { tmpDir } from '../../helpers';
 import { slurpQueryHistory, splatQueryHistory } from '../../query-serialization';
-
-chai.use(chaiAsPromised);
-const expect = chai.expect;
 
 describe('query-results', () => {
   let disposeSpy: sinon.SinonSpy;

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-query-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-query-history.test.ts
@@ -1,10 +1,7 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as sinon from 'sinon';
-import * as chai from 'chai';
-import 'mocha';
-import 'sinon-chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import { expect } from 'chai';
 
 import { CancellationToken, ExtensionContext, Uri, window, workspace } from 'vscode';
 import { QueryHistoryConfig } from '../../config';
@@ -19,9 +16,6 @@ import { DisposableBucket } from '../disposable-bucket';
 import { testDisposeHandler } from '../test-dispose-handler';
 import { walkDirectory } from '../../helpers';
 import { getErrorMessage } from '../../pure/helpers-pure';
-
-chai.use(chaiAsPromised);
-const expect = chai.expect;
 
 /**
  * Tests for remote queries and how they interact with the query history manager.

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/run-queries.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/run-queries.test.ts
@@ -1,17 +1,11 @@
-import * as chai from 'chai';
+import { expect } from 'chai';
 import * as path from 'path';
-import 'mocha';
-import 'sinon-chai';
 import * as sinon from 'sinon';
-import * as chaiAsPromised from 'chai-as-promised';
 import { Uri } from 'vscode';
 
 import { QueryEvaluationInfo } from '../../run-queries';
 import { Severity, compileQuery } from '../../pure/messages';
 import * as config from '../../config';
-
-chai.use(chaiAsPromised);
-const expect = chai.expect;
 
 describe('run-queries', () => {
   let sandbox: sinon.SinonSandbox;

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/run-remote-query.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/run-remote-query.test.ts
@@ -1,14 +1,10 @@
 import 'vscode-test';
-import 'mocha';
-import * as chaiAsPromised from 'chai-as-promised';
 import * as sinon from 'sinon';
-import * as chai from 'chai';
+import { expect } from 'chai';
 import { window } from 'vscode';
 import * as pq from 'proxyquire';
 
 const proxyquire = pq.noPreserveCache();
-chai.use(chaiAsPromised);
-const expect = chai.expect;
 
 describe('run-remote-query', function() {
 

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/telemetry.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/telemetry.test.ts
@@ -1,17 +1,11 @@
-import * as chai from 'chai';
-import 'mocha';
-import 'sinon-chai';
+import { expect } from 'chai';
 import * as sinon from 'sinon';
-import * as chaiAsPromised from 'chai-as-promised';
 import TelemetryReporter from 'vscode-extension-telemetry';
 import { ExtensionContext, workspace, ConfigurationTarget, window } from 'vscode';
 import { TelemetryListener, telemetryListener as globalTelemetryListener } from '../../telemetry';
 import { UserCancellationException } from '../../commandRunner';
 import { fail } from 'assert';
 import { ENABLE_TELEMETRY } from '../../config';
-
-chai.use(chaiAsPromised);
-const expect = chai.expect;
 
 const sandbox = sinon.createSandbox();
 

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/test-adapter.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/test-adapter.test.ts
@@ -1,5 +1,4 @@
 import 'vscode-test';
-import 'mocha';
 import * as sinon from 'sinon';
 import * as fs from 'fs-extra';
 import { Uri, WorkspaceFolder } from 'vscode';
@@ -138,7 +137,7 @@ describe('test-adapter', () => {
     // However, we can pretend the same thing by just returning an async array.
     runTestsSpy = sandox.stub();
     runTestsSpy.returns(
-      (async function* () {
+      (async function*() {
         yield Promise.resolve({
           test: Uri.parse('file:/ab/c/d.ql').fsPath,
           pass: true,


### PR DESCRIPTION
1. Source map support means that stack traces will point to the *.ts
   file instead of the generated *.js file
2. Cleaning test dependencies means moving all mocha and chai
   registration into the respective index files and removing unnecessary
   imports.

Development only. No user facing changes.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
