### PR TITLE
Add loading component

### DIFF
--- a/extensions/ql-vscode/src/stories/variant-analysis/VariantAnalysisLoading.stories.tsx
+++ b/extensions/ql-vscode/src/stories/variant-analysis/VariantAnalysisLoading.stories.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import { VariantAnalysisContainer } from '../../view/variant-analysis/VariantAnalysisContainer';
+import { VariantAnalysisLoading as VariantAnalysisLoadingComponent } from '../../view/variant-analysis/VariantAnalysisLoading';
+
+export default {
+  title: 'Variant Analysis/Variant Analysis Loading',
+  component: VariantAnalysisLoadingComponent,
+  decorators: [
+    (Story) => (
+      <VariantAnalysisContainer>
+        <Story />
+      </VariantAnalysisContainer>
+    )
+  ],
+  argTypes: {}
+} as ComponentMeta<typeof VariantAnalysisLoadingComponent>;
+
+const Template: ComponentStory<typeof VariantAnalysisLoadingComponent> = () => (
+  <VariantAnalysisLoadingComponent />
+);
+
+export const VariantAnalysisLoading = Template.bind({});

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../remote-queries/shared/variant-analysis';
 import { VariantAnalysisContainer } from './VariantAnalysisContainer';
 import { VariantAnalysisHeader } from './VariantAnalysisHeader';
+import { VariantAnalysisLoading } from './VariantAnalysisLoading';
 
 const variantAnalysis: VariantAnalysisDomainModel = {
   id: 1,
@@ -19,6 +20,7 @@ const variantAnalysis: VariantAnalysisDomainModel = {
   },
   databases: {},
   status: VariantAnalysisStatus.InProgress,
+  actionsWorkflowRunId: 123,
   scannedRepos: [
     {
       repository: {
@@ -103,18 +105,28 @@ const variantAnalysis: VariantAnalysisDomainModel = {
   ]
 };
 
+function getContainerContents(variantAnalysis: VariantAnalysisDomainModel) {
+  if (variantAnalysis.actionsWorkflowRunId === undefined) {
+    return <VariantAnalysisLoading />;
+  }
+
+  return (
+    <VariantAnalysisHeader
+      variantAnalysis={variantAnalysis}
+      onOpenQueryFileClick={() => console.log('Open query')}
+      onViewQueryTextClick={() => console.log('View query')}
+      onStopQueryClick={() => console.log('Stop query')}
+      onCopyRepositoryListClick={() => console.log('Copy repository list')}
+      onExportResultsClick={() => console.log('Export results')}
+      onViewLogsClick={() => console.log('View logs')}
+    />
+  );
+}
+
 export function VariantAnalysis(): JSX.Element {
   return (
     <VariantAnalysisContainer>
-      <VariantAnalysisHeader
-        variantAnalysis={variantAnalysis}
-        onOpenQueryFileClick={() => console.log('Open query')}
-        onViewQueryTextClick={() => console.log('View query')}
-        onStopQueryClick={() => console.log('Stop query')}
-        onCopyRepositoryListClick={() => console.log('Copy repository list')}
-        onExportResultsClick={() => console.log('Export results')}
-        onViewLogsClick={() => console.log('View logs')}
-      />
+      {getContainerContents(variantAnalysis)}
     </VariantAnalysisContainer>
   );
 }

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisLoading.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisLoading.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import styled from 'styled-components';
+
+const FirstRow = styled.div`
+  font-size: x-large;
+  font-weight: 600;
+  text-align: center;
+  margin-bottom: 0.5em;
+`;
+
+const SecondRow = styled.div`
+  text-align: center;
+  color: var(--vscode-descriptionForeground);
+`;
+
+export const VariantAnalysisLoading = () => {
+  return (
+    <div>
+      <FirstRow>We are getting everything ready</FirstRow>
+      <SecondRow>Results will appear here shortly</SecondRow>
+    </div>
+  );
+};

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisLoading.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisLoading.tsx
@@ -1,23 +1,28 @@
 import * as React from 'react';
 import styled from 'styled-components';
 
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1em;
+  padding: 1em;
+`;
+
 const FirstRow = styled.div`
   font-size: x-large;
   font-weight: 600;
-  text-align: center;
-  margin-bottom: 0.5em;
 `;
 
 const SecondRow = styled.div`
-  text-align: center;
   color: var(--vscode-descriptionForeground);
 `;
 
 export const VariantAnalysisLoading = () => {
   return (
-    <div>
+    <Container>
       <FirstRow>We are getting everything ready</FirstRow>
       <SecondRow>Results will appear here shortly</SecondRow>
-    </div>
+    </Container>
   );
 };

--- a/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisLoading.spec.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisLoading.spec.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { render as reactRender, screen } from '@testing-library/react';
+import { VariantAnalysisLoading } from '../VariantAnalysisLoading';
+
+describe(VariantAnalysisLoading.name, () => {
+  const render = () =>
+    reactRender(<VariantAnalysisLoading />);
+
+  it('renders loading text', async () => {
+    render();
+
+    expect(screen.getByText('We are getting everything ready')).toBeInTheDocument();
+    expect(screen.getByText('Results will appear here shortly')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Implements a component to show when the variant analysis submission is being processed. This component doesn't have any props as there's only state it needs to show. The decision on whether to show it or not based on the variant analysis status will be decided by the parent component.

Storybook screenshot:
<img width="925" alt="Screenshot 2022-09-23 at 17 21 48" src="https://user-images.githubusercontent.com/3749000/192007417-4d529a9b-a3ad-4513-ada9-eef04b101d4c.png">

See the internal issue for how it's meant to look. I've tried to copy the style as closely as possible but please do tell me if this could fit in better.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
