### PR TITLE
Use the repos defined in the query result instead of the query

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
@@ -71,6 +71,7 @@ export class RemoteQueriesInterfaceManager {
     const totalResultCount = queryResult.analysisSummaries.reduce((acc, cur) => acc + cur.resultCount, 0);
     const executionDuration = this.getDuration(queryResult.executionEndTime, query.executionStartTime);
     const analysisSummaries = this.buildAnalysisSummaries(queryResult.analysisSummaries);
+    const totalRepositoryCount = queryResult.analysisSummaries.length;
     const affectedRepositories = queryResult.analysisSummaries.filter(r => r.resultCount > 0);
 
     return {
@@ -80,7 +81,7 @@ export class RemoteQueriesInterfaceManager {
       queryText: query.queryText,
       language: query.language,
       workflowRunUrl: `https://github.com/${query.controllerRepository.owner}/${query.controllerRepository.name}/actions/runs/${query.actionsWorkflowRunId}`,
-      totalRepositoryCount: query.repositories.length,
+      totalRepositoryCount: totalRepositoryCount,
       affectedRepositoryCount: affectedRepositories.length,
       totalResultCount: totalResultCount,
       executionTimestamp: this.formatDate(query.executionStartTime),

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
@@ -226,7 +226,8 @@ export class RemoteQueriesManager extends DisposableObject {
 
   private async askToOpenResults(query: RemoteQuery, queryResult: RemoteQueryResult): Promise<void> {
     const totalResultCount = queryResult.analysisSummaries.reduce((acc, cur) => acc + cur.resultCount, 0);
-    const message = `Query "${query.queryName}" run on ${query.repositories.length} repositories and returned ${totalResultCount} results`;
+    const totalRepoCount = queryResult.analysisSummaries.length;
+    const message = `Query "${query.queryName}" run on ${totalRepoCount} repositories and returned ${totalResultCount} results`;
 
     const shouldOpenView = await showInformationMessageWithAction(message, 'View');
     if (shouldOpenView) {

--- a/extensions/ql-vscode/src/remote-queries/remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-query.ts
@@ -6,7 +6,6 @@ export interface RemoteQuery {
   queryText: string;
   language: string;
   controllerRepository: Repository;
-  repositories: Repository[];
   executionStartTime: number; // Use number here since it needs to be serialized and desserialized.
   actionsWorkflowRunId: number;
 }

--- a/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
@@ -308,7 +308,6 @@ export async function runRemoteQuery(
       }
 
       const remoteQuery = await buildRemoteQueryEntity(
-        repositories,
         queryFile,
         queryMetadata,
         owner,
@@ -395,7 +394,6 @@ async function ensureNameAndSuite(queryPackDir: string, packRelativePath: string
 }
 
 async function buildRemoteQueryEntity(
-  repositories: string[],
   queryFilePath: string,
   queryMetadata: QueryMetadata | undefined,
   controllerRepoOwner: string,
@@ -406,11 +404,6 @@ async function buildRemoteQueryEntity(
 ): Promise<RemoteQuery> {
   // The query name is either the name as specified in the query metadata, or the file name.
   const queryName = queryMetadata?.name ?? path.basename(queryFilePath);
-
-  const queryRepos = repositories.map(r => {
-    const [owner, repo] = r.split('/');
-    return { owner: owner, name: repo };
-  });
 
   const queryText = await fs.readFile(queryFilePath, 'utf8');
 
@@ -423,7 +416,6 @@ async function buildRemoteQueryEntity(
       owner: controllerRepoOwner,
       name: controllerRepoName,
     },
-    repositories: queryRepos,
     executionStartTime: queryStartTime,
     actionsWorkflowRunId: workflowRunId
   };


### PR DESCRIPTION
In order to support system defined repo lists (see linked internal issue) we need to stop relying on the repository names being available to us on the query object, but instead get that information from the query result.

This PR updates a couple of uses of the repo lists to be using the query result instead of the query.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
