### PR TITLE
Allow remote query items to have their labels edited

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -225,7 +225,7 @@
         },
         "codeQL.queryHistory.format": {
           "type": "string",
-          "default": "%q on %d - %s, %r result count [%t]",
+          "default": "%q on %d - %s, %r [%t]",
           "markdownDescription": "Default string for how to label query history items.\n* %t is the time of the query\n* %q is the human-readable query name\n* %f is the query file name\n* %d is the database name\n* %r is the number of results\n* %s is a status string"
         },
         "codeQL.queryHistory.ttl": {

--- a/extensions/ql-vscode/src/compare/compare-interface.ts
+++ b/extensions/ql-vscode/src/compare/compare-interface.ts
@@ -22,6 +22,7 @@ import { transformBqrsResultSet, RawResultSet, BQRSInfo } from '../pure/bqrs-cli
 import resultsDiff from './resultsDiff';
 import { CompletedLocalQueryInfo } from '../query-results';
 import { getErrorMessage } from '../pure/helpers-pure';
+import { HistoryItemLabelProvider } from '../history-item-label-provider';
 
 interface ComparePair {
   from: CompletedLocalQueryInfo;
@@ -39,6 +40,7 @@ export class CompareInterfaceManager extends DisposableObject {
     private databaseManager: DatabaseManager,
     private cliServer: CodeQLCliServer,
     private logger: Logger,
+    private labelProvider: HistoryItemLabelProvider,
     private showQueryResultsCallback: (
       item: CompletedLocalQueryInfo
     ) => Promise<void>
@@ -81,12 +83,12 @@ export class CompareInterfaceManager extends DisposableObject {
             // since we split the description into several rows
             // only run interpolation if the label is user-defined
             // otherwise we will wind up with duplicated rows
-            name: from.getShortLabel(),
+            name: this.labelProvider.getShortLabel(from),
             status: from.completedQuery.statusString,
             time: from.startTime,
           },
           toQuery: {
-            name: to.getShortLabel(),
+            name: this.labelProvider.getShortLabel(to),
             status: to.completedQuery.statusString,
             time: to.startTime,
           },

--- a/extensions/ql-vscode/src/history-item-label-provider.ts
+++ b/extensions/ql-vscode/src/history-item-label-provider.ts
@@ -1,8 +1,6 @@
 import { env } from 'vscode';
 import { QueryHistoryConfig } from './config';
 import { LocalQueryInfo, QueryHistoryInfo } from './query-results';
-import { RemoteQueryHistoryItem } from './remote-queries/remote-query-history-item';
-
 
 interface InterpolateReplacements {
   t: string; // Start time
@@ -20,12 +18,11 @@ export class HistoryItemLabelProvider {
   }
 
   getLabel(item: QueryHistoryInfo) {
-    const replacements = item.t === 'local'
-      ? this.getLocalInterpolateReplacements(item)
-      : this.getRemoteInterpolateReplacements(item);
-
+    if (item.t === 'remote') {
+      return item.remoteQuery.queryName;
+    }
+    const replacements = this.getLocalInterpolateReplacements(item);
     const rawLabel = item.userSpecifiedLabel ?? (this.config.format || '%q');
-
     return this.interpolate(rawLabel, replacements);
   }
 
@@ -61,22 +58,6 @@ export class HistoryItemLabelProvider {
       s: statusString,
       f: item.getQueryFileName(),
       '%': '%',
-    };
-  }
-
-  private getRemoteInterpolateReplacements(item: RemoteQueryHistoryItem): InterpolateReplacements {
-    return {
-      t: new Date(item.remoteQuery.executionStartTime).toLocaleString(env.language),
-      q: item.remoteQuery.queryName,
-
-      // There is no database name for remote queries. Instead use the controller repository name.
-      d: `${item.remoteQuery.controllerRepository.owner}/${item.remoteQuery.controllerRepository.name}`,
-
-      // There is no synchronous way to get the results count.
-      r: '',
-      s: item.status,
-      f: item.remoteQuery.queryFilePath,
-      '%': '%'
     };
   }
 }

--- a/extensions/ql-vscode/src/history-item-label-provider.ts
+++ b/extensions/ql-vscode/src/history-item-label-provider.ts
@@ -1,0 +1,82 @@
+import { env } from 'vscode';
+import { QueryHistoryConfig } from './config';
+import { LocalQueryInfo, QueryHistoryInfo } from './query-results';
+import { RemoteQueryHistoryItem } from './remote-queries/remote-query-history-item';
+
+
+interface InterpolateReplacements {
+  t: string; // Start time
+  q: string; // Query name
+  d: string; // Database/List name
+  r: string; // Result count
+  s: string; // Status
+  f: string; // Query file path
+  '%': '%'; // Percent sign
+}
+
+export class HistoryItemLabelProvider {
+  constructor(private config: QueryHistoryConfig) {
+    /**/
+  }
+
+  getLabel(item: QueryHistoryInfo) {
+    const replacements = item.t === 'local'
+      ? this.getLocalInterpolateReplacements(item)
+      : this.getRemoteInterpolateReplacements(item);
+
+    const rawLabel = item.userSpecifiedLabel ?? (this.config.format || '%q');
+
+    return this.interpolate(rawLabel, replacements);
+  }
+
+  /**
+   * If there is a user-specified label for this query, interpolate and use that.
+   * Otherwise, use the raw name of this query.
+   *
+   * @returns the name of the query, unless there is a custom label for this query.
+   */
+  getShortLabel(item: QueryHistoryInfo): string {
+    return item.userSpecifiedLabel
+      ? this.getLabel(item)
+      : item.t === 'local'
+        ? item.getQueryName()
+        : item.remoteQuery.queryName;
+  }
+
+
+  private interpolate(rawLabel: string, replacements: InterpolateReplacements): string {
+    return rawLabel.replace(/%(.)/g, (match, key: keyof InterpolateReplacements) => {
+      const replacement = replacements[key];
+      return replacement !== undefined ? replacement : match;
+    });
+  }
+
+  private getLocalInterpolateReplacements(item: LocalQueryInfo): InterpolateReplacements {
+    const { resultCount = 0, statusString = 'in progress' } = item.completedQuery || {};
+    return {
+      t: item.startTime,
+      q: item.getQueryName(),
+      d: item.initialInfo.databaseInfo.name,
+      r: resultCount.toString(),
+      s: statusString,
+      f: item.getQueryFileName(),
+      '%': '%',
+    };
+  }
+
+  private getRemoteInterpolateReplacements(item: RemoteQueryHistoryItem): InterpolateReplacements {
+    return {
+      t: new Date(item.remoteQuery.executionStartTime).toLocaleString(env.language),
+      q: item.remoteQuery.queryName,
+
+      // There is no database name for remote queries. Instead use the controller repository name.
+      d: `${item.remoteQuery.controllerRepository.owner}/${item.remoteQuery.controllerRepository.name}`,
+
+      // There is no synchronous way to get the results count.
+      r: '',
+      s: item.status,
+      f: item.remoteQuery.queryFilePath,
+      '%': '%'
+    };
+  }
+}

--- a/extensions/ql-vscode/src/history-item-label-provider.ts
+++ b/extensions/ql-vscode/src/history-item-label-provider.ts
@@ -1,4 +1,5 @@
 import { env } from 'vscode';
+import * as path from 'path';
 import { QueryHistoryConfig } from './config';
 import { LocalQueryInfo, QueryHistoryInfo } from './query-results';
 import { RemoteQueryHistoryItem } from './remote-queries/remote-query-history-item';
@@ -6,10 +7,10 @@ import { RemoteQueryHistoryItem } from './remote-queries/remote-query-history-it
 interface InterpolateReplacements {
   t: string; // Start time
   q: string; // Query name
-  d: string; // Database/List name
-  r: string; // Result count
+  d: string; // Database/Controller repo name
+  r: string; // Result count/Empty
   s: string; // Status
-  f: string; // Query file path
+  f: string; // Query file name
   '%': '%'; // Percent sign
 }
 
@@ -56,7 +57,7 @@ export class HistoryItemLabelProvider {
       t: item.startTime,
       q: item.getQueryName(),
       d: item.initialInfo.databaseInfo.name,
-      r: resultCount.toString(),
+      r: `${resultCount} results`,
       s: statusString,
       f: item.getQueryFileName(),
       '%': '%',
@@ -74,7 +75,7 @@ export class HistoryItemLabelProvider {
       // There is no synchronous way to get the results count.
       r: '',
       s: item.status,
-      f: item.remoteQuery.queryFilePath,
+      f: path.basename(item.remoteQuery.queryFilePath),
       '%': '%'
     };
   }

--- a/extensions/ql-vscode/src/interface.ts
+++ b/extensions/ql-vscode/src/interface.ts
@@ -49,6 +49,7 @@ import { getDefaultResultSetName, ParsedResultSets } from './pure/interface-type
 import { RawResultSet, transformBqrsResultSet, ResultSetSchema } from './pure/bqrs-cli-types';
 import { PAGE_SIZE } from './config';
 import { CompletedLocalQueryInfo } from './query-results';
+import { HistoryItemLabelProvider } from './history-item-label-provider';
 
 /**
  * interface.ts
@@ -136,7 +137,8 @@ export class InterfaceManager extends DisposableObject {
     public ctx: vscode.ExtensionContext,
     private databaseManager: DatabaseManager,
     public cliServer: CodeQLCliServer,
-    public logger: Logger
+    public logger: Logger,
+    private labelProvider: HistoryItemLabelProvider
   ) {
     super();
     this.push(this._diagnosticCollection);
@@ -416,7 +418,7 @@ export class InterfaceManager extends DisposableObject {
         // more asynchronous message to not so abruptly interrupt
         // user's workflow by immediately revealing the panel.
         const showButton = 'View Results';
-        const queryName = fullQuery.getShortLabel();
+        const queryName = this.labelProvider.getShortLabel(fullQuery);
         const resultPromise = vscode.window.showInformationMessage(
           `Finished running query ${queryName.length > 0 ? ` "${queryName}"` : ''
           }.`,
@@ -483,7 +485,7 @@ export class InterfaceManager extends DisposableObject {
       database: fullQuery.initialInfo.databaseInfo,
       shouldKeepOldResultsWhileRendering,
       metadata: fullQuery.completedQuery.query.metadata,
-      queryName: fullQuery.label,
+      queryName: this.labelProvider.getLabel(fullQuery),
       queryPath: fullQuery.initialInfo.queryPath
     });
   }
@@ -516,7 +518,7 @@ export class InterfaceManager extends DisposableObject {
       resultSetNames,
       pageSize: interpretedPageSize(this._interpretation),
       numPages: numInterpretedPages(this._interpretation),
-      queryName: this._displayedQuery.label,
+      queryName: this.labelProvider.getLabel(this._displayedQuery),
       queryPath: this._displayedQuery.initialInfo.queryPath
     });
   }
@@ -601,7 +603,7 @@ export class InterfaceManager extends DisposableObject {
       database: results.initialInfo.databaseInfo,
       shouldKeepOldResultsWhileRendering: false,
       metadata: results.completedQuery.query.metadata,
-      queryName: results.label,
+      queryName: this.labelProvider.getLabel(results),
       queryPath: results.initialInfo.queryPath
     });
   }

--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -653,7 +653,7 @@ export class QueryHistoryManager extends DisposableObject {
     const { finalSingleItem, finalMultiSelect } = this.determineSelection(singleItem, multiSelect);
 
     // TODO will support remote queries
-    if (!this.assertSingleQuery(finalMultiSelect) || finalSingleItem?.t !== 'local') {
+    if (!this.assertSingleQuery(finalMultiSelect)) {
       return;
     }
 

--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -36,6 +36,7 @@ import { QueryStatus } from './query-status';
 import { slurpQueryHistory, splatQueryHistory } from './query-serialization';
 import * as fs from 'fs-extra';
 import { CliVersionConstraint } from './cli';
+import { HistoryItemLabelProvider } from './history-item-label-provider';
 
 /**
  * query-history.ts
@@ -121,7 +122,10 @@ export class HistoryTreeDataProvider extends DisposableObject {
 
   private current: QueryHistoryInfo | undefined;
 
-  constructor(extensionPath: string) {
+  constructor(
+    extensionPath: string,
+    private readonly labelProvider: HistoryItemLabelProvider,
+  ) {
     super();
     this.failedIconPath = path.join(
       extensionPath,
@@ -138,13 +142,13 @@ export class HistoryTreeDataProvider extends DisposableObject {
   }
 
   async getTreeItem(element: QueryHistoryInfo): Promise<TreeItem> {
-    const treeItem = new TreeItem(element.label);
+    const treeItem = new TreeItem(this.labelProvider.getLabel(element));
 
     treeItem.command = {
       title: 'Query History Item',
       command: 'codeQLQueryHistory.itemClicked',
       arguments: [element],
-      tooltip: element.failureReason || element.label
+      tooltip: element.failureReason || this.labelProvider.getLabel(element)
     };
 
     // Populate the icon and the context value. We use the context value to
@@ -183,8 +187,8 @@ export class HistoryTreeDataProvider extends DisposableObject {
   ): ProviderResult<QueryHistoryInfo[]> {
     return element ? [] : this.history.sort((h1, h2) => {
 
-      const h1Label = h1.label.toLowerCase();
-      const h2Label = h2.label.toLowerCase();
+      const h1Label = this.labelProvider.getLabel(h1).toLowerCase();
+      const h2Label = this.labelProvider.getLabel(h2).toLowerCase();
 
       const h1Date = h1.t === 'local'
         ? h1.initialInfo.start.getTime()
@@ -313,12 +317,13 @@ export class QueryHistoryManager extends DisposableObject {
     ._onWillOpenQueryItem.event;
 
   constructor(
-    private qs: QueryServerClient,
-    private dbm: DatabaseManager,
-    private queryStorageDir: string,
+    private readonly qs: QueryServerClient,
+    private readonly dbm: DatabaseManager,
+    private readonly queryStorageDir: string,
     ctx: ExtensionContext,
-    private queryHistoryConfigListener: QueryHistoryConfig,
-    private doCompareCallback: (
+    private readonly queryHistoryConfigListener: QueryHistoryConfig,
+    private readonly labelProvider: HistoryItemLabelProvider,
+    private readonly doCompareCallback: (
       from: CompletedLocalQueryInfo,
       to: CompletedLocalQueryInfo
     ) => Promise<void>
@@ -332,7 +337,8 @@ export class QueryHistoryManager extends DisposableObject {
     this.queryMetadataStorageLocation = path.join((ctx.storageUri || ctx.globalStorageUri).fsPath, WORKSPACE_QUERY_HISTORY_FILE);
 
     this.treeDataProvider = this.push(new HistoryTreeDataProvider(
-      ctx.extensionPath
+      ctx.extensionPath,
+      this.labelProvider
     ));
     this.treeView = this.push(window.createTreeView('codeQLQueryHistory', {
       treeDataProvider: this.treeDataProvider,
@@ -531,7 +537,7 @@ export class QueryHistoryManager extends DisposableObject {
 
   async readQueryHistory(): Promise<void> {
     void logger.log(`Reading cached query history from '${this.queryMetadataStorageLocation}'.`);
-    const history = await slurpQueryHistory(this.queryMetadataStorageLocation, this.queryHistoryConfigListener);
+    const history = await slurpQueryHistory(this.queryMetadataStorageLocation);
     this.treeDataProvider.allHistory = history;
     this.treeDataProvider.allHistory.forEach((item) => {
       this._onDidAddQueryItem.fire(item);
@@ -599,7 +605,7 @@ export class QueryHistoryManager extends DisposableObject {
         // Remote queries can be removed locally, but not remotely.
         // The user must cancel the query on GitHub Actions explicitly.
         this.treeDataProvider.remove(item);
-        void logger.log(`Deleted ${item.label}.`);
+        void logger.log(`Deleted ${this.labelProvider.getLabel(item)}.`);
         if (item.status === QueryStatus.InProgress) {
           void logger.log('The variant analysis is still running on GitHub Actions. To cancel there, you must go to the workflow run in your browser.');
         }
@@ -647,19 +653,21 @@ export class QueryHistoryManager extends DisposableObject {
     const { finalSingleItem, finalMultiSelect } = this.determineSelection(singleItem, multiSelect);
 
     // TODO will support remote queries
-    if (!this.assertSingleQuery(finalMultiSelect) || finalSingleItem?.t !== 'local') {
+    if (!this.assertSingleQuery(finalMultiSelect)) {
       return;
     }
 
     const response = await window.showInputBox({
-      prompt: 'Label:',
-      placeHolder: '(use default)',
-      value: finalSingleItem.label,
+      // prompt: 'Label:',
+      placeHolder: `(use default: ${this.queryHistoryConfigListener.format})`,
+      value: finalSingleItem.userSpecifiedLabel ?? '',
+      title: 'Set query label',
+      prompt: 'Set the query history item label. See the description of the codeQL.queryHistory.format setting for more information.',
     });
     // undefined response means the user cancelled the dialog; don't change anything
     if (response !== undefined) {
       // Interpret empty string response as 'go back to using default'
-      finalSingleItem.initialInfo.userSpecifiedLabel = response === '' ? undefined : response;
+      finalSingleItem.userSpecifiedLabel = response === '' ? undefined : response;
       await this.refreshTreeView();
     }
   }
@@ -816,7 +824,7 @@ export class QueryHistoryManager extends DisposableObject {
     }
 
     if (finalSingleItem.evalLogSummaryLocation) {
-        await this.tryOpenExternalFile(finalSingleItem.evalLogSummaryLocation);
+      await this.tryOpenExternalFile(finalSingleItem.evalLogSummaryLocation);
     } else {
       this.warnNoEvalLogSummary();
     }
@@ -880,7 +888,7 @@ export class QueryHistoryManager extends DisposableObject {
         query.resultsPaths.interpretedResultsPath
       );
     } else {
-      const label = finalSingleItem.label;
+      const label = this.labelProvider.getLabel(finalSingleItem);
       void showAndLogInformationMessage(
         `Query ${label} has no interpreted results.`
       );
@@ -1069,7 +1077,7 @@ the file in the file explorer and dragging it into the workspace.`
           otherQuery.initialInfo.databaseInfo.name === dbName
       )
       .map((item) => ({
-        label: item.label,
+        label: this.labelProvider.getLabel(item),
         description: (item as CompletedLocalQueryInfo).initialInfo.databaseInfo.name,
         detail: (item as CompletedLocalQueryInfo).completedQuery.statusString,
         query: item as CompletedLocalQueryInfo,

--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -652,13 +652,11 @@ export class QueryHistoryManager extends DisposableObject {
   ): Promise<void> {
     const { finalSingleItem, finalMultiSelect } = this.determineSelection(singleItem, multiSelect);
 
-    // TODO will support remote queries
     if (!this.assertSingleQuery(finalMultiSelect)) {
       return;
     }
 
     const response = await window.showInputBox({
-      // prompt: 'Label:',
       placeHolder: `(use default: ${this.queryHistoryConfigListener.format})`,
       value: finalSingleItem.userSpecifiedLabel ?? '',
       title: 'Set query label',

--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -653,7 +653,7 @@ export class QueryHistoryManager extends DisposableObject {
     const { finalSingleItem, finalMultiSelect } = this.determineSelection(singleItem, multiSelect);
 
     // TODO will support remote queries
-    if (!this.assertSingleQuery(finalMultiSelect)) {
+    if (!this.assertSingleQuery(finalMultiSelect) || finalSingleItem?.t !== 'local') {
       return;
     }
 

--- a/extensions/ql-vscode/src/query-serialization.ts
+++ b/extensions/ql-vscode/src/query-serialization.ts
@@ -1,13 +1,12 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
 
-import { QueryHistoryConfig } from './config';
 import { showAndLogErrorMessage } from './helpers';
 import { asyncFilter, getErrorMessage, getErrorStack } from './pure/helpers-pure';
 import { CompletedQueryInfo, LocalQueryInfo, QueryHistoryInfo } from './query-results';
 import { QueryEvaluationInfo } from './run-queries';
 
-export async function slurpQueryHistory(fsPath: string, config: QueryHistoryConfig): Promise<QueryHistoryInfo[]> {
+export async function slurpQueryHistory(fsPath: string): Promise<QueryHistoryInfo[]> {
   try {
     if (!(await fs.pathExists(fsPath))) {
       return [];
@@ -28,10 +27,6 @@ export async function slurpQueryHistory(fsPath: string, config: QueryHistoryConf
       // the constructor invokes extra logic that we don't want to do.
       if (q.t === 'local') {
         Object.setPrototypeOf(q, LocalQueryInfo.prototype);
-
-        // The config object is a global, se we need to set it explicitly
-        // and ensure it is not serialized to JSON.
-        q.setConfig(config);
 
         // Date instances are serialized as strings. Need to
         // convert them back to Date instances.

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
@@ -110,7 +110,6 @@ export class RemoteQueriesManager extends DisposableObject {
         status: QueryStatus.InProgress,
         completed: false,
         queryId,
-        label: query.queryName,
         remoteQuery: query,
       };
       await this.prepareStorageDirectory(queryHistoryItem);
@@ -151,7 +150,7 @@ export class RemoteQueriesManager extends DisposableObject {
           }
         );
       } else {
-        void showAndLogErrorMessage(`There was an issue retrieving the result for the query ${queryItem.label}`);
+        void showAndLogErrorMessage(`There was an issue retrieving the result for the query ${queryItem.remoteQuery.queryName}`);
         queryItem.status = QueryStatus.Failed;
       }
     } else if (queryWorkflowResult.status === 'CompletedUnsuccessfully') {

--- a/extensions/ql-vscode/src/remote-queries/remote-query-history-item.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-query-history-item.ts
@@ -10,6 +10,6 @@ export interface RemoteQueryHistoryItem {
   status: QueryStatus;
   completed: boolean;
   readonly queryId: string,
+  label: string; // TODO, the query label should have interpolation like local queries
   remoteQuery: RemoteQuery;
-  userSpecifiedLabel?: string;
 }

--- a/extensions/ql-vscode/src/remote-queries/remote-query-history-item.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-query-history-item.ts
@@ -10,6 +10,6 @@ export interface RemoteQueryHistoryItem {
   status: QueryStatus;
   completed: boolean;
   readonly queryId: string,
-  label: string; // TODO, the query label should have interpolation like local queries
   remoteQuery: RemoteQuery;
+  userSpecifiedLabel?: string;
 }

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/history-item-label-provider.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/history-item-label-provider.test.ts
@@ -27,10 +27,10 @@ describe('HistoryItemLabelProvider', () => {
       expect(labelProvider.getLabel(fqi)).to.eq('xxx');
 
       fqi.userSpecifiedLabel = '%t %q %d %s %f %r %%';
-      expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name db-name in progress query-file.ql 456 %`);
+      expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name db-name in progress query-file.ql 456 results %`);
 
       fqi.userSpecifiedLabel = '%t %q %d %s %f %r %%::%t %q %d %s %f %r %%';
-      expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name db-name in progress query-file.ql 456 %::${dateStr} query-name db-name in progress query-file.ql 456 %`);
+      expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name db-name in progress query-file.ql 456 results %::${dateStr} query-name db-name in progress query-file.ql 456 results %`);
     });
 
     it('should interpolate query when not user specified', () => {
@@ -40,10 +40,10 @@ describe('HistoryItemLabelProvider', () => {
 
 
       config.format = '%t %q %d %s %f %r %%';
-      expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name db-name in progress query-file.ql 456 %`);
+      expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name db-name in progress query-file.ql 456 results %`);
 
       config.format = '%t %q %d %s %f %r %%::%t %q %d %s %f %r %%';
-      expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name db-name in progress query-file.ql 456 %::${dateStr} query-name db-name in progress query-file.ql 456 %`);
+      expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name db-name in progress query-file.ql 456 results %::${dateStr} query-name db-name in progress query-file.ql 456 results %`);
     });
 
     it('should get query short label', () => {

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/history-item-label-provider.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/history-item-label-provider.test.ts
@@ -1,0 +1,139 @@
+import { env } from 'vscode';
+import { expect } from 'chai';
+import { QueryHistoryConfig } from '../../config';
+import { HistoryItemLabelProvider } from '../../history-item-label-provider';
+import { CompletedLocalQueryInfo, CompletedQueryInfo, InitialQueryInfo } from '../../query-results';
+import { RemoteQueryHistoryItem } from '../../remote-queries/remote-query-history-item';
+
+
+describe('HistoryItemLabelProvider', () => {
+
+  let labelProvider: HistoryItemLabelProvider;
+  let config: QueryHistoryConfig;
+  const date = new Date('2022-01-01T00:00:00.000Z');
+  const dateStr = date.toLocaleString(env.language);
+
+  beforeEach(() => {
+    config = {
+      format: 'xxx %q xxx'
+    } as unknown as QueryHistoryConfig;
+    labelProvider = new HistoryItemLabelProvider(config);
+  });
+
+  describe('local queries', () => {
+    it('should interpolate query when user specified', () => {
+      const fqi = createMockLocalQueryInfo('xxx');
+
+      expect(labelProvider.getLabel(fqi)).to.eq('xxx');
+
+      fqi.userSpecifiedLabel = '%t %q %d %s %f %r %%';
+      expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name db-name in progress query-file.ql 456 %`);
+
+      fqi.userSpecifiedLabel = '%t %q %d %s %f %r %%::%t %q %d %s %f %r %%';
+      expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name db-name in progress query-file.ql 456 %::${dateStr} query-name db-name in progress query-file.ql 456 %`);
+    });
+
+    it('should interpolate query when not user specified', () => {
+      const fqi = createMockLocalQueryInfo();
+
+      expect(labelProvider.getLabel(fqi)).to.eq('xxx query-name xxx');
+
+
+      config.format = '%t %q %d %s %f %r %%';
+      expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name db-name in progress query-file.ql 456 %`);
+
+      config.format = '%t %q %d %s %f %r %%::%t %q %d %s %f %r %%';
+      expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name db-name in progress query-file.ql 456 %::${dateStr} query-name db-name in progress query-file.ql 456 %`);
+    });
+
+    it('should get query short label', () => {
+      const fqi = createMockLocalQueryInfo('xxx');
+
+      // fall back on user specified if one exists.
+      expect(labelProvider.getShortLabel(fqi)).to.eq('xxx');
+
+      // use query name if no user-specified label exists
+      delete (fqi as any).userSpecifiedLabel;
+      expect(labelProvider.getShortLabel(fqi)).to.eq('query-name');
+    });
+
+    function createMockLocalQueryInfo(userSpecifiedLabel?: string) {
+      return {
+        t: 'local',
+        userSpecifiedLabel,
+        startTime: date.toLocaleString(env.language),
+        getQueryFileName() {
+          return 'query-file.ql';
+        },
+        getQueryName() {
+          return 'query-name';
+        },
+        initialInfo: {
+          databaseInfo: {
+            databaseUri: 'unused',
+            name: 'db-name'
+          }
+        } as unknown as InitialQueryInfo,
+        completedQuery: {
+          resultCount: 456,
+          statusString: 'in progress',
+        } as unknown as CompletedQueryInfo,
+      } as unknown as CompletedLocalQueryInfo;
+    }
+  });
+
+  describe('remote queries', () => {
+    it('should interpolate query when user specified', () => {
+      const fqi = createMockRemoteQueryInfo('xxx');
+
+      expect(labelProvider.getLabel(fqi)).to.eq('xxx');
+
+      fqi.userSpecifiedLabel = '%t %q %d %s %%';
+      expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name github/vscode-codeql-integration-tests in progress %`);
+
+      fqi.userSpecifiedLabel = '%t %q %d %s %%::%t %q %d %s %%';
+      expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name github/vscode-codeql-integration-tests in progress %::${dateStr} query-name github/vscode-codeql-integration-tests in progress %`);
+    });
+
+    it('should interpolate query when not user specified', () => {
+      const fqi = createMockRemoteQueryInfo();
+
+      expect(labelProvider.getLabel(fqi)).to.eq('xxx query-name xxx');
+
+
+      config.format = '%t %q %d %s %f %r %%';
+      expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name github/vscode-codeql-integration-tests in progress query-file.ql  %`);
+
+      config.format = '%t %q %d %s %f %r %%::%t %q %d %s %f %r %%';
+      expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name github/vscode-codeql-integration-tests in progress query-file.ql  %::${dateStr} query-name github/vscode-codeql-integration-tests in progress query-file.ql  %`);
+    });
+
+    it('should get query short label', () => {
+      const fqi = createMockRemoteQueryInfo('xxx');
+
+      // fall back on user specified if one exists.
+      expect(labelProvider.getShortLabel(fqi)).to.eq('xxx');
+
+      // use query name if no user-specified label exists
+      delete (fqi as any).userSpecifiedLabel;
+      expect(labelProvider.getShortLabel(fqi)).to.eq('query-name');
+    });
+
+    function createMockRemoteQueryInfo(userSpecifiedLabel?: string) {
+      return {
+        t: 'remote',
+        userSpecifiedLabel,
+        remoteQuery: {
+          executionStartTime: date.getTime(),
+          queryName: 'query-name',
+          queryFilePath: 'query-file.ql',
+          controllerRepository: {
+            owner: 'github',
+            name: 'vscode-codeql-integration-tests'
+          }
+        },
+        status: 'in progress',
+      } as unknown as RemoteQueryHistoryItem;
+    }
+  });
+});

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/remote-query-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/remote-query-history.test.ts
@@ -16,6 +16,7 @@ import { DisposableBucket } from '../../disposable-bucket';
 import { testDisposeHandler } from '../../test-dispose-handler';
 import { walkDirectory } from '../../../helpers';
 import { getErrorMessage } from '../../../pure/helpers-pure';
+import { HistoryItemLabelProvider } from '../../../history-item-label-provider';
 
 /**
  * Tests for remote queries and how they interact with the query history manager.
@@ -71,6 +72,7 @@ describe('Remote queries and query history manager', function() {
       {
         onDidChangeConfiguration: () => new DisposableBucket(),
       } as unknown as QueryHistoryConfig,
+      new HistoryItemLabelProvider({} as QueryHistoryConfig),
       asyncNoop
     );
     disposables.push(qhm);

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/remote-query-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/remote-query-history.test.ts
@@ -16,7 +16,6 @@ import { DisposableBucket } from '../../disposable-bucket';
 import { testDisposeHandler } from '../../test-dispose-handler';
 import { walkDirectory } from '../../../helpers';
 import { getErrorMessage } from '../../../pure/helpers-pure';
-import { HistoryItemLabelProvider } from '../../../history-item-label-provider';
 
 /**
  * Tests for remote queries and how they interact with the query history manager.
@@ -72,7 +71,6 @@ describe('Remote queries and query history manager', function() {
       {
         onDidChangeConfiguration: () => new DisposableBucket(),
       } as unknown as QueryHistoryConfig,
-      new HistoryItemLabelProvider({} as QueryHistoryConfig),
       asyncNoop
     );
     disposables.push(qhm);


### PR DESCRIPTION
The labels for remote query items are interpolated using the same
strategy as local queries with two caveats:

1. There is no easy way to get the result count without reading files,
   so, this value is kept empty.
2. There is no database name for remote queries. Instead, use the 
   nwo of the controller repo.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->
