### PR TITLE
Remove unnecessary commas from alert `shortDescription`

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/sarif-processing.ts
+++ b/extensions/ql-vscode/src/remote-queries/sarif-processing.ts
@@ -86,7 +86,7 @@ function getShortDescription(
     return rule.shortDescription.text;
   }
 
-  return message.tokens.map(token => token.text).join();
+  return message.tokens.map(token => token.text).join('');
 }
 
 export function tryGetSeverity(


### PR DESCRIPTION
Tiny bug fix. When processing SARIF, we accidentally added some extra commas. Looks like this is because `.join()` uses commas as the default separator, instead of just concatenating the parts. I've changed the separator to be the empty string.

This was most visible in the MRVA results view when displaying paths. 

Before:
![image](https://user-images.githubusercontent.com/42641846/167404696-77a06734-9267-46ca-a6c8-7896edb68840.png)
After: 
![image](https://user-images.githubusercontent.com/42641846/167404626-a2be6a70-35e2-425a-a918-d229fb529929.png)


## Checklist

N/A - internal only 💅🏽 

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
