### PR TITLE
Release PR for v1.7.0

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CodeQL for Visual Studio Code: Changelog
 
-## [UNRELEASED]
+## 1.7.0 - 20 September 2022
 
 - Remove ability to download databases from LGTM. [#1467](https://github.com/github/vscode-codeql/pull/1467)
 - Removed the ability to manually upgrade databases from the context menu on databases. Databases are non-destructively upgraded automatically so 

--- a/extensions/ql-vscode/package-lock.json
+++ b/extensions/ql-vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-codeql",
-  "version": "1.6.13",
+  "version": "1.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-codeql",
-      "version": "1.6.13",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "@octokit/plugin-retry": "^3.0.9",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -4,7 +4,7 @@
   "description": "CodeQL for Visual Studio Code",
   "author": "GitHub",
   "private": true,
-  "version": "1.6.13",
+  "version": "1.7.0",
   "publisher": "GitHub",
   "license": "MIT",
   "icon": "media/VS-marketplace-CodeQL-icon.png",


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

PR for v1.7.0 release.

Bumping to 1.7.0 because of two potentially breaking changes, though each is mitigated:
- Remove ability to download databases from LGTM.
  - This is still available behind the canary flag, to be removed at a later date.
- Removed the ability to manually upgrade databases from the context menu on databases.
  - This is still available in the command palate.