### PR TITLE
Fix "Export All" not always exporting the correct query

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -915,8 +915,8 @@ async function activateWithInstalledDistribution(
     }));
 
   ctx.subscriptions.push(
-    commandRunner('codeQL.exportVariantAnalysisResults', async () => {
-      await exportRemoteQueryResults(qhm, rqm, ctx);
+    commandRunner('codeQL.exportVariantAnalysisResults', async (queryId?: string) => {
+      await exportRemoteQueryResults(qhm, rqm, ctx, queryId);
     })
   );
 

--- a/extensions/ql-vscode/src/pure/interface-types.ts
+++ b/extensions/ql-vscode/src/pure/interface-types.ts
@@ -422,6 +422,7 @@ export interface RemoteQueryDownloadAllAnalysesResultsMessage {
 
 export interface RemoteQueryExportResultsMessage {
   t: 'remoteQueryExportResults';
+  queryId: string;
 }
 
 export interface CopyRepoListMessage {

--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -680,7 +680,7 @@ export class QueryHistoryManager extends DisposableObject {
     return this.treeDataProvider.getCurrent();
   }
 
-  getQueryById(queryId: string): RemoteQueryHistoryItem | undefined {
+  getRemoteQueryById(queryId: string): RemoteQueryHistoryItem | undefined {
     return this.treeDataProvider.allHistory.find(i => i.t === 'remote' && i.queryId === queryId) as RemoteQueryHistoryItem;
   }
 

--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -680,6 +680,10 @@ export class QueryHistoryManager extends DisposableObject {
     return this.treeDataProvider.getCurrent();
   }
 
+  getQueryById(queryId: string): RemoteQueryHistoryItem | undefined {
+    return this.treeDataProvider.allHistory.find(i => i.t === 'remote' && i.queryId === queryId) as RemoteQueryHistoryItem;
+  }
+
   async removeDeletedQueries() {
     await Promise.all(this.treeDataProvider.allHistory.map(async (item) => {
       if (item.t == 'local' && item.completedQuery && !(await fs.pathExists(item.completedQuery?.query.querySaveDir))) {

--- a/extensions/ql-vscode/src/remote-queries/export-results.ts
+++ b/extensions/ql-vscode/src/remote-queries/export-results.ts
@@ -15,26 +15,40 @@ import { RemoteQueriesManager } from './remote-queries-manager';
 import { generateMarkdown } from './remote-queries-markdown-generation';
 import { RemoteQuery } from './remote-query';
 import { AnalysisResults, sumAnalysesResults } from './shared/analysis-result';
+import { RemoteQueryHistoryItem } from './remote-query-history-item';
 
 /**
- * Exports the results of the currently-selected remote query.
+ * Exports the results of the given or currently-selected remote query.
  * The user is prompted to select the export format.
  */
 export async function exportRemoteQueryResults(
   queryHistoryManager: QueryHistoryManager,
   remoteQueriesManager: RemoteQueriesManager,
   ctx: ExtensionContext,
+  queryId?: string,
 ): Promise<void> {
-  const queryHistoryItem = queryHistoryManager.getCurrentQueryHistoryItem();
-  if (!queryHistoryItem || queryHistoryItem.t !== 'remote') {
-    throw new Error('No variant analysis results currently open. To open results, click an item in the query history view.');
-  } else if (!queryHistoryItem.completed) {
+  let queryHistoryItem: RemoteQueryHistoryItem;
+  if (queryId) {
+    const query = queryHistoryManager.getQueryById(queryId);
+    if (!query) {
+      throw new Error(`Could not find query with id ${queryId}`);
+    }
+    queryHistoryItem = query;
+  } else {
+    const query = queryHistoryManager.getCurrentQueryHistoryItem();
+    if (!query || query.t !== 'remote') {
+      throw new Error('No variant analysis results currently open. To open results, click an item in the query history view.');
+    }
+    queryHistoryItem = query;
+  }
+
+  if (!queryHistoryItem.completed) {
     throw new Error('Variant analysis results are not yet available.');
   }
-  const queryId = queryHistoryItem.queryId;
-  void logger.log(`Exporting variant analysis results for query: ${queryId}`);
+
+  void logger.log(`Exporting variant analysis results for query: ${queryHistoryItem.queryId}`);
   const query = queryHistoryItem.remoteQuery;
-  const analysesResults = remoteQueriesManager.getAnalysesResults(queryId);
+  const analysesResults = remoteQueriesManager.getAnalysesResults(queryHistoryItem.queryId);
 
   const gistOption = {
     label: '$(ports-open-browser-icon) Create Gist (GitHub)',

--- a/extensions/ql-vscode/src/remote-queries/export-results.ts
+++ b/extensions/ql-vscode/src/remote-queries/export-results.ts
@@ -31,7 +31,8 @@ export async function exportRemoteQueryResults(
   if (queryId) {
     const query = queryHistoryManager.getQueryById(queryId);
     if (!query) {
-      throw new Error(`Could not find query with id ${queryId}`);
+      void logger.log(`Could not find query with id ${queryId}`);
+      throw new Error('There was an error when trying to retrieve variant analysis information');
     }
     queryHistoryItem = query;
   } else {

--- a/extensions/ql-vscode/src/remote-queries/export-results.ts
+++ b/extensions/ql-vscode/src/remote-queries/export-results.ts
@@ -29,7 +29,7 @@ export async function exportRemoteQueryResults(
 ): Promise<void> {
   let queryHistoryItem: RemoteQueryHistoryItem;
   if (queryId) {
-    const query = queryHistoryManager.getQueryById(queryId);
+    const query = queryHistoryManager.getRemoteQueryById(queryId);
     if (!query) {
       void logger.log(`Could not find query with id ${queryId}`);
       throw new Error('There was an error when trying to retrieve variant analysis information');

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-view.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-view.ts
@@ -145,7 +145,7 @@ export class RemoteQueriesView extends AbstractWebview<ToRemoteQueriesMessage, F
         await this.downloadAllAnalysesResults(msg);
         break;
       case 'remoteQueryExportResults':
-        await commands.executeCommand('codeQL.exportVariantAnalysisResults');
+        await commands.executeCommand('codeQL.exportVariantAnalysisResults', msg.queryId);
         break;
       default:
         assertNever(msg);

--- a/extensions/ql-vscode/src/view/remote-queries/RemoteQueries.tsx
+++ b/extensions/ql-vscode/src/view/remote-queries/RemoteQueries.tsx
@@ -270,9 +270,10 @@ const AnalysesResultsTitle = ({ totalAnalysesResults, totalResults }: { totalAna
   return <SectionTitle>{totalAnalysesResults}/{totalResults} results</SectionTitle>;
 };
 
-const exportResults = () => {
+const exportResults = (queryResult: RemoteQueryResult) => {
   vscode.postMessage({
     t: 'remoteQueryExportResults',
+    queryId: queryResult.queryId,
   });
 };
 
@@ -362,7 +363,7 @@ const AnalysesResults = ({
             totalResults={totalResults} />
         </div>
         <div>
-          <VSCodeButton onClick={exportResults}>Export all</VSCodeButton>
+          <VSCodeButton onClick={() => exportResults(queryResult)}>Export all</VSCodeButton>
         </div>
       </div>
       <AnalysesResultsDescription


### PR DESCRIPTION
The "Export All" button was always exporting the selected query, while a different query could be open in a VSCode panel. This will ensure that the query ID is passed to the export function, so that the correct query is exported.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
