### PR TITLE
Reenable publishing to open-vsx

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,13 +147,11 @@ jobs:
                   If this was an authentication problem, please make sure the \
                   auth token hasn't expired."
 
-  # TODO This job is currently broken and is blocked on https://github.com/github/vscode-codeql/issues/1085
   open-vsx-publish:
     name: Publish to Open VSX Registry
     needs: build
     environment: publish-open-vsx
     runs-on: ubuntu-latest
-    if: 1 == 0
     env:
       OPEN_VSX_TOKEN: ${{ secrets.OPEN_VSX_TOKEN }}
     steps:

--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [UNRELEASED]
 
+- Re-enable publishing to open-vsx. [#1285](https://github.com/github/vscode-codeql/pull/1285)
+
 ## 1.6.4 - 6 April 2022
 
 No user facing changes.

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -21,8 +21,7 @@
     "Programming Languages"
   ],
   "extensionDependencies": [
-    "hbenl.vscode-test-explorer",
-    "ms-vscode.test-adapter-converter"
+    "hbenl.vscode-test-explorer"
   ],
   "capabilities": {
     "untrustedWorkspaces": {


### PR DESCRIPTION
The extension ms-vscode.test-adapter-converter is now available on
open-vsx, but under a different name.

Fixes https://github.com/github/vscode-codeql/issues/1085

I have verified that I can publish and install the extension by
manually publishing v1.6.4.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Replace this with a description of the changes your pull request makes.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
