### PR TITLE
Ensure completed flag is set on remote query history items

### DIFF
--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -574,6 +574,9 @@ export class QueryHistoryManager extends DisposableObject {
         const remoteQueryHistoryItem = item as RemoteQueryHistoryItem;
         remoteQueryHistoryItem.status = event.status;
         remoteQueryHistoryItem.failureReason = event.failureReason;
+        if (event.status === QueryStatus.Completed) {
+          remoteQueryHistoryItem.completed = true;
+        }
         await this.refreshTreeView();
       } else {
         void logger.log('Variant analysis status update event received for unknown variant analysis');

--- a/extensions/ql-vscode/src/query-serialization.ts
+++ b/extensions/ql-vscode/src/query-serialization.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import { showAndLogErrorMessage } from './helpers';
 import { asyncFilter, getErrorMessage, getErrorStack } from './pure/helpers-pure';
 import { CompletedQueryInfo, LocalQueryInfo, QueryHistoryInfo } from './query-results';
+import { QueryStatus } from './query-status';
 import { QueryEvaluationInfo } from './run-queries';
 
 export async function slurpQueryHistory(fsPath: string): Promise<QueryHistoryInfo[]> {
@@ -39,7 +40,12 @@ export async function slurpQueryHistory(fsPath: string): Promise<QueryHistoryInf
           q.completedQuery.dispose = () => { /**/ };
         }
       } else if (q.t === 'remote') {
-        // noop
+        // A bug was introduced that didn't set the completed flag in query history
+        // items. The following code makes sure that the flag is set in order to
+        // "patch" older query history items.
+        if (q.status === QueryStatus.Completed) {
+          q.completed = true;
+        }
       }
       return q;
     });


### PR DESCRIPTION
Query history items have a `completed` flag as well as a status that could be `Completed`. I believe the reason we have a `completed` flag is historical. This PR makes sure the `completed` flag is set if the status is Completed for remote query history items and also adds some logic to patch up existing data.


## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
