### PR TITLE
Implement message for setting download status

### DIFF
--- a/extensions/ql-vscode/src/pure/interface-types.ts
+++ b/extensions/ql-vscode/src/pure/interface-types.ts
@@ -2,7 +2,11 @@ import * as sarif from 'sarif';
 import { AnalysisResults } from '../remote-queries/shared/analysis-result';
 import { AnalysisSummary, RemoteQueryResult } from '../remote-queries/shared/remote-query-result';
 import { RawResultSet, ResultRow, ResultSetSchema, Column, ResolvableLocationValue } from './bqrs-cli-types';
-import { VariantAnalysis, VariantAnalysisScannedRepositoryResult } from '../remote-queries/shared/variant-analysis';
+import {
+  VariantAnalysis,
+  VariantAnalysisScannedRepositoryResult,
+  VariantAnalysisScannedRepositoryState,
+} from '../remote-queries/shared/variant-analysis';
 
 /**
  * This module contains types and code that are shared between
@@ -441,9 +445,15 @@ export interface SetRepoResultsMessage {
   repoResults: VariantAnalysisScannedRepositoryResult[];
 }
 
+export interface SetRepoStatesMessage {
+  t: 'setRepoStates';
+  repoStates: VariantAnalysisScannedRepositoryState[];
+}
+
 export type ToVariantAnalysisMessage =
   | SetVariantAnalysisMessage
-  | SetRepoResultsMessage;
+  | SetRepoResultsMessage
+  | SetRepoStatesMessage;
 
 export type FromVariantAnalysisMessage =
   | ViewLoadedMsg;

--- a/extensions/ql-vscode/src/pure/interface-types.ts
+++ b/extensions/ql-vscode/src/pure/interface-types.ts
@@ -2,7 +2,7 @@ import * as sarif from 'sarif';
 import { AnalysisResults } from '../remote-queries/shared/analysis-result';
 import { AnalysisSummary, RemoteQueryResult } from '../remote-queries/shared/remote-query-result';
 import { RawResultSet, ResultRow, ResultSetSchema, Column, ResolvableLocationValue } from './bqrs-cli-types';
-import { VariantAnalysis } from '../remote-queries/shared/variant-analysis';
+import { VariantAnalysis, VariantAnalysisScannedRepositoryResult } from '../remote-queries/shared/variant-analysis';
 
 /**
  * This module contains types and code that are shared between
@@ -436,8 +436,14 @@ export interface SetVariantAnalysisMessage {
   variantAnalysis: VariantAnalysis;
 }
 
+export interface SetRepoResultsMessage {
+  t: 'setRepoResults';
+  repoResults: VariantAnalysisScannedRepositoryResult[];
+}
+
 export type ToVariantAnalysisMessage =
-  | SetVariantAnalysisMessage;
+  | SetVariantAnalysisMessage
+  | SetRepoResultsMessage;
 
 export type FromVariantAnalysisMessage =
   | ViewLoadedMsg;

--- a/extensions/ql-vscode/src/remote-queries/shared/variant-analysis.ts
+++ b/extensions/ql-vscode/src/remote-queries/shared/variant-analysis.ts
@@ -82,6 +82,18 @@ export interface VariantAnalysisSkippedRepository {
   private?: boolean,
 }
 
+export enum VariantAnalysisScannedRepositoryDownloadStatus {
+  Pending = 'pending',
+  InProgress = 'inProgress',
+  Succeeded = 'succeeded',
+  Failed = 'failed',
+}
+
+export interface VariantAnalysisScannedRepositoryState {
+  repositoryId: number;
+  downloadStatus: VariantAnalysisScannedRepositoryDownloadStatus;
+}
+
 export interface VariantAnalysisScannedRepositoryResult {
   repositoryId: number;
   interpretedResults?: AnalysisAlert[];

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-view.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-view.ts
@@ -3,7 +3,7 @@ import { AbstractWebview, WebviewPanelConfig } from '../abstract-webview';
 import { WebviewMessage } from '../interface-utils';
 import { logger } from '../logging';
 import { VariantAnalysisViewInterface, VariantAnalysisViewManager } from './variant-analysis-view-manager';
-import { VariantAnalysis } from './shared/variant-analysis';
+import { VariantAnalysis, VariantAnalysisScannedRepositoryState } from './shared/variant-analysis';
 import { FromVariantAnalysisMessage, ToVariantAnalysisMessage } from '../pure/interface-types';
 
 export class VariantAnalysisView extends AbstractWebview<ToVariantAnalysisMessage, FromVariantAnalysisMessage> implements VariantAnalysisViewInterface {
@@ -29,6 +29,17 @@ export class VariantAnalysisView extends AbstractWebview<ToVariantAnalysisMessag
     await this.postMessage({
       t: 'setVariantAnalysis',
       variantAnalysis,
+    });
+  }
+
+  public async updateRepoState(repoState: VariantAnalysisScannedRepositoryState): Promise<void> {
+    if (!this.isShowingPanel) {
+      return;
+    }
+
+    await this.postMessage({
+      t: 'setRepoStates',
+      repoStates: [repoState],
     });
   }
 

--- a/extensions/ql-vscode/src/stories/variant-analysis/RepoRow.stories.tsx
+++ b/extensions/ql-vscode/src/stories/variant-analysis/RepoRow.stories.tsx
@@ -3,7 +3,10 @@ import React from 'react';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 
 import { VariantAnalysisContainer } from '../../view/variant-analysis/VariantAnalysisContainer';
-import { VariantAnalysisRepoStatus } from '../../remote-queries/shared/variant-analysis';
+import {
+  VariantAnalysisRepoStatus,
+  VariantAnalysisScannedRepositoryDownloadStatus,
+} from '../../remote-queries/shared/variant-analysis';
 import { AnalysisAlert, AnalysisRawResults } from '../../remote-queries/shared/analysis-result';
 
 import analysesResults from '../remote-queries/data/analysesResultsMessage.json';
@@ -60,6 +63,14 @@ export const Canceled = Template.bind({});
 Canceled.args = {
   ...Pending.args,
   status: VariantAnalysisRepoStatus.Canceled,
+};
+
+export const SucceededDownloading = Template.bind({});
+SucceededDownloading.args = {
+  ...Pending.args,
+  status: VariantAnalysisRepoStatus.Succeeded,
+  resultCount: 198,
+  downloadStatus: VariantAnalysisScannedRepositoryDownloadStatus.InProgress,
 };
 
 export const InterpretedResults = Template.bind({});

--- a/extensions/ql-vscode/src/view/variant-analysis/RepoRow.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/RepoRow.tsx
@@ -76,6 +76,7 @@ export type RepoRowProps = {
 export const RepoRow = ({
   repository,
   status,
+  downloadStatus,
   resultCount,
   interpretedResults,
   rawResults,
@@ -104,6 +105,7 @@ export const RepoRow = ({
           {status === VariantAnalysisRepoStatus.InProgress && <LoadingIcon label="In progress" />}
           {!status && <WarningIcon />}
         </span>
+        {downloadStatus === VariantAnalysisScannedRepositoryDownloadStatus.InProgress && <LoadingIcon label="Downloading" />}
       </TitleContainer>
       {isExpanded && status &&
         <AnalyzedRepoItemContent status={status} interpretedResults={interpretedResults} rawResults={rawResults} />}

--- a/extensions/ql-vscode/src/view/variant-analysis/RepoRow.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/RepoRow.tsx
@@ -2,7 +2,11 @@ import * as React from 'react';
 import { useCallback, useState } from 'react';
 import styled from 'styled-components';
 import { VSCodeBadge, VSCodeCheckbox } from '@vscode/webview-ui-toolkit/react';
-import { isCompletedAnalysisRepoStatus, VariantAnalysisRepoStatus } from '../../remote-queries/shared/variant-analysis';
+import {
+  isCompletedAnalysisRepoStatus,
+  VariantAnalysisRepoStatus,
+  VariantAnalysisScannedRepositoryDownloadStatus
+} from '../../remote-queries/shared/variant-analysis';
 import { formatDecimal } from '../../pure/number';
 import { Codicon, ErrorIcon, LoadingIcon, SuccessIcon, WarningIcon } from '../common';
 import { Repository } from '../../remote-queries/shared/repository';
@@ -62,6 +66,7 @@ export type RepoRowProps = {
   // Only fullName is required
   repository: Partial<Repository> & Pick<Repository, 'fullName'>;
   status?: VariantAnalysisRepoStatus;
+  downloadStatus?: VariantAnalysisScannedRepositoryDownloadStatus;
   resultCount?: number;
 
   interpretedResults?: AnalysisAlert[];

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
@@ -200,7 +200,7 @@ const repositoryResults: VariantAnalysisScannedRepositoryResult[] = [
   }
 ];
 
-function getContainerContents(variantAnalysis: VariantAnalysisDomainModel) {
+function getContainerContents(variantAnalysis: VariantAnalysisDomainModel, repoResults: VariantAnalysisScannedRepositoryResult[]) {
   if (variantAnalysis.actionsWorkflowRunId === undefined) {
     return <VariantAnalysisLoading />;
   }
@@ -218,7 +218,7 @@ function getContainerContents(variantAnalysis: VariantAnalysisDomainModel) {
       />
       <VariantAnalysisOutcomePanels
         variantAnalysis={variantAnalysis}
-        repositoryResults={repositoryResults}
+        repositoryResults={repoResults}
       />
     </>
   );
@@ -226,12 +226,15 @@ function getContainerContents(variantAnalysis: VariantAnalysisDomainModel) {
 
 type Props = {
   variantAnalysis?: VariantAnalysisDomainModel;
+  repoResults?: VariantAnalysisScannedRepositoryResult[];
 }
 
 export function VariantAnalysis({
   variantAnalysis: initialVariantAnalysis = variantAnalysis,
+  repoResults: initialRepoResults = repositoryResults,
 }: Props): JSX.Element {
   const [variantAnalysis, setVariantAnalysis] = useState<VariantAnalysisDomainModel>(initialVariantAnalysis);
+  const [repoResults, setRepoResults] = useState<VariantAnalysisScannedRepositoryResult[]>(initialRepoResults);
 
   useEffect(() => {
     window.addEventListener('message', (evt: MessageEvent) => {
@@ -239,6 +242,11 @@ export function VariantAnalysis({
         const msg: ToVariantAnalysisMessage = evt.data;
         if (msg.t === 'setVariantAnalysis') {
           setVariantAnalysis(msg.variantAnalysis);
+        } else if (msg.t === 'setRepoResults') {
+          setRepoResults(oldRepoResults => {
+            const newRepoIds = msg.repoResults.map(r => r.repositoryId);
+            return [...oldRepoResults.filter(v => !newRepoIds.includes(v.repositoryId)), ...msg.repoResults];
+          });
         }
       } else {
         // sanitize origin
@@ -250,7 +258,7 @@ export function VariantAnalysis({
 
   return (
     <VariantAnalysisContainer>
-      {getContainerContents(variantAnalysis)}
+      {getContainerContents(variantAnalysis, repoResults)}
     </VariantAnalysisContainer>
   );
 }

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
@@ -5,10 +5,9 @@ import { ToVariantAnalysisMessage } from '../../pure/interface-types';
 import {
   VariantAnalysis as VariantAnalysisDomainModel,
   VariantAnalysisQueryLanguage,
-  VariantAnalysisRepoStatus, VariantAnalysisScannedRepositoryResult,
+  VariantAnalysisRepoStatus, VariantAnalysisScannedRepositoryResult, VariantAnalysisScannedRepositoryState,
   VariantAnalysisStatus
 } from '../../remote-queries/shared/variant-analysis';
-import { VariantAnalysisContainer } from './VariantAnalysisContainer';
 import { VariantAnalysisHeader } from './VariantAnalysisHeader';
 import { VariantAnalysisOutcomePanels } from './VariantAnalysisOutcomePanels';
 import { VariantAnalysisLoading } from './VariantAnalysisLoading';
@@ -200,7 +199,46 @@ const repositoryResults: VariantAnalysisScannedRepositoryResult[] = [
   }
 ];
 
-function getContainerContents(variantAnalysis: VariantAnalysisDomainModel, repoResults: VariantAnalysisScannedRepositoryResult[]) {
+type Props = {
+  variantAnalysis?: VariantAnalysisDomainModel;
+  repoStates?: VariantAnalysisScannedRepositoryState[];
+  repoResults?: VariantAnalysisScannedRepositoryResult[];
+}
+
+export function VariantAnalysis({
+  variantAnalysis: initialVariantAnalysis = variantAnalysis,
+  repoStates: initialRepoStates = [],
+  repoResults: initialRepoResults = repositoryResults,
+}: Props): JSX.Element {
+  const [variantAnalysis, setVariantAnalysis] = useState<VariantAnalysisDomainModel>(initialVariantAnalysis);
+  const [repoStates, setRepoStates] = useState<VariantAnalysisScannedRepositoryState[]>(initialRepoStates);
+  const [repoResults, setRepoResults] = useState<VariantAnalysisScannedRepositoryResult[]>(initialRepoResults);
+
+  useEffect(() => {
+    window.addEventListener('message', (evt: MessageEvent) => {
+      if (evt.origin === window.origin) {
+        const msg: ToVariantAnalysisMessage = evt.data;
+        if (msg.t === 'setVariantAnalysis') {
+          setVariantAnalysis(msg.variantAnalysis);
+        } else if (msg.t === 'setRepoResults') {
+          setRepoResults(oldRepoResults => {
+            const newRepoIds = msg.repoResults.map(r => r.repositoryId);
+            return [...oldRepoResults.filter(v => !newRepoIds.includes(v.repositoryId)), ...msg.repoResults];
+          });
+        } else if (msg.t === 'setRepoStates') {
+          setRepoStates(oldRepoStates => {
+            const newRepoIds = msg.repoStates.map(r => r.repositoryId);
+            return [...oldRepoStates.filter(v => !newRepoIds.includes(v.repositoryId)), ...msg.repoStates];
+          });
+        }
+      } else {
+        // sanitize origin
+        const origin = evt.origin.replace(/\n|\r/g, '');
+        console.error(`Invalid event origin ${origin}`);
+      }
+    });
+  });
+
   if (variantAnalysis.actionsWorkflowRunId === undefined) {
     return <VariantAnalysisLoading />;
   }
@@ -218,47 +256,9 @@ function getContainerContents(variantAnalysis: VariantAnalysisDomainModel, repoR
       />
       <VariantAnalysisOutcomePanels
         variantAnalysis={variantAnalysis}
+        repositoryStates={repoStates}
         repositoryResults={repoResults}
       />
     </>
-  );
-}
-
-type Props = {
-  variantAnalysis?: VariantAnalysisDomainModel;
-  repoResults?: VariantAnalysisScannedRepositoryResult[];
-}
-
-export function VariantAnalysis({
-  variantAnalysis: initialVariantAnalysis = variantAnalysis,
-  repoResults: initialRepoResults = repositoryResults,
-}: Props): JSX.Element {
-  const [variantAnalysis, setVariantAnalysis] = useState<VariantAnalysisDomainModel>(initialVariantAnalysis);
-  const [repoResults, setRepoResults] = useState<VariantAnalysisScannedRepositoryResult[]>(initialRepoResults);
-
-  useEffect(() => {
-    window.addEventListener('message', (evt: MessageEvent) => {
-      if (evt.origin === window.origin) {
-        const msg: ToVariantAnalysisMessage = evt.data;
-        if (msg.t === 'setVariantAnalysis') {
-          setVariantAnalysis(msg.variantAnalysis);
-        } else if (msg.t === 'setRepoResults') {
-          setRepoResults(oldRepoResults => {
-            const newRepoIds = msg.repoResults.map(r => r.repositoryId);
-            return [...oldRepoResults.filter(v => !newRepoIds.includes(v.repositoryId)), ...msg.repoResults];
-          });
-        }
-      } else {
-        // sanitize origin
-        const origin = evt.origin.replace(/\n|\r/g, '');
-        console.error(`Invalid event origin ${origin}`);
-      }
-    });
-  });
-
-  return (
-    <VariantAnalysisContainer>
-      {getContainerContents(variantAnalysis, repoResults)}
-    </VariantAnalysisContainer>
   );
 }

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisAnalyzedRepos.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisAnalyzedRepos.tsx
@@ -1,7 +1,11 @@
 import * as React from 'react';
 import styled from 'styled-components';
-import { VariantAnalysis, VariantAnalysisScannedRepositoryResult } from '../../remote-queries/shared/variant-analysis';
 import { RepoRow } from './RepoRow';
+import {
+  VariantAnalysis,
+  VariantAnalysisScannedRepositoryResult,
+  VariantAnalysisScannedRepositoryState
+} from '../../remote-queries/shared/variant-analysis';
 import { useMemo } from 'react';
 
 const Container = styled.div`
@@ -12,13 +16,23 @@ const Container = styled.div`
 
 export type VariantAnalysisAnalyzedReposProps = {
   variantAnalysis: VariantAnalysis;
+  repositoryStates?: VariantAnalysisScannedRepositoryState[];
   repositoryResults?: VariantAnalysisScannedRepositoryResult[];
 }
 
 export const VariantAnalysisAnalyzedRepos = ({
   variantAnalysis,
+  repositoryStates,
   repositoryResults,
 }: VariantAnalysisAnalyzedReposProps) => {
+  const repositoryStateById = useMemo(() => {
+    const map = new Map<number, VariantAnalysisScannedRepositoryState>();
+    repositoryStates?.forEach((repository) => {
+      map.set(repository.repositoryId, repository);
+    });
+    return map;
+  }, [repositoryStates]);
+
   const repositoryResultsById = useMemo(() => {
     const map = new Map<number, VariantAnalysisScannedRepositoryResult>();
     repositoryResults?.forEach((repository) => {
@@ -30,6 +44,7 @@ export const VariantAnalysisAnalyzedRepos = ({
   return (
     <Container>
       {variantAnalysis.scannedRepos?.map(repository => {
+        const state = repositoryStateById.get(repository.repository.id);
         const results = repositoryResultsById.get(repository.repository.id);
 
         return (
@@ -37,6 +52,7 @@ export const VariantAnalysisAnalyzedRepos = ({
             key={repository.repository.id}
             repository={repository.repository}
             status={repository.analysisStatus}
+            downloadStatus={state?.downloadStatus}
             resultCount={repository.resultCount}
             interpretedResults={results?.interpretedResults}
             rawResults={results?.rawResults}

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisOutcomePanels.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisOutcomePanels.tsx
@@ -2,13 +2,18 @@ import * as React from 'react';
 import styled from 'styled-components';
 import { VSCodeBadge, VSCodePanels, VSCodePanelTab, VSCodePanelView } from '@vscode/webview-ui-toolkit/react';
 import { formatDecimal } from '../../pure/number';
-import { VariantAnalysis, VariantAnalysisScannedRepositoryResult } from '../../remote-queries/shared/variant-analysis';
+import {
+  VariantAnalysis,
+  VariantAnalysisScannedRepositoryResult,
+  VariantAnalysisScannedRepositoryState
+} from '../../remote-queries/shared/variant-analysis';
 import { VariantAnalysisAnalyzedRepos } from './VariantAnalysisAnalyzedRepos';
 import { Alert } from '../common';
 import { VariantAnalysisSkippedRepositoriesTab } from './VariantAnalysisSkippedRepositoriesTab';
 
 export type VariantAnalysisOutcomePanelProps = {
   variantAnalysis: VariantAnalysis;
+  repositoryStates?: VariantAnalysisScannedRepositoryState[];
   repositoryResults?: VariantAnalysisScannedRepositoryResult[];
 };
 
@@ -34,6 +39,7 @@ const WarningsContainer = styled.div`
 
 export const VariantAnalysisOutcomePanels = ({
   variantAnalysis,
+  repositoryStates,
   repositoryResults,
 }: VariantAnalysisOutcomePanelProps) => {
   const noCodeqlDbRepos = variantAnalysis.skippedRepos?.noCodeqlDbRepos;
@@ -64,7 +70,11 @@ export const VariantAnalysisOutcomePanels = ({
     return (
       <>
         {warnings}
-        <VariantAnalysisAnalyzedRepos variantAnalysis={variantAnalysis} repositoryResults={repositoryResults} />
+        <VariantAnalysisAnalyzedRepos
+          variantAnalysis={variantAnalysis}
+          repositoryStates={repositoryStates}
+          repositoryResults={repositoryResults}
+        />
       </>
     );
   }
@@ -89,7 +99,13 @@ export const VariantAnalysisOutcomePanels = ({
             <VSCodeBadge appearance="secondary">{formatDecimal(noCodeqlDbRepos.repositoryCount)}</VSCodeBadge>
           </Tab>
         )}
-        <VSCodePanelView><VariantAnalysisAnalyzedRepos variantAnalysis={variantAnalysis} repositoryResults={repositoryResults} /></VSCodePanelView>
+        <VSCodePanelView>
+          <VariantAnalysisAnalyzedRepos
+            variantAnalysis={variantAnalysis}
+            repositoryStates={repositoryStates}
+            repositoryResults={repositoryResults}
+          />
+        </VSCodePanelView>
         {notFoundRepos?.repositoryCount &&
           <VSCodePanelView>
             <VariantAnalysisSkippedRepositoriesTab


### PR DESCRIPTION
This implements a message for setting the download status and adds the code on the receiving side for the `setRepoResults` message.

Since there is no "manager" to keep track of actual download results yet and the results are not yet read, this does not implement sending the actual results to the webview.

It's easiest to review this PR commit-by-commit.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
