### PR TITLE
Add unit tests for `query-history-info`

### DIFF
--- a/extensions/ql-vscode/test/pure-tests/query-history-info.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/query-history-info.test.ts
@@ -1,0 +1,43 @@
+import { expect } from 'chai';
+
+import { QueryStatus } from '../../src/query-status';
+import { getRawQueryName } from '../../src/query-history-info';
+import { VariantAnalysisHistoryItem } from '../../src/remote-queries/variant-analysis-history-item';
+import { createMockVariantAnalysis } from '../../src/vscode-tests/factories/remote-queries/shared/variant-analysis';
+import { createMockLocalQueryInfo } from '../../src/vscode-tests/factories/local-queries/local-query-history-item';
+import { createMockRemoteQueryHistoryItem } from '../../src/vscode-tests/factories/remote-queries/remote-query-history-item';
+
+describe('Query history info', () => {
+  describe('getRawQueryName', () => {
+    it('should get the name for local history items', () => {
+      const date = new Date('2022-01-01T00:00:00.000Z');
+      const dateStr = date.toLocaleString();
+
+      const queryHistoryItem = createMockLocalQueryInfo(dateStr);
+
+      const queryName = getRawQueryName(queryHistoryItem);
+
+      expect(queryName).to.equal(queryHistoryItem.getQueryName());
+    });
+
+    it('should get the name for remote query history items', () => {
+      const queryHistoryItem = createMockRemoteQueryHistoryItem({});
+      const queryName = getRawQueryName(queryHistoryItem);
+
+      expect(queryName).to.equal(queryHistoryItem.remoteQuery.queryName);
+    });
+
+    it('should get the name for variant analysis history items', () => {
+      const queryHistoryItem: VariantAnalysisHistoryItem = {
+        t: 'variant-analysis',
+        status: QueryStatus.InProgress,
+        completed: false,
+        variantAnalysis: createMockVariantAnalysis()
+      };
+
+      const queryName = getRawQueryName(queryHistoryItem);
+
+      expect(queryName).to.equal(queryHistoryItem.variantAnalysis.query.name);
+    });
+  });
+});


### PR DESCRIPTION
Follow-up to #1600 and #1603. Adds tests for the `getRawQueryName` helper function. 
(Nothing particularly interesting yet, but once I've implemented more helpers for handling `QueryHistoryInfo`, I'll add tests for them here too!)

## Checklist

N/A - internal only 🍕 

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
