### PR TITLE
Add ability to define repo lists in a file outside of settings

### DIFF
--- a/extensions/ql-vscode/package-lock.json
+++ b/extensions/ql-vscode/package-lock.json
@@ -11390,9 +11390,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
-      "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
+      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
       "dev": true
     },
     "node_modules/shimmer": {
@@ -23492,9 +23492,9 @@
       "dev": true
     },
     "shell-quote": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
-      "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
+      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
       "dev": true
     },
     "shimmer": {

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -343,6 +343,21 @@ export async function setRemoteRepositoryLists(lists: Record<string, string[]> |
 }
 
 /**
+ * Path to a file that contains lists of GitHub repositories that you want to query remotely via 
+ * the "Run Variant Analysis" command.
+ * Note: This command is only available for internal users.
+ * 
+ * This setting should be a path to a JSON file that contains a JSON object where each key is a
+ * user-specified name (string), and the value is an array of GitHub repositories 
+ * (of the form `<owner>/<repo>`).
+ */
+const REPO_LISTS_PATH = new Setting('repositoryListsPath', REMOTE_QUERIES_SETTING);
+
+export function getRemoteRepositoryListsPath(): string | undefined {
+  return REPO_LISTS_PATH.getValue<string>() || undefined;
+}
+
+/**
  * The name of the "controller" repository that you want to use with the "Run Variant Analysis" command.
  * Note: This command is only available for internal users.
  *

--- a/extensions/ql-vscode/src/remote-queries/repository-selection.ts
+++ b/extensions/ql-vscode/src/remote-queries/repository-selection.ts
@@ -142,7 +142,7 @@ async function readExternalRepoListsJson(path: string): Promise<Record<string, u
   }
 
   if (Array.isArray(json)) {
-    throw Error('Invalid repository lists file. It should be an object mapping names to a list of repositories..');
+    throw Error('Invalid repository lists file. It should be an object mapping names to a list of repositories.');
   }
 
   return json;

--- a/extensions/ql-vscode/src/remote-queries/repository-selection.ts
+++ b/extensions/ql-vscode/src/remote-queries/repository-selection.ts
@@ -1,6 +1,7 @@
+import * as fs from 'fs-extra';
 import { QuickPickItem, window } from 'vscode';
 import { logger } from '../logging';
-import { getRemoteRepositoryLists } from '../config';
+import { getRemoteRepositoryLists, getRemoteRepositoryListsPath } from '../config';
 import { OWNER_REGEX, REPO_REGEX } from '../pure/helpers-pure';
 import { UserCancellationException } from '../commandRunner';
 
@@ -17,6 +18,11 @@ interface RepoListQuickPickItem extends QuickPickItem {
   useAllReposOfOwner?: boolean;
 }
 
+interface RepoList {
+  label: string;
+  repositories: string[];
+}
+
 /**
  * Gets the repositories or repository lists to run the query against.
  * @returns The user selection.
@@ -26,7 +32,7 @@ export async function getRepositorySelection(): Promise<RepositorySelection> {
     createCustomRepoQuickPickItem(),
     createAllReposOfOwnerQuickPickItem(),
     ...createSystemDefinedRepoListsQuickPickItems(),
-    ...createUserDefinedRepoListsQuickPickItems(),
+    ...(await createUserDefinedRepoListsQuickPickItems()),
   ];
 
   const options = {
@@ -88,18 +94,79 @@ function createSystemDefinedRepoListsQuickPickItems(): RepoListQuickPickItem[] {
   } as RepoListQuickPickItem));
 }
 
-function createUserDefinedRepoListsQuickPickItems(): RepoListQuickPickItem[] {
+async function readExternalRepoLists(): Promise<RepoList[]> {
+  const repoLists: RepoList[] = [];
+
+  const path = getRemoteRepositoryListsPath();
+  if (!path) {
+    return repoLists;
+  }
+
+  await validateExternalRepoListsFile(path);
+  const json = await readExternalRepoListsJson(path);
+
+  for (const [repoListName, repositories] of Object.entries(json)) {
+    if (!Array.isArray(repositories)) {
+      throw Error('Invalid repository lists file. It should contain an array of repositories for each list.');
+    }
+
+    repoLists.push({
+      label: repoListName,
+      repositories
+    });
+  }
+
+  return repoLists;
+}
+
+async function validateExternalRepoListsFile(path: string): Promise<void> {
+  const pathExists = await fs.pathExists(path);
+  if (!pathExists) {
+    throw Error(`External repository lists file does not exist at ${path}`);
+  }
+
+  const pathStat = await fs.stat(path);
+  if (pathStat.isDirectory()) {
+    throw Error('External repository lists path should not point to a directory');
+  }
+}
+
+async function readExternalRepoListsJson(path: string): Promise<Record<string, unknown>> {
+  let json;
+
+  try {
+    const fileContents = await fs.readFile(path, 'utf8');
+    json = await JSON.parse(fileContents);
+  } catch (error) {
+    throw Error('Invalid repository lists file. It should contain valid JSON.');
+  }
+
+  if (Array.isArray(json)) {
+    throw Error('Invalid repository lists file. It should not contain an array.');
+  }
+
+  return json;
+}
+
+function readRepoListsFromSettings(): RepoList[] {
   const repoLists = getRemoteRepositoryLists();
   if (!repoLists) {
     return [];
   }
 
-  return Object.entries(repoLists).map<RepoListQuickPickItem>(([label, repositories]) => (
+  return Object.entries(repoLists).map<RepoList>(([label, repositories]) => (
     {
-      label,            // the name of the repository list
-      repositories  // the actual array of repositories
+      label,
+      repositories
     }
   ));
+}
+
+async function createUserDefinedRepoListsQuickPickItems(): Promise<RepoListQuickPickItem[]> {
+  const repoListsFromSetings = readRepoListsFromSettings();
+  const repoListsFromExternalFile = await readExternalRepoLists();
+
+  return [...repoListsFromSetings, ...repoListsFromExternalFile];
 }
 
 function createCustomRepoQuickPickItem(): RepoListQuickPickItem {

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/repository-selection.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/repository-selection.test.ts
@@ -9,22 +9,42 @@ const proxyquire = pq.noPreserveCache();
 
 describe('repository selection', async () => {
   let sandbox: sinon.SinonSandbox;
+
   let quickPickSpy: sinon.SinonStub;
   let showInputBoxSpy: sinon.SinonStub;
+
   let getRemoteRepositoryListsSpy: sinon.SinonStub;
   let getRemoteRepositoryListsPathSpy: sinon.SinonStub;
+
+  let pathExistsStub: sinon.SinonStub;
+  let fsStatStub: sinon.SinonStub;
+  let fsReadFileStub: sinon.SinonStub;
+
   let mod: any;
+
   beforeEach(() => {
     sandbox = sinon.createSandbox();
+
     quickPickSpy = sandbox.stub(window, 'showQuickPick');
     showInputBoxSpy = sandbox.stub(window, 'showInputBox');
+
     getRemoteRepositoryListsSpy = sandbox.stub();
     getRemoteRepositoryListsPathSpy = sandbox.stub();
+
+    pathExistsStub = sandbox.stub(fs, 'pathExists');
+    fsStatStub = sandbox.stub(fs, 'stat');
+    fsReadFileStub = sandbox.stub(fs, 'readFile');
+
     mod = proxyquire('../../../remote-queries/repository-selection', {
       '../config': {
         getRemoteRepositoryLists: getRemoteRepositoryListsSpy,
         getRemoteRepositoryListsPath: getRemoteRepositoryListsPathSpy
       },
+      'fs-extra': {
+        pathExists: pathExistsStub,
+        stat: fsStatStub,
+        readFile: fsReadFileStub
+      }
     });
   });
 
@@ -179,22 +199,6 @@ describe('repository selection', async () => {
   });
 
   describe('external repository lists file', async () => {
-    let pathExistsStub: sinon.SinonStub;
-    let fsStatStub: sinon.SinonStub;
-    let fsReadFileStub: sinon.SinonStub;
-
-    beforeEach(() => {
-      pathExistsStub = sandbox.stub(fs, 'pathExists');
-      fsStatStub = sandbox.stub(fs, 'stat');
-      fsReadFileStub = sandbox.stub(fs, 'readFile');
-    });
-
-    afterEach(() => {
-      pathExistsStub.restore();
-      fsStatStub.restore();
-      fsReadFileStub.restore();
-    });
-
     it('should fail if path does not exist', async () => {
       const fakeFilePath = '/path/that/does/not/exist.json';
       getRemoteRepositoryListsPathSpy.returns(fakeFilePath);

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/repository-selection.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/repository-selection.test.ts
@@ -233,7 +233,7 @@ describe('repository selection', async () => {
       fsStatStub.resolves({ isDirectory: () => false } as any);
       fsReadFileStub.resolves('[]' as any as Buffer);
 
-      await expect(mod.getRepositorySelection()).to.be.rejectedWith(Error, 'Invalid repository lists file. It should not contain an array.');
+      await expect(mod.getRepositorySelection()).to.be.rejectedWith(Error, 'Invalid repository lists file. It should be an object mapping names to a list of repositories.');
     });
 
     it('should fail if file does not contain repo lists in the right format', async () => {


### PR DESCRIPTION
Adds a new `repositoryListsPath` setting that allows users to define repository lists for MRVA outside of their settings.json file.


## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
