### PR TITLE
Reset VSCode configuration between tests

### DIFF
--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -332,7 +332,7 @@ const REMOTE_QUERIES_SETTING = new Setting('variantAnalysis', ROOT_SETTING);
  * This setting should be a JSON object where each key is a user-specified name (string),
  * and the value is an array of GitHub repositories (of the form `<owner>/<repo>`).
  */
-const REMOTE_REPO_LISTS = new Setting('repositoryLists', REMOTE_QUERIES_SETTING);
+export const REMOTE_REPO_LISTS = new Setting('repositoryLists', REMOTE_QUERIES_SETTING);
 
 export function getRemoteRepositoryLists(): Record<string, string[]> | undefined {
   return REMOTE_REPO_LISTS.getValue<Record<string, string[]>>() || undefined;
@@ -363,7 +363,7 @@ export function getRemoteRepositoryListsPath(): string | undefined {
  *
  * This setting should be a GitHub repository of the form `<owner>/<repo>`.
  */
-const REMOTE_CONTROLLER_REPO = new Setting('controllerRepo', REMOTE_QUERIES_SETTING);
+export const REMOTE_CONTROLLER_REPO = new Setting('controllerRepo', REMOTE_QUERIES_SETTING);
 
 export function getRemoteControllerRepo(): string | undefined {
   return REMOTE_CONTROLLER_REPO.getValue<string>() || undefined;

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -35,6 +35,19 @@ export class Setting {
     }
     return workspace.getConfiguration(this.parent.qualifiedName).update(this.name, value, target);
   }
+
+  inspect<T>(): InspectionResult<T> | undefined {
+    if (this.parent === undefined) {
+      throw new Error('Cannot update the value of a root setting.');
+    }
+    return workspace.getConfiguration(this.parent.qualifiedName).inspect(this.name);
+  }
+}
+
+export interface InspectionResult<T> {
+  globalValue?: T;
+  workspaceValue?: T,
+  workspaceFolderValue?: T,
 }
 
 const ROOT_SETTING = new Setting('codeQL');

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -35,7 +35,6 @@ export class Setting {
     }
     return workspace.getConfiguration(this.parent.qualifiedName).update(this.name, value, target);
   }
-
 }
 
 const ROOT_SETTING = new Setting('codeQL');
@@ -338,17 +337,13 @@ export function getRemoteRepositoryLists(): Record<string, string[]> | undefined
   return REMOTE_REPO_LISTS.getValue<Record<string, string[]>>() || undefined;
 }
 
-export async function setRemoteRepositoryLists(lists: Record<string, string[]> | undefined) {
-  await REMOTE_REPO_LISTS.updateValue(lists, ConfigurationTarget.Global);
-}
-
 /**
- * Path to a file that contains lists of GitHub repositories that you want to query remotely via 
+ * Path to a file that contains lists of GitHub repositories that you want to query remotely via
  * the "Run Variant Analysis" command.
  * Note: This command is only available for internal users.
- * 
+ *
  * This setting should be a path to a JSON file that contains a JSON object where each key is a
- * user-specified name (string), and the value is an array of GitHub repositories 
+ * user-specified name (string), and the value is an array of GitHub repositories
  * (of the form `<owner>/<repo>`).
  */
 const REPO_LISTS_PATH = new Setting('repositoryListsPath', REMOTE_QUERIES_SETTING);

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -4,6 +4,8 @@ import { DistributionManager } from './distribution';
 import { logger } from './logging';
 import { ONE_DAY_IN_MS } from './pure/time';
 
