### PR TITLE
Avoid loading wrong results into an open window

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
@@ -196,7 +196,7 @@ export class RemoteQueriesManager extends DisposableObject {
     await this.analysesResultsManager.loadAnalysesResults(
       analysesToDownload,
       token,
-      results => this.interfaceManager.setAnalysisResults(results));
+      results => this.interfaceManager.setAnalysisResults(results, queryResult.queryId));
   }
 
   private mapQueryResult(executionEndTime: number, resultIndex: RemoteQueryResultIndex, queryId: string): RemoteQueryResult {


### PR DESCRIPTION
This fixes a bug where an open results view will accumulate results from
other queries who have their results downloaded while this view is open.

The fix is to ensure that the results view for the query is open when
some results are downloaded.
