### PR TITLE
Add new variant analysis view

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -315,7 +315,7 @@
       },
       {
         "command": "codeQL.mockVariantAnalysisView",
-        "title": "CodeQL: Variant Analysis mock view"
+        "title": "CodeQL: Variant Analysis Mock View"
       },
       {
         "command": "codeQL.runQueries",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -314,6 +314,10 @@
         "title": "CodeQL: Export Variant Analysis Results"
       },
       {
+        "command": "codeQL.mockVariantAnalysisView",
+        "title": "CodeQL: Variant Analysis mock view"
+      },
+      {
         "command": "codeQL.runQueries",
         "title": "CodeQL: Run Queries in Selected Files"
       },
@@ -892,6 +896,10 @@
         {
           "command": "codeQL.exportVariantAnalysisResults",
           "when": "config.codeQL.canary"
+        },
+        {
+          "command": "codeQL.mockVariantAnalysisView",
+          "when": "config.codeQL.canary && config.codeQL.variantAnalysis.liveResults"
         },
         {
           "command": "codeQL.runQueries",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -315,7 +315,7 @@
       },
       {
         "command": "codeQL.mockVariantAnalysisView",
-        "title": "CodeQL: Variant Analysis Mock View"
+        "title": "CodeQL: Open Variant Analysis Mock View"
       },
       {
         "command": "codeQL.runQueries",

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -387,3 +387,13 @@ export function getActionBranch(): string {
 export function isIntegrationTestMode() {
   return process.env.INTEGRATION_TEST_MODE === 'true';
 }
+
+/**
+ * A flag indicating whether to enable the experimental "live results" feature
+ * for multi-repo variant analyses.
+ */
+const LIVE_RESULTS = new Setting('liveResults', REMOTE_QUERIES_SETTING);
+
+export function isVariantAnalysisLiveResultsEnabled(): boolean {
+  return !!LIVE_RESULTS.getValue<boolean>();
+}

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -102,6 +102,7 @@ import { EvalLogViewer } from './eval-log-viewer';
 import { SummaryLanguageSupport } from './log-insights/summary-language-support';
 import { JoinOrderScannerProvider } from './log-insights/join-order';
 import { LogScannerService } from './log-insights/log-scanner-service';
+import { VariantAnalysisInterfaceManager } from './remote-queries/variant-analysis-interface';
 
 /**
  * extension.ts
@@ -916,6 +917,13 @@ async function activateWithInstalledDistribution(
   ctx.subscriptions.push(
     commandRunner('codeQL.exportVariantAnalysisResults', async () => {
       await exportRemoteQueryResults(qhm, rqm, ctx);
+    })
+  );
+
+  ctx.subscriptions.push(
+    commandRunner('codeQL.mockVariantAnalysisView', async () => {
+      const variantAnalysisView = new VariantAnalysisInterfaceManager(ctx);
+      variantAnalysisView.openView();
     })
   );
 

--- a/extensions/ql-vscode/src/interface-utils.ts
+++ b/extensions/ql-vscode/src/interface-utils.ts
@@ -112,7 +112,7 @@ export function tryResolveLocation(
   }
 }
 
-export type WebviewView = 'results' | 'compare' | 'remote-queries';
+export type WebviewView = 'results' | 'compare' | 'remote-queries' | 'variant-analysis';
 
 export interface WebviewMessage {
   t: string;

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-interface.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-interface.ts
@@ -1,0 +1,28 @@
+import { ViewColumn } from 'vscode';
+import { AbstractInterfaceManager, InterfacePanelConfig } from '../abstract-interface-manager';
+import { WebviewMessage } from '../interface-utils';
+import { logger } from '../logging';
+
+export class VariantAnalysisInterfaceManager extends AbstractInterfaceManager<WebviewMessage, WebviewMessage> {
+  public openView() {
+    this.getPanel().reveal(undefined, true);
+  }
+
+  protected getPanelConfig(): InterfacePanelConfig {
+    return {
+      viewId: 'variantAnalysisView',
+      title: 'CodeQL Query Results',
+      viewColumn: ViewColumn.Active,
+      preserveFocus: true,
+      view: 'variant-analysis'
+    };
+  }
+
+  protected onPanelDispose(): void {
+    // Nothing to dispose currently.
+  }
+
+  protected async onMessage(msg: WebviewMessage): Promise<void> {
+    void logger.log('Received message on variant analysis view: ' + msg.t);
+  }
+}

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+
+export function VariantAnalysis(): JSX.Element {
+  return <span>Hello!</span>;
+}

--- a/extensions/ql-vscode/src/view/variant-analysis/index.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/index.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import { WebviewDefinition } from '../webview-interface';
+import { VariantAnalysis } from './VariantAnalysis';
+
+const definition: WebviewDefinition = {
+  component: <VariantAnalysis />,
+
+  // This is temporarily using the wrong message type.
+  // We will change it in the near future. 
+  loadedMessage: 'remoteQueryLoaded'
+};
+
+export default definition;


### PR DESCRIPTION
Add a new variant analysis view that will support live results and will eventually replace the current remote queries view.

Mobbed with @koesie10 @robertbrignull and @shati-patel 

As part of this we:
- Added a new configuration setting to control whether to enable new variant analysis live result flows.
- Added a new web view that will be used to render the outcome of a variant analysis.
- Added a new command that will be used to easily load up the view with some mock data. The command will be removed when we have implemented the required functionality.

## Checklist
N/A - internal feature:

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
