### PR TITLE
Fix data not being loaded in MRVA results panel

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-interface.ts
@@ -125,6 +125,7 @@ export class RemoteQueriesInterfaceManager {
         () => {
           this.panel = undefined;
           this.currentQueryId = undefined;
+          this.panelLoaded = false;
         },
         null,
         ctx.subscriptions


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

When the MRVA results panel is closed (so the panel gets disposed) and opened again, it would not load the MRVA data (such as whether a query has already been downloaded). This fixes it by also resetting the internal state of whether the panel is loaded when the panel is disposed.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
