### PR TITLE
MRVA: Include filename when generating markdown files

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/remote-queries-markdown-generation.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-markdown-generation.ts
@@ -90,7 +90,7 @@ export function generateMarkdownSummary(query: RemoteQuery): MarkdownFile {
   );
   // nwo and result count will be appended to this table
   return {
-    fileName: 'summary.md',
+    fileName: 'summary',
     content: lines
   };
 }

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/markdown-generation.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/markdown-generation.test.ts
@@ -27,9 +27,9 @@ describe('markdown generation', async function() {
       const expectedTestOutput2 = await readTestOutputFile('data/interpreted-results/path-problem/results-repo2.md');
 
       // Check that markdown output is correct, after making line endings consistent
-      expect(markdownFile0.join('\n')).to.equal(expectedSummaryFile);
-      expect(markdownFile1.join('\n')).to.equal(expectedTestOutput1);
-      expect(markdownFile2.join('\n')).to.equal(expectedTestOutput2);
+      expect(markdownFile0.content.join('\n')).to.equal(expectedSummaryFile);
+      expect(markdownFile1.content.join('\n')).to.equal(expectedTestOutput1);
+      expect(markdownFile2.content.join('\n')).to.equal(expectedTestOutput2);
     });
   });
 
@@ -56,9 +56,9 @@ describe('markdown generation', async function() {
       const expectedTestOutput2 = await readTestOutputFile('data/interpreted-results/problem/results-repo2.md');
 
       // Check that markdown output is correct, after making line endings consistent
-      expect(markdownFile0.join('\n')).to.equal(expectedSummaryFile);
-      expect(markdownFile1.join('\n')).to.equal(expectedTestOutput1);
-      expect(markdownFile2.join('\n')).to.equal(expectedTestOutput2);
+      expect(markdownFile0.content.join('\n')).to.equal(expectedSummaryFile);
+      expect(markdownFile1.content.join('\n')).to.equal(expectedTestOutput1);
+      expect(markdownFile2.content.join('\n')).to.equal(expectedTestOutput2);
     });
   });
 
@@ -85,9 +85,9 @@ describe('markdown generation', async function() {
       const expectedTestOutput2 = await readTestOutputFile('data/raw-results/results-repo2.md');
 
       // Check that markdown output is correct, after making line endings consistent
-      expect(markdownFile0.join('\n')).to.equal(expectedSummaryFile);
-      expect(markdownFile1.join('\n')).to.equal(expectedTestOutput1);
-      expect(markdownFile2.join('\n')).to.equal(expectedTestOutput2);
+      expect(markdownFile0.content.join('\n')).to.equal(expectedSummaryFile);
+      expect(markdownFile1.content.join('\n')).to.equal(expectedTestOutput1);
+      expect(markdownFile2.content.join('\n')).to.equal(expectedTestOutput2);
     });
   });
 });


### PR DESCRIPTION
This PR updates the `MarkdownFile` type to include the filename as well as the file contents. This is so we can keep track of the filenames more consistently and link to them correctly, e.g. when uploading as a gist. _(Originally suggested in https://github.com/github/vscode-codeql/pull/1288#discussion_r847672799.)_

Note: there's no behaviour change here yet, I've just updated the existing functions/tests to work with the updated type. I will tweak the tests (to check that file name is expected) in a follow-up PR.

## Checklist

N/A - internal only 🦈

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
