### PR TITLE
Download variant analysis results

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -105,8 +105,8 @@ import { createInitialQueryInfo } from './run-queries-shared';
 import { LegacyQueryRunner } from './legacy-query-server/legacyRunner';
 import { QueryRunner } from './queryRunner';
 import { VariantAnalysisView } from './remote-queries/variant-analysis-view';
-import { VariantAnalysisMonitor } from './remote-queries/variant-analysis-monitor';
 import { VariantAnalysis } from './remote-queries/shared/variant-analysis';
+import { VariantAnalysisManager } from './remote-queries/variant-analysis-manager';
 
 /**
  * extension.ts
@@ -896,13 +896,13 @@ async function activateWithInstalledDistribution(
     })
   );
 
-  const variantAnalysisMonitor = new VariantAnalysisMonitor(ctx, logger);
+  const variantAnalysisManager = new VariantAnalysisManager(ctx, logger);
   ctx.subscriptions.push(
     commandRunner('codeQL.monitorVariantAnalysis', async (
       variantAnalysis: VariantAnalysis,
       token: CancellationToken
     ) => {
-      await variantAnalysisMonitor.monitorVariantAnalysis(variantAnalysis, token);
+      await variantAnalysisManager.monitorVariantAnalysis(variantAnalysis, token);
     })
   );
 

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -106,6 +106,10 @@ import { LegacyQueryRunner } from './legacy-query-server/legacyRunner';
 import { QueryRunner } from './queryRunner';
 import { VariantAnalysisView } from './remote-queries/variant-analysis-view';
 import { VariantAnalysis } from './remote-queries/shared/variant-analysis';
+import {
+  VariantAnalysis as VariantAnalysisApiResponse,
+  VariantAnalysisScannedRepository as ApiVariantAnalysisScannedRepository
+} from './remote-queries/gh-api/variant-analysis';
 import { VariantAnalysisManager } from './remote-queries/variant-analysis-manager';
 
 /**
@@ -903,6 +907,16 @@ async function activateWithInstalledDistribution(
       token: CancellationToken
     ) => {
       await variantAnalysisManager.monitorVariantAnalysis(variantAnalysis, token);
+    })
+  );
+
+  ctx.subscriptions.push(
+    commandRunner('codeQL.autoDownloadVariantAnalysisResult', async (
+      scannedRepo: ApiVariantAnalysisScannedRepository,
+      variantAnalysisSummary: VariantAnalysisApiResponse,
+      token: CancellationToken
+    ) => {
+      await variantAnalysisManager.autoDownloadVariantAnalysisResult(scannedRepo, variantAnalysisSummary, token);
     })
   );
 

--- a/extensions/ql-vscode/src/remote-queries/gh-api/gh-api-client.ts
+++ b/extensions/ql-vscode/src/remote-queries/gh-api/gh-api-client.ts
@@ -74,6 +74,19 @@ export async function getVariantAnalysisRepo(
   return response.data;
 }
 
+export async function getVariantAnalysisRepoResult(
+  credentials: Credentials,
+  downloadUrl: string,
+): Promise<unknown> {
+  const octokit = await credentials.getOctokit();
+
+  const response: OctokitResponse<VariantAnalysisRepoTask> = await octokit.request(
+    `GET ${downloadUrl}`
+  );
+
+  return response.data;
+}
+
 export async function getRepositoryFromNwo(
   credentials: Credentials,
   owner: string,

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
@@ -1,8 +1,18 @@
-import { CancellationToken, commands, ExtensionContext } from 'vscode';
+import * as ghApiClient from './gh-api/gh-api-client';
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import { CancellationToken, ExtensionContext } from 'vscode';
 import { DisposableObject } from '../pure/disposable-object';
 import { Logger } from '../logging';
+import { Credentials } from '../authentication';
 import { VariantAnalysisMonitor } from './variant-analysis-monitor';
+import {
+  VariantAnalysis as VariantAnalysisApiResponse,
+  VariantAnalysisRepoTask,
+  VariantAnalysisScannedRepository as ApiVariantAnalysisScannedRepository
+} from './gh-api/variant-analysis';
 import { VariantAnalysis } from './shared/variant-analysis';
+import { getErrorMessage } from '../pure/helpers-pure';
 
 export class VariantAnalysisManager extends DisposableObject {
   private readonly variantAnalysisMonitor: VariantAnalysisMonitor;
@@ -20,5 +30,52 @@ export class VariantAnalysisManager extends DisposableObject {
     cancellationToken: CancellationToken
   ): Promise<void> {
     await this.variantAnalysisMonitor.monitorVariantAnalysis(variantAnalysis, cancellationToken);
+  }
+
+  public async autoDownloadVariantAnalysisResult(
+    scannedRepo: ApiVariantAnalysisScannedRepository,
+    variantAnalysisSummary: VariantAnalysisApiResponse,
+    cancellationToken: CancellationToken
+  ): Promise<void> {
+
+    const credentials = await Credentials.initialize(this.ctx);
+    if (!credentials) { throw Error('Error authenticating with GitHub'); }
+
+    if (cancellationToken && cancellationToken.isCancellationRequested) {
+      return;
+    }
+
+    let repoTask: VariantAnalysisRepoTask;
+    try {
+      repoTask = await ghApiClient.getVariantAnalysisRepo(
+        credentials,
+        variantAnalysisSummary.controller_repo.id,
+        variantAnalysisSummary.id,
+        scannedRepo.repository.id
+      );
+    }
+    catch (e) { throw new Error(`Could not download the results for variant analysis with id: ${variantAnalysisSummary.id}. Error: ${getErrorMessage(e)}`); }
+
+    if (repoTask.artifact_url) {
+      const resultDirectory = path.join(
+        this.ctx.globalStorageUri.fsPath,
+        'variant-analyses',
+        `${variantAnalysisSummary.id}`,
+        scannedRepo.repository.full_name
+      );
+
+      const storagePath = path.join(
+        resultDirectory,
+        scannedRepo.repository.full_name
+      );
+
+      const result = await ghApiClient.getVariantAnalysisRepoResult(
+        credentials,
+        repoTask.artifact_url
+      );
+
+      fs.mkdirSync(resultDirectory, { recursive: true });
+      await fs.writeFile(storagePath, JSON.stringify(result, null, 2), 'utf8');
+    }
   }
 }

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
@@ -1,0 +1,24 @@
+import { CancellationToken, commands, ExtensionContext } from 'vscode';
+import { DisposableObject } from '../pure/disposable-object';
+import { Logger } from '../logging';
+import { VariantAnalysisMonitor } from './variant-analysis-monitor';
+import { VariantAnalysis } from './shared/variant-analysis';
+
+export class VariantAnalysisManager extends DisposableObject {
+  private readonly variantAnalysisMonitor: VariantAnalysisMonitor;
+
+  constructor(
+    private readonly ctx: ExtensionContext,
+    logger: Logger,
+  ) {
+    super();
+    this.variantAnalysisMonitor = new VariantAnalysisMonitor(ctx, logger);
+  }
+
+  public async monitorVariantAnalysis(
+    variantAnalysis: VariantAnalysis,
+    cancellationToken: CancellationToken
+  ): Promise<void> {
+    await this.variantAnalysisMonitor.monitorVariantAnalysis(variantAnalysis, cancellationToken);
+  }
+}

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-monitor.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-monitor.ts
@@ -1,4 +1,4 @@
-import { ExtensionContext, CancellationToken } from 'vscode';
+import { ExtensionContext, CancellationToken, commands } from 'vscode';
 import { Credentials } from '../authentication';
 import { Logger } from '../logging';
 import * as ghApiClient from './gh-api/gh-api-client';
@@ -64,6 +64,7 @@ export class VariantAnalysisMonitor {
       if (variantAnalysisSummary.scanned_repositories) {
         variantAnalysisSummary.scanned_repositories.forEach(scannedRepo => {
           if (!scannedReposDownloaded.includes(scannedRepo.repository.id) && scannedRepo.analysis_status === 'succeeded') {
+            void commands.executeCommand('codeQL.autoDownloadVariantAnalysisResult', scannedRepo);
             scannedReposDownloaded.push(scannedRepo.repository.id);
           }
         });

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-monitor.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-monitor.ts
@@ -1,4 +1,4 @@
-import * as vscode from 'vscode';
+import { ExtensionContext, CancellationToken } from 'vscode';
 import { Credentials } from '../authentication';
 import { Logger } from '../logging';
 import * as ghApiClient from './gh-api/gh-api-client';
@@ -17,14 +17,14 @@ export class VariantAnalysisMonitor {
   public static sleepTime = 5000;
 
   constructor(
-    private readonly extensionContext: vscode.ExtensionContext,
+    private readonly extensionContext: ExtensionContext,
     private readonly logger: Logger
   ) {
   }
 
   public async monitorVariantAnalysis(
     variantAnalysis: VariantAnalysis,
-    cancellationToken: vscode.CancellationToken
+    cancellationToken: CancellationToken
   ): Promise<VariantAnalysisMonitorResult> {
 
     const credentials = await Credentials.initialize(this.extensionContext);

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-monitor.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-monitor.ts
@@ -64,7 +64,7 @@ export class VariantAnalysisMonitor {
       if (variantAnalysisSummary.scanned_repositories) {
         variantAnalysisSummary.scanned_repositories.forEach(scannedRepo => {
           if (!scannedReposDownloaded.includes(scannedRepo.repository.id) && scannedRepo.analysis_status === 'succeeded') {
-            void commands.executeCommand('codeQL.autoDownloadVariantAnalysisResult', scannedRepo);
+            void commands.executeCommand('codeQL.autoDownloadVariantAnalysisResult', scannedRepo, variantAnalysisSummary);
             scannedReposDownloaded.push(scannedRepo.repository.id);
           }
         });

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-manager.test.ts
@@ -1,0 +1,156 @@
+import * as sinon from 'sinon';
+import { expect } from 'chai';
+import { CancellationToken, extensions } from 'vscode';
+import { CodeQLExtensionInterface } from '../../../extension';
+import { logger } from '../../../logging';
+import * as config from '../../../config';
+import * as ghApiClient from '../../../remote-queries/gh-api/gh-api-client';
+import { Credentials } from '../../../authentication';
+import * as fs from 'fs-extra';
+
+import { VariantAnalysisManager } from '../../../remote-queries/variant-analysis-manager';
+import {
+  VariantAnalysis as VariantAnalysisApiResponse,
+  VariantAnalysisScannedRepository as ApiVariantAnalysisScannedRepository
+} from '../../../remote-queries/gh-api/variant-analysis';
+import { createMockApiResponse } from '../../factories/remote-queries/gh-api/variant-analysis-api-response';
+import { createMockScannedRepos } from '../../factories/remote-queries/gh-api/scanned-repositories';
+import { createMockVariantAnalysisRepoTask } from '../../factories/remote-queries/gh-api/variant-analysis-repo-task';
+
+describe('Variant Analysis Manager', async function() {
+  let sandbox: sinon.SinonSandbox;
+  let cancellationToken: CancellationToken;
+  let variantAnalysisManager: VariantAnalysisManager;
+  let variantAnalysis: VariantAnalysisApiResponse;
+  let scannedRepos: ApiVariantAnalysisScannedRepository[];
+  let getVariantAnalysisRepoStub: sinon.SinonStub;
+  let getVariantAnalysisRepoResultStub: sinon.SinonStub;
+
+  beforeEach(async () => {
+    sandbox = sinon.createSandbox();
+    sandbox.stub(logger, 'log');
+    sandbox.stub(config, 'isVariantAnalysisLiveResultsEnabled').returns(false);
+    sandbox.stub(fs, 'mkdirSync');
+    sandbox.stub(fs, 'writeFile');
+
+    cancellationToken = {
+      isCancellationRequested: false
+    } as unknown as CancellationToken;
+
+    scannedRepos = createMockScannedRepos();
+    variantAnalysis = createMockApiResponse('in_progress', scannedRepos);
+
+    try {
+      const extension = await extensions.getExtension<CodeQLExtensionInterface | Record<string, never>>('GitHub.vscode-codeql')!.activate();
+      variantAnalysisManager = new VariantAnalysisManager(extension.ctx, logger);
+    } catch (e) {
+      fail(e as Error);
+    }
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  describe('when credentials are invalid', async () => {
+    beforeEach(async () => { sandbox.stub(Credentials, 'initialize').resolves(undefined); });
+
+    it('should return early if credentials are wrong', async () => {
+      try {
+        await variantAnalysisManager.autoDownloadVariantAnalysisResult(
+          scannedRepos[0],
+          variantAnalysis,
+          cancellationToken
+        );
+      } catch (error: any) {
+        expect(error.message).to.equal('Error authenticating with GitHub');
+      }
+    });
+  });
+
+  describe('when credentials are valid', async () => {
+    let getOctokitStub: sinon.SinonStub;
+
+    beforeEach(async () => {
+      const mockCredentials = {
+        getOctokit: () => Promise.resolve({
+          request: getOctokitStub
+        })
+      } as unknown as Credentials;
+      sandbox.stub(Credentials, 'initialize').resolves(mockCredentials);
+    });
+
+    describe('when the artifact_url is missing', async () => {
+      beforeEach(async () => {
+        const dummyRepoTask = createMockVariantAnalysisRepoTask();
+        delete dummyRepoTask.artifact_url;
+        getVariantAnalysisRepoStub = sandbox.stub(ghApiClient, 'getVariantAnalysisRepo').resolves(dummyRepoTask);
+
+        const dummyResult = 'this-is-a-repo-result';
+        getVariantAnalysisRepoResultStub = sandbox.stub(ghApiClient, 'getVariantAnalysisRepoResult').resolves(dummyResult);
+      });
+
+      it('should not try to download the result', async () => {
+        await variantAnalysisManager.autoDownloadVariantAnalysisResult(
+          scannedRepos[0],
+          variantAnalysis,
+          cancellationToken
+        );
+
+        expect(getVariantAnalysisRepoResultStub.notCalled).to.be.true;
+      });
+    });
+
+    describe('when the artifact_url is present', async () => {
+      beforeEach(async () => {
+        const dummyRepoTask = createMockVariantAnalysisRepoTask();
+        getVariantAnalysisRepoStub = sandbox.stub(ghApiClient, 'getVariantAnalysisRepo').resolves(dummyRepoTask);
+
+        const dummyResult = 'this-is-a-repo-result';
+        getVariantAnalysisRepoResultStub = sandbox.stub(ghApiClient, 'getVariantAnalysisRepoResult').resolves(dummyResult);
+      });
+
+      it('should return early if variant analysis is cancelled', async () => {
+        cancellationToken.isCancellationRequested = true;
+
+        await variantAnalysisManager.autoDownloadVariantAnalysisResult(
+          scannedRepos[0],
+          variantAnalysis,
+          cancellationToken
+        );
+
+        expect(getVariantAnalysisRepoStub.notCalled).to.be.true;
+      });
+
+      it('should fetch a repo task', async () => {
+        await variantAnalysisManager.autoDownloadVariantAnalysisResult(
+          scannedRepos[0],
+          variantAnalysis,
+          cancellationToken
+        );
+
+        expect(getVariantAnalysisRepoStub.calledOnce).to.be.true;
+      });
+
+      it('should fetch a repo result', async () => {
+        await variantAnalysisManager.autoDownloadVariantAnalysisResult(
+          scannedRepos[0],
+          variantAnalysis,
+          cancellationToken
+        );
+
+        expect(getVariantAnalysisRepoResultStub.calledOnce).to.be.true;
+      });
+
+      it('should save the result to disk', async () => {
+        await variantAnalysisManager.autoDownloadVariantAnalysisResult(
+          scannedRepos[0],
+          variantAnalysis,
+          cancellationToken
+        );
+
+        expect(getVariantAnalysisRepoResultStub.calledOnce).to.be.true;
+      });
+    });
+  });
+});

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-monitor.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-monitor.test.ts
@@ -95,8 +95,8 @@ describe('Variant Analysis Monitor', async function() {
         expect(mockGetVariantAnalysis.calledOnce).to.be.true;
         expect(result.status).to.eql('Failed');
         expect(result.error).to.eql(`Variant Analysis has failed: ${mockFailedApiResponse.failure_reason}`);
-        expect(result?.variantAnalysis?.status).to.equal(VariantAnalysisStatus.Failed);
-        expect(result?.variantAnalysis?.failureReason).to.equal(processFailureReason(mockFailedApiResponse.failure_reason as VariantAnalysisFailureReason));
+        expect(result.variantAnalysis?.status).to.equal(VariantAnalysisStatus.Failed);
+        expect(result.variantAnalysis?.failureReason).to.equal(processFailureReason(mockFailedApiResponse.failure_reason as VariantAnalysisFailureReason));
       });
     });
 

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-processor.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-processor.test.ts
@@ -25,8 +25,8 @@ describe('Variant Analysis processor', function() {
     const { access_mismatch_repos, no_codeql_db_repos, not_found_repo_nwos, over_limit_repos } = skippedRepos;
 
     expect(result).to.eql({
-      'id': 123,
-      'controllerRepoId': 456,
+      'id': mockApiResponse.id,
+      'controllerRepoId': mockApiResponse.controller_repo.id,
       'query': {
         'filePath': 'query-file-path',
         'language': VariantAnalysisQueryLanguage.Javascript,
@@ -36,7 +36,7 @@ describe('Variant Analysis processor', function() {
         'repositories': ['1', '2', '3'],
       },
       'status': 'succeeded',
-      'actionsWorkflowRunId': 456,
+      'actionsWorkflowRunId': mockApiResponse.actions_workflow_run_id,
       'scannedRepos': [
         transformScannedRepo(VariantAnalysisRepoStatus.Succeeded, scannedRepos[0]),
         transformScannedRepo(VariantAnalysisRepoStatus.Pending, scannedRepos[1]),

--- a/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/gh-api/variant-analysis-api-response.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/gh-api/variant-analysis-api-response.ts
@@ -1,3 +1,4 @@
+import { faker } from '@faker-js/faker';
 import {
   VariantAnalysis as VariantAnalysisApiResponse,
   VariantAnalysisScannedRepository,
@@ -15,19 +16,20 @@ export function createMockApiResponse(
   scannedRepos: VariantAnalysisScannedRepository[] = createMockScannedRepos(),
   skippedRepos: VariantAnalysisSkippedRepositories = createMockSkippedRepos()
 ): VariantAnalysisApiResponse {
+
   const variantAnalysis: VariantAnalysisApiResponse = {
-    id: 123,
+    id: faker.datatype.number(),
     controller_repo: {
-      id: 456,
+      id: faker.datatype.number(),
       name: 'pickles',
       full_name: 'github/pickles',
       private: false,
     },
-    actor_id: 123,
+    actor_id: faker.datatype.number(),
     query_language: VariantAnalysisQueryLanguage.Javascript,
     query_pack_url: 'https://example.com/foo',
     status: status,
-    actions_workflow_run_id: 456,
+    actions_workflow_run_id: faker.datatype.number(),
     scanned_repositories: scannedRepos,
     skipped_repositories: skippedRepos
   };

--- a/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/gh-api/variant-analysis-repo-task.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/gh-api/variant-analysis-repo-task.ts
@@ -1,0 +1,19 @@
+import { faker } from '@faker-js/faker';
+import { VariantAnalysisRepoTask } from '../../../../remote-queries/gh-api/variant-analysis';
+import { VariantAnalysisRepoStatus } from '../../../../remote-queries/shared/variant-analysis';
+
+export function createMockVariantAnalysisRepoTask(): VariantAnalysisRepoTask {
+  return {
+    repository: {
+      id: faker.datatype.number(),
+      name: faker.random.word(),
+      full_name: 'github/' + faker.random.word(),
+      private: false,
+    },
+    analysis_status: VariantAnalysisRepoStatus.Succeeded,
+    result_count: faker.datatype.number(),
+    artifact_size_in_bytes: faker.datatype.number(),
+    artifact_url: 'https://www.pickles.com'
+  };
+}
+

--- a/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/shared/scanned-repositories.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/shared/scanned-repositories.ts
@@ -1,0 +1,33 @@
+import { faker } from '@faker-js/faker';
+import {
+  VariantAnalysisRepoStatus,
+  VariantAnalysisScannedRepository
+} from '../../../../remote-queries/shared/variant-analysis';
+
+export function createMockScannedRepo(
+  name: string,
+  isPrivate: boolean,
+  analysisStatus: VariantAnalysisRepoStatus,
+): VariantAnalysisScannedRepository {
+  return {
+    repository: {
+      id: faker.datatype.number(),
+      fullName: 'github/' + name,
+      private: isPrivate,
+    },
+    analysisStatus: analysisStatus,
+    resultCount: faker.datatype.number(),
+    artifactSizeInBytes: faker.datatype.number()
+  };
+}
+
+export function createMockScannedRepos(
+  statuses: VariantAnalysisRepoStatus[] = [
+    VariantAnalysisRepoStatus.Succeeded,
+    VariantAnalysisRepoStatus.Pending,
+    VariantAnalysisRepoStatus.InProgress,
+  ]
+): VariantAnalysisScannedRepository[] {
+  return statuses.map(status => createMockScannedRepo(`mona-${status}`, false, status));
+}
+

--- a/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/shared/skipped-repositories.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/shared/skipped-repositories.ts
@@ -1,0 +1,30 @@
+import { faker } from '@faker-js/faker';
+import {
+  VariantAnalysisSkippedRepositories,
+  VariantAnalysisSkippedRepositoryGroup
+} from '../../../../remote-queries/shared/variant-analysis';
+
+export function createMockSkippedRepos(): VariantAnalysisSkippedRepositories {
+  return {
+    accessMismatchRepos: createMockSkippedRepoGroup(),
+    noCodeqlDbRepos: createMockSkippedRepoGroup(),
+    notFoundRepos: createMockSkippedRepoGroup(),
+    overLimitRepos: createMockSkippedRepoGroup()
+  };
+}
+
+export function createMockSkippedRepoGroup(): VariantAnalysisSkippedRepositoryGroup {
+  return {
+    repositoryCount: 2,
+    repositories: [
+      {
+        id: faker.datatype.number(),
+        fullName: 'github/' + faker.random.word(),
+      },
+      {
+        id: faker.datatype.number(),
+        fullName: 'github/' + faker.random.word(),
+      }
+    ]
+  };
+}

--- a/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/shared/skipped-repositories.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/shared/skipped-repositories.ts
@@ -8,7 +8,7 @@ export function createMockSkippedRepos(): VariantAnalysisSkippedRepositories {
   return {
     accessMismatchRepos: createMockSkippedRepoGroup(),
     noCodeqlDbRepos: createMockSkippedRepoGroup(),
-    notFoundRepos: createMockSkippedRepoGroup(),
+    notFoundRepos: createMockNotFoundRepoGroup(),
     overLimitRepos: createMockSkippedRepoGroup()
   };
 }
@@ -23,6 +23,20 @@ export function createMockSkippedRepoGroup(): VariantAnalysisSkippedRepositoryGr
       },
       {
         id: faker.datatype.number(),
+        fullName: 'github/' + faker.random.word(),
+      }
+    ]
+  };
+}
+
+export function createMockNotFoundRepoGroup(): VariantAnalysisSkippedRepositoryGroup {
+  return {
+    repositoryCount: 2,
+    repositories: [
+      {
+        fullName: 'github/' + faker.random.word(),
+      },
+      {
         fullName: 'github/' + faker.random.word(),
       }
     ]

--- a/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/shared/variant-analysis-submission.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/shared/variant-analysis-submission.ts
@@ -1,9 +1,10 @@
+import { faker } from '@faker-js/faker';
 import { VariantAnalysisQueryLanguage, VariantAnalysisSubmission } from '../../../../remote-queries/shared/variant-analysis';
 
 export function createMockSubmission(): VariantAnalysisSubmission {
   return {
-    startTime: 1234,
-    controllerRepoId: 5678,
+    startTime: faker.datatype.number(),
+    controllerRepoId: faker.datatype.number(),
     actionRepoRef: 'repo-ref',
     query: {
       name: 'query-name',

--- a/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/shared/variant-analysis.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/shared/variant-analysis.ts
@@ -1,0 +1,34 @@
+import {
+  VariantAnalysis,
+  VariantAnalysisQueryLanguage,
+  VariantAnalysisScannedRepository,
+  VariantAnalysisSkippedRepositories,
+  VariantAnalysisStatus,
+} from '../../../../remote-queries/shared/variant-analysis';
+import { createMockScannedRepos } from './scanned-repositories';
+import { createMockSkippedRepos } from './skipped-repositories';
+
+export function createMockVariantAnalysis(
+  status: VariantAnalysisStatus = VariantAnalysisStatus.InProgress,
+  scannedRepos: VariantAnalysisScannedRepository[] = createMockScannedRepos(),
+  skippedRepos: VariantAnalysisSkippedRepositories = createMockSkippedRepos()
+): VariantAnalysis {
+  const variantAnalysis: VariantAnalysis = {
+    id: 123,
+    controllerRepoId: 456,
+    query: {
+      name: 'a-query-name',
+      filePath: 'a-query-file-path',
+      language: VariantAnalysisQueryLanguage.Javascript
+    },
+    databases: {
+      repositories: ['1', '2', '3'],
+    },
+    status: status,
+    actionsWorkflowRunId: 789,
+    scannedRepos: scannedRepos,
+    skippedRepos: skippedRepos
+  };
+
+  return variantAnalysis;
+}

--- a/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/shared/variant-analysis.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/shared/variant-analysis.ts
@@ -1,3 +1,4 @@
+import { faker } from '@faker-js/faker';
 import {
   VariantAnalysis,
   VariantAnalysisQueryLanguage,
@@ -14,8 +15,8 @@ export function createMockVariantAnalysis(
   skippedRepos: VariantAnalysisSkippedRepositories = createMockSkippedRepos()
 ): VariantAnalysis {
   const variantAnalysis: VariantAnalysis = {
-    id: 123,
-    controllerRepoId: 456,
+    id: faker.datatype.number(),
+    controllerRepoId: faker.datatype.number(),
     query: {
       name: 'a-query-name',
       filePath: 'a-query-file-path',
@@ -25,7 +26,7 @@ export function createMockVariantAnalysis(
       repositories: ['1', '2', '3'],
     },
     status: status,
-    actionsWorkflowRunId: 789,
+    actionsWorkflowRunId: faker.datatype.number(),
     scannedRepos: scannedRepos,
     skippedRepos: skippedRepos
   };


### PR DESCRIPTION
🚨 Please review this PR commit-by-commit.

## What
Follow-up from [this PR](https://github.com/github/vscode-codeql/pull/1545) where we introduced a monitor to check on the status of the variant analysis. 

We'd like to auto-download results from the variant analysis as they become ready. 

## Why
Based on a previous [discussion](https://github.com/github/vscode-codeql/pull/1545#discussion_r982591809) while implementing the variant analysis monitor, we decided that we'd like to trigger separate commands for actually downloading the results rather than performing it in the same process as the monitor.

The reason for this is that it would delay the polling and isn't really connected to what the monitor is supposed to do.

## Future
In a separate PR, we'll also change the monitor and manager in order to emit events to the UI. These will be the various states of a download.


## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
