### PR TITLE
Add retry for finding result-index artifact

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/gh-actions-api-client.ts
+++ b/extensions/ql-vscode/src/remote-queries/gh-actions-api-client.ts
@@ -10,6 +10,8 @@ import { RemoteQuery } from './remote-query';
 import { RemoteQueryFailureIndexItem, RemoteQueryResultIndex, RemoteQuerySuccessIndexItem } from './remote-query-result-index';
 import { getErrorMessage } from '../pure/helpers-pure';
 
+export const RESULT_INDEX_ARTIFACT_NAME = 'result-index';
+
 interface ApiSuccessIndexItem {
   nwo: string;
   id: string;
@@ -43,7 +45,8 @@ export async function getRemoteQueryIndex(
   const workflowUri = `https://github.com/${owner}/${repoName}/actions/runs/${workflowRunId}`;
   const artifactsUrlPath = `/repos/${owner}/${repoName}/actions/artifacts`;
 
-  const [artifactList, resultIndexArtifactId] = await waitForArtifact(credentials, owner, repoName, workflowRunId, 'result-indx');
+  const artifactList = await listWorkflowRunArtifacts(credentials, owner, repoName, workflowRunId);
+  const resultIndexArtifactId = tryGetArtifactIDfromName(RESULT_INDEX_ARTIFACT_NAME, artifactList);
   if (!resultIndexArtifactId) {
     return undefined;
   }
@@ -113,6 +116,27 @@ export async function downloadArtifactFromLink(
     await unzipFile(zipFilePath, extractedPath);
   }
   return path.join(extractedPath, downloadLink.innerFilePath || '');
+}
+
+/**
+ * Checks whether a specific artifact is present in the list of artifacts of a workflow run.
+ * @param credentials Credentials for authenticating to the GitHub API.
+ * @param owner
+ * @param repo
+ * @param workflowRunId The ID of the workflow run to get the artifact for.
+ * @param artifactName The artifact name, as a string.
+ * @returns A boolean indicating if the artifact is available.
+ */
+export async function isArtifactAvailable(
+  credentials: Credentials,
+  owner: string,
+  repo: string,
+  workflowRunId: number,
+  artifactName: string,
+): Promise<boolean> {
+  const artifactList = await listWorkflowRunArtifacts(credentials, owner, repo, workflowRunId);
+
+  return tryGetArtifactIDfromName(artifactName, artifactList) !== undefined;
 }
 
 /**
@@ -252,44 +276,6 @@ function tryGetArtifactIDfromName(
   const artifact = artifacts.find(a => a.name === artifactName);
 
   return artifact?.id;
-}
-
-/**
- * Wait for an artifact to be available in a workflow run.
- * @param credentials Credentials for authenticating to the GitHub API.
- * @param owner
- * @param repo
- * @param workflowRunId The ID of the workflow run to get the artifact for.
- * @param artifactName The artifact name, as a string.
- * @param maxAttempts The maximum number of attempts to download the artifact.
- * @returns An array containing the full list of artifacts and the ID of the artifact with the given name.
- */
-async function waitForArtifact(
-  credentials: Credentials,
-  owner: string,
-  repo: string,
-  workflowRunId: number,
-  artifactName: string,
-  maxAttempts = 10,
-  intervalBetweenAttempts = 1000
-): Promise<[Awaited<ReturnType<typeof listWorkflowRunArtifacts>>, number | undefined]> {
-  let attemptCount = 0;
-  let artifactList: Awaited<ReturnType<typeof listWorkflowRunArtifacts>> = [];
-
-  while (attemptCount < maxAttempts) {
-    artifactList = await listWorkflowRunArtifacts(credentials, owner, repo, workflowRunId);
-
-    const resultIndexArtifactId = tryGetArtifactIDfromName(artifactName, artifactList);
-    if (resultIndexArtifactId) {
-      return [artifactList, resultIndexArtifactId];
-    }
-
-    await new Promise(resolve => setTimeout(resolve, intervalBetweenAttempts));
-
-    attemptCount++;
-  }
-
-  return [artifactList, undefined];
 }
 
 /**


### PR DESCRIPTION
It seems like the result-index artifact may not be available immediately after the workflow run has finished. This adds a retry mechanism to wait for the result-index to be available. It will retry at most 10 times with a wait of 1 second between each retry.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
