### PR TITLE
Move common React components to separate directory

### DIFF
--- a/extensions/ql-vscode/src/view/common/HorizontalSpace.tsx
+++ b/extensions/ql-vscode/src/view/common/HorizontalSpace.tsx
@@ -1,9 +1,7 @@
 import styled from 'styled-components';
 
-const HorizontalSpace = styled.div<{ size: 1 | 2 | 3 }>`
+export const HorizontalSpace = styled.div<{ size: 1 | 2 | 3 }>`
   flex: 0 0 auto;
   display: inline-block;
   width: ${props => 0.2 * props.size}em;
 `;
-
-export default HorizontalSpace;

--- a/extensions/ql-vscode/src/view/common/SectionTitle.tsx
+++ b/extensions/ql-vscode/src/view/common/SectionTitle.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-const SectionTitle = styled.h2`
+export const SectionTitle = styled.h2`
   font-size: medium;
   font-weight: 500;
   padding: 0 0.5em 0 0;
@@ -8,5 +8,3 @@ const SectionTitle = styled.h2`
   display: inline-block;
   vertical-align: middle;
 `;
-
-export default SectionTitle;

--- a/extensions/ql-vscode/src/view/common/VerticalSpace.tsx
+++ b/extensions/ql-vscode/src/view/common/VerticalSpace.tsx
@@ -1,8 +1,6 @@
 import styled from 'styled-components';
 
-const VerticalSpace = styled.div<{ size: 1 | 2 | 3 }>`
+export const VerticalSpace = styled.div<{ size: 1 | 2 | 3 }>`
   flex: 0 0 auto;
   height: ${props => 0.5 * props.size}em;
 `;
-
-export default VerticalSpace;

--- a/extensions/ql-vscode/src/view/common/ViewTitle.tsx
+++ b/extensions/ql-vscode/src/view/common/ViewTitle.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-const ViewTitle = styled.h1`
+export const ViewTitle = styled.h1`
   font-size: 2em;
   margin-bottom: 0.5em;
   font-weight: 500;
@@ -9,5 +9,3 @@ const ViewTitle = styled.h1`
   overflow: hidden;
   text-overflow: ellipsis;
 `;
-
-export default ViewTitle;

--- a/extensions/ql-vscode/src/view/common/index.ts
+++ b/extensions/ql-vscode/src/view/common/index.ts
@@ -1,0 +1,4 @@
+export * from './HorizontalSpace';
+export * from './SectionTitle';
+export * from './VerticalSpace';
+export * from './ViewTitle';

--- a/extensions/ql-vscode/src/view/remote-queries/CodePaths.tsx
+++ b/extensions/ql-vscode/src/view/remote-queries/CodePaths.tsx
@@ -5,9 +5,8 @@ import * as React from 'react';
 import { ChangeEvent, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { CodeFlow, AnalysisMessage, ResultSeverity } from '../../remote-queries/shared/analysis-result';
+import { SectionTitle, VerticalSpace } from '../common';
 import FileCodeSnippet from './FileCodeSnippet';
-import SectionTitle from './SectionTitle';
-import VerticalSpace from './VerticalSpace';
 
 const StyledCloseButton = styled.button`
   position: absolute;

--- a/extensions/ql-vscode/src/view/remote-queries/FileCodeSnippet.tsx
+++ b/extensions/ql-vscode/src/view/remote-queries/FileCodeSnippet.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import styled from 'styled-components';
 import { CodeSnippet, FileLink, HighlightedRegion, AnalysisMessage, ResultSeverity } from '../../remote-queries/shared/analysis-result';
-import VerticalSpace from './VerticalSpace';
 import { createRemoteFileRef } from '../../pure/location-link-utils';
 import { parseHighlightedLine, shouldHighlightLine } from '../../pure/sarif-utils';
 import { VSCodeLink } from '@vscode/webview-ui-toolkit/react';
+import { VerticalSpace } from '../common';
 
 const borderColor = 'var(--vscode-editor-snippetFinalTabstopHighlightBorder)';
 const warningColor = '#966C23';

--- a/extensions/ql-vscode/src/view/remote-queries/RemoteQueries.tsx
+++ b/extensions/ql-vscode/src/view/remote-queries/RemoteQueries.tsx
@@ -6,10 +6,7 @@ import { AnalysisSummary, RemoteQueryResult } from '../../remote-queries/shared/
 import { MAX_RAW_RESULTS } from '../../remote-queries/shared/result-limits';
 import { vscode } from '../vscode-api';
 import { VSCodeBadge, VSCodeButton } from '@vscode/webview-ui-toolkit/react';
-import SectionTitle from './SectionTitle';
-import VerticalSpace from './VerticalSpace';
-import HorizontalSpace from './HorizontalSpace';
-import ViewTitle from './ViewTitle';
+import { HorizontalSpace, SectionTitle, VerticalSpace, ViewTitle } from '../common';
 import DownloadButton from './DownloadButton';
 import { AnalysisResults, getAnalysisResultCount } from '../../remote-queries/shared/analysis-result';
 import DownloadSpinner from './DownloadSpinner';

--- a/extensions/ql-vscode/src/view/variant-analysis/QueryDetails.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/QueryDetails.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import styled from 'styled-components';
-import ViewTitle from '../remote-queries/ViewTitle';
+import { ViewTitle } from '../common';
 import { LinkIconButton } from './LinkIconButton';
 
 export type QueryDetailsProps = {


### PR DESCRIPTION
This moves the common React components between the remote queries and variant analysis views to a `common` directory, as discussed [here](https://github.com/github/vscode-codeql/pull/1512#discussion_r972764156).

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
