### PR TITLE
Ensure results view is opened in column beside 

### DIFF
--- a/extensions/ql-vscode/src/abstract-webview.ts
+++ b/extensions/ql-vscode/src/abstract-webview.ts
@@ -46,7 +46,7 @@ export abstract class AbstractWebview<ToMessage extends WebviewMessage, FromMess
       this.panel = Window.createWebviewPanel(
         config.viewId,
         config.title,
-        { viewColumn: ViewColumn.Active, preserveFocus: true },
+        { viewColumn: config.viewColumn, preserveFocus: config.preserveFocus },
         {
           enableScripts: true,
           enableFindWidget: true,

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -551,7 +551,7 @@ async function activateWithInstalledDistribution(
           item,
         );
         qhm.completeQuery(item, completedQueryInfo);
-        await showResultsForCompletedQuery(item as CompletedLocalQueryInfo, WebviewReveal.NotForced);
+        await showResultsForCompletedQuery(item as CompletedLocalQueryInfo, WebviewReveal.Forced);
         // Note we must update the query history view after showing results as the
         // display and sorting might depend on the number of results
       } catch (e) {


### PR DESCRIPTION
The results view will always open next to the current editor.

This restores previous behaviour of the results view. Question: Do we want our other views to have the same behaviour? 

Previously, our users specifically asked for the results view to open in a way that would not block the currently active editor.

Fixes https://github.com/github/vscode-codeql/issues/1556

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
