### PR TITLE
MRVA: Support both local and gist links when generating markdown

### DIFF
--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/markdown-generation.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/markdown-generation.test.ts
@@ -13,7 +13,7 @@ describe('markdown generation', async function() {
       const analysesResults = JSON.parse(
         await fs.readFile(path.join(__dirname, 'data/interpreted-results/path-problem/analyses-results.json'), 'utf8')
       );
-      const markdownFiles = generateMarkdown(pathProblemQuery, analysesResults);
+      const markdownFiles = generateMarkdown(pathProblemQuery, analysesResults, 'gist');
 
       // Check that query has results for two repositories, plus a summary file
       expect(markdownFiles.length).to.equal(3);
@@ -42,7 +42,7 @@ describe('markdown generation', async function() {
       const analysesResults = JSON.parse(
         await fs.readFile(path.join(__dirname, 'data/interpreted-results/problem/analyses-results.json'), 'utf8')
       );
-      const markdownFiles = generateMarkdown(problemQuery, analysesResults);
+      const markdownFiles = generateMarkdown(problemQuery, analysesResults, 'gist');
 
       // Check that query has results for two repositories, plus a summary file
       expect(markdownFiles.length).to.equal(3);
@@ -71,7 +71,7 @@ describe('markdown generation', async function() {
         await fs.readFile(path.join(__dirname, 'data/raw-results/analyses-results.json'), 'utf8')
       );
 
-      const markdownFiles = generateMarkdown(query, analysesResults);
+      const markdownFiles = generateMarkdown(query, analysesResults, 'gist');
 
       // Check that query has results for two repositories, plus a summary file
       expect(markdownFiles.length).to.equal(3);


### PR DESCRIPTION
We will need to support two types of links when generating markdown - gist links and local links. 

This PR adds support for both (but none are actually in use yet).

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
