### PR TITLE
Allow repo names with periods

### DIFF
--- a/extensions/ql-vscode/src/pure/helpers-pure.ts
+++ b/extensions/ql-vscode/src/pure/helpers-pure.ts
@@ -34,9 +34,9 @@ export const asyncFilter = async function <T>(arr: T[], predicate: (arg0: T) => 
 /**
  * This regex matches strings of the form `owner/repo` where:
  * - `owner` is made up of alphanumeric characters or single hyphens, starting and ending in an alphanumeric character
- * - `repo` is made up of alphanumeric characters, hyphens, or underscores
+ * - `repo` is made up of alphanumeric characters, hyphens, periods, or underscores
  */
-export const REPO_REGEX = /^(?:[a-zA-Z0-9]+-)*[a-zA-Z0-9]+\/[a-zA-Z0-9-_]+$/;
+export const REPO_REGEX = /^(?:[a-zA-Z0-9]+-)*[a-zA-Z0-9]+\/[a-zA-Z0-9-_\.]+$/;
 
 export function getErrorMessage(e: any) {
   return e instanceof Error ? e.message : String(e);

--- a/extensions/ql-vscode/src/pure/helpers-pure.ts
+++ b/extensions/ql-vscode/src/pure/helpers-pure.ts
@@ -33,10 +33,10 @@ export const asyncFilter = async function <T>(arr: T[], predicate: (arg0: T) => 
 
 /**
  * This regex matches strings of the form `owner/repo` where:
- * - `owner` is made up of alphanumeric characters or single hyphens, starting and ending in an alphanumeric character
- * - `repo` is made up of alphanumeric characters, hyphens, periods, or underscores
+ * - `owner` is made up of alphanumeric characters, hyphens, underscores, or periods
+ * - `repo` is made up of alphanumeric characters, hyphens, underscores, or periods
  */
-export const REPO_REGEX = /^(?:[a-zA-Z0-9]+-)*[a-zA-Z0-9]+\/[a-zA-Z0-9-_\.]+$/;
+export const REPO_REGEX = /^[a-zA-Z0-9-_\.]+\/[a-zA-Z0-9-_\.]+$/;
 
 export function getErrorMessage(e: any) {
   return e instanceof Error ? e.message : String(e);

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/repository-selection.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/repository-selection.test.ts
@@ -78,7 +78,8 @@ describe('repository-selection', function() {
     const goodRepos = [
       'owner/repo',
       'owner-with-hyphens/repo-with-hyphens_and_underscores',
-      'ownerWithNumbers58/repoWithNumbers37'
+      'ownerWithNumbers58/repoWithNumbers37',
+      'owner/repo.with.periods',
     ];
     goodRepos.forEach(repo => {
       it(`should run on a valid repo that you enter in the text box: ${repo}`, async () => {

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/repository-selection.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/repository-selection.test.ts
@@ -77,9 +77,8 @@ describe('repository-selection', function() {
     // Test the regex in various "good" cases
     const goodRepos = [
       'owner/repo',
-      'owner-with-hyphens/repo-with-hyphens_and_underscores',
-      'ownerWithNumbers58/repoWithNumbers37',
-      'owner/repo.with.periods',
+      'owner_with.symbols-/repo.with-symbols_',
+      'ownerWithNumbers58/repoWithNumbers37'
     ];
     goodRepos.forEach(repo => {
       it(`should run on a valid repo that you enter in the text box: ${repo}`, async () => {
@@ -102,7 +101,7 @@ describe('repository-selection', function() {
 
     // Test the regex in various "bad" cases
     const badRepos = [
-      'invalid_owner/repo',
+      'invalid*owner/repo',
       'owner/repo+some&invalid&stuff',
       'owner-with-no-repo/',
       '/repo-with-no-owner'


### PR DESCRIPTION
Turns out that repo names can include periods (e.g. https://github.com/mozilla/pdf.js)! This PR updates the regex for permitted repo names, so that we no longer throw an error: 
![image](https://user-images.githubusercontent.com/42641846/174102862-3b81c6db-83a2-4dae-9ad7-cff720d21c3c.png)

Note: There are possibly some restrictions around whether the period (or hyphen/underscore) can appear anywhere in the repo name or only in the middle. I don't think it's necessary to be that specific (especially because I don't know what the exact rules are 😄) 

## Checklist

N/A: This is currently only used in MRVA and for downloading databases from GitHub, both of which are still internal-only.

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
