### PR TITLE
Remove jsonc dependency

### DIFF
--- a/extensions/ql-vscode/gulpfile.ts/deploy.ts
+++ b/extensions/ql-vscode/gulpfile.ts/deploy.ts
@@ -1,5 +1,4 @@
 import * as fs from 'fs-extra';
-import * as jsonc from 'jsonc-parser';
 import * as path from 'path';
 
 export interface DeployedPackage {
@@ -28,7 +27,7 @@ async function copyPackage(sourcePath: string, destPath: string): Promise<void> 
 
 export async function deployPackage(packageJsonPath: string): Promise<DeployedPackage> {
   try {
-    const packageJson: any = jsonc.parse(await fs.readFile(packageJsonPath, 'utf8'));
+    const packageJson: any = JSON.parse(await fs.readFile(packageJsonPath, 'utf8'));
 
     // Default to development build; use flag --release to indicate release build.
     const isDevBuild = !process.argv.includes('--release');

--- a/extensions/ql-vscode/package-lock.json
+++ b/extensions/ql-vscode/package-lock.json
@@ -93,7 +93,6 @@
         "gulp-sourcemaps": "^3.0.0",
         "gulp-typescript": "^5.0.1",
         "husky": "~4.2.5",
-        "jsonc-parser": "^2.3.0",
         "lint-staged": "~10.2.2",
         "mocha": "^9.1.3",
         "mocha-sinon": "~2.1.2",
@@ -7618,12 +7617,6 @@
       "bin": {
         "json5": "lib/cli.js"
       }
-    },
-    "node_modules/jsonc-parser": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.0.tgz",
-      "integrity": "sha512-b0EBt8SWFNnixVdvoR2ZtEGa9ZqLhbJnOjezn+WP+8kspFm+PFYDN8Z4Bc7pRlDjvuVcADSUkroIuTWWn/YiIA==",
-      "dev": true
     },
     "node_modules/jsonfile": {
       "version": "6.1.0",
@@ -20125,12 +20118,6 @@
       "requires": {
         "minimist": "^1.2.0"
       }
-    },
-    "jsonc-parser": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.0.tgz",
-      "integrity": "sha512-b0EBt8SWFNnixVdvoR2ZtEGa9ZqLhbJnOjezn+WP+8kspFm+PFYDN8Z4Bc7pRlDjvuVcADSUkroIuTWWn/YiIA==",
-      "dev": true
     },
     "jsonfile": {
       "version": "6.1.0",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1193,7 +1193,6 @@
     "gulp-sourcemaps": "^3.0.0",
     "gulp-typescript": "^5.0.1",
     "husky": "~4.2.5",
-    "jsonc-parser": "^2.3.0",
     "lint-staged": "~10.2.2",
     "mocha": "^9.1.3",
     "mocha-sinon": "~2.1.2",


### PR DESCRIPTION
This dependency was only used to parse package.json and
this can be just as easily parsed by regular JSON object.

jsonc can also parse JSON with comments, but there are no
comments in package.json.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

See https://github.com/github/vscode-codeql/pull/1262
