### PR TITLE
Create markdown summary file for sharing MRVA results

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/remote-queries-markdown-generation.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-markdown-generation.ts
@@ -19,9 +19,10 @@ export function generateMarkdown(query: RemoteQuery, analysesResults: AnalysisRe
     }
 
     // Append nwo and results count to the summary table
-    summaryLines.push(
-      `| ${analysisResult.nwo} | [${analysisResult.interpretedResults.length} result(s)](${createGistRelativeLink(analysisResult.nwo)}) |`
-    );
+    const nwo = analysisResult.nwo;
+    const resultsCount = analysisResult.interpretedResults.length;
+    const link = createGistRelativeLink(nwo);
+    summaryLines.push(`| ${nwo} | [${resultsCount} result(s)](${link}) |`);
 
     // Generate individual markdown file for each repository
     const lines = [
@@ -34,15 +35,16 @@ export function generateMarkdown(query: RemoteQuery, analysesResults: AnalysisRe
     }
     files.push(lines);
   }
-  files.push(summaryLines);
-  return files;
+  return [summaryLines, ...files];
 }
 
 export function generateMarkdownSummary(query: RemoteQuery): MarkdownFile {
   const lines: MarkdownFile = [];
   // Title
-  lines.push(`## Results for "${query.queryName}"`);
-  lines.push('');
+  lines.push(
+    `### Results for "${query.queryName}"`,
+    ''
+  );
 
   // Expandable section containing query text
   const queryCodeBlock = [
@@ -54,12 +56,16 @@ export function generateMarkdownSummary(query: RemoteQuery): MarkdownFile {
     ...buildExpandableMarkdownSection('Query', queryCodeBlock)
   );
 
+  // Padding between sections
+  lines.push(
+    '<br />',
+    '',
+  );
+
   // Summary table
   lines.push(
     '### Summary',
-    ''
-  );
-  lines.push(
+    '',
     '| Repository | Results |',
     '| --- | --- |',
   );
@@ -151,9 +157,7 @@ function buildExpandableMarkdownSection(title: string, contents: MarkdownFile): 
     '<details>',
     `<summary>${title}</summary>`,
     '',
-  );
-  expandableLines.push(...contents);
-  expandableLines.push(
+    ...contents,
     '',
     '</details>',
     ''

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/interpreted-results/data/summary.md
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/interpreted-results/data/summary.md
@@ -1,4 +1,4 @@
-## Results for "Shell command built from environment values"
+### Results for "Shell command built from environment values"
 
 <details>
 <summary>Query</summary>
@@ -38,6 +38,8 @@ select highlight, source, sink, "This shell command depends on an uncontrolled $
 ```
 
 </details>
+
+<br />
 
 ### Summary
 

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/interpreted-results/data/summary.md
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/interpreted-results/data/summary.md
@@ -1,0 +1,47 @@
+## Results for "Shell command built from environment values"
+
+<details>
+<summary>Query</summary>
+
+```ql
+/**
+ * @name Shell command built from environment values
+ * @description Building a shell command string with values from the enclosing
+ *              environment may cause subtle bugs or vulnerabilities.
+ * @kind path-problem
+ * @problem.severity warning
+ * @security-severity 6.3
+ * @precision high
+ * @id js/shell-command-injection-from-environment
+ * @tags correctness
+ *       security
+ *       external/cwe/cwe-078
+ *       external/cwe/cwe-088
+ */
+
+import javascript
+import DataFlow::PathGraph
+import semmle.javascript.security.dataflow.ShellCommandInjectionFromEnvironmentQuery
+
+from
+  Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink, DataFlow::Node highlight,
+  Source sourceNode
+where
+  sourceNode = source.getNode() and
+  cfg.hasFlowPath(source, sink) and
+  if cfg.isSinkWithHighlight(sink.getNode(), _)
+  then cfg.isSinkWithHighlight(sink.getNode(), highlight)
+  else highlight = sink.getNode()
+select highlight, source, sink, "This shell command depends on an uncontrolled $@.", sourceNode,
+  sourceNode.getSourceType()
+
+```
+
+</details>
+
+### Summary
+
+| Repository | Results |
+| --- | --- |
+| github/codeql | [4 result(s)](#file-github-codeql-md) |
+| meteor/meteor | [1 result(s)](#file-meteor-meteor-md) |

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/interpreted-results/markdown-generation.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/interpreted-results/markdown-generation.test.ts
@@ -17,18 +17,18 @@ describe('markdown generation', async function() {
     // Check that query has results for two repositories, plus a summary file
     expect(markdownFiles.length).to.equal(3);
 
-    const markdownFile1 = markdownFiles[0]; // results for github/codeql repo
-    const markdownFile2 = markdownFiles[1]; // results for meteor/meteor repo
-    const markdownFile3 = markdownFiles[2]; // summary file
+    const markdownFile0 = markdownFiles[0]; // summary file
+    const markdownFile1 = markdownFiles[1]; // results for github/codeql repo
+    const markdownFile2 = markdownFiles[2]; // results for meteor/meteor repo
 
+    const expectedSummaryFile = await readTestOutputFile('data/summary.md');
     const expectedTestOutput1 = await readTestOutputFile('data/results-repo1.md');
     const expectedTestOutput2 = await readTestOutputFile('data/results-repo2.md');
-    const expectedSummaryFile = await readTestOutputFile('data/summary.md');
 
     // Check that markdown output is correct, after making line endings consistent
+    expect(markdownFile0.join('\n')).to.equal(expectedSummaryFile);
     expect(markdownFile1.join('\n')).to.equal(expectedTestOutput1);
     expect(markdownFile2.join('\n')).to.equal(expectedTestOutput2);
-    expect(markdownFile3.join('\n')).to.equal(expectedSummaryFile);
   });
 });
 

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/interpreted-results/markdown-generation.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/interpreted-results/markdown-generation.test.ts
@@ -14,18 +14,21 @@ describe('markdown generation', async function() {
     );
     const markdownFiles = generateMarkdown(problemQuery, analysesResults);
 
-    // Check that query has results for two repositories
-    expect(markdownFiles.length).to.equal(2);
+    // Check that query has results for two repositories, plus a summary file
+    expect(markdownFiles.length).to.equal(3);
 
     const markdownFile1 = markdownFiles[0]; // results for github/codeql repo
     const markdownFile2 = markdownFiles[1]; // results for meteor/meteor repo
+    const markdownFile3 = markdownFiles[2]; // summary file
 
     const expectedTestOutput1 = await readTestOutputFile('data/results-repo1.md');
     const expectedTestOutput2 = await readTestOutputFile('data/results-repo2.md');
+    const expectedSummaryFile = await readTestOutputFile('data/summary.md');
 
     // Check that markdown output is correct, after making line endings consistent
     expect(markdownFile1.join('\n')).to.equal(expectedTestOutput1);
     expect(markdownFile2.join('\n')).to.equal(expectedTestOutput2);
+    expect(markdownFile3.join('\n')).to.equal(expectedSummaryFile);
   });
 });
 


### PR DESCRIPTION
Follow-up to #1286. As well as generating individual markdown files for each repository, generate an overarching summary file. Example [here](https://github.com/github/vscode-codeql/blob/shati-patel/sharing-summary/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/interpreted-results/data/summary.md) 🖼️ 

See internal issue for more info!

## Checklist

N/A - internal only 💌

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
