### PR TITLE
MRVA: Expand path results individually

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/remote-queries-markdown-generation.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-markdown-generation.ts
@@ -178,10 +178,12 @@ function generateMarkdownForPathResults(
   interpretedResult: AnalysisAlert,
   language: string
 ): MarkdownFile {
-  const pathLines: MarkdownFile = [];
+  const lines: MarkdownFile = [];
+  lines.push('#### Paths', '');
   for (const codeFlow of interpretedResult.codeFlows) {
+    const pathLines: MarkdownFile = [];
     const stepCount = codeFlow.threadFlows.length;
-    pathLines.push(`#### Path with ${stepCount} steps`);
+    const title = `Path with ${stepCount} steps`;
     for (let i = 0; i < stepCount; i++) {
       const threadFlow = codeFlow.threadFlows[i];
       const link = createMarkdownRemoteFileRef(
@@ -198,8 +200,11 @@ function generateMarkdownForPathResults(
       const codeSnippetIndented = codeSnippet.map((line) => `    ${line}`);
       pathLines.push(`${i + 1}. ${link}`, ...codeSnippetIndented);
     }
+    lines.push(
+      ...buildExpandableMarkdownSection(title, pathLines)
+    );
   }
-  return buildExpandableMarkdownSection('Show paths', pathLines);
+  return lines;
 }
 
 function generateMarkdownForRawResults(

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/path-problem/results-repo1.md
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/path-problem/results-repo1.md
@@ -10,10 +10,11 @@
 
 *This shell command depends on an uncontrolled [absolute path](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js#L4-L4).*
 
-<details>
-<summary>Show paths</summary>
+#### Paths
 
-#### Path with 5 steps
+<details>
+<summary>Path with 5 steps</summary>
+
 1. [javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js#L4-L4)
     <pre><code class="javascript">  path = require("path");
     function cleanupTemp() {
@@ -69,10 +70,11 @@
 
 *This shell command depends on an uncontrolled [absolute path](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L6-L6).*
 
-<details>
-<summary>Show paths</summary>
+#### Paths
 
-#### Path with 3 steps
+<details>
+<summary>Path with 3 steps</summary>
+
 1. [javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L6-L6)
     <pre><code class="javascript">(function() {
     	cp.execFileSync('rm',  ['-rf', path.join(__dirname, "temp")]); // GOOD
@@ -113,10 +115,11 @@
 
 *This shell command depends on an uncontrolled [absolute path](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L8-L8).*
 
-<details>
-<summary>Show paths</summary>
+#### Paths
 
-#### Path with 3 steps
+<details>
+<summary>Path with 3 steps</summary>
+
 1. [javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L8-L8)
     <pre><code class="javascript">	cp.execSync('rm -rf ' + path.join(__dirname, "temp")); // BAD
     
@@ -157,10 +160,11 @@
 
 *This shell command depends on an uncontrolled [absolute path](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L9-L9).*
 
-<details>
-<summary>Show paths</summary>
+#### Paths
 
-#### Path with 3 steps
+<details>
+<summary>Path with 3 steps</summary>
+
 1. [javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L9-L9)
     <pre><code class="javascript">
     	execa.shell('rm -rf ' + path.join(__dirname, "temp")); // NOT OK

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/path-problem/results-repo2.md
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/path-problem/results-repo2.md
@@ -11,10 +11,11 @@
 
 *This shell command depends on an uncontrolled [absolute path](https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec/npm-packages/meteor-installer/config.js#L39-L39).*
 
-<details>
-<summary>Show paths</summary>
+#### Paths
 
-#### Path with 7 steps
+<details>
+<summary>Path with 7 steps</summary>
+
 1. [npm-packages/meteor-installer/config.js](https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec/npm-packages/meteor-installer/config.js#L39-L39)
     <pre><code class="javascript">
     const meteorLocalFolder = '.meteor';
@@ -83,7 +84,12 @@
       }
     </code></pre>
     
-#### Path with 2 steps
+
+</details>
+
+<details>
+<summary>Path with 2 steps</summary>
+
 1. [npm-packages/meteor-installer/config.js](https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec/npm-packages/meteor-installer/config.js#L39-L39)
     <pre><code class="javascript">
     const meteorLocalFolder = '.meteor';


### PR DESCRIPTION
Tweak the way we render path queries to display individual paths instead of the whole "show paths" section. (As suggested in internal linked issue 👀 )

Here is a [before](https://github.com/github/vscode-codeql/blob/ed84825e651bbb42ecd1106abe3e110ca8367ed1/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/path-problem/results-repo2.md) and [after](https://github.com/github/vscode-codeql/blob/24b84c7da06d90d5b5d1e9b1a5ea8723249cc209/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/path-problem/results-repo2.md)! 🖼️ 

## Checklist

N/A - internal only 🤠

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
