### PR TITLE
Move helper functions (for creating mock query history items) to shared location

### DIFF
--- a/extensions/ql-vscode/src/vscode-tests/factories/local-queries/local-query-history-item.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/local-queries/local-query-history-item.ts
@@ -1,0 +1,33 @@
+import {
+  InitialQueryInfo,
+  CompletedQueryInfo,
+  CompletedLocalQueryInfo,
+  LocalQueryInfo,
+} from '../../../query-results';
+
+export function createMockLocalQueryInfo(
+  startTime: string,
+  userSpecifiedLabel?: string
+): LocalQueryInfo {
+  return ({
+    t: 'local',
+    userSpecifiedLabel,
+    startTime: startTime,
+    getQueryFileName() {
+      return 'query-file.ql';
+    },
+    getQueryName() {
+      return 'query-name';
+    },
+    initialInfo: ({
+      databaseInfo: {
+        databaseUri: 'unused',
+        name: 'db-name',
+      },
+    } as unknown) as InitialQueryInfo,
+    completedQuery: ({
+      resultCount: 456,
+      statusString: 'in progress',
+    } as unknown) as CompletedQueryInfo,
+  } as unknown) as CompletedLocalQueryInfo;
+}

--- a/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/remote-query-history-item.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/remote-query-history-item.ts
@@ -1,0 +1,31 @@
+import { RemoteQueryHistoryItem } from '../../../remote-queries/remote-query-history-item';
+
+export function createMockRemoteQueryHistoryItem({
+  date = new Date('2022-01-01T00:00:00.000Z'),
+  resultCount = 16,
+  userSpecifiedLabel = undefined,
+  repositoryCount = 0,
+}: {
+  date?: Date;
+  resultCount?: number;
+  userSpecifiedLabel?: string;
+  repositoryCount?: number;
+}): RemoteQueryHistoryItem {
+  return ({
+    t: 'remote',
+    userSpecifiedLabel,
+    remoteQuery: {
+      executionStartTime: date.getTime(),
+      queryName: 'query-name',
+      queryFilePath: 'query-file.ql',
+      controllerRepository: {
+        owner: 'github',
+        name: 'vscode-codeql-integration-tests',
+      },
+      language: 'javascript',
+      repositoryCount,
+    },
+    status: 'in progress',
+    resultCount,
+  } as unknown) as RemoteQueryHistoryItem;
+}

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/history-item-label-provider.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/history-item-label-provider.test.ts
@@ -2,9 +2,9 @@ import { env } from 'vscode';
 import { expect } from 'chai';
 import { QueryHistoryConfig } from '../../config';
 import { HistoryItemLabelProvider } from '../../history-item-label-provider';
-import { CompletedLocalQueryInfo, CompletedQueryInfo, InitialQueryInfo } from '../../query-results';
 import { QueryHistoryInfo } from '../../query-history-info';
 import { RemoteQueryHistoryItem } from '../../remote-queries/remote-query-history-item';
