### PR TITLE
Ensure `safeMax` is safe for undefined values

### DIFF
--- a/extensions/ql-vscode/src/log-insights/join-order.ts
+++ b/extensions/ql-vscode/src/log-insights/join-order.ts
@@ -7,8 +7,8 @@ const DEFAULT_WARNING_THRESHOLD = 50;
 /**
  * Like `max`, but returns 0 if no meaningful maximum can be computed.
  */
-function safeMax(it: Iterable<number>) {
-  const m = Math.max(...it);
+function safeMax(it?: Iterable<number>) {
+  const m = Math.max(...(it || []));
   return Number.isFinite(m) ? m : 0;
 }
 


### PR DESCRIPTION
I came across this when I had a query that threw an error while running for unrelated reasons. At this point, the query results were in a bad state, but this caused `safeMax` to be called with `undefined` and it prevented the extension from starting. This changed fixed the error.
