### PR TITLE
Update dependency-review.yml

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,5 +1,7 @@
 name: 'Dependency Review'
-on: [pull_request]
+on:
+  - pull_request
+  - workflow_dispatch
 
 permissions:
   contents: read

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,11 +1,8 @@
 name: 'Dependency Review'
-on: 
-  - pull_request
-  - workflow_dispatch
+on: [pull_request]
 
 permissions:
-  actions: read
-  pull-requests: read
+  contents: read
 
 jobs:
   dependency-review:
@@ -14,4 +11,4 @@ jobs:
       - name: 'Checkout Repository'
         uses: actions/checkout@v3
       - name: 'Dependency Review'
-        uses: dsp-testing/dependency-review-action@main
+        uses: actions/dependency-review-action@v1


### PR DESCRIPTION
This PR updates the `dependency-review.yml` workflow to use the a public URL and version. Pushing as a draft, will mark as ready for review once we've GA'd.

Tracking issue: https://github.com/github/dependency-graph/issues/1019