### PR TITLE
Open variant analysis view after submission

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -909,7 +909,15 @@ async function activateWithInstalledDistribution(
 
   ctx.subscriptions.push(
     commandRunner('codeQL.mockVariantAnalysisView', async () => {
-      const variantAnalysisView = new VariantAnalysisView(ctx);
+      const variantAnalysisView = new VariantAnalysisView(ctx, 1);
+      variantAnalysisView.openView();
+    })
+  );
+
+  // The "openVariantAnalysisView" command is internal-only.
+  ctx.subscriptions.push(
+    commandRunner('codeQL.openVariantAnalysisView', async (variantAnalysisId: number) => {
+      const variantAnalysisView = new VariantAnalysisView(ctx, variantAnalysisId);
       variantAnalysisView.openView();
     })
   );

--- a/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
@@ -1,4 +1,4 @@
-import { CancellationToken, Uri, window } from 'vscode';
+import { CancellationToken, commands, Uri, window } from 'vscode';
 import * as path from 'path';
 import * as yaml from 'js-yaml';
 import * as fs from 'fs-extra';
@@ -12,7 +12,7 @@ import {
   showAndLogInformationMessage,
   tryGetQueryMetadata,
   pluralize,
-  tmpDir
+  tmpDir,
 } from '../helpers';
 import { Credentials } from '../authentication';
 import * as cli from '../cli';
@@ -286,9 +286,11 @@ export async function runRemoteQuery(
         status: VariantAnalysisStatus.InProgress,
       };
 
-      // TODO: Remove once we have a proper notification
-      void showAndLogInformationMessage('Variant analysis submitted for processing');
       void logger.log(`Variant analysis:\n${JSON.stringify(variantAnalysis, null, 2)}`);
+
+      void showAndLogInformationMessage(`Variant analysis ${variantAnalysis.query.name} submitted for processing`);
+
+      void commands.executeCommand('codeQL.openVariantAnalysisView', variantAnalysis.id);
 
       return { variantAnalysis };
 

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-view.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-view.ts
@@ -1,9 +1,16 @@
-import { ViewColumn } from 'vscode';
+import { ExtensionContext, ViewColumn } from 'vscode';
 import { AbstractWebview, WebviewPanelConfig } from '../abstract-webview';
 import { WebviewMessage } from '../interface-utils';
 import { logger } from '../logging';
 
 export class VariantAnalysisView extends AbstractWebview<WebviewMessage, WebviewMessage> {
+  public constructor(
+    ctx: ExtensionContext,
+    private readonly variantAnalysisId: number,
+  ) {
+    super(ctx);
+  }
+
   public openView() {
     this.getPanel().reveal(undefined, true);
   }
@@ -11,7 +18,7 @@ export class VariantAnalysisView extends AbstractWebview<WebviewMessage, Webview
   protected getPanelConfig(): WebviewPanelConfig {
     return {
       viewId: 'variantAnalysisView',
-      title: 'CodeQL Query Results',
+      title: `CodeQL Query Results for ${this.variantAnalysisId}`,
       viewColumn: ViewColumn.Active,
       preserveFocus: true,
       view: 'variant-analysis'


### PR DESCRIPTION
This will open the variant analysis view after the variant analysis has been submitted. It will also show a notification that the analysis has been submitted, which includes the query name.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
