### PR TITLE
Replace code paths dropdown with VS Code UI Toolkit

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/view/CodePaths.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/CodePaths.tsx
@@ -2,7 +2,7 @@ import { XCircleIcon } from '@primer/octicons-react';
 import { Overlay } from '@primer/react';
 import { VSCodeDropdown, VSCodeLink, VSCodeOption, VSCodeTag } from '@vscode/webview-ui-toolkit/react';
 import * as React from 'react';
-import { useRef, useState } from 'react';
+import { ChangeEvent, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { CodeFlow, AnalysisMessage, ResultSeverity } from '../shared/analysis-result';
 import FileCodeSnippet from './FileCodeSnippet';
@@ -95,9 +95,9 @@ const Menu = ({
   setSelectedCodeFlow: (value: React.SetStateAction<CodeFlow>) => void
 }) => {
   return <VSCodeDropdown
-    onChange={(event: any) => {
+    onChange={(event: ChangeEvent<HTMLSelectElement>) => {
       const selectedOption = event.target;
-      const selectedIndex = selectedOption.value;
+      const selectedIndex = selectedOption.value as unknown as number;
       setSelectedCodeFlow(codeFlows[selectedIndex]);
     }}
   >

--- a/extensions/ql-vscode/src/remote-queries/view/CodePaths.tsx
+++ b/extensions/ql-vscode/src/remote-queries/view/CodePaths.tsx
@@ -1,6 +1,6 @@
-import { TriangleDownIcon, XCircleIcon } from '@primer/octicons-react';
-import { ActionList, ActionMenu, Button, Overlay } from '@primer/react';
-import { VSCodeLink, VSCodeTag } from '@vscode/webview-ui-toolkit/react';
+import { XCircleIcon } from '@primer/octicons-react';
+import { Overlay } from '@primer/react';
+import { VSCodeDropdown, VSCodeLink, VSCodeOption, VSCodeTag } from '@vscode/webview-ui-toolkit/react';
 import * as React from 'react';
 import { useRef, useState } from 'react';
 import styled from 'styled-components';
@@ -94,25 +94,22 @@ const Menu = ({
   codeFlows: CodeFlow[],
   setSelectedCodeFlow: (value: React.SetStateAction<CodeFlow>) => void
 }) => {
-  return <ActionMenu>
-    <ActionMenu.Anchor>
-      <Button variant="invisible" sx={{ fontWeight: 'normal', color: 'var(--vscode-editor-foreground);', padding: 0 }} >
-        {getCodeFlowName(codeFlows[0])}
-        <TriangleDownIcon size={16} />
-      </Button>
-    </ActionMenu.Anchor>
-    <ActionMenu.Overlay sx={{ backgroundColor: 'var(--vscode-editor-background)' }}>
-      <ActionList>
-        {codeFlows.map((codeFlow, index) =>
-          <ActionList.Item
-            key={`codeflow-${index}'`}
-            onSelect={(e: React.MouseEvent) => { setSelectedCodeFlow(codeFlow); }}>
-            {getCodeFlowName(codeFlow)}
-          </ActionList.Item>
-        )}
-      </ActionList>
-    </ActionMenu.Overlay>
-  </ActionMenu>;
+  return <VSCodeDropdown
+    onChange={(event: any) => {
+      const selectedOption = event.target;
+      const selectedIndex = selectedOption.value;
+      setSelectedCodeFlow(codeFlows[selectedIndex]);
+    }}
+  >
+    {codeFlows.map((codeFlow, index) =>
+      <VSCodeOption
+        key={`codeflow-${index}'`}
+        value={index}
+      >
+        {getCodeFlowName(codeFlow)}
+      </VSCodeOption>
+    )}
+  </VSCodeDropdown>;
 };
 
 const CodePaths = ({


### PR DESCRIPTION
Another step towards transitioning to the VS Code UI Toolkit! See internal issue for more details.

This PR replaces the dropdown in the "code paths" view with a more VS Code native one:

| Before 😿  |  After 😸 |
|--------|--------|
| ![F36A257D-A5E9-4A46-8AF1-FE93A909B028](https://user-images.githubusercontent.com/42641846/179027093-fadf4ac1-20e5-4edb-8e8f-7df22a88f15e.GIF) | ![72959120-8613-4E8D-9A17-660BDFDE4B06](https://user-images.githubusercontent.com/42641846/179027120-3f287bd5-3e6a-4561-9ea4-23b57aed935e.GIF) | 



## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
