### PR TITLE
Fix not being able to run variant analyses

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
@@ -361,9 +361,9 @@ async function runRemoteQueriesApiRequest(
   try {
     const octokit = await credentials.getOctokit();
     const response: OctokitResponse<QueriesResponse, number> = await octokit.request(
-      'POST /repos/:controllerRepo/code-scanning/codeql/queries',
+      'POST /repositories/:controllerRepoId/code-scanning/codeql/queries',
       {
-        controllerRepo: controllerRepo.fullName,
+        controllerRepoId: controllerRepo.id,
         data
       }
     );


### PR DESCRIPTION
The `controllerRepo` parameter was being encoded/escaped by Octokit, resulting in a URL like
`repos/dsp-testing%2Fqc-controller/code-scanning/codeql/queries` rather than `repos/dsp-testing/qc-controller/code-scanning/codeql/queries`.

This switches it to use the ID instead, since we already have the ID and do not have access to the owner and repo separately anymore.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
