### PR TITLE
Implement monitoring for variant analysis live results 

### DIFF
--- a/extensions/ql-vscode/package-lock.json
+++ b/extensions/ql-vscode/package-lock.json
@@ -50,6 +50,7 @@
       "devDependencies": {
         "@babel/core": "^7.18.13",
         "@babel/plugin-transform-modules-commonjs": "^7.18.6",
+        "@faker-js/faker": "^7.5.0",
         "@storybook/addon-actions": "^6.5.10",
         "@storybook/addon-essentials": "^6.5.10",
         "@storybook/addon-interactions": "^6.5.10",
@@ -2525,6 +2526,16 @@
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-7.5.0.tgz",
+      "integrity": "sha512-8wNUCCUHvfvI0gQpDUho/3gPzABffnCn5um65F8dzQ86zz6dlt4+nmAA7PQUc8L+eH+9RgR/qzy5N/8kN0Ozdw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=6.0.0"
+      }
     },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
@@ -41706,6 +41717,12 @@
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+    },
+    "@faker-js/faker": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-7.5.0.tgz",
+      "integrity": "sha512-8wNUCCUHvfvI0gQpDUho/3gPzABffnCn5um65F8dzQ86zz6dlt4+nmAA7PQUc8L+eH+9RgR/qzy5N/8kN0Ozdw==",
+      "dev": true
     },
     "@gar/promisify": {
       "version": "1.1.3",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1246,6 +1246,7 @@
   "devDependencies": {
     "@babel/core": "^7.18.13",
     "@babel/plugin-transform-modules-commonjs": "^7.18.6",
+    "@faker-js/faker": "^7.5.0",
     "@storybook/addon-actions": "^6.5.10",
     "@storybook/addon-essentials": "^6.5.10",
     "@storybook/addon-interactions": "^6.5.10",

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -105,6 +105,8 @@ import { createInitialQueryInfo } from './run-queries-shared';
 import { LegacyQueryRunner } from './legacy-query-server/legacyRunner';
 import { QueryRunner } from './queryRunner';
 import { VariantAnalysisView } from './remote-queries/variant-analysis-view';
+import { VariantAnalysisMonitor } from './remote-queries/variant-analysis-monitor';
+import { VariantAnalysis } from './remote-queries/shared/variant-analysis';
 
 /**
  * extension.ts
@@ -891,6 +893,16 @@ async function activateWithInstalledDistribution(
   ctx.subscriptions.push(
     commandRunner('codeQL.copyRepoList', async (queryId: string) => {
       await rqm.copyRemoteQueryRepoListToClipboard(queryId);
+    })
+  );
+
+  const variantAnalysisMonitor = new VariantAnalysisMonitor(ctx, logger);
+  ctx.subscriptions.push(
+    commandRunner('codeQL.monitorVariantAnalysis', async (
+      variantAnalysis: VariantAnalysis,
+      token: CancellationToken
+    ) => {
+      await variantAnalysisMonitor.monitorVariantAnalysis(variantAnalysis, token);
     })
   );
 

--- a/extensions/ql-vscode/src/remote-queries/gh-api/variant-analysis.ts
+++ b/extensions/ql-vscode/src/remote-queries/gh-api/variant-analysis.ts
@@ -62,7 +62,7 @@ export interface VariantAnalysisSkippedRepositoryGroup {
 
 export interface VariantAnalysisNotFoundRepositoryGroup {
   repository_count: number,
-  repository_nwos: string[]
+  repository_full_names: string[]
 }
 export interface VariantAnalysisRepoTask {
   repository: Repository,

--- a/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
@@ -1,4 +1,4 @@
-import { CancellationToken, Uri, window } from 'vscode';
+import { CancellationToken, commands, Uri, window } from 'vscode';
 import * as path from 'path';
 import * as yaml from 'js-yaml';
 import * as fs from 'fs-extra';
@@ -26,8 +26,9 @@ import { QueryMetadata } from '../pure/interface-types';
 import { getErrorMessage, REPO_REGEX } from '../pure/helpers-pure';
 import * as ghApiClient from './gh-api/gh-api-client';
 import { getRepositorySelection, isValidSelection, RepositorySelection } from './repository-selection';
-import { parseVariantAnalysisQueryLanguage, VariantAnalysis, VariantAnalysisStatus, VariantAnalysisSubmission } from './shared/variant-analysis';
+import { parseVariantAnalysisQueryLanguage, VariantAnalysisSubmission } from './shared/variant-analysis';
 import { Repository } from './shared/repository';
+import { processVariantAnalysis } from './variant-analysis-processor';
 
 export interface QlPack {
   name: string;
@@ -270,28 +271,15 @@ export async function runRemoteQuery(
         variantAnalysisSubmission
       );
 
-      const variantAnalysis: VariantAnalysis = {
-        id: variantAnalysisResponse.id,
-        controllerRepoId: variantAnalysisResponse.controller_repo.id,
-        query: {
-          name: variantAnalysisSubmission.query.name,
-          filePath: variantAnalysisSubmission.query.filePath,
-          language: variantAnalysisSubmission.query.language,
-        },
-        databases: {
-          repositories: variantAnalysisSubmission.databases.repositories,
-          repositoryLists: variantAnalysisSubmission.databases.repositoryLists,
-          repositoryOwners: variantAnalysisSubmission.databases.repositoryOwners,
-        },
-        status: VariantAnalysisStatus.InProgress,
-      };
+      const processedVariantAnalysis = processVariantAnalysis(variantAnalysisSubmission, variantAnalysisResponse);
 
       // TODO: Remove once we have a proper notification
       void showAndLogInformationMessage('Variant analysis submitted for processing');
-      void logger.log(`Variant analysis:\n${JSON.stringify(variantAnalysis, null, 2)}`);
+      void logger.log(`Variant analysis:\n${JSON.stringify(processedVariantAnalysis, null, 2)}`);
 
-      return { variantAnalysis };
+      void commands.executeCommand('codeQL.monitorVariantAnalysis', processedVariantAnalysis);
 
+      return { variantAnalysis: processedVariantAnalysis };
     } else {
       const apiResponse = await runRemoteQueriesApiRequest(credentials, actionBranch, language, repoSelection, controllerRepo, base64Pack, dryRun);
 

--- a/extensions/ql-vscode/src/remote-queries/shared/variant-analysis-monitor-result.ts
+++ b/extensions/ql-vscode/src/remote-queries/shared/variant-analysis-monitor-result.ts
@@ -1,0 +1,16 @@
+import { VariantAnalysis } from './variant-analysis';
+
+export type VariantAnalysisMonitorStatus =
+  | 'InProgress'
+  | 'CompletedSuccessfully'
+  | 'CompletedUnsuccessfully'
+  | 'Failed'
+  | 'Cancelled'
+  | 'TimedOut';
+
+export interface VariantAnalysisMonitorResult {
+  status: VariantAnalysisMonitorStatus;
+  error?: string;
+  scannedReposDownloaded?: number[],
+  variantAnalysis?: VariantAnalysis
+}

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-monitor.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-monitor.ts
@@ -49,7 +49,7 @@ export class VariantAnalysisMonitor {
         variantAnalysis.id
       );
 
-      if (variantAnalysisSummary.status == 'in_progress' && variantAnalysisSummary.failure_reason) {
+      if (variantAnalysisSummary.failure_reason) {
         variantAnalysis.status = VariantAnalysisStatus.Failed;
         variantAnalysis.failureReason = processFailureReason(variantAnalysisSummary.failure_reason);
         return {

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-monitor.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-monitor.ts
@@ -69,6 +69,10 @@ export class VariantAnalysisMonitor {
         });
       }
 
+      if (variantAnalysisSummary.status === 'completed') {
+        break;
+      }
+
       attemptCount++;
     }
 

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-monitor.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-monitor.ts
@@ -1,0 +1,81 @@
+import * as vscode from 'vscode';
+import { Credentials } from '../authentication';
+import { Logger } from '../logging';
+import * as ghApiClient from './gh-api/gh-api-client';
+
+import { VariantAnalysis, VariantAnalysisStatus } from './shared/variant-analysis';
+import {
+  VariantAnalysis as VariantAnalysisApiResponse
+} from './gh-api/variant-analysis';
+import { VariantAnalysisMonitorResult } from './shared/variant-analysis-monitor-result';
+import { processFailureReason } from './variant-analysis-processor';
+
+export class VariantAnalysisMonitor {
+  // With a sleep of 5 seconds, the maximum number of attempts takes
+  // us to just over 2 days worth of monitoring.
+  public static maxAttemptCount = 17280;
+  public static sleepTime = 5000;
+
+  constructor(
+    private readonly extensionContext: vscode.ExtensionContext,
+    private readonly logger: Logger
+  ) {
+  }
+
+  public async monitorVariantAnalysis(
+    variantAnalysis: VariantAnalysis,
+    cancellationToken: vscode.CancellationToken
+  ): Promise<VariantAnalysisMonitorResult> {
+
+    const credentials = await Credentials.initialize(this.extensionContext);
+    if (!credentials) {
+      throw Error('Error authenticating with GitHub');
+    }
+
+    let variantAnalysisSummary: VariantAnalysisApiResponse;
+    let attemptCount = 0;
+    const scannedReposDownloaded: number[] = [];
+
+    while (attemptCount <= VariantAnalysisMonitor.maxAttemptCount) {
+      await this.sleep(VariantAnalysisMonitor.sleepTime);
+
+      if (cancellationToken && cancellationToken.isCancellationRequested) {
+        return { status: 'Cancelled', error: 'Variant Analysis was canceled.' };
+      }
+
+      variantAnalysisSummary = await ghApiClient.getVariantAnalysis(
+        credentials,
+        variantAnalysis.controllerRepoId,
+        variantAnalysis.id
+      );
+
+      if (variantAnalysisSummary.status == 'in_progress' && variantAnalysisSummary.failure_reason) {
+        variantAnalysis.status = VariantAnalysisStatus.Failed;
+        variantAnalysis.failureReason = processFailureReason(variantAnalysisSummary.failure_reason);
+        return {
+          status: 'Failed',
+          error: `Variant Analysis has failed: ${variantAnalysisSummary.failure_reason}`,
+          variantAnalysis: variantAnalysis
+        };
+      }
+
+      void this.logger.log('****** Retrieved variant analysis' + JSON.stringify(variantAnalysisSummary));
+
+      if (variantAnalysisSummary.scanned_repositories) {
+        variantAnalysisSummary.scanned_repositories.forEach(scannedRepo => {
+          if (!scannedReposDownloaded.includes(scannedRepo.repository.id) && scannedRepo.analysis_status === 'succeeded') {
+            scannedReposDownloaded.push(scannedRepo.repository.id);
+          }
+        });
+      }
+
+      attemptCount++;
+    }
+
+    return { status: 'CompletedSuccessfully', scannedReposDownloaded: scannedReposDownloaded };
+  }
+
+  private async sleep(ms: number) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+}

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-processor.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-processor.ts
@@ -102,7 +102,7 @@ function processRepoGroup(repoGroup: ApiVariantAnalysisSkippedRepositoryGroup): 
 }
 
 function processNotFoundRepoGroup(repoGroup: ApiVariantAnalysisNotFoundRepositoryGroup): VariantAnalysisSkippedRepositoryGroup {
-  const repo_nwos = repoGroup.repository_nwos.map(nwo => {
+  const repo_full_names = repoGroup.repository_full_names.map(nwo => {
     return {
       fullName: nwo
     };
@@ -110,7 +110,7 @@ function processNotFoundRepoGroup(repoGroup: ApiVariantAnalysisNotFoundRepositor
 
   return {
     repositoryCount: repoGroup.repository_count,
-    repositories: repo_nwos
+    repositories: repo_full_names
   };
 }
 

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-processor.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-processor.ts
@@ -60,11 +60,8 @@ export function processVariantAnalysis(
 function processScannedRepositories(
   scannedRepos: ApiVariantAnalysisScannedRepository[]
 ): VariantAnalysisScannedRepository[] {
-
-  const result: VariantAnalysisScannedRepository[] = [];
-
-  scannedRepos.forEach(function(scannedRepo) {
-    const parsedRepo: VariantAnalysisScannedRepository = {
+  return scannedRepos.map(scannedRepo => {
+    return {
       repository: {
         id: scannedRepo.repository.id,
         fullName: scannedRepo.repository.full_name,
@@ -75,11 +72,7 @@ function processScannedRepositories(
       artifactSizeInBytes: scannedRepo.artifact_size_in_bytes,
       failureMessage: scannedRepo.failure_message
     };
-
-    result.push(parsedRepo);
   });
-
-  return result;
 }
 
 function processSkippedRepositories(

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-processor.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-processor.ts
@@ -51,7 +51,7 @@ export function processVariantAnalysis(
   };
 
   if (response.failure_reason) {
-    variantAnalysis.failureReason = response.failure_reason as VariantAnalysisFailureReason;
+    variantAnalysis.failureReason = processFailureReason(response.failure_reason);
   }
 
   return variantAnalysis;

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-processor.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-processor.ts
@@ -1,0 +1,157 @@
+import {
+  VariantAnalysis as ApiVariantAnalysis,
+  VariantAnalysisScannedRepository as ApiVariantAnalysisScannedRepository,
+  VariantAnalysisSkippedRepositories as ApiVariantAnalysisSkippedRepositories,
+  VariantAnalysisRepoStatus as ApiVariantAnalysisRepoStatus,
+  VariantAnalysisFailureReason as ApiVariantAnalysisFailureReason,
+  VariantAnalysisStatus as ApiVariantAnalysisStatus,
+  VariantAnalysisSkippedRepositoryGroup as ApiVariantAnalysisSkippedRepositoryGroup,
+  VariantAnalysisNotFoundRepositoryGroup as ApiVariantAnalysisNotFoundRepositoryGroup
+} from './gh-api/variant-analysis';
+import {
+  VariantAnalysis,
+  VariantAnalysisFailureReason,
+  VariantAnalysisScannedRepository,
+  VariantAnalysisSkippedRepositories,
+  VariantAnalysisStatus,
+  VariantAnalysisRepoStatus,
+  VariantAnalysisSubmission,
+  VariantAnalysisSkippedRepositoryGroup
+} from './shared/variant-analysis';
+
+export function processVariantAnalysis(
+  submission: VariantAnalysisSubmission,
+  response: ApiVariantAnalysis
+): VariantAnalysis {
+
+  let scannedRepos: VariantAnalysisScannedRepository[] = [];
+  let skippedRepos: VariantAnalysisSkippedRepositories = {};
+
+  if (response.scanned_repositories) {
+    scannedRepos = processScannedRepositories(response.scanned_repositories as ApiVariantAnalysisScannedRepository[]);
+  }
+
+  if (response.skipped_repositories) {
+    skippedRepos = processSkippedRepositories(response.skipped_repositories as ApiVariantAnalysisSkippedRepositories);
+  }
+
+  const variantAnalysis: VariantAnalysis = {
+    id: response.id,
+    controllerRepoId: response.controller_repo.id,
+    query: {
+      name: submission.query.name,
+      filePath: submission.query.filePath,
+      language: submission.query.language
+    },
+    databases: submission.databases,
+    status: processApiStatus(response.status),
+    actionsWorkflowRunId: response.actions_workflow_run_id,
+    scannedRepos: scannedRepos,
+    skippedRepos: skippedRepos
+  };
+
+  if (response.failure_reason) {
+    variantAnalysis.failureReason = response.failure_reason as VariantAnalysisFailureReason;
+  }
+
+  return variantAnalysis;
+}
+
+function processScannedRepositories(
+  scannedRepos: ApiVariantAnalysisScannedRepository[]
+): VariantAnalysisScannedRepository[] {
+
+  const result: VariantAnalysisScannedRepository[] = [];
+
+  scannedRepos.forEach(function(scannedRepo) {
+    const parsedRepo: VariantAnalysisScannedRepository = {
+      repository: {
+        id: scannedRepo.repository.id,
+        fullName: scannedRepo.repository.full_name,
+        private: scannedRepo.repository.private,
+      },
+      analysisStatus: processApiRepoStatus(scannedRepo.analysis_status),
+      resultCount: scannedRepo.result_count,
+      artifactSizeInBytes: scannedRepo.artifact_size_in_bytes,
+      failureMessage: scannedRepo.failure_message
+    };
+
+    result.push(parsedRepo);
+  });
+
+  return result;
+}
+
+function processSkippedRepositories(
+  skippedRepos: ApiVariantAnalysisSkippedRepositories
+): VariantAnalysisSkippedRepositories {
+
+  return {
+    accessMismatchRepos: processRepoGroup(skippedRepos.access_mismatch_repos),
+    notFoundRepos: processNotFoundRepoGroup(skippedRepos.not_found_repo_nwos),
+    noCodeqlDbRepos: processRepoGroup(skippedRepos.no_codeql_db_repos),
+    overLimitRepos: processRepoGroup(skippedRepos.over_limit_repos)
+  };
+}
+
+function processRepoGroup(repoGroup: ApiVariantAnalysisSkippedRepositoryGroup): VariantAnalysisSkippedRepositoryGroup {
+  const repos = repoGroup.repositories.map(repo => {
+    return {
+      id: repo.id,
+      fullName: repo.full_name
+    };
+  });
+
+  return {
+    repositoryCount: repoGroup.repository_count,
+    repositories: repos
+  };
+}
+
+function processNotFoundRepoGroup(repoGroup: ApiVariantAnalysisNotFoundRepositoryGroup): VariantAnalysisSkippedRepositoryGroup {
+  const repo_nwos = repoGroup.repository_nwos.map(nwo => {
+    return {
+      fullName: nwo
+    };
+  });
+
+  return {
+    repositoryCount: repoGroup.repository_count,
+    repositories: repo_nwos
+  };
+}
+
+function processApiRepoStatus(analysisStatus: ApiVariantAnalysisRepoStatus): VariantAnalysisRepoStatus {
+  switch (analysisStatus) {
+    case 'pending':
+      return VariantAnalysisRepoStatus.Pending;
+    case 'in_progress':
+      return VariantAnalysisRepoStatus.InProgress;
+    case 'succeeded':
+      return VariantAnalysisRepoStatus.Succeeded;
+    case 'failed':
+      return VariantAnalysisRepoStatus.Failed;
+    case 'canceled':
+      return VariantAnalysisRepoStatus.Canceled;
+    case 'timed_out':
+      return VariantAnalysisRepoStatus.TimedOut;
+  }
+}
+
+function processApiStatus(status: ApiVariantAnalysisStatus): VariantAnalysisStatus {
+  switch (status) {
+    case 'in_progress':
+      return VariantAnalysisStatus.InProgress;
+    case 'completed':
+      return VariantAnalysisStatus.Succeeded;
+  }
+}
+
+export function processFailureReason(failureReason: ApiVariantAnalysisFailureReason): VariantAnalysisFailureReason {
+  switch (failureReason) {
+    case 'no_repos_queried':
+      return VariantAnalysisFailureReason.NoReposQueried;
+    case 'internal_error':
+      return VariantAnalysisFailureReason.InternalError;
+  }
+}

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-monitor.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-monitor.test.ts
@@ -1,0 +1,165 @@
+import * as sinon from 'sinon';
+import { expect } from 'chai';
+import { CancellationToken, extensions } from 'vscode';
+import { CodeQLExtensionInterface } from '../../../extension';
+import { logger } from '../../../logging';
+import * as config from '../../../config';
+
+import * as ghApiClient from '../../../remote-queries/gh-api/gh-api-client';
+import { VariantAnalysisMonitor } from '../../../remote-queries/variant-analysis-monitor';
+import {
+  VariantAnalysis as VariantAnalysisApiResponse,
+  VariantAnalysisScannedRepository as ApiVariantAnalysisScannedRepository,
+  VariantAnalysisFailureReason
+} from '../../../remote-queries/gh-api/variant-analysis';
+import { createFailedMockApiResponse, createMockApiResponse } from '../../factories/remote-queries/gh-api/variant-analysis-api-response';
+import { VariantAnalysisStatus } from '../../../remote-queries/shared/variant-analysis';
+import { createMockScannedRepos } from '../../factories/remote-queries/gh-api/scanned-repositories';
+import { processFailureReason } from '../../../remote-queries/variant-analysis-processor';
+import { Credentials } from '../../../authentication';
+
+describe('Variant Analysis Monitor', async function() {
+  let sandbox: sinon.SinonSandbox;
+  let mockGetVariantAnalysis: sinon.SinonStub;
+  let cancellationToken: CancellationToken;
+  let variantAnalysisMonitor: VariantAnalysisMonitor;
+  let variantAnalysis: any;
+
+  beforeEach(async () => {
+    sandbox = sinon.createSandbox();
+    sandbox.stub(logger, 'log');
+    sandbox.stub(config, 'isVariantAnalysisLiveResultsEnabled').returns(false);
+
+    cancellationToken = {
+      isCancellationRequested: false
+    } as unknown as CancellationToken;
+
+    variantAnalysis = {
+      id: 123,
+      controllerRepoId: 1,
+    };
+
+    try {
+      const extension = await extensions.getExtension<CodeQLExtensionInterface | Record<string, never>>('GitHub.vscode-codeql')!.activate();
+      variantAnalysisMonitor = new VariantAnalysisMonitor(extension.ctx, logger);
+    } catch (e) {
+      fail(e as Error);
+    }
+
+    limitNumberOfAttemptsToMonitor();
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  describe('when credentials are invalid', async () => {
+    beforeEach(async () => { sandbox.stub(Credentials, 'initialize').resolves(undefined); });
+
+    it('should return early if credentials are wrong', async () => {
+      try {
+        await variantAnalysisMonitor.monitorVariantAnalysis(variantAnalysis, cancellationToken);
+      } catch (error: any) {
+        expect(error.message).to.equal('Error authenticating with GitHub');
+      }
+    });
+  });
+
+  describe('when credentials are valid', async () => {
+    beforeEach(async () => {
+      const mockCredentials = {
+        getOctokit: () => Promise.resolve({
+          request: mockGetVariantAnalysis
+        })
+      } as unknown as Credentials;
+      sandbox.stub(Credentials, 'initialize').resolves(mockCredentials);
+    });
+
+    it('should return early if variant analysis is cancelled', async () => {
+      cancellationToken.isCancellationRequested = true;
+
+      const result = await variantAnalysisMonitor.monitorVariantAnalysis(variantAnalysis, cancellationToken);
+
+      expect(result).to.eql({ status: 'Cancelled', error: 'Variant Analysis was canceled.' });
+    });
+
+    describe('when the variant analysis fails', async () => {
+      let mockFailedApiResponse: VariantAnalysisApiResponse;
+
+      beforeEach(async function() {
+        mockFailedApiResponse = createFailedMockApiResponse('in_progress');
+        mockGetVariantAnalysis = sandbox.stub(ghApiClient, 'getVariantAnalysis').resolves(mockFailedApiResponse);
+      });
+
+      it('should mark as failed locally and stop monitoring', async () => {
+        const result = await variantAnalysisMonitor.monitorVariantAnalysis(variantAnalysis, cancellationToken);
+        variantAnalysis = result.variantAnalysis;
+
+        expect(mockGetVariantAnalysis.calledOnce).to.be.true;
+        expect(result.status).to.eql('Failed');
+        expect(result.error).to.eql(`Variant Analysis has failed: ${mockFailedApiResponse.failure_reason}`);
+        expect(variantAnalysis.status).to.equal(VariantAnalysisStatus.Failed);
+        expect(variantAnalysis.failureReason).to.equal(processFailureReason(mockFailedApiResponse.failure_reason as VariantAnalysisFailureReason));
+      });
+    });
+
+    describe('when the variant analysis completes', async () => {
+      let mockApiResponse: VariantAnalysisApiResponse;
+      let scannedRepos: ApiVariantAnalysisScannedRepository[];
+
+      describe('when there are successfully scanned repos', async () => {
+        beforeEach(async function() {
+          scannedRepos = createMockScannedRepos(['pending', 'in_progress', 'succeeded']);
+          mockApiResponse = createMockApiResponse('completed', scannedRepos);
+          mockGetVariantAnalysis = sandbox.stub(ghApiClient, 'getVariantAnalysis').resolves(mockApiResponse);
+        });
+
+        it('should succeed and return a list of scanned repo ids', async () => {
+          const result = await variantAnalysisMonitor.monitorVariantAnalysis(variantAnalysis, cancellationToken);
+          const scannedRepoIds = scannedRepos.filter(r => r.analysis_status == 'succeeded').map(r => r.repository.id);
+
+          expect(result.status).to.equal('CompletedSuccessfully');
+          expect(result.scannedReposDownloaded).to.eql(scannedRepoIds);
+        });
+      });
+
+      describe('when there are only in progress repos', async () => {
+        let scannedRepos: ApiVariantAnalysisScannedRepository[];
+
+        beforeEach(async function() {
+          scannedRepos = createMockScannedRepos(['pending', 'in_progress']);
+          mockApiResponse = createMockApiResponse('in_progress', scannedRepos);
+          mockGetVariantAnalysis = sandbox.stub(ghApiClient, 'getVariantAnalysis').resolves(mockApiResponse);
+        });
+
+        it('should succeed and return an empty list of scanned repo ids', async () => {
+          const result = await variantAnalysisMonitor.monitorVariantAnalysis(variantAnalysis, cancellationToken);
+
+          expect(result.status).to.equal('CompletedSuccessfully');
+          expect(result.scannedReposDownloaded).to.eql([]);
+        });
+      });
+
+      describe('when there are no repos to scan', async () => {
+        beforeEach(async function() {
+          scannedRepos = [];
+          mockApiResponse = createMockApiResponse('completed', scannedRepos);
+          mockGetVariantAnalysis = sandbox.stub(ghApiClient, 'getVariantAnalysis').resolves(mockApiResponse);
+        });
+
+        it('should succeed and return an empty list of scanned repo ids', async () => {
+          const result = await variantAnalysisMonitor.monitorVariantAnalysis(variantAnalysis, cancellationToken);
+
+          expect(result.status).to.equal('CompletedSuccessfully');
+          expect(result.scannedReposDownloaded).to.eql([]);
+        });
+      });
+    });
+  });
+
+  function limitNumberOfAttemptsToMonitor() {
+    VariantAnalysisMonitor.maxAttemptCount = 3;
+    VariantAnalysisMonitor.sleepTime = 1;
+  }
+});
+

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-processor.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-processor.test.ts
@@ -1,0 +1,231 @@
+import { faker } from '@faker-js/faker';
+import { expect } from 'chai';
+import {
+  VariantAnalysis as VariantAnalysisApiResponse,
+  VariantAnalysisRepoStatus as ApiVariantAnalysisRepoStatus,
+  VariantAnalysisScannedRepository as ApiVariantAnalysisScannedRepository,
+  VariantAnalysisSkippedRepositories as ApiVariantAnalysisSkippedRepositories,
+  VariantAnalysisSkippedRepositoryGroup as ApiVariantAnalysisSkippedRepositoryGroup,
+  VariantAnalysisNotFoundRepositoryGroup as ApiVariantAnalysisNotFoundRepositoryGroup
+} from '../../../remote-queries/gh-api/variant-analysis';
+import {
+  VariantAnalysisSubmission,
+  VariantAnalysisQueryLanguage,
+  VariantAnalysisSkippedRepositories,
+  VariantAnalysisSkippedRepositoryGroup
+} from '../../../remote-queries/shared/variant-analysis';
+import { processVariantAnalysis } from '../../../remote-queries/variant-analysis-processor';
+
+describe('Variant Analysis processor', function() {
+  let mockApiResponse: VariantAnalysisApiResponse;
+  let mockSubmission: VariantAnalysisSubmission;
+  let scannedRepo1: ApiVariantAnalysisScannedRepository;
+  let scannedRepo2: ApiVariantAnalysisScannedRepository;
+  let scannedRepo3: ApiVariantAnalysisScannedRepository;
+  let skippedRepos: ApiVariantAnalysisSkippedRepositories;
+
+  beforeEach(() => {
+    scannedRepo1 = createMockScannedRepo('mona1', false, 'succeeded');
+    scannedRepo2 = createMockScannedRepo('mona2', false, 'pending');
+    scannedRepo3 = createMockScannedRepo('mona3', false, 'in_progress');
+    skippedRepos = createMockSkippedRepos();
+
+    mockApiResponse = createMockApiResponse();
+    mockSubmission = createMockSubmission();
+  });
+
+  it('should process an API response and return a variant analysis', () => {
+    const result = processVariantAnalysis(mockSubmission, mockApiResponse);
+
+    expect(result).to.eql({
+      'id': 123,
+      'controllerRepoId': 456,
+      'query': {
+        'filePath': 'query-file-path',
+        'language': 'javascript',
+        'name': 'query-name',
+      },
+      'databases': {
+        'repositories': ['1', '2', '3'],
+        'repositoryLists': ['top10', 'top100'],
+        'repositoryOwners': ['mona', 'lisa']
+      },
+      'status': 'succeeded',
+      'actionsWorkflowRunId': 456,
+      'failureReason': 'internal_error',
+      'scannedRepos': [
+        {
+          'analysisStatus': 'succeeded',
+          'artifactSizeInBytes': scannedRepo1.artifact_size_in_bytes,
+          'failureMessage': '',
+          'repository': {
+            'fullName': scannedRepo1.repository.full_name,
+            'id': scannedRepo1.repository.id,
+            'private': scannedRepo1.repository.private,
+          },
+          'resultCount': scannedRepo1.result_count
+        },
+        {
+          'analysisStatus': 'pending',
+          'artifactSizeInBytes': scannedRepo2.artifact_size_in_bytes,
+          'failureMessage': '',
+          'repository': {
+            'fullName': scannedRepo2.repository.full_name,
+            'id': scannedRepo2.repository.id,
+            'private': scannedRepo2.repository.private,
+          },
+          'resultCount': scannedRepo2.result_count
+        },
+        {
+          'analysisStatus': 'inProgress',
+          'artifactSizeInBytes': scannedRepo3.artifact_size_in_bytes,
+          'failureMessage': '',
+          'repository': {
+            'fullName': scannedRepo3.repository.full_name,
+            'id': scannedRepo3.repository.id,
+            'private': scannedRepo3.repository.private,
+          },
+          'resultCount': scannedRepo3.result_count
+        }
+      ],
+      'skippedRepos': transformSkippedRepos(skippedRepos)
+    });
+  });
+
+  function createMockApiResponse(): VariantAnalysisApiResponse {
+    const variantAnalysis: VariantAnalysisApiResponse = {
+      id: 123,
+      controller_repo: {
+        id: 456,
+        name: 'pickles',
+        full_name: 'github/pickles',
+        private: false,
+      },
+      actor_id: 123,
+      query_language: 'javascript',
+      query_pack_url: 'https://example.com/foo',
+      status: 'in_progress',
+      actions_workflow_run_id: 456,
+      failure_reason: 'internal_error',
+      scanned_repositories: [scannedRepo1, scannedRepo2, scannedRepo3],
+      skipped_repositories: skippedRepos
+    };
+
+    return variantAnalysis;
+  }
+
+  function createMockScannedRepo(
+    name: string,
+    isPrivate: boolean,
+    analysisStatus: ApiVariantAnalysisRepoStatus,
+  ): ApiVariantAnalysisScannedRepository {
+    return {
+      repository: {
+        id: faker.datatype.number(),
+        name: name,
+        full_name: 'github/' + name,
+        private: isPrivate,
+      },
+      analysis_status: analysisStatus,
+      result_count: faker.datatype.number(),
+      artifact_size_in_bytes: faker.datatype.number(),
+      failure_message: ''
+    };
+  }
+
+  function createMockSubmission(): VariantAnalysisSubmission {
+    return {
+      startTime: 1234,
+      controllerRepoId: 5678,
+      actionRepoRef: 'repo-ref',
+      query: {
+        name: 'query-name',
+        filePath: 'query-file-path',
+        language: VariantAnalysisQueryLanguage.Javascript,
+        pack: 'base64-encoded-string',
+      },
+      databases: {
+        repositories: ['1', '2', '3'],
+        repositoryLists: ['top10', 'top100'],
+        repositoryOwners: ['mona', 'lisa'],
+      }
+    };
+  }
+
+  function createMockSkippedRepos(): ApiVariantAnalysisSkippedRepositories {
+    return {
+      access_mismatch_repos: createMockSkippedRepoGroup(),
+      no_codeql_db_repos: createMockSkippedRepoGroup(),
+      not_found_repo_nwos: createMockNotFoundSkippedRepoGroup(),
+      over_limit_repos: createMockSkippedRepoGroup()
+    };
+  }
+
+  function createMockSkippedRepoGroup(): ApiVariantAnalysisSkippedRepositoryGroup {
+    return {
+      repository_count: 2,
+      repositories: [
+        {
+          id: faker.datatype.number(),
+          name: faker.random.word(),
+          full_name: 'github/' + faker.random.word(),
+          private: true
+        },
+        {
+          id: faker.datatype.number(),
+          name: faker.random.word(),
+          full_name: 'github/' + faker.random.word(),
+          private: false
+        }
+      ]
+    };
+  }
+
+  function createMockNotFoundSkippedRepoGroup(): ApiVariantAnalysisNotFoundRepositoryGroup {
+    const repoName1 = 'github' + faker.random.word();
+    const repoName2 = 'github' + faker.random.word();
+
+    return {
+      repository_count: 2,
+      repository_nwos: [repoName1, repoName2]
+    };
+  }
+
+  function transformSkippedRepos(
+    skippedRepos: ApiVariantAnalysisSkippedRepositories
+  ): VariantAnalysisSkippedRepositories {
+    return {
+      accessMismatchRepos: transformSkippedRepoGroup(skippedRepos.access_mismatch_repos),
+      noCodeqlDbRepos: transformSkippedRepoGroup(skippedRepos.no_codeql_db_repos),
+      notFoundRepos: transformNotFoundRepoGroup(skippedRepos.not_found_repo_nwos),
+      overLimitRepos: transformSkippedRepoGroup(skippedRepos.over_limit_repos)
+    };
+  }
+});
+
+function transformSkippedRepoGroup(repoGroup: ApiVariantAnalysisSkippedRepositoryGroup): VariantAnalysisSkippedRepositoryGroup {
+  const repos = repoGroup.repositories.map(repo => {
+    return {
+      id: repo.id,
+      fullName: repo.full_name
+    };
+  });
+
+  return {
+    repositoryCount: repoGroup.repository_count,
+    repositories: repos
+  };
+}
+
+function transformNotFoundRepoGroup(repoGroup: ApiVariantAnalysisNotFoundRepositoryGroup): VariantAnalysisSkippedRepositoryGroup {
+  const repos = repoGroup.repository_nwos.map(nwo => {
+    return {
+      fullName: nwo
+    };
+  });
+
+  return {
+    repositoryCount: repoGroup.repository_count,
+    repositories: repos
+  };
+}

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-processor.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-processor.test.ts
@@ -21,7 +21,7 @@ import { createMockSubmission } from '../../factories/remote-queries/shared/vari
 describe('Variant Analysis processor', function() {
   const scannedRepos = createMockScannedRepos();
   const skippedRepos = createMockSkippedRepos();
-  const mockApiResponse = createMockApiResponse(scannedRepos, skippedRepos);
+  const mockApiResponse = createMockApiResponse('completed', scannedRepos, skippedRepos);
   const mockSubmission = createMockSubmission();
 
   it('should process an API response and return a variant analysis', () => {

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-processor.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-processor.test.ts
@@ -34,8 +34,6 @@ describe('Variant Analysis processor', function() {
       },
       'databases': {
         'repositories': ['1', '2', '3'],
-        'repositoryLists': ['top10', 'top100'],
-        'repositoryOwners': ['mona', 'lisa']
       },
       'status': 'succeeded',
       'actionsWorkflowRunId': 456,

--- a/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/gh-api/scanned-repositories.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/gh-api/scanned-repositories.ts
@@ -1,0 +1,31 @@
+import { faker } from '@faker-js/faker';
+import {
+  VariantAnalysisRepoStatus,
+  VariantAnalysisScannedRepository
+} from '../../../../remote-queries/gh-api/variant-analysis';
+
+export function createMockScannedRepo(
+  name: string,
+  isPrivate: boolean,
+  analysisStatus: VariantAnalysisRepoStatus,
+): VariantAnalysisScannedRepository {
+  return {
+    repository: {
+      id: faker.datatype.number(),
+      name: name,
+      full_name: 'github/' + name,
+      private: isPrivate,
+    },
+    analysis_status: analysisStatus,
+    result_count: faker.datatype.number(),
+    artifact_size_in_bytes: faker.datatype.number(),
+    failure_message: ''
+  };
+}
+
+export function createMockScannedRepos(
+  statuses: VariantAnalysisRepoStatus[] = ['succeeded', 'pending', 'in_progress']
+): VariantAnalysisScannedRepository[] {
+  return statuses.map(status => createMockScannedRepo(`mona-${status}`, false, status));
+}
+

--- a/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/gh-api/scanned-repositories.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/gh-api/scanned-repositories.ts
@@ -18,8 +18,7 @@ export function createMockScannedRepo(
     },
     analysis_status: analysisStatus,
     result_count: faker.datatype.number(),
-    artifact_size_in_bytes: faker.datatype.number(),
-    failure_message: ''
+    artifact_size_in_bytes: faker.datatype.number()
   };
 }
 

--- a/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/gh-api/skipped-repositories.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/gh-api/skipped-repositories.ts
@@ -40,6 +40,6 @@ export function createMockNotFoundSkippedRepoGroup(): VariantAnalysisNotFoundRep
 
   return {
     repository_count: 2,
-    repository_nwos: [repoName1, repoName2]
+    repository_full_names: [repoName1, repoName2]
   };
 }

--- a/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/gh-api/skipped-repositories.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/gh-api/skipped-repositories.ts
@@ -35,8 +35,8 @@ export function createMockSkippedRepoGroup(): VariantAnalysisSkippedRepositoryGr
 }
 
 export function createMockNotFoundSkippedRepoGroup(): VariantAnalysisNotFoundRepositoryGroup {
-  const repoName1 = 'github' + faker.random.word();
-  const repoName2 = 'github' + faker.random.word();
+  const repoName1 = 'github/' + faker.random.word();
+  const repoName2 = 'github/' + faker.random.word();
 
   return {
     repository_count: 2,

--- a/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/gh-api/skipped-repositories.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/gh-api/skipped-repositories.ts
@@ -1,0 +1,45 @@
+import { faker } from '@faker-js/faker';
+import {
+  VariantAnalysisNotFoundRepositoryGroup,
+  VariantAnalysisSkippedRepositories,
+  VariantAnalysisSkippedRepositoryGroup
+} from '../../../../remote-queries/gh-api/variant-analysis';
+
+export function createMockSkippedRepos(): VariantAnalysisSkippedRepositories {
+  return {
+    access_mismatch_repos: createMockSkippedRepoGroup(),
+    no_codeql_db_repos: createMockSkippedRepoGroup(),
+    not_found_repo_nwos: createMockNotFoundSkippedRepoGroup(),
+    over_limit_repos: createMockSkippedRepoGroup()
+  };
+}
+
+export function createMockSkippedRepoGroup(): VariantAnalysisSkippedRepositoryGroup {
+  return {
+    repository_count: 2,
+    repositories: [
+      {
+        id: faker.datatype.number(),
+        name: faker.random.word(),
+        full_name: 'github/' + faker.random.word(),
+        private: true
+      },
+      {
+        id: faker.datatype.number(),
+        name: faker.random.word(),
+        full_name: 'github/' + faker.random.word(),
+        private: false
+      }
+    ]
+  };
+}
+
+export function createMockNotFoundSkippedRepoGroup(): VariantAnalysisNotFoundRepositoryGroup {
+  const repoName1 = 'github' + faker.random.word();
+  const repoName2 = 'github' + faker.random.word();
+
+  return {
+    repository_count: 2,
+    repository_nwos: [repoName1, repoName2]
+  };
+}

--- a/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/gh-api/variant-analysis-api-response.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/gh-api/variant-analysis-api-response.ts
@@ -11,7 +11,7 @@ import { createMockScannedRepos } from './scanned-repositories';
 import { createMockSkippedRepos } from './skipped-repositories';
 
 export function createMockApiResponse(
-  status = 'in_progress',
+  status: VariantAnalysisStatus = 'in_progress',
   scannedRepos: VariantAnalysisScannedRepository[] = createMockScannedRepos(),
   skippedRepos: VariantAnalysisSkippedRepositories = createMockSkippedRepos()
 ): VariantAnalysisApiResponse {
@@ -26,7 +26,7 @@ export function createMockApiResponse(
     actor_id: 123,
     query_language: VariantAnalysisQueryLanguage.Javascript,
     query_pack_url: 'https://example.com/foo',
-    status: status as VariantAnalysisStatus,
+    status: status,
     actions_workflow_run_id: 456,
     scanned_repositories: scannedRepos,
     skipped_repositories: skippedRepos
@@ -36,12 +36,12 @@ export function createMockApiResponse(
 }
 
 export function createFailedMockApiResponse(
-  status = 'in_progress',
+  status: VariantAnalysisStatus = 'in_progress',
   scannedRepos: VariantAnalysisScannedRepository[] = createMockScannedRepos(),
   skippedRepos: VariantAnalysisSkippedRepositories = createMockSkippedRepos(),
 ): VariantAnalysisApiResponse {
   const variantAnalysis = createMockApiResponse(status, scannedRepos, skippedRepos);
-  variantAnalysis.status = status as VariantAnalysisStatus;
+  variantAnalysis.status = status;
   variantAnalysis.failure_reason = 'internal_error';
 
   return variantAnalysis;

--- a/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/gh-api/variant-analysis-api-response.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/gh-api/variant-analysis-api-response.ts
@@ -1,0 +1,43 @@
+import {
+  VariantAnalysis as VariantAnalysisApiResponse,
+  VariantAnalysisScannedRepository,
+  VariantAnalysisSkippedRepositories,
+} from '../../../../remote-queries/gh-api/variant-analysis';
+import {
+  VariantAnalysisQueryLanguage
+} from '../../../../remote-queries/shared/variant-analysis';
+
+export function createMockApiResponse(
+  scannedRepos: VariantAnalysisScannedRepository[],
+  skippedRepos: VariantAnalysisSkippedRepositories
+): VariantAnalysisApiResponse {
+  const variantAnalysis: VariantAnalysisApiResponse = {
+    id: 123,
+    controller_repo: {
+      id: 456,
+      name: 'pickles',
+      full_name: 'github/pickles',
+      private: false,
+    },
+    actor_id: 123,
+    query_language: VariantAnalysisQueryLanguage.Javascript,
+    query_pack_url: 'https://example.com/foo',
+    status: 'in_progress',
+    actions_workflow_run_id: 456,
+    scanned_repositories: scannedRepos,
+    skipped_repositories: skippedRepos
+  };
+
+  return variantAnalysis;
+}
+
+export function createFailedMockApiResponse(
+  scannedRepos: VariantAnalysisScannedRepository[],
+  skippedRepos: VariantAnalysisSkippedRepositories
+): VariantAnalysisApiResponse {
+  const variantAnalysis = createMockApiResponse(scannedRepos, skippedRepos);
+  variantAnalysis.status = 'completed';
+  variantAnalysis.failure_reason = 'internal_error';
+
+  return variantAnalysis;
+}

--- a/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/gh-api/variant-analysis-api-response.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/gh-api/variant-analysis-api-response.ts
@@ -2,14 +2,18 @@ import {
   VariantAnalysis as VariantAnalysisApiResponse,
   VariantAnalysisScannedRepository,
   VariantAnalysisSkippedRepositories,
+  VariantAnalysisStatus,
 } from '../../../../remote-queries/gh-api/variant-analysis';
 import {
   VariantAnalysisQueryLanguage
 } from '../../../../remote-queries/shared/variant-analysis';
+import { createMockScannedRepos } from './scanned-repositories';
+import { createMockSkippedRepos } from './skipped-repositories';
 
 export function createMockApiResponse(
-  scannedRepos: VariantAnalysisScannedRepository[],
-  skippedRepos: VariantAnalysisSkippedRepositories
+  status = 'in_progress',
+  scannedRepos: VariantAnalysisScannedRepository[] = createMockScannedRepos(),
+  skippedRepos: VariantAnalysisSkippedRepositories = createMockSkippedRepos()
 ): VariantAnalysisApiResponse {
   const variantAnalysis: VariantAnalysisApiResponse = {
     id: 123,
@@ -22,7 +26,7 @@ export function createMockApiResponse(
     actor_id: 123,
     query_language: VariantAnalysisQueryLanguage.Javascript,
     query_pack_url: 'https://example.com/foo',
-    status: 'in_progress',
+    status: status as VariantAnalysisStatus,
     actions_workflow_run_id: 456,
     scanned_repositories: scannedRepos,
     skipped_repositories: skippedRepos
@@ -32,11 +36,12 @@ export function createMockApiResponse(
 }
 
 export function createFailedMockApiResponse(
-  scannedRepos: VariantAnalysisScannedRepository[],
-  skippedRepos: VariantAnalysisSkippedRepositories
+  status = 'in_progress',
+  scannedRepos: VariantAnalysisScannedRepository[] = createMockScannedRepos(),
+  skippedRepos: VariantAnalysisSkippedRepositories = createMockSkippedRepos(),
 ): VariantAnalysisApiResponse {
-  const variantAnalysis = createMockApiResponse(scannedRepos, skippedRepos);
-  variantAnalysis.status = 'completed';
+  const variantAnalysis = createMockApiResponse(status, scannedRepos, skippedRepos);
+  variantAnalysis.status = status as VariantAnalysisStatus;
   variantAnalysis.failure_reason = 'internal_error';
 
   return variantAnalysis;

--- a/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/shared/variant-analysis-submission.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/shared/variant-analysis-submission.ts
@@ -13,8 +13,6 @@ export function createMockSubmission(): VariantAnalysisSubmission {
     },
     databases: {
       repositories: ['1', '2', '3'],
-      repositoryLists: ['top10', 'top100'],
-      repositoryOwners: ['mona', 'lisa'],
     }
   };
 }

--- a/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/shared/variant-analysis-submission.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/shared/variant-analysis-submission.ts
@@ -1,0 +1,20 @@
+import { VariantAnalysisQueryLanguage, VariantAnalysisSubmission } from '../../../../remote-queries/shared/variant-analysis';
+
+export function createMockSubmission(): VariantAnalysisSubmission {
+  return {
+    startTime: 1234,
+    controllerRepoId: 5678,
+    actionRepoRef: 'repo-ref',
+    query: {
+      name: 'query-name',
+      filePath: 'query-file-path',
+      language: VariantAnalysisQueryLanguage.Javascript,
+      pack: 'base64-encoded-string',
+    },
+    databases: {
+      repositories: ['1', '2', '3'],
+      repositoryLists: ['top10', 'top100'],
+      repositoryOwners: ['mona', 'lisa'],
+    }
+  };
+}


### PR DESCRIPTION
🚨 Please review this PR commit-by-commit.

Continues from a [previous PR](https://github.com/github/vscode-codeql/pull/1538) which introduced a way to submit new
variant analyses to the API.

Here we're creating a way to keep track of variant analysis results as
they become ready. To do this we're introducing a new 
`VariantAnalysisMonitor` class. This will poll the API every 5 seconds 
for changes to the variant analysis. By default it will continue to run for 
a maximum of 2 days, or when the user closes VSCode.

The monitor will receive a `variantAnalysis` summary from the API that
will contain an up-to-date list of scanned repos and will return a list of
scanned repo ids.

In a future PR, we'll add the functionality to:
- update the UI for in-progress/completed states
- raise an error on timeout
- download the results

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
