### PR TITLE
Use real `CancellationTokenSource` in tests

### DIFF
--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/run-remote-query.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/run-remote-query.test.ts
@@ -56,14 +56,7 @@ describe('Remote queries', function() {
     }
     credentials = {} as unknown as Credentials;
 
-    cancellationTokenSource = {
-      token: {
-        isCancellationRequested: false,
-        onCancellationRequested: sandbox.stub()
-      },
-      cancel: sandbox.stub(),
-      dispose: sandbox.stub()
-    };
+    cancellationTokenSource = new CancellationTokenSource();
 
     progress = sandbox.spy();
     // Should not have asked for a language
@@ -282,7 +275,7 @@ describe('Remote queries', function() {
 
       const promise = runRemoteQuery(cli, credentials, fileUri, true, progress, cancellationTokenSource.token);
 
-      cancellationTokenSource.token.isCancellationRequested = true;
+      cancellationTokenSource.cancel();
 
       try {
         await promise;
@@ -347,7 +340,7 @@ describe('Remote queries', function() {
 
       const promise = runRemoteQuery(cli, credentials, fileUri, true, progress, cancellationTokenSource.token);
 
-      cancellationTokenSource.token.isCancellationRequested = true;
+      cancellationTokenSource.cancel();
 
       try {
         await promise;

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-manager.test.ts
@@ -36,14 +36,7 @@ describe('Variant Analysis Manager', async function() {
     sandbox.stub(fs, 'mkdirSync');
     sandbox.stub(fs, 'writeFile');
 
-    cancellationTokenSource = {
-      token: {
-        isCancellationRequested: false,
-        onCancellationRequested: sandbox.stub()
-      },
-      cancel: sandbox.stub(),
-      dispose: sandbox.stub()
-    };
+    cancellationTokenSource = new CancellationTokenSource();
 
     scannedRepos = createMockScannedRepos();
     variantAnalysis = createMockApiResponse('in_progress', scannedRepos);
@@ -120,7 +113,7 @@ describe('Variant Analysis Manager', async function() {
       });
 
       it('should return early if variant analysis is cancelled', async () => {
-        cancellationTokenSource.token.isCancellationRequested = true;
+        cancellationTokenSource.cancel();
 
         await variantAnalysisManager.autoDownloadVariantAnalysisResult(
           scannedRepos[0],

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-monitor.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-monitor.test.ts
@@ -31,14 +31,7 @@ describe('Variant Analysis Monitor', async function() {
     sandbox.stub(logger, 'log');
     sandbox.stub(config, 'isVariantAnalysisLiveResultsEnabled').returns(false);
 
-    cancellationTokenSource = {
-      token: {
-        isCancellationRequested: false,
-        onCancellationRequested: sandbox.stub()
-      },
-      cancel: sandbox.stub(),
-      dispose: sandbox.stub()
-    };
+    cancellationTokenSource = new CancellationTokenSource();
 
     variantAnalysis = createMockVariantAnalysis();
 
@@ -79,7 +72,7 @@ describe('Variant Analysis Monitor', async function() {
     });
 
     it('should return early if variant analysis is cancelled', async () => {
-      cancellationTokenSource.token.isCancellationRequested = true;
+      cancellationTokenSource.cancel();
 
       const result = await variantAnalysisMonitor.monitorVariantAnalysis(variantAnalysis, cancellationTokenSource.token);
 


### PR DESCRIPTION
This will change tests that are using a mocked `CancellationTokenSource` to use a real `CancellationTokenSource` instead. Tests are run inside VSCode, so we can use these without mocking.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
