### PR TITLE
Move time constants to time module

### DIFF
--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -2,7 +2,7 @@ import { DisposableObject } from './pure/disposable-object';
 import { workspace, Event, EventEmitter, ConfigurationChangeEvent, ConfigurationTarget } from 'vscode';
 import { DistributionManager } from './distribution';
 import { logger } from './logging';
-import { ONE_DAY_IN_MS } from './pure/helpers-pure';
+import { ONE_DAY_IN_MS } from './pure/time';
 
 /** Helper class to look up a labelled (and possibly nested) setting. */
 export class Setting {

--- a/extensions/ql-vscode/src/pure/helpers-pure.ts
+++ b/extensions/ql-vscode/src/pure/helpers-pure.ts
@@ -31,11 +31,6 @@ export const asyncFilter = async function <T>(arr: T[], predicate: (arg0: T) => 
   return arr.filter((_, index) => results[index]);
 };
 
-export const ONE_DAY_IN_MS = 24 * 60 * 60 * 1000;
-export const ONE_HOUR_IN_MS = 1000 * 60 * 60;
-export const TWO_HOURS_IN_MS = 1000 * 60 * 60 * 2;
-export const THREE_HOURS_IN_MS = 1000 * 60 * 60 * 3;
-
 /**
  * This regex matches strings of the form `owner/repo` where:
  * - `owner` is made up of alphanumeric characters or single hyphens, starting and ending in an alphanumeric character

--- a/extensions/ql-vscode/src/pure/time.ts
+++ b/extensions/ql-vscode/src/pure/time.ts
@@ -1,7 +1,11 @@
 /*
- * Contains an assortment of helper functions for working with time, dates, and durations.
+ * Contains an assortment of helper constants and functions for working with time, dates, and durations.
  */
 
+export const ONE_DAY_IN_MS = 24 * 60 * 60 * 1000;
+export const ONE_HOUR_IN_MS = 1000 * 60 * 60;
+export const TWO_HOURS_IN_MS = 1000 * 60 * 60 * 2;
+export const THREE_HOURS_IN_MS = 1000 * 60 * 60 * 3;
 
 const durationFormatter = new Intl.RelativeTimeFormat('en', {
   numeric: 'auto',

--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -28,7 +28,8 @@ import { URLSearchParams } from 'url';
 import { QueryServerClient } from './queryserver-client';
 import { DisposableObject } from './pure/disposable-object';
 import { commandRunner } from './commandRunner';
-import { assertNever, ONE_HOUR_IN_MS, TWO_HOURS_IN_MS, getErrorMessage, getErrorStack } from './pure/helpers-pure';
+import { ONE_HOUR_IN_MS, TWO_HOURS_IN_MS } from './pure/time';
+import { assertNever, getErrorMessage, getErrorStack } from './pure/helpers-pure';
 import { CompletedLocalQueryInfo, LocalQueryInfo as LocalQueryInfo, QueryHistoryInfo } from './query-results';
 import { DatabaseManager } from './databases';
 import { registerQueryHistoryScubber } from './query-history-scrubber';
@@ -854,7 +855,7 @@ export class QueryHistoryManager extends DisposableObject {
 
     if (finalSingleItem.evalLogSummaryLocation) {
       await this.tryOpenExternalFile(finalSingleItem.evalLogSummaryLocation);
-    } 
+    }
     // Summary log file doesn't exist.
     else {
       if (finalSingleItem.evalLogLocation && fs.pathExists(finalSingleItem.evalLogLocation)) {
@@ -862,7 +863,7 @@ export class QueryHistoryManager extends DisposableObject {
         this.warnInProgressEvalLogSummary();
       } else {
         this.warnNoEvalLogSummary();
-      }   
+      }
     }
   }
 

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
@@ -14,7 +14,7 @@ import { QueryServerClient } from '../../queryserver-client';
 import { LocalQueryInfo, InitialQueryInfo } from '../../query-results';
 import { DatabaseManager } from '../../databases';
 import * as tmp from 'tmp-promise';
-import { ONE_DAY_IN_MS, ONE_HOUR_IN_MS, TWO_HOURS_IN_MS, THREE_HOURS_IN_MS } from '../../pure/helpers-pure';
+import { ONE_DAY_IN_MS, ONE_HOUR_IN_MS, TWO_HOURS_IN_MS, THREE_HOURS_IN_MS } from '../../pure/time';
 import { tmpDir } from '../../helpers';
 import { getErrorMessage } from '../../pure/helpers-pure';
 import { HistoryItemLabelProvider } from '../../history-item-label-provider';


### PR DESCRIPTION
Moved time related constants out of `helpers-pure` and into `time`.


## Checklist
N/A:

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
