### PR TITLE
Fix failing integration test

### DIFF
--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/global.helper.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/global.helper.ts
@@ -12,9 +12,13 @@ import { DatabaseManager } from '../../databases';
 
 export const DB_URL = 'https://github.com/github/vscode-codeql/files/5586722/simple-db.zip';
 
-process.addListener('unhandledRejection', (reason, p) => {
-  console.log('Unhandled Rejection at: Promise ', p, ' reason: ', reason);
-  fail(String(reason));
+process.addListener('unhandledRejection', (reason) => {
+  if (reason instanceof Error && reason.message === 'Canceled') {
+    console.log('Cancellation requested after the test has ended.');
+    process.exit(0);
+  } else {
+    fail(String(reason));
+  }
 });
 
 // We need to resolve the path, but the final three segments won't exist until later, so we only resolve the

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/queries.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/queries.test.ts
@@ -157,10 +157,11 @@ describe('Queries', function() {
   });
 
   it('should avoid creating a quick query', async () => {
+    fs.mkdirpSync(path.dirname(qlpackFile));
     fs.writeFileSync(qlpackFile, yaml.dump({
       name: 'quick-query',
       version: '1.0.0',
-      libraryPathDependencies: ['codeql-javascript']
+      libraryPathDependencies: ['codeql/javascript-all']
     }));
     fs.writeFileSync(qlFile, 'xxx');
     await commands.executeCommand('codeQL.quickQuery');


### PR DESCRIPTION
How did this ever work? It was using an old variant of the
qlpack name.

Also, this commit makes the unhandledRejection handler less
verbose. This gets hit when the tests end and there is a cancellation.
this is not an error.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

@elenatanasoiu I hit some test failures when I was looking into your troubles this morning. I don't think this will fix what you've been seeing, but it's perhaps related.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
