### PR TITLE
Refactor: Invert dependency between query history and remote quries managers

### DIFF
--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -40,6 +40,10 @@ import { CliVersionConstraint } from './cli';
 import { HistoryItemLabelProvider } from './history-item-label-provider';
 import { Credentials } from './authentication';
 import { cancelRemoteQuery } from './remote-queries/gh-actions-api-client';
+import { RemoteQueriesManager } from './remote-queries/remote-queries-manager';
+import { RemoteQueryHistoryItem } from './remote-queries/remote-query-history-item';
+import { InterfaceManager } from './interface';
+import { WebviewReveal } from './interface-utils';
 
 /**
  * query-history.ts
@@ -307,21 +311,11 @@ export class QueryHistoryManager extends DisposableObject {
   queryHistoryScrubber: Disposable | undefined;
   private queryMetadataStorageLocation;
 
-  private readonly _onDidAddQueryItem = super.push(new EventEmitter<QueryHistoryInfo>());
-  readonly onDidAddQueryItem: Event<QueryHistoryInfo> = this
-    ._onDidAddQueryItem.event;
-
-  private readonly _onDidRemoveQueryItem = super.push(new EventEmitter<QueryHistoryInfo>());
-  readonly onDidRemoveQueryItem: Event<QueryHistoryInfo> = this
-    ._onDidRemoveQueryItem.event;
-
-  private readonly _onWillOpenQueryItem = super.push(new EventEmitter<QueryHistoryInfo>());
-  readonly onWillOpenQueryItem: Event<QueryHistoryInfo> = this
-    ._onWillOpenQueryItem.event;
-
   constructor(
     private readonly qs: QueryServerClient,
     private readonly dbm: DatabaseManager,
+    private readonly localQueriesInterfaceManager: InterfaceManager,
+    private readonly remoteQueriesManager: RemoteQueriesManager,
     private readonly queryStorageDir: string,
     private readonly ctx: ExtensionContext,
     private readonly queryHistoryConfigListener: QueryHistoryConfig,
@@ -525,6 +519,7 @@ export class QueryHistoryManager extends DisposableObject {
     }));
 
     this.registerQueryHistoryScrubber(queryHistoryConfigListener, ctx);
+    this.registerToRemoteQueriesEvents();
   }
 
   private getCredentials() {
@@ -548,12 +543,47 @@ export class QueryHistoryManager extends DisposableObject {
     );
   }
 
+  private registerToRemoteQueriesEvents() {
+    this.remoteQueriesManager.onRemoteQueryAdded(event => {
+      const historyItem: RemoteQueryHistoryItem = {
+        t: 'remote',
+        status: QueryStatus.InProgress,
+        completed: false,
+        queryId: event.queryId,
+        remoteQuery: event.query,
+      };
+
+      this.addQuery(historyItem);
+    });
+
+    this.remoteQueriesManager.onRemoteQueryRemoved(async (event) => {
+      const item = this.treeDataProvider.allHistory.find(i => i.t === 'remote' && i.queryId === event.queryId);
+      if (item) {
+        await this.removeRemoteQuery(item as RemoteQueryHistoryItem);
+      }
+    });
+
+    this.remoteQueriesManager.onRemoteQueryStatusUpdate(async (event) => {
+      const item = this.treeDataProvider.allHistory.find(i => i.t === 'remote' && i.queryId === event.queryId);
+      if (item) {
+        const remoteQueryHistoryItem = item as RemoteQueryHistoryItem;
+        remoteQueryHistoryItem.status = event.status;
+        remoteQueryHistoryItem.failureReason = event.failureReason;
+        await this.refreshTreeView();
+      } else {
+        void logger.log('Variant analysis status update event received for unknown variant analysis');
+      }
+    });
+  }
+
   async readQueryHistory(): Promise<void> {
     void logger.log(`Reading cached query history from '${this.queryMetadataStorageLocation}'.`);
     const history = await slurpQueryHistory(this.queryMetadataStorageLocation);
     this.treeDataProvider.allHistory = history;
-    this.treeDataProvider.allHistory.forEach((item) => {
-      this._onDidAddQueryItem.fire(item);
+    this.treeDataProvider.allHistory.forEach(async (item) => {
+      if (item.t === 'remote') {
+        await this.remoteQueriesManager.rehydrateRemoteQuery(item.queryId, item.remoteQuery, item.status);
+      }
     });
   }
 
@@ -619,24 +649,28 @@ export class QueryHistoryManager extends DisposableObject {
           await item.completedQuery?.query.deleteQuery();
         }
       } else {
-        // Remote queries can be removed locally, but not remotely.
-        // The user must cancel the query on GitHub Actions explicitly.
-        this.treeDataProvider.remove(item);
-        void logger.log(`Deleted ${this.labelProvider.getLabel(item)}.`);
-        if (item.status === QueryStatus.InProgress) {
-          void logger.log('The variant analysis is still running on GitHub Actions. To cancel there, you must go to the workflow run in your browser.');
-        }
-
-        this._onDidRemoveQueryItem.fire(item);
+        await this.removeRemoteQuery(item);
       }
-
     }));
+
     await this.writeQueryHistory();
     const current = this.treeDataProvider.getCurrent();
     if (current !== undefined) {
       await this.treeView.reveal(current, { select: true });
-      this._onWillOpenQueryItem.fire(current);
+      await this.openQueryResults(current);
     }
+  }
+
+  private async removeRemoteQuery(item: RemoteQueryHistoryItem): Promise<void> {
+    // Remote queries can be removed locally, but not remotely.
+    // The user must cancel the query on GitHub Actions explicitly.
+    this.treeDataProvider.remove(item);
+    void logger.log(`Deleted ${this.labelProvider.getLabel(item)}.`);
+    if (item.status === QueryStatus.InProgress) {
+      void logger.log('The variant analysis is still running on GitHub Actions. To cancel there, you must go to the workflow run in your browser.');
+    }
+
+    await this.remoteQueriesManager.removeRemoteQuery(item.queryId);
   }
 
   async handleSortByName() {
@@ -739,7 +773,7 @@ export class QueryHistoryManager extends DisposableObject {
     } else {
       // show results on single click only if query is completed successfully.
       if (finalSingleItem.status === QueryStatus.Completed) {
-        await this._onWillOpenQueryItem.fire(finalSingleItem);
+        await this.openQueryResults(finalSingleItem);
       }
     }
   }
@@ -1027,7 +1061,6 @@ export class QueryHistoryManager extends DisposableObject {
   addQuery(item: QueryHistoryInfo) {
     this.treeDataProvider.pushQuery(item);
     this.updateTreeViewSelectionIfVisible();
-    this._onDidAddQueryItem.fire(item);
   }
 
   /**
@@ -1227,5 +1260,14 @@ the file in the file explorer and dragging it into the workspace.`
   async refreshTreeView(): Promise<void> {
     this.treeDataProvider.refresh();
     await this.writeQueryHistory();
+  }
+
+  private async openQueryResults(item: QueryHistoryInfo) {
+    if (item.t === 'local') {
+      await this.localQueriesInterfaceManager.showResults(item as CompletedLocalQueryInfo, WebviewReveal.Forced, false);
+    }
+    else if (item.t === 'remote') {
+      await this.remoteQueriesManager.openRemoteQueryResults(item.queryId);
+    }
   }
 }

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
@@ -66,9 +66,9 @@ export class RemoteQueriesManager extends DisposableObject {
     this.interfaceManager = new RemoteQueriesInterfaceManager(ctx, logger, this.analysesResultsManager);
     this.remoteQueriesMonitor = new RemoteQueriesMonitor(ctx, logger);
 
-    this.remoteQueryAddedEventEmitter = super.push(new EventEmitter<NewQueryEvent>());
-    this.remoteQueryRemovedEventEmitter = super.push(new EventEmitter<RemovedQueryEvent>());
-    this.remoteQueryStatusUpdateEventEmitter = super.push(new EventEmitter<UpdatedQueryStatusEvent>());
+    this.remoteQueryAddedEventEmitter = this.push(new EventEmitter<NewQueryEvent>());
+    this.remoteQueryRemovedEventEmitter = this.push(new EventEmitter<RemovedQueryEvent>());
+    this.remoteQueryStatusUpdateEventEmitter = this.push(new EventEmitter<UpdatedQueryStatusEvent>());
     this.onRemoteQueryAdded = this.remoteQueryAddedEventEmitter.event;
     this.onRemoteQueryRemoved = this.remoteQueryRemovedEventEmitter.event;
     this.onRemoteQueryStatusUpdate = this.remoteQueryStatusUpdateEventEmitter.event;

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
@@ -128,7 +128,7 @@ export class RemoteQueriesManager extends DisposableObject {
       await this.storeJsonFile(queryId, 'query.json', query);
 
       this.remoteQueryAddedEventEmitter.fire({ queryId, query });
-      await commands.executeCommand('codeQL.monitorRemoteQuery', queryId, query);
+      void commands.executeCommand('codeQL.monitorRemoteQuery', queryId, query);
     }
   }
 

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
@@ -18,6 +18,8 @@ import { ONE_DAY_IN_MS, ONE_HOUR_IN_MS, TWO_HOURS_IN_MS, THREE_HOURS_IN_MS } fro
 import { tmpDir } from '../../helpers';
 import { getErrorMessage } from '../../pure/helpers-pure';
 import { HistoryItemLabelProvider } from '../../history-item-label-provider';
+import { RemoteQueriesManager } from '../../remote-queries/remote-queries-manager';
+import { InterfaceManager } from '../../interface';
 
 describe('query-history', () => {
   const mockExtensionLocation = path.join(tmpDir.name, 'mock-extension-location');
@@ -27,8 +29,10 @@ describe('query-history', () => {
   let executeCommandSpy: sinon.SinonStub;
   let showQuickPickSpy: sinon.SinonStub;
   let queryHistoryManager: QueryHistoryManager | undefined;
-  let selectedCallback: sinon.SinonStub;
   let doCompareCallback: sinon.SinonStub;
+
+  let localQueriesInterfaceManagerStub: InterfaceManager;
+  let remoteQueriesManagerStub: RemoteQueriesManager;
 
   let tryOpenExternalFile: Function;
   let sandbox: sinon.SinonSandbox;
@@ -49,8 +53,15 @@ describe('query-history', () => {
     sandbox.stub(logger, 'log');
     tryOpenExternalFile = (QueryHistoryManager.prototype as any).tryOpenExternalFile;
     configListener = new QueryHistoryConfigListener();
-    selectedCallback = sandbox.stub();
     doCompareCallback = sandbox.stub();
+    localQueriesInterfaceManagerStub = {
+      showResults: sandbox.stub()
+    } as any as InterfaceManager;
+    remoteQueriesManagerStub = {
+      onRemoteQueryAdded: sandbox.stub(),
+      onRemoteQueryRemoved: sandbox.stub(),
+      onRemoteQueryStatusUpdate: sandbox.stub()
+    } as any as RemoteQueriesManager;
   });
 
   afterEach(async () => {
@@ -190,22 +201,28 @@ describe('query-history', () => {
   describe('handleItemClicked', () => {
     it('should call the selectedCallback when an item is clicked', async () => {
       queryHistoryManager = await createMockQueryHistory(allHistory);
+
       await queryHistoryManager.handleItemClicked(allHistory[0], [allHistory[0]]);
-      expect(selectedCallback).to.have.been.calledOnceWith(allHistory[0]);
+
+      expect(localQueriesInterfaceManagerStub.showResults).to.have.been.calledOnceWith(allHistory[0]);
       expect(queryHistoryManager.treeDataProvider.getCurrent()).to.eq(allHistory[0]);
     });
 
     it('should do nothing if there is a multi-selection', async () => {
       queryHistoryManager = await createMockQueryHistory(allHistory);
+
       await queryHistoryManager.handleItemClicked(allHistory[0], [allHistory[0], allHistory[1]]);
-      expect(selectedCallback).not.to.have.been.called;
+
+      expect(localQueriesInterfaceManagerStub.showResults).not.to.have.been.called;
       expect(queryHistoryManager.treeDataProvider.getCurrent()).to.be.undefined;
     });
 
     it('should do nothing if there is no selection', async () => {
       queryHistoryManager = await createMockQueryHistory(allHistory);
+
       await queryHistoryManager.handleItemClicked(undefined!, []);
-      expect(selectedCallback).not.to.have.been.called;
+
+      expect(localQueriesInterfaceManagerStub.showResults).not.to.have.been.called;
       expect(queryHistoryManager.treeDataProvider.getCurrent()).to.be.undefined;
     });
   });
@@ -234,7 +251,7 @@ describe('query-history', () => {
     expect(queryHistoryManager.treeDataProvider.allHistory).not.to.contain(toDelete);
 
     // the same item should be selected
-    expect(selectedCallback).to.have.been.calledOnceWith(selected);
+    expect(localQueriesInterfaceManagerStub.showResults).to.have.been.calledOnceWith(selected);
   });
 
   it('should remove an item and select a new one', async () => {
@@ -254,7 +271,7 @@ describe('query-history', () => {
     expect(queryHistoryManager.treeDataProvider.allHistory).not.to.contain(toDelete);
 
     // the current item should have been selected
-    expect(selectedCallback).to.have.been.calledOnceWith(newSelected);
+    expect(localQueriesInterfaceManagerStub.showResults).to.have.been.calledOnceWith(newSelected);
   });
 
   describe('Compare callback', () => {
@@ -762,6 +779,8 @@ describe('query-history', () => {
     const qhm = new QueryHistoryManager(
       {} as QueryServerClient,
       {} as DatabaseManager,
+      localQueriesInterfaceManagerStub,
+      remoteQueriesManagerStub,
       'xxx',
       {
         globalStorageUri: vscode.Uri.file(mockExtensionLocation),
@@ -771,7 +790,6 @@ describe('query-history', () => {
       new HistoryItemLabelProvider({} as QueryHistoryConfig),
       doCompareCallback
     );
-    qhm.onWillOpenQueryItem(selectedCallback);
     (qhm.treeDataProvider as any).history = [...allHistory];
     await vscode.workspace.saveAll();
     await qhm.refreshTreeView();


### PR DESCRIPTION
Currently, the `RemoteQueriesManager` depends on the `QueryHistoryManager` and related models e.g. `QueryHistoryInfo`. This is a bit problematic because the `RemoteQueriesManager` ends up having knowledge about query history stuff and can receive events that are potentially for local queries. 

This PR inverts that dependency and makes `RemoteQueriesManager` a dependency of QueryHistoryManager. The `RemoteQueriesManager` is completely independent of query history and simply publishes events that the `QueryHistoryManager` can consume. I think this way makes more sense because the query history area **has** to be aware of local/remote queries, but remote queries don't have to necessarily be aware of the query history.


## Checklist
N/A
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
