### PR TITLE
Emit "update" events while variant analysis is being monitored

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-monitor.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-monitor.ts
@@ -57,6 +57,9 @@ export class VariantAnalysisMonitor extends DisposableObject {
       if (variantAnalysisSummary.failure_reason) {
         variantAnalysis.status = VariantAnalysisStatus.Failed;
         variantAnalysis.failureReason = processFailureReason(variantAnalysisSummary.failure_reason);
+
+        this._onVariantAnalysisChange.fire(variantAnalysis);
+
         return {
           status: 'Failed',
           error: `Variant Analysis has failed: ${variantAnalysisSummary.failure_reason}`,

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-monitor.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-monitor.test.ts
@@ -20,6 +20,8 @@ import { Credentials } from '../../../authentication';
 import { createMockVariantAnalysis } from '../../factories/remote-queries/shared/variant-analysis';
 
 describe('Variant Analysis Monitor', async function() {
+  this.timeout(60000);
+
   let sandbox: sinon.SinonSandbox;
   let mockGetVariantAnalysis: sinon.SinonStub;
   let cancellationTokenSource: CancellationTokenSource;

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-monitor.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-monitor.test.ts
@@ -109,9 +109,19 @@ describe('Variant Analysis Monitor', async function() {
       });
     });
 
-    describe('when the variant analysis completes', async () => {
+    describe('when the variant analysis is being monitored', async () => {
       let mockApiResponse: VariantAnalysisApiResponse;
       let scannedRepos: ApiVariantAnalysisScannedRepository[];
+
+      it('should emit `onVariantAnalysisChange`', async () => {
+        mockApiResponse = createMockApiResponse('completed');
+        mockGetVariantAnalysis = sandbox.stub(ghApiClient, 'getVariantAnalysis').resolves(mockApiResponse);
+
+        const spy = sandbox.spy();
+        variantAnalysisMonitor.onVariantAnalysisChange(spy);
+        await variantAnalysisMonitor.monitorVariantAnalysis(variantAnalysis, cancellationTokenSource.token);
+        expect(spy).to.have.been.calledOnce;
+      });
 
       describe('when there are successfully scanned repos', async () => {
         beforeEach(async function() {

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-monitor.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-monitor.test.ts
@@ -98,6 +98,15 @@ describe('Variant Analysis Monitor', async function() {
         expect(result.variantAnalysis?.status).to.equal(VariantAnalysisStatus.Failed);
         expect(result.variantAnalysis?.failureReason).to.equal(processFailureReason(mockFailedApiResponse.failure_reason as VariantAnalysisFailureReason));
       });
+
+      it('should emit `onVariantAnalysisChange`', async () => {
+        const spy = sandbox.spy();
+        variantAnalysisMonitor.onVariantAnalysisChange(spy);
+
+        await variantAnalysisMonitor.monitorVariantAnalysis(variantAnalysis, cancellationTokenSource.token);
+
+        expect(spy).to.have.been.calledOnce;
+      });
     });
 
     describe('when the variant analysis completes', async () => {


### PR DESCRIPTION
We had an existing `onVariantAnalysisChange` which got fired during the monitoring: https://github.com/github/vscode-codeql/blob/e45be0f4a5831e5a66bb262aad108d2f04f64a57/extensions/ql-vscode/src/remote-queries/variant-analysis-monitor.ts#L72

This PR also makes that event fire if the variant analysis fails, and adds a test for the failed and completed case (to check that the even was fired).

Note: I've left some additional context and comments in the internal issue!

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
