### PR TITLE
MRVA: Tweak code snippets and links in results view

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/view/FileCodeSnippet.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/FileCodeSnippet.tsx
@@ -163,8 +163,8 @@ const FileCodeSnippet = ({
 
   const titleFileUri = createRemoteFileRef(
     fileLink,
-    startingLine,
-    endingLine);
+    highlightedRegion?.startLine || startingLine,
+    highlightedRegion?.endLine || endingLine);
 
   if (!codeSnippet) {
     return (

--- a/extensions/ql-vscode/src/remote-queries/view/FileCodeSnippet.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/FileCodeSnippet.tsx
@@ -21,7 +21,7 @@ const getSeverityColor = (severity: ResultSeverity) => {
   }
 };
 
-const replaceSpaceChar = (text: string) => text.replaceAll(' ', '\u00a0');
+const replaceSpaceAndTabChar = (text: string) => text.replaceAll(' ', '\u00a0').replaceAll('\t', '\u00a0\u00a0\u00a0\u00a0');
 
 const Container = styled.div`
   font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
@@ -56,11 +56,11 @@ const MessageContainer = styled.div`
 `;
 
 const PlainLine = ({ text }: { text: string }) => {
-  return <span>{replaceSpaceChar(text)}</span>;
+  return <span>{replaceSpaceAndTabChar(text)}</span>;
 };
 
 const HighlightedLine = ({ text }: { text: string }) => {
-  return <span style={{ backgroundColor: highlightColor }}>{replaceSpaceChar(text)}</span>;
+  return <span style={{ backgroundColor: highlightColor }}>{replaceSpaceAndTabChar(text)}</span>;
 };
 
 const Message = ({


### PR DESCRIPTION
Two small fixes!
- These file links now link to the specific highlighted section on GitHub, instead of the whole code snippet:  
   ![image](https://user-images.githubusercontent.com/42641846/165735364-5d2522e2-3149-4995-be7e-a14704a2295a.png)
- We now properly indent code snippets that use tabs 😇 

## Checklist

N/A - internal only 🦈 

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
