### PR TITLE
Implement `setVariantAnalysis` message

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -104,7 +104,6 @@ import { LogScannerService } from './log-insights/log-scanner-service';
 import { createInitialQueryInfo } from './run-queries-shared';
 import { LegacyQueryRunner } from './legacy-query-server/legacyRunner';
 import { QueryRunner } from './queryRunner';
-import { VariantAnalysisView } from './remote-queries/variant-analysis-view';
 import { VariantAnalysis } from './remote-queries/shared/variant-analysis';
 import {
   VariantAnalysis as VariantAnalysisApiResponse,
@@ -935,16 +934,14 @@ async function activateWithInstalledDistribution(
 
   ctx.subscriptions.push(
     commandRunner('codeQL.mockVariantAnalysisView', async () => {
-      const variantAnalysisView = new VariantAnalysisView(ctx, 1);
-      variantAnalysisView.openView();
+      await variantAnalysisManager.showView(1);
     })
   );
 
   // The "openVariantAnalysisView" command is internal-only.
   ctx.subscriptions.push(
     commandRunner('codeQL.openVariantAnalysisView', async (variantAnalysisId: number) => {
-      const variantAnalysisView = new VariantAnalysisView(ctx, variantAnalysisId);
-      variantAnalysisView.openView();
+      await variantAnalysisManager.showView(variantAnalysisId);
     })
   );
 

--- a/extensions/ql-vscode/src/pure/interface-types.ts
+++ b/extensions/ql-vscode/src/pure/interface-types.ts
@@ -2,6 +2,7 @@ import * as sarif from 'sarif';
 import { AnalysisResults } from '../remote-queries/shared/analysis-result';
 import { AnalysisSummary, RemoteQueryResult } from '../remote-queries/shared/remote-query-result';
 import { RawResultSet, ResultRow, ResultSetSchema, Column, ResolvableLocationValue } from './bqrs-cli-types';
+import { VariantAnalysis } from '../remote-queries/shared/variant-analysis';
 
 /**
  * This module contains types and code that are shared between
@@ -429,3 +430,14 @@ export interface CopyRepoListMessage {
   t: 'copyRepoList';
   queryId: string;
 }
+
+export interface SetVariantAnalysisMessage {
+  t: 'setVariantAnalysis';
+  variantAnalysis: VariantAnalysis;
+}
+
+export type ToVariantAnalysisMessage =
+  | SetVariantAnalysisMessage;
+
+export type FromVariantAnalysisMessage =
+  | ViewLoadedMsg;

--- a/extensions/ql-vscode/src/remote-queries/gh-api/variant-analysis.ts
+++ b/extensions/ql-vscode/src/remote-queries/gh-api/variant-analysis.ts
@@ -76,8 +76,8 @@ export interface VariantAnalysisRepoTask {
 }
 
 export interface VariantAnalysisSkippedRepositories {
-  access_mismatch_repos: VariantAnalysisSkippedRepositoryGroup,
-  not_found_repo_nwos: VariantAnalysisNotFoundRepositoryGroup,
-  no_codeql_db_repos: VariantAnalysisSkippedRepositoryGroup,
-  over_limit_repos: VariantAnalysisSkippedRepositoryGroup
+  access_mismatch_repos?: VariantAnalysisSkippedRepositoryGroup,
+  not_found_repo_nwos?: VariantAnalysisNotFoundRepositoryGroup,
+  no_codeql_db_repos?: VariantAnalysisSkippedRepositoryGroup,
+  over_limit_repos?: VariantAnalysisSkippedRepositoryGroup
 }

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
@@ -25,7 +25,7 @@ export class VariantAnalysisManager extends DisposableObject implements VariantA
     logger: Logger,
   ) {
     super();
-    this.variantAnalysisMonitor = new VariantAnalysisMonitor(ctx, logger);
+    this.variantAnalysisMonitor = this.push(new VariantAnalysisMonitor(ctx, logger));
   }
 
   public async showView(variantAnalysisId: number): Promise<void> {

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
@@ -32,7 +32,7 @@ export class VariantAnalysisManager extends DisposableObject implements VariantA
   public async showView(variantAnalysisId: number): Promise<void> {
     if (!this.views.has(variantAnalysisId)) {
       // The view will register itself with the manager, so we don't need to do anything here.
-      new VariantAnalysisView(this.ctx, variantAnalysisId, this);
+      this.push(new VariantAnalysisView(this.ctx, variantAnalysisId, this));
     }
 
     const variantAnalysisView = this.views.get(variantAnalysisId)!;

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
@@ -26,6 +26,7 @@ export class VariantAnalysisManager extends DisposableObject implements VariantA
   ) {
     super();
     this.variantAnalysisMonitor = this.push(new VariantAnalysisMonitor(ctx, logger));
+    this.variantAnalysisMonitor.onVariantAnalysisChange(this.onVariantAnalysisUpdated.bind(this));
   }
 
   public async showView(variantAnalysisId: number): Promise<void> {
@@ -49,6 +50,19 @@ export class VariantAnalysisManager extends DisposableObject implements VariantA
 
   public unregisterView(view: VariantAnalysisView): void {
     this.views.delete(view.variantAnalysisId);
+  }
+
+  private async onVariantAnalysisUpdated(variantAnalysis: VariantAnalysis | undefined): Promise<void> {
+    if (!variantAnalysis) {
+      return;
+    }
+
+    const view = this.views.get(variantAnalysis.id);
+    if (!view) {
+      return;
+    }
+
+    await view.updateView(variantAnalysis);
   }
 
   public async monitorVariantAnalysis(

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-monitor.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-monitor.ts
@@ -1,4 +1,4 @@
-import { ExtensionContext, CancellationToken, commands } from 'vscode';
+import { ExtensionContext, CancellationToken, commands, EventEmitter } from 'vscode';
 import { Credentials } from '../authentication';
 import { Logger } from '../logging';
 import * as ghApiClient from './gh-api/gh-api-client';
@@ -9,17 +9,22 @@ import {
 } from './gh-api/variant-analysis';
 import { VariantAnalysisMonitorResult } from './shared/variant-analysis-monitor-result';
 import { processFailureReason, processUpdatedVariantAnalysis } from './variant-analysis-processor';
+import { DisposableObject } from '../pure/disposable-object';
 
-export class VariantAnalysisMonitor {
+export class VariantAnalysisMonitor extends DisposableObject {
   // With a sleep of 5 seconds, the maximum number of attempts takes
   // us to just over 2 days worth of monitoring.
   public static maxAttemptCount = 17280;
   public static sleepTime = 5000;
 
+  private readonly _onVariantAnalysisChange = this.push(new EventEmitter<VariantAnalysis | undefined>());
+  readonly onVariantAnalysisChange = this._onVariantAnalysisChange.event;
+
   constructor(
     private readonly extensionContext: ExtensionContext,
     private readonly logger: Logger
   ) {
+    super();
   }
 
   public async monitorVariantAnalysis(
@@ -60,6 +65,8 @@ export class VariantAnalysisMonitor {
       }
 
       variantAnalysis = processUpdatedVariantAnalysis(variantAnalysis, variantAnalysisSummary);
+
+      this._onVariantAnalysisChange.fire(variantAnalysis);
 
       void this.logger.log('****** Retrieved variant analysis' + JSON.stringify(variantAnalysisSummary));
 

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-monitor.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-monitor.ts
@@ -8,7 +8,7 @@ import {
   VariantAnalysis as VariantAnalysisApiResponse
 } from './gh-api/variant-analysis';
 import { VariantAnalysisMonitorResult } from './shared/variant-analysis-monitor-result';
-import { processFailureReason } from './variant-analysis-processor';
+import { processFailureReason, processUpdatedVariantAnalysis } from './variant-analysis-processor';
 
 export class VariantAnalysisMonitor {
   // With a sleep of 5 seconds, the maximum number of attempts takes
@@ -58,6 +58,8 @@ export class VariantAnalysisMonitor {
           variantAnalysis: variantAnalysis
         };
       }
+
+      variantAnalysis = processUpdatedVariantAnalysis(variantAnalysis, variantAnalysisSummary);
 
       void this.logger.log('****** Retrieved variant analysis' + JSON.stringify(variantAnalysisSummary));
 

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-processor.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-processor.ts
@@ -23,7 +23,20 @@ export function processVariantAnalysis(
   submission: VariantAnalysisSubmission,
   response: ApiVariantAnalysis
 ): VariantAnalysis {
+  return processUpdatedVariantAnalysis({
+    query: {
+      name: submission.query.name,
+      filePath: submission.query.filePath,
+      language: submission.query.language
+    },
+    databases: submission.databases,
+  }, response);
+}
 
+export function processUpdatedVariantAnalysis(
+  previousVariantAnalysis: Pick<VariantAnalysis, 'query' | 'databases'>,
+  response: ApiVariantAnalysis
+): VariantAnalysis {
   let scannedRepos: VariantAnalysisScannedRepository[] = [];
   let skippedRepos: VariantAnalysisSkippedRepositories = {};
 
@@ -39,11 +52,11 @@ export function processVariantAnalysis(
     id: response.id,
     controllerRepoId: response.controller_repo.id,
     query: {
-      name: submission.query.name,
-      filePath: submission.query.filePath,
-      language: submission.query.language
+      name: previousVariantAnalysis.query.name,
+      filePath: previousVariantAnalysis.query.filePath,
+      language: previousVariantAnalysis.query.language
     },
-    databases: submission.databases,
+    databases: previousVariantAnalysis.databases,
     status: processApiStatus(response.status),
     actionsWorkflowRunId: response.actions_workflow_run_id,
     scannedRepos: scannedRepos,

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-processor.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-processor.ts
@@ -100,7 +100,11 @@ function processSkippedRepositories(
   };
 }
 
-function processRepoGroup(repoGroup: ApiVariantAnalysisSkippedRepositoryGroup): VariantAnalysisSkippedRepositoryGroup {
+function processRepoGroup(repoGroup: ApiVariantAnalysisSkippedRepositoryGroup | undefined): VariantAnalysisSkippedRepositoryGroup | undefined {
+  if (!repoGroup) {
+    return undefined;
+  }
+
   const repos = repoGroup.repositories.map(repo => {
     return {
       id: repo.id,
@@ -114,7 +118,11 @@ function processRepoGroup(repoGroup: ApiVariantAnalysisSkippedRepositoryGroup): 
   };
 }
 
-function processNotFoundRepoGroup(repoGroup: ApiVariantAnalysisNotFoundRepositoryGroup): VariantAnalysisSkippedRepositoryGroup {
+function processNotFoundRepoGroup(repoGroup: ApiVariantAnalysisNotFoundRepositoryGroup | undefined): VariantAnalysisSkippedRepositoryGroup | undefined {
+  if (!repoGroup) {
+    return undefined;
+  }
+
   const repo_full_names = repoGroup.repository_full_names.map(nwo => {
     return {
       fullName: nwo

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-view-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-view-manager.ts
@@ -1,0 +1,9 @@
+export interface VariantAnalysisViewInterface {
+  variantAnalysisId: number;
+  openView(): Promise<void>;
+}
+
+export interface VariantAnalysisViewManager<T extends VariantAnalysisViewInterface> {
+  registerView(view: T): void;
+  unregisterView(view: T): void;
+}

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-view.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-view.ts
@@ -2,16 +2,20 @@ import { ExtensionContext, ViewColumn } from 'vscode';
 import { AbstractWebview, WebviewPanelConfig } from '../abstract-webview';
 import { WebviewMessage } from '../interface-utils';
 import { logger } from '../logging';
+import { VariantAnalysisViewInterface, VariantAnalysisViewManager } from './variant-analysis-view-manager';
 
-export class VariantAnalysisView extends AbstractWebview<WebviewMessage, WebviewMessage> {
+export class VariantAnalysisView extends AbstractWebview<WebviewMessage, WebviewMessage> implements VariantAnalysisViewInterface {
   public constructor(
     ctx: ExtensionContext,
-    private readonly variantAnalysisId: number,
+    public readonly variantAnalysisId: number,
+    private readonly manager: VariantAnalysisViewManager<VariantAnalysisView>,
   ) {
     super(ctx);
+
+    manager.registerView(this);
   }
 
-  public openView() {
+  public async openView() {
     this.getPanel().reveal(undefined, true);
   }
 
@@ -26,7 +30,7 @@ export class VariantAnalysisView extends AbstractWebview<WebviewMessage, Webview
   }
 
   protected onPanelDispose(): void {
-    // Nothing to dispose currently.
+    this.manager.unregisterView(this);
   }
 
   protected async onMessage(msg: WebviewMessage): Promise<void> {

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-view.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-view.ts
@@ -3,8 +3,10 @@ import { AbstractWebview, WebviewPanelConfig } from '../abstract-webview';
 import { WebviewMessage } from '../interface-utils';
 import { logger } from '../logging';
 import { VariantAnalysisViewInterface, VariantAnalysisViewManager } from './variant-analysis-view-manager';
+import { VariantAnalysis } from './shared/variant-analysis';
+import { FromVariantAnalysisMessage, ToVariantAnalysisMessage } from '../pure/interface-types';
 
-export class VariantAnalysisView extends AbstractWebview<WebviewMessage, WebviewMessage> implements VariantAnalysisViewInterface {
+export class VariantAnalysisView extends AbstractWebview<ToVariantAnalysisMessage, FromVariantAnalysisMessage> implements VariantAnalysisViewInterface {
   public constructor(
     ctx: ExtensionContext,
     public readonly variantAnalysisId: number,
@@ -17,6 +19,17 @@ export class VariantAnalysisView extends AbstractWebview<WebviewMessage, Webview
 
   public async openView() {
     this.getPanel().reveal(undefined, true);
+  }
+
+  public async updateView(variantAnalysis: VariantAnalysis): Promise<void> {
+    if (!this.isShowingPanel) {
+      return;
+    }
+
+    await this.postMessage({
+      t: 'setVariantAnalysis',
+      variantAnalysis,
+    });
   }
 
   protected getPanelConfig(): WebviewPanelConfig {

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
+import { useEffect, useState } from 'react';
 
+import { ToVariantAnalysisMessage } from '../../pure/interface-types';
 import {
   VariantAnalysis as VariantAnalysisDomainModel,
   VariantAnalysisQueryLanguage,
@@ -222,7 +224,30 @@ function getContainerContents(variantAnalysis: VariantAnalysisDomainModel) {
   );
 }
 
-export function VariantAnalysis(): JSX.Element {
+type Props = {
+  variantAnalysis?: VariantAnalysisDomainModel;
+}
+
+export function VariantAnalysis({
+  variantAnalysis: initialVariantAnalysis = variantAnalysis,
+}: Props): JSX.Element {
+  const [variantAnalysis, setVariantAnalysis] = useState<VariantAnalysisDomainModel>(initialVariantAnalysis);
+
+  useEffect(() => {
+    window.addEventListener('message', (evt: MessageEvent) => {
+      if (evt.origin === window.origin) {
+        const msg: ToVariantAnalysisMessage = evt.data;
+        if (msg.t === 'setVariantAnalysis') {
+          setVariantAnalysis(msg.variantAnalysis);
+        }
+      } else {
+        // sanitize origin
+        const origin = evt.origin.replace(/\n|\r/g, '');
+        console.error(`Invalid event origin ${origin}`);
+      }
+    });
+  });
+
   return (
     <VariantAnalysisContainer>
       {getContainerContents(variantAnalysis)}

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-processor.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-processor.test.ts
@@ -46,25 +46,25 @@ describe('Variant Analysis processor', function() {
         'accessMismatchRepos': {
           'repositories': [
             {
-              'fullName': access_mismatch_repos.repositories[0].full_name,
-              'id': access_mismatch_repos.repositories[0].id
+              'fullName': access_mismatch_repos?.repositories[0].full_name,
+              'id': access_mismatch_repos?.repositories[0].id
             },
             {
-              'fullName': access_mismatch_repos.repositories[1].full_name,
-              'id': access_mismatch_repos.repositories[1].id
+              'fullName': access_mismatch_repos?.repositories[1].full_name,
+              'id': access_mismatch_repos?.repositories[1].id
             }
           ],
-          'repositoryCount': access_mismatch_repos.repository_count
+          'repositoryCount': access_mismatch_repos?.repository_count
         },
         'noCodeqlDbRepos': {
           'repositories': [
             {
-              'fullName': no_codeql_db_repos.repositories[0].full_name,
-              'id': no_codeql_db_repos.repositories[0].id
+              'fullName': no_codeql_db_repos?.repositories[0].full_name,
+              'id': no_codeql_db_repos?.repositories[0].id
             },
             {
-              'fullName': no_codeql_db_repos.repositories[1].full_name,
-              'id': no_codeql_db_repos.repositories[1].id,
+              'fullName': no_codeql_db_repos?.repositories[1].full_name,
+              'id': no_codeql_db_repos?.repositories[1].id,
             }
           ],
           'repositoryCount': 2
@@ -72,26 +72,26 @@ describe('Variant Analysis processor', function() {
         'notFoundRepos': {
           'repositories': [
             {
-              'fullName': not_found_repo_nwos.repository_full_names[0]
+              'fullName': not_found_repo_nwos?.repository_full_names[0]
             },
             {
-              'fullName': not_found_repo_nwos.repository_full_names[1]
+              'fullName': not_found_repo_nwos?.repository_full_names[1]
             }
           ],
-          'repositoryCount': not_found_repo_nwos.repository_count
+          'repositoryCount': not_found_repo_nwos?.repository_count
         },
         'overLimitRepos': {
           'repositories': [
             {
-              'fullName': over_limit_repos.repositories[0].full_name,
-              'id': over_limit_repos.repositories[0].id
+              'fullName': over_limit_repos?.repositories[0].full_name,
+              'id': over_limit_repos?.repositories[0].id
             },
             {
-              'fullName': over_limit_repos.repositories[1].full_name,
-              'id': over_limit_repos.repositories[1].id
+              'fullName': over_limit_repos?.repositories[1].full_name,
+              'id': over_limit_repos?.repositories[1].id
             }
           ],
-          'repositoryCount': over_limit_repos.repository_count
+          'repositoryCount': over_limit_repos?.repository_count
         }
       }
     });


### PR DESCRIPTION
It's probably easiest to review this PR commit-by-commit.

This implements the `setVariantAnalysis` message, both in the extension host and in the webview. This will only send this message when the monitor retrieves a new variant analysis summary, but this should be extended in the future once we have a central place for managing variant analyses. Then, the view could receive the variant analysis message when the view is loaded (i.e. https://github.com/github/vscode-codeql/pull/1550/files#diff-29b0e9f4687addd3c5aaa5c980a9d079de9f0e1e804cd79aacf81f3239fcd2d1R50-R53).

I was able to test that this (merged in with `main` to open the view automatically) will open the view, show the incorrect data until the first poll returns data. When the polling has properly started, it will show the correct data.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
