### PR TITLE
MRVA: Add open on GitHub action to cancelled/failed queries

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -775,7 +775,7 @@
         {
           "command": "codeQLQueryHistory.openOnGithub",
           "group": "9_qlCommands",
-          "when": "viewItem == remoteResultsItem || viewItem == inProgressRemoteResultsItem"
+          "when": "viewItem == remoteResultsItem || viewItem == inProgressRemoteResultsItem || viewItem == cancelledResultsItem"
         },
         {
           "command": "codeQLTests.showOutputDifferences",


### PR DESCRIPTION
Allowed the "open on GitHub" action to cancelled/failed queries.

When a query fails, we set a value on the tree item to "cancelledResultsItem" (see [here](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/src/query-history.ts#L178)) - we then use that to decide whether to show the action or not. So the code could do with a bit of refactoring as it suggests that it only deals with cancelled queries, when in fact it deals with any failed queries. However, I won't be making that refactoring as part of this work.


## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
