### PR TITLE
Move zipFile util to its own module for easy re-use

### DIFF
--- a/extensions/ql-vscode/src/pure/zip.ts
+++ b/extensions/ql-vscode/src/pure/zip.ts
@@ -1,0 +1,11 @@
+import * as unzipper from 'unzipper';
+
+/**
+ * Unzips a zip file to a directory.
+ * @param sourcePath The path to the zip file.
+ * @param destinationPath The path to the directory to unzip to.
+ */
+export async function unzipFile(sourcePath: string, destinationPath: string) {
+  const file = await unzipper.Open.file(sourcePath);
+  await file.extract({ path: destinationPath });
+}


### PR DESCRIPTION
Started a new `zip` module to put utility functions around zipping/unzipping. I've only updated one location in the codebase to use it for now, other code can take advantage when its being changed.

## Checklist
N/A: Refactoring

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
