### PR TITLE
Fix newline handling for cross-platform logs

### DIFF
--- a/extensions/ql-vscode/src/pure/log-summary-parser.ts
+++ b/extensions/ql-vscode/src/pure/log-summary-parser.ts
@@ -1,7 +1,5 @@
-import * as os from 'os';
-
 // TODO(angelapwen): Only load in necessary information and
-// location in bytes for this log to save memory. 
+// location in bytes for this log to save memory.
 export interface EvaluatorLogData {
     queryCausingWork: string;
     predicateName: string;
@@ -9,25 +7,25 @@ export interface EvaluatorLogData {
     resultSize: number;
     ra: Pipelines;
 }
-  
+
 interface Pipelines {
-    // Key: pipeline identifier; Value: array of pipeline steps 
+    // Key: pipeline identifier; Value: array of pipeline steps
     pipelineNamesToSteps: Map<string, string[]>;
 }
-  
+
 /**
  * A pure method that parses a string of evaluator log summaries into
- * an array of EvaluatorLogData objects. 
- * 
+ * an array of EvaluatorLogData objects.
+ *
  */
  export function parseVisualizerData(logSummary: string): EvaluatorLogData[] {
     // Remove newline delimiters because summary is in .jsonl format.
-    const jsonSummaryObjects: string[] = logSummary.split(os.EOL + os.EOL);
+    const jsonSummaryObjects: string[] = logSummary.split(/\r?\n\r?\n/g);
     const visualizerData: EvaluatorLogData[] = [];
-  
+
     for (const obj of jsonSummaryObjects) {
       const jsonObj = JSON.parse(obj);
-  
+
       // Only convert log items that have an RA and millis field
       if (jsonObj.ra !== undefined && jsonObj.millis !== undefined) {
         const newLogData: EvaluatorLogData = {
@@ -39,6 +37,6 @@ interface Pipelines {
         };
         visualizerData.push(newLogData);
       }
-    } 
+    }
     return visualizerData;
 }


### PR DESCRIPTION
We were splitting JSONL records based on the current OS newline sequence. In order to handle reading of logs from the opposite OS, I've switched our split to handle both flavors of line ending. This originally showed up as log parser unit tests failing on Windows (the checked-in log used Unix line endings), but could affect real world usage as well.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Replace this with a description of the changes your pull request makes.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
