### PR TITLE
MRVA: Generate markdown for raw result tables

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/remote-queries-markdown-generation.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-markdown-generation.ts
@@ -244,7 +244,7 @@ function generateMarkdownForRawTableCell(
       break;
   }
   // `|` characters break the table, so we need to escape them
-  return cellValue.replace('|', '\\|');
+  return cellValue.replaceAll('|', '\\|');
 }
 
 

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-markdown-generation.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-markdown-generation.ts
@@ -244,7 +244,7 @@ function generateMarkdownForRawTableCell(
       break;
   }
   // `|` characters break the table, so we need to escape them
-  return cellValue.replaceAll('|', '\\|');
+  return cellValue.replace(/\|/g, '\\|');
 }
 
 

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-markdown-generation.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-markdown-generation.ts
@@ -244,7 +244,7 @@ function generateMarkdownForRawTableCell(
       break;
   }
   // `|` characters break the table, so we need to escape them
-  return cellValue.replace(/\|/g, '\\|');
+  return cellValue.replaceAll('|', '\\|');
 }
 
 

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/raw-results/analyses-results.json
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/raw-results/analyses-results.json
@@ -307,7 +307,7 @@
           ],
           [
             {
-              "label": "functio ... i+1); }",
+              "label": "| functio ... i+1); |}",
               "url": {
                 "uri": "file:/home/runner/work/bulk-builder/bulk-builder/javascript/ql/test/query-tests/Statements/UselessComparisonTest/tst.js",
                 "startLine": 9,

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/raw-results/results-repo1.md
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/raw-results/results-repo1.md
@@ -23,4 +23,4 @@
 | [`functio ...  true\n}`](https://github.com/github/codeql/blob/cbdd4927cee593b715d8469240ce1d31edaaef9b/javascript/ql/test/query-tests/Statements/UselessComparisonTest/constant.js#L1-L4) | `4` |
 | [`functio ... n -1;\n}`](https://github.com/github/codeql/blob/cbdd4927cee593b715d8469240ce1d31edaaef9b/javascript/ql/test/query-tests/Statements/UselessComparisonTest/example.js#L1-L12) | `12` |
 | [`functio ... turn; }`](https://github.com/github/codeql/blob/cbdd4927cee593b715d8469240ce1d31edaaef9b/javascript/ql/test/query-tests/Statements/UselessComparisonTest/tst.js#L8-L8) | `1` |
-| [`| functio ... i+1); |}`](https://github.com/github/codeql/blob/cbdd4927cee593b715d8469240ce1d31edaaef9b/javascript/ql/test/query-tests/Statements/UselessComparisonTest/tst.js#L9-L9) | `1` |
+| [`\| functio ... i+1); \|}`](https://github.com/github/codeql/blob/cbdd4927cee593b715d8469240ce1d31edaaef9b/javascript/ql/test/query-tests/Statements/UselessComparisonTest/tst.js#L9-L9) | `1` |

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/raw-results/results-repo1.md
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/raw-results/results-repo1.md
@@ -23,4 +23,4 @@
 | [`functio ...  true\n}`](https://github.com/github/codeql/blob/cbdd4927cee593b715d8469240ce1d31edaaef9b/javascript/ql/test/query-tests/Statements/UselessComparisonTest/constant.js#L1-L4) | `4` |
 | [`functio ... n -1;\n}`](https://github.com/github/codeql/blob/cbdd4927cee593b715d8469240ce1d31edaaef9b/javascript/ql/test/query-tests/Statements/UselessComparisonTest/example.js#L1-L12) | `12` |
 | [`functio ... turn; }`](https://github.com/github/codeql/blob/cbdd4927cee593b715d8469240ce1d31edaaef9b/javascript/ql/test/query-tests/Statements/UselessComparisonTest/tst.js#L8-L8) | `1` |
-| [`functio ... i+1); }`](https://github.com/github/codeql/blob/cbdd4927cee593b715d8469240ce1d31edaaef9b/javascript/ql/test/query-tests/Statements/UselessComparisonTest/tst.js#L9-L9) | `1` |
+| [`| functio ... i+1); |}`](https://github.com/github/codeql/blob/cbdd4927cee593b715d8469240ce1d31edaaef9b/javascript/ql/test/query-tests/Statements/UselessComparisonTest/tst.js#L9-L9) | `1` |

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/raw-results/results-repo1.md
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/raw-results/results-repo1.md
@@ -1,1 +1,26 @@
 ### github/codeql
+
+| c |  |
+| --- | --- |
+| [`functio ... ght);\n}`](https://github.com/github/codeql/blob/cbdd4927cee593b715d8469240ce1d31edaaef9b/javascript/ql/src/Expressions/examples/CompareIdenticalValues.js#L8-L13) | `6` |
+| [`functio ... i-1);\n}`](https://github.com/github/codeql/blob/cbdd4927cee593b715d8469240ce1d31edaaef9b/javascript/ql/src/LanguageFeatures/examples/ArgumentsCallerCallee.js#L1-L5) | `5` |
+| [`functio ... i-1);\n}`](https://github.com/github/codeql/blob/cbdd4927cee593b715d8469240ce1d31edaaef9b/javascript/ql/src/LanguageFeatures/examples/ArgumentsCallerCalleeGood.js#L1-L5) | `5` |
+| [`functio ... n -1;\n}`](https://github.com/github/codeql/blob/cbdd4927cee593b715d8469240ce1d31edaaef9b/javascript/ql/src/Statements/examples/UselessComparisonTest.js#L1-L12) | `12` |
+| [`functio ... false\n}`](https://github.com/github/codeql/blob/cbdd4927cee593b715d8469240ce1d31edaaef9b/javascript/ql/test/library-tests/RangeAnalysis/constants.js#L1-L8) | `8` |
+| [`functio ...  \n  }\n}`](https://github.com/github/codeql/blob/cbdd4927cee593b715d8469240ce1d31edaaef9b/javascript/ql/test/library-tests/RangeAnalysis/loop.js#L1-L12) | `12` |
+| [`functio ... e\n  }\n}`](https://github.com/github/codeql/blob/cbdd4927cee593b715d8469240ce1d31edaaef9b/javascript/ql/test/library-tests/RangeAnalysis/loop.js#L14-L22) | `9` |
+| [`functio ... K\n  }\n}`](https://github.com/github/codeql/blob/cbdd4927cee593b715d8469240ce1d31edaaef9b/javascript/ql/test/library-tests/RangeAnalysis/loop.js#L24-L40) | `17` |
+| [`functio ... e\n  }\n}`](https://github.com/github/codeql/blob/cbdd4927cee593b715d8469240ce1d31edaaef9b/javascript/ql/test/library-tests/RangeAnalysis/plus.js#L1-L17) | `17` |
+| [`functio ... alse \n}`](https://github.com/github/codeql/blob/cbdd4927cee593b715d8469240ce1d31edaaef9b/javascript/ql/test/library-tests/RangeAnalysis/plus.js#L19-L28) | `10` |
+| [`functio ...  true\n}`](https://github.com/github/codeql/blob/cbdd4927cee593b715d8469240ce1d31edaaef9b/javascript/ql/test/library-tests/RangeAnalysis/plus.js#L30-L33) | `4` |
+| [`functio ... K\n  }\n}`](https://github.com/github/codeql/blob/cbdd4927cee593b715d8469240ce1d31edaaef9b/javascript/ql/test/library-tests/RangeAnalysis/tst.js#L1-L15) | `15` |
+| [`functio ... e\n  }\n}`](https://github.com/github/codeql/blob/cbdd4927cee593b715d8469240ce1d31edaaef9b/javascript/ql/test/library-tests/RangeAnalysis/tst.js#L17-L31) | `15` |
+| [`functio ... false\n}`](https://github.com/github/codeql/blob/cbdd4927cee593b715d8469240ce1d31edaaef9b/javascript/ql/test/library-tests/RangeAnalysis/tst.js#L33-L41) | `9` |
+| [`functio ... e\n  }\n}`](https://github.com/github/codeql/blob/cbdd4927cee593b715d8469240ce1d31edaaef9b/javascript/ql/test/library-tests/RangeAnalysis/tst.js#L43-L52) | `10` |
+| [`functio ... ght);\n}`](https://github.com/github/codeql/blob/cbdd4927cee593b715d8469240ce1d31edaaef9b/javascript/ql/test/query-tests/Expressions/CompareIdenticalValues/tst.js#L8-L13) | `6` |
+| [`functio ... i-1);\n}`](https://github.com/github/codeql/blob/cbdd4927cee593b715d8469240ce1d31edaaef9b/javascript/ql/test/query-tests/LanguageFeatures/ArgumentsCallerCallee/tst.js#L1-L5) | `5` |
+| [`functio ...     }\n}`](https://github.com/github/codeql/blob/cbdd4927cee593b715d8469240ce1d31edaaef9b/javascript/ql/test/query-tests/Security/CWE-834/LoopBoundInjectionExitBad.js#L17-L29) | `13` |
+| [`functio ...  true\n}`](https://github.com/github/codeql/blob/cbdd4927cee593b715d8469240ce1d31edaaef9b/javascript/ql/test/query-tests/Statements/UselessComparisonTest/constant.js#L1-L4) | `4` |
+| [`functio ... n -1;\n}`](https://github.com/github/codeql/blob/cbdd4927cee593b715d8469240ce1d31edaaef9b/javascript/ql/test/query-tests/Statements/UselessComparisonTest/example.js#L1-L12) | `12` |
+| [`functio ... turn; }`](https://github.com/github/codeql/blob/cbdd4927cee593b715d8469240ce1d31edaaef9b/javascript/ql/test/query-tests/Statements/UselessComparisonTest/tst.js#L8-L8) | `1` |
+| [`functio ... i+1); }`](https://github.com/github/codeql/blob/cbdd4927cee593b715d8469240ce1d31edaaef9b/javascript/ql/test/query-tests/Statements/UselessComparisonTest/tst.js#L9-L9) | `1` |

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/raw-results/results-repo2.md
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/raw-results/results-repo2.md
@@ -1,1 +1,6 @@
 ### meteor/meteor
+
+| c |  |
+| --- | --- |
+| [`functio ... rn H\|0}`](https://github.com/meteor/meteor/blob/53f3c4442d3542d3d2a012a854472a0d1bef9d12/packages/logic-solver/minisat.js#L7-L7) | `1` |
+| [`functio ... ext;\n\t}`](https://github.com/meteor/meteor/blob/53f3c4442d3542d3d2a012a854472a0d1bef9d12/packages/sha/sha256.js#L94-L124) | `31` |


### PR DESCRIPTION
Follow-up to #1318 for rendering raw results! This PR adds the actual table with results (see internal linked issue).

Some example rendered results [here](https://github.com/github/vscode-codeql/blob/shati-patel/md-raw-results/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/raw-results/results-repo1.md) and [here](https://github.com/github/vscode-codeql/blob/shati-patel/md-raw-results/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/raw-results/results-repo2.md) 🖼️ 🎨 

(It looks kinda ugly, but maybe that's mainly because these example results and column names are fairly meaningless 😂)

## Checklist

N/A - still internal only 🕳️ 

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
