### PR TITLE
Upgrade from vscode-test to @vscode/test-electron

### DIFF
--- a/extensions/ql-vscode/package-lock.json
+++ b/extensions/ql-vscode/package-lock.json
@@ -100,6 +100,7 @@
         "@types/xml2js": "~0.4.4",
         "@typescript-eslint/eslint-plugin": "^4.26.0",
         "@typescript-eslint/parser": "^4.26.0",
+        "@vscode/test-electron": "^2.1.5",
         "ansi-colors": "^4.1.1",
         "applicationinsights": "^2.3.5",
         "babel-loader": "^8.2.5",
@@ -138,7 +139,6 @@
         "typescript": "^4.5.5",
         "typescript-formatter": "^7.2.2",
         "vsce": "^2.7.0",
-        "vscode-test": "^1.4.0",
         "webpack": "^5.62.2",
         "webpack-cli": "^4.6.0"
       },
@@ -14533,6 +14533,36 @@
       "version": "0.0.31",
       "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.31.tgz",
       "integrity": "sha512-fldpXy7pHsQAMlU1pnGI23ypQ6xLk5u6SiABMFoAmlj4f2MR0iwg7C19IB1xvAEGG+dkxOfRSrbKF8ry7QqGQA=="
+    },
+    "node_modules/@vscode/test-electron": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.1.5.tgz",
+      "integrity": "sha512-O/ioqFpV+RvKbRykX2ItYPnbcZ4Hk5V0rY4uhQjQTLhGL9WZUvS7exzuYQCCI+ilSqJpctvxq2llTfGXf9UnnA==",
+      "dev": true,
+      "dependencies": {
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "rimraf": "^3.0.2",
+        "unzipper": "^0.10.11"
+      },
+      "engines": {
+        "node": ">=8.9.3"
+      }
+    },
+    "node_modules/@vscode/test-electron/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/@vscode/webview-ui-toolkit": {
       "version": "1.0.1",
@@ -39042,22 +39072,6 @@
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz",
       "integrity": "sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ=="
     },
-    "node_modules/vscode-test": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
-      "integrity": "sha512-086q88T2ca1k95mUzffvbzb7esqQNvJgiwY4h29ukPhFo8u+vXOOmelUoU5EQUHs3Of8+JuQ3oGdbVCqaxuTXA==",
-      "deprecated": "This package has been renamed to @vscode/test-electron, please update to the new name",
-      "dev": true,
-      "dependencies": {
-        "http-proxy-agent": "^4.0.1",
-        "https-proxy-agent": "^5.0.0",
-        "rimraf": "^3.0.2",
-        "unzipper": "^0.10.11"
-      },
-      "engines": {
-        "node": ">=8.9.3"
-      }
-    },
     "node_modules/vscode-test-adapter-api": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/vscode-test-adapter-api/-/vscode-test-adapter-api-1.7.0.tgz",
