### PR TITLE
MRVA: Add webview button to export results

### DIFF
--- a/extensions/ql-vscode/src/pure/interface-types.ts
+++ b/extensions/ql-vscode/src/pure/interface-types.ts
@@ -394,7 +394,8 @@ export type FromRemoteQueriesMessage =
   | OpenFileMsg
   | OpenVirtualFileMsg
   | RemoteQueryDownloadAnalysisResultsMessage
-  | RemoteQueryDownloadAllAnalysesResultsMessage;
+  | RemoteQueryDownloadAllAnalysesResultsMessage
+  | RemoteQueryExportResultsMessage;
 
 export type ToRemoteQueriesMessage =
   | SetRemoteQueryResultMessage
@@ -429,3 +430,6 @@ export interface RemoteQueryDownloadAllAnalysesResultsMessage {
   analysisSummaries: AnalysisSummary[];
 }
 
+export interface RemoteQueryExportResultsMessage {
+  t: 'remoteQueryExportResults';
+}

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
@@ -4,7 +4,8 @@ import {
   window as Window,
   ViewColumn,
   Uri,
-  workspace
+  workspace,
+  commands
 } from 'vscode';
 import * as path from 'path';
 
@@ -209,6 +210,9 @@ export class RemoteQueriesInterfaceManager {
         break;
       case 'remoteQueryDownloadAllAnalysesResults':
         await this.downloadAllAnalysesResults(msg);
+        break;
+      case 'remoteQueryExportResults':
+        await await commands.executeCommand('codeQL.exportVariantAnalysisResults');
         break;
       default:
         assertNever(msg);

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
@@ -212,7 +212,7 @@ export class RemoteQueriesInterfaceManager {
         await this.downloadAllAnalysesResults(msg);
         break;
       case 'remoteQueryExportResults':
-        await await commands.executeCommand('codeQL.exportVariantAnalysisResults');
+        await commands.executeCommand('codeQL.exportVariantAnalysisResults');
         break;
       default:
         assertNever(msg);

--- a/extensions/ql-vscode/src/remote-queries/view/ActionButton.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/ActionButton.tsx
@@ -13,10 +13,10 @@ const Button = styled.button`
   border: 0;
 `;
 
-const ExportButton = ({ text, onClick }: { text: string, onClick: () => void }) => (
+const ActionButton = ({ text, onClick }: { text: string, onClick: () => void }) => (
   <Button onClick={onClick}>
     {text}
   </Button>
 );
 
-export default ExportButton;
+export default ActionButton;

--- a/extensions/ql-vscode/src/remote-queries/view/ExportButton.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/ExportButton.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import styled from 'styled-components';
+
+const Button = styled.a`
+  color: var(--vscode-button-foreground);
+  background-color: var(--vscode-button-background);
+  &:hover {
+    color: var(--vscode-button-foreground);
+    text-decoration: none;
+    background-color: var(--vscode-button-hoverBackground);
+  }
+  cursor: pointer;
+  padding: 5px 10px;
+`;
+
+const ExportButton = ({ text, onClick }: { text: string, onClick: () => void }) => (
+  <Button className="monaco-button monaco-text-button" onClick={onClick}>
+    {text}
+  </Button>
+);
+
+export default ExportButton;

--- a/extensions/ql-vscode/src/remote-queries/view/ExportButton.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/ExportButton.tsx
@@ -1,20 +1,20 @@
 import * as React from 'react';
 import styled from 'styled-components';
 
-const Button = styled.a`
+const Button = styled.button`
   color: var(--vscode-button-foreground);
   background-color: var(--vscode-button-background);
   &:hover {
-    color: var(--vscode-button-foreground);
     text-decoration: none;
     background-color: var(--vscode-button-hoverBackground);
   }
   cursor: pointer;
   padding: 5px 10px;
+  border: 0;
 `;
 
 const ExportButton = ({ text, onClick }: { text: string, onClick: () => void }) => (
-  <Button className="monaco-button monaco-text-button" onClick={onClick}>
+  <Button onClick={onClick}>
     {text}
   </Button>
 );

--- a/extensions/ql-vscode/src/remote-queries/view/ExportButton.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/ExportButton.tsx
@@ -9,7 +9,7 @@ const Button = styled.button`
     background-color: var(--vscode-button-hoverBackground);
   }
   cursor: pointer;
-  padding: 5px 10px;
+  padding: 8px;
   border: 0;
 `;
 

--- a/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
@@ -327,7 +327,7 @@ const AnalysesResults = ({
             totalResults={totalResults} />
         </Box>
         <Box>
-          <ExportButton text="Export all" onClick={() => exportResults()}></ExportButton>
+          <ExportButton text="Export all" onClick={exportResults}></ExportButton>
         </Box>
       </Box>
       <AnalysesResultsDescription

--- a/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
@@ -20,7 +20,7 @@ import { AlertIcon, CodeSquareIcon, FileCodeIcon, RepoIcon, TerminalIcon } from 
 import AnalysisAlertResult from './AnalysisAlertResult';
 import RawResultsTable from './RawResultsTable';
 import RepositoriesSearch from './RepositoriesSearch';
-import ExportButton from './ExportButton';
+import ActionButton from './ActionButton';
 
 const numOfReposInContractedMode = 10;
 
@@ -327,7 +327,7 @@ const AnalysesResults = ({
             totalResults={totalResults} />
         </Box>
         <Box>
-          <ExportButton text="Export all" onClick={exportResults}></ExportButton>
+          <ActionButton text="Export all" onClick={exportResults}></ActionButton>
         </Box>
       </Box>
       <AnalysesResultsDescription

--- a/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useEffect, useState } from 'react';
 import * as Rdom from 'react-dom';
-import { Flash, ThemeProvider } from '@primer/react';
+import { Box, Flash, ThemeProvider } from '@primer/react';
 import { ToRemoteQueriesMessage } from '../../pure/interface-types';
 import { AnalysisSummary, RemoteQueryResult } from '../shared/remote-query-result';
 import { MAX_RAW_RESULTS } from '../shared/result-limits';
@@ -20,6 +20,7 @@ import { AlertIcon, CodeSquareIcon, FileCodeIcon, RepoIcon, TerminalIcon } from 
 import AnalysisAlertResult from './AnalysisAlertResult';
 import RawResultsTable from './RawResultsTable';
 import RepositoriesSearch from './RepositoriesSearch';
+import ExportButton from './ExportButton';
 
 const numOfReposInContractedMode = 10;
 
@@ -238,6 +239,12 @@ const AnalysesResultsTitle = ({ totalAnalysesResults, totalResults }: { totalAna
   return <SectionTitle>{totalAnalysesResults}/{totalResults} results</SectionTitle>;
 };
 
+const exportResults = () => {
+  vscode.postMessage({
+    t: 'remoteQueryExportResults',
+  });
+};
+
 const AnalysesResultsDescription = ({
   queryResult,
   analysesResults,
@@ -313,9 +320,16 @@ const AnalysesResults = ({
   return (
     <>
       <VerticalSpace size={2} />
-      <AnalysesResultsTitle
-        totalAnalysesResults={totalAnalysesResults}
-        totalResults={totalResults} />
+      <Box display="flex">
+        <Box flexGrow={1}>
+          <AnalysesResultsTitle
+            totalAnalysesResults={totalAnalysesResults}
+            totalResults={totalResults} />
+        </Box>
+        <Box>
+          <ExportButton text="Export all" onClick={() => exportResults()}></ExportButton>
+        </Box>
+      </Box>
       <AnalysesResultsDescription
         queryResult={queryResult}
         analysesResults={analysesResults} />


### PR DESCRIPTION
Adds a button to the webview that calls the "Export Results" command (from #1341). This makes the export functionality more discoverable:
![image](https://user-images.githubusercontent.com/42641846/168323267-c975473a-eee9-4f20-96a2-03f6e876c413.png)

I couldn't find an exact match for a Primer component (https://primer.style/react/Button wasn't quite right), so I copied the VS Code style. The button doesn't look _exactly_ like our design (padding/font look bit off), but it's close? 🤞🏽 😅 

## Checklist

N/A - internal only 🤫 

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
