### PR TITLE
Fix error messages in extension log when quick evalling library files with CodeQL CLI v2.10.0

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [UNRELEASED]
 
 - Fix a bug where quick queries cannot be compiled if the core libraries are not in the workspace. [#1411](https://github.com/github/vscode-codeql/pull/1411)
-- Fix a bug where quick evaluation of library files would print an error message to the log when using CodeQL CLI v2.10.0. [#1412](https://github.com/github/vscode-codeql/pull/1412)
+- Fix a bug where quick evaluation of library files would display an error message when using CodeQL CLI v2.10.0. [#1412](https://github.com/github/vscode-codeql/pull/1412)
 
 ## 1.6.7 - 15 June 2022
 

--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [UNRELEASED]
 
 - Fix a bug where quick queries cannot be compiled if the core libraries are not in the workspace. [#1411](https://github.com/github/vscode-codeql/pull/1411)
+- Fix a bug where quick evaluation of library files would print an error message to the log when using CodeQL CLI v2.10.0. [#1412](https://github.com/github/vscode-codeql/pull/1412)
 
 ## 1.6.7 - 15 June 2022
 

--- a/extensions/ql-vscode/src/run-queries.ts
+++ b/extensions/ql-vscode/src/run-queries.ts
@@ -789,7 +789,11 @@ export async function compileAndRunQueryAgainstDatabase(
   const metadata = await tryGetQueryMetadata(cliServer, qlProgram.queryPath);
 
   let availableMlModels: cli.MlModelInfo[] = [];
-  if (await cliServer.cliConstraints.supportsResolveMlModels()) {
+  if (!initialInfo.queryPath.endsWith('.ql')) {
+    void logger.log('Quick evaluation within a query library does not currently support using ML models. Continuing without any ML models.');
+  } else if (!await cliServer.cliConstraints.supportsResolveMlModels()) {
+    void logger.log('Resolving ML models is unsupported by this version of the CLI. Running the query without any ML models.');
+  } else {
     try {
       availableMlModels = (await cliServer.resolveMlModels(diskWorkspaceFolders, initialInfo.queryPath)).models;
       if (availableMlModels.length) {


### PR DESCRIPTION
Currently `resolve ml-models` only supports queryspecs, i.e. .ql, .qls, directory, and query pack specifications. However, a quick evaluation within a library will have a path ending in .qll, and currently the extension tries to call `resolve ml-models` on this path, logging an error message like this to the extension log:

```
[2022-06-29 10:15:25] Calling plumbing command: codeql resolve queries --additional-packs=/home/edoardo/semmle-code/ql --qlconfig-file=/home/edoardo/semmle-code/ql/qlconfig.yml --format startingpacks -- /home/edoardo/semmle-code/ql/cpp/ql/lib/semmle/code/cpp/internal/ResolveClass.qll
A fatal error occurred: /home/edoardo/semmle-code/ql/cpp/ql/lib/semmle/code/cpp/internal/ResolveClass.qll is not a .ql file, .qls file, a directory, or a query pack specification.
[2022-06-29 10:15:25] Exception caught at top level: /home/edoardo/semmle-code/ql/cpp/ql/lib/semmle/code/cpp/internal/ResolveClass.qll is not a .ql file, .qls file, a directory, or a query pack specification.
                      com.semmle.cli2.resolve.ResolveQueriesCommand.resolveQuerySpecifier(ResolveQueriesCommand.java:237)
                      com.semmle.cli2.resolve.ResolveQueriesCommand.executeJSON(ResolveQueriesCommand.java:174)
                      com.semmle.cli2.resolve.ResolveQueriesCommand.executeJSON(ResolveQueriesCommand.java:71)
                      com.semmle.cli2.picocli.SimpleJsonSubcommand.executeInsistingOnJSON(SimpleJsonSubcommand.java:117)
                      com.semmle.cli2.picocli.PlumbingRunner.call(PlumbingRunner.java:54)
                      com.semmle.cli2.picocli.SubcommandCommon.callPlumbingInProcess(SubcommandCommon.java:126)
                      com.semmle.cli2.resolve.ResolveMlModelsCommand.resolvePackDependencies(ResolveMlModelsCommand.java:233)
                      com.semmle.cli2.resolve.ResolveMlModelsCommand.executeJSON(ResolveMlModelsCommand.java:92)
                      com.semmle.cli2.resolve.ResolveMlModelsCommand.executeJSON(ResolveMlModelsCommand.java:49)
                      com.semmle.cli2.picocli.SimpleJsonSubcommand.executeInsistingOnJSON(SimpleJsonSubcommand.java:117)
                      com.semmle.cli2.picocli.SimpleJsonSubcommand.executeSubcommand(SimpleJsonSubcommand.java:80)
                      com.semmle.cli2.picocli.SubcommandCommon.executeWithParent(SubcommandCommon.java:484)
                      com.semmle.cli2.execute.CliServerCommand.lambda$executeSubcommand$0(CliServerCommand.java:67)
                      com.semmle.cli2.picocli.SubcommandMaker.runMain(SubcommandMaker.java:205)
                      com.semmle.cli2.execute.CliServerCommand.executeSubcommand(CliServerCommand.java:67)
                      com.semmle.cli2.picocli.SubcommandCommon.call(SubcommandCommon.java:500)
                      com.semmle.cli2.picocli.SubcommandMaker.runMain(SubcommandMaker.java:205)
                      com.semmle.cli2.picocli.SubcommandMaker.runMain(SubcommandMaker.java:214)
                      com.semmle.cli2.CodeQL.main(CodeQL.java:98)

Couldn't resolve available ML models for /home/edoardo/semmle-code/ql/cpp/ql/lib/semmle/code/cpp/internal/ResolveClass.qll. Running the query without any ML models: Error: Resolving ML models failed: [2022-06-29 10:15:25] Calling plumbing command: codeql resolve queries --additional-packs=/home/edoardo/semmle-code/ql --qlconfig-file=/home/edoardo/semmle-code/ql/qlconfig.yml --format startingpacks -- /home/edoardo/semmle-code/ql/cpp/ql/lib/semmle/code/cpp/internal/ResolveClass.qll
A fatal error occurred: /home/edoardo/semmle-code/ql/cpp/ql/lib/semmle/code/cpp/internal/ResolveClass.qll is not a .ql file, .qls file, a directory, or a query pack specification.
```

With this PR, we no longer try to resolve ML models when doing a quick evaluation within a library. Instead, we print an informative message "Quick evaluation within a query library does not currently support using ML models. Continuing without any ML models." to the extension log.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.