### PR TITLE
Parse summary of evaluator logs into data model

### DIFF
--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -689,6 +689,23 @@ export class CodeQLCliServer implements Disposable {
   }
 
   /**
+  * Generate a JSON summary of an evaluation log.
+  * @param inputPath The path of an evaluation event log.
+  * @param outputPath The path to write a JSON summary of it to.
+  */
+   async generateJsonLogSummary(
+    inputPath: string,
+    outputPath: string,
+  ): Promise<string> {
+    const subcommandArgs = [
+      '--format=predicates',
+      inputPath,
+      outputPath
+    ];
+    return await this.runCodeQlCliCommand(['generate', 'log-summary'], subcommandArgs, 'Generating JSON log summary');
+  }
+
+  /**
   * Gets the results from a bqrs.
   * @param bqrsPath The path to the bqrs.
   * @param resultSet The result set to get.

--- a/extensions/ql-vscode/src/pure/log-summary-parser.ts
+++ b/extensions/ql-vscode/src/pure/log-summary-parser.ts
@@ -1,0 +1,31 @@
+import { EvaluatorLogData } from '../run-queries';
+
+/**
+ * A pure method that parses a string of evaluator log summaries into
+ * an array of EvaluatorLogData objects. 
+ * 
+ */
+ export function parseVisualizerData(logSummary: string): EvaluatorLogData[] {
+    // Remove newline delimiters because summary is in .jsonl format.
+    const jsonSummaryObjects: string[] = logSummary.split('\n\n');
+    const visualizerData: EvaluatorLogData[] = [];
+  
+    for (const obj of jsonSummaryObjects) {
+      const jsonObj = JSON.parse(obj);
+  
+      // Only convert log items that have an RA and millis field
+      // REVIEW: Not sure this is exactly what we want. Are we now excluding too many items?
+      // REVIEW: Is there a way to make this less brittle? 
+      if (jsonObj.ra != undefined && jsonObj.millis != undefined) {
+        const newLogData: EvaluatorLogData = {
+          queryName: jsonObj.queryCausingWork,
+          predicateName: jsonObj.predicateName,
+          timeInMillis: jsonObj.millis,
+          resultSize: jsonObj.resultSize
+          // TODO: need to also parse RA, pipeline arrays into the object. 
+        };
+        visualizerData.push(newLogData);
+      }
+    } 
+    return visualizerData;
+}

--- a/extensions/ql-vscode/src/queryserver-client.ts
+++ b/extensions/ql-vscode/src/queryserver-client.ts
@@ -267,6 +267,10 @@ export function findQueryEvalLogSummaryFile(resultPath: string): string {
   return path.join(resultPath, 'evaluator-log.summary');
 }
 
+export function findJsonQueryEvalLogSummaryFile(resultPath: string): string {
+  return path.join(resultPath, 'evaluator-log.summary.jsonl');
+}
+
 export function findQueryEvalLogEndSummaryFile(resultPath: string): string {
   return path.join(resultPath, 'evaluator-log-end.summary');
 }

