### PR TITLE
Use VSCodeProgressRing instead of Primer's Spinner

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/view/DownloadSpinner.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/DownloadSpinner.tsx
@@ -1,19 +1,15 @@
-import { Spinner } from '@primer/react';
+import { VSCodeProgressRing } from '@vscode/webview-ui-toolkit/react';
 import * as React from 'react';
 import styled from 'styled-components';
 
 const SpinnerContainer = styled.span`
   vertical-align: middle;
-
-  svg {
-    width: 0.8em;
-    height: 0.8em;  
-  }
+  display: inline-block;
 `;
 
 const DownloadSpinner = () => (
   <SpinnerContainer>
-    <Spinner size="small" />
+    <VSCodeProgressRing style={{ height: '0.8em', width: '0.8em' }} />
   </SpinnerContainer>
 );
 


### PR DESCRIPTION
Another small migration from Primer to the VS Code UI toolkit.

To see this in action without running a whole query, replace `Completed` with `InProgress` on [this](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/src/remote-queries/analyses-results-manager.ts#L148) line.


## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
