### PR TITLE
Fail fast if codeql repo is missing from the workspace

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,9 +95,11 @@ Running from a terminal, you _must_ set the `TEST_CODEQL_PATH` variable to point
 
 ### Running the integration tests
 
-The _Launch Integration Tests - With CLI_ tests require a CLI instance in order to run. There are several environment variables you can use to configure this.
+You will need to run CLI tests using a task from inside of VS Code called _Launch Integration Tests - With CLI_.
 
-From inside of VSCode, open the `launch.json` file and in the _Launch Integration Tests - With CLI_ uncomment and change the environment variables appropriate for your purpose.
+The CLI integration tests require the CodeQL standard libraries in order to run so you will need to clone a local copy of the `github/codeql` repository.
+
+From inside of VSCode, open the `launch.json` file and in the _Launch Integration Tests - With CLI_ task, uncomment the `"${workspaceRoot}/../codeql"` line. If necessary, replace value with a path to your checkout, and then run the task.
 
 ## Releasing (write access required)
 

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/global.helper.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/global.helper.ts
@@ -75,7 +75,7 @@ export default function(mocha: Mocha) {
     }
   );
 
-  // ensure etension is cleaned up.
+  // ensure extension is cleaned up.
   (mocha.options as any).globalTeardown.push(
     async () => {
       const extension = await extensions.getExtension<CodeQLExtensionInterface | Record<string, never>>('GitHub.vscode-codeql')!.activate();
@@ -91,6 +91,21 @@ export default function(mocha: Mocha) {
   (mocha.options as any).globalTeardown.push(
     () => {
       removeStorage?.();
+    }
+  );
+
+  // check that the codeql folder is found in the workspace
+  (mocha.options as any).globalSetup.push(
+    async () => {
+      const folders = workspace.workspaceFolders;
+      if (!folders) {
+        fail('\n\n\nNo workspace folders found.\nYou will need a local copy of the codeql repo.\nMake sure you specify the path to it in launch.json.\nIt should be something along the lines of "${workspaceRoot}/../codeql" depending on where you have your local copy of the codeql repo.\n\n\n');
+      } else {
+        const codeqlFolder = folders.find(folder => folder.name === 'codeql');
+        if (!codeqlFolder) {
+          fail('\n\n\nNo workspace folders found.\nYou will need a local copy of the codeql repo.\nMake sure you specify the path to it in launch.json.\nIt should be something along the lines of "${workspaceRoot}/../codeql" depending on where you have your local copy of the codeql repo.\n\n\n');
+        }
+      }
     }
   );
 }


### PR DESCRIPTION
In order to run our cli-integration tests, we're required to have a
local copy of the `github/codeql` repo. We can then run the tests by 
running the `Launch Integration Tests - With CLI` task from inside 
VS Code.

(See CONTRIBUTING.md for details.)

If we don't have the repo cloned locally or we're not pointing to it
in `launch.json`, we don't get a clear indication of what the problem is.

The tests will still attempt to run.

Let's fail fast instead and add an actionable error message to the output.

![Screenshot 2022-06-22 at 19 24 13](https://user-images.githubusercontent.com/1354439/175112284-90210e88-8967-4d7d-ae8e-cb80accdae99.png)

We're also updating `CONTRIBUTING.md` to make it a bit friendlier for 
newcomers.


