### PR TITLE
Move GitHub Actions API client to gh-api directory

### DIFF
--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -40,7 +40,7 @@ import * as fs from 'fs-extra';
 import { CliVersionConstraint } from './cli';
 import { HistoryItemLabelProvider } from './history-item-label-provider';
 import { Credentials } from './authentication';
-import { cancelRemoteQuery } from './remote-queries/gh-actions-api-client';
+import { cancelRemoteQuery } from './remote-queries/gh-api/gh-actions-api-client';
 import { RemoteQueriesManager } from './remote-queries/remote-queries-manager';
 import { RemoteQueryHistoryItem } from './remote-queries/remote-query-history-item';
 import { ResultsView } from './interface';

--- a/extensions/ql-vscode/src/remote-queries/analyses-results-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/analyses-results-manager.ts
@@ -5,7 +5,7 @@ import { CancellationToken, ExtensionContext } from 'vscode';
 
 import { Credentials } from '../authentication';
 import { Logger } from '../logging';
-import { downloadArtifactFromLink } from './gh-actions-api-client';
+import { downloadArtifactFromLink } from './gh-api/gh-actions-api-client';
 import { AnalysisSummary } from './shared/remote-query-result';
 import { AnalysisResults, AnalysisAlert, AnalysisRawResults } from './shared/analysis-result';
 import { UserCancellationException } from '../commandRunner';

--- a/extensions/ql-vscode/src/remote-queries/export-results.ts
+++ b/extensions/ql-vscode/src/remote-queries/export-results.ts
@@ -10,7 +10,7 @@ import {
 } from '../helpers';
 import { logger } from '../logging';
 import { QueryHistoryManager } from '../query-history';
-import { createGist } from './gh-actions-api-client';
+import { createGist } from './gh-api/gh-actions-api-client';
 import { RemoteQueriesManager } from './remote-queries-manager';
 import { generateMarkdown } from './remote-queries-markdown-generation';
 import { RemoteQuery } from './remote-query';

--- a/extensions/ql-vscode/src/remote-queries/gh-api/gh-actions-api-client.ts
+++ b/extensions/ql-vscode/src/remote-queries/gh-api/gh-actions-api-client.ts
@@ -1,14 +1,14 @@
 import * as path from 'path';
 import * as fs from 'fs-extra';
-import { showAndLogErrorMessage, showAndLogWarningMessage, tmpDir } from '../helpers';
-import { Credentials } from '../authentication';
-import { logger } from '../logging';
-import { RemoteQueryWorkflowResult } from './remote-query-workflow-result';
-import { DownloadLink, createDownloadPath } from './download-link';
-import { RemoteQuery } from './remote-query';
-import { RemoteQueryFailureIndexItem, RemoteQueryResultIndex, RemoteQuerySuccessIndexItem } from './remote-query-result-index';
-import { getErrorMessage } from '../pure/helpers-pure';
-import { unzipFile } from '../pure/zip';
+import { showAndLogErrorMessage, showAndLogWarningMessage, tmpDir } from '../../helpers';
+import { Credentials } from '../../authentication';
+import { logger } from '../../logging';
+import { RemoteQueryWorkflowResult } from '../remote-query-workflow-result';
+import { DownloadLink, createDownloadPath } from '../download-link';
+import { RemoteQuery } from '../remote-query';
+import { RemoteQueryFailureIndexItem, RemoteQueryResultIndex, RemoteQuerySuccessIndexItem } from '../remote-query-result-index';
+import { getErrorMessage } from '../../pure/helpers-pure';
+import { unzipFile } from '../../pure/zip';
 
 export const RESULT_INDEX_ARTIFACT_NAME = 'result-index';
 

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
@@ -13,7 +13,7 @@ import { runRemoteQuery } from './run-remote-query';
 import { RemoteQueriesView } from './remote-queries-view';
 import { RemoteQuery } from './remote-query';
 import { RemoteQueriesMonitor } from './remote-queries-monitor';
-import { getRemoteQueryIndex, getRepositoriesMetadata, RepositoriesMetadata } from './gh-actions-api-client';
+import { getRemoteQueryIndex, getRepositoriesMetadata, RepositoriesMetadata } from './gh-api/gh-actions-api-client';
 import { RemoteQueryResultIndex } from './remote-query-result-index';
 import { RemoteQueryResult, sumAnalysisSummariesResults } from './remote-query-result';
 import { DownloadLink } from './download-link';

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-monitor.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-monitor.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { Credentials } from '../authentication';
 import { Logger } from '../logging';
-import { getWorkflowStatus, isArtifactAvailable, RESULT_INDEX_ARTIFACT_NAME } from './gh-actions-api-client';
+import { getWorkflowStatus, isArtifactAvailable, RESULT_INDEX_ARTIFACT_NAME } from './gh-api/gh-actions-api-client';
 import { RemoteQuery } from './remote-query';
 import { RemoteQueryWorkflowResult } from './remote-query-workflow-result';
 

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/export-results.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/export-results.test.ts
@@ -7,7 +7,7 @@ import { ExtensionContext } from 'vscode';
 import { createMockExtensionContext } from '../index';
 import { Credentials } from '../../../authentication';
 import { MarkdownFile } from '../../../remote-queries/remote-queries-markdown-generation';
-import * as actionsApiClient from '../../../remote-queries/gh-actions-api-client';
+import * as actionsApiClient from '../../../remote-queries/gh-api/gh-actions-api-client';
 import { exportResultsToGist } from '../../../remote-queries/export-results';
 
 const proxyquire = pq.noPreserveCache();

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/gh-api/gh-actions-api-client.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/gh-api/gh-actions-api-client.test.ts
@@ -1,9 +1,9 @@
 import { fail } from 'assert';
 import { expect } from 'chai';
 import * as sinon from 'sinon';
-import { Credentials } from '../../../authentication';
-import { cancelRemoteQuery, getRepositoriesMetadata } from '../../../remote-queries/gh-actions-api-client';
-import { RemoteQuery } from '../../../remote-queries/remote-query';
+import { Credentials } from '../../../../authentication';
+import { cancelRemoteQuery, getRepositoriesMetadata } from '../../../../remote-queries/gh-api/gh-actions-api-client';
+import { RemoteQuery } from '../../../../remote-queries/remote-query';
 
 describe('gh-actions-api-client mock responses', () => {
   let sandbox: sinon.SinonSandbox;


### PR DESCRIPTION
Moved the `gh-actions-api-client` into a `gh-api` subdir. We will soon have a few more files around calling the GitHub API so I think it's worth starting a subdir for them.

I've also noticed that the `gh-actions-api-client` also has logic around non-action stuff, but I'll leave that as a separate change.

## Checklist
N/A - refactoring.
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
