### PR TITLE
MRVA: Fix Gist description when repository count is undefined

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/export-results.ts
+++ b/extensions/ql-vscode/src/remote-queries/export-results.ts
@@ -110,7 +110,7 @@ export async function exportResultsToGist(
 const buildGistDescription = (query: RemoteQuery, analysesResults: AnalysisResults[]) => {
   const resultCount = sumAnalysesResults(analysesResults);
   const resultLabel = pluralize(resultCount, 'result', 'results');
-  const repositoryLabel = query.repositoryCount ? `(${pluralize(query.repositoryCount, 'repository', 'repositories')})` : '';
+  const repositoryLabel = query.repositoryCount !== undefined ? `(${pluralize(query.repositoryCount, 'repository', 'repositories')})` : '';
   return `${query.queryName} (${query.language}) ${resultLabel} ${repositoryLabel}`;
 };
 

--- a/extensions/ql-vscode/src/remote-queries/export-results.ts
+++ b/extensions/ql-vscode/src/remote-queries/export-results.ts
@@ -110,7 +110,7 @@ export async function exportResultsToGist(
 const buildGistDescription = (query: RemoteQuery, analysesResults: AnalysisResults[]) => {
   const resultCount = sumAnalysesResults(analysesResults);
   const resultLabel = pluralize(resultCount, 'result', 'results');
-  const repositoryLabel = query.repositoryCount !== undefined ? `(${pluralize(query.repositoryCount, 'repository', 'repositories')})` : '';
+  const repositoryLabel = query.repositoryCount ? `(${pluralize(query.repositoryCount, 'repository', 'repositories')})` : '';
   return `${query.queryName} (${query.language}) ${resultLabel} ${repositoryLabel}`;
 };
 

--- a/extensions/ql-vscode/src/remote-queries/export-results.ts
+++ b/extensions/ql-vscode/src/remote-queries/export-results.ts
@@ -110,8 +110,8 @@ export async function exportResultsToGist(
 const buildGistDescription = (query: RemoteQuery, analysesResults: AnalysisResults[]) => {
   const resultCount = sumAnalysesResults(analysesResults);
   const resultLabel = pluralize(resultCount, 'result', 'results');
-  const repositoryLabel = pluralize(query.repositoryCount, 'repository', 'repositories');
-  return `${query.queryName} (${query.language}) ${resultLabel} (${repositoryLabel})`;
+  const repositoryLabel = query.repositoryCount ? `(${pluralize(query.repositoryCount, 'repository', 'repositories')})` : '';
+  return `${query.queryName} (${query.language}) ${resultLabel} ${repositoryLabel}`;
 };
 
 /**


### PR DESCRIPTION
Fixes a minor bug in exporting results to Gist. For queries in your history that were run before #1431, the `repositoryCount` property is undefined, so the Gist description looks like:
```
Empty Block (go) 10 results ()
``` 

This PR updates that Gist description so that we don't show those empty parentheses.


## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
