### PR TITLE
Hide repositories with raw results without rows

### DIFF
--- a/extensions/ql-vscode/src/view/remote-queries/RemoteQueries.tsx
+++ b/extensions/ql-vscode/src/view/remote-queries/RemoteQueries.tsx
@@ -377,7 +377,7 @@ const AnalysesResults = ({
 
       <ul className="vscode-codeql__flat-list">
         {analysesResults
-          .filter(a => a.interpretedResults.length > 0 || (a.rawResults?.resultSet.rows && a.rawResults.resultSet.rows.length > 0))
+          .filter(a => a.interpretedResults.length || a.rawResults?.resultSet?.rows?.length)
           .filter(a => a.nwo.toLowerCase().includes(filterValue.toLowerCase()))
           .sort(sorter(sort))
           .map(r =>

--- a/extensions/ql-vscode/src/view/remote-queries/RemoteQueries.tsx
+++ b/extensions/ql-vscode/src/view/remote-queries/RemoteQueries.tsx
@@ -377,7 +377,7 @@ const AnalysesResults = ({
 
       <ul className="vscode-codeql__flat-list">
         {analysesResults
-          .filter(a => a.interpretedResults.length > 0 || a.rawResults)
+          .filter(a => a.interpretedResults.length > 0 || (a.rawResults?.resultSet.rows && a.rawResults.resultSet.rows.length > 0))
           .filter(a => a.nwo.toLowerCase().includes(filterValue.toLowerCase()))
           .sort(sorter(sort))
           .map(r =>


### PR DESCRIPTION
Currently, when running a query which produces raw results, we will show all repositories, even if they do not have any results. This change will ensure that we are only showing repositories which have results. This matches the behavior for queries which produce interpreted results.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
