### PR TITLE
Upgrade webview-ui-toolkit version with long link fix

### DIFF
--- a/extensions/ql-vscode/package-lock.json
+++ b/extensions/ql-vscode/package-lock.json
@@ -14,7 +14,7 @@
         "@primer/octicons-react": "^16.3.0",
         "@primer/react": "^35.0.0",
         "@vscode/codicons": "^0.0.31",
-        "@vscode/webview-ui-toolkit": "^1.0.0",
+        "@vscode/webview-ui-toolkit": "^1.0.1",
         "child-process-promise": "^2.2.1",
         "classnames": "~2.2.6",
         "d3": "^6.3.1",
@@ -2169,9 +2169,9 @@
       "integrity": "sha512-fldpXy7pHsQAMlU1pnGI23ypQ6xLk5u6SiABMFoAmlj4f2MR0iwg7C19IB1xvAEGG+dkxOfRSrbKF8ry7QqGQA=="
     },
     "node_modules/@vscode/webview-ui-toolkit": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@vscode/webview-ui-toolkit/-/webview-ui-toolkit-1.0.0.tgz",
-      "integrity": "sha512-/qaHYZXqvIKkao54b7bLzyNH8BC+X4rBmTUx1MvcIiCjqRMxml0BCpqJhnDpfrCb0IOxXRO8cAy1eB5ayzQfBA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@vscode/webview-ui-toolkit/-/webview-ui-toolkit-1.0.1.tgz",
+      "integrity": "sha512-jitA17enYUoMadv9exoHJiYcBK+X+gTlUyyIFvXRrA/mhHrxZfel5Eh6z/u57UZScK/i0Sn7EtlEYV1ZKFbeHw==",
       "dependencies": {
         "@microsoft/fast-element": "^1.6.2",
         "@microsoft/fast-foundation": "^2.38.0",
@@ -16203,9 +16203,9 @@
       "integrity": "sha512-fldpXy7pHsQAMlU1pnGI23ypQ6xLk5u6SiABMFoAmlj4f2MR0iwg7C19IB1xvAEGG+dkxOfRSrbKF8ry7QqGQA=="
     },
     "@vscode/webview-ui-toolkit": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@vscode/webview-ui-toolkit/-/webview-ui-toolkit-1.0.0.tgz",
-      "integrity": "sha512-/qaHYZXqvIKkao54b7bLzyNH8BC+X4rBmTUx1MvcIiCjqRMxml0BCpqJhnDpfrCb0IOxXRO8cAy1eB5ayzQfBA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@vscode/webview-ui-toolkit/-/webview-ui-toolkit-1.0.1.tgz",
+      "integrity": "sha512-jitA17enYUoMadv9exoHJiYcBK+X+gTlUyyIFvXRrA/mhHrxZfel5Eh6z/u57UZScK/i0Sn7EtlEYV1ZKFbeHw==",
       "requires": {
         "@microsoft/fast-element": "^1.6.2",
         "@microsoft/fast-foundation": "^2.38.0",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1196,7 +1196,7 @@
     "@primer/octicons-react": "^16.3.0",
     "@primer/react": "^35.0.0",
     "@vscode/codicons": "^0.0.31",
-    "@vscode/webview-ui-toolkit": "^1.0.0",
+    "@vscode/webview-ui-toolkit": "^1.0.1",
     "child-process-promise": "^2.2.1",
     "classnames": "~2.2.6",
     "d3": "^6.3.1",


### PR DESCRIPTION
The latest version of webview-ui-toolkit contains a fix for long links. See https://github.com/microsoft/vscode-webview-ui-toolkit/issues/388.

Before:

![image](https://user-images.githubusercontent.com/311693/186359325-99a3ca30-5626-4c2c-a9f1-0248383391f4.png)

After:

<img width="1043" alt="image" src="https://user-images.githubusercontent.com/311693/186359538-4f32c993-9abd-454c-8d15-23e1e87b6d90.png">


## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
