### PR TITLE
Move reository selection code to own module

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/repository-selection.ts
+++ b/extensions/ql-vscode/src/remote-queries/repository-selection.ts
@@ -1,0 +1,54 @@
+import { QuickPickItem, window } from 'vscode';
+import { showAndLogErrorMessage } from '../helpers';
+import { getRemoteRepositoryLists } from '../config';
+import { logger } from '../logging';
+import { REPO_REGEX } from '../pure/helpers-pure';
+
+interface RepoListQuickPickItem extends QuickPickItem {
+  repoList: string[];
+}
+
+/**
+ * Gets the repositories to run the query against.
+ */
+export async function getRepositories(): Promise<string[] | undefined> {
+  const repoLists = getRemoteRepositoryLists();
+  if (repoLists && Object.keys(repoLists).length) {
+    const quickPickItems = Object.entries(repoLists).map<RepoListQuickPickItem>(([key, value]) => (
+      {
+        label: key,       // the name of the repository list
+        repoList: value,  // the actual array of repositories
+      }
+    ));
+    const quickpick = await window.showQuickPick<RepoListQuickPickItem>(
+      quickPickItems,
+      {
+        placeHolder: 'Select a repository list. You can define repository lists in the `codeQL.variantAnalysis.repositoryLists` setting.',
+        ignoreFocusOut: true,
+      });
+    if (quickpick?.repoList.length) {
+      void logger.log(`Selected repositories: ${quickpick.repoList.join(', ')}`);
+      return quickpick.repoList;
+    } else {
+      void showAndLogErrorMessage('No repositories selected.');
+      return;
+    }
+  } else {
+    void logger.log('No repository lists defined. Displaying text input box.');
+    const remoteRepo = await window.showInputBox({
+      title: 'Enter a GitHub repository in the format <owner>/<repo> (e.g. github/codeql)',
+      placeHolder: '<owner>/<repo>',
+      prompt: 'Tip: you can save frequently used repositories in the `codeQL.variantAnalysis.repositoryLists` setting',
+      ignoreFocusOut: true,
+    });
+    if (!remoteRepo) {
+      void showAndLogErrorMessage('No repositories entered.');
+      return;
+    } else if (!REPO_REGEX.test(remoteRepo)) { // Check if user entered invalid input
+      void showAndLogErrorMessage('Invalid repository format. Must be in the format <owner>/<repo> (e.g. github/codeql)');
+      return;
+    }
+    void logger.log(`Entered repository: ${remoteRepo}`);
+    return [remoteRepo];
+  }
+}


### PR DESCRIPTION
The `run-remote-query` module is getting quite large, and we're about to add more complexity to it to handle system defined repository lists, so I've extracted functionality that deals with repository selection out into its own module.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
