### PR TITLE
MRVA: Don't show notification if user aborts firing off a query

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/repository-selection.ts
+++ b/extensions/ql-vscode/src/remote-queries/repository-selection.ts
@@ -52,6 +52,10 @@ export async function getRepositorySelection(): Promise<RepositorySelection> {
     return { repositoryLists: [quickpick.repositoryList] };
   } else if (quickpick?.useCustomRepo) {
     const customRepo = await getCustomRepo();
+    if (customRepo === undefined) {
+      // The user cancelled, do nothing.
+      throw new UserCancellationException('No repositories selected', true);
+    }
     if (!customRepo || !REPO_REGEX.test(customRepo)) {
       throw new UserCancellationException('Invalid repository format. Please enter a valid repository in the format <owner>/<repo> (e.g. github/codeql)');
     }
@@ -59,6 +63,10 @@ export async function getRepositorySelection(): Promise<RepositorySelection> {
     return { repositories: [customRepo] };
   } else if (quickpick?.useAllReposOfOwner) {
     const owner = await getOwner();
+    if (owner === undefined) {
+      // The user cancelled, do nothing.
+      throw new UserCancellationException('No repositories selected', true);
+    }
     if (!owner || !OWNER_REGEX.test(owner)) {
       throw new Error(`Invalid user or organization: ${owner}`);
     }
@@ -197,6 +205,6 @@ async function getCustomRepo(): Promise<string | undefined> {
 async function getOwner(): Promise<string | undefined> {
   return await window.showInputBox({
     title: 'Enter a GitHub user or organization',
-    ignoreFocusOut: true,
+    ignoreFocusOut: true
   });
 }

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/repository-selection.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/repository-selection.test.ts
@@ -100,7 +100,9 @@ describe('repository selection', async () => {
         ['top_100']
       );
     });
+  });
 
+  describe('custom owner', async () => {
     // Test the owner regex in various "good" cases
     const goodOwners = [
       'owner',
@@ -145,6 +147,18 @@ describe('repository selection', async () => {
         // Function call should throw a UserCancellationException
         await expect(mod.getRepositorySelection()).to.be.rejectedWith(Error, `Invalid user or organization: ${owner}`);
       });
+    });
+
+    it('should be ok for the user to change their mind', async () => {
+      quickPickSpy.resolves(
+        { useAllReposOfOwner: true }
+      );
+      getRemoteRepositoryListsSpy.returns({});
+
+      // The user pressed escape to cancel the operation
+      showInputBoxSpy.resolves(undefined);
+
+      await expect(mod.getRepositorySelection()).to.be.rejectedWith(UserCancellationException, 'No repositories selected');
     });
   });
 
@@ -195,6 +209,18 @@ describe('repository selection', async () => {
         // Function call should throw a UserCancellationException
         await expect(mod.getRepositorySelection()).to.be.rejectedWith(UserCancellationException, 'Invalid repository format');
       });
+    });
+
+    it('should be ok for the user to change their mind', async () => {
+      quickPickSpy.resolves(
+        { useCustomRepo: true }
+      );
+      getRemoteRepositoryListsSpy.returns({});
+
+      // The user pressed escape to cancel the operation
+      showInputBoxSpy.resolves(undefined);
+
+      await expect(mod.getRepositorySelection()).to.be.rejectedWith(UserCancellationException, 'No repositories selected');
     });
   });
 


### PR DESCRIPTION
We currently show a notification if a user presses "escape" after they selected to run a MRVA against a repo or an owner. This change removes that behaviour and leaves the user alone 😸 


## Checklist
N/A:

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
