### PR TITLE
Fix freezing of live results view

### DIFF
--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
@@ -65,7 +65,7 @@ export function VariantAnalysis({
   const [repoResults, setRepoResults] = useState<VariantAnalysisScannedRepositoryResult[]>(initialRepoResults);
 
   useEffect(() => {
-    window.addEventListener('message', (evt: MessageEvent) => {
+    const listener = (evt: MessageEvent) => {
       if (evt.origin === window.origin) {
         const msg: ToVariantAnalysisMessage = evt.data;
         if (msg.t === 'setVariantAnalysis') {
@@ -89,7 +89,12 @@ export function VariantAnalysis({
         const origin = evt.origin.replace(/\n|\r/g, '');
         console.error(`Invalid event origin ${origin}`);
       }
-    });
+    };
+    window.addEventListener('message', listener);
+
+    return () => {
+      window.removeEventListener('message', listener);
+    };
   }, []);
 
   if (variantAnalysis?.actionsWorkflowRunId === undefined) {

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
@@ -90,7 +90,7 @@ export function VariantAnalysis({
         console.error(`Invalid event origin ${origin}`);
       }
     });
-  });
+  }, []);
 
   if (variantAnalysis?.actionsWorkflowRunId === undefined) {
     return <VariantAnalysisLoading />;


### PR DESCRIPTION
It's probably easiest to review this PR commit-by-commit; these also contain some more detailed information about why certain things are necessary. In summary, on every rerender we were registering a new message listener. This would cause every message sent by the extension to trigger N+1 rerenders for the Nth render. The renders would look as follows:

1. 1 message listener, new listener registered. Total rerenders: 1
2. 2 message listeners, new listener registered. Total rerenders: 2
3. 3 message listeners, new listener registered. Total rerenders: 3
4. 4 message listeners, new listener registered. Total rerenders: 4

This would continue forever and would sometimes result in 10's of thousands of renders happening. This caused the live results view to be unresponsive until no more messages were being sent.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
