### PR TITLE
Split handling of highlighted code lines into helper function

### DIFF
--- a/extensions/ql-vscode/src/pure/sarif-utils.ts
+++ b/extensions/ql-vscode/src/pure/sarif-utils.ts
@@ -200,7 +200,7 @@ export function shouldHighlightLine(
  * A line of code split into: plain text before the highlighted section, the highlighted
  * text itself, and plain text after the highlighted section.
  */
-interface partiallyHighlightedLine {
+export interface PartiallyHighlightedLine {
   plainSection1: string;
   highlightedSection: string;
   plainSection2: string;
@@ -213,7 +213,7 @@ export function parseHighlightedLine(
   line: string,
   lineNumber: number,
   highlightedRegion: HighlightedRegion
-): partiallyHighlightedLine {
+): PartiallyHighlightedLine {
   const isSingleLineHighlight = highlightedRegion.endLine === undefined;
   const isFirstHighlightedLine = lineNumber === highlightedRegion.startLine;
   const isLastHighlightedLine = lineNumber === highlightedRegion.endLine;


### PR DESCRIPTION
For sharing variant analysis results, we're building up a markdown copy of the results. See internal issue for more context!

I'd like to re-use the code that checks which sections of a code snippet to highlight in the results view, so I've moved it to a shared helper file 🤠

## Checklist

N/A - no visible changes

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
