### PR TITLE
MRVA: Export results from query history menu

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -542,6 +542,10 @@
         "title": "Show Query Text"
       },
       {
+        "command": "codeQLQueryHistory.exportResults",
+        "title": "Export Results"
+      },
+      {
         "command": "codeQLQueryHistory.viewCsvResults",
         "title": "View Results (CSV)"
       },
@@ -750,6 +754,11 @@
           "command": "codeQLQueryHistory.showQueryText",
           "group": "9_qlCommands",
           "when": "view == codeQLQueryHistory"
+        },
+        {
+          "command": "codeQLQueryHistory.exportResults",
+          "group": "9_qlCommands",
+          "when": "view == codeQLQueryHistory && viewItem == remoteResultsItem"
         },
         {
           "command": "codeQLQueryHistory.viewCsvResults",
@@ -971,6 +980,10 @@
         },
         {
           "command": "codeQLQueryHistory.showQueryText",
+          "when": "false"
+        },
+        {
+          "command": "codeQLQueryHistory.exportResults",
           "when": "false"
         },
         {

--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -452,6 +452,12 @@ export class QueryHistoryManager extends DisposableObject {
     );
     this.push(
       commandRunner(
+        'codeQLQueryHistory.exportResults',
+        this.handleExportResults.bind(this)
+      )
+    );
+    this.push(
+      commandRunner(
         'codeQLQueryHistory.viewCsvResults',
         this.handleViewCsvResults.bind(this)
       )
@@ -989,6 +995,10 @@ export class QueryHistoryManager extends DisposableObject {
     return item.t === 'local'
       ? item.initialInfo.queryText
       : item.remoteQuery.queryText;
+  }
+
+  async handleExportResults(): Promise<void> {
+    await commands.executeCommand('codeQL.exportVariantAnalysisResults');
   }
 
   addQuery(item: QueryHistoryInfo) {


### PR DESCRIPTION
Adds the "Export (variant analysis) results" command from #1341 to the query history menu for remote result items: 

![export results from query history](https://user-images.githubusercontent.com/42641846/168345400-0b638429-3b4e-48ef-8f4e-149fd017432b.png)

This just executes the existing `codeQL.exportVariantAnalysisResults` command, which itself depends on information from the query history manager 🤔 This works, but feels like a slight circular dependency? (Other suggestions welcome, or maybe I'm just overthinking it 😄) 

## Checklist

N/A - internal only ⚔️ 

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
