### PR TITLE
Markdown rendering: Display paths

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/remote-queries-markdown-generation.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-markdown-generation.ts
@@ -176,7 +176,7 @@ function generateMarkdownForPathResults(
   for (const codeFlow of interpretedResult.codeFlows) {
     const stepCount = codeFlow.threadFlows.length;
     pathLines.push(`#### Path with ${stepCount} steps`);
-    for (let i = 0; i < codeFlow.threadFlows.length; i++) {
+    for (let i = 0; i < stepCount; i++) {
       const threadFlow = codeFlow.threadFlows[i];
       const link = createMarkdownRemoteFileRef(
         threadFlow.fileLink,

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/path-problem/analyses-results.json
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/path-problem/analyses-results.json
@@ -618,6 +618,44 @@
                 }
               }
             ]
+          },
+          {
+            "threadFlows": [
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec",
+                  "filePath": "npm-packages/meteor-installer/config.js"
+                },
+                "codeSnippet": {
+                  "startLine": 37,
+                  "endLine": 41,
+                  "text": "\nconst meteorLocalFolder = '.meteor';\nconst meteorPath = path.resolve(rootPath, meteorLocalFolder);\n\nmodule.exports = {\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 39,
+                  "startColumn": 20,
+                  "endLine": 39,
+                  "endColumn": 61
+                }
+              },
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec",
+                  "filePath": "npm-packages/meteor-installer/install.js"
+                },
+                "codeSnippet": {
+                  "startLine": 257,
+                  "endLine": 261,
+                  "text": "  if (isWindows()) {\n    //set for the current session and beyond\n    child_process.execSync(`setx path \"${meteorPath}/;%path%`);\n    return;\n  }\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 259,
+                  "startColumn": 28,
+                  "endLine": 259,
+                  "endColumn": 62
+                }
+              }
+            ]
           }
         ]
       }

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/path-problem/results-repo1.md
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/path-problem/results-repo1.md
@@ -8,7 +8,54 @@
 }
 </code></pre>
 
