### PR TITLE
Fix ESLint VSCode configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,10 +30,8 @@
     "typescript",
     "typescriptreact"
   ],
-  "eslint.options": {
-    // This is necessary so that eslint can properly resolve its plugins
-    "resolvePluginsRelativeTo": "./extensions/ql-vscode"
-  },
+  // This is necessary to ensure that ESLint can find the correct configuration files and plugins.
+  "eslint.workingDirectories": ["./extensions/ql-vscode"],
   "editor.formatOnSave": false,
   "typescript.preferences.quoteStyle": "single",
   "javascript.preferences.quoteStyle": "single",


### PR DESCRIPTION
The working directory of ESLint was not set directly, so ESLint warnings did not show up in VSCode. This sets the working directory properly such that ESLint warnings are shown in VSCode.

See: https://github.com/Microsoft/vscode-eslint#settings-options

@charisk This should resolve the error you saw yesterday in VSCode.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
