### PR TITLE
Print end-of-query summary logs to Query Server Console

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Avoid synchronizing the `codeQL.cli.executablePath` setting. [#1252](https://github.com/github/vscode-codeql/pull/1252)
 - Open the directory in the finder/explorer (instead of just highlighting it) when running the "Open query directory" command from the query history view. [#1235](https://github.com/github/vscode-codeql/pull/1235)
 - Ensure query label in the query history view changes are persisted across restarts. [#1235](https://github.com/github/vscode-codeql/pull/1235)
+- Prints end-of-query evaluator log summaries to the Query Server Console. [#1264](https://github.com/github/vscode-codeql/pull/1264)
 
 ## 1.6.1 - 17 March 2022
 

--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -667,15 +667,18 @@ export class CodeQLCliServer implements Disposable {
 
   /**
   * Generate a summary of an evaluation log.
+  * @param endSummaryPath The path to write only the end of query part of the human-readable summary to. 
   * @param inputPath The path of an evaluation event log.
   * @param outputPath The path to write a human-readable summary of it to.
   */
    async generateLogSummary(
     inputPath: string,
     outputPath: string,
+    endSummaryPath: string,
   ): Promise<string> {
     const subcommandArgs = [
       '--format=text',
+      `--end-summary=${endSummaryPath}`,
       inputPath,
       outputPath
     ];

--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -1282,8 +1282,14 @@ export class CliVersionConstraint {
 
    /**
     * CLI version that supports rotating structured logs to produce one per query.
+    * 
+    * Note that 2.8.4 supports generating the evaluation logs and summaries,
+    * but 2.9.0 includes a new option to produce the end-of-query summary logs to
+    * the query server console. For simplicity we gate all features behind 2.9.0,
+    * but if a user is tied to the 2.8 release, we can enable evaluator logs 
+    * and summaries for them.
     */
-    public static CLI_VERSION_WITH_PER_QUERY_EVAL_LOG = new SemVer('2.8.4');
+    public static CLI_VERSION_WITH_PER_QUERY_EVAL_LOG = new SemVer('2.9.0');
 
   constructor(private readonly cli: CodeQLCliServer) {
     /**/

--- a/extensions/ql-vscode/src/pure/messages.ts
+++ b/extensions/ql-vscode/src/pure/messages.ts
@@ -722,7 +722,7 @@ export interface StartLogResult {
 }
 
 /**
- * The result of terminating a structured.
+ * The result of terminating a structured log.
  */
 export interface EndLogResult {
   /**

--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -781,6 +781,11 @@ export class QueryHistoryManager extends DisposableObject {
     void showAndLogWarningMessage('No evaluator log is available for this run. Perhaps it failed before evaluation, or you are running with a version of CodeQL before ' + CliVersionConstraint.CLI_VERSION_WITH_PER_QUERY_EVAL_LOG + '?');
   }
 
+  private warnNoEvalLogSummary() {
+    void showAndLogWarningMessage('No evaluator log summary is available for this run. Perhaps it failed before evaluation, or you are running with a version of CodeQL before ' + CliVersionConstraint.CLI_VERSION_WITH_PER_QUERY_EVAL_LOG + '?');
+  }
+
+
   async handleShowEvalLog(
     singleItem: QueryHistoryInfo,
     multiSelect: QueryHistoryInfo[]
@@ -810,13 +815,10 @@ export class QueryHistoryManager extends DisposableObject {
       return;
     }
 
-    if (finalSingleItem.evalLogLocation) {
-      if (!fs.existsSync(finalSingleItem.evalLogSummaryLocation)) {
-        await this.qs.cliServer.generateLogSummary(finalSingleItem.evalLogLocation, finalSingleItem.evalLogSummaryLocation);
-      }
-      await this.tryOpenExternalFile(finalSingleItem.evalLogSummaryLocation);
+    if (finalSingleItem.evalLogSummaryLocation) {
+        await this.tryOpenExternalFile(finalSingleItem.evalLogSummaryLocation);
     } else {
-      this.warnNoEvalLog();
+      this.warnNoEvalLogSummary();
     }
   }
 

--- a/extensions/ql-vscode/src/query-results.ts
+++ b/extensions/ql-vscode/src/query-results.ts
@@ -217,6 +217,7 @@ export class LocalQueryInfo {
   public failureReason: string | undefined;
   public completedQuery: CompletedQueryInfo | undefined;
   public evalLogLocation: string | undefined;
+  public evalLogSummaryLocation: string | undefined;
   private config: QueryHistoryConfig | undefined;
 
   /**
@@ -310,14 +311,6 @@ export class LocalQueryInfo {
     } else {
       return this.getQueryFileName();
     }
-  }
-
-  /**
-   * Return the location of a query's evaluator log summary. This file may not exist yet,
-   * in which case it can be created by invoking `codeql generate log-summary`.
-   */
-  get evalLogSummaryLocation(): string {
-    return this.evalLogLocation + '.summary';
   }
 
   get completed(): boolean {

--- a/extensions/ql-vscode/src/queryserver-client.ts
+++ b/extensions/ql-vscode/src/queryserver-client.ts
@@ -259,14 +259,14 @@ export function findQueryLogFile(resultPath: string): string {
   return path.join(resultPath, 'query.log');
 }
 
-export function findQueryStructLogFile(resultPath: string): string {
+export function findQueryEvalLogFile(resultPath: string): string {
   return path.join(resultPath, 'evaluator-log.jsonl');
 }
 
-export function findQueryStructLogSummaryFile(resultPath: string): string {
+export function findQueryEvalLogSummaryFile(resultPath: string): string {
   return path.join(resultPath, 'evaluator-log.jsonl.summary');
 }
 
-export function findQueryStructLogEndSummaryFile(resultPath: string): string {
+export function findQueryEvalLogEndSummaryFile(resultPath: string): string {
   return path.join(resultPath, 'eoq-evaluator-log.jsonl.summary');
 }

--- a/extensions/ql-vscode/src/queryserver-client.ts
+++ b/extensions/ql-vscode/src/queryserver-client.ts
@@ -262,3 +262,11 @@ export function findQueryLogFile(resultPath: string): string {
 export function findQueryStructLogFile(resultPath: string): string {
   return path.join(resultPath, 'evaluator-log.jsonl');
 }
+
+export function findQueryStructLogSummaryFile(resultPath: string): string {
+  return path.join(resultPath, 'evaluator-log.jsonl.summary');
+}
+
+export function findQueryStructLogEndSummaryFile(resultPath: string): string {
+  return path.join(resultPath, 'eoq-evaluator-log.jsonl.summary');
+}

--- a/extensions/ql-vscode/src/queryserver-client.ts
+++ b/extensions/ql-vscode/src/queryserver-client.ts
@@ -264,9 +264,9 @@ export function findQueryEvalLogFile(resultPath: string): string {
 }
 
 export function findQueryEvalLogSummaryFile(resultPath: string): string {
-  return path.join(resultPath, 'evaluator-log.jsonl.summary');
+  return path.join(resultPath, 'evaluator-log.summary');
 }
 
 export function findQueryEvalLogEndSummaryFile(resultPath: string): string {
-  return path.join(resultPath, 'eoq-evaluator-log.jsonl.summary');
+  return path.join(resultPath, 'evaluator-log-end.summary');
 }

--- a/extensions/ql-vscode/src/run-queries.ts
+++ b/extensions/ql-vscode/src/run-queries.ts
@@ -197,10 +197,9 @@ export class QueryEvaluationInfo {
           db: dataset,
           logPath: this.evalLogPath,
         });
-        if (this.hasEvalLog()) {
+        if (await this.hasEvalLog()) {
           queryInfo.evalLogLocation = this.evalLogPath;
           await qs.cliServer.generateLogSummary(this.evalLogPath, this.evalLogSummaryPath, this.evalLogEndSummaryPath);
-          
           fs.readFile(this.evalLogEndSummaryPath, (err, buffer) => {
             if (err) {
               throw new Error(`Could not read structured evaluator log end of summary file at ${this.evalLogEndSummaryPath}.`);

--- a/extensions/ql-vscode/src/run-queries.ts
+++ b/extensions/ql-vscode/src/run-queries.ts
@@ -95,16 +95,16 @@ export class QueryEvaluationInfo {
     return qsClient.findQueryLogFile(this.querySaveDir);
   }
 
-  get structLogPath() {
-    return qsClient.findQueryStructLogFile(this.querySaveDir);
+  get evalLogPath() {
+    return qsClient.findQueryEvalLogFile(this.querySaveDir);
   }
 
-  get structLogSummaryPath() {
-    return qsClient.findQueryStructLogSummaryFile(this.querySaveDir);
+  get evalLogSummaryPath() {
+    return qsClient.findQueryEvalLogSummaryFile(this.querySaveDir);
   }
 
-  get structLogEndSummaryPath() {
-    return qsClient.findQueryStructLogEndSummaryFile(this.querySaveDir);
+  get evalLogEndSummaryPath() {
+    return qsClient.findQueryEvalLogEndSummaryFile(this.querySaveDir);
   }
 
   get resultsPaths() {
@@ -172,7 +172,7 @@ export class QueryEvaluationInfo {
     if (queryInfo && await qs.cliServer.cliConstraints.supportsPerQueryEvalLog()) {
       await qs.sendRequest(messages.startLog, {
         db: dataset,
-        logPath: this.structLogPath,
+        logPath: this.evalLogPath,
       });
       
     }
@@ -195,21 +195,21 @@ export class QueryEvaluationInfo {
       if (queryInfo && await qs.cliServer.cliConstraints.supportsPerQueryEvalLog()) {
         await qs.sendRequest(messages.endLog, {
           db: dataset,
-          logPath: this.structLogPath,
+          logPath: this.evalLogPath,
         });
-        if (this.hasStructLog()) {
-          queryInfo.evalLogLocation = this.structLogPath;
-          await qs.cliServer.generateLogSummary(this.structLogPath, this.structLogSummaryPath, this.structLogEndSummaryPath);
+        if (this.hasEvalLog()) {
+          queryInfo.evalLogLocation = this.evalLogPath;
+          await qs.cliServer.generateLogSummary(this.evalLogPath, this.evalLogSummaryPath, this.evalLogEndSummaryPath);
           
-          fs.readFile(this.structLogEndSummaryPath, (err, buffer) => {
+          fs.readFile(this.evalLogEndSummaryPath, (err, buffer) => {
             if (err) {
-              throw new Error(`Could not read structured evaluator log end of summary file at ${this.structLogEndSummaryPath}.`);
+              throw new Error(`Could not read structured evaluator log end of summary file at ${this.evalLogEndSummaryPath}.`);
             }
             void qs.logger.log(' --- Evaluator Log Summary --- ', { additionalLogLocation: this.logPath });
             void qs.logger.log(buffer.toString(), { additionalLogLocation: this.logPath });
           });
         } else {
-          void showAndLogWarningMessage(`Failed to write structured evaluator log to ${this.structLogPath}.`);
+          void showAndLogWarningMessage(`Failed to write structured evaluator log to ${this.evalLogPath}.`);
         }
       }
     }
@@ -328,8 +328,8 @@ export class QueryEvaluationInfo {
   /**
    * Holds if this query already has a completed structured evaluator log
    */
-   async hasStructLog(): Promise<boolean> {
-    return fs.pathExists(this.structLogPath);
+   async hasEvalLog(): Promise<boolean> {
+    return fs.pathExists(this.evalLogPath);
   }
 
   /**

--- a/extensions/ql-vscode/src/run-queries.ts
+++ b/extensions/ql-vscode/src/run-queries.ts
@@ -200,6 +200,7 @@ export class QueryEvaluationInfo {
         if (await this.hasEvalLog()) {
           queryInfo.evalLogLocation = this.evalLogPath;
           await qs.cliServer.generateLogSummary(this.evalLogPath, this.evalLogSummaryPath, this.evalLogEndSummaryPath);
+          queryInfo.evalLogSummaryLocation = this.evalLogSummaryPath;
           fs.readFile(this.evalLogEndSummaryPath, (err, buffer) => {
             if (err) {
               throw new Error(`Could not read structured evaluator log end of summary file at ${this.evalLogEndSummaryPath}.`);

--- a/extensions/ql-vscode/src/run-queries.ts
+++ b/extensions/ql-vscode/src/run-queries.ts
@@ -204,8 +204,8 @@ export class QueryEvaluationInfo {
             if (err) {
               throw new Error(`Could not read structured evaluator log end of summary file at ${this.evalLogEndSummaryPath}.`);
             }
-            void qs.logger.log(' --- Evaluator Log Summary --- ', { additionalLogLocation: this.logPath });
-            void qs.logger.log(buffer.toString(), { additionalLogLocation: this.logPath });
+            void qs.logger.log(' --- Evaluator Log Summary --- ');
+            void qs.logger.log(buffer.toString());
           });
         } else {
           void showAndLogWarningMessage(`Failed to write structured evaluator log to ${this.evalLogPath}.`);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->
This change passes the `--end-summary=$eoq-evaluator-log.jsonl.summary` option to the CLI so that a separate file in the given location is written, with only the end-of-query summary information (most expensive predicate and timings). It then directly logs the contents of this file to the query server console.

It also changes the CLI version we gate all evaluator logs behind to 2.9.0 for simplicity. Otherwise, we would need to pass in one set of arguments to the CLI for 2.8.4 and another for 2.9.0. If in the future a user must be on a 2.8.x release and would like evaluator logs, we will be able to modify this for them easily.

This has been tested locally on VSCode (by modifying the CLI version expected to 2.8.3 and using the main checkout of the CLI) and works as we expect:
<img width="1756" alt="Screen Shot 2022-03-30 at 4 18 36 PM" src="https://user-images.githubusercontent.com/39155301/160946240-8ce58f01-4288-4f5d-b450-e52981b72f55.png">

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
