### PR TITLE
Add better error messages for partial failing variant analysis

### DIFF
--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -76,9 +76,10 @@ export async function showAndLogWarningMessage(message: string, {
  */
 export async function showAndLogInformationMessage(message: string, {
   outputLogger = logger,
-  items = [] as string[]
+  items = [] as string[],
+  fullMessage = ''
 } = {}): Promise<string | undefined> {
-  return internalShowAndLog(message, items, outputLogger, Window.showInformationMessage);
+  return internalShowAndLog(message, items, outputLogger, Window.showInformationMessage, fullMessage);
 }
 
 type ShowMessageFn = (message: string, ...items: string[]) => Thenable<string | undefined>;

--- a/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
@@ -337,18 +337,22 @@ async function runRemoteQueriesApiRequest(
   }
 }
 
-function parseResponse(owner: string, repo: string, response: QueriesResponse) {
-  const popupMessage = `Successfully scheduled runs. [Click here to see the progress](https://github.com/${owner}/${repo}/actions/runs/${response.workflowRunId}).`
+// exported for testng only
+export function parseResponse(owner: string, repo: string, response: QueriesResponse) {
+  const popupMessage = `Successfully scheduled runs. [Click here to see the progress](https://github.com/${owner}/${repo}/actions/runs/${response.workflow_run_id}).`
     + (response.errors ? '\n\nSome repositories could not be scheduled. See extension log for details.' : '');
 
   let logMessage = `Successfully scheduled runs. See https://github.com/${owner}/${repo}/actions/runs/${response.workflow_run_id}.`;
+  if (response.repositories_queried) {
+    logMessage += `\n\nRepositories queried:\n${response.repositories_queried.join(', ')}`;
+  }
   if (response.errors) {
-    logMessage += '\nSome repositories could not be scheduled.';
+    logMessage += '\n\nSome repositories could not be scheduled.';
     if (response.errors.invalid_repositories?.length) {
-      logMessage += `\nInvalid repositories: ${response.errors.invalid_repositories.join(', ')}`;
+      logMessage += `\n\nInvalid repositories:\n${response.errors.invalid_repositories.join(', ')}`;
     }
     if (response.errors.repositories_without_database?.length) {
-      logMessage += `\nRepositories without databases: ${response.errors.repositories_without_database.join(', ')}`;
+      logMessage += `\n\nRepositories without databases:\n${response.errors.repositories_without_database.join(', ')}`;
     }
   }
 

--- a/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
@@ -33,7 +33,12 @@ export interface QlPack {
 }
 
 interface QueriesResponse {
-  workflow_run_id: number
+  workflow_run_id: number,
+  errors?: {
+    invalid_repositories?: string[],
+    repositories_without_database?: string[],
+  },
+  repositories_queried?: string[],
 }
 
 /**
@@ -324,12 +329,33 @@ async function runRemoteQueriesApiRequest(
         data
       }
     );
-    const workflowRunId = response.data.workflow_run_id;
-    void showAndLogInformationMessage(`Successfully scheduled runs. [Click here to see the progress](https://github.com/${owner}/${repo}/actions/runs/${workflowRunId}).`);
-    return workflowRunId;
+    const { popupMessage, logMessage } = parseResponse(owner, repo, response.data);
+    void showAndLogInformationMessage(popupMessage, { fullMessage: logMessage });
+    return response.data.workflow_run_id;
   } catch (error) {
     void showAndLogErrorMessage(getErrorMessage(error));
   }
+}
+
+function parseResponse(owner: string, repo: string, response: QueriesResponse) {
+  const popupMessage = `Successfully scheduled runs. [Click here to see the progress](https://github.com/${owner}/${repo}/actions/runs/${response.workflowRunId}).`
+    + (response.errors ? '\n\nSome repositories could not be scheduled. See extension log for details.' : '');
+
+  let logMessage = `Successfully scheduled runs. See https://github.com/${owner}/${repo}/actions/runs/${response.workflow_run_id}.`;
+  if (response.errors) {
+    logMessage += '\nSome repositories could not be scheduled.';
+    if (response.errors.invalid_repositories?.length) {
+      logMessage += `\nInvalid repositories: ${response.errors.invalid_repositories.join(', ')}`;
+    }
+    if (response.errors.repositories_without_database?.length) {
+      logMessage += `\nRepositories without databases: ${response.errors.repositories_without_database.join(', ')}`;
+    }
+  }
+
+  return {
+    popupMessage,
+    logMessage
+  };
 }
 
 /**

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/run-remote-queries.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/run-remote-queries.test.ts
@@ -1,0 +1,103 @@
+import { expect } from 'chai';
+import { parseResponse } from '../../../remote-queries/run-remote-query';
+
+describe('run-remote-queries', () => {
+  describe('parseResponse', () => {
+    it('should parse a successful response', () => {
+      const result = parseResponse('org', 'name', {
+        workflow_run_id: 123,
+        repositories_queried: ['a/b', 'c/d'],
+      });
+
+      expect(result.popupMessage).to.equal('Successfully scheduled runs. [Click here to see the progress](https://github.com/org/name/actions/runs/123).');
+      expect(result.logMessage).to.equal(
+        ['Successfully scheduled runs. See https://github.com/org/name/actions/runs/123.',
+          '',
+          'Repositories queried:',
+          'a/b, c/d'].join('\n')
+      );
+    });
+
+    it('should parse a response with invalid repos', () => {
+      const result = parseResponse('org', 'name', {
+        workflow_run_id: 123,
+        repositories_queried: ['a/b', 'c/d'],
+        errors: {
+          invalid_repositories: ['e/f', 'g/h'],
+        }
+      });
+
+      expect(result.popupMessage).to.equal(
+        ['Successfully scheduled runs. [Click here to see the progress](https://github.com/org/name/actions/runs/123).',
+          '',
+          'Some repositories could not be scheduled. See extension log for details.'].join('\n')
+      );
+      expect(result.logMessage).to.equal(
+        ['Successfully scheduled runs. See https://github.com/org/name/actions/runs/123.',
+          '',
+          'Repositories queried:',
+          'a/b, c/d',
+          '',
+          'Some repositories could not be scheduled.',
+          '',
+          'Invalid repositories:',
+          'e/f, g/h'].join('\n')
+      );
+    });
+
+    it('should parse a response with repos w/o databases', () => {
+      const result = parseResponse('org', 'name', {
+        workflow_run_id: 123,
+        repositories_queried: ['a/b', 'c/d'],
+        errors: {
+          repositories_without_database: ['e/f', 'g/h'],
+        }
+      });
+
+      expect(result.popupMessage).to.equal(
+        ['Successfully scheduled runs. [Click here to see the progress](https://github.com/org/name/actions/runs/123).',
+          '',
+          'Some repositories could not be scheduled. See extension log for details.'].join('\n')
+      );
+      expect(result.logMessage).to.equal(
+        ['Successfully scheduled runs. See https://github.com/org/name/actions/runs/123.',
+          '',
+          'Repositories queried:\na/b, c/d',
+          '',
+          'Some repositories could not be scheduled.',
+          '',
+          'Repositories without databases:\ne/f, g/h'].join('\n')
+      );
+    });
+
+    it('should parse a response with invalid repos and repos w/o databases', () => {
+      const result = parseResponse('org', 'name', {
+        workflow_run_id: 123,
+        repositories_queried: ['a/b', 'c/d'],
+        errors: {
+          invalid_repositories: ['e/f', 'g/h'],
+          repositories_without_database: ['i/j', 'k/l'],
+        }
+      });
+
+      expect(result.popupMessage).to.equal(
+        ['Successfully scheduled runs. [Click here to see the progress](https://github.com/org/name/actions/runs/123).',
+          '',
+          'Some repositories could not be scheduled. See extension log for details.'].join('\n')
+      );
+      expect(result.logMessage).to.equal(
+        ['Successfully scheduled runs. See https://github.com/org/name/actions/runs/123.',
+          '',
+          'Repositories queried:\na/b, c/d',
+          '',
+          'Some repositories could not be scheduled.',
+          '',
+          'Invalid repositories:',
+          'e/f, g/h',
+          '',
+          'Repositories without databases:',
+          'i/j, k/l'].join('\n')
+      );
+    });
+  });
+});

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/run-remote-query.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/run-remote-query.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { parseResponse } from '../../../remote-queries/run-remote-query';
 
-describe('run-remote-queries', () => {
+describe('run-remote-query', () => {
   describe('parseResponse', () => {
     it('should parse a successful response', () => {
       const result = parseResponse('org', 'name', {
@@ -15,6 +15,17 @@ describe('run-remote-queries', () => {
           '',
           'Repositories queried:',
           'a/b, c/d'].join('\n')
+      );
+    });
+
+    it('should parse a response with no repositories queried', () => {
+      const result = parseResponse('org', 'name', {
+        workflow_run_id: 123,
+      });
+
+      expect(result.popupMessage).to.equal('Successfully scheduled runs. [Click here to see the progress](https://github.com/org/name/actions/runs/123).');
+      expect(result.logMessage).to.equal(
+        'Successfully scheduled runs. See https://github.com/org/name/actions/runs/123.'
       );
     });
 


### PR DESCRIPTION
Two scenarios handled:

1. no database for existing repo
2. repo does not exits (or no access rights for current user)

In either case, an error message is sent to the logs, with a notificaiton
in a popup.

Log message looks like this:

```
Successfully scheduled runs. See https://github.com/dsp-testing/qc-run2/actions/runs/2164299232.
Some repositories could not be scheduled.
Invalid repositories: aeisenberg/xxx, other/idontexist
Repositories without databases: aeisenberg/actions-test, aeisenberg/actions-test2
```