### PR TITLE
Add variant analysis results manager

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -457,9 +457,15 @@ async function activateWithInstalledDistribution(
   const localQueryResultsView = new ResultsView(ctx, dbm, cliServer, queryServerLogger, labelProvider);
   ctx.subscriptions.push(localQueryResultsView);
 
-  void logger.log('Initializing variant analysis manager.');
+  void logger.log('Initializing remote queries manager.');
   const rqm = new RemoteQueriesManager(ctx, cliServer, queryStorageDir, logger);
   ctx.subscriptions.push(rqm);
+
+  void logger.log('Initializing variant analysis manager.');
+  const variantAnalysisStorageDir = path.join(ctx.globalStorageUri.fsPath, 'variant-analyses');
+  await fs.ensureDir(variantAnalysisStorageDir);
+  const variantAnalysisManager = new VariantAnalysisManager(ctx, cliServer, variantAnalysisStorageDir, logger);
+  ctx.subscriptions.push(variantAnalysisManager);
 
   void logger.log('Initializing query history.');
   const qhm = new QueryHistoryManager(
@@ -899,7 +905,6 @@ async function activateWithInstalledDistribution(
     })
   );
 
-  const variantAnalysisManager = new VariantAnalysisManager(ctx, logger);
   ctx.subscriptions.push(
     commandRunner('codeQL.monitorVariantAnalysis', async (
       variantAnalysis: VariantAnalysis,

--- a/extensions/ql-vscode/src/remote-queries/shared/variant-analysis.ts
+++ b/extensions/ql-vscode/src/remote-queries/shared/variant-analysis.ts
@@ -95,6 +95,7 @@ export interface VariantAnalysisScannedRepositoryState {
 }
 
 export interface VariantAnalysisScannedRepositoryResult {
+  variantAnalysisId: number;
   repositoryId: number;
   interpretedResults?: AnalysisAlert[];
   rawResults?: AnalysisRawResults;

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-results-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-results-manager.ts
@@ -1,0 +1,178 @@
+import * as fs from 'fs-extra';
+import * as os from 'os';
+import * as path from 'path';
+
+import { Credentials } from '../authentication';
+import { Logger } from '../logging';
+import { AnalysisAlert, AnalysisRawResults } from './shared/analysis-result';
+import { sarifParser } from '../sarif-parser';
+import { extractAnalysisAlerts } from './sarif-processing';
+import { CodeQLCliServer } from '../cli';
+import { extractRawResults } from './bqrs-processing';
+import { VariantAnalysisScannedRepositoryResult } from './shared/variant-analysis';
+import { DisposableObject, DisposeHandler } from '../pure/disposable-object';
+import { VariantAnalysisRepoTask } from './gh-api/variant-analysis';
+import * as ghApiClient from './gh-api/gh-api-client';
+import { EventEmitter } from 'vscode';
+
+type CacheKey = `${number}/${string}`;
+
+const createCacheKey = (variantAnalysisId: number, repoTask: VariantAnalysisRepoTask): CacheKey => `${variantAnalysisId}/${repoTask.repository.full_name}`;
+
+export type ResultDownloadedEvent = {
+  variantAnalysisId: number;
+  repoTask: VariantAnalysisRepoTask;
+}
+
+export class VariantAnalysisResultsManager extends DisposableObject {
+  private readonly cachedResults: Map<CacheKey, VariantAnalysisScannedRepositoryResult>;
+
+  private readonly _onResultDownloaded = this.push(new EventEmitter<ResultDownloadedEvent>());
+  readonly onResultDownloaded = this._onResultDownloaded.event;
+
+  private readonly _onResultLoaded = this.push(new EventEmitter<VariantAnalysisScannedRepositoryResult>());
+  readonly onResultLoaded = this._onResultLoaded.event;
+
+  constructor(
+    private readonly cliServer: CodeQLCliServer,
+    private readonly storagePath: string,
+    private readonly logger: Logger,
+  ) {
+    super();
+    this.cachedResults = new Map();
+  }
+
+  public async download(
+    credentials: Credentials,
+    variantAnalysisId: number,
+    repoTask: VariantAnalysisRepoTask,
+  ): Promise<void> {
+    if (!repoTask.artifact_url) {
+      throw new Error('Missing artifact URL');
+    }
+
+    const resultDirectory = this.getRepoStorageDirectory(variantAnalysisId, repoTask.repository.full_name);
+
+    const result = await ghApiClient.getVariantAnalysisRepoResult(
+      credentials,
+      repoTask.artifact_url
+    );
+
+    fs.mkdirSync(resultDirectory, { recursive: true });
+    await fs.writeFile(path.join(resultDirectory, 'results.zip'), JSON.stringify(result, null, 2), 'utf8');
+
+    this._onResultDownloaded.fire({
+      variantAnalysisId,
+      repoTask,
+    });
+  }
+
+  public async loadResults(
+    variantAnalysisId: number,
+    repoTask: VariantAnalysisRepoTask
+  ): Promise<VariantAnalysisScannedRepositoryResult> {
+    const result = this.cachedResults.get(createCacheKey(variantAnalysisId, repoTask));
+    if (result) {
+      return result;
+    }
+
+    return this.loadResultsIntoMemory(variantAnalysisId, repoTask);
+  }
+
+  private async loadResultsIntoMemory(
+    variantAnalysisId: number,
+    repoTask: VariantAnalysisRepoTask,
+  ): Promise<VariantAnalysisScannedRepositoryResult> {
+    const result = await this.loadResultsFromStorage(variantAnalysisId, repoTask);
+    this.cachedResults.set(createCacheKey(variantAnalysisId, repoTask), result);
+    this._onResultLoaded.fire(result);
+    return result;
+  }
+
+  private async loadResultsFromStorage(
+    variantAnalysisId: number,
+    repoTask: VariantAnalysisRepoTask,
+  ): Promise<VariantAnalysisScannedRepositoryResult> {
+    if (!(await this.isVariantAnalysisRepoDownloaded(variantAnalysisId, repoTask))) {
+      throw new Error('Variant analysis results not downloaded');
+    }
+
+    if (!repoTask.database_commit_sha || !repoTask.source_location_prefix) {
+      throw new Error('Missing database commit SHA');
+    }
+
+    const fileLinkPrefix = this.createGitHubDotcomFileLinkPrefix(repoTask.repository.full_name, repoTask.database_commit_sha);
+
+    const storageDirectory = this.getRepoStorageDirectory(variantAnalysisId, repoTask.repository.full_name);
+
+    const sarifPath = path.join(storageDirectory, 'results.sarif');
+    const bqrsPath = path.join(storageDirectory, 'results.bqrs');
+    if (await fs.pathExists(sarifPath)) {
+      const interpretedResults = await this.readSarifResults(sarifPath, fileLinkPrefix);
+
+      return {
+        variantAnalysisId,
+        repositoryId: repoTask.repository.id,
+        interpretedResults,
+      };
+    }
+
+    if (await fs.pathExists(bqrsPath)) {
+      const rawResults = await this.readBqrsResults(bqrsPath, fileLinkPrefix, repoTask.source_location_prefix);
+
+      return {
+        variantAnalysisId,
+        repositoryId: repoTask.repository.id,
+        rawResults,
+      };
+    }
+
+    throw new Error('Missing results file');
+  }
+
+  private async isVariantAnalysisRepoDownloaded(
+    variantAnalysisId: number,
+    repoTask: VariantAnalysisRepoTask,
+  ): Promise<boolean> {
+    return await fs.pathExists(this.getRepoStorageDirectory(variantAnalysisId, repoTask.repository.full_name));
+  }
+
+  private async readBqrsResults(filePath: string, fileLinkPrefix: string, sourceLocationPrefix: string): Promise<AnalysisRawResults> {
+    return await extractRawResults(this.cliServer, this.logger, filePath, fileLinkPrefix, sourceLocationPrefix);
+  }
+
+  private async readSarifResults(filePath: string, fileLinkPrefix: string): Promise<AnalysisAlert[]> {
+    const sarifLog = await sarifParser(filePath);
+
+    const processedSarif = extractAnalysisAlerts(sarifLog, fileLinkPrefix);
+    if (processedSarif.errors.length) {
+      void this.logger.log(`Error processing SARIF file: ${os.EOL}${processedSarif.errors.join(os.EOL)}`);
+    }
+
+    return processedSarif.alerts;
+  }
+
+  private getStorageDirectory(variantAnalysisId: number): string {
+    return path.join(
+      this.storagePath,
+      `${variantAnalysisId}`
+    );
+  }
+
+  private getRepoStorageDirectory(variantAnalysisId: number, fullName: string): string {
+    return path.join(
+      this.getStorageDirectory(variantAnalysisId),
+      fullName
+    );
+  }
+
+  private createGitHubDotcomFileLinkPrefix(fullName: string, sha: string): string {
+    return `https://github.com/${fullName}/blob/${sha}`;
+  }
+
+  public dispose(disposeHandler?: DisposeHandler) {
+    super.dispose(disposeHandler);
+
+    this.cachedResults.clear();
+  }
+}

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-results-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-results-manager.ts
@@ -72,11 +72,8 @@ export class VariantAnalysisResultsManager extends DisposableObject {
     repoTask: VariantAnalysisRepoTask
   ): Promise<VariantAnalysisScannedRepositoryResult> {
     const result = this.cachedResults.get(createCacheKey(variantAnalysisId, repoTask));
-    if (result) {
-      return result;
-    }
 
-    return this.loadResultsIntoMemory(variantAnalysisId, repoTask);
+    return result ?? await this.loadResultsIntoMemory(variantAnalysisId, repoTask);
   }
 
   private async loadResultsIntoMemory(

--- a/extensions/ql-vscode/src/stories/variant-analysis/VariantAnalysisAnalyzedRepos.stories.tsx
+++ b/extensions/ql-vscode/src/stories/variant-analysis/VariantAnalysisAnalyzedRepos.stories.tsx
@@ -100,14 +100,17 @@ Example.args = {
   },
   repositoryResults: [
     {
+      variantAnalysisId: 1,
       repositoryId: 63537249,
       interpretedResults: interpretedResultsForRepo('facebook/create-react-app'),
     },
     {
+      variantAnalysisId: 1,
       repositoryId: 167174,
       interpretedResults: interpretedResultsForRepo('jquery/jquery'),
     },
     {
+      variantAnalysisId: 1,
       repositoryId: 237159,
       interpretedResults: interpretedResultsForRepo('expressjs/express'),
     }

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
@@ -165,6 +165,7 @@ const variantAnalysis: VariantAnalysisDomainModel = {
 
 const repositoryResults: VariantAnalysisScannedRepositoryResult[] = [
   {
+    variantAnalysisId: 1,
     repositoryId: 1,
     rawResults: {
       schema: {

--- a/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisAnalyzedRepos.spec.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisAnalyzedRepos.spec.tsx
@@ -78,6 +78,7 @@ describe(VariantAnalysisAnalyzedRepos.name, () => {
     render({
       repositoryResults: [
         {
+          variantAnalysisId: 1,
           repositoryId: 2,
           interpretedResults: [
             {

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-manager.test.ts
@@ -16,9 +16,12 @@ import {
 import { createMockApiResponse } from '../../factories/remote-queries/gh-api/variant-analysis-api-response';
 import { createMockScannedRepos } from '../../factories/remote-queries/gh-api/scanned-repositories';
 import { createMockVariantAnalysisRepoTask } from '../../factories/remote-queries/gh-api/variant-analysis-repo-task';
+import { CodeQLCliServer } from '../../../cli';
+import { storagePath } from '../global.helper';
 
 describe('Variant Analysis Manager', async function() {
   let sandbox: sinon.SinonSandbox;
+  let cli: CodeQLCliServer;
   let cancellationTokenSource: CancellationTokenSource;
   let variantAnalysisManager: VariantAnalysisManager;
   let variantAnalysis: VariantAnalysisApiResponse;
@@ -47,7 +50,8 @@ describe('Variant Analysis Manager', async function() {
 
     try {
       const extension = await extensions.getExtension<CodeQLExtensionInterface | Record<string, never>>('GitHub.vscode-codeql')!.activate();
-      variantAnalysisManager = new VariantAnalysisManager(extension.ctx, logger);
+      cli = extension.cliServer;
+      variantAnalysisManager = new VariantAnalysisManager(extension.ctx, cli, storagePath, logger);
     } catch (e) {
       fail(e as Error);
     }

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-results-manager.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-results-manager.test.ts
@@ -1,0 +1,88 @@
+import * as sinon from 'sinon';
+import { expect } from 'chai';
+import { extensions } from 'vscode';
+import { CodeQLExtensionInterface } from '../../../extension';
+import { logger } from '../../../logging';
+import { Credentials } from '../../../authentication';
+import * as fs from 'fs-extra';
+
+import { VariantAnalysisResultsManager } from '../../../remote-queries/variant-analysis-results-manager';
+import { createMockVariantAnalysisRepoTask } from '../../factories/remote-queries/gh-api/variant-analysis-repo-task';
+import { CodeQLCliServer } from '../../../cli';
+import { storagePath } from '../global.helper';
+import { faker } from '@faker-js/faker';
+import * as ghApiClient from '../../../remote-queries/gh-api/gh-api-client';
+
+describe(VariantAnalysisResultsManager.name, () => {
+  let sandbox: sinon.SinonSandbox;
+  let cli: CodeQLCliServer;
+  let variantAnalysisId: number;
+  let variantAnalysisResultsManager: VariantAnalysisResultsManager;
+  let getVariantAnalysisRepoResultStub: sinon.SinonStub;
+
+  beforeEach(async () => {
+    sandbox = sinon.createSandbox();
+    sandbox.stub(logger, 'log');
+    sandbox.stub(fs, 'mkdirSync');
+    sandbox.stub(fs, 'writeFile');
+
+    variantAnalysisId = faker.datatype.number();
+
+    try {
+      const extension = await extensions.getExtension<CodeQLExtensionInterface | Record<string, never>>('GitHub.vscode-codeql')!.activate();
+      cli = extension.cliServer;
+      variantAnalysisResultsManager = new VariantAnalysisResultsManager(cli, storagePath, logger);
+    } catch (e) {
+      fail(e as Error);
+    }
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+  });
+
+  describe('download', () => {
+    let getOctokitStub: sinon.SinonStub;
+    const mockCredentials = {
+      getOctokit: () => Promise.resolve({
+        request: getOctokitStub
+      })
+    } as unknown as Credentials;
+
+    describe('when the artifact_url is missing', async () => {
+      it('should not try to download the result', async () => {
+        const dummyRepoTask = createMockVariantAnalysisRepoTask();
+        delete dummyRepoTask.artifact_url;
+
+        try {
+          await variantAnalysisResultsManager.download(
+            mockCredentials,
+            variantAnalysisId,
+            dummyRepoTask
+          );
+
+          expect.fail('Expected an error to be thrown');
+        } catch (e: any) {
+          expect(e.message).to.equal('Missing artifact URL');
+        }
+      });
+    });
+
+    describe('when the artifact_url is present', async () => {
+      it('should save the result to disk', async () => {
+        const dummyRepoTask = createMockVariantAnalysisRepoTask();
+
+        const dummyResult = 'this-is-a-repo-result';
+        getVariantAnalysisRepoResultStub = sandbox.stub(ghApiClient, 'getVariantAnalysisRepoResult').withArgs(mockCredentials, dummyRepoTask.artifact_url as string).resolves(dummyResult);
+
+        await variantAnalysisResultsManager.download(
+          mockCredentials,
+          variantAnalysisId,
+          dummyRepoTask
+        );
+
+        expect(getVariantAnalysisRepoResultStub.calledOnce).to.be.true;
+      });
+    });
+  });
+});


### PR DESCRIPTION
This adds a new variant analysis results manager which is responsible for downloading and loading variant analysis results to/from the filesystem. It is essentially the `AnalysesResultsManager` modified to suit the variant analysis results.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->



## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
