### PR TITLE
MRVA: Include more info in query history label

### DIFF
--- a/extensions/ql-vscode/src/history-item-label-provider.ts
+++ b/extensions/ql-vscode/src/history-item-label-provider.ts
@@ -67,7 +67,7 @@ export class HistoryItemLabelProvider {
   private getRemoteInterpolateReplacements(item: RemoteQueryHistoryItem): InterpolateReplacements {
     return {
       t: new Date(item.remoteQuery.executionStartTime).toLocaleString(env.language),
-      q: item.remoteQuery.queryName,
+      q: `${item.remoteQuery.queryName} (${item.remoteQuery.language})`,
 
       // There is no database name for remote queries. Instead use the controller repository name.
       d: `${item.remoteQuery.controllerRepository.owner}/${item.remoteQuery.controllerRepository.name}`,

--- a/extensions/ql-vscode/src/history-item-label-provider.ts
+++ b/extensions/ql-vscode/src/history-item-label-provider.ts
@@ -65,12 +65,14 @@ export class HistoryItemLabelProvider {
   }
 
   private getRemoteInterpolateReplacements(item: RemoteQueryHistoryItem): InterpolateReplacements {
+    const numRepositoriesQueried = item.remoteQuery.numRepositoriesQueried;
+    const numRepositoriesLabel = `${numRepositoriesQueried} ${numRepositoriesQueried === 1 ? 'repository' : 'repositories'}`;
     return {
       t: new Date(item.remoteQuery.executionStartTime).toLocaleString(env.language),
       q: `${item.remoteQuery.queryName} (${item.remoteQuery.language})`,
 
-      // There is no database name for remote queries. Instead use the controller repository name.
-      d: `${item.remoteQuery.controllerRepository.owner}/${item.remoteQuery.controllerRepository.name}`,
+      // Return the number of repositories queried if available. Otherwise, use the controller repository name.
+      d: numRepositoriesQueried ? numRepositoriesLabel : `${item.remoteQuery.controllerRepository.owner}/${item.remoteQuery.controllerRepository.name}`,
 
       // There is no synchronous way to get the results count.
       r: '',

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
@@ -41,6 +41,7 @@ export interface UpdatedQueryStatusEvent {
   queryId: string;
   status: QueryStatus;
   failureReason?: string;
+  numRepositoriesQueried?: number;
 }
 
 export class RemoteQueriesManager extends DisposableObject {
@@ -314,9 +315,13 @@ export class RemoteQueriesManager extends DisposableObject {
   ): Promise<void> {
     const resultIndex = await getRemoteQueryIndex(credentials, remoteQuery);
     if (resultIndex) {
-      this.remoteQueryStatusUpdateEventEmitter.fire({ queryId, status: QueryStatus.Completed });
       const metadata = await this.getRepositoriesMetadata(resultIndex, credentials);
       const queryResult = this.mapQueryResult(executionEndTime, resultIndex, queryId, metadata);
+      this.remoteQueryStatusUpdateEventEmitter.fire({
+        queryId,
+        status: QueryStatus.Completed,
+        numRepositoriesQueried: queryResult.analysisSummaries.length,
+      });
 
       await this.storeJsonFile(queryId, 'query-result.json', queryResult);
 

--- a/extensions/ql-vscode/src/remote-queries/remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-query.ts
@@ -8,4 +8,5 @@ export interface RemoteQuery {
   controllerRepository: Repository;
   executionStartTime: number; // Use number here since it needs to be serialized and desserialized.
   actionsWorkflowRunId: number;
+  numRepositoriesQueried: number;
 }

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/history-item-label-provider.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/history-item-label-provider.test.ts
@@ -89,23 +89,30 @@ describe('HistoryItemLabelProvider', () => {
       expect(labelProvider.getLabel(fqi)).to.eq('xxx');
 
       fqi.userSpecifiedLabel = '%t %q %d %s %%';
-      expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name github/vscode-codeql-integration-tests in progress %`);
+      expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name (javascript) github/vscode-codeql-integration-tests in progress %`);
 
       fqi.userSpecifiedLabel = '%t %q %d %s %%::%t %q %d %s %%';
-      expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name github/vscode-codeql-integration-tests in progress %::${dateStr} query-name github/vscode-codeql-integration-tests in progress %`);
+      expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name (javascript) github/vscode-codeql-integration-tests in progress %::${dateStr} query-name (javascript) github/vscode-codeql-integration-tests in progress %`);
     });
 
     it('should interpolate query when not user specified', () => {
       const fqi = createMockRemoteQueryInfo();
 
-      expect(labelProvider.getLabel(fqi)).to.eq('xxx query-name xxx');
+      expect(labelProvider.getLabel(fqi)).to.eq('xxx query-name (javascript) xxx');
 
 
       config.format = '%t %q %d %s %f %r %%';
-      expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name github/vscode-codeql-integration-tests in progress query-file.ql  %`);
+      expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name (javascript) github/vscode-codeql-integration-tests in progress query-file.ql  %`);
 
       config.format = '%t %q %d %s %f %r %%::%t %q %d %s %f %r %%';
-      expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name github/vscode-codeql-integration-tests in progress query-file.ql  %::${dateStr} query-name github/vscode-codeql-integration-tests in progress query-file.ql  %`);
+      expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name (javascript) github/vscode-codeql-integration-tests in progress query-file.ql  %::${dateStr} query-name (javascript) github/vscode-codeql-integration-tests in progress query-file.ql  %`);
+    });
+
+    it('should use number of repositories instead of controller repo if available', () => {
+      const fqi = createMockRemoteQueryInfo(undefined, 2);
+
+      config.format = '%t %q %d %s %f %r %%';
+      expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name (javascript) 2 repositories in progress query-file.ql  %`);
     });
 
     it('should get query short label', () => {
@@ -119,7 +126,7 @@ describe('HistoryItemLabelProvider', () => {
       expect(labelProvider.getShortLabel(fqi)).to.eq('query-name');
     });
 
-    function createMockRemoteQueryInfo(userSpecifiedLabel?: string) {
+    function createMockRemoteQueryInfo(userSpecifiedLabel?: string, numRepositoriesQueried?: number) {
       return {
         t: 'remote',
         userSpecifiedLabel,
@@ -130,7 +137,9 @@ describe('HistoryItemLabelProvider', () => {
           controllerRepository: {
             owner: 'github',
             name: 'vscode-codeql-integration-tests'
-          }
+          },
+          language: 'javascript',
+          numRepositoriesQueried,
         },
         status: 'in progress',
       } as unknown as RemoteQueryHistoryItem;


### PR DESCRIPTION
Updates the default query history label for remote items to also include the language and number of repos queried. See internal issue for more details.

- Before: 
 
  ![image](https://user-images.githubusercontent.com/42641846/178986653-b39bb9f3-c56b-4a6b-a85d-d9e1849c2fe6.png)

- After: (Note: old query items still say `xxx on <controller-repo>`, but new ones give the number of repos)

  ![image](https://user-images.githubusercontent.com/42641846/178986681-9a20db04-8e94-4841-b34f-eca90541341a.png)

---------

### Comments/questions

- I'm not particularly happy about the different behaviour for older runs (i.e. using the controller repo name vs # repositories), but I couldn't see an obvious way to "backfill" the number of repos for older items 🤔 Happy for any suggestions!
- I've currently added the `(language)` to the end of the "query name" (`%q`) for remote queries. Do we want to make the `(language)` label a separate interpolated "thing" (e.g `%l`) or is this okay? 🔍 If we add it as a new interpolation option, we'd also need to handle it for local queries, which is probably beyond the scope of this PR 😅 

## Checklist

N/A - internal only 🍉 

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
