### PR TITLE
Add ability to open the query text

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -114,6 +114,7 @@ import {
   VariantAnalysisScannedRepository as ApiVariantAnalysisScannedRepository
 } from './remote-queries/gh-api/variant-analysis';
 import { VariantAnalysisManager } from './remote-queries/variant-analysis-manager';
+import { createVariantAnalysisContentProvider } from './remote-queries/variant-analysis-content-provider';
 
 /**
  * extension.ts
@@ -485,6 +486,7 @@ async function activateWithInstalledDistribution(
   await fs.ensureDir(variantAnalysisStorageDir);
   const variantAnalysisManager = new VariantAnalysisManager(ctx, cliServer, variantAnalysisStorageDir, logger);
   ctx.subscriptions.push(variantAnalysisManager);
+  ctx.subscriptions.push(workspace.registerTextDocumentContentProvider('codeql-variant-analysis', createVariantAnalysisContentProvider(variantAnalysisManager)));
 
   void logger.log('Initializing remote queries manager.');
   const rqm = new RemoteQueriesManager(ctx, cliServer, queryStorageDir, logger, variantAnalysisManager);

--- a/extensions/ql-vscode/src/pure/interface-types.ts
+++ b/extensions/ql-vscode/src/pure/interface-types.ts
@@ -468,6 +468,10 @@ export interface OpenQueryFileMessage {
   t: 'openQueryFile';
 }
 
+export interface OpenQueryTextMessage {
+  t: 'openQueryText';
+}
+
 export type ToVariantAnalysisMessage =
   | SetVariantAnalysisMessage
   | SetRepoResultsMessage
@@ -477,4 +481,5 @@ export type FromVariantAnalysisMessage =
   | ViewLoadedMsg
   | StopVariantAnalysisMessage
   | RequestRepositoryResultsMessage
-  | OpenQueryFileMessage;
+  | OpenQueryFileMessage
+  | OpenQueryTextMessage;

--- a/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
@@ -251,6 +251,8 @@ export async function runRemoteQuery(
         throw new UserCancellationException(`Found unsupported language: ${language}`);
       }
 
+      const queryText = await fs.readFile(queryFile, 'utf8');
+
       const variantAnalysisSubmission: VariantAnalysisSubmission = {
         startTime: queryStartTime,
         actionRepoRef: actionBranch,
@@ -260,6 +262,7 @@ export async function runRemoteQuery(
           filePath: queryFile,
           pack: base64Pack,
           language: variantAnalysisLanguage,
+          queryText,
         },
         databases: {
           repositories: repoSelection.repositories,

--- a/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
@@ -262,7 +262,7 @@ export async function runRemoteQuery(
           filePath: queryFile,
           pack: base64Pack,
           language: variantAnalysisLanguage,
-          queryText,
+          text: queryText,
         },
         databases: {
           repositories: repoSelection.repositories,

--- a/extensions/ql-vscode/src/remote-queries/shared/variant-analysis.ts
+++ b/extensions/ql-vscode/src/remote-queries/shared/variant-analysis.ts
@@ -8,7 +8,7 @@ export interface VariantAnalysis {
     name: string,
     filePath: string,
     language: VariantAnalysisQueryLanguage,
-    queryText: string,
+    text: string,
   },
   databases: {
     repositories?: string[],
@@ -114,7 +114,7 @@ export interface VariantAnalysisSubmission {
     name: string,
     filePath: string,
     language: VariantAnalysisQueryLanguage,
-    queryText: string,
+    text: string,
 
     // Base64 encoded query pack.
     pack: string,

--- a/extensions/ql-vscode/src/remote-queries/shared/variant-analysis.ts
+++ b/extensions/ql-vscode/src/remote-queries/shared/variant-analysis.ts
@@ -7,7 +7,8 @@ export interface VariantAnalysis {
   query: {
     name: string,
     filePath: string,
-    language: VariantAnalysisQueryLanguage
+    language: VariantAnalysisQueryLanguage,
+    queryText: string,
   },
   databases: {
     repositories?: string[],
@@ -113,6 +114,7 @@ export interface VariantAnalysisSubmission {
     name: string,
     filePath: string,
     language: VariantAnalysisQueryLanguage,
+    queryText: string,
 
     // Base64 encoded query pack.
     pack: string,

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-content-provider.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-content-provider.ts
@@ -10,14 +10,14 @@ export const createVariantAnalysisContentProvider = (variantAnalysisManager: Var
 
     const variantAnalysisIdString = params.get('variantAnalysisId');
     if (!variantAnalysisIdString) {
-      void showAndLogWarningMessage('No variant analysis ID provided');
+      void showAndLogWarningMessage('Unable to show query text. No variant analysis ID provided.');
       return undefined;
     }
     const variantAnalysisId = parseInt(variantAnalysisIdString);
 
     const variantAnalysis = await variantAnalysisManager.getVariantAnalysis(variantAnalysisId);
     if (!variantAnalysis) {
-      void showAndLogWarningMessage('No variant analysis found');
+      void showAndLogWarningMessage('Unable to show query text. No variant analysis found.');
       return undefined;
     }
 

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-content-provider.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-content-provider.ts
@@ -21,6 +21,6 @@ export const createVariantAnalysisContentProvider = (variantAnalysisManager: Var
       return undefined;
     }
 
-    return SHOW_QUERY_TEXT_MSG + variantAnalysis.query.queryText;
+    return SHOW_QUERY_TEXT_MSG + variantAnalysis.query.text;
   }
 });

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-content-provider.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-content-provider.ts
@@ -1,0 +1,26 @@
+import { TextDocumentContentProvider, Uri } from 'vscode';
+import { URLSearchParams } from 'url';
+import { showAndLogWarningMessage } from '../helpers';
+import { SHOW_QUERY_TEXT_MSG } from '../query-history';
+import { VariantAnalysisManager } from './variant-analysis-manager';
+
+export const createVariantAnalysisContentProvider = (variantAnalysisManager: VariantAnalysisManager): TextDocumentContentProvider => ({
+  async provideTextDocumentContent(uri: Uri): Promise<string | undefined> {
+    const params = new URLSearchParams(uri.query);
+
+    const variantAnalysisIdString = params.get('variantAnalysisId');
+    if (!variantAnalysisIdString) {
+      void showAndLogWarningMessage('No variant analysis ID provided');
+      return undefined;
+    }
+    const variantAnalysisId = parseInt(variantAnalysisIdString);
+
+    const variantAnalysis = await variantAnalysisManager.getVariantAnalysis(variantAnalysisId);
+    if (!variantAnalysis) {
+      void showAndLogWarningMessage('No variant analysis found');
+      return undefined;
+    }
+
+    return SHOW_QUERY_TEXT_MSG + variantAnalysis.query.queryText;
+  }
+});

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
@@ -183,6 +183,7 @@ export class VariantAnalysisManager extends DisposableObject implements VariantA
         name: `Variant analysis ${variantAnalysisId}`,
         filePath: `variant_analysis_${variantAnalysisId}.ql`,
         language: variantAnalysisResponse.query_language as VariantAnalysisQueryLanguage,
+        queryText: '',
       },
       databases: {}
     }, variantAnalysisResponse);

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
@@ -183,7 +183,7 @@ export class VariantAnalysisManager extends DisposableObject implements VariantA
         name: `Variant analysis ${variantAnalysisId}`,
         filePath: `variant_analysis_${variantAnalysisId}.ql`,
         language: variantAnalysisResponse.query_language as VariantAnalysisQueryLanguage,
-        queryText: '',
+        text: '',
       },
       databases: {}
     }, variantAnalysisResponse);

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-processor.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-processor.ts
@@ -27,7 +27,8 @@ export function processVariantAnalysis(
     query: {
       name: submission.query.name,
       filePath: submission.query.filePath,
-      language: submission.query.language
+      language: submission.query.language,
+      queryText: submission.query.queryText,
     },
     databases: submission.databases,
   }, response);
@@ -51,11 +52,7 @@ export function processUpdatedVariantAnalysis(
   const variantAnalysis: VariantAnalysis = {
     id: response.id,
     controllerRepoId: response.controller_repo.id,
-    query: {
-      name: previousVariantAnalysis.query.name,
-      filePath: previousVariantAnalysis.query.filePath,
-      language: previousVariantAnalysis.query.language
-    },
+    query: previousVariantAnalysis.query,
     databases: previousVariantAnalysis.databases,
     status: processApiStatus(response.status),
     actionsWorkflowRunId: response.actions_workflow_run_id,

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-processor.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-processor.ts
@@ -28,7 +28,7 @@ export function processVariantAnalysis(
       name: submission.query.name,
       filePath: submission.query.filePath,
       language: submission.query.language,
-      queryText: submission.query.queryText,
+      text: submission.query.text,
     },
     databases: submission.databases,
   }, response);

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-view.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-view.ts
@@ -138,7 +138,7 @@ export class VariantAnalysisView extends AbstractWebview<ToVariantAnalysisMessag
   private async openQueryText(): Promise<void> {
     const variantAnalysis = await this.manager.getVariantAnalysis(this.variantAnalysisId);
     if (!variantAnalysis) {
-      void showAndLogWarningMessage('Could not open variant analysis query text');
+      void showAndLogWarningMessage('Could not open variant analysis query text. Variant analysis not found.');
       return;
     }
 
@@ -156,7 +156,7 @@ export class VariantAnalysisView extends AbstractWebview<ToVariantAnalysisMessag
       const doc = await workspace.openTextDocument(uri);
       await Window.showTextDocument(doc, { preview: false });
     } catch (error) {
-      void showAndLogWarningMessage('Could not open query text');
+      void showAndLogWarningMessage('Could not open variant analysis query text. Failed to open text document.');
     }
   }
 }

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
@@ -24,6 +24,12 @@ const openQueryFile = () => {
   });
 };
 
+const openQueryText = () => {
+  vscode.postMessage({
+    t: 'openQueryText',
+  });
+};
+
 export function VariantAnalysis({
   variantAnalysis: initialVariantAnalysis,
   repoStates: initialRepoStates = [],
@@ -75,7 +81,7 @@ export function VariantAnalysis({
       <VariantAnalysisHeader
         variantAnalysis={variantAnalysis}
         onOpenQueryFileClick={openQueryFile}
-        onViewQueryTextClick={() => console.log('View query')}
+        onViewQueryTextClick={openQueryText}
         onStopQueryClick={() => console.log('Stop query')}
         onCopyRepositoryListClick={() => console.log('Copy repository list')}
         onExportResultsClick={() => console.log('Export results')}

--- a/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisAnalyzedRepos.spec.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisAnalyzedRepos.spec.tsx
@@ -17,7 +17,7 @@ describe(VariantAnalysisAnalyzedRepos.name, () => {
       name: 'Example query',
       filePath: 'example.ql',
       language: VariantAnalysisQueryLanguage.Javascript,
-      queryText: 'import javascript\nselect 1',
+      text: 'import javascript\nselect 1',
     },
     databases: {},
     status: VariantAnalysisStatus.InProgress,

--- a/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisAnalyzedRepos.spec.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisAnalyzedRepos.spec.tsx
@@ -17,6 +17,7 @@ describe(VariantAnalysisAnalyzedRepos.name, () => {
       name: 'Example query',
       filePath: 'example.ql',
       language: VariantAnalysisQueryLanguage.Javascript,
+      queryText: 'import javascript\nselect 1',
     },
     databases: {},
     status: VariantAnalysisStatus.InProgress,

--- a/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisOutcomePanels.spec.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisOutcomePanels.spec.tsx
@@ -16,6 +16,7 @@ describe(VariantAnalysisOutcomePanels.name, () => {
       name: 'Example query',
       filePath: 'example.ql',
       language: VariantAnalysisQueryLanguage.Javascript,
+      queryText: 'import javascript\nselect 1',
     },
     databases: {},
     status: VariantAnalysisStatus.InProgress,

--- a/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisOutcomePanels.spec.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisOutcomePanels.spec.tsx
@@ -16,7 +16,7 @@ describe(VariantAnalysisOutcomePanels.name, () => {
       name: 'Example query',
       filePath: 'example.ql',
       language: VariantAnalysisQueryLanguage.Javascript,
-      queryText: 'import javascript\nselect 1',
+      text: 'import javascript\nselect 1',
     },
     databases: {},
     status: VariantAnalysisStatus.InProgress,

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-processor.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-processor.test.ts
@@ -31,6 +31,7 @@ describe('Variant Analysis processor', function() {
         'filePath': 'query-file-path',
         'language': VariantAnalysisQueryLanguage.Javascript,
         'name': 'query-name',
+        'queryText': mockSubmission.query.queryText,
       },
       'databases': {
         'repositories': ['1', '2', '3'],

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-processor.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-processor.test.ts
@@ -31,7 +31,7 @@ describe('Variant Analysis processor', function() {
         'filePath': 'query-file-path',
         'language': VariantAnalysisQueryLanguage.Javascript,
         'name': 'query-name',
-        'queryText': mockSubmission.query.queryText,
+        'text': mockSubmission.query.text,
       },
       'databases': {
         'repositories': ['1', '2', '3'],

--- a/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/shared/variant-analysis-submission.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/shared/variant-analysis-submission.ts
@@ -10,7 +10,7 @@ export function createMockSubmission(): VariantAnalysisSubmission {
       name: 'query-name',
       filePath: 'query-file-path',
       language: VariantAnalysisQueryLanguage.Javascript,
-      queryText: 'query-text',
+      text: 'query-text',
       pack: 'base64-encoded-string',
     },
     databases: {

--- a/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/shared/variant-analysis-submission.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/shared/variant-analysis-submission.ts
@@ -10,6 +10,7 @@ export function createMockSubmission(): VariantAnalysisSubmission {
       name: 'query-name',
       filePath: 'query-file-path',
       language: VariantAnalysisQueryLanguage.Javascript,
+      queryText: 'query-text',
       pack: 'base64-encoded-string',
     },
     databases: {

--- a/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/shared/variant-analysis.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/shared/variant-analysis.ts
@@ -21,7 +21,7 @@ export function createMockVariantAnalysis(
       name: 'a-query-name',
       filePath: 'a-query-file-path',
       language: VariantAnalysisQueryLanguage.Javascript,
-      queryText: 'a-query-text',
+      text: 'a-query-text',
     },
     databases: {
       repositories: ['1', '2', '3'],

--- a/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/shared/variant-analysis.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/shared/variant-analysis.ts
@@ -20,7 +20,8 @@ export function createMockVariantAnalysis(
     query: {
       name: 'a-query-name',
       filePath: 'a-query-file-path',
-      language: VariantAnalysisQueryLanguage.Javascript
+      language: VariantAnalysisQueryLanguage.Javascript,
+      queryText: 'a-query-text',
     },
     databases: {
       repositories: ['1', '2', '3'],


### PR DESCRIPTION
This makes it possible to view the query text of a variant analysis. It adds the `queryText` property to the variant analysis and implements all necessary components to open a virtual file.

It's probably easiest to review this commit-by-commit.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
