### PR TITLE
Show in log message when repos are filtered out for being private

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
@@ -38,6 +38,7 @@ interface QueriesResponse {
   errors?: {
     invalid_repositories?: string[],
     repositories_without_database?: string[],
+    private_repositories?: string[],
   },
   repositories_queried: string[],
 }
@@ -360,6 +361,10 @@ export function parseResponse(owner: string, repo: string, response: QueriesResp
     if (response.errors.repositories_without_database?.length) {
       logMessage += `${eol2}Repositories without databases:${eol}${response.errors.repositories_without_database.join(', ')}`;
       logMessage += `${eol}For each public repository that has not yet been added to the database service, we will try to create a database next time the store is updated.`;
+    }
+    if (response.errors.private_repositories?.length) {
+      logMessage += `${eol2}Non-public repositories:${eol}${response.errors.private_repositories.join(', ')}`;
+      logMessage += `${eol}When using a public controller repository, only public repositories can be queried.`;
     }
   }
 

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/run-remote-query.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/run-remote-query.test.ts
@@ -98,7 +98,7 @@ describe('run-remote-query', () => {
           '',
           'Non-public repositories:',
           'e/f, g/h',
-          'When using a public controller repository, only public repositories can be queried'].join(os.EOL)
+          'When using a public controller repository, only public repositories can be queried.'].join(os.EOL)
       );
     });
 

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/run-remote-query.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/run-remote-query.test.ts
@@ -74,6 +74,34 @@ describe('run-remote-query', () => {
       );
     });
 
+    it('should parse a response with private repos', () => {
+      const result = parseResponse('org', 'name', {
+        workflow_run_id: 123,
+        repositories_queried: ['a/b', 'c/d'],
+        errors: {
+          private_repositories: ['e/f', 'g/h'],
+        }
+      });
+
+      expect(result.popupMessage).to.equal(
+        ['Successfully scheduled runs on 2 repositories. [Click here to see the progress](https://github.com/org/name/actions/runs/123).',
+          '',
+          'Some repositories could not be scheduled. See extension log for details.'].join(os.EOL)
+      );
+      expect(result.logMessage).to.equal(
+        ['Successfully scheduled runs on 2 repositories. See https://github.com/org/name/actions/runs/123.',
+          '',
+          'Repositories queried:',
+          'a/b, c/d',
+          '',
+          'Some repositories could not be scheduled.',
+          '',
+          'Non-public repositories:',
+          'e/f, g/h',
+          'When using a public controller repository, only public repositories can be queried'].join(os.EOL)
+      );
+    });
+
     it('should parse a response with invalid repos and repos w/o databases', () => {
       const result = parseResponse('org', 'name', {
         workflow_run_id: 123,


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Handle when the MRVA API returns that some repositories were skipped because they are private and you are using a public controller repository. The API change to start returning this will also be made, but it should be safe to merge these changes in any order.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