+export const ALL_SETTINGS: Setting[] = [];
+
 /** Helper class to look up a labelled (and possibly nested) setting. */
 export class Setting {
   name: string;
@@ -12,6 +14,7 @@ export class Setting {
   constructor(name: string, parent?: Setting) {
     this.name = name;
     this.parent = parent;
+    ALL_SETTINGS.push(this);
   }
 
   get qualifiedName(): string {
@@ -344,10 +347,14 @@ const REMOTE_QUERIES_SETTING = new Setting('variantAnalysis', ROOT_SETTING);
  * This setting should be a JSON object where each key is a user-specified name (string),
  * and the value is an array of GitHub repositories (of the form `<owner>/<repo>`).
  */
-export const REMOTE_REPO_LISTS = new Setting('repositoryLists', REMOTE_QUERIES_SETTING);
+const REMOTE_REPO_LISTS = new Setting('repositoryLists', REMOTE_QUERIES_SETTING);
 
 export function getRemoteRepositoryLists(): Record<string, string[]> | undefined {
   return REMOTE_REPO_LISTS.getValue<Record<string, string[]>>() || undefined;
+}
+
+export async function setRemoteRepositoryLists(lists: Record<string, string[]> | undefined) {
+  await REMOTE_REPO_LISTS.updateValue(lists, ConfigurationTarget.Global);
 }
 
 /**
@@ -371,7 +378,7 @@ export function getRemoteRepositoryListsPath(): string | undefined {
  *
  * This setting should be a GitHub repository of the form `<owner>/<repo>`.
  */
-export const REMOTE_CONTROLLER_REPO = new Setting('controllerRepo', REMOTE_QUERIES_SETTING);
+const REMOTE_CONTROLLER_REPO = new Setting('controllerRepo', REMOTE_QUERIES_SETTING);
 
 export function getRemoteControllerRepo(): string | undefined {
   return REMOTE_CONTROLLER_REPO.getValue<string>() || undefined;

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/global.helper.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/global.helper.ts
@@ -4,9 +4,10 @@ import * as fs from 'fs-extra';
 import fetch from 'node-fetch';
 
 import { fail } from 'assert';
-import { commands, ConfigurationTarget, extensions, workspace } from 'vscode';
+import { commands, extensions, workspace } from 'vscode';
 import { CodeQLExtensionInterface } from '../../extension';
 import { DatabaseManager } from '../../databases';
+import { testConfig } from '../test-config';
 
 // This file contains helpers shared between actual tests.
 
@@ -58,7 +59,7 @@ export default function(mocha: Mocha) {
   // Set the CLI version here before activation to ensure we don't accidentally try to download a cli
   (mocha.options as any).globalSetup.push(
     async () => {
-      await workspace.getConfiguration().update('codeQL.cli.executablePath', process.env.CLI_PATH, ConfigurationTarget.Global);
+      await testConfig.cliExecutablePath.setInitialTestValue(process.env.CLI_PATH);
     }
   );
 

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/global.helper.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/global.helper.ts
@@ -7,7 +7,8 @@ import { fail } from 'assert';
 import { commands, extensions, workspace } from 'vscode';
 import { CodeQLExtensionInterface } from '../../extension';
 import { DatabaseManager } from '../../databases';
-import { testConfig } from '../test-config';
+import { getTestSetting } from '../test-config';
+import { CUSTOM_CODEQL_PATH_SETTING } from '../../config';
 
 // This file contains helpers shared between actual tests.
 
@@ -59,7 +60,7 @@ export default function(mocha: Mocha) {
   // Set the CLI version here before activation to ensure we don't accidentally try to download a cli
   (mocha.options as any).globalSetup.push(
     async () => {
-      await testConfig.cliExecutablePath.setInitialTestValue(process.env.CLI_PATH);
+      await getTestSetting(CUSTOM_CODEQL_PATH_SETTING)?.setInitialTestValue(process.env.CLI_PATH);
     }
   );
 

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/run-remote-query.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/run-remote-query.test.ts
@@ -10,7 +10,6 @@ import { QlPack, runRemoteQuery } from '../../../remote-queries/run-remote-query
 import { Credentials } from '../../../authentication';
 import { CliVersionConstraint, CodeQLCliServer } from '../../../cli';
 import { CodeQLExtensionInterface } from '../../../extension';
-import { setRemoteControllerRepo, setRemoteRepositoryLists } from '../../../config';
 import * as config from '../../../config';
 import { UserCancellationException } from '../../../commandRunner';
 import * as ghApiClient from '../../../remote-queries/gh-api/gh-api-client';
@@ -24,6 +23,7 @@ import { createMockApiResponse } from '../../factories/remote-queries/gh-api/var
 import { createMockExtensionContext } from '../../no-workspace';
 import { VariantAnalysisManager } from '../../../remote-queries/variant-analysis-manager';
 import { OutputChannelLogger } from '../../../logging';
+import { testConfig } from '../../test-config';
 
 describe('Remote queries', function() {
   const baseDir = path.join(__dirname, '../../../../src/vscode-tests/cli-integration');
@@ -83,8 +83,8 @@ describe('Remote queries', function() {
     getRepositoryFromNwoStub = sandbox.stub(ghApiClient, 'getRepositoryFromNwo').resolves(dummyRepository);
 
     // always run in the vscode-codeql repo
-    await setRemoteControllerRepo('github/vscode-codeql');
-    await setRemoteRepositoryLists({ 'vscode-codeql': ['github/vscode-codeql'] });
+    await testConfig.remoteControllerRepo.set('github/vscode-codeql');
+    await testConfig.remoteRepoLists.set({ 'vscode-codeql': ['github/vscode-codeql'] });
 
     liveResultsStub = sandbox.stub(config, 'isVariantAnalysisLiveResultsEnabled').returns(false);
   });

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/run-remote-query.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/run-remote-query.test.ts
@@ -10,6 +10,7 @@ import { QlPack, runRemoteQuery } from '../../../remote-queries/run-remote-query
 import { Credentials } from '../../../authentication';
 import { CliVersionConstraint, CodeQLCliServer } from '../../../cli';
 import { CodeQLExtensionInterface } from '../../../extension';
+import { setRemoteControllerRepo, setRemoteRepositoryLists } from '../../../config';
 import * as config from '../../../config';
 import { UserCancellationException } from '../../../commandRunner';
 import * as ghApiClient from '../../../remote-queries/gh-api/gh-api-client';
@@ -23,7 +24,6 @@ import { createMockApiResponse } from '../../factories/remote-queries/gh-api/var
 import { createMockExtensionContext } from '../../no-workspace';
 import { VariantAnalysisManager } from '../../../remote-queries/variant-analysis-manager';
 import { OutputChannelLogger } from '../../../logging';
-import { testConfig } from '../../test-config';
 
 describe('Remote queries', function() {
   const baseDir = path.join(__dirname, '../../../../src/vscode-tests/cli-integration');
@@ -83,8 +83,8 @@ describe('Remote queries', function() {
     getRepositoryFromNwoStub = sandbox.stub(ghApiClient, 'getRepositoryFromNwo').resolves(dummyRepository);
 
     // always run in the vscode-codeql repo
-    await testConfig.remoteControllerRepo.set('github/vscode-codeql');
-    await testConfig.remoteRepoLists.set({ 'vscode-codeql': ['github/vscode-codeql'] });
+    await setRemoteControllerRepo('github/vscode-codeql');
+    await setRemoteRepositoryLists({ 'vscode-codeql': ['github/vscode-codeql'] });
 
     liveResultsStub = sandbox.stub(config, 'isVariantAnalysisLiveResultsEnabled').returns(false);
   });

--- a/extensions/ql-vscode/src/vscode-tests/index-template.ts
+++ b/extensions/ql-vscode/src/vscode-tests/index-template.ts
@@ -3,6 +3,7 @@ import * as Mocha from 'mocha';
 import * as glob from 'glob-promise';
 import { ensureCli } from './ensureCli';
 import { env } from 'vscode';
+import { testConfigHelper } from './test-config';
 
 
 // Use this handler to avoid swallowing unhandled rejections.
@@ -69,6 +70,9 @@ export async function runTestsInDirectory(testsRoot: string, useCli = false): Pr
       mocha.addFile(path.resolve(testsRoot, f));
     });
 
+  // Setup the config helper. This needs to run before other helpers so any config they setup
+  // is restored.
+  await testConfigHelper(mocha);
 
   // Add helpers. Helper files add global setup and teardown blocks
   // for a test run.

--- a/extensions/ql-vscode/src/vscode-tests/test-config.ts
+++ b/extensions/ql-vscode/src/vscode-tests/test-config.ts
@@ -1,0 +1,93 @@
+import { ConfigurationTarget, workspace } from 'vscode';
+import { CUSTOM_CODEQL_PATH_SETTING, REMOTE_CONTROLLER_REPO, REMOTE_REPO_LISTS, Setting } from '../config';
+
+class TestSetting<T> {
+  private settingState: {
+    globalValue?: T;
+    workspaceValue?: T,
+    workspaceFolderValue?: T,
+  } | undefined;
+
+  constructor(
+    public readonly setting: Setting,
+    private initialTestValue: T | undefined = undefined
+  ) { }
+
+  public async get(): Promise<T | undefined> {
+    return this.section.get(this.setting.name);
+  }
+
+  public async set(value: T | undefined, target: ConfigurationTarget = ConfigurationTarget.Global): Promise<void> {
+    await this.section.update(this.setting.name, value, target);
+  }
+
+  public async setInitialTestValue(value: T | undefined) {
+    this.initialTestValue = value;
+  }
+
+  public async initialSetup() {
+    this.settingState = this.section.inspect(this.setting.name);
+
+    // Unfortunately it's not well-documented how to check whether we can write to a workspace
+    // configuration. This is the best I could come up with. It only fails for initial test values
+    // which are not undefined.
+    if (this.settingState?.workspaceValue !== undefined) {
+      await this.set(this.initialTestValue, ConfigurationTarget.Workspace);
+    }
+    if (this.settingState?.workspaceFolderValue !== undefined) {
+      await this.set(this.initialTestValue, ConfigurationTarget.WorkspaceFolder);
+    }
+
+    await this.setup();
+  }
+
+  public async setup() {
+    await this.set(this.initialTestValue, ConfigurationTarget.Global);
+  }
+
+  public async restoreToInitialValues() {
+    const state = this.section.inspect(this.setting.name);
+
+    // We need to check the state of the setting before we restore it. This is less important for the global
+    // configuration target, but the workspace/workspace folder configuration might not even exist. If they
+    // don't exist, VSCode will error when trying to write the new value (even if that value is undefined).
+    if (state?.globalValue !== this.settingState?.globalValue) {
+      await this.set(this.settingState?.globalValue, ConfigurationTarget.Global);
+    }
+    if (state?.workspaceValue !== this.settingState?.workspaceValue) {
+      await this.set(this.settingState?.workspaceValue, ConfigurationTarget.Workspace);
+    }
+    if (state?.workspaceFolderValue !== this.settingState?.workspaceFolderValue) {
+      await this.set(this.settingState?.workspaceFolderValue, ConfigurationTarget.WorkspaceFolder);
+    }
+  }
+
+  private get section() {
+    if (this.setting.parent === undefined) {
+      throw new Error('Cannot get the value of a root setting.');
+    }
+    return workspace.getConfiguration(this.setting.parent.qualifiedName);
+  }
+}
+
+export const testConfig = {
+  remoteControllerRepo: new TestSetting<string>(REMOTE_CONTROLLER_REPO),
+  remoteRepoLists: new TestSetting<Record<string, string[]>>(REMOTE_REPO_LISTS),
+  cliExecutablePath: new TestSetting<string>(CUSTOM_CODEQL_PATH_SETTING),
+};
+
+export const testConfigHelper = async (mocha: Mocha) => {
+  // Read in all current settings
+  await Promise.all(Object.values(testConfig).map(setting => setting.initialSetup()));
+
+  mocha.rootHooks({
+    async beforeEach() {
+      // Reset the settings to their initial values before each test
+      await Promise.all(Object.values(testConfig).map(setting => setting.setup()));
+    },
+    async afterAll() {
+      // Restore all settings to their default values after each test suite
+      await Promise.all(Object.values(testConfig).map(setting => setting.restoreToInitialValues()));
+    }
+  });
+};

--- a/extensions/ql-vscode/src/vscode-tests/test-config.ts
+++ b/extensions/ql-vscode/src/vscode-tests/test-config.ts
@@ -2,7 +2,7 @@ import { ConfigurationTarget } from 'vscode';
 import { CUSTOM_CODEQL_PATH_SETTING, InspectionResult, REMOTE_CONTROLLER_REPO, REMOTE_REPO_LISTS, Setting } from '../config';
 
 class TestSetting<T> {
-  private settingState: InspectionResult<T> | undefined;
+  private initialSettingState: InspectionResult<T> | undefined;
 
   constructor(
     public readonly setting: Setting,
@@ -22,15 +22,15 @@ class TestSetting<T> {
   }
 
   public async initialSetup() {
-    this.settingState = this.setting.inspect();
+    this.initialSettingState = this.setting.inspect();
 
     // Unfortunately it's not well-documented how to check whether we can write to a workspace
     // configuration. This is the best I could come up with. It only fails for initial test values
     // which are not undefined.
-    if (this.settingState?.workspaceValue !== undefined) {
+    if (this.initialSettingState?.workspaceValue !== undefined) {
       await this.set(this.initialTestValue, ConfigurationTarget.Workspace);
     }
-    if (this.settingState?.workspaceFolderValue !== undefined) {
+    if (this.initialSettingState?.workspaceFolderValue !== undefined) {
       await this.set(this.initialTestValue, ConfigurationTarget.WorkspaceFolder);
     }
 
@@ -47,14 +47,14 @@ class TestSetting<T> {
     // We need to check the state of the setting before we restore it. This is less important for the global
     // configuration target, but the workspace/workspace folder configuration might not even exist. If they
     // don't exist, VSCode will error when trying to write the new value (even if that value is undefined).
-    if (state?.globalValue !== this.settingState?.globalValue) {
-      await this.set(this.settingState?.globalValue, ConfigurationTarget.Global);
+    if (state?.globalValue !== this.initialSettingState?.globalValue) {
+      await this.set(this.initialSettingState?.globalValue, ConfigurationTarget.Global);
     }
-    if (state?.workspaceValue !== this.settingState?.workspaceValue) {
-      await this.set(this.settingState?.workspaceValue, ConfigurationTarget.Workspace);
+    if (state?.workspaceValue !== this.initialSettingState?.workspaceValue) {
+      await this.set(this.initialSettingState?.workspaceValue, ConfigurationTarget.Workspace);
     }
-    if (state?.workspaceFolderValue !== this.settingState?.workspaceFolderValue) {
-      await this.set(this.settingState?.workspaceFolderValue, ConfigurationTarget.WorkspaceFolder);
+    if (state?.workspaceFolderValue !== this.initialSettingState?.workspaceFolderValue) {
+      await this.set(this.initialSettingState?.workspaceFolderValue, ConfigurationTarget.WorkspaceFolder);
     }
   }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

This will introduce a new helper that can be used to set config values in VSCode. Instead of the previous behaviour where it would retain the value after the tests had finished (resulting in e.g. the `codeQL.variantAnalysis.controllerRepo` setting being changed when you run the CLI tests from VSCode's Run and Debug menu), this will restore the value set by the user after finishing all tests. It will also set the value of specified config settings to a known value before each test.

It's probably easiest to review this PR commit-by-commit.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
