### PR TITLE
MRVA: Improve experience when controller repo does not exist

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
@@ -333,8 +333,12 @@ async function runRemoteQueriesApiRequest(
     const { popupMessage, logMessage } = parseResponse(owner, repo, response.data);
     void showAndLogInformationMessage(popupMessage, { fullMessage: logMessage });
     return response.data.workflow_run_id;
-  } catch (error) {
-    void showAndLogErrorMessage(getErrorMessage(error));
+  } catch (error: any) {
+    if (error.status === 404) {
+      void showAndLogErrorMessage(`Controller repository was not found. Please make sure it's a valid repo name.${eol}`);
+    } else {
+      void showAndLogErrorMessage(getErrorMessage(error));
+    }
   }
 }
 


### PR DESCRIPTION
The controller repo is set via the `codeQL.variantAnalysis.controllerRepo`
setting in VSCode.

While we have validation to check that the repo is not null and the
format of the controller repo is correct: `<owner>/<repo>`, we still
allow you to provide a non-existent repo (e.g. a mispelled one).

When the MRVA request is sent over to the API, it will verify that the
repo exists and return a very generic "Not Found" response.

This will then be logged out in the "Output" tab for VSCode.

We'd like to give users a better indication of what has gone wrong in
this case so we're making the error message more verbose.

![Screenshot 2022-06-21 at 21 47 26](https://user-images.githubusercontent.com/1354439/174895937-b97bf644-58d8-43c0-ac4c-071e702a30b5.png)

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
