### PR TITLE
Use HTML code blocks

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/remote-queries-markdown-generation.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-markdown-generation.ts
@@ -102,9 +102,9 @@ function generateMarkdownForInterpretedResult(interpretedResult: AnalysisAlert, 
 function generateMarkdownForCodeSnippet(codeSnippet: string, language: string): MarkdownFile {
   const lines: MarkdownFile = [];
   lines.push(
-    `\`\`\`${language}`,
+    `<pre><code class="${language}">`,
     ...codeSnippet.split('\n'),
-    '```',
+    '</code></pre>',
   );
   lines.push('');
   return lines;

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/interpreted-results/data/results-repo1.md
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/interpreted-results/data/results-repo1.md
@@ -2,13 +2,13 @@
 
 [javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js#L5-L5)
 
-```javascript
+<pre><code class="javascript">
 function cleanupTemp() {
   let cmd = "rm -rf " + path.join(__dirname, "temp");
   cp.execSync(cmd); // BAD
 }
 
-```
+</code></pre>
 
 *This shell command depends on an uncontrolled [absolute path](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js#L4-L4).*
 
@@ -16,14 +16,14 @@ function cleanupTemp() {
 
 [javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L6-L6)
 
-```javascript
+<pre><code class="javascript">
 (function() {
 	cp.execFileSync('rm',  ['-rf', path.join(__dirname, "temp")]); // GOOD
 	cp.execSync('rm -rf ' + path.join(__dirname, "temp")); // BAD
 
 	execa.shell('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
 
-```
+</code></pre>
 
 *This shell command depends on an uncontrolled [absolute path](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L6-L6).*
 
@@ -31,14 +31,14 @@ function cleanupTemp() {
 
 [javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L8-L8)
 
-```javascript
+<pre><code class="javascript">
 	cp.execSync('rm -rf ' + path.join(__dirname, "temp")); // BAD
 
 	execa.shell('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
 	execa.shellSync('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
 
 
-```
+</code></pre>
 
 *This shell command depends on an uncontrolled [absolute path](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L8-L8).*
 
@@ -46,14 +46,14 @@ function cleanupTemp() {
 
 [javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L9-L9)
 
-```javascript
+<pre><code class="javascript">
 
 	execa.shell('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
 	execa.shellSync('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
 
 	const safe = "\"" + path.join(__dirname, "temp") + "\"";
 
-```
+</code></pre>
 
 *This shell command depends on an uncontrolled [absolute path](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L9-L9).*
 

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/interpreted-results/data/results-repo2.md
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/interpreted-results/data/results-repo2.md
@@ -2,14 +2,14 @@
 
 [npm-packages/meteor-installer/install.js](https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec/npm-packages/meteor-installer/install.js#L259-L259)
 
-```javascript
+<pre><code class="javascript">
   if (isWindows()) {
     //set for the current session and beyond
     child_process.execSync(`setx path "${meteorPath}/;%path%`);
     return;
   }
 
-```
+</code></pre>
 
 *This shell command depends on an uncontrolled [absolute path](https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec/npm-packages/meteor-installer/config.js#L39-L39).*
 


### PR DESCRIPTION
This is so that we can highlight code snippets using `<strong>` tags, which doesn't work in normal markdown code blocks 😢  (Will do the actual highlighting in a separate PR!) 

See internal issue for more context.


## Checklist

N/A - internal only (and only used in tests for now)

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
