### PR TITLE
Emit `variantAnalysisAdded` event

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -467,15 +467,15 @@ async function activateWithInstalledDistribution(
   const localQueryResultsView = new ResultsView(ctx, dbm, cliServer, queryServerLogger, labelProvider);
   ctx.subscriptions.push(localQueryResultsView);
 
-  void logger.log('Initializing remote queries manager.');
-  const rqm = new RemoteQueriesManager(ctx, cliServer, queryStorageDir, logger);
-  ctx.subscriptions.push(rqm);
-
   void logger.log('Initializing variant analysis manager.');
   const variantAnalysisStorageDir = path.join(ctx.globalStorageUri.fsPath, 'variant-analyses');
   await fs.ensureDir(variantAnalysisStorageDir);
   const variantAnalysisManager = new VariantAnalysisManager(ctx, cliServer, variantAnalysisStorageDir, logger);
   ctx.subscriptions.push(variantAnalysisManager);
+
+  void logger.log('Initializing remote queries manager.');
+  const rqm = new RemoteQueriesManager(ctx, cliServer, queryStorageDir, logger, variantAnalysisManager);
+  ctx.subscriptions.push(rqm);
 
   void logger.log('Initializing query history.');
   const qhm = new QueryHistoryManager(

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
@@ -22,6 +22,7 @@ import { assertNever } from '../pure/helpers-pure';
 import { QueryStatus } from '../query-status';
 import { DisposableObject } from '../pure/disposable-object';
 import { AnalysisResults } from './shared/analysis-result';
+import { VariantAnalysisManager } from './variant-analysis-manager';
 
 const autoDownloadMaxSize = 300 * 1024;
 const autoDownloadMaxCount = 100;
@@ -56,6 +57,7 @@ export class RemoteQueriesManager extends DisposableObject {
 
   private readonly remoteQueriesMonitor: RemoteQueriesMonitor;
   private readonly analysesResultsManager: AnalysesResultsManager;
+  private readonly variantAnalysisManager: VariantAnalysisManager;
   private readonly view: RemoteQueriesView;
 
   constructor(
@@ -63,11 +65,13 @@ export class RemoteQueriesManager extends DisposableObject {
     private readonly cliServer: CodeQLCliServer,
     private readonly storagePath: string,
     logger: Logger,
+    variantAnalysisManager: VariantAnalysisManager,
   ) {
     super();
     this.analysesResultsManager = new AnalysesResultsManager(ctx, cliServer, storagePath, logger);
     this.view = new RemoteQueriesView(ctx, logger, this.analysesResultsManager);
     this.remoteQueriesMonitor = new RemoteQueriesMonitor(ctx, logger);
+    this.variantAnalysisManager = variantAnalysisManager;
 
     this.remoteQueryAddedEventEmitter = this.push(new EventEmitter<NewQueryEvent>());
     this.remoteQueryRemovedEventEmitter = this.push(new EventEmitter<RemovedQueryEvent>());
@@ -123,7 +127,8 @@ export class RemoteQueriesManager extends DisposableObject {
       credentials, uri || window.activeTextEditor?.document.uri,
       false,
       progress,
-      token);
+      token,
+      this.variantAnalysisManager);
 
     if (querySubmission?.query) {
       const query = querySubmission.query;

--- a/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
@@ -29,6 +29,7 @@ import { getRepositorySelection, isValidSelection, RepositorySelection } from '.
 import { parseVariantAnalysisQueryLanguage, VariantAnalysisSubmission } from './shared/variant-analysis';
 import { Repository } from './shared/repository';
 import { processVariantAnalysis } from './variant-analysis-processor';
+import { VariantAnalysisManager } from './variant-analysis-manager';
 
 export interface QlPack {
   name: string;
@@ -182,7 +183,8 @@ export async function runRemoteQuery(
   uri: Uri | undefined,
   dryRun: boolean,
   progress: ProgressCallback,
-  token: CancellationToken
+  token: CancellationToken,
+  variantAnalysisManager: VariantAnalysisManager
 ): Promise<void | RemoteQuerySubmissionResult> {
   if (!(await cliServer.cliConstraints.supportsRemoteQueries())) {
     throw new Error(`Variant analysis is not supported by this version of CodeQL. Please upgrade to v${cli.CliVersionConstraint.CLI_VERSION_REMOTE_QUERIES
@@ -272,6 +274,8 @@ export async function runRemoteQuery(
       );
 
       const processedVariantAnalysis = processVariantAnalysis(variantAnalysisSubmission, variantAnalysisResponse);
+
+      variantAnalysisManager.onVariantAnalysisSubmitted(processedVariantAnalysis);
 
       void logger.log(`Variant analysis:\n${JSON.stringify(processedVariantAnalysis, null, 2)}`);
 

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
@@ -1,5 +1,5 @@
 import * as ghApiClient from './gh-api/gh-api-client';
-import { CancellationToken, ExtensionContext } from 'vscode';
+import { CancellationToken, EventEmitter, ExtensionContext } from 'vscode';
 import { DisposableObject } from '../pure/disposable-object';
 import { Logger } from '../logging';
 import { Credentials } from '../authentication';
@@ -21,6 +21,9 @@ import { VariantAnalysisResultsManager } from './variant-analysis-results-manage
 import { CodeQLCliServer } from '../cli';
 
 export class VariantAnalysisManager extends DisposableObject implements VariantAnalysisViewManager<VariantAnalysisView> {
+  private readonly _onVariantAnalysisAdded = this.push(new EventEmitter<VariantAnalysis | undefined>());
+  readonly onVariantAnalysisAdded = this._onVariantAnalysisAdded.event;
+
   private readonly variantAnalysisMonitor: VariantAnalysisMonitor;
   private readonly variantAnalysisResultsManager: VariantAnalysisResultsManager;
   private readonly views = new Map<number, VariantAnalysisView>();
@@ -71,6 +74,10 @@ export class VariantAnalysisManager extends DisposableObject implements VariantA
     }
 
     await this.getView(variantAnalysis.id)?.updateView(variantAnalysis);
+  }
+
+  public onVariantAnalysisSubmitted(variantAnalysis: VariantAnalysis): void {
+    this._onVariantAnalysisAdded.fire(variantAnalysis);
   }
 
   private async onRepoStateUpdated(variantAnalysisId: number, repoState: VariantAnalysisScannedRepositoryState): Promise<void> {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

When we first submit the variant analysis for processing, we'd like to update
the query history panel.

At the moment we're just adding the setup for triggering the event. In a future
PR we'll consume this event and change the query history panel accordingly.

In order for this second part to happen we will need to introduce a new 
`VariantAnalysisHistoryItem` type which will massage the data we get from the 
API into a type which the QueryHistory panel can consume.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
