### PR TITLE
Escape HTML characters when rendering MRVA results as markdown

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/remote-queries-markdown-generation.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-markdown-generation.ts
@@ -138,7 +138,7 @@ function generateMarkdownForCodeSnippet(
   const codeLines = codeSnippet.text
     .split('\n')
     .map((line, index) =>
-      highlightCodeLines(line, index + snippetStartLine, highlightedRegion)
+      highlightAndEscapeCodeLines(line, index + snippetStartLine, highlightedRegion)
     );
 
   // Make sure there are no extra newlines before or after the <code> block:
@@ -153,20 +153,25 @@ function generateMarkdownForCodeSnippet(
   return lines;
 }
 
-function highlightCodeLines(
+function highlightAndEscapeCodeLines(
   line: string,
   lineNumber: number,
   highlightedRegion?: HighlightedRegion
 ): string {
   if (!highlightedRegion || !shouldHighlightLine(lineNumber, highlightedRegion)) {
-    return line;
+    return escapeHtmlCharacters(line);
   }
   const partiallyHighlightedLine = parseHighlightedLine(
     line,
     lineNumber,
     highlightedRegion
   );
-  return `${partiallyHighlightedLine.plainSection1}<strong>${partiallyHighlightedLine.highlightedSection}</strong>${partiallyHighlightedLine.plainSection2}`;
+
+  const plainSection1 = escapeHtmlCharacters(partiallyHighlightedLine.plainSection1);
+  const highlightedSection = escapeHtmlCharacters(partiallyHighlightedLine.highlightedSection);
+  const plainSection2 = escapeHtmlCharacters(partiallyHighlightedLine.plainSection2);
+
+  return `${plainSection1}<strong>${highlightedSection}</strong>${plainSection2}`;
 }
 
 function generateMarkdownForAlertMessage(
@@ -329,4 +334,11 @@ function createRelativeLink(fileName: string, linkType: MarkdownLinkType): strin
 function createFileName(nwo: string) {
   const [owner, repo] = nwo.split('/');
   return `${owner}-${repo}`;
+}
+
+/**
+ * Escape characters that could be interpreted as HTML instead of raw code.
+ */
+function escapeHtmlCharacters(text: string): string {
+  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/problem/analyses-results.json
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/problem/analyses-results.json
@@ -148,6 +148,34 @@
           "endColumn": 57
         },
         "codeFlows": []
+      },
+      {
+        "message": {
+          "tokens": [
+            {
+              "t": "text",
+              "text": "This component is implicitly exported."
+            }
+          ]
+        },
+        "shortDescription": "This component is implicitly exported.",
+        "fileLink": {
+          "fileLinkPrefix": "https://github.com/AlexRogalskiy/android-nrf-toolbox/blob/034cf3aa7d2a3a4145177de32546ca518a462a66",
+          "filePath": "app/src/main/AndroidManifest.xml"
+        },
+        "severity": "Warning",
+        "codeSnippet": {
+          "startLine": 237,
+          "endLine": 251,
+          "text": "\t\t</service>\n\n\t\t<activity\n\t\t\tandroid:name=\"no.nordicsemi.android.nrftoolbox.dfu.DfuInitiatorActivity\"\n\t\t\tandroid:label=\"@string/dfu_service_title\"\n\t\t\tandroid:noHistory=\"true\"\n\t\t\tandroid:theme=\"@style/AppTheme.Translucent\" >\n\t\t\t<intent-filter>\n\t\t\t\t<action android:name=\"no.nordicsemi.android.action.DFU_UPLOAD\" />\n\n\t\t\t\t<category android:name=\"android.intent.category.DEFAULT\" />\n\t\t\t</intent-filter>\n\t\t</activity>\n\n\t\t<service\n"
+        },
+        "highlightedRegion": {
+          "startLine": 239,
+          "startColumn": 3,
+          "endLine": 249,
+          "endColumn": 15
+        },
+        "codeFlows": []
       }
     ]
   }

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/problem/expected/_summary.md
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/problem/expected/_summary.md
@@ -41,4 +41,4 @@ select t,
 | Repository | Results |
 | --- | --- |
 | github/codeql | [1 result(s)](#file-github-codeql-md) |
-| meteor/meteor | [4 result(s)](#file-meteor-meteor-md) |
+| meteor/meteor | [5 result(s)](#file-meteor-meteor-md) |

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/problem/expected/meteor-meteor.md
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/problem/expected/meteor-meteor.md
@@ -4,9 +4,9 @@
 
 <pre><code class="javascript">		/g,hashElement);
 	*/
-	text = text.replace(/(\n\n[ ]{0,3}<!(--<strong>[^\r]*?</strong>--\s*)+>[ \t]*(?=\n{2,}))/g,hashElement);
+	text = text.replace(/(\n\n[ ]{0,3}&lt;!(--<strong>[^\r]*?</strong>--\s*)+&gt;[ \t]*(?=\n{2,}))/g,hashElement);
 
-	// PHP and ASP-style processor instructions (<?...?> and <%...%>)
+	// PHP and ASP-style processor instructions (&lt;?...?&gt; and &lt;%...%&gt;)
 </code></pre>
 
 *This part of the regular expression may cause exponential backtracking on strings containing many repetitions of '----'.*
@@ -17,7 +17,7 @@
 
 <pre><code class="javascript">	// Build a regex to find HTML tags and comments.  See Friedl's
 	// "Mastering Regular Expressions", 2nd Ed., pp. 200-201.
-	var regex = /(<[a-z\/!$]("[^"]*"|'[^']*'|[^'">])*>|<!(--<strong>.*?</strong>--\s*)+>)/gi;
+	var regex = /(&lt;[a-z\/!$]("[^"]*"|'[^']*'|[^'"&gt;])*&gt;|&lt;!(--<strong>.*?</strong>--\s*)+&gt;)/gi;
 
 	text = text.replace(regex, function(wholeMatch) {
 </code></pre>
@@ -44,5 +44,28 @@ pp.strictDirective = function(start) {
 <pre><code class="javascript">const literal = /^(?:'((?:\\.|[^'])*?)'|"(<strong>(?:\\.|[^"])*?</strong>)")/</code></pre>
 
 *This part of the regular expression may cause exponential backtracking on strings starting with '"' and containing many repetitions of '\!'.*
+
+----------------------------------------
+
+[app/src/main/AndroidManifest.xml](https://github.com/AlexRogalskiy/android-nrf-toolbox/blob/034cf3aa7d2a3a4145177de32546ca518a462a66/app/src/main/AndroidManifest.xml#L239-L249)
+
+<pre><code class="javascript">		&lt;/service&gt;
+
+		<strong>&lt;activity</strong>
+<strong>			android:name="no.nordicsemi.android.nrftoolbox.dfu.DfuInitiatorActivity"</strong>
+<strong>			android:label="@string/dfu_service_title"</strong>
+<strong>			android:noHistory="true"</strong>
+<strong>			android:theme="@style/AppTheme.Translucent" &gt;</strong>
+<strong>			&lt;intent-filter&gt;</strong>
+<strong>				&lt;action android:name="no.nordicsemi.android.action.DFU_UPLOAD" /&gt;</strong>
+<strong></strong>
+<strong>				&lt;category android:name="android.intent.category.DEFAULT" /&gt;</strong>
+<strong>			&lt;/intent-filter&gt;</strong>
+<strong>		&lt;/activity&gt;</strong>
+
+		&lt;service
+</code></pre>
+
+*This component is implicitly exported.*
 
 ----------------------------------------


### PR DESCRIPTION
Our MRVA markdown export uses HTML `<pre>` and `<code>` blocks to render code snippets. When the code snippet itself is HTML (or XML or similar), the snippet is treated as HTML instead of raw code. To fix this, we can escape certain HTML characters (such as `<`).

See internal linked issue for some examples and a bit more context! 🖼️ 


## Checklist

N/A - this is part of the internal variant analysis feature 🦺 

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
