### PR TITLE
MRVA: Be nicer about users cancelling out of the repository quickpick

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/repository-selection.ts
+++ b/extensions/ql-vscode/src/remote-queries/repository-selection.ts
@@ -1,8 +1,8 @@
 import { QuickPickItem, window } from 'vscode';
-import { showAndLogErrorMessage } from '../helpers';
 import { logger } from '../logging';
 import { getRemoteRepositoryLists } from '../config';
 import { REPO_REGEX } from '../pure/helpers-pure';
+import { UserCancellationException } from '../commandRunner';
 
 export interface RepositorySelection {
   repositories?: string[];
@@ -44,14 +44,14 @@ export async function getRepositorySelection(): Promise<RepositorySelection> {
   } else if (quickpick?.useCustomRepository) {
     const customRepo = await getCustomRepo();
     if (!customRepo || !REPO_REGEX.test(customRepo)) {
-      void showAndLogErrorMessage('Invalid repository format. Please enter a valid repository in the format <owner>/<repo> (e.g. github/codeql)');
-      return {};
+      throw new UserCancellationException('Invalid repository format. Please enter a valid repository in the format <owner>/<repo> (e.g. github/codeql)');
     }
     void logger.log(`Entered repository: ${customRepo}`);
     return { repositories: [customRepo] };
   } else {
-    void showAndLogErrorMessage('No repositories selected.');
-    return {};
+    // We don't need to display a warning pop-up in this case, since the user just escaped out of the operation.
+    // We set 'true' to make this a silent exception.
+    throw new UserCancellationException('No repositories selected', true);
   }
 }
 


### PR DESCRIPTION
We used to display 2 error/warning pop-ups if a user cancels out of selecting a repo for variant analysis 😅 See internal issue.

Instead:
- If a user just cancels without selecting anything, don't display a pop-up
- If a user enters an invalid repo, display a single pop-up

<details><summary>Expand for demo GIF</summary>
<p>

![Example of error handling in repo quickpick](https://user-images.githubusercontent.com/42641846/164708269-303b0ec6-d69c-4c2c-85a8-83cbe34874fa.GIF)

</p>
</details> 


## Checklist

N/A - internal only 🕳

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
