### PR TITLE
Use a method to handle results without sucess data

### DIFF
--- a/extensions/ql-vscode/src/interface.ts
+++ b/extensions/ql-vscode/src/interface.ts
@@ -326,7 +326,7 @@ export class ResultsView extends AbstractWebview<IntoResultsViewMsg, FromResults
     forceReveal: WebviewReveal,
     shouldKeepOldResultsWhileRendering = false
   ): Promise<void> {
-    if (!fullQuery.completedQuery.successful) {
+    if (!fullQuery.completedQuery.ranSucessfully()) {
       return;
     }
 

--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -836,7 +836,7 @@ export class QueryHistoryManager extends DisposableObject {
         throw new Error('Please select a local query.');
       }
 
-      if (!finalSingleItem.completedQuery?.successful) {
+      if (!finalSingleItem.completedQuery?.ranSucessfully()) {
         throw new Error('Please select a query that has completed successfully.');
       }
 
@@ -1289,7 +1289,7 @@ the file in the file explorer and dragging it into the workspace.`
       if (!otherQuery.completedQuery) {
         throw new Error('Please select a completed query.');
       }
-      if (!otherQuery.completedQuery.successful) {
+      if (!otherQuery.completedQuery.ranSucessfully()) {
         throw new Error('Please select a successful query.');
       }
       if (otherQuery.initialInfo.databaseInfo.name !== dbName) {
@@ -1309,7 +1309,7 @@ the file in the file explorer and dragging it into the workspace.`
           otherQuery !== singleItem &&
           otherQuery.t === 'local' &&
           otherQuery.completedQuery &&
-          otherQuery.completedQuery.successful &&
+          otherQuery.completedQuery.ranSucessfully() &&
           otherQuery.initialInfo.databaseInfo.name === dbName
       )
       .map((item) => ({

--- a/extensions/ql-vscode/src/query-results.ts
+++ b/extensions/ql-vscode/src/query-results.ts
@@ -101,6 +101,14 @@ export class CompletedQueryInfo implements QueryWithResults {
     this.resultCount = value;
   }
 
+  ranSucessfully(): boolean {
+    if(this.successful !== undefined) {
+      return this.successful; 
+    } else {
+      return this.result.resultType == legacyMessages.QueryResultType.SUCCESS;
+    }
+  }
+
   get statusString(): string {
     if (this.message) {
       return this.message;
@@ -302,7 +310,7 @@ export class LocalQueryInfo {
       return QueryStatus.Failed;
     } else if (!this.completedQuery) {
       return QueryStatus.InProgress;
-    } else if (this.completedQuery.successful) {
+    } else if (this.completedQuery.ranSucessfully()) {
       return QueryStatus.Completed;
     } else {
       return QueryStatus.Failed;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

This fixes a bug when loading old results where we think they weren't successful. This is a bit awkward due to having to create a method as the old getter would no longer work.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