-*This shell command depends on an uncontrolled [absolute path](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js#L4-L4).*
+<details>
+<summary><i>This shell command depends on an uncontrolled absolute path.</i></summary>
+
+#### Paths
+
+Path with 5 steps
+1. [javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js#L4-L4)
+    <pre><code class="javascript">  path = require("path");
+    function cleanupTemp() {
+      let cmd = "rm -rf " + path.join(<strong>__dirname</strong>, "temp");
+      cp.execSync(cmd); // BAD
+    }
+    </code></pre>
+    
+2. [javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js#L4-L4)
+    <pre><code class="javascript">  path = require("path");
+    function cleanupTemp() {
+      let cmd = "rm -rf " + <strong>path.join(__dirname, "temp")</strong>;
+      cp.execSync(cmd); // BAD
+    }
+    </code></pre>
+    
+3. [javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js#L4-L4)
+    <pre><code class="javascript">  path = require("path");
+    function cleanupTemp() {
+      let cmd = <strong>"rm -rf " + path.join(__dirname, "temp")</strong>;
+      cp.execSync(cmd); // BAD
+    }
+    </code></pre>
+    
+4. [javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js#L4-L4)
+    <pre><code class="javascript">  path = require("path");
+    function cleanupTemp() {
+      let <strong>cmd = "rm -rf " + path.join(__dirname, "temp")</strong>;
+      cp.execSync(cmd); // BAD
+    }
+    </code></pre>
+    
+5. [javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js#L5-L5)
+    <pre><code class="javascript">function cleanupTemp() {
+      let cmd = "rm -rf " + path.join(__dirname, "temp");
+      cp.execSync(<strong>cmd</strong>); // BAD
+    }
+    </code></pre>
+    
+
+</details>
+
 
 ----------------------------------------
 
@@ -21,7 +68,39 @@
 	execa.shell('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
 </code></pre>
 
-*This shell command depends on an uncontrolled [absolute path](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L6-L6).*
+<details>
+<summary><i>This shell command depends on an uncontrolled absolute path.</i></summary>
+
+#### Paths
+
+Path with 3 steps
+1. [javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L6-L6)
+    <pre><code class="javascript">(function() {
+    	cp.execFileSync('rm',  ['-rf', path.join(__dirname, "temp")]); // GOOD
+    	cp.execSync('rm -rf ' + path.join(<strong>__dirname</strong>, "temp")); // BAD
+    
+    	execa.shell('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
+    </code></pre>
+    
+2. [javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L6-L6)
+    <pre><code class="javascript">(function() {
+    	cp.execFileSync('rm',  ['-rf', path.join(__dirname, "temp")]); // GOOD
+    	cp.execSync('rm -rf ' + <strong>path.join(__dirname, "temp")</strong>); // BAD
+    
+    	execa.shell('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
+    </code></pre>
+    
+3. [javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L6-L6)
+    <pre><code class="javascript">(function() {
+    	cp.execFileSync('rm',  ['-rf', path.join(__dirname, "temp")]); // GOOD
+    	cp.execSync(<strong>'rm -rf ' + path.join(__dirname, "temp")</strong>); // BAD
+    
+    	execa.shell('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
+    </code></pre>
+    
+
+</details>
+
 
 ----------------------------------------
 
@@ -34,7 +113,39 @@
 
 </code></pre>
 
-*This shell command depends on an uncontrolled [absolute path](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L8-L8).*
+<details>
+<summary><i>This shell command depends on an uncontrolled absolute path.</i></summary>
+
+#### Paths
+
+Path with 3 steps
+1. [javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L8-L8)
+    <pre><code class="javascript">	cp.execSync('rm -rf ' + path.join(__dirname, "temp")); // BAD
+    
+    	execa.shell('rm -rf ' + path.join(<strong>__dirname</strong>, "temp")); // NOT OK
+    	execa.shellSync('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
+    
+    </code></pre>
+    
+2. [javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L8-L8)
+    <pre><code class="javascript">	cp.execSync('rm -rf ' + path.join(__dirname, "temp")); // BAD
+    
+    	execa.shell('rm -rf ' + <strong>path.join(__dirname, "temp")</strong>); // NOT OK
+    	execa.shellSync('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
+    
+    </code></pre>
+    
+3. [javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L8-L8)
+    <pre><code class="javascript">	cp.execSync('rm -rf ' + path.join(__dirname, "temp")); // BAD
+    
+    	execa.shell(<strong>'rm -rf ' + path.join(__dirname, "temp")</strong>); // NOT OK
+    	execa.shellSync('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
+    
+    </code></pre>
+    
+
+</details>
+
 
 ----------------------------------------
 
@@ -47,6 +158,38 @@
 	const safe = "\"" + path.join(__dirname, "temp") + "\"";
 </code></pre>
 
-*This shell command depends on an uncontrolled [absolute path](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L9-L9).*
+<details>
+<summary><i>This shell command depends on an uncontrolled absolute path.</i></summary>
+
+#### Paths
+
+Path with 3 steps
+1. [javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L9-L9)
+    <pre><code class="javascript">
+    	execa.shell('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
+    	execa.shellSync('rm -rf ' + path.join(<strong>__dirname</strong>, "temp")); // NOT OK
+    
+    	const safe = "\"" + path.join(__dirname, "temp") + "\"";
+    </code></pre>
+    
+2. [javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L9-L9)
+    <pre><code class="javascript">
+    	execa.shell('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
+    	execa.shellSync('rm -rf ' + <strong>path.join(__dirname, "temp")</strong>); // NOT OK
+    
+    	const safe = "\"" + path.join(__dirname, "temp") + "\"";
+    </code></pre>
+    
+3. [javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L9-L9)
+    <pre><code class="javascript">
+    	execa.shell('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
+    	execa.shellSync(<strong>'rm -rf ' + path.join(__dirname, "temp")</strong>); // NOT OK
+    
+    	const safe = "\"" + path.join(__dirname, "temp") + "\"";
+    </code></pre>
+    
+
+</details>
+
 
 ----------------------------------------

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/path-problem/results-repo1.md
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/path-problem/results-repo1.md
@@ -8,12 +8,12 @@
 }
 </code></pre>
 
+*This shell command depends on an uncontrolled [absolute path](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js#L4-L4).*
+
 <details>
-<summary><i>This shell command depends on an uncontrolled absolute path.</i></summary>
+<summary>Show paths</summary>
 
-#### Paths
-
-Path with 5 steps
+#### Path with 5 steps
 1. [javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js#L4-L4)
     <pre><code class="javascript">  path = require("path");
     function cleanupTemp() {
@@ -56,7 +56,6 @@ Path with 5 steps
 
 </details>
 
-
 ----------------------------------------
 
 [javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L6-L6)
@@ -68,12 +67,12 @@ Path with 5 steps
 	execa.shell('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
 </code></pre>
 
+*This shell command depends on an uncontrolled [absolute path](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L6-L6).*
+
 <details>
-<summary><i>This shell command depends on an uncontrolled absolute path.</i></summary>
+<summary>Show paths</summary>
 
-#### Paths
-
-Path with 3 steps
+#### Path with 3 steps
 1. [javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L6-L6)
     <pre><code class="javascript">(function() {
     	cp.execFileSync('rm',  ['-rf', path.join(__dirname, "temp")]); // GOOD
@@ -101,7 +100,6 @@ Path with 3 steps
 
 </details>
 
-
 ----------------------------------------
 
 [javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L8-L8)
@@ -113,12 +111,12 @@ Path with 3 steps
 
 </code></pre>
 
+*This shell command depends on an uncontrolled [absolute path](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L8-L8).*
+
 <details>
-<summary><i>This shell command depends on an uncontrolled absolute path.</i></summary>
+<summary>Show paths</summary>
 
-#### Paths
-
-Path with 3 steps
+#### Path with 3 steps
 1. [javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L8-L8)
     <pre><code class="javascript">	cp.execSync('rm -rf ' + path.join(__dirname, "temp")); // BAD
     
@@ -146,7 +144,6 @@ Path with 3 steps
 
 </details>
 
-
 ----------------------------------------
 
 [javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L9-L9)
@@ -158,12 +155,12 @@ Path with 3 steps
 	const safe = "\"" + path.join(__dirname, "temp") + "\"";
 </code></pre>
 
+*This shell command depends on an uncontrolled [absolute path](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L9-L9).*
+
 <details>
-<summary><i>This shell command depends on an uncontrolled absolute path.</i></summary>
+<summary>Show paths</summary>
 
-#### Paths
-
-Path with 3 steps
+#### Path with 3 steps
 1. [javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L9-L9)
     <pre><code class="javascript">
     	execa.shell('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
@@ -190,6 +187,5 @@ Path with 3 steps
     
 
 </details>
-
 
 ----------------------------------------

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/path-problem/results-repo2.md
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/path-problem/results-repo2.md
@@ -9,12 +9,12 @@
   }
 </code></pre>
 
+*This shell command depends on an uncontrolled [absolute path](https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec/npm-packages/meteor-installer/config.js#L39-L39).*
+
 <details>
-<summary><i>This shell command depends on an uncontrolled absolute path.</i></summary>
+<summary>Show paths</summary>
 
-#### Paths
-
-Path with 7 steps
+#### Path with 7 steps
 1. [npm-packages/meteor-installer/config.js](https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec/npm-packages/meteor-installer/config.js#L39-L39)
     <pre><code class="javascript">
     const meteorLocalFolder = '.meteor';
@@ -85,6 +85,5 @@ Path with 7 steps
     
 
 </details>
-
 
 ----------------------------------------

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/path-problem/results-repo2.md
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/path-problem/results-repo2.md
@@ -9,6 +9,82 @@
   }
 </code></pre>
 
-*This shell command depends on an uncontrolled [absolute path](https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec/npm-packages/meteor-installer/config.js#L39-L39).*
+<details>
+<summary><i>This shell command depends on an uncontrolled absolute path.</i></summary>
+
+#### Paths
+
+Path with 7 steps
+1. [npm-packages/meteor-installer/config.js](https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec/npm-packages/meteor-installer/config.js#L39-L39)
+    <pre><code class="javascript">
+    const meteorLocalFolder = '.meteor';
+    const meteorPath = <strong>path.resolve(rootPath, meteorLocalFolder)</strong>;
+    
+    module.exports = {
+    </code></pre>
+    
+2. [npm-packages/meteor-installer/config.js](https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec/npm-packages/meteor-installer/config.js#L39-L39)
+    <pre><code class="javascript">
+    const meteorLocalFolder = '.meteor';
+    const <strong>meteorPath = path.resolve(rootPath, meteorLocalFolder)</strong>;
+    
+    module.exports = {
+    </code></pre>
+    
+3. [npm-packages/meteor-installer/config.js](https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec/npm-packages/meteor-installer/config.js#L44-L44)
+    <pre><code class="javascript">  METEOR_LATEST_VERSION,
+      extractPath: rootPath,
+      <strong>meteorPath</strong>,
+      release: process.env.INSTALL_METEOR_VERSION || METEOR_LATEST_VERSION,
+      rootPath,
+    </code></pre>
+    
+4. [npm-packages/meteor-installer/install.js](https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec/npm-packages/meteor-installer/install.js#L12-L12)
+    <pre><code class="javascript">const os = require('os');
+    const {
+      <strong>meteorPath</strong>,
+      release,
+      startedPath,
+    </code></pre>
+    
+5. [npm-packages/meteor-installer/install.js](https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec/npm-packages/meteor-installer/install.js#L11-L23)
+    <pre><code class="javascript">const tmp = require('tmp');
+    const os = require('os');
+    const <strong>{</strong>
+    <strong>  meteorPath,</strong>
+    <strong>  release,</strong>
+    <strong>  startedPath,</strong>
+    <strong>  extractPath,</strong>
+    <strong>  isWindows,</strong>
+    <strong>  rootPath,</strong>
+    <strong>  sudoUser,</strong>
+    <strong>  isSudo,</strong>
+    <strong>  isMac,</strong>
+    <strong>  METEOR_LATEST_VERSION,</strong>
+    <strong>  shouldSetupExecPath,</strong>
+    <strong>} = require('./config.js')</strong>;
+    const { uninstall } = require('./uninstall');
+    const {
+    </code></pre>
+    
+6. [npm-packages/meteor-installer/install.js](https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec/npm-packages/meteor-installer/install.js#L259-L259)
+    <pre><code class="javascript">  if (isWindows()) {
+        //set for the current session and beyond
+        child_process.execSync(`setx path "${<strong>meteorPath</strong>}/;%path%`);
+        return;
+      }
+    </code></pre>
+    
+7. [npm-packages/meteor-installer/install.js](https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec/npm-packages/meteor-installer/install.js#L259-L259)
+    <pre><code class="javascript">  if (isWindows()) {
+        //set for the current session and beyond
+        child_process.execSync(<strong>`setx path "${meteorPath}/;%path%`</strong>);
+        return;
+      }
+    </code></pre>
+    
+
+</details>
+
 
 ----------------------------------------

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/path-problem/results-repo2.md
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/path-problem/results-repo2.md
@@ -83,6 +83,23 @@
       }
     </code></pre>
     
+#### Path with 2 steps
+1. [npm-packages/meteor-installer/config.js](https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec/npm-packages/meteor-installer/config.js#L39-L39)
+    <pre><code class="javascript">
+    const meteorLocalFolder = '.meteor';
+    const meteorPath = <strong>path.resolve(rootPath, meteorLocalFolder)</strong>;
+    
+    module.exports = {
+    </code></pre>
+    
+2. [npm-packages/meteor-installer/install.js](https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec/npm-packages/meteor-installer/install.js#L259-L259)
+    <pre><code class="javascript">  if (isWindows()) {
+        //set for the current session and beyond
+        child_process.execSync(<strong>`setx path "${meteorPath}/;%path%`</strong>);
+        return;
+      }
+    </code></pre>
+    
 
 </details>
 


### PR DESCRIPTION
_(based on #1312)_

Render path results in an expandable section (as shown in the example in the linked internal issue!) 

Click [here](https://github.com/github/vscode-codeql/blob/shati-patel/sharing-path-results/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/path-problem/results-repo1.md) for a cute rendered preview  🖼️ 

## Checklist

N/A - internal only 😄 

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
