### PR TITLE
Resolve ml-queries from directory

### DIFF
--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -606,7 +606,8 @@ export class CodeQLCliServer implements Disposable {
   /** Resolves the ML models that should be available when evaluating a query. */
   async resolveMlModels(additionalPacks: string[], queryPath: string): Promise<MlModelsInfo> {
     const args = await this.cliConstraints.supportsPreciseResolveMlModels()
-      ? [...this.getAdditionalPacksArg(additionalPacks), queryPath]
+      // use the dirname of the path so that we can handle query libraries
+      ? [...this.getAdditionalPacksArg(additionalPacks), path.dirname(queryPath)]
       : this.getAdditionalPacksArg(additionalPacks);
     return await this.runJsonCodeQlCliCommand<MlModelsInfo>(
       ['resolve', 'ml-models'],

--- a/extensions/ql-vscode/src/run-queries.ts
+++ b/extensions/ql-vscode/src/run-queries.ts
@@ -789,9 +789,7 @@ export async function compileAndRunQueryAgainstDatabase(
   const metadata = await tryGetQueryMetadata(cliServer, qlProgram.queryPath);
 
   let availableMlModels: cli.MlModelInfo[] = [];
-  if (!initialInfo.queryPath.endsWith('.ql')) {
-    void logger.log('Quick evaluation within a query library does not currently support using ML models. Continuing without any ML models.');
-  } else if (!await cliServer.cliConstraints.supportsResolveMlModels()) {
+  if (!await cliServer.cliConstraints.supportsResolveMlModels()) {
     void logger.log('Resolving ML models is unsupported by this version of the CLI. Running the query without any ML models.');
   } else {
     try {


### PR DESCRIPTION
Previously, there was a bug where quick eval queries would crash when
the eval snippet is in a library file.

The problem was that the `codeql resolve queries` command fails when
passed a library file. The fix is to avoid passing the library file at
all. Instead, pass the directory. This is safe because the resolve
queries command only needs to know which query pack the file is
contained in. Passing in the parent directory is the same as passing in
a file in this particular case.

This PR removes a previous workaround implemented here: https://github.com/github/vscode-codeql/pull/1412. This previous workaround simply disabled ml packs for quick eval.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Replace this with a description of the changes your pull request makes.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
