### PR TITLE
MRVA: Display alert text even if location is undefined

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/view/FileCodeSnippet.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/FileCodeSnippet.tsx
@@ -150,7 +150,7 @@ const Line = ({
   message?: AnalysisMessage,
   messageChildren?: React.ReactNode,
 }) => {
-  const showMessage = message &&
+  const shouldShowMessage = message &&
     severity &&
     highlightedRegion &&
     highlightedRegion.endLine == startingLineIndex + lineIndex;
@@ -181,7 +181,7 @@ const Line = ({
           highlightedRegion={highlightedRegion} />
       </div>
     </div>
-    {showMessage &&
+    {shouldShowMessage &&
       <MessageContainer>
         <Message
           message={message}


### PR DESCRIPTION
Show the alert message, even if the location of a result isn't defined. See internal issue for details. I've also done some minor refactoring/renaming to make things easier to read.

Before:
<img width="883" alt="image" src="https://user-images.githubusercontent.com/311693/176137045-89d40504-8dd5-43d9-a8d2-ab95e7e4c3cc.png">

After:
<img width="877" alt="image" src="https://user-images.githubusercontent.com/311693/176137137-27c8aa52-de2d-43f6-b6a4-d7eb564d5269.png">


## Checklist
N/A:

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
