### PR TITLE
MRVA: Make markdown code snippets look nicer

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/remote-queries-markdown-generation.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-markdown-generation.ts
@@ -115,16 +115,14 @@ function generateMarkdownForCodeSnippet(
     );
 
   // Make sure there are no extra newlines before or after the <code> block:
-  if (codeLines.length === 1) {
-    lines.push(`<pre><code class="${language}">${codeLines[0]}</code></pre>`);
-  } else {
-    lines.push(
-      `<pre><code class="${language}">${codeLines[0]}`,
-      ...codeLines.slice(1, -1),
-      `${codeLines[codeLines.length - 1]}</code></pre>`,
-    );
-  }
-  lines.push('');
+  const codeLinesWrapped = [...codeLines];
+  codeLinesWrapped[0] = `<pre><code class="${language}">${codeLinesWrapped[0]}`;
+  codeLinesWrapped[codeLinesWrapped.length - 1] = `${codeLinesWrapped[codeLinesWrapped.length - 1]}</code></pre>`;
+
+  lines.push(
+    ...codeLinesWrapped,
+    '',
+  );
   return lines;
 }
 

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-markdown-generation.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-markdown-generation.ts
@@ -113,11 +113,17 @@ function generateMarkdownForCodeSnippet(
     .map((line, index) =>
       highlightCodeLines(line, index + snippetStartLine, highlightedRegion)
     );
-  lines.push(
-    `<pre><code class="${language}">`,
-    ...codeLines,
-    '</code></pre>',
-  );
+
+  // Make sure there are no extra newlines before or after the <code> block:
+  if (codeLines.length === 1) {
+    lines.push(`<pre><code class="${language}">${codeLines[0]}</code></pre>`);
+  } else {
+    lines.push(
+      `<pre><code class="${language}">${codeLines[0]}`,
+      ...codeLines.slice(1, -1),
+      `${codeLines[codeLines.length - 1]}</code></pre>`,
+    );
+  }
   lines.push('');
   return lines;
 }

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/path-problem/results-repo1.md
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/path-problem/results-repo1.md
@@ -2,12 +2,10 @@
 
 [javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js#L5-L5)
 
-<pre><code class="javascript">
-function cleanupTemp() {
+<pre><code class="javascript">function cleanupTemp() {
   let cmd = "rm -rf " + path.join(__dirname, "temp");
   cp.execSync(<strong>cmd</strong>); // BAD
 }
-
 </code></pre>
 
 *This shell command depends on an uncontrolled [absolute path](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js#L4-L4).*
@@ -16,13 +14,11 @@ function cleanupTemp() {
 
 [javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L6-L6)
 
-<pre><code class="javascript">
-(function() {
+<pre><code class="javascript">(function() {
 	cp.execFileSync('rm',  ['-rf', path.join(__dirname, "temp")]); // GOOD
 	cp.execSync(<strong>'rm -rf ' + path.join(__dirname, "temp")</strong>); // BAD
 
 	execa.shell('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
-
 </code></pre>
 
 *This shell command depends on an uncontrolled [absolute path](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L6-L6).*
@@ -31,12 +27,10 @@ function cleanupTemp() {
 
 [javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L8-L8)
 
-<pre><code class="javascript">
-	cp.execSync('rm -rf ' + path.join(__dirname, "temp")); // BAD
+<pre><code class="javascript">	cp.execSync('rm -rf ' + path.join(__dirname, "temp")); // BAD
 
 	execa.shell(<strong>'rm -rf ' + path.join(__dirname, "temp")</strong>); // NOT OK
 	execa.shellSync('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
-
 
 </code></pre>
 
@@ -47,12 +41,10 @@ function cleanupTemp() {
 [javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L9-L9)
 
 <pre><code class="javascript">
-
 	execa.shell('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
 	execa.shellSync(<strong>'rm -rf ' + path.join(__dirname, "temp")</strong>); // NOT OK
 
 	const safe = "\"" + path.join(__dirname, "temp") + "\"";
-
 </code></pre>
 
 *This shell command depends on an uncontrolled [absolute path](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L9-L9).*

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/path-problem/results-repo2.md
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/path-problem/results-repo2.md
@@ -2,13 +2,11 @@
 
 [npm-packages/meteor-installer/install.js](https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec/npm-packages/meteor-installer/install.js#L259-L259)
 
-<pre><code class="javascript">
-  if (isWindows()) {
+<pre><code class="javascript">  if (isWindows()) {
     //set for the current session and beyond
     child_process.execSync(<strong>`setx path "${meteorPath}/;%path%`</strong>);
     return;
   }
-
 </code></pre>
 
 *This shell command depends on an uncontrolled [absolute path](https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec/npm-packages/meteor-installer/config.js#L39-L39).*

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/problem/analyses-results.json
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/problem/analyses-results.json
@@ -137,9 +137,9 @@
         },
         "severity": "Warning",
         "codeSnippet": {
-          "startLine": 7,
-          "endLine": 11,
-          "text": "// ## Parser utilities\n\nconst literal = /^(?:'((?:\\\\.|[^'])*?)'|\"((?:\\\\.|[^\"])*?)\")/\npp.strictDirective = function(start) {\n  for (;;) {\n"
+          "startLine": 9,
+          "endLine": 9,
+          "text": "const literal = /^(?:'((?:\\\\.|[^'])*?)'|\"((?:\\\\.|[^\"])*?)\")/"
         },
         "highlightedRegion": {
           "startLine": 9,

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/problem/results-repo1.md
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/problem/results-repo1.md
@@ -3,14 +3,12 @@
 [javascript/extractor/tests/regexp/input/multipart.js](https://github.com/github/codeql/blob/d094bbc06d063d0da8d0303676943c345e61de53/javascript/extractor/tests/regexp/input/multipart.js#L17-L20)
 
 <pre><code class="javascript">
-
 var bad95 = new RegExp(
     "<strong>(a" + </strong>
 <strong>    "|" + </strong>
 <strong>    "aa)*" + </strong>
 <strong>    "</strong>b$"
 );
-
 
 </code></pre>
 

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/problem/results-repo2.md
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/problem/results-repo2.md
@@ -41,12 +41,7 @@ pp.strictDirective = function(start) {
 
 [tools/tests/apps/modules/imports/links/acorn/src/parseutil.js](https://github.com/meteor/meteor/blob/53f3c4442d3542d3d2a012a854472a0d1bef9d12/tools/tests/apps/modules/imports/links/acorn/src/parseutil.js#L9-L9)
 
-<pre><code class="javascript">// ## Parser utilities
-
-const literal = /^(?:'((?:\\.|[^'])*?)'|"(<strong>(?:\\.|[^"])*?</strong>)")/
-pp.strictDirective = function(start) {
-  for (;;) {
-</code></pre>
+<pre><code class="javascript">const literal = /^(?:'((?:\\.|[^'])*?)'|"(<strong>(?:\\.|[^"])*?</strong>)")/</code></pre>
 
 *This part of the regular expression may cause exponential backtracking on strings starting with '"' and containing many repetitions of '\!'.*
 

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/problem/results-repo2.md
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/problem/results-repo2.md
@@ -2,13 +2,11 @@
 
 [packages/deprecated/markdown/showdown.js](https://github.com/meteor/meteor/blob/53f3c4442d3542d3d2a012a854472a0d1bef9d12/packages/deprecated/markdown/showdown.js#L415-L415)
 
-<pre><code class="javascript">
-		/g,hashElement);
+<pre><code class="javascript">		/g,hashElement);
 	*/
 	text = text.replace(/(\n\n[ ]{0,3}<!(--<strong>[^\r]*?</strong>--\s*)+>[ \t]*(?=\n{2,}))/g,hashElement);
 
 	// PHP and ASP-style processor instructions (<?...?> and <%...%>)
-
 </code></pre>
 
 *This part of the regular expression may cause exponential backtracking on strings containing many repetitions of '----'.*
@@ -17,13 +15,11 @@
 
 [packages/deprecated/markdown/showdown.js](https://github.com/meteor/meteor/blob/53f3c4442d3542d3d2a012a854472a0d1bef9d12/packages/deprecated/markdown/showdown.js#L523-L523)
 
-<pre><code class="javascript">
-	// Build a regex to find HTML tags and comments.  See Friedl's
+<pre><code class="javascript">	// Build a regex to find HTML tags and comments.  See Friedl's
 	// "Mastering Regular Expressions", 2nd Ed., pp. 200-201.
 	var regex = /(<[a-z\/!$]("[^"]*"|'[^']*'|[^'">])*>|<!(--<strong>.*?</strong>--\s*)+>)/gi;
 
 	text = text.replace(regex, function(wholeMatch) {
-
 </code></pre>
 
 *This part of the regular expression may cause exponential backtracking on strings starting with '<!--' and containing many repetitions of '----'.*
@@ -32,13 +28,11 @@
 
 [tools/tests/apps/modules/imports/links/acorn/src/parseutil.js](https://github.com/meteor/meteor/blob/53f3c4442d3542d3d2a012a854472a0d1bef9d12/tools/tests/apps/modules/imports/links/acorn/src/parseutil.js#L9-L9)
 
-<pre><code class="javascript">
-// ## Parser utilities
+<pre><code class="javascript">// ## Parser utilities
 
 const literal = /^(?:'(<strong>(?:\\.|[^'])*?</strong>)'|"((?:\\.|[^"])*?)")/
 pp.strictDirective = function(start) {
   for (;;) {
-
 </code></pre>
 
 *This part of the regular expression may cause exponential backtracking on strings starting with ''' and containing many repetitions of '\&'.*
@@ -47,13 +41,11 @@ pp.strictDirective = function(start) {
 
 [tools/tests/apps/modules/imports/links/acorn/src/parseutil.js](https://github.com/meteor/meteor/blob/53f3c4442d3542d3d2a012a854472a0d1bef9d12/tools/tests/apps/modules/imports/links/acorn/src/parseutil.js#L9-L9)
 
-<pre><code class="javascript">
-// ## Parser utilities
+<pre><code class="javascript">// ## Parser utilities
 
 const literal = /^(?:'((?:\\.|[^'])*?)'|"(<strong>(?:\\.|[^"])*?</strong>)")/
 pp.strictDirective = function(start) {
   for (;;) {
-
 </code></pre>
 
 *This part of the regular expression may cause exponential backtracking on strings starting with '"' and containing many repetitions of '\!'.*


### PR DESCRIPTION
A quick PR to remove some extraneous newlines in our markdown rendering! 🔪 (Because otherwise the code blocks looked huge) 

See [before](https://github.com/github/vscode-codeql/blob/1a03c0e4acc3a449b6e20ddc0e90c59d630273ba/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/path-problem/results-repo1.md) 😢 and [after](https://github.com/github/vscode-codeql/blob/b8fef48757f0a4090acbac731d317c757f3aff3a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/path-problem/results-repo1.md) 😄 

## Checklist

N/A - internal only 🤭

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
