### PR TITLE
Invoke `codeql pack install` after adding a quick query

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [UNRELEASED]
 
+- Fix a bug where quick queries cannot be compiled if the core libraries are not in the workspace. [#1411](https://github.com/github/vscode-codeql/pull/1411)
+
 ## 1.6.7 - 15 June 2022
 
 - Prints end-of-query evaluator log summaries to the Query Log. [#1349](https://github.com/github/vscode-codeql/pull/1349)

--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -917,8 +917,12 @@ export class CodeQLCliServer implements Disposable {
     return this.runJsonCodeQlCliCommand(['pack', 'download'], packs, 'Downloading packs');
   }
 
-  async packInstall(dir: string) {
-    return this.runJsonCodeQlCliCommand(['pack', 'install'], [dir], 'Installing pack dependencies');
+  async packInstall(dir: string, forceUpdate = false) {
+    const args = [dir];
+    if (forceUpdate) {
+      args.push('--mode', 'update');
+    }
+    return this.runJsonCodeQlCliCommand(['pack', 'install'], args, 'Installing pack dependencies');
   }
 
   async packBundle(dir: string, workspaceFolders: string[], outputPath: string, precompile = true): Promise<void> {
@@ -1270,7 +1274,7 @@ export class CliVersionConstraint {
   /**
    * CLI version where the `resolve ml-models` subcommand was enhanced to work with packaging.
    */
-public static CLI_VERSION_WITH_PRECISE_RESOLVE_ML_MODELS = new SemVer('2.10.0');
+  public static CLI_VERSION_WITH_PRECISE_RESOLVE_ML_MODELS = new SemVer('2.10.0');
 
   /**
    * CLI version where the `--old-eval-stats` option to the query server was introduced.

--- a/extensions/ql-vscode/src/quick-query.ts
+++ b/extensions/ql-vscode/src/quick-query.ts
@@ -121,13 +121,20 @@ export async function displayQuickQuery(
       const quickQueryQlpackYaml: any = {
         name: 'vscode/quick-query',
         version: '1.0.0',
-        libraryPathDependencies: [qlpack]
+        dependencies: {
+          [qlpack]: '*'
+        }
       };
       await fs.writeFile(qlPackFile, QLPACK_FILE_HEADER + yaml.dump(quickQueryQlpackYaml), 'utf8');
     }
 
     if (shouldRewrite || !(await fs.pathExists(qlFile))) {
       await fs.writeFile(qlFile, getInitialQueryContents(dbItem.language, dbscheme), 'utf8');
+    }
+
+    if (shouldRewrite) {
+      await cliServer.clearCache();
+      await cliServer.packInstall(queriesDir, true);
     }
 
     await Window.showTextDocument(await workspace.openTextDocument(qlFile));
@@ -145,5 +152,5 @@ async function checkShouldRewrite(qlPackFile: string, newDependency: string) {
     return true;
   }
   const qlPackContents: any = yaml.load(await fs.readFile(qlPackFile, 'utf8'));
-  return qlPackContents.libraryPathDependencies?.[0] !== newDependency;
+  return !qlPackContents.dependencies?.[newDependency];
 }


### PR DESCRIPTION
This ensures the pack lock file is in place after the quick query is generated.

Fixes a bug where quick queries cannot be compiled if the core libraries are not in the workspace.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
