### PR TITLE
 Use `VSCodeTag`s instead of Primer `Label`s in webview

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/view/CodePaths.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/CodePaths.tsx
@@ -1,6 +1,6 @@
 import { TriangleDownIcon, XCircleIcon } from '@primer/octicons-react';
-import { ActionList, ActionMenu, Button, Label, Overlay } from '@primer/react';
-import { VSCodeLink } from '@vscode/webview-ui-toolkit/react';
+import { ActionList, ActionMenu, Button, Overlay } from '@primer/react';
+import { VSCodeLink, VSCodeTag } from '@vscode/webview-ui-toolkit/react';
 import * as React from 'react';
 import { useRef, useState } from 'react';
 import styled from 'styled-components';
@@ -60,12 +60,12 @@ const CodePath = ({
           </div>
           {index === 0 &&
             <div style={{ padding: 0, border: 'none' }}>
-              <Label>Source</Label>
+              <VSCodeTag>Source</VSCodeTag>
             </div>
           }
           {index === codeFlow.threadFlows.length - 1 &&
             <div style={{ padding: 0, border: 'none' }}>
-              <Label>Sink</Label>
+              <VSCodeTag>Sink</VSCodeTag>
             </div>
           }
         </div>


### PR DESCRIPTION
Moves the `Source`/`Sink` label with to a VSCodeTag component. This is another step of the transition from Primer to the VS Code UI Toolkit. See internal linked issue for more details! 🎨 

Before:
![old labels](https://user-images.githubusercontent.com/311693/173772697-c1bb2814-be66-4344-b71c-190a3e3e3543.png)

After:
![image](https://user-images.githubusercontent.com/42641846/176899068-ce2a9216-76b9-489b-bfdd-6e8c890016a0.png)

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
