### PR TITLE
Add new support for resolve ml-models

### DIFF
--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -1270,8 +1270,7 @@ export class CliVersionConstraint {
   /**
    * CLI version where the `resolve ml-models` subcommand was enhanced to work with packaging.
    */
-  // TODO: This is not the right version yet
-  public static CLI_VERSION_WITH_PRECISE_RESOLVE_ML_MODELS = new SemVer('2.9.3');
+public static CLI_VERSION_WITH_PRECISE_RESOLVE_ML_MODELS = new SemVer('2.10.0');
 
   /**
    * CLI version where the `--old-eval-stats` option to the query server was introduced.

--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -604,10 +604,13 @@ export class CodeQLCliServer implements Disposable {
   }
 
   /** Resolves the ML models that should be available when evaluating a query. */
-  async resolveMlModels(additionalPacks: string[]): Promise<MlModelsInfo> {
+  async resolveMlModels(additionalPacks: string[], queryPath: string): Promise<MlModelsInfo> {
+    const args = await this.cliConstraints.supportsPreciseResolveMlModels()
+      ? [...this.getAdditionalPacksArg(additionalPacks), queryPath]
+      : this.getAdditionalPacksArg(additionalPacks);
     return await this.runJsonCodeQlCliCommand<MlModelsInfo>(
       ['resolve', 'ml-models'],
-      this.getAdditionalPacksArg(additionalPacks),
+      args,
       'Resolving ML models',
       false
     );
@@ -1265,6 +1268,12 @@ export class CliVersionConstraint {
   public static CLI_VERSION_WITH_RESOLVE_ML_MODELS = new SemVer('2.7.3');
 
   /**
+   * CLI version where the `resolve ml-models` subcommand was enhanced to work with packaging.
+   */
+  // TODO: This is not the right version yet
+  public static CLI_VERSION_WITH_PRECISE_RESOLVE_ML_MODELS = new SemVer('2.9.3');
+
+  /**
    * CLI version where the `--old-eval-stats` option to the query server was introduced.
    */
   public static CLI_VERSION_WITH_OLD_EVAL_STATS = new SemVer('2.7.4');
@@ -1337,6 +1346,10 @@ export class CliVersionConstraint {
 
   async supportsResolveMlModels() {
     return this.isVersionAtLeast(CliVersionConstraint.CLI_VERSION_WITH_RESOLVE_ML_MODELS);
+  }
+
+  async supportsPreciseResolveMlModels() {
+    return this.isVersionAtLeast(CliVersionConstraint.CLI_VERSION_WITH_PRECISE_RESOLVE_ML_MODELS);
   }
 
   async supportsOldEvalStats() {

--- a/extensions/ql-vscode/src/run-queries.ts
+++ b/extensions/ql-vscode/src/run-queries.ts
@@ -174,7 +174,7 @@ export class QueryEvaluationInfo {
         db: dataset,
         logPath: this.evalLogPath,
       });
-      
+
     }
     const params: messages.EvaluateQueriesParams = {
       db: dataset,
@@ -204,7 +204,7 @@ export class QueryEvaluationInfo {
               queryInfo.evalLogSummaryLocation = this.evalLogSummaryPath;
               fs.readFile(this.evalLogEndSummaryPath, (err, buffer) => {
                 if (err) {
-                 throw new Error(`Could not read structured evaluator log end of summary file at ${this.evalLogEndSummaryPath}.`);
+                  throw new Error(`Could not read structured evaluator log end of summary file at ${this.evalLogEndSummaryPath}.`);
                 }
                 void qs.logger.log(' --- Evaluator Log Summary --- ', { additionalLogLocation: this.logPath });
                 void qs.logger.log(buffer.toString(), { additionalLogLocation: this.logPath });
@@ -334,7 +334,7 @@ export class QueryEvaluationInfo {
   /**
    * Holds if this query already has a completed structured evaluator log
    */
-   async hasEvalLog(): Promise<boolean> {
+  async hasEvalLog(): Promise<boolean> {
     return fs.pathExists(this.evalLogPath);
   }
 
@@ -755,8 +755,12 @@ export async function compileAndRunQueryAgainstDatabase(
   let availableMlModels: cli.MlModelInfo[] = [];
   if (await cliServer.cliConstraints.supportsResolveMlModels()) {
     try {
-      availableMlModels = (await cliServer.resolveMlModels(diskWorkspaceFolders)).models;
-      void logger.log(`Found available ML models at the following paths: ${availableMlModels.map(x => `'${x.path}'`).join(', ')}.`);
+      availableMlModels = (await cliServer.resolveMlModels(diskWorkspaceFolders, initialInfo.queryPath)).models;
+      if (availableMlModels.length) {
+        void logger.log(`Found available ML models at the following paths: ${availableMlModels.map(x => `'${x.path}'`).join(', ')}.`);
+      } else {
+        void logger.log('Did not find any available ML models.');
+      }
     } catch (e) {
       const message = `Couldn't resolve available ML models for ${qlProgram.queryPath}. Running the ` +
         `query without any ML models: ${e}.`;


### PR DESCRIPTION
The new support will be available in the next
release of the CLI, ~most likely 2.9.3~, 2.10.0.

This change requires the query to be run to be
passed in to the call to resolve ml-models.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Not a user facing change.

## Checklist

- [n/a] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
