### PR TITLE
Add cutoff repos and counts to error message

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
@@ -39,6 +39,8 @@ interface QueriesResponse {
     invalid_repositories?: string[],
     repositories_without_database?: string[],
     private_repositories?: string[],
+    cutoff_repositories?: string[],
+    cutoff_repositories_count?: number,
   },
   repositories_queried: string[],
 }
@@ -358,17 +360,30 @@ export function parseResponse(owner: string, repo: string, response: QueriesResp
   let logMessage = `Successfully scheduled runs on ${numRepositoriesQueried} repositories. See https://github.com/${owner}/${repo}/actions/runs/${response.workflow_run_id}.`;
   logMessage += `${eol2}Repositories queried:${eol}${repositoriesQueried.join(', ')}`;
   if (response.errors) {
+    const { invalid_repositories, repositories_without_database, private_repositories, cutoff_repositories, cutoff_repositories_count } = response.errors;
     logMessage += `${eol2}Some repositories could not be scheduled.`;
-    if (response.errors.invalid_repositories?.length) {
-      logMessage += `${eol2}Invalid repositories:${eol}${response.errors.invalid_repositories.join(', ')}`;
+    if (invalid_repositories?.length) {
+      logMessage += `${eol2}${invalid_repositories.length} repositories were invalid and could not be found:${eol}${invalid_repositories.join(', ')}`;
     }
-    if (response.errors.repositories_without_database?.length) {
-      logMessage += `${eol2}Repositories without databases:${eol}${response.errors.repositories_without_database.join(', ')}`;
+    if (repositories_without_database?.length) {
+      logMessage += `${eol2}${repositories_without_database.length} repositories did not have a CodeQL database available:${eol}${repositories_without_database.join(', ')}`;
       logMessage += `${eol}For each public repository that has not yet been added to the database service, we will try to create a database next time the store is updated.`;
     }
-    if (response.errors.private_repositories?.length) {
-      logMessage += `${eol2}Non-public repositories:${eol}${response.errors.private_repositories.join(', ')}`;
+    if (private_repositories?.length) {
+      logMessage += `${eol2}${private_repositories.length} repositories are not public:${eol}${private_repositories.join(', ')}`;
       logMessage += `${eol}When using a public controller repository, only public repositories can be queried.`;
+    }
+    if (cutoff_repositories_count) {
+      logMessage += `${eol2}${cutoff_repositories_count} repositories over the limit for a single request`;
+      if (cutoff_repositories) {
+        logMessage += `:${eol}${cutoff_repositories.join(', ')}`;
+        if (cutoff_repositories_count !== cutoff_repositories.length) {
+          logMessage += `${eol}...${eol}And ${cutoff_repositories_count - cutoff_repositories.length} more repositrories.`;
+        }
+      } else {
+        logMessage += '.';
+      }
+      logMessage += `${eol}Repositories were selected based on how recently they had been updated.`;
     }
   }
 

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/run-remote-query.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/run-remote-query.test.ts
@@ -41,7 +41,7 @@ describe('run-remote-query', () => {
           '',
           'Some repositories could not be scheduled.',
           '',
-          'Invalid repositories:',
+          '2 repositories were invalid and could not be found:',
           'e/f, g/h'].join(os.EOL)
       );
     });
@@ -68,7 +68,7 @@ describe('run-remote-query', () => {
           '',
           'Some repositories could not be scheduled.',
           '',
-          'Repositories without databases:',
+          '2 repositories did not have a CodeQL database available:',
           'e/f, g/h',
           'For each public repository that has not yet been added to the database service, we will try to create a database next time the store is updated.'].join(os.EOL)
       );
@@ -96,9 +96,65 @@ describe('run-remote-query', () => {
           '',
           'Some repositories could not be scheduled.',
           '',
-          'Non-public repositories:',
+          '2 repositories are not public:',
           'e/f, g/h',
           'When using a public controller repository, only public repositories can be queried.'].join(os.EOL)
+      );
+    });
+
+    it('should parse a response with cutoff repos and cutoff repos count', () => {
+      const result = parseResponse('org', 'name', {
+        workflow_run_id: 123,
+        repositories_queried: ['a/b', 'c/d'],
+        errors: {
+          cutoff_repositories: ['e/f', 'g/h'],
+          cutoff_repositories_count: 2,
+        }
+      });
+
+      expect(result.popupMessage).to.equal(
+        ['Successfully scheduled runs on 2 repositories. [Click here to see the progress](https://github.com/org/name/actions/runs/123).',
+          '',
+          'Some repositories could not be scheduled. See extension log for details.'].join(os.EOL)
+      );
+      expect(result.logMessage).to.equal(
+        ['Successfully scheduled runs on 2 repositories. See https://github.com/org/name/actions/runs/123.',
+          '',
+          'Repositories queried:',
+          'a/b, c/d',
+          '',
+          'Some repositories could not be scheduled.',
+          '',
+          '2 repositories over the limit for a single request:',
+          'e/f, g/h',
+          'Repositories were selected based on how recently they had been updated.'].join(os.EOL)
+      );
+    });
+
+    it('should parse a response with cutoff repos count but not cutoff repos', () => {
+      const result = parseResponse('org', 'name', {
+        workflow_run_id: 123,
+        repositories_queried: ['a/b', 'c/d'],
+        errors: {
+          cutoff_repositories_count: 2,
+        }
+      });
+
+      expect(result.popupMessage).to.equal(
+        ['Successfully scheduled runs on 2 repositories. [Click here to see the progress](https://github.com/org/name/actions/runs/123).',
+          '',
+          'Some repositories could not be scheduled. See extension log for details.'].join(os.EOL)
+      );
+      expect(result.logMessage).to.equal(
+        ['Successfully scheduled runs on 2 repositories. See https://github.com/org/name/actions/runs/123.',
+          '',
+          'Repositories queried:',
+          'a/b, c/d',
+          '',
+          'Some repositories could not be scheduled.',
+          '',
+          '2 repositories over the limit for a single request.',
+          'Repositories were selected based on how recently they had been updated.'].join(os.EOL)
       );
     });
 
@@ -125,10 +181,10 @@ describe('run-remote-query', () => {
           '',
           'Some repositories could not be scheduled.',
           '',
-          'Invalid repositories:',
+          '2 repositories were invalid and could not be found:',
           'e/f, g/h',
           '',
-          'Repositories without databases:',
+          '2 repositories did not have a CodeQL database available:',
           'i/j, k/l',
           'For each public repository that has not yet been added to the database service, we will try to create a database next time the store is updated.'].join(os.EOL)
       );


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

The queries API is changing so that it won't fail when you try to run a query on more than 1000 repos. Instead it'll  cap the repos off at 1000 and tell you in the response which repos weren't queried (up to a limit of 100 repos).

This PR is for handling that change in the API and display the information in the log message. While there I also updated the log message in general to include the counts of the repositories in the various states. I think this makes it more consistent if we're including the count for the cutoff repositories case.

Any input on the wording of the log message is very welcome. Writing these messages is very hard 😢 

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
