### PR TITLE
Ensure query history state is persisted after new query is added

### DIFF
--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -560,7 +560,7 @@ export class QueryHistoryManager extends DisposableObject {
   }
 
   private registerToRemoteQueriesEvents() {
-    const queryAddedSubscription = this.remoteQueriesManager.onRemoteQueryAdded(event => {
+    const queryAddedSubscription = this.remoteQueriesManager.onRemoteQueryAdded(async (event) => {
       this.addQuery({
         t: 'remote',
         status: QueryStatus.InProgress,
@@ -568,6 +568,8 @@ export class QueryHistoryManager extends DisposableObject {
         queryId: event.queryId,
         remoteQuery: event.query,
       });
+
+      await this.refreshTreeView();
     });
 
     const queryRemovedSubscription = this.remoteQueriesManager.onRemoteQueryRemoved(async (event) => {


### PR DESCRIPTION
Added refreshing of the tree view (which in turn persists the query history data on disk) when a new remote query is added. See internal issue for bug repro steps and context.


## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
