### PR TITLE
Add sorting to variant analysis results

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -118,6 +118,8 @@ jobs:
       - name: Run integration tests (Linux)
         if: matrix.os == 'ubuntu-latest'
         working-directory: extensions/ql-vscode
+        env:
+          VSCODE_CODEQL_GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
           sudo apt-get install xvfb
           /usr/bin/xvfb-run npm run integration
@@ -125,6 +127,8 @@ jobs:
       - name: Run integration tests (Windows)
         if: matrix.os == 'windows-latest'
         working-directory: extensions/ql-vscode
+        env:
+          VSCODE_CODEQL_GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
           npm run integration
 

--- a/extensions/ql-vscode/src/authentication.ts
+++ b/extensions/ql-vscode/src/authentication.ts
@@ -35,7 +35,15 @@ export class Credentials {
     return c;
   }
 
-  static async initializeOverride(overrideToken: string) {
+  /**
+   * Initializes an instance of credentials with an octokit instance using
+   * a token from the user's GitHub account. This method is meant to be
+   * used non-interactive environments such as tests.
+   *
+   * @param overrideToken The GitHub token to use for authentication.
+   * @returns An instance of credentials.
+   */
+  static async initializeWithToken(overrideToken: string) {
     const c = new Credentials();
     c.octokit = await c.createOctokit(false, overrideToken);
     return c;

--- a/extensions/ql-vscode/src/authentication.ts
+++ b/extensions/ql-vscode/src/authentication.ts
@@ -35,7 +35,17 @@ export class Credentials {
     return c;
   }
 
-  private async createOctokit(createIfNone: boolean): Promise<Octokit.Octokit | undefined> {
+  static async initializeOverride(overrideToken: string) {
+    const c = new Credentials();
+    c.octokit = await c.createOctokit(false, overrideToken);
+    return c;
+  }
+
+  private async createOctokit(createIfNone: boolean, overrideToken?: string): Promise<Octokit.Octokit | undefined> {
+    if (overrideToken) {
+      return new Octokit.Octokit({ auth: overrideToken });
+    }
+
     const session = await vscode.authentication.getSession(GITHUB_AUTH_PROVIDER_ID, SCOPES, { createIfNone });
 
     if (session) {

--- a/extensions/ql-vscode/src/remote-queries/analyses-results-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/analyses-results-manager.ts
@@ -116,7 +116,9 @@ export class AnalysesResultsManager {
     const analysisResults: AnalysisResults = {
       nwo: analysis.nwo,
       status: 'InProgress',
-      interpretedResults: []
+      interpretedResults: [],
+      resultCount: analysis.resultCount,
+      starCount: analysis.starCount,
     };
     const queryId = analysis.downloadLink.queryId;
     const resultsForQuery = this.internalGetAnalysesResults(queryId);

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
@@ -306,7 +306,8 @@ export class RemoteQueriesInterfaceManager {
       databaseSha: analysisResult.databaseSha || 'HEAD',
       resultCount: analysisResult.resultCount,
       downloadLink: analysisResult.downloadLink,
-      fileSize: this.formatFileSize(analysisResult.fileSizeInBytes)
+      fileSize: this.formatFileSize(analysisResult.fileSizeInBytes),
+      starCount: analysisResult.starCount,
     }));
   }
 }

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
@@ -307,7 +307,7 @@ export class RemoteQueriesInterfaceManager {
       resultCount: analysisResult.resultCount,
       downloadLink: analysisResult.downloadLink,
       fileSize: this.formatFileSize(analysisResult.fileSizeInBytes),
-      starCount: analysisResult.starCount,
+      starCount: analysisResult.starCount
     }));
   }
 }