+import { createMockLocalQueryInfo } from '../factories/local-queries/local-query-history-item';
 
 
 describe('HistoryItemLabelProvider', () => {
@@ -23,7 +23,7 @@ describe('HistoryItemLabelProvider', () => {
 
   describe('local queries', () => {
     it('should interpolate query when user specified', () => {
-      const fqi = createMockLocalQueryInfo('xxx');
+      const fqi = createMockLocalQueryInfo(dateStr, 'xxx');
 
       expect(labelProvider.getLabel(fqi)).to.eq('xxx');
 
@@ -35,7 +35,7 @@ describe('HistoryItemLabelProvider', () => {
     });
 
     it('should interpolate query when not user specified', () => {
-      const fqi = createMockLocalQueryInfo();
+      const fqi = createMockLocalQueryInfo(dateStr);
 
       expect(labelProvider.getLabel(fqi)).to.eq('xxx query-name xxx');
 
@@ -48,7 +48,7 @@ describe('HistoryItemLabelProvider', () => {
     });
 
     it('should get query short label', () => {
-      const fqi = createMockLocalQueryInfo('xxx');
+      const fqi = createMockLocalQueryInfo(dateStr, 'xxx');
 
       // fall back on user specified if one exists.
       expect(labelProvider.getShortLabel(fqi)).to.eq('xxx');
@@ -57,30 +57,6 @@ describe('HistoryItemLabelProvider', () => {
       delete (fqi as any).userSpecifiedLabel;
       expect(labelProvider.getShortLabel(fqi)).to.eq('query-name');
     });
-
-    function createMockLocalQueryInfo(userSpecifiedLabel?: string) {
-      return {
-        t: 'local',
-        userSpecifiedLabel,
-        startTime: date.toLocaleString(env.language),
-        getQueryFileName() {
-          return 'query-file.ql';
-        },
-        getQueryName() {
-          return 'query-name';
-        },
-        initialInfo: {
-          databaseInfo: {
-            databaseUri: 'unused',
-            name: 'db-name'
-          }
-        } as unknown as InitialQueryInfo,
-        completedQuery: {
-          resultCount: 456,
-          statusString: 'in progress',
-        } as unknown as CompletedQueryInfo,
-      } as unknown as CompletedLocalQueryInfo;
-    }
   });
 
   describe('remote queries', () => {

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/history-item-label-provider.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/history-item-label-provider.test.ts
@@ -2,9 +2,8 @@ import { env } from 'vscode';
 import { expect } from 'chai';
 import { QueryHistoryConfig } from '../../config';
 import { HistoryItemLabelProvider } from '../../history-item-label-provider';
-import { QueryHistoryInfo } from '../../query-history-info';
-import { RemoteQueryHistoryItem } from '../../remote-queries/remote-query-history-item';
 import { createMockLocalQueryInfo } from '../factories/local-queries/local-query-history-item';
+import { createMockRemoteQueryHistoryItem } from '../factories/remote-queries/remote-query-history-item';
 
 
 describe('HistoryItemLabelProvider', () => {
@@ -61,7 +60,7 @@ describe('HistoryItemLabelProvider', () => {
 
   describe('remote queries', () => {
     it('should interpolate query when user specified', () => {
-      const fqi = createMockRemoteQueryInfo({ userSpecifiedLabel: 'xxx' });
+      const fqi = createMockRemoteQueryHistoryItem({ userSpecifiedLabel: 'xxx' });
 
       expect(labelProvider.getLabel(fqi)).to.eq('xxx');
 
@@ -73,7 +72,7 @@ describe('HistoryItemLabelProvider', () => {
     });
 
     it('should interpolate query when not user-specified', () => {
-      const fqi = createMockRemoteQueryInfo({});
+      const fqi = createMockRemoteQueryHistoryItem({});
 
       expect(labelProvider.getLabel(fqi)).to.eq('xxx query-name (javascript) xxx');
 
@@ -86,14 +85,14 @@ describe('HistoryItemLabelProvider', () => {
     });
 
     it('should use number of repositories instead of controller repo if available', () => {
-      const fqi = createMockRemoteQueryInfo({ repositoryCount: 2 });
+      const fqi = createMockRemoteQueryHistoryItem({ repositoryCount: 2 });
 
       config.format = '%t %q %d %s %f %r %%';
       expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name (javascript) 2 repositories in progress query-file.ql (16 results) %`);
     });
 
     it('should get query short label', () => {
-      const fqi = createMockRemoteQueryInfo({ userSpecifiedLabel: 'xxx' });
+      const fqi = createMockRemoteQueryHistoryItem({ userSpecifiedLabel: 'xxx' });
 
       // fall back on user specified if one exists.
       expect(labelProvider.getShortLabel(fqi)).to.eq('xxx');
@@ -105,7 +104,7 @@ describe('HistoryItemLabelProvider', () => {
 
     describe('when results are present', () => {
       it('should display results if there are any', () => {
-        const fqi = createMockRemoteQueryInfo({ resultCount: 16, repositoryCount: 2 });
+        const fqi = createMockRemoteQueryHistoryItem({ resultCount: 16, repositoryCount: 2 });
         config.format = '%t %q %d %s %f %r %%';
         expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name (javascript) 2 repositories in progress query-file.ql (16 results) %`);
       });
@@ -113,7 +112,7 @@ describe('HistoryItemLabelProvider', () => {
 
     describe('when results are not present', () => {
       it('should skip displaying them', () => {
-        const fqi = createMockRemoteQueryInfo({ resultCount: 0, repositoryCount: 2 });
+        const fqi = createMockRemoteQueryHistoryItem({ resultCount: 0, repositoryCount: 2 });
         config.format = '%t %q %d %s %f %r %%';
         expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name (javascript) 2 repositories in progress query-file.ql %`);
       });
@@ -121,7 +120,7 @@ describe('HistoryItemLabelProvider', () => {
 
     describe('when extra whitespace is present in the middle of the label', () => {
       it('should squash it down to a single whitespace', () => {
-        const fqi = createMockRemoteQueryInfo({ resultCount: 0, repositoryCount: 2 });
+        const fqi = createMockRemoteQueryHistoryItem({ resultCount: 0, repositoryCount: 2 });
         config.format = '%t   %q        %d %s   %f   %r %%';
         expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name (javascript) 2 repositories in progress query-file.ql %`);
       });
@@ -129,7 +128,7 @@ describe('HistoryItemLabelProvider', () => {
 
     describe('when extra whitespace is present at the start of the label', () => {
       it('should squash it down to a single whitespace', () => {
-        const fqi = createMockRemoteQueryInfo({ resultCount: 0, repositoryCount: 2 });
+        const fqi = createMockRemoteQueryHistoryItem({ resultCount: 0, repositoryCount: 2 });
         config.format = '   %t %q %d %s %f %r %%';
         expect(labelProvider.getLabel(fqi)).to.eq(` ${dateStr} query-name (javascript) 2 repositories in progress query-file.ql %`);
       });
@@ -137,38 +136,10 @@ describe('HistoryItemLabelProvider', () => {
 
     describe('when extra whitespace is present at the end of the label', () => {
       it('should squash it down to a single whitespace', () => {
-        const fqi = createMockRemoteQueryInfo({ resultCount: 0, repositoryCount: 2 });
+        const fqi = createMockRemoteQueryHistoryItem({ resultCount: 0, repositoryCount: 2 });
         config.format = '%t %q %d %s %f %r %%   ';
         expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name (javascript) 2 repositories in progress query-file.ql % `);
       });
     });
-
-    function createMockRemoteQueryInfo({
-      resultCount = 16,
-      userSpecifiedLabel = undefined,
-      repositoryCount = 0
-    }: {
-      resultCount?: number;
-      userSpecifiedLabel?: string;
-      repositoryCount?: number;
-    }): QueryHistoryInfo {
-      return {
-        t: 'remote',
-        userSpecifiedLabel,
-        remoteQuery: {
-          executionStartTime: date.getTime(),
-          queryName: 'query-name',
-          queryFilePath: 'query-file.ql',
-          controllerRepository: {
-            owner: 'github',
-            name: 'vscode-codeql-integration-tests'
-          },
-          language: 'javascript',
-          repositoryCount,
-        },
-        status: 'in progress',
-        resultCount,
-      } as unknown as RemoteQueryHistoryItem;
-    }
   });
 });


### PR DESCRIPTION
We had some existing functions for creating a mock local query history item and a mock remote query history item. I plan to re-use those for some new `query-history-info` unit tests (see https://github.com/github/vscode-codeql/pull/1600#discussion_r995676466). This PR pre-emptively moves those helper functions into separate files in the `factories` folder.



## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
