### PR TITLE
Add command for opening existing variant analysis

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -315,6 +315,10 @@
         "title": "CodeQL: Export Variant Analysis Results"
       },
       {
+        "command": "codeQL.openVariantAnalysis",
+        "title": "CodeQL: Open Variant Analysis"
+      },
+      {
         "command": "codeQL.runQueries",
         "title": "CodeQL: Run Queries in Selected Files"
       },
@@ -889,6 +893,10 @@
         {
           "command": "codeQL.runVariantAnalysis",
           "when": "config.codeQL.canary && editorLangId == ql && resourceExtname == .ql"
+        },
+        {
+          "command": "codeQL.openVariantAnalysis",
+          "when": "config.codeQL.canary && config.codeQL.variantAnalysis.liveResults"
         },
         {
           "command": "codeQL.exportVariantAnalysisResults",

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -935,6 +935,12 @@ async function activateWithInstalledDistribution(
   );
 
   ctx.subscriptions.push(
+    commandRunner('codeQL.openVariantAnalysis', async () => {
+      await variantAnalysisManager.promptOpenVariantAnalysis();
+    })
+  );
+
+  ctx.subscriptions.push(
     commandRunner('codeQL.autoDownloadRemoteQueryResults', async (
       queryResult: RemoteQueryResult,
       token: CancellationToken) => {

--- a/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
@@ -477,7 +477,7 @@ function getQueryName(queryMetadata: QueryMetadata | undefined, queryFilePath: s
   return queryMetadata?.name ?? path.basename(queryFilePath);
 }
 
-async function getControllerRepo(credentials: Credentials): Promise<Repository> {
+export async function getControllerRepo(credentials: Credentials): Promise<Repository> {
   // Get the controller repo from the config, if it exists.
   // If it doesn't exist, prompt the user to enter it, and save that value to the config.
   let controllerRepoNwo: string | undefined;

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
@@ -188,9 +188,7 @@ export class VariantAnalysisManager extends DisposableObject implements VariantA
     }, variantAnalysisResponse);
 
     void commands.executeCommand('codeQL.openVariantAnalysisView', processedVariantAnalysis.id);
-    if (variantAnalysisResponse.status !== 'completed') {
-      void commands.executeCommand('codeQL.monitorVariantAnalysis', processedVariantAnalysis);
-    }
+    void commands.executeCommand('codeQL.monitorVariantAnalysis', processedVariantAnalysis);
 
     this._onVariantAnalysisAdded.fire(processedVariantAnalysis);
   }

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
@@ -1,5 +1,5 @@
 import * as ghApiClient from './gh-api/gh-api-client';
-import { CancellationToken, EventEmitter, ExtensionContext } from 'vscode';
+import { CancellationToken, commands, EventEmitter, ExtensionContext, window } from 'vscode';
 import { DisposableObject } from '../pure/disposable-object';
 import { Logger } from '../logging';
 import { Credentials } from '../authentication';
@@ -10,7 +10,7 @@ import {
   VariantAnalysisScannedRepository as ApiVariantAnalysisScannedRepository
 } from './gh-api/variant-analysis';
 import {
-  VariantAnalysis,
+  VariantAnalysis, VariantAnalysisQueryLanguage,
   VariantAnalysisScannedRepositoryDownloadStatus,
   VariantAnalysisScannedRepositoryResult,
   VariantAnalysisScannedRepositoryState
@@ -20,6 +20,8 @@ import { VariantAnalysisView } from './variant-analysis-view';
 import { VariantAnalysisViewManager } from './variant-analysis-view-manager';
 import { VariantAnalysisResultsManager } from './variant-analysis-results-manager';
 import { CodeQLCliServer } from '../cli';
+import { getControllerRepo } from './run-remote-query';
+import { processUpdatedVariantAnalysis } from './variant-analysis-processor';
 
 export class VariantAnalysisManager extends DisposableObject implements VariantAnalysisViewManager<VariantAnalysisView> {
   private readonly _onVariantAnalysisAdded = this.push(new EventEmitter<VariantAnalysis | undefined>());
@@ -157,5 +159,39 @@ export class VariantAnalysisManager extends DisposableObject implements VariantA
 
     repoState.downloadStatus = VariantAnalysisScannedRepositoryDownloadStatus.Succeeded;
     await this.onRepoStateUpdated(variantAnalysisSummary.id, repoState);
+  }
+
+  public async promptOpenVariantAnalysis() {
+    const credentials = await Credentials.initialize(this.ctx);
+    if (!credentials) { throw Error('Error authenticating with GitHub'); }
+
+    const controllerRepo = await getControllerRepo(credentials);
+
+    const variantAnalysisIdString = await window.showInputBox({
+      title: 'Enter the variant analysis ID',
+    });
+    if (!variantAnalysisIdString) {
+      return;
+    }
+    const variantAnalysisId = parseInt(variantAnalysisIdString, 10);
+
+    const variantAnalysisResponse = await ghApiClient.getVariantAnalysis(credentials, controllerRepo.id, variantAnalysisId);
+
+    const processedVariantAnalysis = processUpdatedVariantAnalysis({
+      // We don't really know these values, so just fill in some placeholder values
+      query: {
+        name: `Variant analysis ${variantAnalysisId}`,
+        filePath: `variant_analysis_${variantAnalysisId}.ql`,
+        language: variantAnalysisResponse.query_language as VariantAnalysisQueryLanguage,
+      },
+      databases: {}
+    }, variantAnalysisResponse);
+
+    void commands.executeCommand('codeQL.openVariantAnalysisView', processedVariantAnalysis.id);
+    if (variantAnalysisResponse.status !== 'completed') {
+      void commands.executeCommand('codeQL.monitorVariantAnalysis', processedVariantAnalysis);
+    }
+
+    this._onVariantAnalysisAdded.fire(processedVariantAnalysis);
   }
 }


### PR DESCRIPTION
To make debugging the view easier and prevent needing to run a variant analysis for each change, this will add a simple command which opens a variant analysis by its ID. This it not intended to be visible to users at any point.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
