### PR TITLE
MRVA: Get more accurate links using `sourceLocationPrefix`

### DIFF
--- a/extensions/ql-vscode/src/pure/bqrs-utils.ts
+++ b/extensions/ql-vscode/src/pure/bqrs-utils.ts
@@ -98,7 +98,7 @@ export function isStringLoc(loc: UrlValue): loc is string {
 export function tryGetRemoteLocation(
   loc: UrlValue | undefined,
   fileLinkPrefix: string,
-  sourceLocationPrefix: string,
+  sourceLocationPrefix: string | undefined,
 ): string | undefined {
   const resolvableLocation = tryGetResolvableLocation(loc);
   if (!resolvableLocation) {

--- a/extensions/ql-vscode/src/pure/bqrs-utils.ts
+++ b/extensions/ql-vscode/src/pure/bqrs-utils.ts
@@ -111,12 +111,18 @@ export function tryGetRemoteLocation(
   // "file:${sourceLocationPrefix}/relative/path/to/file"
   // So we need to strip off the first part to get the relative path.
   if (sourceLocationPrefix) {
+    if (!resolvableLocation.uri.startsWith(`file:${sourceLocationPrefix}/`)) {
+      return undefined;
+    }
     trimmedLocation = resolvableLocation.uri.replace(`file:${sourceLocationPrefix}/`, '');
   } else {
     // If the source location prefix is empty (e.g. for older remote queries), we assume that the database
     // was created on a Linux actions runner and has the format:
-    // "file:/home/runner/work/<repo>/<repo/relative/path/to/file"
+    // "file:/home/runner/work/<repo>/<repo>/relative/path/to/file"
     // So we need to drop the first 6 parts of the path.
+    if (!resolvableLocation.uri.startsWith('file:/home/runner/work/')) {
+      return undefined;
+    }
     const locationParts = resolvableLocation.uri.split('/');
     trimmedLocation = locationParts.slice(6, locationParts.length).join('/');
   }

--- a/extensions/ql-vscode/src/remote-queries/analyses-results-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/analyses-results-manager.ts
@@ -148,7 +148,7 @@ export class AnalysesResultsManager {
         status: 'Completed'
       };
     } else if (fileExtension === '.bqrs') {
-      const queryResults = await this.readBqrsResults(artifactPath, fileLinkPrefix);
+      const queryResults = await this.readBqrsResults(artifactPath, fileLinkPrefix, analysis.sourceLocationPrefix);
       newAnaysisResults = {
         ...analysisResults,
         rawResults: queryResults,
@@ -180,8 +180,8 @@ export class AnalysesResultsManager {
     return await fs.pathExists(createDownloadPath(this.storagePath, analysis.downloadLink));
   }
 
-  private async readBqrsResults(filePath: string, fileLinkPrefix: string): Promise<AnalysisRawResults> {
-    return await extractRawResults(this.cliServer, this.logger, filePath, fileLinkPrefix);
+  private async readBqrsResults(filePath: string, fileLinkPrefix: string, sourceLocationPrefix: string): Promise<AnalysisRawResults> {
+    return await extractRawResults(this.cliServer, this.logger, filePath, fileLinkPrefix, sourceLocationPrefix);
   }
 
   private async readSarifResults(filePath: string, fileLinkPrefix: string): Promise<AnalysisAlert[]> {

--- a/extensions/ql-vscode/src/remote-queries/bqrs-processing.ts
+++ b/extensions/ql-vscode/src/remote-queries/bqrs-processing.ts
@@ -9,6 +9,7 @@ export async function extractRawResults(
   logger: Logger,
   filePath: string,
   fileLinkPrefix: string,
+  sourceLocationPrefix: string
 ): Promise<AnalysisRawResults> {
   const bqrsInfo = await cliServer.bqrsInfo(filePath);
   const resultSets = bqrsInfo['result-sets'];
@@ -31,5 +32,5 @@ export async function extractRawResults(
 
   const capped = !!chunk.next;
 
-  return { schema, resultSet, fileLinkPrefix, capped };
+  return { schema, resultSet, fileLinkPrefix, sourceLocationPrefix, capped };
 }

--- a/extensions/ql-vscode/src/remote-queries/gh-actions-api-client.ts
+++ b/extensions/ql-vscode/src/remote-queries/gh-actions-api-client.ts
@@ -17,6 +17,7 @@ interface ApiSuccessIndexItem {
   results_count: number;
   bqrs_file_size: number;
   sarif_file_size?: number;
+  source_location_prefix: string;
 }
 
 interface ApiFailureIndexItem {
@@ -59,7 +60,8 @@ export async function getRemoteQueryIndex(
       sha: item.sha,
       resultCount: item.results_count,
       bqrsFileSize: item.bqrs_file_size,
-      sarifFileSize: item.sarif_file_size
+      sarifFileSize: item.sarif_file_size,
+      sourceLocationPrefix: item.source_location_prefix
     } as RemoteQuerySuccessIndexItem;
   });
 

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
@@ -306,6 +306,7 @@ export class RemoteQueriesInterfaceManager {
       databaseSha: analysisResult.databaseSha || 'HEAD',
       resultCount: analysisResult.resultCount,
       downloadLink: analysisResult.downloadLink,
+      sourceLocationPrefix: analysisResult.sourceLocationPrefix,
       fileSize: this.formatFileSize(analysisResult.fileSizeInBytes),
       starCount: analysisResult.starCount,
       lastUpdated: analysisResult.lastUpdated

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
@@ -171,6 +171,7 @@ export class RemoteQueriesManager extends DisposableObject {
         nwo: a.nwo,
         databaseSha: a.databaseSha,
         resultCount: a.resultCount,
+        sourceLocationPrefix: a.sourceLocationPrefix,
         downloadLink: a.downloadLink,
         fileSize: String(a.fileSizeInBytes)
       }));
@@ -191,6 +192,7 @@ export class RemoteQueriesManager extends DisposableObject {
       nwo: item.nwo,
       databaseSha: item.sha || 'HEAD',
       resultCount: item.resultCount,
+      sourceLocationPrefix: item.sourceLocationPrefix,
       fileSizeInBytes: item.sarifFileSize ? item.sarifFileSize : item.bqrsFileSize,
       starCount: metadata[item.nwo].starCount,
       lastUpdated: metadata[item.nwo].lastUpdated,

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-markdown-generation.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-markdown-generation.ts
@@ -260,7 +260,11 @@ function generateMarkdownForRawTableCell(
     case 'object':
       {
         const url = tryGetRemoteLocation(value.url, fileLinkPrefix, sourceLocationPrefix);
-        cellValue = `[\`${convertNonPrintableChars(value.label)}\`](${url})`;
+        if (url) {
+          cellValue = `[\`${convertNonPrintableChars(value.label)}\`](${url})`;
+        } else {
+          cellValue = `\`${convertNonPrintableChars(value.label)}\``;
+        }
       }
       break;
   }

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-markdown-generation.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-markdown-generation.ts
@@ -238,7 +238,7 @@ function generateMarkdownForRawResults(
 
   for (const row of analysisRawResults.resultSet.rows) {
     const cells = row.map((cell) =>
-      generateMarkdownForRawTableCell(cell, analysisRawResults.fileLinkPrefix)
+      generateMarkdownForRawTableCell(cell, analysisRawResults.fileLinkPrefix, analysisRawResults.sourceLocationPrefix)
     );
     tableRows.push(`| ${cells.join(' | ')} |`);
   }
@@ -247,7 +247,8 @@ function generateMarkdownForRawResults(
 
 function generateMarkdownForRawTableCell(
   value: CellValue,
-  fileLinkPrefix: string
+  fileLinkPrefix: string,
+  sourceLocationPrefix: string
 ) {
   let cellValue: string;
   switch (typeof value) {
@@ -258,7 +259,7 @@ function generateMarkdownForRawTableCell(
       break;
     case 'object':
       {
-        const url = tryGetRemoteLocation(value.url, fileLinkPrefix);
+        const url = tryGetRemoteLocation(value.url, fileLinkPrefix, sourceLocationPrefix);
         cellValue = `[\`${convertNonPrintableChars(value.label)}\`](${url})`;
       }
       break;

--- a/extensions/ql-vscode/src/remote-queries/remote-query-result-index.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-query-result-index.ts
@@ -12,6 +12,7 @@ export interface RemoteQuerySuccessIndexItem {
   resultCount: number;
   bqrsFileSize: number;
   sarifFileSize?: number;
+  sourceLocationPrefix: string;
 }
 
 export interface RemoteQueryFailureIndexItem {

--- a/extensions/ql-vscode/src/remote-queries/remote-query-result.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-query-result.ts
@@ -12,6 +12,7 @@ export interface AnalysisSummary {
   nwo: string,
   databaseSha: string,
   resultCount: number,
+  sourceLocationPrefix: string,
   downloadLink: DownloadLink,
   fileSizeInBytes: number,
   starCount?: number,

--- a/extensions/ql-vscode/src/remote-queries/shared/analysis-result.ts
+++ b/extensions/ql-vscode/src/remote-queries/shared/analysis-result.ts
@@ -16,6 +16,7 @@ export interface AnalysisRawResults {
   schema: ResultSetSchema;
   resultSet: RawResultSet;
   fileLinkPrefix: string;
+  sourceLocationPrefix: string;
   capped: boolean;
 }
 

--- a/extensions/ql-vscode/src/remote-queries/shared/remote-query-result.ts
+++ b/extensions/ql-vscode/src/remote-queries/shared/remote-query-result.ts
@@ -21,6 +21,7 @@ export interface AnalysisSummary {
   nwo: string,
   databaseSha: string,
   resultCount: number,
+  sourceLocationPrefix: string,
   downloadLink: DownloadLink,
   fileSize: string,
   starCount?: number,

--- a/extensions/ql-vscode/src/remote-queries/view/RawResultsTable.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/RawResultsTable.tsx
@@ -48,10 +48,11 @@ const Cell = ({
       return <span>{convertNonPrintableChars(value.toString())}</span>;
     case 'object': {
       const url = tryGetRemoteLocation(value.url, fileLinkPrefix, sourceLocationPrefix);
+      const safeLabel = convertNonPrintableChars(value.label);
       if (url) {
-        return <Link href={url}>{convertNonPrintableChars(value.label)}</Link>;
+        return <Link href={url}>{safeLabel}</Link>;
       } else {
-        return <span>{convertNonPrintableChars(value.label)}</span>;
+        return <span>{safeLabel}</span>;
       }
     }
   }

--- a/extensions/ql-vscode/src/remote-queries/view/RawResultsTable.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/RawResultsTable.tsx
@@ -48,7 +48,11 @@ const Cell = ({
       return <span>{convertNonPrintableChars(value.toString())}</span>;
     case 'object': {
       const url = tryGetRemoteLocation(value.url, fileLinkPrefix, sourceLocationPrefix);
-      return <Link href={url}>{convertNonPrintableChars(value.label)}</Link>;
+      if (url) {
+        return <Link href={url}>{convertNonPrintableChars(value.label)}</Link>;
+      } else {
+        return <span>{convertNonPrintableChars(value.label)}</span>;
+      }
     }
   }
 };

--- a/extensions/ql-vscode/src/remote-queries/view/RawResultsTable.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/RawResultsTable.tsx
@@ -10,10 +10,12 @@ const numOfResultsInContractedMode = 5;
 
 const Row = ({
   row,
-  fileLinkPrefix
+  fileLinkPrefix,
+  sourceLocationPrefix
 }: {
   row: CellValue[],
-  fileLinkPrefix: string
+  fileLinkPrefix: string,
+  sourceLocationPrefix: string
 }) => (
   <>
     {row.map((cell, cellIndex) => (
@@ -24,7 +26,7 @@ const Row = ({
         alignItems="center"
         p={2}
         sx={{ wordBreak: 'break-word' }}>
-        <Cell value={cell} fileLinkPrefix={fileLinkPrefix} />
+        <Cell value={cell} fileLinkPrefix={fileLinkPrefix} sourceLocationPrefix={sourceLocationPrefix} />
       </Box>
     ))}
   </>
@@ -32,10 +34,12 @@ const Row = ({
 
 const Cell = ({
   value,
-  fileLinkPrefix
+  fileLinkPrefix,
+  sourceLocationPrefix
 }: {
   value: CellValue,
   fileLinkPrefix: string
+  sourceLocationPrefix: string
 }) => {
   switch (typeof value) {
     case 'string':
@@ -43,7 +47,7 @@ const Cell = ({
     case 'boolean':
       return <span>{convertNonPrintableChars(value.toString())}</span>;
     case 'object': {
-      const url = tryGetRemoteLocation(value.url, fileLinkPrefix);
+      const url = tryGetRemoteLocation(value.url, fileLinkPrefix, sourceLocationPrefix);
       return <Link href={url}>{convertNonPrintableChars(value.label)}</Link>;
     }
   }
@@ -52,11 +56,13 @@ const Cell = ({
 const RawResultsTable = ({
   schema,
   results,
-  fileLinkPrefix
+  fileLinkPrefix,
+  sourceLocationPrefix
 }: {
   schema: ResultSetSchema,
   results: RawResultSet,
-  fileLinkPrefix: string
+  fileLinkPrefix: string,
+  sourceLocationPrefix: string
 }) => {
   const [tableExpanded, setTableExpanded] = useState(false);
   const numOfResultsToShow = tableExpanded ? results.rows.length : numOfResultsInContractedMode;
@@ -75,7 +81,7 @@ const RawResultsTable = ({
         maxWidth="45rem"
         p={2}>
         {results.rows.slice(0, numOfResultsToShow).map((row, rowIndex) => (
-          <Row key={rowIndex} row={row} fileLinkPrefix={fileLinkPrefix} />
+          <Row key={rowIndex} row={row} fileLinkPrefix={fileLinkPrefix} sourceLocationPrefix={sourceLocationPrefix} />
         ))}
       </Box>
       {

--- a/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
@@ -316,7 +316,8 @@ const RepoAnalysisResults = (analysisResults: AnalysisResults) => {
         <RawResultsTable
           schema={analysisResults.rawResults.schema}
           results={analysisResults.rawResults.resultSet}
-          fileLinkPrefix={analysisResults.rawResults.fileLinkPrefix} />
+          fileLinkPrefix={analysisResults.rawResults.fileLinkPrefix}
+          sourceLocationPrefix={analysisResults.rawResults.sourceLocationPrefix} />
       }
     </CollapsibleItem>
   );

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/raw-results/analyses-results.json
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/raw-results/analyses-results.json
@@ -386,6 +386,7 @@
         ]
       },
       "fileLinkPrefix": "https://github.com/meteor/meteor/blob/53f3c4442d3542d3d2a012a854472a0d1bef9d12",
+      "sourceLocationPrefix": "/home/runner/work/bulk-builder/bulk-builder",
       "capped": false
     }
   }


### PR DESCRIPTION
The MRVA action includes the `sourceLocationPrefix` in the result index. This PR updates the VS Code interface to use that prefix to construct links (instead of making a "best guess" based on the expected format). This is only used for raw (non-interpreted) results.

Main change is in https://github.com/github/vscode-codeql/commit/7b9e6a8effb57d08c34b4a0d4bb348f39b806ed2 (the other commits just pass `sourceLocationPrefix` around through various functions).

There shouldn't be any visible change, so I've tested this by running some queries and checking the resulting links. I've also updated the test data for markdown generation to use a `sourceLocationPrefix` for one of the repos, and the rendered links look fine there too.

See internal issue for more details.

## Checklist

N/A - internal only 🦒 

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
