### PR TITLE
Show query results before structured evaluator log summary completes

### DIFF
--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -800,13 +800,16 @@ export class QueryHistoryManager extends DisposableObject {
   }
 
   private warnNoEvalLog() {
-    void showAndLogWarningMessage('No evaluator log is available for this run. Perhaps it failed before evaluation, or you are running with a version of CodeQL before ' + CliVersionConstraint.CLI_VERSION_WITH_PER_QUERY_EVAL_LOG + '?');
+    void showAndLogWarningMessage(`No evaluator log is available for this run. Perhaps it failed before evaluation, or you are running with a version of CodeQL before ' + ${CliVersionConstraint.CLI_VERSION_WITH_PER_QUERY_EVAL_LOG}?`);
   }
 
   private warnNoEvalLogSummary() {
-    void showAndLogWarningMessage(`No evaluator log summary is available for this run. Perhaps it failed before evaluation, or you are running with a version of CodeQL before ${CliVersionConstraint.CLI_VERSION_WITH_PER_QUERY_EVAL_LOG}?`);
+    void showAndLogWarningMessage(`Evaluator log summary and evaluator log are not available for this run. Perhaps they failed before evaluation, or you are running with a version of CodeQL before ${CliVersionConstraint.CLI_VERSION_WITH_PER_QUERY_EVAL_LOG}?`);
   }
 
+  private warnInProgressEvalLogSummary() {
+    void showAndLogWarningMessage('The evaluator log summary is still being generated. Please try again later. The summary generation process is tracked in the "CodeQL Extension Log" view.');
+  }
 
   async handleShowEvalLog(
     singleItem: QueryHistoryInfo,
@@ -839,8 +842,15 @@ export class QueryHistoryManager extends DisposableObject {
 
     if (finalSingleItem.evalLogSummaryLocation) {
       await this.tryOpenExternalFile(finalSingleItem.evalLogSummaryLocation);
-    } else {
-      this.warnNoEvalLogSummary();
+    } 
+    // Summary log file doesn't exist.
+    else {
+      if (finalSingleItem.evalLogLocation && fs.pathExists(finalSingleItem.evalLogLocation)) {
+        // If raw log does exist, then the summary log is still being generated.
+        this.warnInProgressEvalLogSummary();
+      } else {
+        this.warnNoEvalLogSummary();
+      }   
     }
   }
 

--- a/extensions/ql-vscode/src/run-queries.ts
+++ b/extensions/ql-vscode/src/run-queries.ts
@@ -212,7 +212,7 @@ export class QueryEvaluationInfo {
             })
 
             .catch(err => {
-              void logger.log(`Failed to generate structured evaluator log summary. Reason: ${err.message}`);
+              void showAndLogWarningMessage(`Failed to generate structured evaluator log summary. Reason: ${err.message}`);
             });
         } else {
           void showAndLogWarningMessage(`Failed to write structured evaluator log to ${this.evalLogPath}.`);

--- a/extensions/ql-vscode/src/run-queries.ts
+++ b/extensions/ql-vscode/src/run-queries.ts
@@ -199,15 +199,21 @@ export class QueryEvaluationInfo {
         });
         if (await this.hasEvalLog()) {
           queryInfo.evalLogLocation = this.evalLogPath;
-          await qs.cliServer.generateLogSummary(this.evalLogPath, this.evalLogSummaryPath, this.evalLogEndSummaryPath);
-          queryInfo.evalLogSummaryLocation = this.evalLogSummaryPath;
-          fs.readFile(this.evalLogEndSummaryPath, (err, buffer) => {
-            if (err) {
-              throw new Error(`Could not read structured evaluator log end of summary file at ${this.evalLogEndSummaryPath}.`);
-            }
-            void qs.logger.log(' --- Evaluator Log Summary --- ');
-            void qs.logger.log(buffer.toString());
-          });
+          void qs.cliServer.generateLogSummary(this.evalLogPath, this.evalLogSummaryPath, this.evalLogEndSummaryPath)
+            .then(() => {
+              queryInfo.evalLogSummaryLocation = this.evalLogSummaryPath;
+              fs.readFile(this.evalLogEndSummaryPath, (err, buffer) => {
+                if (err) {
+                 throw new Error(`Could not read structured evaluator log end of summary file at ${this.evalLogEndSummaryPath}.`);
+                }
+                void qs.logger.log(' --- Evaluator Log Summary --- ');
+                void qs.logger.log(buffer.toString());
+              });
+            })
+
+            .catch(err => {
+              void logger.log(`Failed to generate structured evaluator log summary. Reason: ${err.message}`);
+            });
         } else {
           void showAndLogWarningMessage(`Failed to write structured evaluator log to ${this.evalLogPath}.`);
         }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Previously, we were `await`ing the structured evaluator log summary to be fully generated before the query result and raw structured log could be viewed, even though they were already available.

This change allows the structured evaluator log summary to execute asynchronously. If the user attempts to click the "Show Structured Evaluator Log (Summary)" command on the query history item before the summary is complete, the user receives a popup saying "The evaluator log summary is still being generated. Please try again later. The summary generation process is tracked in the "CodeQL Extension Log" view." — 

<img width="1857" alt="Screen Shot 2022-05-16 at 4 41 16 PM" src="https://user-images.githubusercontent.com/39155301/168680688-b6cdf10e-d6dc-47a9-9fbf-a709e1fcf397.png">

The CodeQL Extension Log view will indicate the summary generation is in-progress and when it is complete. It will also log the same warning line as above every time the user attempts to view the summary file before it is completed (in the following screenshot the command was clicked twice):
<img width="1850" alt="Screen Shot 2022-05-16 at 4 45 41 PM" src="https://user-images.githubusercontent.com/39155301/168680752-4620f9e4-dd07-4462-ab5c-98aa05910710.png">

and at this point the user will be able to view the log summary by clicking the query history command. 

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
