### PR TITLE
Create markdown files for sharing results

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1222,7 +1222,7 @@
     }
   },
   "lint-staged": {
-    "./**/*.{json,css,scss,md}": [
+    "./**/*.{json,css,scss}": [
       "prettier --write"
     ],
     "./**/*.{ts,tsx}": [

--- a/extensions/ql-vscode/src/pure/location-link-utils.ts
+++ b/extensions/ql-vscode/src/pure/location-link-utils.ts
@@ -13,17 +13,3 @@ export function createRemoteFileRef(
     return `${fileLink.fileLinkPrefix}/${fileLink.filePath}`;
   }
 }
-
-/**
- * Creates a markdown link to a remote file.
- * If the "link text" is not provided, we use the file path.
- */
-export function createMarkdownRemoteFileRef(
-  fileLink: FileLink,
-  startLine?: number,
-  endLine?: number,
-  linkText?: string,
-): string {
-  const markdownLink = `[${linkText || fileLink.filePath}](${createRemoteFileRef(fileLink, startLine, endLine)})`;
-  return markdownLink;
-}

--- a/extensions/ql-vscode/src/pure/location-link-utils.ts
+++ b/extensions/ql-vscode/src/pure/location-link-utils.ts
@@ -13,3 +13,17 @@ export function createRemoteFileRef(
     return `${fileLink.fileLinkPrefix}/${fileLink.filePath}`;
   }
 }
+
+/**
+ * Creates a markdown link to a remote file.
+ * If the "link text" is not provided, we use the file path.
+ */
+export function createMarkdownRemoteFileRef(
+  fileLink: FileLink,
+  startLine?: number,
+  endLine?: number,
+  linkText?: string,
+): string {
+  const markdownLink = `[${linkText || fileLink.filePath}](${createRemoteFileRef(fileLink, startLine, endLine)})`;
+  return markdownLink;
+}

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-markdown-generation.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-markdown-generation.ts
@@ -1,14 +1,18 @@
-import { createMarkdownRemoteFileRef } from '../pure/location-link-utils';
+import { createRemoteFileRef } from '../pure/location-link-utils';
 import { RemoteQuery } from './remote-query';
-import { AnalysisAlert, AnalysisResults } from './shared/analysis-result';
+import { AnalysisAlert, AnalysisResults, FileLink } from './shared/analysis-result';
 
 // Each array item is a line of the markdown file.
 export type MarkdownFile = string[];
 
+/**
+ * Generates markdown files with variant analysis results.
+ */
 export function generateMarkdown(query: RemoteQuery, analysesResults: AnalysisResults[]): MarkdownFile[] {
   const files: MarkdownFile[] = [];
   for (const analysisResult of analysesResults) {
     if (analysisResult.interpretedResults.length === 0) {
+      // TODO: We'll add support for non-interpreted results later.
       continue;
     }
     const lines = [
@@ -31,17 +35,15 @@ function generateMarkdownForInterpretedResult(interpretedResult: AnalysisAlert, 
     interpretedResult.fileLink,
     interpretedResult.highlightedRegion?.startLine,
     interpretedResult.highlightedRegion?.endLine
-  ), '');
+  ));
+  lines.push('');
   const codeSnippet = interpretedResult.codeSnippet?.text;
   if (codeSnippet) {
     lines.push(
-      `\`\`\`${language}`,
-      ...codeSnippet.split('\n'),
-      '```',
-      ''
+      ...generateMarkdownForCodeSnippet(codeSnippet, language),
     );
   }
-  const alertMessage = buildAlertMessage(interpretedResult);
+  const alertMessage = buildMarkdownAlertMessage(interpretedResult);
   lines.push(alertMessage);
 
   // Padding between results
@@ -53,7 +55,18 @@ function generateMarkdownForInterpretedResult(interpretedResult: AnalysisAlert, 
   return lines;
 }
 
-function buildAlertMessage(interpretedResult: AnalysisAlert): string {
+function generateMarkdownForCodeSnippet(codeSnippet: string, language: string): MarkdownFile {
+  const lines: MarkdownFile = [];
+  lines.push(
+    `\`\`\`${language}`,
+    ...codeSnippet.split('\n'),
+    '```',
+  );
+  lines.push('');
+  return lines;
+}
+
+function buildMarkdownAlertMessage(interpretedResult: AnalysisAlert): string {
   let alertMessage = '';
   for (const token of interpretedResult.message.tokens) {
     if (token.t === 'text') {
@@ -67,5 +80,20 @@ function buildAlertMessage(interpretedResult: AnalysisAlert): string {
       );
     }
   }
-  return alertMessage;
+  // Italicize the alert message
+  return `*${alertMessage}*`;
+}
+
+/**
+ * Creates a markdown link to a remote file.
+ * If the "link text" is not provided, we use the file path.
+ */
+export function createMarkdownRemoteFileRef(
+  fileLink: FileLink,
+  startLine?: number,
+  endLine?: number,
+  linkText?: string,
+): string {
+  const markdownLink = `[${linkText || fileLink.filePath}](${createRemoteFileRef(fileLink, startLine, endLine)})`;
+  return markdownLink;
 }

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-markdown-generation.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-markdown-generation.ts
@@ -1,0 +1,71 @@
+import { createMarkdownRemoteFileRef } from '../pure/location-link-utils';
+import { RemoteQuery } from './remote-query';
+import { AnalysisAlert, AnalysisResults } from './shared/analysis-result';
+
+// Each array item is a line of the markdown file.
+export type MarkdownFile = string[];
+
+export function generateMarkdown(query: RemoteQuery, analysesResults: AnalysisResults[]): MarkdownFile[] {
+  const files: MarkdownFile[] = [];
+  for (const analysisResult of analysesResults) {
+    if (analysisResult.interpretedResults.length === 0) {
+      continue;
+    }
+    const lines = [
+      `### ${analysisResult.nwo}`,
+      ''
+    ];
+    for (const interpretedResult of analysisResult.interpretedResults) {
+      const individualResult = generateMarkdownForInterpretedResult(interpretedResult, query.language);
+      lines.push(...individualResult);
+    }
+    files.push(lines);
+  }
+  return files;
+
+}
+
+function generateMarkdownForInterpretedResult(interpretedResult: AnalysisAlert, language: string): MarkdownFile {
+  const lines: MarkdownFile = [];
+  lines.push(createMarkdownRemoteFileRef(
+    interpretedResult.fileLink,
+    interpretedResult.highlightedRegion?.startLine,
+    interpretedResult.highlightedRegion?.endLine
+  ), '');
+  const codeSnippet = interpretedResult.codeSnippet?.text;
+  if (codeSnippet) {
+    lines.push(
+      `\`\`\`${language}`,
+      ...codeSnippet.split('\n'),
+      '```',
+      ''
+    );
+  }
+  const alertMessage = buildAlertMessage(interpretedResult);
+  lines.push(alertMessage);
+
+  // Padding between results
+  lines.push(
+    '',
+    '----------------------------------------',
+    '',
+  );
+  return lines;
+}
+
+function buildAlertMessage(interpretedResult: AnalysisAlert): string {
+  let alertMessage = '';
+  for (const token of interpretedResult.message.tokens) {
+    if (token.t === 'text') {
+      alertMessage += token.text;
+    } else if (token.t === 'location') {
+      alertMessage += createMarkdownRemoteFileRef(
+        token.location.fileLink,
+        token.location.highlightedRegion?.startLine,
+        token.location.highlightedRegion?.endLine,
+        token.text,
+      );
+    }
+  }
+  return alertMessage;
+}

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/interpreted-results/data/analyses-results.json
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/interpreted-results/data/analyses-results.json
@@ -1,0 +1,626 @@
+[
+  {
+    "nwo": "github/codeql",
+    "status": "Completed",
+    "interpretedResults": [
+      {
+        "message": {
+          "tokens": [
+            {
+              "t": "text",
+              "text": "This shell command depends on an uncontrolled "
+            },
+            {
+              "t": "location",
+              "text": "absolute path",
+              "location": {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b",
+                  "filePath": "javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js"
+                },
+                "highlightedRegion": {
+                  "startLine": 4,
+                  "startColumn": 35,
+                  "endLine": 4,
+                  "endColumn": 44
+                }
+              }
+            },
+            { "t": "text", "text": "." }
+          ]
+        },
+        "shortDescription": "This shell command depends on an uncontrolled ,absolute path,.",
+        "fileLink": {
+          "fileLinkPrefix": "https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b",
+          "filePath": "javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js"
+        },
+        "severity": "Warning",
+        "codeSnippet": {
+          "startLine": 3,
+          "endLine": 6,
+          "text": "function cleanupTemp() {\n  let cmd = \"rm -rf \" + path.join(__dirname, \"temp\");\n  cp.execSync(cmd); // BAD\n}\n"
+        },
+        "highlightedRegion": {
+          "startLine": 5,
+          "startColumn": 15,
+          "endLine": 5,
+          "endColumn": 18
+        },
+        "codeFlows": [
+          {
+            "threadFlows": [
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b",
+                  "filePath": "javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js"
+                },
+                "codeSnippet": {
+                  "startLine": 2,
+                  "endLine": 6,
+                  "text": "  path = require(\"path\");\nfunction cleanupTemp() {\n  let cmd = \"rm -rf \" + path.join(__dirname, \"temp\");\n  cp.execSync(cmd); // BAD\n}\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 4,
+                  "startColumn": 35,
+                  "endLine": 4,
+                  "endColumn": 44
+                }
+              },
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b",
+                  "filePath": "javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js"
+                },
+                "codeSnippet": {
+                  "startLine": 2,
+                  "endLine": 6,
+                  "text": "  path = require(\"path\");\nfunction cleanupTemp() {\n  let cmd = \"rm -rf \" + path.join(__dirname, \"temp\");\n  cp.execSync(cmd); // BAD\n}\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 4,
+                  "startColumn": 25,
+                  "endLine": 4,
+                  "endColumn": 53
+                }
+              },
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b",
+                  "filePath": "javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js"
+                },
+                "codeSnippet": {
+                  "startLine": 2,
+                  "endLine": 6,
+                  "text": "  path = require(\"path\");\nfunction cleanupTemp() {\n  let cmd = \"rm -rf \" + path.join(__dirname, \"temp\");\n  cp.execSync(cmd); // BAD\n}\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 4,
+                  "startColumn": 13,
+                  "endLine": 4,
+                  "endColumn": 53
+                }
+              },
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b",
+                  "filePath": "javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js"
+                },
+                "codeSnippet": {
+                  "startLine": 2,
+                  "endLine": 6,
+                  "text": "  path = require(\"path\");\nfunction cleanupTemp() {\n  let cmd = \"rm -rf \" + path.join(__dirname, \"temp\");\n  cp.execSync(cmd); // BAD\n}\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 4,
+                  "startColumn": 7,
+                  "endLine": 4,
+                  "endColumn": 53
+                }
+              },
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b",
+                  "filePath": "javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js"
+                },
+                "codeSnippet": {
+                  "startLine": 3,
+                  "endLine": 6,
+                  "text": "function cleanupTemp() {\n  let cmd = \"rm -rf \" + path.join(__dirname, \"temp\");\n  cp.execSync(cmd); // BAD\n}\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 5,
+                  "startColumn": 15,
+                  "endLine": 5,
+                  "endColumn": 18
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "message": {
+          "tokens": [
+            {
+              "t": "text",
+              "text": "This shell command depends on an uncontrolled "
+            },
+            {
+              "t": "location",
+              "text": "absolute path",
+              "location": {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b",
+                  "filePath": "javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js"
+                },
+                "highlightedRegion": {
+                  "startLine": 6,
+                  "startColumn": 36,
+                  "endLine": 6,
+                  "endColumn": 45
+                }
+              }
+            },
+            { "t": "text", "text": "." }
+          ]
+        },
+        "shortDescription": "This shell command depends on an uncontrolled ,absolute path,.",
+        "fileLink": {
+          "fileLinkPrefix": "https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b",
+          "filePath": "javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js"
+        },
+        "severity": "Warning",
+        "codeSnippet": {
+          "startLine": 4,
+          "endLine": 8,
+          "text": "(function() {\n\tcp.execFileSync('rm',  ['-rf', path.join(__dirname, \"temp\")]); // GOOD\n\tcp.execSync('rm -rf ' + path.join(__dirname, \"temp\")); // BAD\n\n\texeca.shell('rm -rf ' + path.join(__dirname, \"temp\")); // NOT OK\n"
+        },
+        "highlightedRegion": {
+          "startLine": 6,
+          "startColumn": 14,
+          "endLine": 6,
+          "endColumn": 54
+        },
+        "codeFlows": [
+          {
+            "threadFlows": [
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b",
+                  "filePath": "javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js"
+                },
+                "codeSnippet": {
+                  "startLine": 4,
+                  "endLine": 8,
+                  "text": "(function() {\n\tcp.execFileSync('rm',  ['-rf', path.join(__dirname, \"temp\")]); // GOOD\n\tcp.execSync('rm -rf ' + path.join(__dirname, \"temp\")); // BAD\n\n\texeca.shell('rm -rf ' + path.join(__dirname, \"temp\")); // NOT OK\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 6,
+                  "startColumn": 36,
+                  "endLine": 6,
+                  "endColumn": 45
+                }
+              },
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b",
+                  "filePath": "javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js"
+                },
+                "codeSnippet": {
+                  "startLine": 4,
+                  "endLine": 8,
+                  "text": "(function() {\n\tcp.execFileSync('rm',  ['-rf', path.join(__dirname, \"temp\")]); // GOOD\n\tcp.execSync('rm -rf ' + path.join(__dirname, \"temp\")); // BAD\n\n\texeca.shell('rm -rf ' + path.join(__dirname, \"temp\")); // NOT OK\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 6,
+                  "startColumn": 26,
+                  "endLine": 6,
+                  "endColumn": 54
+                }
+              },
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b",
+                  "filePath": "javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js"
+                },
+                "codeSnippet": {
+                  "startLine": 4,
+                  "endLine": 8,
+                  "text": "(function() {\n\tcp.execFileSync('rm',  ['-rf', path.join(__dirname, \"temp\")]); // GOOD\n\tcp.execSync('rm -rf ' + path.join(__dirname, \"temp\")); // BAD\n\n\texeca.shell('rm -rf ' + path.join(__dirname, \"temp\")); // NOT OK\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 6,
+                  "startColumn": 14,
+                  "endLine": 6,
+                  "endColumn": 54
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "message": {
+          "tokens": [
+            {
+              "t": "text",
+              "text": "This shell command depends on an uncontrolled "
+            },
+            {
+              "t": "location",
+              "text": "absolute path",
+              "location": {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b",
+                  "filePath": "javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js"
+                },
+                "highlightedRegion": {
+                  "startLine": 8,
+                  "startColumn": 36,
+                  "endLine": 8,
+                  "endColumn": 45
+                }
+              }
+            },
+            { "t": "text", "text": "." }
+          ]
+        },
+        "shortDescription": "This shell command depends on an uncontrolled ,absolute path,.",
+        "fileLink": {
+          "fileLinkPrefix": "https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b",
+          "filePath": "javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js"
+        },
+        "severity": "Warning",
+        "codeSnippet": {
+          "startLine": 6,
+          "endLine": 10,
+          "text": "\tcp.execSync('rm -rf ' + path.join(__dirname, \"temp\")); // BAD\n\n\texeca.shell('rm -rf ' + path.join(__dirname, \"temp\")); // NOT OK\n\texeca.shellSync('rm -rf ' + path.join(__dirname, \"temp\")); // NOT OK\n\n"
+        },
+        "highlightedRegion": {
+          "startLine": 8,
+          "startColumn": 14,
+          "endLine": 8,
+          "endColumn": 54
+        },
+        "codeFlows": [
+          {
+            "threadFlows": [
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b",
+                  "filePath": "javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js"
+                },
+                "codeSnippet": {
+                  "startLine": 6,
+                  "endLine": 10,
+                  "text": "\tcp.execSync('rm -rf ' + path.join(__dirname, \"temp\")); // BAD\n\n\texeca.shell('rm -rf ' + path.join(__dirname, \"temp\")); // NOT OK\n\texeca.shellSync('rm -rf ' + path.join(__dirname, \"temp\")); // NOT OK\n\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 8,
+                  "startColumn": 36,
+                  "endLine": 8,
+                  "endColumn": 45
+                }
+              },
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b",
+                  "filePath": "javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js"
+                },
+                "codeSnippet": {
+                  "startLine": 6,
+                  "endLine": 10,
+                  "text": "\tcp.execSync('rm -rf ' + path.join(__dirname, \"temp\")); // BAD\n\n\texeca.shell('rm -rf ' + path.join(__dirname, \"temp\")); // NOT OK\n\texeca.shellSync('rm -rf ' + path.join(__dirname, \"temp\")); // NOT OK\n\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 8,
+                  "startColumn": 26,
+                  "endLine": 8,
+                  "endColumn": 54
+                }
+              },
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b",
+                  "filePath": "javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js"
+                },
+                "codeSnippet": {
+                  "startLine": 6,
+                  "endLine": 10,
+                  "text": "\tcp.execSync('rm -rf ' + path.join(__dirname, \"temp\")); // BAD\n\n\texeca.shell('rm -rf ' + path.join(__dirname, \"temp\")); // NOT OK\n\texeca.shellSync('rm -rf ' + path.join(__dirname, \"temp\")); // NOT OK\n\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 8,
+                  "startColumn": 14,
+                  "endLine": 8,
+                  "endColumn": 54
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "message": {
+          "tokens": [
+            {
+              "t": "text",
+              "text": "This shell command depends on an uncontrolled "
+            },
+            {
+              "t": "location",
+              "text": "absolute path",
+              "location": {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b",
+                  "filePath": "javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js"
+                },
+                "highlightedRegion": {
+                  "startLine": 9,
+                  "startColumn": 40,
+                  "endLine": 9,
+                  "endColumn": 49
+                }
+              }
+            },
+            { "t": "text", "text": "." }
+          ]
+        },
+        "shortDescription": "This shell command depends on an uncontrolled ,absolute path,.",
+        "fileLink": {
+          "fileLinkPrefix": "https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b",
+          "filePath": "javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js"
+        },
+        "severity": "Warning",
+        "codeSnippet": {
+          "startLine": 7,
+          "endLine": 11,
+          "text": "\n\texeca.shell('rm -rf ' + path.join(__dirname, \"temp\")); // NOT OK\n\texeca.shellSync('rm -rf ' + path.join(__dirname, \"temp\")); // NOT OK\n\n\tconst safe = \"\\\"\" + path.join(__dirname, \"temp\") + \"\\\"\";\n"
+        },
+        "highlightedRegion": {
+          "startLine": 9,
+          "startColumn": 18,
+          "endLine": 9,
+          "endColumn": 58
+        },
+        "codeFlows": [
+          {
+            "threadFlows": [
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b",
+                  "filePath": "javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js"
+                },
+                "codeSnippet": {
+                  "startLine": 7,
+                  "endLine": 11,
+                  "text": "\n\texeca.shell('rm -rf ' + path.join(__dirname, \"temp\")); // NOT OK\n\texeca.shellSync('rm -rf ' + path.join(__dirname, \"temp\")); // NOT OK\n\n\tconst safe = \"\\\"\" + path.join(__dirname, \"temp\") + \"\\\"\";\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 9,
+                  "startColumn": 40,
+                  "endLine": 9,
+                  "endColumn": 49
+                }
+              },
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b",
+                  "filePath": "javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js"
+                },
+                "codeSnippet": {
+                  "startLine": 7,
+                  "endLine": 11,
+                  "text": "\n\texeca.shell('rm -rf ' + path.join(__dirname, \"temp\")); // NOT OK\n\texeca.shellSync('rm -rf ' + path.join(__dirname, \"temp\")); // NOT OK\n\n\tconst safe = \"\\\"\" + path.join(__dirname, \"temp\") + \"\\\"\";\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 9,
+                  "startColumn": 30,
+                  "endLine": 9,
+                  "endColumn": 58
+                }
+              },
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b",
+                  "filePath": "javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js"
+                },
+                "codeSnippet": {
+                  "startLine": 7,
+                  "endLine": 11,
+                  "text": "\n\texeca.shell('rm -rf ' + path.join(__dirname, \"temp\")); // NOT OK\n\texeca.shellSync('rm -rf ' + path.join(__dirname, \"temp\")); // NOT OK\n\n\tconst safe = \"\\\"\" + path.join(__dirname, \"temp\") + \"\\\"\";\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 9,
+                  "startColumn": 18,
+                  "endLine": 9,
+                  "endColumn": 58
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "nwo": "test/no-results",
+    "status": "Completed",
+    "interpretedResults": []
+  },
+  {
+    "nwo": "meteor/meteor",
+    "status": "Completed",
+    "interpretedResults": [
+      {
+        "message": {
+          "tokens": [
+            {
+              "t": "text",
+              "text": "This shell command depends on an uncontrolled "
+            },
+            {
+              "t": "location",
+              "text": "absolute path",
+              "location": {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec",
+                  "filePath": "npm-packages/meteor-installer/config.js"
+                },
+                "highlightedRegion": {
+                  "startLine": 39,
+                  "startColumn": 20,
+                  "endLine": 39,
+                  "endColumn": 61
+                }
+              }
+            },
+            { "t": "text", "text": "." }
+          ]
+        },
+        "shortDescription": "This shell command depends on an uncontrolled ,absolute path,.",
+        "fileLink": {
+          "fileLinkPrefix": "https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec",
+          "filePath": "npm-packages/meteor-installer/install.js"
+        },
+        "severity": "Warning",
+        "codeSnippet": {
+          "startLine": 257,
+          "endLine": 261,
+          "text": "  if (isWindows()) {\n    //set for the current session and beyond\n    child_process.execSync(`setx path \"${meteorPath}/;%path%`);\n    return;\n  }\n"
+        },
+        "highlightedRegion": {
+          "startLine": 259,
+          "startColumn": 28,
+          "endLine": 259,
+          "endColumn": 62
+        },
+        "codeFlows": [
+          {
+            "threadFlows": [
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec",
+                  "filePath": "npm-packages/meteor-installer/config.js"
+                },
+                "codeSnippet": {
+                  "startLine": 37,
+                  "endLine": 41,
+                  "text": "\nconst meteorLocalFolder = '.meteor';\nconst meteorPath = path.resolve(rootPath, meteorLocalFolder);\n\nmodule.exports = {\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 39,
+                  "startColumn": 20,
+                  "endLine": 39,
+                  "endColumn": 61
+                }
+              },
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec",
+                  "filePath": "npm-packages/meteor-installer/config.js"
+                },
+                "codeSnippet": {
+                  "startLine": 37,
+                  "endLine": 41,
+                  "text": "\nconst meteorLocalFolder = '.meteor';\nconst meteorPath = path.resolve(rootPath, meteorLocalFolder);\n\nmodule.exports = {\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 39,
+                  "startColumn": 7,
+                  "endLine": 39,
+                  "endColumn": 61
+                }
+              },
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec",
+                  "filePath": "npm-packages/meteor-installer/config.js"
+                },
+                "codeSnippet": {
+                  "startLine": 42,
+                  "endLine": 46,
+                  "text": "  METEOR_LATEST_VERSION,\n  extractPath: rootPath,\n  meteorPath,\n  release: process.env.INSTALL_METEOR_VERSION || METEOR_LATEST_VERSION,\n  rootPath,\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 44,
+                  "startColumn": 3,
+                  "endLine": 44,
+                  "endColumn": 13
+                }
+              },
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec",
+                  "filePath": "npm-packages/meteor-installer/install.js"
+                },
+                "codeSnippet": {
+                  "startLine": 10,
+                  "endLine": 14,
+                  "text": "const os = require('os');\nconst {\n  meteorPath,\n  release,\n  startedPath,\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 12,
+                  "startColumn": 3,
+                  "endLine": 12,
+                  "endColumn": 13
+                }
+              },
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec",
+                  "filePath": "npm-packages/meteor-installer/install.js"
+                },
+                "codeSnippet": {
+                  "startLine": 9,
+                  "endLine": 25,
+                  "text": "const tmp = require('tmp');\nconst os = require('os');\nconst {\n  meteorPath,\n  release,\n  startedPath,\n  extractPath,\n  isWindows,\n  rootPath,\n  sudoUser,\n  isSudo,\n  isMac,\n  METEOR_LATEST_VERSION,\n  shouldSetupExecPath,\n} = require('./config.js');\nconst { uninstall } = require('./uninstall');\nconst {\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 11,
+                  "startColumn": 7,
+                  "endLine": 23,
+                  "endColumn": 27
+                }
+              },
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec",
+                  "filePath": "npm-packages/meteor-installer/install.js"
+                },
+                "codeSnippet": {
+                  "startLine": 257,
+                  "endLine": 261,
+                  "text": "  if (isWindows()) {\n    //set for the current session and beyond\n    child_process.execSync(`setx path \"${meteorPath}/;%path%`);\n    return;\n  }\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 259,
+                  "startColumn": 42,
+                  "endLine": 259,
+                  "endColumn": 52
+                }
+              },
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec",
+                  "filePath": "npm-packages/meteor-installer/install.js"
+                },
+                "codeSnippet": {
+                  "startLine": 257,
+                  "endLine": 261,
+                  "text": "  if (isWindows()) {\n    //set for the current session and beyond\n    child_process.execSync(`setx path \"${meteorPath}/;%path%`);\n    return;\n  }\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 259,
+                  "startColumn": 28,
+                  "endLine": 259,
+                  "endColumn": 62
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/interpreted-results/data/problem-query.json
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/interpreted-results/data/problem-query.json
@@ -1,0 +1,9 @@
+{
+  "queryName": "Shell command built from environment values",
+  "queryFilePath": "c:\\git-repo\\vscode-codeql-starter\\ql\\javascript\\ql\\src\\Security\\CWE-078\\ShellCommandInjectionFromEnvironment.ql",
+  "queryText": "/**\n * @name Shell command built from environment values\n * @description Building a shell command string with values from the enclosing\n *              environment may cause subtle bugs or vulnerabilities.\n * @kind path-problem\n * @problem.severity warning\n * @security-severity 6.3\n * @precision high\n * @id js/shell-command-injection-from-environment\n * @tags correctness\n *       security\n *       external/cwe/cwe-078\n *       external/cwe/cwe-088\n */\n\nimport javascript\nimport DataFlow::PathGraph\nimport semmle.javascript.security.dataflow.ShellCommandInjectionFromEnvironmentQuery\n\nfrom\n  Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink, DataFlow::Node highlight,\n  Source sourceNode\nwhere\n  sourceNode = source.getNode() and\n  cfg.hasFlowPath(source, sink) and\n  if cfg.isSinkWithHighlight(sink.getNode(), _)\n  then cfg.isSinkWithHighlight(sink.getNode(), highlight)\n  else highlight = sink.getNode()\nselect highlight, source, sink, \"This shell command depends on an uncontrolled $@.\", sourceNode,\n  sourceNode.getSourceType()\n",
+  "language": "javascript",
+  "controllerRepository": { "owner": "dsp-testing", "name": "qc-controller" },
+  "executionStartTime": 1649419081990,
+  "actionsWorkflowRunId": 2115000864
+}

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/interpreted-results/data/results-repo1.md
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/interpreted-results/data/results-repo1.md
@@ -1,0 +1,60 @@
+### github/codeql
+
+[javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js#L5-L5)
+
+```javascript
+function cleanupTemp() {
+  let cmd = "rm -rf " + path.join(__dirname, "temp");
+  cp.execSync(cmd); // BAD
+}
+
+```
+
+This shell command depends on an uncontrolled [absolute path](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js#L4-L4).
+
+----------------------------------------
+
+[javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L6-L6)
+
+```javascript
+(function() {
+	cp.execFileSync('rm',  ['-rf', path.join(__dirname, "temp")]); // GOOD
+	cp.execSync('rm -rf ' + path.join(__dirname, "temp")); // BAD
+
+	execa.shell('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
+
+```
+
+This shell command depends on an uncontrolled [absolute path](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L6-L6).
+
+----------------------------------------
+
+[javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L8-L8)
+
+```javascript
+	cp.execSync('rm -rf ' + path.join(__dirname, "temp")); // BAD
+
+	execa.shell('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
+	execa.shellSync('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
+
+
+```
+
+This shell command depends on an uncontrolled [absolute path](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L8-L8).
+
+----------------------------------------
+
+[javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L9-L9)
+
+```javascript
+
+	execa.shell('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
+	execa.shellSync('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
+
+	const safe = "\"" + path.join(__dirname, "temp") + "\"";
+
+```
+
+This shell command depends on an uncontrolled [absolute path](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L9-L9).
+
+----------------------------------------

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/interpreted-results/data/results-repo1.md
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/interpreted-results/data/results-repo1.md
@@ -10,7 +10,7 @@ function cleanupTemp() {
 
 ```
 
-This shell command depends on an uncontrolled [absolute path](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js#L4-L4).
+*This shell command depends on an uncontrolled [absolute path](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js#L4-L4).*
 
 ----------------------------------------
 
@@ -25,7 +25,7 @@ This shell command depends on an uncontrolled [absolute path](https://github.com
 
 ```
 
-This shell command depends on an uncontrolled [absolute path](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L6-L6).
+*This shell command depends on an uncontrolled [absolute path](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L6-L6).*
 
 ----------------------------------------
 
@@ -40,7 +40,7 @@ This shell command depends on an uncontrolled [absolute path](https://github.com
 
 ```
 
-This shell command depends on an uncontrolled [absolute path](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L8-L8).
+*This shell command depends on an uncontrolled [absolute path](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L8-L8).*
 
 ----------------------------------------
 
@@ -55,6 +55,6 @@ This shell command depends on an uncontrolled [absolute path](https://github.com
 
 ```
 
-This shell command depends on an uncontrolled [absolute path](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L9-L9).
+*This shell command depends on an uncontrolled [absolute path](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L9-L9).*
 
 ----------------------------------------

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/interpreted-results/data/results-repo2.md
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/interpreted-results/data/results-repo2.md
@@ -1,0 +1,16 @@
+### meteor/meteor
+
+[npm-packages/meteor-installer/install.js](https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec/npm-packages/meteor-installer/install.js#L259-L259)
+
+```javascript
+  if (isWindows()) {
+    //set for the current session and beyond
+    child_process.execSync(`setx path "${meteorPath}/;%path%`);
+    return;
+  }
+
+```
+
+This shell command depends on an uncontrolled [absolute path](https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec/npm-packages/meteor-installer/config.js#L39-L39).
+
+----------------------------------------

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/interpreted-results/data/results-repo2.md
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/interpreted-results/data/results-repo2.md
@@ -11,6 +11,6 @@
 
 ```
 
-This shell command depends on an uncontrolled [absolute path](https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec/npm-packages/meteor-installer/config.js#L39-L39).
+*This shell command depends on an uncontrolled [absolute path](https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec/npm-packages/meteor-installer/config.js#L39-L39).*
 
 ----------------------------------------

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/interpreted-results/markdown-generation.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/interpreted-results/markdown-generation.test.ts
@@ -23,8 +23,8 @@ describe('markdown generation', async function() {
     const expectedTestOutput1 = await fs.readFile(path.join(__dirname, 'data/results-repo1.md'), 'utf8');
     const expectedTestOutput2 = await fs.readFile(path.join(__dirname, 'data/results-repo2.md'), 'utf8');
 
-    // Check that markdown output is correct
-    expect(markdownFile1.join('\n')).to.equal(expectedTestOutput1);
-    expect(markdownFile2.join('\n')).to.equal(expectedTestOutput2);
+    // Check that markdown output is correct, after making line endings consistent
+    expect(markdownFile1.join('\n')).to.equal(expectedTestOutput1.replace(/\r?\n/g, '\n'));
+    expect(markdownFile2.join('\n')).to.equal(expectedTestOutput2.replace(/\r?\n/g, '\n'));
   });
 });

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/interpreted-results/markdown-generation.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/interpreted-results/markdown-generation.test.ts
@@ -20,11 +20,20 @@ describe('markdown generation', async function() {
     const markdownFile1 = markdownFiles[0]; // results for github/codeql repo
     const markdownFile2 = markdownFiles[1]; // results for meteor/meteor repo
 
-    const expectedTestOutput1 = await fs.readFile(path.join(__dirname, 'data/results-repo1.md'), 'utf8');
-    const expectedTestOutput2 = await fs.readFile(path.join(__dirname, 'data/results-repo2.md'), 'utf8');
+    const expectedTestOutput1 = await readTestOutputFile('data/results-repo1.md');
+    const expectedTestOutput2 = await readTestOutputFile('data/results-repo2.md');
 
     // Check that markdown output is correct, after making line endings consistent
-    expect(markdownFile1.join('\n')).to.equal(expectedTestOutput1.replace(/\r?\n/g, '\n'));
-    expect(markdownFile2.join('\n')).to.equal(expectedTestOutput2.replace(/\r?\n/g, '\n'));
+    expect(markdownFile1.join('\n')).to.equal(expectedTestOutput1);
+    expect(markdownFile2.join('\n')).to.equal(expectedTestOutput2);
   });
 });
+
+/**
+ * Reads a test output file and returns it as a string.
+ * Replaces line endings with '\n' for consistency across operating systems.
+ */
+async function readTestOutputFile(relativePath: string): Promise<string> {
+  const file = await fs.readFile(path.join(__dirname, relativePath), 'utf8');
+  return file.replace(/\r?\n/g, '\n');
+}

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/interpreted-results/markdown-generation.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/interpreted-results/markdown-generation.test.ts
@@ -1,0 +1,30 @@
+import { expect } from 'chai';
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import { generateMarkdown } from '../../../../../src/remote-queries/remote-queries-markdown-generation';
+
+describe('markdown generation', async function() {
+  it('should generate markdown file for each repo with results', async function() {
+    const problemQuery = JSON.parse(
+      await fs.readFile(path.join(__dirname, 'data/problem-query.json'), 'utf8')
+    );
+
+    const analysesResults = JSON.parse(
+      await fs.readFile(path.join(__dirname, 'data/analyses-results.json'), 'utf8')
+    );
+    const markdownFiles = generateMarkdown(problemQuery, analysesResults);
+
+    // Check that query has results for two repositories
+    expect(markdownFiles.length).to.equal(2);
+
+    const markdownFile1 = markdownFiles[0]; // results for github/codeql repo
+    const markdownFile2 = markdownFiles[1]; // results for meteor/meteor repo
+
+    const expectedTestOutput1 = await fs.readFile(path.join(__dirname, 'data/results-repo1.md'), 'utf8');
+    const expectedTestOutput2 = await fs.readFile(path.join(__dirname, 'data/results-repo2.md'), 'utf8');
+
+    // Check that markdown output is correct
+    expect(markdownFile1.join('\n')).to.equal(expectedTestOutput1);
+    expect(markdownFile2.join('\n')).to.equal(expectedTestOutput2);
+  });
+});


### PR DESCRIPTION
Eventually, users will be able to share results from variant analysis by linking to a generated markdown gist. We don't have the UX for this yet, so this just adds some backend functionality to generate markdown files for repos with results. The function isn't used anywhere yet, except in tests. You can see some example markdown output [here](https://github.com/github/vscode-codeql/blob/shati-patel/sharing-is-caring/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/interpreted-results/data/results-repo1.md) and [here](https://github.com/github/vscode-codeql/blob/shati-patel/sharing-is-caring/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/interpreted-results/data/results-repo2.md) 🖼️ 

See internal issue for details 👀 

Note: This just deals with alerts from problem queries. Will handle paths and non-interpreted results in a separate PR, but I wanted to get this out in smaller chunks, so it's easier to review 🤞🏽 (no rush though!) 

## Checklist

N/A: internal only! 📦 

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
