### PR TITLE
Add ability to create repo list from MRVA results

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -306,6 +306,10 @@
         "title": "CodeQL: Export Variant Analysis Results"
       },
       {
+        "command": "codeQL.copyRepoList",
+        "title": "Copy repository list"
+      },
+      {
         "command": "codeQL.runQueries",
         "title": "CodeQL: Run Queries in Selected Files"
       },
@@ -574,6 +578,10 @@
         "title": "Open Variant Analysis on GitHub"
       },
       {
+        "command": "codeQLQueryHistory.copyRepoList",
+        "title": "Copy Repository List"
+      },
+      {
         "command": "codeQLQueryResults.nextPathStep",
         "title": "CodeQL: Show Next Step on Path"
       },
@@ -789,6 +797,11 @@
           "command": "codeQLQueryHistory.openOnGithub",
           "group": "9_qlCommands",
           "when": "viewItem == remoteResultsItem || viewItem == inProgressRemoteResultsItem || viewItem == cancelledResultsItem"
+        },
+        {
+          "command": "codeQLQueryHistory.copyRepoList",
+          "group": "9_qlCommands",
+          "when": "viewItem == remoteResultsItem"
         },
         {
           "command": "codeQLTests.showOutputDifferences",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -306,10 +306,6 @@
         "title": "CodeQL: Export Variant Analysis Results"
       },
       {
-        "command": "codeQL.copyRepoList",
-        "title": "Copy repository list"
-      },
-      {
         "command": "codeQL.runQueries",
         "title": "CodeQL: Run Queries in Selected Files"
       },