--- a/extensions/ql-vscode/test/pure-tests/log-summary-parser.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/log-summary-parser.test.ts
@@ -1,0 +1,129 @@
+import { expect } from 'chai';
+import 'mocha';
+
+import { parseVisualizerData } from '../../src/pure/log-summary-parser';
+
+describe('Parsing Valid Summary Text', () => {
+    let validSummaryText = `
+    {
+      "completionTime" : "2022-06-23T14:02:42.007Z",
+      "raHash" : "e77dfaa9ciimqv7gb3imoesdb11",
+      "predicateName" : "query::ClassPointerType::getBaseType#dispred#f0820431#ff",
+      "appearsAs" : {
+        "query::ClassPointerType::getBaseType#dispred#f0820431#ff" : {
+          "uboot-taint.ql" : [ 3 ]
+        }
+      },
+      "queryCausingWork" : "uboot-taint.ql",
+      "evaluationStrategy" : "COMPUTE_SIMPLE",
+      "millis" : 11,
+      "resultSize" : 1413,
+      "dependencies" : {
+        "derivedtypes_2013#join_rhs" : "0da8f1fqbiin9i0mcitjedvlbc7",
+        "query::Class#class#f0820431#f" : "2e5d24rnudi1l99mvtse9u567b7",
+        "derivedtypes" : "070e120iu2i3dhj6pt13oqnbi66"
+      },
+      "ra" : {
+        "pipeline" : [
+          "    {1} r1 = CONSTANT(unique int)[1]",
+          "    {3} r2 = JOIN r1 WITH derivedtypes_2013#join_rhs ON FIRST 1 OUTPUT Rhs.3, Rhs.1, Rhs.2",
+          "    {4} r3 = JOIN r2 WITH query::Class#class#f0820431#f ON FIRST 1 OUTPUT Lhs.1, Lhs.2, 1, Lhs.0",
+          "    {2} r4 = JOIN r3 WITH derivedtypes ON FIRST 4 OUTPUT Lhs.0, Lhs.3",
+          "    return r4"
+        ]
+      },
+      "pipelineRuns" : [ {
+        "raReference" : "pipeline"
+      } ]
+    }
+
+    {
+      "completionTime" : "2022-06-23T14:02:42.072Z",
+      "raHash" : "0a0e3cicgtsru1m0cun896qhi61",
+      "predicateName" : "query::DefinedMemberFunction#class#f0820431#f",
+      "appearsAs" : {
+        "query::DefinedMemberFunction#class#f0820431#f" : {
+          "uboot-taint.ql" : [ 3 ]
+        }
+      },
+      "queryCausingWork" : "uboot-taint.ql",
+      "evaluationStrategy" : "COMPUTE_SIMPLE",
+      "millis" : 20,
+      "resultSize" : 8740,
+      "dependencies" : {
+        "fun_decls" : "e6e2e6vn02fcrrtp1ks1f75cd01",
+        "fun_def" : "6bec314lcq8sm3skg9mpecscp02",
+        "function_instantiation" : "8caddafufc3it9svjph9m8d43me",
+        "fun_decls_10#join_rhs" : "16474d6lehg7ssk83gnv2q7r8t8"
+      },
+      "ra" : {
+        "pipeline" : [
+          "    {2} r1 = SCAN fun_decls OUTPUT In.0, In.1",
+          "    {2} r2 = STREAM DEDUP r1",
+          "    {1} r3 = JOIN r2 WITH fun_def ON FIRST 1 OUTPUT Lhs.1",
+          "",
+          "    {2} r4 = SCAN function_instantiation OUTPUT In.1, In.0",
+          "    {2} r5 = JOIN r4 WITH fun_decls_10#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1",
+          "    {1} r6 = JOIN r5 WITH fun_def ON FIRST 1 OUTPUT Lhs.1",
+          "",
+          "    {1} r7 = r3 UNION r6",
+          "    return r7"
+        ]
+      },
+      "pipelineRuns" : [ {
+        "raReference" : "pipeline"
+      } ]
+    }    
+  `
+  it('should return only valid EvaluatorLogData objects', () => {
+    const evaluatorLogData = parseVisualizerData(validSummaryText);
+    expect (evaluatorLogData.length).to.eq(2);
+    for (let item of evaluatorLogData) {
+        expect(item.queryName).to.not.be.empty;
+        expect(item.predicateName).to.not.be.empty;
+        expect(item.timeInMillis).to.be.a('number');
+        expect(item.resultSize).to.be.a('number');
+    }
+  });
+
+  let invalidHeaderText = `
+  {
+    "summaryLogVersion" : "0.3.0",
+    "codeqlVersion" : "2.9.0+202204201304plus",
+    "startTime" : "2022-06-23T14:02:41.607Z"
+  }
+  `
+
+  it('should not parse a summary header object', () => {
+    const evaluatorLogData = parseVisualizerData(invalidHeaderText);
+    expect (evaluatorLogData.length).to.eq(0);
+    for (let item of evaluatorLogData) {
+      expect(item).to.be.empty;
+    }
+  });
+
+  let invalidSummaryText = `
+  {
+    "completionTime" : "2022-06-23T14:02:42.019Z",
+    "raHash" : "6bec314lcq8sm3skg9mpecscp02",
+    "predicateName" : "fun_def",
+    "appearsAs" : {
+      "fun_def" : {
+        "uboot-taint.ql" : [ 3, 21, 22, 24 ]
+      }
+    },
+    "queryCausingWork" : "uboot-taint.ql",
+    "evaluationStrategy" : "EXTENSIONAL",
+    "millis" : 3,
+    "resultSize" : 8857
+  }  
+  `
+
+  it('should not parse a log event missing RA or millis fields', () => {
+    const evaluatorLogData = parseVisualizerData(invalidSummaryText);
+    expect (evaluatorLogData.length).to.eq(0);
+    for (let item of evaluatorLogData) {
+      expect(item).to.be.empty;
+    }
+  });
+});


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

This PR is the first step towards adding a visualizer for evaluator log data. It includes the following logic:
- running the command to generate log summaries, after a query is complete, in JSON format for ease of parsing
- parsing each interesting JSON object from the log summary into a data model (where interesting means the object contains all fields that our data model require) 
- adding a data model encapsulating fields that we expect to surface in our visualizer

After this PR is merged, we will merge a PR displaying the data in the data model in a [VSCode TreeView](https://code.visualstudio.com/api/extension-guides/tree-view).

The PR is marked as draft due to the number of comments labeled `REVIEW`. 

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
