### PR TITLE
MRVA: Generate markdown summary for query with raw results

### DIFF
--- a/extensions/ql-vscode/src/pure/sarif-utils.ts
+++ b/extensions/ql-vscode/src/pure/sarif-utils.ts
@@ -1,5 +1,5 @@
 import * as Sarif from 'sarif';
-import { HighlightedRegion } from '../remote-queries/shared/analysis-result';
+import { AnalysisResults, HighlightedRegion } from '../remote-queries/shared/analysis-result';
 import { ResolvableLocationValue } from './bqrs-cli-types';
 
 export interface SarifLink {
@@ -236,3 +236,11 @@ export function parseHighlightedLine(
 
   return { plainSection1, highlightedSection, plainSection2 };
 }
+
+/**
+ * Returns the number of (raw + interpreted) results for an analysis.
+ */
+export const getAnalysisResultCount = (analysisResults: AnalysisResults): number => {
+  const rawResultCount = analysisResults.rawResults?.resultSet.rows.length || 0;
+  return analysisResults.interpretedResults.length + rawResultCount;
+};

--- a/extensions/ql-vscode/src/pure/sarif-utils.ts
+++ b/extensions/ql-vscode/src/pure/sarif-utils.ts
@@ -1,5 +1,5 @@
 import * as Sarif from 'sarif';
-import { AnalysisResults, HighlightedRegion } from '../remote-queries/shared/analysis-result';
+import { HighlightedRegion } from '../remote-queries/shared/analysis-result';
 import { ResolvableLocationValue } from './bqrs-cli-types';
 
 export interface SarifLink {
@@ -236,11 +236,3 @@ export function parseHighlightedLine(
 
   return { plainSection1, highlightedSection, plainSection2 };
 }
-
-/**
- * Returns the number of (raw + interpreted) results for an analysis.
- */
-export const getAnalysisResultCount = (analysisResults: AnalysisResults): number => {
-  const rawResultCount = analysisResults.rawResults?.resultSet.rows.length || 0;
-  return analysisResults.interpretedResults.length + rawResultCount;
-};

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-markdown-generation.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-markdown-generation.ts
@@ -1,5 +1,5 @@
 import { createRemoteFileRef } from '../pure/location-link-utils';
-import { parseHighlightedLine, shouldHighlightLine } from '../pure/sarif-utils';
+import { getAnalysisResultCount, parseHighlightedLine, shouldHighlightLine } from '../pure/sarif-utils';
 import { RemoteQuery } from './remote-query';
 import { AnalysisAlert, AnalysisResults, CodeSnippet, FileLink, HighlightedRegion } from './shared/analysis-result';
 
@@ -14,14 +14,13 @@ export function generateMarkdown(query: RemoteQuery, analysesResults: AnalysisRe
   // Generate summary file with links to individual files
   const summaryLines: MarkdownFile = generateMarkdownSummary(query);
   for (const analysisResult of analysesResults) {
-    if (analysisResult.interpretedResults.length === 0) {
-      // TODO: We'll add support for non-interpreted results later.
+    if (analysisResult.interpretedResults.length === 0 && !analysisResult.rawResults) {
       continue;
     }
 
     // Append nwo and results count to the summary table
     const nwo = analysisResult.nwo;
-    const resultsCount = analysisResult.interpretedResults.length;
+    const resultsCount = getAnalysisResultCount(analysisResult);
     const link = createGistRelativeLink(nwo);
     summaryLines.push(`| ${nwo} | [${resultsCount} result(s)](${link}) |`);
 
@@ -33,6 +32,9 @@ export function generateMarkdown(query: RemoteQuery, analysesResults: AnalysisRe
     for (const interpretedResult of analysisResult.interpretedResults) {
       const individualResult = generateMarkdownForInterpretedResult(interpretedResult, query.language);
       lines.push(...individualResult);
+    }
+    if (analysisResult.rawResults) {
+      // TODO: Generate markdown table for raw results
     }
     files.push(lines);
   }

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-markdown-generation.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-markdown-generation.ts
@@ -1,7 +1,7 @@
 import { createRemoteFileRef } from '../pure/location-link-utils';
-import { getAnalysisResultCount, parseHighlightedLine, shouldHighlightLine } from '../pure/sarif-utils';
+import { parseHighlightedLine, shouldHighlightLine } from '../pure/sarif-utils';
 import { RemoteQuery } from './remote-query';
-import { AnalysisAlert, AnalysisResults, CodeSnippet, FileLink, HighlightedRegion } from './shared/analysis-result';
+import { AnalysisAlert, AnalysisResults, CodeSnippet, FileLink, getAnalysisResultCount, HighlightedRegion } from './shared/analysis-result';
 
 // Each array item is a line of the markdown file.
 export type MarkdownFile = string[];
@@ -14,13 +14,13 @@ export function generateMarkdown(query: RemoteQuery, analysesResults: AnalysisRe
   // Generate summary file with links to individual files
   const summaryLines: MarkdownFile = generateMarkdownSummary(query);
   for (const analysisResult of analysesResults) {
-    if (analysisResult.interpretedResults.length === 0 && !analysisResult.rawResults) {
+    const resultsCount = getAnalysisResultCount(analysisResult);
+    if (resultsCount === 0) {
       continue;
     }
 
     // Append nwo and results count to the summary table
     const nwo = analysisResult.nwo;
-    const resultsCount = getAnalysisResultCount(analysisResult);
     const link = createGistRelativeLink(nwo);
     summaryLines.push(`| ${nwo} | [${resultsCount} result(s)](${link}) |`);
 

--- a/extensions/ql-vscode/src/remote-queries/shared/analysis-result.ts
+++ b/extensions/ql-vscode/src/remote-queries/shared/analysis-result.ts
@@ -78,3 +78,11 @@ export interface AnalysisMessageLocationToken {
 }
 
 export type ResultSeverity = 'Recommendation' | 'Warning' | 'Error';
+
+/**
+ * Returns the number of (raw + interpreted) results for an analysis.
+ */
+export const getAnalysisResultCount = (analysisResults: AnalysisResults): number => {
+  const rawResultCount = analysisResults.rawResults?.resultSet.rows.length || 0;
+  return analysisResults.interpretedResults.length + rawResultCount;
+};

--- a/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
@@ -13,14 +13,13 @@ import HorizontalSpace from './HorizontalSpace';
 import Badge from './Badge';
 import ViewTitle from './ViewTitle';
 import DownloadButton from './DownloadButton';
-import { AnalysisResults } from '../shared/analysis-result';
+import { AnalysisResults, getAnalysisResultCount } from '../shared/analysis-result';
 import DownloadSpinner from './DownloadSpinner';
 import CollapsibleItem from './CollapsibleItem';
 import { AlertIcon, CodeSquareIcon, FileCodeIcon, RepoIcon, TerminalIcon } from '@primer/octicons-react';
 import AnalysisAlertResult from './AnalysisAlertResult';
 import RawResultsTable from './RawResultsTable';
 import RepositoriesSearch from './RepositoriesSearch';
-import { getAnalysisResultCount } from '../../pure/sarif-utils';
 
 const numOfReposInContractedMode = 10;
 

--- a/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
@@ -20,6 +20,7 @@ import { AlertIcon, CodeSquareIcon, FileCodeIcon, RepoIcon, TerminalIcon } from 
 import AnalysisAlertResult from './AnalysisAlertResult';
 import RawResultsTable from './RawResultsTable';
 import RepositoriesSearch from './RepositoriesSearch';
+import { getAnalysisResultCount } from '../../pure/sarif-utils';
 
 const numOfReposInContractedMode = 10;
 
@@ -65,11 +66,6 @@ const openQueryTextVirtualFile = (queryResult: RemoteQueryResult) => {
     t: 'openVirtualFile',
     queryText: queryResult.queryText
   });
-};
-
-const getAnalysisResultCount = (analysisResults: AnalysisResults): number => {
-  const rawResultCount = analysisResults.rawResults?.resultSet.rows.length || 0;
-  return analysisResults.interpretedResults.length + rawResultCount;
 };
 
 const sumAnalysesResults = (analysesResults: AnalysisResults[]) =>

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/raw-results/analyses-results.json
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/raw-results/analyses-results.json
@@ -1,0 +1,392 @@
+[
+  {
+    "nwo": "github/codeql",
+    "status": "Completed",
+    "interpretedResults": [],
+    "rawResults": {
+      "schema": {
+        "name": "#select",
+        "rows": 22,
+        "columns": [
+          {
+            "name": "c",
+            "kind": "e"
+          },
+          {
+            "kind": "i"
+          }
+        ]
+      },
+      "resultSet": {
+        "schema": {
+          "name": "#select",
+          "rows": 22,
+          "columns": [
+            {
+              "name": "c",
+              "kind": "e"
+            },
+            {
+              "kind": "i"
+            }
+          ]
+        },
+        "rows": [
+          [
+            {
+              "label": "functio ... ght);\\n}",
+              "url": {
+                "uri": "file:/home/runner/work/bulk-builder/bulk-builder/javascript/ql/src/Expressions/examples/CompareIdenticalValues.js",
+                "startLine": 8,
+                "startColumn": 32,
+                "endLine": 13,
+                "endColumn": 1
+              }
+            },
+            6
+          ],
+          [
+            {
+              "label": "functio ... i-1);\\n}",
+              "url": {
+                "uri": "file:/home/runner/work/bulk-builder/bulk-builder/javascript/ql/src/LanguageFeatures/examples/ArgumentsCallerCallee.js",
+                "startLine": 1,
+                "startColumn": 2,
+                "endLine": 5,
+                "endColumn": 1
+              }
+            },
+            5
+          ],
+          [
+            {
+              "label": "functio ... i-1);\\n}",
+              "url": {
+                "uri": "file:/home/runner/work/bulk-builder/bulk-builder/javascript/ql/src/LanguageFeatures/examples/ArgumentsCallerCalleeGood.js",
+                "startLine": 1,
+                "startColumn": 2,
+                "endLine": 5,
+                "endColumn": 1
+              }
+            },
+            5
+          ],
+          [
+            {
+              "label": "functio ... n -1;\\n}",
+              "url": {
+                "uri": "file:/home/runner/work/bulk-builder/bulk-builder/javascript/ql/src/Statements/examples/UselessComparisonTest.js",
+                "startLine": 1,
+                "startColumn": 1,
+                "endLine": 12,
+                "endColumn": 1
+              }
+            },
+            12
+          ],
+          [
+            {
+              "label": "functio ... false\\n}",
+              "url": {
+                "uri": "file:/home/runner/work/bulk-builder/bulk-builder/javascript/ql/test/library-tests/RangeAnalysis/constants.js",
+                "startLine": 1,
+                "startColumn": 1,
+                "endLine": 8,
+                "endColumn": 1
+              }
+            },
+            8
+          ],
+          [
+            {
+              "label": "functio ...  \\n  }\\n}",
+              "url": {
+                "uri": "file:/home/runner/work/bulk-builder/bulk-builder/javascript/ql/test/library-tests/RangeAnalysis/loop.js",
+                "startLine": 1,
+                "startColumn": 1,
+                "endLine": 12,
+                "endColumn": 1
+              }
+            },
+            12
+          ],
+          [
+            {
+              "label": "functio ... e\\n  }\\n}",
+              "url": {
+                "uri": "file:/home/runner/work/bulk-builder/bulk-builder/javascript/ql/test/library-tests/RangeAnalysis/loop.js",
+                "startLine": 14,
+                "startColumn": 1,
+                "endLine": 22,
+                "endColumn": 1
+              }
+            },
+            9
+          ],
+          [
+            {
+              "label": "functio ... K\\n  }\\n}",
+              "url": {
+                "uri": "file:/home/runner/work/bulk-builder/bulk-builder/javascript/ql/test/library-tests/RangeAnalysis/loop.js",
+                "startLine": 24,
+                "startColumn": 1,
+                "endLine": 40,
+                "endColumn": 1
+              }
+            },
+            17
+          ],
+          [
+            {
+              "label": "functio ... e\\n  }\\n}",
+              "url": {
+                "uri": "file:/home/runner/work/bulk-builder/bulk-builder/javascript/ql/test/library-tests/RangeAnalysis/plus.js",
+                "startLine": 1,
+                "startColumn": 1,
+                "endLine": 17,
+                "endColumn": 1
+              }
+            },
+            17
+          ],
+          [
+            {
+              "label": "functio ... alse \\n}",
+              "url": {
+                "uri": "file:/home/runner/work/bulk-builder/bulk-builder/javascript/ql/test/library-tests/RangeAnalysis/plus.js",
+                "startLine": 19,
+                "startColumn": 1,
+                "endLine": 28,
+                "endColumn": 1
+              }
+            },
+            10
+          ],
+          [
+            {
+              "label": "functio ...  true\\n}",
+              "url": {
+                "uri": "file:/home/runner/work/bulk-builder/bulk-builder/javascript/ql/test/library-tests/RangeAnalysis/plus.js",
+                "startLine": 30,
+                "startColumn": 1,
+                "endLine": 33,
+                "endColumn": 1
+              }
+            },
+            4
+          ],
+          [
+            {
+              "label": "functio ... K\\n  }\\n}",
+              "url": {
+                "uri": "file:/home/runner/work/bulk-builder/bulk-builder/javascript/ql/test/library-tests/RangeAnalysis/tst.js",
+                "startLine": 1,
+                "startColumn": 1,
+                "endLine": 15,
+                "endColumn": 1
+              }
+            },
+            15
+          ],
+          [
+            {
+              "label": "functio ... e\\n  }\\n}",
+              "url": {
+                "uri": "file:/home/runner/work/bulk-builder/bulk-builder/javascript/ql/test/library-tests/RangeAnalysis/tst.js",
+                "startLine": 17,
+                "startColumn": 1,
+                "endLine": 31,
+                "endColumn": 1
+              }
+            },
+            15
+          ],
+          [
+            {
+              "label": "functio ... false\\n}",
+              "url": {
+                "uri": "file:/home/runner/work/bulk-builder/bulk-builder/javascript/ql/test/library-tests/RangeAnalysis/tst.js",
+                "startLine": 33,
+                "startColumn": 1,
+                "endLine": 41,
+                "endColumn": 1
+              }
+            },
+            9
+          ],
+          [
+            {
+              "label": "functio ... e\\n  }\\n}",
+              "url": {
+                "uri": "file:/home/runner/work/bulk-builder/bulk-builder/javascript/ql/test/library-tests/RangeAnalysis/tst.js",
+                "startLine": 43,
+                "startColumn": 1,
+                "endLine": 52,
+                "endColumn": 1
+              }
+            },
+            10
+          ],
+          [
+            {
+              "label": "functio ... ght);\\n}",
+              "url": {
+                "uri": "file:/home/runner/work/bulk-builder/bulk-builder/javascript/ql/test/query-tests/Expressions/CompareIdenticalValues/tst.js",
+                "startLine": 8,
+                "startColumn": 32,
+                "endLine": 13,
+                "endColumn": 1
+              }
+            },
+            6
+          ],
+          [
+            {
+              "label": "functio ... i-1);\\n}",
+              "url": {
+                "uri": "file:/home/runner/work/bulk-builder/bulk-builder/javascript/ql/test/query-tests/LanguageFeatures/ArgumentsCallerCallee/tst.js",
+                "startLine": 1,
+                "startColumn": 2,
+                "endLine": 5,
+                "endColumn": 1
+              }
+            },
+            5
+          ],
+          [
+            {
+              "label": "functio ...     }\\n}",
+              "url": {
+                "uri": "file:/home/runner/work/bulk-builder/bulk-builder/javascript/ql/test/query-tests/Security/CWE-834/LoopBoundInjectionExitBad.js",
+                "startLine": 17,
+                "startColumn": 1,
+                "endLine": 29,
+                "endColumn": 1
+              }
+            },
+            13
+          ],
+          [
+            {
+              "label": "functio ...  true\\n}",
+              "url": {
+                "uri": "file:/home/runner/work/bulk-builder/bulk-builder/javascript/ql/test/query-tests/Statements/UselessComparisonTest/constant.js",
+                "startLine": 1,
+                "startColumn": 1,
+                "endLine": 4,
+                "endColumn": 1
+              }
+            },
+            4
+          ],
+          [
+            {
+              "label": "functio ... n -1;\\n}",
+              "url": {
+                "uri": "file:/home/runner/work/bulk-builder/bulk-builder/javascript/ql/test/query-tests/Statements/UselessComparisonTest/example.js",
+                "startLine": 1,
+                "startColumn": 1,
+                "endLine": 12,
+                "endColumn": 1
+              }
+            },
+            12
+          ],
+          [
+            {
+              "label": "functio ... turn; }",
+              "url": {
+                "uri": "file:/home/runner/work/bulk-builder/bulk-builder/javascript/ql/test/query-tests/Statements/UselessComparisonTest/tst.js",
+                "startLine": 8,
+                "startColumn": 3,
+                "endLine": 8,
+                "endColumn": 43
+              }
+            },
+            1
+          ],
+          [
+            {
+              "label": "functio ... i+1); }",
+              "url": {
+                "uri": "file:/home/runner/work/bulk-builder/bulk-builder/javascript/ql/test/query-tests/Statements/UselessComparisonTest/tst.js",
+                "startLine": 9,
+                "startColumn": 3,
+                "endLine": 9,
+                "endColumn": 52
+              }
+            },
+            1
+          ]
+        ]
+      },
+      "fileLinkPrefix": "https://github.com/github/codeql/blob/cbdd4927cee593b715d8469240ce1d31edaaef9b",
+      "capped": false
+    }
+  },
+  {
+    "nwo": "meteor/meteor",
+    "status": "Completed",
+    "interpretedResults": [],
+    "rawResults": {
+      "schema": {
+        "name": "#select",
+        "rows": 2,
+        "columns": [
+          {
+            "name": "c",
+            "kind": "e"
+          },
+          {
+            "kind": "i"
+          }
+        ]
+      },
+      "resultSet": {
+        "schema": {
+          "name": "#select",
+          "rows": 2,
+          "columns": [
+            {
+              "name": "c",
+              "kind": "e"
+            },
+            {
+              "kind": "i"
+            }
+          ]
+        },
+        "rows": [
+          [
+            {
+              "label": "functio ... rn H|0}",
+              "url": {
+                "uri": "file:/home/runner/work/bulk-builder/bulk-builder/packages/logic-solver/minisat.js",
+                "startLine": 7,
+                "startColumn": 91430,
+                "endLine": 7,
+                "endColumn": 105027
+              }
+            },
+            1
+          ],
+          [
+            {
+              "label": "functio ... ext;\\n\\t}",
+              "url": {
+                "uri": "file:/home/runner/work/bulk-builder/bulk-builder/packages/sha/sha256.js",
+                "startLine": 94,
+                "startColumn": 2,
+                "endLine": 124,
+                "endColumn": 2
+              }
+            },
+            31
+          ]
+        ]
+      },
+      "fileLinkPrefix": "https://github.com/meteor/meteor/blob/53f3c4442d3542d3d2a012a854472a0d1bef9d12",
+      "capped": false
+    }
+  }
+]

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/raw-results/query.json
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/raw-results/query.json
@@ -1,0 +1,12 @@
+{
+  "queryName": "Contradictory guard nodes",
+  "queryFilePath": "c:\\Users\\foo\\bar\\quick-query.ql",
+  "queryText": "/**\n * @name Contradictory guard nodes\n * \n * @description Snippet from \"UselessComparisonTest.ql\"\n */\n\nimport javascript\n\n/**\n * Holds if there are any contradictory guard nodes in `container`.\n *\n * We use this to restrict reachability analysis to a small set of containers.\n */\npredicate hasContradictoryGuardNodes(StmtContainer container) {\n  exists(ConditionGuardNode guard |\n    RangeAnalysis::isContradictoryGuardNode(guard) and\n    container = guard.getContainer()\n  )\n}\n\nfrom StmtContainer c\nwhere hasContradictoryGuardNodes(c)\nselect c, c.getNumLines()",
+  "language": "javascript",
+  "controllerRepository": {
+    "owner": "dsp-testing",
+    "name": "qc-controller"
+  },
+  "executionStartTime": 1650979054479,
+  "actionsWorkflowRunId": 2226920623
+}

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/raw-results/results-repo1.md
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/raw-results/results-repo1.md
@@ -1,0 +1,1 @@
+### github/codeql

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/raw-results/results-repo2.md
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/raw-results/results-repo2.md
@@ -1,0 +1,1 @@
+### meteor/meteor

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/raw-results/summary.md
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/raw-results/summary.md
@@ -1,0 +1,41 @@
+### Results for "Contradictory guard nodes"
+
+<details>
+<summary>Query</summary>
+
+```ql
+/**
+ * @name Contradictory guard nodes
+ * 
+ * @description Snippet from "UselessComparisonTest.ql"
+ */
+
+import javascript
+
+/**
+ * Holds if there are any contradictory guard nodes in `container`.
+ *
+ * We use this to restrict reachability analysis to a small set of containers.
+ */
+predicate hasContradictoryGuardNodes(StmtContainer container) {
+  exists(ConditionGuardNode guard |
+    RangeAnalysis::isContradictoryGuardNode(guard) and
+    container = guard.getContainer()
+  )
+}
+
+from StmtContainer c
+where hasContradictoryGuardNodes(c)
+select c, c.getNumLines()
+```
+
+</details>
+
+<br />
+
+### Summary
+
+| Repository | Results |
+| --- | --- |
+| github/codeql | [22 result(s)](#file-github-codeql-md) |
+| meteor/meteor | [2 result(s)](#file-meteor-meteor-md) |

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/markdown-generation.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/markdown-generation.test.ts
@@ -61,6 +61,35 @@ describe('markdown generation', async function() {
       expect(markdownFile2.join('\n')).to.equal(expectedTestOutput2);
     });
   });
+
+  describe('for non-alert query', async function() {
+    it('should generate markdown file for each repo with results', async function() {
+      const query = JSON.parse(
+        await fs.readFile(path.join(__dirname, 'data/raw-results/query.json'), 'utf8')
+      );
+      const analysesResults = JSON.parse(
+        await fs.readFile(path.join(__dirname, 'data/raw-results/analyses-results.json'), 'utf8')
+      );
+
+      const markdownFiles = generateMarkdown(query, analysesResults);
+
+      // Check that query has results for two repositories, plus a summary file
+      expect(markdownFiles.length).to.equal(3);
+
+      const markdownFile0 = markdownFiles[0]; // summary file
+      const markdownFile1 = markdownFiles[1]; // results for github/codeql repo
+      const markdownFile2 = markdownFiles[2]; // results for meteor/meteor repo
+
+      const expectedSummaryFile = await readTestOutputFile('data/raw-results/summary.md');
+      const expectedTestOutput1 = await readTestOutputFile('data/raw-results/results-repo1.md');
+      const expectedTestOutput2 = await readTestOutputFile('data/raw-results/results-repo2.md');
+
+      // Check that markdown output is correct, after making line endings consistent
+      expect(markdownFile0.join('\n')).to.equal(expectedSummaryFile);
+      expect(markdownFile1.join('\n')).to.equal(expectedTestOutput1);
+      expect(markdownFile2.join('\n')).to.equal(expectedTestOutput2);
+    });
+  });
 });
 
 /**


### PR DESCRIPTION
First step towards rendering markdown for non-interpreted results (see internal issue).

This PR adds new test data and creates a summary file (example [here](https://github.com/github/vscode-codeql/blob/shati-patel/md-raw-result/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/raw-results/summary.md)) 🖼️ 
I haven't yet added support for the rendering the actual results table (I'll do that in a follow-up PR 🔜 ) 

## Checklist

N/A - internal only 🔐 

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