--- a/extensions/ql-vscode/src/remote-queries/remote-query-result.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-query-result.ts
@@ -2,10 +2,10 @@ import { DownloadLink } from './download-link';
 import { AnalysisFailure } from './shared/analysis-failure';
 
 export interface RemoteQueryResult {
-  executionEndTime: number; // Can't use a Date here since it needs to be serialized and desserialized.
-  analysisSummaries: AnalysisSummary[];
-  analysisFailures: AnalysisFailure[];
-  queryId: string;
+  executionEndTime: number, // Can't use a Date here since it needs to be serialized and desserialized.
+  analysisSummaries: AnalysisSummary[],
+  analysisFailures: AnalysisFailure[],
+  queryId: string,
 }
 
 export interface AnalysisSummary {
@@ -13,5 +13,6 @@ export interface AnalysisSummary {
   databaseSha: string,
   resultCount: number,
   downloadLink: DownloadLink,
-  fileSizeInBytes: number
+  fileSizeInBytes: number,
+  starCount?: number,
 }

--- a/extensions/ql-vscode/src/remote-queries/shared/analysis-result.ts
+++ b/extensions/ql-vscode/src/remote-queries/shared/analysis-result.ts
@@ -7,6 +7,8 @@ export interface AnalysisResults {
   status: AnalysisResultStatus;
   interpretedResults: AnalysisAlert[];
   rawResults?: AnalysisRawResults;
+  resultCount: number,
+  starCount?: number,
 }
 
 export interface AnalysisRawResults {

--- a/extensions/ql-vscode/src/remote-queries/shared/remote-query-result.ts
+++ b/extensions/ql-vscode/src/remote-queries/shared/remote-query-result.ts
@@ -2,19 +2,19 @@ import { DownloadLink } from '../download-link';
 import { AnalysisFailure } from './analysis-failure';
 
 export interface RemoteQueryResult {
-  queryTitle: string;
-  queryFileName: string;
-  queryFilePath: string;
-  queryText: string;
-  language: string;
-  workflowRunUrl: string;
-  totalRepositoryCount: number;
-  affectedRepositoryCount: number;
-  totalResultCount: number;
-  executionTimestamp: string;
-  executionDuration: string;
-  analysisSummaries: AnalysisSummary[];
-  analysisFailures: AnalysisFailure[];
+  queryTitle: string,
+  queryFileName: string,
+  queryFilePath: string,
+  queryText: string,
+  language: string,
+  workflowRunUrl: string,
+  totalRepositoryCount: number,
+  affectedRepositoryCount: number,
+  totalResultCount: number,
+  executionTimestamp: string,
+  executionDuration: string,
+  analysisSummaries: AnalysisSummary[],
+  analysisFailures: AnalysisFailure[],
 }
 
 export interface AnalysisSummary {
@@ -23,4 +23,5 @@ export interface AnalysisSummary {
   resultCount: number,
   downloadLink: DownloadLink,
   fileSize: string,
+  starCount?: number,
 }

--- a/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
@@ -128,7 +128,8 @@ const Failures = (queryResult: RemoteQueryResult) => {
 const SummaryTitleWithResults = ({
   queryResult,
   analysesResults,
-  sort, setSort
+  sort,
+  setSort
 }: {
   queryResult: RemoteQueryResult,
   analysesResults: AnalysisResults[],
@@ -145,7 +146,6 @@ const SummaryTitleWithResults = ({
           text="Download all"
           onClick={() => downloadAllAnalysesResults(queryResult)} />
       }
-
       <SortRepoFilter
         sort={sort}
         setSort={setSort}

--- a/extensions/ql-vscode/src/remote-queries/view/SortRepoFilter.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/SortRepoFilter.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+import { FilterIcon } from '@primer/octicons-react';
+import { ActionList, ActionMenu } from '@primer/react';
+
+export type Sort = 'name' | 'stars' | 'results';
+type SortBy = { name: string, sort: Sort }[];
+type Props = {
+  sort: Sort;
+  setSort: (sort: Sort) => void;
+};
+
+type Sortable = {
+  nwo: string;
+  starCount?: number;
+  resultCount?: number;
+};
+
+const sortBy: SortBy = [
+  { name: 'Sort by Name', sort: 'name' },
+  { name: 'Sort by Results', sort: 'results' },
+  { name: 'Sort by Stars', sort: 'stars' },
+];
+
+export function sorter(sort: Sort) {
+  // stars and results are highest to lowest
+  // name is alphabetical
+  return (left: Sortable, right: Sortable) => {
+    if (sort === 'stars') {
+      const stars = (right.starCount || 0) - (left.starCount || 0);
+      if (stars !== 0) {
+        return stars;
+      }
+    }
+    if (sort === 'results') {
+      const results = (right.resultCount || 0) - (left.resultCount || 0);
+      if (results !== 0) {
+        return results;
+      }
+    }
+
+    // Fall back on name compare if results or stars are equal
+    return left.nwo.localeCompare(right.nwo, undefined, { sensitivity: 'base' });
+  };
+}
+
+const SortRepoFilter = ({ sort, setSort }: Props) => {
+  return <span className="vscode-codeql__analysis-sorter">
+    <ActionMenu>
+      <ActionMenu.Button
+        className="vscode-codeql__analysis-sort-dropdown"
+        aria-label="Sort results"
+        leadingIcon={FilterIcon}
+        trailingIcon="" />
+      <ActionMenu.Overlay width="medium">
+        <ActionList selectionVariant="single">
+          {sortBy.map((type, index) => (
+            <ActionList.Item key={index} selected={type.sort === sort} onSelect={() => setSort(type.sort)}>
+              {type.name}
+            </ActionList.Item>
+          ))}
+        </ActionList>
+      </ActionMenu.Overlay>
+    </ActionMenu>
+  </span>;
+
+};
+
+export default SortRepoFilter;

--- a/extensions/ql-vscode/src/remote-queries/view/SortRepoFilter.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/SortRepoFilter.tsx
@@ -1,9 +1,15 @@
 import * as React from 'react';
 import { FilterIcon } from '@primer/octicons-react';
-import { ActionList, ActionMenu } from '@primer/react';
+import { ActionList, ActionMenu, IconButton } from '@primer/react';
+import styled from 'styled-components';
+
+const SortWrapper = styled.span`
+  flex-grow: 2;
+  text-align: right;
+  margin-right: 0;
+`;
 
 export type Sort = 'name' | 'stars' | 'results';
-type SortBy = { name: string, sort: Sort }[];
 type Props = {
   sort: Sort;
   setSort: (sort: Sort) => void;
@@ -15,13 +21,13 @@ type Sortable = {
   resultCount?: number;
 };
 
-const sortBy: SortBy = [
+const sortBy = [
   { name: 'Sort by Name', sort: 'name' },
   { name: 'Sort by Results', sort: 'results' },
   { name: 'Sort by Stars', sort: 'stars' },
 ];
 
-export function sorter(sort: Sort) {
+export function sorter(sort: Sort): (left: Sortable, right: Sortable) => number {
   // stars and results are highest to lowest
   // name is alphabetical
   return (left: Sortable, right: Sortable) => {
@@ -43,25 +49,29 @@ export function sorter(sort: Sort) {
   };
 }
 
+// FIXME These styles are not correct. Need to figure out
+// why the theme is not being applied to the ActionMenu
 const SortRepoFilter = ({ sort, setSort }: Props) => {
-  return <span className="vscode-codeql__analysis-sorter">
+  return <SortWrapper>
     <ActionMenu>
-      <ActionMenu.Button
-        className="vscode-codeql__analysis-sort-dropdown"
-        aria-label="Sort results"
-        leadingIcon={FilterIcon}
-        trailingIcon="" />
-      <ActionMenu.Overlay width="medium">
+      <ActionMenu.Anchor>
+        <IconButton icon={FilterIcon} variant="invisible" aria-label="Sort results" />
+      </ActionMenu.Anchor>
+
+      <ActionMenu.Overlay width="small" anchorSide="outside-bottom">
         <ActionList selectionVariant="single">
           {sortBy.map((type, index) => (
-            <ActionList.Item key={index} selected={type.sort === sort} onSelect={() => setSort(type.sort)}>
+            <ActionList.Item
+              key={index}
+              selected={type.sort === sort} onSelect={() => setSort(type.sort as Sort)}
+            >
               {type.name}
             </ActionList.Item>
           ))}
         </ActionList>
       </ActionMenu.Overlay>
     </ActionMenu>
-  </span>;
+  </SortWrapper>;
 
 };
 

--- a/extensions/ql-vscode/src/remote-queries/view/StarCount.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/StarCount.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { StarIcon } from '@primer/octicons-react';
+
+type Props = { starCount?: number };
+
+const StarCount = ({ starCount }: Props) => (
+  Number.isFinite(starCount) ? (
+    <>
+      <span className="vscode-codeql__analysis-star">
+        <StarIcon size={16} />
+      </span>
+      <span className='vscode-codeql__analysis-count'>
+        {displayStars(starCount!)}
+      </span>
+    </>
+  ) : (
+    <>
+      <span className="vscode-codeql__analysis-star">
+        {/* empty */}
+      </span>
+      <span className='vscode-codeql__analysis-count'>
+        {/* empty */}
+      </span>
+    </>
+  )
+);
+
+function displayStars(starCount: number) {
+  if (starCount > 10000) {
+    return `${(starCount / 1000).toFixed(0)}k`;
+  }
+  if (starCount > 1000) {
+    return `${(starCount / 1000).toFixed(1)}k`;
+  }
+  return starCount.toFixed(0);
+}
+
+export default StarCount;

--- a/extensions/ql-vscode/src/remote-queries/view/StarCount.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/StarCount.tsx
@@ -1,27 +1,33 @@
 import * as React from 'react';
 import { StarIcon } from '@primer/octicons-react';
+import styled from 'styled-components';
+
+const Star = styled.span`
+  flex-grow: 2;
+  text-align: right;
+  margin-right: 0;
+`;
+
+const Count = styled.span`
+  text-align: left;
+  width: 2em;
+  margin-left: 0.5em;
+`;
 
 type Props = { starCount?: number };
 
 const StarCount = ({ starCount }: Props) => (
   Number.isFinite(starCount) ? (
     <>
-      <span className="vscode-codeql__analysis-star">
+      <Star>
         <StarIcon size={16} />
-      </span>
-      <span className='vscode-codeql__analysis-count'>
+      </Star>
+      <Count>
         {displayStars(starCount!)}
-      </span>
+      </Count>
     </>
   ) : (
-    <>
-      <span className="vscode-codeql__analysis-star">
-        {/* empty */}
-      </span>
-      <span className='vscode-codeql__analysis-count'>
-        {/* empty */}
-      </span>
-    </>
+    <></>
   )
 );
 

--- a/extensions/ql-vscode/src/remote-queries/view/remoteQueries.css
+++ b/extensions/ql-vscode/src/remote-queries/view/remoteQueries.css
@@ -30,19 +30,6 @@
   padding-right: 0.1em;
 }
 
-.vscode-codeql__analysis-sorter,
-.vscode-codeql__analysis-star {
-  flex-grow: 2;
-  text-align: right;
-  margin-right: 0;
-}
-
-.vscode-codeql__analysis-count {
-  text-align: left;
-  width: 2em;
-  margin-left: 0.5em;
-}
-
 .vscode-codeql__expand-button {
   background: none;
   color: var(--vscode-textLink-foreground);
@@ -50,13 +37,6 @@
   cursor: pointer;
   padding-top: 1em;
   font-size: x-small;
-}
-
-button.vscode-codeql__analysis-sort-dropdown {
-  display: inline-grid;
-  background-color: var(--vscode-editor-background);
-  border: none;
-  padding: 0.5em;
 }
 
 .vscode-codeql__analysis-failure {

--- a/extensions/ql-vscode/src/remote-queries/view/remoteQueries.css
+++ b/extensions/ql-vscode/src/remote-queries/view/remoteQueries.css
@@ -14,10 +14,12 @@
 
 .vscode-codeql__query-summary-container {
   padding-top: 1.5em;
+  display: flex;
 }
 
 .vscode-codeql__analysis-summaries-list-item {
   margin-top: 0.5em;
+  display: flex;
 }
 
 .vscode-codeql__analyses-results-list-item {
@@ -28,6 +30,19 @@
   padding-right: 0.1em;
 }
 
+.vscode-codeql__analysis-sorter,
+.vscode-codeql__analysis-star {
+  flex-grow: 2;
+  text-align: right;
+  margin-right: 0;
+}
+
+.vscode-codeql__analysis-count {
+  text-align: left;
+  width: 2em;
+  margin-left: 0.5em;
+}
+
 .vscode-codeql__expand-button {
   background: none;
   color: var(--vscode-textLink-foreground);
@@ -35,6 +50,13 @@
   cursor: pointer;
   padding-top: 1em;
   font-size: x-small;
+}
+
+button.vscode-codeql__analysis-sort-dropdown {
+  display: inline-grid;
+  background-color: var(--vscode-editor-background);
+  border: none;
+  padding: 0.5em;
 }
 
 .vscode-codeql__analysis-failure {

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/data/remote-queries/queries/MRVA Integration test 1-6sBi6oaky_fxqXW2NA4bx/query-result.json
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/data/remote-queries/queries/MRVA Integration test 1-6sBi6oaky_fxqXW2NA4bx/query-result.json
@@ -4,6 +4,7 @@
     {
       "nwo": "github/vscode-codeql",
       "resultCount": 15,
+      "starCount": 1,
       "fileSizeInBytes": 191025,
       "downloadLink": {
         "id": "171543249",
@@ -15,6 +16,7 @@
     {
       "nwo": "other/hucairz",
       "resultCount": 15,
+      "starCount": 1,
       "fileSizeInBytes": 191025,
       "downloadLink": {
         "id": "11111111",
@@ -26,6 +28,7 @@
     {
       "nwo": "hucairz/i-dont-exist",
       "resultCount": 5,
+      "starCount": 1,
       "fileSizeInBytes": 81237,
       "downloadLink": {
         "id": "999999",

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/data/remote-queries/queries/MRVA Integration test 2-UL-vbKAjP8ffObxjsp7hN/query-result.json
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/data/remote-queries/queries/MRVA Integration test 2-UL-vbKAjP8ffObxjsp7hN/query-result.json
@@ -4,6 +4,7 @@
     {
       "nwo": "github/vscode-codeql",
       "resultCount": 5,
+      "starCount": 1,
       "fileSizeInBytes": 81237,
       "downloadLink": {
         "id": "171544171",

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/gh-actions-api-client.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/gh-actions-api-client.test.ts
@@ -2,7 +2,7 @@ import { fail } from 'assert';
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { Credentials } from '../../../authentication';
-import { cancelRemoteQuery, getStargazers } from '../../../remote-queries/gh-actions-api-client';
+import { cancelRemoteQuery, getStargazers as getStargazersCount } from '../../../remote-queries/gh-actions-api-client';
 import { RemoteQuery } from '../../../remote-queries/remote-query';
 
 describe('gh-actions-api-client mock responses', () => {
@@ -55,13 +55,13 @@ describe('gh-actions-api-client mock responses', () => {
 describe('gh-actions-api-client real responses', function() {
   this.timeout(10000);
 
-  it('should get the stargazers for projects', async () => {
+  it('should get the stargazers for repos', async () => {
     if (skip()) {
       return;
     }
 
-    const credentials = await Credentials.initializeOverride(process.env.VSCODE_CODEQL_GITHUB_TOKEN!);
-    const stargazers = await getStargazers(credentials, [
+    const credentials = await Credentials.initializeWithToken(process.env.VSCODE_CODEQL_GITHUB_TOKEN!);
+    const stargazers = await getStargazersCount(credentials, [
       'github/codeql',
       'github/vscode-codeql',
       'rails/rails',

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/remote-query-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/remote-query-history.test.ts
@@ -253,14 +253,20 @@ describe('Remote queries and query history manager', function() {
       expect(trimmed[0]).to.deep.eq([{
         nwo: 'github/vscode-codeql',
         status: 'InProgress',
+        resultCount: 15,
+        starCount: 1
       }]);
 
       expect(trimmed[1]).to.deep.eq([{
         nwo: 'github/vscode-codeql',
         status: 'InProgress',
+        resultCount: 15,
+        starCount: 1
       }, {
         nwo: 'other/hucairz',
         status: 'InProgress',
+        resultCount: 15,
+        starCount: 1
       }]);
 
       // there is a third call. It is non-deterministic if
@@ -270,9 +276,13 @@ describe('Remote queries and query history manager', function() {
       expect(trimmed[3]).to.deep.eq([{
         nwo: 'github/vscode-codeql',
         status: 'Completed',
+        resultCount: 15,
+        starCount: 1
       }, {
         nwo: 'other/hucairz',
         status: 'Completed',
+        resultCount: 15,
+        starCount: 1
       }]);
 
       expect(publisher).to.have.callCount(4);


### PR DESCRIPTION
Sort by stars, number of results, and name.

This also includes a graphql query that retrieves all the stars
for relevant repositories.

Here is an example of what it looks like:

![sorting](https://user-images.githubusercontent.com/363559/169140308-3c1e0eaf-f498-4852-85be-c6a6bbd6e00d.gif)

This PR also includes an integration test that ensures the graphql call to get the stargazers counts for each repo works.  I had to make a change to the credentials class to allow a way of instantiating based on an environment variable.