### PR TITLE
Avoid prompting for upgrades when they wouldn't be prompted.

### DIFF
--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -1261,8 +1261,16 @@ export class CliVersionConstraint {
 
   /**
    * CLI version where database registration was introduced
-  */
+   */
   public static CLI_VERSION_WITH_DB_REGISTRATION = new SemVer('2.4.1');
+
+  /**
+   * CLI version where non destructive upgrades were introduced.
+   *
+   * This was landed in multiple parts so this is the version where all necessary feature were supported.
+   */
+  public static CLI_VERSION_WITH_NON_DESTRUCTIVE_UPGRADES = new SemVer('2.4.2');
+
 
   /**
    * CLI version where the `--allow-library-packs` option to `codeql resolve queries` was
@@ -1357,6 +1365,10 @@ export class CliVersionConstraint {
 
   async supportsDatabaseRegistration() {
     return this.isVersionAtLeast(CliVersionConstraint.CLI_VERSION_WITH_DB_REGISTRATION);
+  }
+
+  async supportsNonDestructiveUpgrades(): Promise<boolean> {
+    return this.isVersionAtLeast(CliVersionConstraint.CLI_VERSION_WITH_NON_DESTRUCTIVE_UPGRADES);
   }
 
   async supportsDatabaseUnbundle() {

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -782,7 +782,7 @@ async function activateWithInstalledDistribution(
           });
         }
 
-        if (queryUris.length > 1) {
+        if (queryUris.length > 1 && !await cliServer.cliConstraints.supportsNonDestructiveUpgrades()) {
           // Try to upgrade the current database before running any queries
           // so that the user isn't confronted with multiple upgrade
           // requests for each query to run.

--- a/extensions/ql-vscode/src/run-queries.ts
+++ b/extensions/ql-vscode/src/run-queries.ts
@@ -32,7 +32,7 @@ import * as messages from './pure/messages';
 import { InitialQueryInfo, LocalQueryInfo } from './query-results';
 import * as qsClient from './queryserver-client';
 import { isQuickQueryPath } from './quick-query';
-import { compileDatabaseUpgradeSequence, hasNondestructiveUpgradeCapabilities, upgradeDatabaseExplicit } from './upgrades';
+import { compileDatabaseUpgradeSequence, upgradeDatabaseExplicit } from './upgrades';
 import { ensureMetadataIsComplete } from './query-results';
 import { SELECT_QUERY_NAME } from './contextual/locationFinder';
 import { DecodedBqrsChunk } from './pure/bqrs-cli-types';
@@ -862,7 +862,7 @@ export async function compileAndRunQueryAgainstDatabase(
   let upgradeDir: tmp.DirectoryResult | undefined;
   try {
     let upgradeQlo;
-    if (await hasNondestructiveUpgradeCapabilities(qs)) {
+    if (await qs.cliServer.cliConstraints.supportsNonDestructiveUpgrades()) {
       upgradeDir = await tmp.dir({ dir: upgradesTmpDir, unsafeCleanup: true });
       upgradeQlo = await compileNonDestructiveUpgrade(qs, upgradeDir, query, qlProgram, dbItem, progress, token);
     } else {

--- a/extensions/ql-vscode/src/upgrades.ts
+++ b/extensions/ql-vscode/src/upgrades.ts
@@ -6,7 +6,6 @@ import * as messages from './pure/messages';
 import * as qsClient from './queryserver-client';
 import * as tmp from 'tmp-promise';
 import * as path from 'path';
-import * as semver from 'semver';
 import { DatabaseItem } from './databases';
 
 /**
@@ -16,16 +15,6 @@ import { DatabaseItem } from './databases';
  */
 const MAX_UPGRADE_MESSAGE_LINES = 10;
 
-/**
- * Check that we support non-destructive upgrades.
- *
- * This requires 3 features. The ability to compile an upgrade sequence; The ability to
- * run a non-destructive upgrades as a query; the ability to specify a target when
- * resolving upgrades. We check for a version of codeql that has all three features.
- */
-export async function hasNondestructiveUpgradeCapabilities(qs: qsClient.QueryServerClient): Promise<boolean> {
-  return semver.gte(await qs.cliServer.getVersion(), '2.4.2');
-}
 
 
 /**
@@ -43,7 +32,7 @@ export async function compileDatabaseUpgradeSequence(
   if (dbItem.contents === undefined || dbItem.contents.dbSchemeUri === undefined) {
     throw new Error('Database is invalid, and cannot be upgraded.');
   }
-  if (!await hasNondestructiveUpgradeCapabilities(qs)) {
+  if (!await qs.cliServer.cliConstraints.supportsNonDestructiveUpgrades()) {
     throw new Error('The version of codeql is too old to run non-destructive upgrades.');
   }
   // If possible just compile the upgrade sequence


### PR DESCRIPTION
We prompt for destructive upgrades once at the start of running multiple queries so the user doesn't get repeated prompts but with non-destructive they wouldn't any way and it would be worse. This also moves the version check to live with all the other version checks.

I pulled this out of #1498 because it isn't directly related.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
