### PR TITLE
Add ability to open the query file

### DIFF
--- a/extensions/ql-vscode/src/pure/interface-types.ts
+++ b/extensions/ql-vscode/src/pure/interface-types.ts
@@ -464,6 +464,10 @@ export interface RequestRepositoryResultsMessage {
   repositoryFullName: string;
 }
 
+export interface OpenQueryFileMessage {
+  t: 'openQueryFile';
+}
+
 export type ToVariantAnalysisMessage =
   | SetVariantAnalysisMessage
   | SetRepoResultsMessage
@@ -472,4 +476,5 @@ export type ToVariantAnalysisMessage =
 export type FromVariantAnalysisMessage =
   | ViewLoadedMsg
   | StopVariantAnalysisMessage
-  | RequestRepositoryResultsMessage;
+  | RequestRepositoryResultsMessage
+  | OpenQueryFileMessage;

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
@@ -18,6 +18,12 @@ type Props = {
   repoResults?: VariantAnalysisScannedRepositoryResult[];
 }
 
+const openQueryFile = () => {
+  vscode.postMessage({
+    t: 'openQueryFile',
+  });
+};
+
 export function VariantAnalysis({
   variantAnalysis: initialVariantAnalysis,
   repoStates: initialRepoStates = [],
@@ -68,7 +74,7 @@ export function VariantAnalysis({
     <>
       <VariantAnalysisHeader
         variantAnalysis={variantAnalysis}
-        onOpenQueryFileClick={() => console.log('Open query')}
+        onOpenQueryFileClick={openQueryFile}
         onViewQueryTextClick={() => console.log('View query')}
         onStopQueryClick={() => console.log('Stop query')}
         onCopyRepositoryListClick={() => console.log('Copy repository list')}


### PR DESCRIPTION
This makes it possible to open the query file in the editor when clicking on the query filename.

This is a slightly different implementation from the remote queries implementation. The remote queries implementation will send the file path to open to the extension host, and the extension host will simply open the given file path. If someone is able to inject JavaScript into the webview, this would allow them to open an arbitrary file in VSCode.

By moving the file path logic to the extension host, we can ensure that we only allow opening the actual query file.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
