### PR TITLE
Add ESLint plugin for React hooks

### DIFF
--- a/extensions/ql-vscode/package-lock.json
+++ b/extensions/ql-vscode/package-lock.json
@@ -109,6 +109,7 @@
         "eslint": "~6.8.0",
         "eslint-plugin-jest-dom": "^4.0.2",
         "eslint-plugin-react": "~7.19.0",
+        "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-storybook": "^0.6.4",
         "file-loader": "^6.2.0",
         "glob": "^7.1.4",
@@ -20907,6 +20908,18 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
+      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/doctrine": {
@@ -56084,6 +56097,12 @@
           "dev": true
         }
       }
+    },
+    "eslint-plugin-react-hooks": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
+      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+      "dev": true
     },
     "eslint-plugin-storybook": {
       "version": "0.6.4",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1305,6 +1305,7 @@
     "eslint": "~6.8.0",
     "eslint-plugin-jest-dom": "^4.0.2",
     "eslint-plugin-react": "~7.19.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-storybook": "^0.6.4",
     "file-loader": "^6.2.0",
     "glob": "^7.1.4",

--- a/extensions/ql-vscode/src/stories/.eslintrc.js
+++ b/extensions/ql-vscode/src/stories/.eslintrc.js
@@ -4,6 +4,7 @@ module.exports = {
   },
   extends: [
     "plugin:react/recommended",
+    "plugin:react-hooks/recommended",
     "plugin:storybook/recommended",
   ],
   settings: {

--- a/extensions/ql-vscode/src/view/.eslintrc.js
+++ b/extensions/ql-vscode/src/view/.eslintrc.js
@@ -3,7 +3,8 @@ module.exports = {
     browser: true
   },
   extends: [
-    "plugin:react/recommended"
+    "plugin:react/recommended",
+    "plugin:react-hooks/recommended",
   ],
   settings: {
     react: {


### PR DESCRIPTION
This will add the ESLint plugin for React hooks which will automatically check that all dependencies are listed in `useMemo`, `useEffect`, etc.

See: https://www.npmjs.com/package/eslint-plugin-react-hooks

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
