### PR TITLE
Add 50ms wait for flaky telemetry popup test

### DIFF
--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/telemetry.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/telemetry.test.ts
@@ -249,6 +249,9 @@ describe('telemetry reporting', function() {
 
     await telemetryListener.initialize();
 
+    // Wait 50 ms for user's selection to propagate in settings.
+    await wait(50);
+
     // Dialog opened, user clicks "yes" and telemetry enabled
     expect(window.showInformationMessage).to.have.been.calledOnce;
     expect(ENABLE_TELEMETRY.getValue()).to.eq(true);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

This change adds a 50 ms waiting period in the `should request permission if popup has never been seen before` telemetry test. We believe the test is flaky due to the `ENABLE_TELEMETRY` value sometimes not propagating quickly enough before its value is checked in the test. 

## Checklist

- [N/A] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [N/A] Issues have been created for any UI or other user-facing changes made by this pull request.
- [N/A] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