@@ -989,6 +985,10 @@
         },
         {
           "command": "codeQLQueryHistory.openOnGithub",
+          "when": "false"
+        },
+        {
+          "command": "codeQLQueryHistory.copyRepoList",
           "when": "false"
         },
         {

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -887,6 +887,12 @@ async function activateWithInstalledDistribution(
     }));
 
   ctx.subscriptions.push(
+    commandRunner('codeQL.copyRepoList', async (queryId: string) => {
+      await rqm.copyRemoteQueryRepoListToClipboard(queryId);
+    })
+  );
+
+  ctx.subscriptions.push(
     commandRunner('codeQL.autoDownloadRemoteQueryResults', async (
       queryResult: RemoteQueryResult,
       token: CancellationToken) => {

--- a/extensions/ql-vscode/src/pure/interface-types.ts
+++ b/extensions/ql-vscode/src/pure/interface-types.ts
@@ -395,7 +395,8 @@ export type FromRemoteQueriesMessage =
   | OpenVirtualFileMsg
   | RemoteQueryDownloadAnalysisResultsMessage
   | RemoteQueryDownloadAllAnalysesResultsMessage
-  | RemoteQueryExportResultsMessage;
+  | RemoteQueryExportResultsMessage
+  | CopyRepoListMessage;
 
 export type ToRemoteQueriesMessage =
   | SetRemoteQueryResultMessage
@@ -432,4 +433,9 @@ export interface RemoteQueryDownloadAllAnalysesResultsMessage {
 
 export interface RemoteQueryExportResultsMessage {
   t: 'remoteQueryExportResults';
+}
+
+export interface CopyRepoListMessage {
+  t: 'copyRepoList';
+  queryId: string;
 }

--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -493,7 +493,7 @@ export class QueryHistoryManager extends DisposableObject {
     );
     this.push(
       commandRunner(
-        'codeQlQueryHistory.copyRepoList',
+        'codeQLQueryHistory.copyRepoList',
         this.handleCopyRepoList.bind(this)
       )
     );

--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -491,6 +491,12 @@ export class QueryHistoryManager extends DisposableObject {
         }
       )
     );
+    this.push(
+      commandRunner(
+        'codeQlQueryHistory.copyRepoList',
+        this.handleCopyRepoList.bind(this)
+      )
+    );
 
     // There are two configuration items that affect the query history:
     // 1. The ttl for query history items.
@@ -1048,6 +1054,20 @@ export class QueryHistoryManager extends DisposableObject {
       'vscode.open',
       Uri.parse(`https://github.com/${owner}/${name}/actions/runs/${workflowRunId}`)
     );
+  }
+
+  async handleCopyRepoList(
+    singleItem: QueryHistoryInfo,
+    multiSelect: QueryHistoryInfo[],
+  ) {
+    const { finalSingleItem, finalMultiSelect } = this.determineSelection(singleItem, multiSelect);
+
+    // Remote queries only
+    if (!this.assertSingleQuery(finalMultiSelect) || !finalSingleItem || finalSingleItem.t !== 'remote') {
+      return;
+    }
+
+    await commands.executeCommand('codeQL.copyRepoList', finalSingleItem.queryId);
   }
 
   async getQueryText(item: QueryHistoryInfo): Promise<string> {

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
@@ -80,6 +80,7 @@ export class RemoteQueriesInterfaceManager {
     const affectedRepositories = queryResult.analysisSummaries.filter(r => r.resultCount > 0);
 
     return {
+      queryId: queryResult.queryId,
       queryTitle: query.queryName,
       queryFileName: queryFileName,
       queryFilePath: query.queryFilePath,
@@ -205,6 +206,9 @@ export class RemoteQueriesInterfaceManager {
         break;
       case 'openVirtualFile':
         await this.openVirtualFile(msg.queryText);
+        break;
+      case 'copyRepoList':
+        await commands.executeCommand('codeQL.copyRepoList', msg.queryId);
         break;
       case 'remoteQueryDownloadAnalysisResults':
         await this.downloadAnalysisResults(msg);

--- a/extensions/ql-vscode/src/remote-queries/shared/remote-query-result.ts
+++ b/extensions/ql-vscode/src/remote-queries/shared/remote-query-result.ts
@@ -2,6 +2,7 @@ import { DownloadLink } from '../download-link';
 import { AnalysisFailure } from './analysis-failure';
 
 export interface RemoteQueryResult {
+  queryId: string,
   queryTitle: string,
   queryFileName: string,
   queryFilePath: string,

--- a/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/RemoteQueries.tsx
@@ -22,10 +22,12 @@ import RepositoriesSearch from './RepositoriesSearch';
 import StarCount from './StarCount';
 import SortRepoFilter, { Sort, sorter } from './SortRepoFilter';
 import LastUpdated from './LastUpdated';
+import RepoListCopyButton from './RepoListCopyButton';
 
 const numOfReposInContractedMode = 10;
 
 const emptyQueryResult: RemoteQueryResult = {
+  queryId: '',
   queryTitle: '',
   queryFileName: '',
   queryFilePath: '',
@@ -149,10 +151,14 @@ const SummaryTitleWithResults = ({
           text="Download all"
           onClick={() => downloadAllAnalysesResults(queryResult)} />
       }
-      <SortRepoFilter
-        sort={sort}
-        setSort={setSort}
-      />
+      <div style={{ flexGrow: 2, textAlign: 'right' }}>
+        <RepoListCopyButton queryResult={queryResult} />
+        <HorizontalSpace size={1} />
+        <SortRepoFilter
+          sort={sort}
+          setSort={setSort}
+        />
+      </div>
     </div>
   );
 };

--- a/extensions/ql-vscode/src/remote-queries/view/RepoListCopyButton.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/RepoListCopyButton.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import { vscode } from '../../view/vscode-api';
+import { RemoteQueryResult } from '../shared/remote-query-result';
+import { CopyIcon } from '@primer/octicons-react';
+import { IconButton } from '@primer/react';
+
+const copyRepositoryList = (queryResult: RemoteQueryResult) => {
+  vscode.postMessage({
+    t: 'copyRepoList',
+    queryId: queryResult.queryId
+  });
+};
+
+const RepoListCopyButton = ({ queryResult }: { queryResult: RemoteQueryResult }) => (
+  <IconButton
+    aria-label="Copy repository list"
+    icon={CopyIcon}
+    variant="invisible"
+    size="small"
+    sx={{ 'text-align': 'right' }}
+    onClick={() => copyRepositoryList(queryResult)} />
+);
+
+export default RepoListCopyButton;


### PR DESCRIPTION
Add the ability to easily create a new repository list from previous MRVA results. This is done by adding a copy to clipboard button in the results and history views.

<img width="638" alt="image" src="https://user-images.githubusercontent.com/311693/175306658-033f338c-9b40-49f2-8517-f77ecd3f32e4.png">

<img width="334" alt="image" src="https://user-images.githubusercontent.com/311693/175306730-339c0840-758d-4217-af4a-a432101f4a2b.png">

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