@@ -39084,21 +39098,6 @@
       "integrity": "sha512-lltjehUP0J9H3R/HBctjlqeUCwn2t9Lbhj2Y500ib+j5Y4H3hw+hVTzuSsfw16LtxY37knlU39QIlasa7svzOQ==",
       "engines": {
         "vscode": "^1.23.0"
-      }
-    },
-    "node_modules/vscode-test/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/w3c-hr-time": {
@@ -51050,6 +51049,29 @@
       "version": "0.0.31",
       "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.31.tgz",
       "integrity": "sha512-fldpXy7pHsQAMlU1pnGI23ypQ6xLk5u6SiABMFoAmlj4f2MR0iwg7C19IB1xvAEGG+dkxOfRSrbKF8ry7QqGQA=="
+    },
+    "@vscode/test-electron": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.1.5.tgz",
+      "integrity": "sha512-O/ioqFpV+RvKbRykX2ItYPnbcZ4Hk5V0rY4uhQjQTLhGL9WZUvS7exzuYQCCI+ilSqJpctvxq2llTfGXf9UnnA==",
+      "dev": true,
+      "requires": {
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "rimraf": "^3.0.2",
+        "unzipper": "^0.10.11"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
     },
     "@vscode/webview-ui-toolkit": {
       "version": "1.0.1",
@@ -70193,29 +70215,6 @@
       "version": "3.15.1",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz",
       "integrity": "sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ=="
-    },
-    "vscode-test": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
-      "integrity": "sha512-086q88T2ca1k95mUzffvbzb7esqQNvJgiwY4h29ukPhFo8u+vXOOmelUoU5EQUHs3Of8+JuQ3oGdbVCqaxuTXA==",
-      "dev": true,
-      "requires": {
-        "http-proxy-agent": "^4.0.1",
-        "https-proxy-agent": "^5.0.0",
-        "rimraf": "^3.0.2",
-        "unzipper": "^0.10.11"
-      },
-      "dependencies": {
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        }
-      }
     },
     "vscode-test-adapter-api": {
       "version": "1.7.0",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1289,6 +1289,7 @@
     "@types/xml2js": "~0.4.4",
     "@typescript-eslint/eslint-plugin": "^4.26.0",
     "@typescript-eslint/parser": "^4.26.0",
+    "@vscode/test-electron": "^2.1.5",
     "ansi-colors": "^4.1.1",
     "applicationinsights": "^2.3.5",
     "babel-loader": "^8.2.5",
@@ -1327,7 +1328,6 @@
     "typescript": "^4.5.5",
     "typescript-formatter": "^7.2.2",
     "vsce": "^2.7.0",
-    "vscode-test": "^1.4.0",
     "webpack": "^5.62.2",
     "webpack-cli": "^4.6.0"
   },

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/index.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/index.ts
@@ -1,5 +1,4 @@
 import 'source-map-support/register';
-import 'vscode-test';
 import { runTestsInDirectory } from '../index-template';
 import 'mocha';
 import * as sinonChai from 'sinon-chai';

--- a/extensions/ql-vscode/src/vscode-tests/minimal-workspace/index.ts
+++ b/extensions/ql-vscode/src/vscode-tests/minimal-workspace/index.ts
@@ -1,5 +1,4 @@
 import 'source-map-support/register';
-import 'vscode-test';
 import * as sinonChai from 'sinon-chai';
 import * as chai from 'chai';
 import 'chai/register-should';

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/index.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/index.ts
@@ -1,5 +1,4 @@
 import 'source-map-support/register';
-import 'vscode-test';
 import * as sinonChai from 'sinon-chai';
 import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';

--- a/extensions/ql-vscode/src/vscode-tests/run-integration-tests.ts
+++ b/extensions/ql-vscode/src/vscode-tests/run-integration-tests.ts
@@ -4,14 +4,14 @@ import * as cp from 'child_process';
 import {
   runTests,
   downloadAndUnzipVSCode,
-  resolveCliPathFromVSCodeExecutablePath
-} from 'vscode-test';
+  resolveCliArgsFromVSCodeExecutablePath
+} from '@vscode/test-electron';
 import { assertNever } from '../pure/helpers-pure';
 import * as tmp from 'tmp-promise';
 
 // For some reason, the following are not exported directly from `vscode-test`,
 // but we can be tricky and import directly from the out file.
-import { TestOptions } from 'vscode-test/out/runTest';
+import { TestOptions } from '@vscode/test-electron/out/runTest';
 
 
 // For CI purposes we want to leave this at 'stable' to catch any bugs
@@ -78,10 +78,11 @@ async function main() {
     const extensionTestsEnv: Record<string, string> = {};
     if (dirs.includes(TestDir.CliIntegration)) {
       console.log('Installing required extensions');
-      const cliPath = resolveCliPathFromVSCodeExecutablePath(vscodeExecutablePath);
+      const [cli, ...args] = resolveCliArgsFromVSCodeExecutablePath(vscodeExecutablePath);
       cp.spawnSync(
-        cliPath,
+        cli,
         [
+          ...args,
           '--install-extension',
           'hbenl.vscode-test-explorer',
           '--install-extension',


### PR DESCRIPTION
The `vscode-test` package was renamed to `@vscode/test-electron` in December of last year. This commit updates the extension to use the new package name.

The reason for this change is that the `vscode-test` package was somewhat flaky in actually starting VSCode to run the tests from the command line. The new package also has some bugfixes and other improvements which would normally have been part of a new version of the `vscode-test` package.

See: https://github.com/microsoft/vscode-test/blob/main/CHANGELOG.md

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
