### PR TITLE
Consolidate view loading messages into one

### DIFF
--- a/extensions/ql-vscode/src/compare/compare-view.ts
+++ b/extensions/ql-vscode/src/compare/compare-view.ts
@@ -111,7 +111,7 @@ export class CompareView extends AbstractWebview<ToCompareViewMessage, FromCompa
 
   protected async onMessage(msg: FromCompareViewMessage): Promise<void> {
     switch (msg.t) {
-      case 'compareViewLoaded':
+      case 'viewLoaded':
         this.onWebViewLoaded();
         break;
 

--- a/extensions/ql-vscode/src/interface.ts
+++ b/extensions/ql-vscode/src/interface.ts
@@ -191,7 +191,7 @@ export class ResultsView extends AbstractWebview<IntoResultsViewMsg, FromResults
   protected async onMessage(msg: FromResultsViewMsg): Promise<void> {
     try {
       switch (msg.t) {
-        case 'resultViewLoaded':
+        case 'viewLoaded':
           this.onWebViewLoaded();
           break;
         case 'viewSourceFile': {

--- a/extensions/ql-vscode/src/pure/interface-types.ts
+++ b/extensions/ql-vscode/src/pure/interface-types.ts
@@ -174,7 +174,7 @@ export type FromResultsViewMsg =
   | ToggleDiagnostics
   | ChangeRawResultsSortMsg
   | ChangeInterpretedResultsSortMsg
-  | ResultViewLoaded
+  | ViewLoadedMsg
   | ChangePage
   | OpenFileMsg;
 
@@ -216,11 +216,11 @@ interface ToggleDiagnostics {
 }
 
 /**
- * Message from the results view to signal that loading the results
- * is complete.
+ * Message from a view signal that loading is complete.
  */
-interface ResultViewLoaded {
-  t: 'resultViewLoaded';
+interface ViewLoadedMsg {
+  t: 'viewLoaded';
+  viewName: string;
 }
 
 /**
@@ -279,17 +279,10 @@ interface ChangeInterpretedResultsSortMsg {
  * Message from the compare view to the extension.
  */
 export type FromCompareViewMessage =
-  | CompareViewLoadedMessage
+  | ViewLoadedMsg
   | ChangeCompareMessage
   | ViewSourceFileMsg
   | OpenQueryMessage;
-
-/**
- * Message from the compare view to signal the completion of loading results.
- */
-interface CompareViewLoadedMessage {
-  t: 'compareViewLoaded';
-}
 
 /**
  * Message from the compare view to request opening a query.
@@ -389,7 +382,7 @@ export interface ParsedResultSets {
 }
 
 export type FromRemoteQueriesMessage =
-  | RemoteQueryLoadedMessage
+  | ViewLoadedMsg
   | RemoteQueryErrorMessage
   | OpenFileMsg
   | OpenVirtualFileMsg
@@ -401,10 +394,6 @@ export type FromRemoteQueriesMessage =
 export type ToRemoteQueriesMessage =
   | SetRemoteQueryResultMessage
   | SetAnalysesResultsMessage;
-
-export interface RemoteQueryLoadedMessage {
-  t: 'remoteQueryLoaded';
-}
 
 export interface SetRemoteQueryResultMessage {
   t: 'setRemoteQueryResult';

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-view.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-view.ts
@@ -121,7 +121,7 @@ export class RemoteQueriesView extends AbstractWebview<ToRemoteQueriesMessage, F
 
   protected async onMessage(msg: FromRemoteQueriesMessage): Promise<void> {
     switch (msg.t) {
-      case 'remoteQueryLoaded':
+      case 'viewLoaded':
         this.onWebViewLoaded();
         break;
       case 'remoteQueryError':

--- a/extensions/ql-vscode/src/view/compare/index.tsx
+++ b/extensions/ql-vscode/src/view/compare/index.tsx
@@ -3,8 +3,7 @@ import { WebviewDefinition } from '../webview-interface';
 import { Compare } from './Compare';
 
 const definition: WebviewDefinition = {
-  component: <Compare />,
-  loadedMessage: 'compareViewLoaded'
+  component: <Compare />
 };
 
 export default definition;

--- a/extensions/ql-vscode/src/view/remote-queries/index.tsx
+++ b/extensions/ql-vscode/src/view/remote-queries/index.tsx
@@ -3,8 +3,7 @@ import { WebviewDefinition } from '../webview-interface';
 import { RemoteQueries } from './RemoteQueries';
 
 const definition: WebviewDefinition = {
-  component: <RemoteQueries />,
-  loadedMessage: 'remoteQueryLoaded'
+  component: <RemoteQueries />
 };
 
 export default definition;

--- a/extensions/ql-vscode/src/view/results/index.tsx
+++ b/extensions/ql-vscode/src/view/results/index.tsx
@@ -3,8 +3,7 @@ import { WebviewDefinition } from '../webview-interface';
 import { ResultsApp } from './results';
 
 const definition: WebviewDefinition = {
-  component: <ResultsApp />,
-  loadedMessage: 'resultViewLoaded'
+  component: <ResultsApp />
 };
 
 export default definition;

--- a/extensions/ql-vscode/src/view/variant-analysis/index.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/index.tsx
@@ -3,11 +3,7 @@ import { WebviewDefinition } from '../webview-interface';
 import { VariantAnalysis } from './VariantAnalysis';
 
 const definition: WebviewDefinition = {
-  component: <VariantAnalysis />,
-
-  // This is temporarily using the wrong message type.
-  // We will change it in the near future. 
-  loadedMessage: 'remoteQueryLoaded'
+  component: <VariantAnalysis />
 };
 
 export default definition;

--- a/extensions/ql-vscode/src/view/webview-interface.ts
+++ b/extensions/ql-vscode/src/view/webview-interface.ts
@@ -1,4 +1,3 @@
 export type WebviewDefinition = {
-  component: JSX.Element,
-  loadedMessage: 'compareViewLoaded' | 'remoteQueryLoaded' | 'resultViewLoaded';
+  component: JSX.Element;
 }

--- a/extensions/ql-vscode/src/view/webview.tsx
+++ b/extensions/ql-vscode/src/view/webview.tsx
@@ -29,7 +29,7 @@ const render = () => {
     view.component,
     document.getElementById('root'),
     // Post a message to the extension when fully loaded.
-    () => vscode.postMessage({ t: view.loadedMessage })
+    () => vscode.postMessage({ t: 'viewLoaded', viewName })
   );
 };
 


### PR DESCRIPTION
We currently have different message types for when a view is loaded. However, they're all handled in the same way. I've consolidated them all into one.