### PR TITLE
Fix max-width for code paths

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/view/CodePaths.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/CodePaths.tsx
@@ -50,10 +50,10 @@ const CodePath = ({
 }) => {
   return <>
     {codeFlow.threadFlows.map((threadFlow, index) =>
-      <div key={`thread-flow-${index}`}>
+      <div key={`thread-flow-${index}`} style={{ maxWidth: '55em' }}>
         {index !== 0 && <VerticalSpace size={3} />}
 
-        <Box display="flex" justifyContent="center" alignItems="center" width="42.5em">
+        <Box display="flex" justifyContent="center" alignItems="center">
           <Box flexGrow={1} p={0} border="none">
             <SectionTitle>Step {index + 1}</SectionTitle>
           </Box>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/311693/164463296-bc20e35b-dc1b-43c0-b902-106d833c5a9b.png)

After:
<img width="957" alt="image" src="https://user-images.githubusercontent.com/311693/164463406-e0c481df-8548-4f8e-91b6-a15aba4da3d9.png">


## Checklist
N/A:

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
