### PR TITLE
Move remote queries test files to be under remote-queries dir

### DIFF
--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/run-remote-query.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/run-remote-query.test.ts
@@ -6,16 +6,16 @@ import * as fs from 'fs-extra';
 import * as os from 'os';
 import * as yaml from 'js-yaml';
 
-import { QlPack, runRemoteQuery } from '../../remote-queries/run-remote-query';
-import { Credentials } from '../../authentication';
-import { CliVersionConstraint, CodeQLCliServer } from '../../cli';
-import { CodeQLExtensionInterface } from '../../extension';
-import { setRemoteControllerRepo, setRemoteRepositoryLists } from '../../config';
-import { UserCancellationException } from '../../commandRunner';
+import { QlPack, runRemoteQuery } from '../../../remote-queries/run-remote-query';
+import { Credentials } from '../../../authentication';
+import { CliVersionConstraint, CodeQLCliServer } from '../../../cli';
+import { CodeQLExtensionInterface } from '../../../extension';
+import { setRemoteControllerRepo, setRemoteRepositoryLists } from '../../../config';
+import { UserCancellationException } from '../../../commandRunner';
 import { lte } from 'semver';
 
 describe('Remote queries', function() {
-  const baseDir = path.join(__dirname, '../../../src/vscode-tests/cli-integration');
+  const baseDir = path.join(__dirname, '../../../../src/vscode-tests/cli-integration');
 
   let sandbox: sinon.SinonSandbox;
 

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/remote-query-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/remote-query-history.test.ts
@@ -4,18 +4,18 @@ import * as sinon from 'sinon';
 import { expect } from 'chai';
 
 import { CancellationToken, ExtensionContext, Uri, window, workspace } from 'vscode';
-import { QueryHistoryConfig } from '../../config';
-import { DatabaseManager } from '../../databases';
-import { tmpDir } from '../../helpers';
-import { QueryHistoryManager } from '../../query-history';
-import { QueryServerClient } from '../../queryserver-client';
-import { Credentials } from '../../authentication';
-import { AnalysesResultsManager } from '../../remote-queries/analyses-results-manager';
-import { RemoteQueryResult } from '../../remote-queries/shared/remote-query-result';
-import { DisposableBucket } from '../disposable-bucket';
-import { testDisposeHandler } from '../test-dispose-handler';
-import { walkDirectory } from '../../helpers';
-import { getErrorMessage } from '../../pure/helpers-pure';
+import { QueryHistoryConfig } from '../../../config';
+import { DatabaseManager } from '../../../databases';
+import { tmpDir } from '../../../helpers';
+import { QueryHistoryManager } from '../../../query-history';
+import { QueryServerClient } from '../../../queryserver-client';
+import { Credentials } from '../../../authentication';
+import { AnalysesResultsManager } from '../../../remote-queries/analyses-results-manager';
+import { RemoteQueryResult } from '../../../remote-queries/shared/remote-query-result';
+import { DisposableBucket } from '../../disposable-bucket';
+import { testDisposeHandler } from '../../test-dispose-handler';
+import { walkDirectory } from '../../../helpers';
+import { getErrorMessage } from '../../../pure/helpers-pure';
 
 /**
  * Tests for remote queries and how they interact with the query history manager.
@@ -23,7 +23,7 @@ import { getErrorMessage } from '../../pure/helpers-pure';
 
 describe('Remote queries and query history manager', function() {
 
-  const EXTENSION_PATH = path.join(__dirname, '../../../');
+  const EXTENSION_PATH = path.join(__dirname, '../../../../');
   const STORAGE_DIR = Uri.file(path.join(tmpDir.name, 'remote-queries')).fsPath;
   const asyncNoop = async () => { /** noop */ };
 
@@ -353,7 +353,7 @@ describe('Remote queries and query history manager', function() {
 
   async function copyHistoryState() {
     fs.ensureDirSync(STORAGE_DIR);
-    fs.copySync(path.join(__dirname, 'data/remote-queries/'), path.join(tmpDir.name, 'remote-queries'));
+    fs.copySync(path.join(__dirname, '../data/remote-queries/'), path.join(tmpDir.name, 'remote-queries'));
 
     // also, replace the files with "PLACEHOLDER" so that they have the correct directory
     for await (const p of walkDirectory(STORAGE_DIR)) {

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/repository-selection.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/repository-selection.test.ts
@@ -21,7 +21,6 @@ describe('repository-selection', function() {
       showInputBoxSpy = sandbox.stub(window, 'showInputBox');
       getRemoteRepositoryListsSpy = sandbox.stub();
       showAndLogErrorMessageSpy = sandbox.stub();
-      // extensions/ql-vscode/src/remote-queries/repository-selection.ts
       mod = proxyquire('../../../remote-queries/repository-selection', {
         '../config': {
           getRemoteRepositoryLists: getRemoteRepositoryListsSpy


### PR DESCRIPTION
Some test files were already under a 'remote-queries' subdir but some weren't so I've moved everything.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
