### PR TITLE
Add useful information to MRVA gist titles

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/export-results.ts
+++ b/extensions/ql-vscode/src/remote-queries/export-results.ts
@@ -80,7 +80,7 @@ async function exportResultsToGist(
   analysesResults: AnalysisResults[]
 ): Promise<void> {
   const credentials = await Credentials.initialize(ctx);
-  const description = 'CodeQL Variant Analysis Results';
+  const description = buildGistDescription(query, analysesResults);
   const markdownFiles = generateMarkdown(query, analysesResults, 'gist');
   // Convert markdownFiles to the appropriate format for uploading to gist
   const gistFiles = markdownFiles.reduce((acc, cur) => {
@@ -99,6 +99,15 @@ async function exportResultsToGist(
     }
   }
 }
+
+/**
+ * Builds Gist description
+ * Ex: Empty Block (Go) x results (y repositories)
+ */
+const buildGistDescription = (query: RemoteQuery, analysesResults: AnalysisResults[]) => {
+  const resultCount = sumAnalysesResults(analysesResults);
+  return `${query.queryName} (${query.language}) ${resultCount} results (${query.numRepositoriesQueried} repositories)`;
+};
 
 /**
  * Converts the results of a remote query to markdown and saves the files locally

--- a/extensions/ql-vscode/src/remote-queries/export-results.ts
+++ b/extensions/ql-vscode/src/remote-queries/export-results.ts
@@ -74,7 +74,7 @@ async function determineExportFormat(
 /**
  * Converts the results of a remote query to markdown and uploads the files as a secret gist.
  */
-async function exportResultsToGist(
+export async function exportResultsToGist(
   ctx: ExtensionContext,
   query: RemoteQuery,
   analysesResults: AnalysisResults[]

--- a/extensions/ql-vscode/src/remote-queries/export-results.ts
+++ b/extensions/ql-vscode/src/remote-queries/export-results.ts
@@ -11,7 +11,7 @@ import { createGist } from './gh-actions-api-client';
 import { RemoteQueriesManager } from './remote-queries-manager';
 import { generateMarkdown } from './remote-queries-markdown-generation';
 import { RemoteQuery } from './remote-query';
-import { AnalysisResults } from './shared/analysis-result';
+import { AnalysisResults, sumAnalysesResults } from './shared/analysis-result';
 
 /**
  * Exports the results of the currently-selected remote query.

--- a/extensions/ql-vscode/src/remote-queries/export-results.ts
+++ b/extensions/ql-vscode/src/remote-queries/export-results.ts
@@ -106,7 +106,9 @@ async function exportResultsToGist(
  */
 const buildGistDescription = (query: RemoteQuery, analysesResults: AnalysisResults[]) => {
   const resultCount = sumAnalysesResults(analysesResults);
-  return `${query.queryName} (${query.language}) ${resultCount} results (${query.numRepositoriesQueried} repositories)`;
+  const repositoryLabel = `${query.numRepositoriesQueried} ${query.numRepositoriesQueried === 1 ? 'repository' : 'repositories'}`;
+  const repositoryCount = query.numRepositoriesQueried ? repositoryLabel : '';
+  return `${query.queryName} (${query.language}) ${resultCount} results (${repositoryCount})`;
 };
 
 /**

--- a/extensions/ql-vscode/src/remote-queries/shared/analysis-result.ts
+++ b/extensions/ql-vscode/src/remote-queries/shared/analysis-result.ts
@@ -90,3 +90,9 @@ export const getAnalysisResultCount = (analysisResults: AnalysisResults): number
   const rawResultCount = analysisResults.rawResults?.resultSet.rows.length || 0;
   return analysisResults.interpretedResults.length + rawResultCount;
 };
+
+/**
+ * Returns the total number of results for an analysis by adding all individual repo results.
+ */
+export const sumAnalysesResults = (analysesResults: AnalysisResults[]) =>
+  analysesResults.reduce((acc, curr) => acc + getAnalysisResultCount(curr), 0);

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/data/remote-queries/query-with-results/analyses-results.json
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/data/remote-queries/query-with-results/analyses-results.json
@@ -1,0 +1,462 @@
+[
+  {
+    "nwo": "github/codeql",
+    "status": "Completed",
+    "interpretedResults": [
+      {
+        "message": {
+          "tokens": [
+            {
+              "t": "text",
+              "text": "This shell command depends on an uncontrolled "
+            },
+            {
+              "t": "location",
+              "text": "absolute path",
+              "location": {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b",
+                  "filePath": "javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js"
+                },
+                "highlightedRegion": {
+                  "startLine": 4,
+                  "startColumn": 35,
+                  "endLine": 4,
+                  "endColumn": 44
+                }
+              }
+            },
+            { "t": "text", "text": "." }
+          ]
+        },
+        "shortDescription": "This shell command depends on an uncontrolled ,absolute path,.",
+        "fileLink": {
+          "fileLinkPrefix": "https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b",
+          "filePath": "javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js"
+        },
+        "severity": "Warning",
+        "codeSnippet": {
+          "startLine": 3,
+          "endLine": 6,
+          "text": "function cleanupTemp() {\n  let cmd = \"rm -rf \" + path.join(__dirname, \"temp\");\n  cp.execSync(cmd); // BAD\n}\n"
+        },
+        "highlightedRegion": {
+          "startLine": 5,
+          "startColumn": 15,
+          "endLine": 5,
+          "endColumn": 18
+        },
+        "codeFlows": [
+          {
+            "threadFlows": [
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b",
+                  "filePath": "javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js"
+                },
+                "codeSnippet": {
+                  "startLine": 2,
+                  "endLine": 6,
+                  "text": "  path = require(\"path\");\nfunction cleanupTemp() {\n  let cmd = \"rm -rf \" + path.join(__dirname, \"temp\");\n  cp.execSync(cmd); // BAD\n}\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 4,
+                  "startColumn": 35,
+                  "endLine": 4,
+                  "endColumn": 44
+                }
+              },
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b",
+                  "filePath": "javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js"
+                },
+                "codeSnippet": {
+                  "startLine": 2,
+                  "endLine": 6,
+                  "text": "  path = require(\"path\");\nfunction cleanupTemp() {\n  let cmd = \"rm -rf \" + path.join(__dirname, \"temp\");\n  cp.execSync(cmd); // BAD\n}\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 4,
+                  "startColumn": 25,
+                  "endLine": 4,
+                  "endColumn": 53
+                }
+              },
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b",
+                  "filePath": "javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js"
+                },
+                "codeSnippet": {
+                  "startLine": 2,
+                  "endLine": 6,
+                  "text": "  path = require(\"path\");\nfunction cleanupTemp() {\n  let cmd = \"rm -rf \" + path.join(__dirname, \"temp\");\n  cp.execSync(cmd); // BAD\n}\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 4,
+                  "startColumn": 13,
+                  "endLine": 4,
+                  "endColumn": 53
+                }
+              },
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b",
+                  "filePath": "javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js"
+                },
+                "codeSnippet": {
+                  "startLine": 2,
+                  "endLine": 6,
+                  "text": "  path = require(\"path\");\nfunction cleanupTemp() {\n  let cmd = \"rm -rf \" + path.join(__dirname, \"temp\");\n  cp.execSync(cmd); // BAD\n}\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 4,
+                  "startColumn": 7,
+                  "endLine": 4,
+                  "endColumn": 53
+                }
+              },
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b",
+                  "filePath": "javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js"
+                },
+                "codeSnippet": {
+                  "startLine": 3,
+                  "endLine": 6,
+                  "text": "function cleanupTemp() {\n  let cmd = \"rm -rf \" + path.join(__dirname, \"temp\");\n  cp.execSync(cmd); // BAD\n}\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 5,
+                  "startColumn": 15,
+                  "endLine": 5,
+                  "endColumn": 18
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "message": {
+          "tokens": [
+            {
+              "t": "text",
+              "text": "This shell command depends on an uncontrolled "
+            },
+            {
+              "t": "location",
+              "text": "absolute path",
+              "location": {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b",
+                  "filePath": "javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js"
+                },
+                "highlightedRegion": {
+                  "startLine": 6,
+                  "startColumn": 36,
+                  "endLine": 6,
+                  "endColumn": 45
+                }
+              }
+            },
+            { "t": "text", "text": "." }
+          ]
+        },
+        "shortDescription": "This shell command depends on an uncontrolled ,absolute path,.",
+        "fileLink": {
+          "fileLinkPrefix": "https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b",
+          "filePath": "javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js"
+        },
+        "severity": "Warning",
+        "codeSnippet": {
+          "startLine": 4,
+          "endLine": 8,
+          "text": "(function() {\n\tcp.execFileSync('rm',  ['-rf', path.join(__dirname, \"temp\")]); // GOOD\n\tcp.execSync('rm -rf ' + path.join(__dirname, \"temp\")); // BAD\n\n\texeca.shell('rm -rf ' + path.join(__dirname, \"temp\")); // NOT OK\n"
+        },
+        "highlightedRegion": {
+          "startLine": 6,
+          "startColumn": 14,
+          "endLine": 6,
+          "endColumn": 54
+        },
+        "codeFlows": [
+          {
+            "threadFlows": [
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b",
+                  "filePath": "javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js"
+                },
+                "codeSnippet": {
+                  "startLine": 4,
+                  "endLine": 8,
+                  "text": "(function() {\n\tcp.execFileSync('rm',  ['-rf', path.join(__dirname, \"temp\")]); // GOOD\n\tcp.execSync('rm -rf ' + path.join(__dirname, \"temp\")); // BAD\n\n\texeca.shell('rm -rf ' + path.join(__dirname, \"temp\")); // NOT OK\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 6,
+                  "startColumn": 36,
+                  "endLine": 6,
+                  "endColumn": 45
+                }
+              },
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b",
+                  "filePath": "javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js"
+                },
+                "codeSnippet": {
+                  "startLine": 4,
+                  "endLine": 8,
+                  "text": "(function() {\n\tcp.execFileSync('rm',  ['-rf', path.join(__dirname, \"temp\")]); // GOOD\n\tcp.execSync('rm -rf ' + path.join(__dirname, \"temp\")); // BAD\n\n\texeca.shell('rm -rf ' + path.join(__dirname, \"temp\")); // NOT OK\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 6,
+                  "startColumn": 26,
+                  "endLine": 6,
+                  "endColumn": 54
+                }
+              },
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b",
+                  "filePath": "javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js"
+                },
+                "codeSnippet": {
+                  "startLine": 4,
+                  "endLine": 8,
+                  "text": "(function() {\n\tcp.execFileSync('rm',  ['-rf', path.join(__dirname, \"temp\")]); // GOOD\n\tcp.execSync('rm -rf ' + path.join(__dirname, \"temp\")); // BAD\n\n\texeca.shell('rm -rf ' + path.join(__dirname, \"temp\")); // NOT OK\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 6,
+                  "startColumn": 14,
+                  "endLine": 6,
+                  "endColumn": 54
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "nwo": "test/no-results",
+    "status": "Completed",
+    "interpretedResults": []
+  },
+  {
+    "nwo": "meteor/meteor",
+    "status": "Completed",
+    "interpretedResults": [
+      {
+        "message": {
+          "tokens": [
+            {
+              "t": "text",
+              "text": "This shell command depends on an uncontrolled "
+            },
+            {
+              "t": "location",
+              "text": "absolute path",
+              "location": {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec",
+                  "filePath": "npm-packages/meteor-installer/config.js"
+                },
+                "highlightedRegion": {
+                  "startLine": 39,
+                  "startColumn": 20,
+                  "endLine": 39,
+                  "endColumn": 61
+                }
+              }
+            },
+            { "t": "text", "text": "." }
+          ]
+        },
+        "shortDescription": "This shell command depends on an uncontrolled ,absolute path,.",
+        "fileLink": {
+          "fileLinkPrefix": "https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec",
+          "filePath": "npm-packages/meteor-installer/install.js"
+        },
+        "severity": "Warning",
+        "codeSnippet": {
+          "startLine": 257,
+          "endLine": 261,
+          "text": "  if (isWindows()) {\n    //set for the current session and beyond\n    child_process.execSync(`setx path \"${meteorPath}/;%path%`);\n    return;\n  }\n"
+        },
+        "highlightedRegion": {
+          "startLine": 259,
+          "startColumn": 28,
+          "endLine": 259,
+          "endColumn": 62
+        },
+        "codeFlows": [
+          {
+            "threadFlows": [
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec",
+                  "filePath": "npm-packages/meteor-installer/config.js"
+                },
+                "codeSnippet": {
+                  "startLine": 37,
+                  "endLine": 41,
+                  "text": "\nconst meteorLocalFolder = '.meteor';\nconst meteorPath = path.resolve(rootPath, meteorLocalFolder);\n\nmodule.exports = {\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 39,
+                  "startColumn": 20,
+                  "endLine": 39,
+                  "endColumn": 61
+                }
+              },
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec",
+                  "filePath": "npm-packages/meteor-installer/config.js"
+                },
+                "codeSnippet": {
+                  "startLine": 37,
+                  "endLine": 41,
+                  "text": "\nconst meteorLocalFolder = '.meteor';\nconst meteorPath = path.resolve(rootPath, meteorLocalFolder);\n\nmodule.exports = {\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 39,
+                  "startColumn": 7,
+                  "endLine": 39,
+                  "endColumn": 61
+                }
+              },
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec",
+                  "filePath": "npm-packages/meteor-installer/config.js"
+                },
+                "codeSnippet": {
+                  "startLine": 42,
+                  "endLine": 46,
+                  "text": "  METEOR_LATEST_VERSION,\n  extractPath: rootPath,\n  meteorPath,\n  release: process.env.INSTALL_METEOR_VERSION || METEOR_LATEST_VERSION,\n  rootPath,\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 44,
+                  "startColumn": 3,
+                  "endLine": 44,
+                  "endColumn": 13
+                }
+              },
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec",
+                  "filePath": "npm-packages/meteor-installer/install.js"
+                },
+                "codeSnippet": {
+                  "startLine": 10,
+                  "endLine": 14,
+                  "text": "const os = require('os');\nconst {\n  meteorPath,\n  release,\n  startedPath,\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 12,
+                  "startColumn": 3,
+                  "endLine": 12,
+                  "endColumn": 13
+                }
+              },
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec",
+                  "filePath": "npm-packages/meteor-installer/install.js"
+                },
+                "codeSnippet": {
+                  "startLine": 9,
+                  "endLine": 25,
+                  "text": "const tmp = require('tmp');\nconst os = require('os');\nconst {\n  meteorPath,\n  release,\n  startedPath,\n  extractPath,\n  isWindows,\n  rootPath,\n  sudoUser,\n  isSudo,\n  isMac,\n  METEOR_LATEST_VERSION,\n  shouldSetupExecPath,\n} = require('./config.js');\nconst { uninstall } = require('./uninstall');\nconst {\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 11,
+                  "startColumn": 7,
+                  "endLine": 23,
+                  "endColumn": 27
+                }
+              },
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec",
+                  "filePath": "npm-packages/meteor-installer/install.js"
+                },
+                "codeSnippet": {
+                  "startLine": 257,
+                  "endLine": 261,
+                  "text": "  if (isWindows()) {\n    //set for the current session and beyond\n    child_process.execSync(`setx path \"${meteorPath}/;%path%`);\n    return;\n  }\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 259,
+                  "startColumn": 42,
+                  "endLine": 259,
+                  "endColumn": 52
+                }
+              },
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec",
+                  "filePath": "npm-packages/meteor-installer/install.js"
+                },
+                "codeSnippet": {
+                  "startLine": 257,
+                  "endLine": 261,
+                  "text": "  if (isWindows()) {\n    //set for the current session and beyond\n    child_process.execSync(`setx path \"${meteorPath}/;%path%`);\n    return;\n  }\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 259,
+                  "startColumn": 28,
+                  "endLine": 259,
+                  "endColumn": 62
+                }
+              }
+            ]
+          },
+          {
+            "threadFlows": [
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec",
+                  "filePath": "npm-packages/meteor-installer/config.js"
+                },
+                "codeSnippet": {
+                  "startLine": 37,
+                  "endLine": 41,
+                  "text": "\nconst meteorLocalFolder = '.meteor';\nconst meteorPath = path.resolve(rootPath, meteorLocalFolder);\n\nmodule.exports = {\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 39,
+                  "startColumn": 20,
+                  "endLine": 39,
+                  "endColumn": 61
+                }
+              },
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec",
+                  "filePath": "npm-packages/meteor-installer/install.js"
+                },
+                "codeSnippet": {
+                  "startLine": 257,
+                  "endLine": 261,
+                  "text": "  if (isWindows()) {\n    //set for the current session and beyond\n    child_process.execSync(`setx path \"${meteorPath}/;%path%`);\n    return;\n  }\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 259,
+                  "startColumn": 28,
+                  "endLine": 259,
+                  "endColumn": 62
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/data/remote-queries/query-with-results/query.json
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/data/remote-queries/query-with-results/query.json
@@ -1,0 +1,10 @@
+{
+  "queryName": "Shell command built from environment values",
+  "queryFilePath": "c:\\git-repo\\vscode-codeql-starter\\ql\\javascript\\ql\\src\\Security\\CWE-078\\ShellCommandInjectionFromEnvironment.ql",
+  "queryText": "/**\n * @name Shell command built from environment values\n * @description Building a shell command string with values from the enclosing\n *              environment may cause subtle bugs or vulnerabilities.\n * @kind path-problem\n * @problem.severity warning\n * @security-severity 6.3\n * @precision high\n * @id js/shell-command-injection-from-environment\n * @tags correctness\n *       security\n *       external/cwe/cwe-078\n *       external/cwe/cwe-088\n */\n\nimport javascript\nimport DataFlow::PathGraph\nimport semmle.javascript.security.dataflow.ShellCommandInjectionFromEnvironmentQuery\n\nfrom\n  Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink, DataFlow::Node highlight,\n  Source sourceNode\nwhere\n  sourceNode = source.getNode() and\n  cfg.hasFlowPath(source, sink) and\n  if cfg.isSinkWithHighlight(sink.getNode(), _)\n  then cfg.isSinkWithHighlight(sink.getNode(), highlight)\n  else highlight = sink.getNode()\nselect highlight, source, sink, \"This shell command depends on an uncontrolled $@.\", sourceNode,\n  sourceNode.getSourceType()\n",
+  "language": "javascript",
+  "controllerRepository": { "owner": "dsp-testing", "name": "qc-controller" },
+  "executionStartTime": 1649419081990,
+  "actionsWorkflowRunId": 2115000864,
+  "numRepositoriesQueried": 10
+}

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/index.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/index.ts
@@ -4,6 +4,7 @@ import * as sinonChai from 'sinon-chai';
 import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 import 'chai/register-should';
+import { ExtensionContext } from 'vscode';
 
 import { runTestsInDirectory } from '../index-template';
 
@@ -12,4 +13,20 @@ chai.use(sinonChai);
 
 export function run(): Promise<void> {
   return runTestsInDirectory(__dirname);
+}
+
+export function createMockExtensionContext(): ExtensionContext {
+  return {
+    globalState: {
+      _state: {
+        'telemetry-request-viewed': true
+      } as Record<string, any>,
+      get(key: string) {
+        return this._state[key];
+      },
+      update(key: string, val: any) {
+        this._state[key] = val;
+      }
+    }
+  } as any;
 }

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/export-results.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/export-results.test.ts
@@ -1,0 +1,56 @@
+import { expect } from 'chai';
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import * as sinon from 'sinon';
+import * as pq from 'proxyquire';
+import { ExtensionContext } from 'vscode';
+import { createMockExtensionContext } from '../index';
+import { Credentials } from '../../../authentication';
+import { MarkdownFile } from '../../../remote-queries/remote-queries-markdown-generation';
+import * as actionsApiClient from '../../../remote-queries/gh-actions-api-client';
+import { exportResultsToGist } from '../../../remote-queries/export-results';
+
+const proxyquire = pq.noPreserveCache();
+
+describe('export results', async function() {
+  describe('exportResultsToGist', async function() {
+    let sandbox: sinon.SinonSandbox;
+    let mockCredentials: Credentials;
+    let mockResponse: sinon.SinonStub<any, Promise<{ status: number }>>;
+    let mockCreateGist: sinon.SinonStub;
+    let ctx: ExtensionContext;
+
+    beforeEach(() => {
+      sandbox = sinon.createSandbox();
+
+      mockCredentials = {
+        getOctokit: () => Promise.resolve({
+          request: mockResponse
+        })
+      } as unknown as Credentials;
+      sandbox.stub(Credentials, 'initialize').resolves(mockCredentials);
+
+      const resultFiles = [] as MarkdownFile[];
+      proxyquire('../../../remote-queries/remote-queries-markdown-generation', {
+        'generateMarkdown': sinon.stub().returns(resultFiles)
+      });
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('should call the GitHub Actions API with the correct gist title', async function() {
+      mockCreateGist = sinon.stub(actionsApiClient, 'createGist');
+
+      ctx = createMockExtensionContext();
+      const query = JSON.parse(await fs.readFile(path.join(__dirname, '../data/remote-queries/query-with-results/query.json'), 'utf8'));
+      const analysesResults = JSON.parse(await fs.readFile(path.join(__dirname, '../data/remote-queries/query-with-results/analyses-results.json'), 'utf8'));
+
+      await exportResultsToGist(ctx, query, analysesResults);
+
+      expect(mockCreateGist.calledOnce).to.be.true;
+      expect(mockCreateGist.firstCall.args[1]).to.equal('Shell command built from environment values (javascript) 3 results (10 repositories)');
+    });
+  });
+});

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/telemetry.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/telemetry.test.ts
@@ -6,6 +6,7 @@ import { TelemetryListener, telemetryListener as globalTelemetryListener } from 
 import { UserCancellationException } from '../../commandRunner';
 import { fail } from 'assert';
 import { ENABLE_TELEMETRY } from '../../config';
+import { createMockExtensionContext } from './index';
 
 const sandbox = sinon.createSandbox();
 
@@ -338,22 +339,6 @@ describe('telemetry reporting', function() {
     expect(ctx.globalState.get('telemetry-request-viewed')).to.be.false;
     expect(window.showInformationMessage).to.have.been.calledOnce;
   });
-
-  function createMockExtensionContext(): ExtensionContext {
-    return {
-      globalState: {
-        _state: {
-          'telemetry-request-viewed': true
-        } as Record<string, any>,
-        get(key: string) {
-          return this._state[key];
-        },
-        update(key: string, val: any) {
-          this._state[key] = val;
-        }
-      }
-    } as any;
-  }
 
   async function enableTelemetry(section: string, value: boolean | undefined) {
     await workspace.getConfiguration(section).update(


### PR DESCRIPTION
Depends on https://github.com/github/vscode-codeql/pull/1427 getting merged first so that we have access to query results.

All exported MRVA gists are given the name `CodeQL variant analysis results`, 
which makes it hard to work out what it contains at a glance.

We're adding more information in the gist title to make it useful.

Example of the new title:

`Empty Block (Go) x results (y repositories)`

This translates to:

`<query name> (<query language>) <number of results> results (<number of repositories> repositories)`

While we're here we're also adding a test for this functionality, as
there were no tests for the `export-results.ts` file.

We initially attempted to add the test to the pure-tests folder, but the
`export-results.ts` file imports some components from `vscode`, which
meant we needed to set up the test in an environment where VSCode
dependencies are available.

We chose to add the test to `vscode-tests/no-workspace` for convenience,
as there are already other unit tests there.

We've also had to import our own query and analysis result to be able
to work with data closer to reality for exported results.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
