### PR TITLE
Fix running Jest unit tests from the debugger on Windows

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -59,7 +59,7 @@
       "name": "Launch Unit Tests - React (vscode-codeql)",
       "type": "node",
       "request": "launch",
-      "program": "${workspaceFolder}/extensions/ql-vscode/node_modules/.bin/jest",
+      "program": "${workspaceFolder}/extensions/ql-vscode/node_modules/jest/bin/jest.js",
       "showAsyncStacks": true,
       "cwd": "${workspaceFolder}/extensions/ql-vscode",
       "stopOnEntry": false,


### PR DESCRIPTION
I wasn't able to run the React/Jest unit tests from the Debug view (on Windows):
![image](https://user-images.githubusercontent.com/42641846/193625188-577333c8-4e4f-4c7a-b0cc-9b2803334013.png)

(Running the tests directly from the command line worked fine 🤷🏽 )

We found an existing issue and the potential solution in https://github.com/facebook/jest/issues/3750, so hopefully this will work here too!

## Checklist

N/A

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
