### PR TITLE
MRVA: Include number of repositories queried in confirmation message

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
@@ -39,7 +39,7 @@ interface QueriesResponse {
     invalid_repositories?: string[],
     repositories_without_database?: string[],
   },
-  repositories_queried?: string[],
+  repositories_queried: string[],
 }
 
 /**
@@ -341,15 +341,16 @@ async function runRemoteQueriesApiRequest(
 const eol = os.EOL;
 const eol2 = os.EOL + os.EOL;
 
-// exported for testng only
+// exported for testing only
 export function parseResponse(owner: string, repo: string, response: QueriesResponse) {
-  const popupMessage = `Successfully scheduled runs. [Click here to see the progress](https://github.com/${owner}/${repo}/actions/runs/${response.workflow_run_id}).`
+  const repositoriesQueried = response.repositories_queried;
+  const numRepositoriesQueried = repositoriesQueried.length;
+
+  const popupMessage = `Successfully scheduled runs on ${numRepositoriesQueried} repositories. [Click here to see the progress](https://github.com/${owner}/${repo}/actions/runs/${response.workflow_run_id}).`
     + (response.errors ? `${eol2}Some repositories could not be scheduled. See extension log for details.` : '');
 
-  let logMessage = `Successfully scheduled runs. See https://github.com/${owner}/${repo}/actions/runs/${response.workflow_run_id}.`;
-  if (response.repositories_queried) {
-    logMessage += `${eol2}Repositories queried:${eol}${response.repositories_queried.join(', ')}`;
-  }
+  let logMessage = `Successfully scheduled runs on ${numRepositoriesQueried} repositories. See https://github.com/${owner}/${repo}/actions/runs/${response.workflow_run_id}.`;
+  logMessage += `${eol2}Repositories queried:${eol}${repositoriesQueried.join(', ')}`;
   if (response.errors) {
     logMessage += `${eol2}Some repositories could not be scheduled.`;
     if (response.errors.invalid_repositories?.length) {

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/run-remote-query.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/run-remote-query.test.ts
@@ -10,23 +10,12 @@ describe('run-remote-query', () => {
         repositories_queried: ['a/b', 'c/d'],
       });
 
-      expect(result.popupMessage).to.equal('Successfully scheduled runs. [Click here to see the progress](https://github.com/org/name/actions/runs/123).');
+      expect(result.popupMessage).to.equal('Successfully scheduled runs on 2 repositories. [Click here to see the progress](https://github.com/org/name/actions/runs/123).');
       expect(result.logMessage).to.equal(
-        ['Successfully scheduled runs. See https://github.com/org/name/actions/runs/123.',
+        ['Successfully scheduled runs on 2 repositories. See https://github.com/org/name/actions/runs/123.',
           '',
           'Repositories queried:',
           'a/b, c/d'].join(os.EOL),
-      );
-    });
-
-    it('should parse a response with no repositories queried', () => {
-      const result = parseResponse('org', 'name', {
-        workflow_run_id: 123,
-      });
-
-      expect(result.popupMessage).to.equal('Successfully scheduled runs. [Click here to see the progress](https://github.com/org/name/actions/runs/123).');
-      expect(result.logMessage).to.equal(
-        'Successfully scheduled runs. See https://github.com/org/name/actions/runs/123.'
       );
     });
 
@@ -40,12 +29,12 @@ describe('run-remote-query', () => {
       });
 
       expect(result.popupMessage).to.equal(
-        ['Successfully scheduled runs. [Click here to see the progress](https://github.com/org/name/actions/runs/123).',
+        ['Successfully scheduled runs on 2 repositories. [Click here to see the progress](https://github.com/org/name/actions/runs/123).',
           '',
           'Some repositories could not be scheduled. See extension log for details.'].join(os.EOL)
       );
       expect(result.logMessage).to.equal(
-        ['Successfully scheduled runs. See https://github.com/org/name/actions/runs/123.',
+        ['Successfully scheduled runs on 2 repositories. See https://github.com/org/name/actions/runs/123.',
           '',
           'Repositories queried:',
           'a/b, c/d',
@@ -67,12 +56,12 @@ describe('run-remote-query', () => {
       });
 
       expect(result.popupMessage).to.equal(
-        ['Successfully scheduled runs. [Click here to see the progress](https://github.com/org/name/actions/runs/123).',
+        ['Successfully scheduled runs on 2 repositories. [Click here to see the progress](https://github.com/org/name/actions/runs/123).',
           '',
           'Some repositories could not be scheduled. See extension log for details.'].join(os.EOL)
       );
       expect(result.logMessage).to.equal(
-        ['Successfully scheduled runs. See https://github.com/org/name/actions/runs/123.',
+        ['Successfully scheduled runs on 2 repositories. See https://github.com/org/name/actions/runs/123.',
           '',
           'Repositories queried:',
           'a/b, c/d',
@@ -96,12 +85,12 @@ describe('run-remote-query', () => {
       });
 
       expect(result.popupMessage).to.equal(
-        ['Successfully scheduled runs. [Click here to see the progress](https://github.com/org/name/actions/runs/123).',
+        ['Successfully scheduled runs on 2 repositories. [Click here to see the progress](https://github.com/org/name/actions/runs/123).',
           '',
           'Some repositories could not be scheduled. See extension log for details.'].join(os.EOL)
       );
       expect(result.logMessage).to.equal(
-        ['Successfully scheduled runs. See https://github.com/org/name/actions/runs/123.',
+        ['Successfully scheduled runs on 2 repositories. See https://github.com/org/name/actions/runs/123.',
           '',
           'Repositories queried:',
           'a/b, c/d',


### PR DESCRIPTION
Updates the MRVA log message and pop-up to include the number of repos that were scheduled (as requested from testers). We also include the list of repos in the logs, but this pop-up saves users from having to count them manually!

![image](https://user-images.githubusercontent.com/42641846/174293096-26ce358c-24a5-45cd-95a6-e00f87119b44.png)

See internal linked issue.

## Checklist

N/A: internal only 💃🏽 

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
