### PR TITLE
Move CodePaths and FileCodeSnippet to common directory

### DIFF
--- a/extensions/ql-vscode/src/stories/common/CodePaths.stories.tsx
+++ b/extensions/ql-vscode/src/stories/common/CodePaths.stories.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { ThemeProvider } from '@primer/react';
 
-import CodePaths from '../../view/remote-queries/CodePaths';
+import { CodePaths } from '../../view/common';
 import type { CodeFlow } from '../../remote-queries/shared/analysis-result';
 
 export default {
@@ -112,8 +112,8 @@ PowerShell.args = {
   message: {
     tokens: [
       {
-        type: 'text',
-        t: 'This zip file may have a dangerous path'
+        t: 'text',
+        text: 'This zip file may have a dangerous path'
       }
     ]
   },

--- a/extensions/ql-vscode/src/stories/common/FileCodeSnippet.stories.tsx
+++ b/extensions/ql-vscode/src/stories/common/FileCodeSnippet.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
-import FileCodeSnippet from '../../view/remote-queries/FileCodeSnippet';
+import { FileCodeSnippet } from '../../view/common';
 
 export default {
   title: 'File Code Snippet',

--- a/extensions/ql-vscode/src/view/common/CodePaths/CodePaths.tsx
+++ b/extensions/ql-vscode/src/view/common/CodePaths/CodePaths.tsx
@@ -4,9 +4,10 @@ import { VSCodeDropdown, VSCodeLink, VSCodeOption, VSCodeTag } from '@vscode/web
 import * as React from 'react';
 import { ChangeEvent, useRef, useState } from 'react';
 import styled from 'styled-components';
-import { CodeFlow, AnalysisMessage, ResultSeverity } from '../../remote-queries/shared/analysis-result';
-import { SectionTitle, VerticalSpace } from '../common';
-import FileCodeSnippet from './FileCodeSnippet';
+import { CodeFlow, AnalysisMessage, ResultSeverity } from '../../../remote-queries/shared/analysis-result';
+import { SectionTitle } from '../SectionTitle';
+import { VerticalSpace } from '../VerticalSpace';
+import { FileCodeSnippet } from '../FileCodeSnippet';
 
 const StyledCloseButton = styled.button`
   position: absolute;
@@ -111,7 +112,7 @@ const Menu = ({
   </VSCodeDropdown>;
 };
 
-const CodePaths = ({
+export const CodePaths = ({
   codeFlows,
   ruleDescription,
   message,
@@ -173,5 +174,3 @@ const CodePaths = ({
     </div>
   );
 };
-
-export default CodePaths;

--- a/extensions/ql-vscode/src/view/common/CodePaths/index.ts
+++ b/extensions/ql-vscode/src/view/common/CodePaths/index.ts
@@ -1,0 +1,1 @@
+export * from './CodePaths';

--- a/extensions/ql-vscode/src/view/common/FileCodeSnippet/FileCodeSnippet.tsx
+++ b/extensions/ql-vscode/src/view/common/FileCodeSnippet/FileCodeSnippet.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import styled from 'styled-components';
-import { CodeSnippet, FileLink, HighlightedRegion, AnalysisMessage, ResultSeverity } from '../../remote-queries/shared/analysis-result';
-import { createRemoteFileRef } from '../../pure/location-link-utils';
-import { parseHighlightedLine, shouldHighlightLine } from '../../pure/sarif-utils';
+import { CodeSnippet, FileLink, HighlightedRegion, AnalysisMessage, ResultSeverity } from '../../../remote-queries/shared/analysis-result';
+import { createRemoteFileRef } from '../../../pure/location-link-utils';
+import { parseHighlightedLine, shouldHighlightLine } from '../../../pure/sarif-utils';
 import { VSCodeLink } from '@vscode/webview-ui-toolkit/react';
-import { VerticalSpace } from '../common';
+import { VerticalSpace } from '../VerticalSpace';
 
 const borderColor = 'var(--vscode-editor-snippetFinalTabstopHighlightBorder)';
 const warningColor = '#966C23';
@@ -193,7 +193,7 @@ const Line = ({
   </div>;
 };
 
-const FileCodeSnippet = ({
+export const FileCodeSnippet = ({
   fileLink,
   codeSnippet,
   highlightedRegion,
@@ -257,5 +257,3 @@ const FileCodeSnippet = ({
     </Container>
   );
 };
-
-export default FileCodeSnippet;

--- a/extensions/ql-vscode/src/view/common/FileCodeSnippet/index.ts
+++ b/extensions/ql-vscode/src/view/common/FileCodeSnippet/index.ts
@@ -1,0 +1,1 @@
+export * from './FileCodeSnippet';

--- a/extensions/ql-vscode/src/view/common/index.ts
+++ b/extensions/ql-vscode/src/view/common/index.ts
@@ -1,4 +1,6 @@
 export * from './icon';
+export * from './CodePaths';
+export * from './FileCodeSnippet';
 export * from './HorizontalSpace';
 export * from './SectionTitle';
 export * from './VerticalSpace';

--- a/extensions/ql-vscode/src/view/remote-queries/AnalysisAlertResult.tsx
+++ b/extensions/ql-vscode/src/view/remote-queries/AnalysisAlertResult.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { AnalysisAlert } from '../../remote-queries/shared/analysis-result';
-import CodePaths from './CodePaths';
-import FileCodeSnippet from './FileCodeSnippet';
+import { CodePaths, FileCodeSnippet } from '../common';
 
 const AnalysisAlertResult = ({ alert }: { alert: AnalysisAlert }) => {
   const showPathsLink = alert.codeFlows.length > 0;


### PR DESCRIPTION
This moves the `CodePaths` and `FileCodeSnippet` components to the common directory since they will be reused by the live results view.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
