### PR TITLE
Typo fixes in query history methods/properties

### DIFF
--- a/extensions/ql-vscode/src/contextual/locationFinder.ts
+++ b/extensions/ql-vscode/src/contextual/locationFinder.ts
@@ -65,7 +65,7 @@ export async function getLocationsForUriString(
       false
     );
     const results = await qs.compileAndRunQueryAgainstDatabase(db, initialInfo, queryStorageDir, progress, token, templates);
-    if (results.sucessful) {
+    if (results.successful) {
       links.push(...await getLinksFromResults(results, cli, db, filter));
     }
   }

--- a/extensions/ql-vscode/src/interface.ts
+++ b/extensions/ql-vscode/src/interface.ts
@@ -326,7 +326,7 @@ export class ResultsView extends AbstractWebview<IntoResultsViewMsg, FromResults
     forceReveal: WebviewReveal,
     shouldKeepOldResultsWhileRendering = false
   ): Promise<void> {
-    if (!fullQuery.completedQuery.sucessful) {
+    if (!fullQuery.completedQuery.successful) {
       return;
     }
 

--- a/extensions/ql-vscode/src/legacy-query-server/run-queries.ts
+++ b/extensions/ql-vscode/src/legacy-query-server/run-queries.ts
@@ -420,7 +420,7 @@ export async function compileAndRunQueryAgainstDatabase(
         query: query.queryEvalInfo,
         message,
         result,
-        sucessful: result.resultType == messages.QueryResultType.SUCCESS,
+        successful: result.resultType == messages.QueryResultType.SUCCESS,
         logFileLocation: result.logFileLocation,
         dispose: () => {
           qs.logger.removeAdditionalLogLocation(result.logFileLocation);
@@ -497,14 +497,14 @@ function createSyntheticResult(
   return {
     query: query.queryEvalInfo,
     message,
-    result:{
-      evaluationTime:0,
+    result: {
+      evaluationTime: 0,
       queryId: 0,
       resultType: messages.QueryResultType.OTHER_ERROR,
       message,
       runId: 0,
     },
-    sucessful: false,
+    successful: false,
     dispose: () => { /**/ },
   };
 }

--- a/extensions/ql-vscode/src/query-history-scrubber.ts
+++ b/extensions/ql-vscode/src/query-history-scrubber.ts
@@ -26,7 +26,7 @@ type Counter = {
  * @param queryDirectory The directory containing all queries.
  * @param ctx The extension context.
  */
-export function registerQueryHistoryScubber(
+export function registerQueryHistoryScrubber(
   wakeInterval: number,
   throttleTime: number,
   maxQueryTime: number,

--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -32,7 +32,7 @@ import { ONE_HOUR_IN_MS, TWO_HOURS_IN_MS } from './pure/time';
 import { assertNever, getErrorMessage, getErrorStack } from './pure/helpers-pure';
 import { CompletedLocalQueryInfo, LocalQueryInfo as LocalQueryInfo, QueryHistoryInfo } from './query-results';
 import { DatabaseManager } from './databases';
-import { registerQueryHistoryScubber } from './query-history-scrubber';
+import { registerQueryHistoryScrubber } from './query-history-scrubber';
 import { QueryStatus } from './query-status';
 import { slurpQueryHistory, splatQueryHistory } from './query-serialization';
 import * as fs from 'fs-extra';
@@ -573,7 +573,7 @@ export class QueryHistoryManager extends DisposableObject {
     this.queryHistoryScrubber?.dispose();
     // Every hour check if we need to re-run the query history scrubber.
     this.queryHistoryScrubber = this.push(
-      registerQueryHistoryScubber(
+      registerQueryHistoryScrubber(
         ONE_HOUR_IN_MS,
         TWO_HOURS_IN_MS,
         queryHistoryConfigListener.ttlInMillis,

--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -795,7 +795,7 @@ export class QueryHistoryManager extends DisposableObject {
         throw new Error('Please select a local query.');
       }
 
-      if (!finalSingleItem.completedQuery?.sucessful) {
+      if (!finalSingleItem.completedQuery?.successful) {
         throw new Error('Please select a query that has completed successfully.');
       }
 
@@ -1236,7 +1236,7 @@ the file in the file explorer and dragging it into the workspace.`
       if (!otherQuery.completedQuery) {
         throw new Error('Please select a completed query.');
       }
-      if (!otherQuery.completedQuery.sucessful) {
+      if (!otherQuery.completedQuery.successful) {
         throw new Error('Please select a successful query.');
       }
       if (otherQuery.initialInfo.databaseInfo.name !== dbName) {
@@ -1256,7 +1256,7 @@ the file in the file explorer and dragging it into the workspace.`
           otherQuery !== singleItem &&
           otherQuery.t === 'local' &&
           otherQuery.completedQuery &&
-          otherQuery.completedQuery.sucessful &&
+          otherQuery.completedQuery.successful &&
           otherQuery.initialInfo.databaseInfo.name === dbName
       )
       .map((item) => ({

--- a/extensions/ql-vscode/src/query-results.ts
+++ b/extensions/ql-vscode/src/query-results.ts
@@ -47,7 +47,7 @@ export interface InitialQueryInfo {
 export class CompletedQueryInfo implements QueryWithResults {
   readonly query: QueryEvaluationInfo;
   readonly message?: string;
-  readonly sucessful?: boolean;
+  readonly successful?: boolean;
   /**
    * The legacy result. This is only set when loading from the query history.
    */
@@ -86,7 +86,7 @@ export class CompletedQueryInfo implements QueryWithResults {
     this.result = evaluation.result;
 
     this.message = evaluation.message;
-    this.sucessful = evaluation.sucessful;
+    this.successful = evaluation.successful;
     // Use the dispose method from the evaluation.
     // The dispose will clean up any additional log locations that this
     // query may have created.
@@ -301,7 +301,7 @@ export class LocalQueryInfo {
       return QueryStatus.Failed;
     } else if (!this.completedQuery) {
       return QueryStatus.InProgress;
-    } else if (this.completedQuery.sucessful) {
+    } else if (this.completedQuery.successful) {
       return QueryStatus.Completed;
     } else {
       return QueryStatus.Failed;

--- a/extensions/ql-vscode/src/query-server/run-queries.ts
+++ b/extensions/ql-vscode/src/query-server/run-queries.ts
@@ -124,18 +124,18 @@ export async function compileAndRunQueryAgainstDatabase(
       message = result.message ? `failed: ${result.message}` : 'failed';
       break;
   }
-  const sucessful = result.resultType === messages.QueryResultType.SUCCESS;
+  const successful = result.resultType === messages.QueryResultType.SUCCESS;
   return {
     query,
     result: {
       evaluationTime: result.evaluationTime,
       queryId: 0,
-      resultType: sucessful ? legacyMessages.QueryResultType.SUCCESS : legacyMessages.QueryResultType.OTHER_ERROR,
+      resultType: successful ? legacyMessages.QueryResultType.SUCCESS : legacyMessages.QueryResultType.OTHER_ERROR,
       runId: 0,
       message
     },
     message,
-    sucessful,
+    successful,
     dispose: () => {
       qs.logger.removeAdditionalLogLocation(undefined);
     }

--- a/extensions/ql-vscode/src/run-queries-shared.ts
+++ b/extensions/ql-vscode/src/run-queries-shared.ts
@@ -373,7 +373,7 @@ export interface QueryWithResults {
   readonly query: QueryEvaluationInfo;
   readonly logFileLocation?: string;
   readonly dispose: () => void;
-  readonly sucessful?: boolean;
+  readonly successful?: boolean;
   readonly message?: string;
   readonly result: legacyMessages.EvaluationResult;
 }

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/queries.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/queries.test.ts
@@ -112,7 +112,7 @@ describe('Queries', function() {
       );
 
       // just check that the query was successful
-      expect((await result).sucessful).to.eq(true);
+      expect((await result).successful).to.eq(true);
     } catch (e) {
       console.error('Test Failed');
       fail(e as Error);
@@ -132,7 +132,7 @@ describe('Queries', function() {
         token
       );
 
-      expect(result.sucessful).to.eq(true);
+      expect(result.successful).to.eq(true);
     } catch (e) {
       console.error('Test Failed');
       fail(e as Error);

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
@@ -581,7 +581,7 @@ describe('query-history', () => {
     }
   });
 
-  function createMockFullQueryInfo(dbName = 'a', queryWitbResults?: QueryWithResults, isFail = false): LocalQueryInfo {
+  function createMockFullQueryInfo(dbName = 'a', queryWithResults?: QueryWithResults, isFail = false): LocalQueryInfo {
     const fqi = new LocalQueryInfo(
       {
         databaseInfo: { name: dbName },
@@ -593,8 +593,8 @@ describe('query-history', () => {
       } as vscode.CancellationTokenSource
     );
 
-    if (queryWitbResults) {
-      fqi.completeThisQuery(queryWitbResults);
+    if (queryWithResults) {
+      fqi.completeThisQuery(queryWithResults);
     }
     if (isFail) {
       fqi.failureReason = 'failure reason';

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
@@ -785,7 +785,7 @@ describe('query-history', () => {
         hasInterpretedResults: () => Promise.resolve(hasInterpretedResults),
         deleteQuery: sandbox.stub(),
       } as unknown as QueryEvaluationInfo,
-      sucessful: didRunSuccessfully,
+      successful: didRunSuccessfully,
       message: 'foo',
       dispose: sandbox.spy(),
       result: {

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 import * as sinon from 'sinon';
 
 import { logger } from '../../logging';
-import { registerQueryHistoryScubber } from '../../query-history-scrubber';
+import { registerQueryHistoryScrubber } from '../../query-history-scrubber';
 import { QueryHistoryManager, HistoryTreeDataProvider, SortOrder } from '../../query-history';
 import { QueryEvaluationInfo, QueryWithResults } from '../../run-queries-shared';
 import { QueryHistoryConfig, QueryHistoryConfigListener } from '../../config';
@@ -759,7 +759,7 @@ describe('query-history', () => {
     }
 
     function registerScrubber(dir: string) {
-      deregister = registerQueryHistoryScubber(
+      deregister = registerQueryHistoryScrubber(
         ONE_HOUR_IN_MS,
         TWO_HOURS_IN_MS,
         LESS_THAN_ONE_DAY,

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/query-results.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/query-results.test.ts
@@ -325,7 +325,7 @@ describe('query-results', () => {
 
     const result: QueryWithResults = {
       query: query.queryEvalInfo,
-      sucessful: didRunSuccessfully,
+      successful: didRunSuccessfully,
       message: 'foo',
       dispose: disposeSpy,
       result: {
@@ -343,7 +343,7 @@ describe('query-results', () => {
     return result;
   }
 
-  function createMockFullQueryInfo(dbName = 'a', queryWitbResults?: QueryWithResults, isFail = false): LocalQueryInfo {
+  function createMockFullQueryInfo(dbName = 'a', queryWithResults?: QueryWithResults, isFail = false): LocalQueryInfo {
     const fqi = new LocalQueryInfo(
       {
         databaseInfo: {
@@ -362,8 +362,8 @@ describe('query-results', () => {
       } as CancellationTokenSource
     );
 
-    if (queryWitbResults) {
-      fqi.completeThisQuery(queryWitbResults);
+    if (queryWithResults) {
+      fqi.completeThisQuery(queryWithResults);
     }
     if (isFail) {
       fqi.failureReason = 'failure reason';


### PR DESCRIPTION
I'm making some changes to the query history, and spotted a few minor typos. I've pulled these out to this separate PR, to avoid cluttering up the "actual" changes later! Lots of changed files, but no actual impact 🤞🏽 

(PS: I double-checked the currently-open PR, and this shouldn't conflict with anything there) 

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
