### PR TITLE
`loadPersistedState` should happen outside of dbm constructor

### DIFF
--- a/extensions/ql-vscode/src/databases.ts
+++ b/extensions/ql-vscode/src/databases.ts
@@ -559,9 +559,6 @@ export class DatabaseManager extends DisposableObject {
     super();
 
     qs.onStart(this.reregisterDatabases.bind(this));
-
-    // Let this run async.
-    void this.loadPersistedState();
   }
 
   public async openDatabase(
@@ -691,7 +688,7 @@ export class DatabaseManager extends DisposableObject {
     return item;
   }
 
-  private async loadPersistedState(): Promise<void> {
+  public async loadPersistedState(): Promise<void> {
     return withProgress({
       location: vscode.ProgressLocation.Notification
     },

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -452,6 +452,10 @@ async function activateWithInstalledDistribution(
 
   void logger.log('Initializing database manager.');
   const dbm = new DatabaseManager(ctx, qs, cliServer, logger);
+
+  // Let this run async.
+  void dbm.loadPersistedState();
+
   ctx.subscriptions.push(dbm);
   void logger.log('Initializing database panel.');
   const databaseUI = new DatabaseUI(

--- a/extensions/ql-vscode/src/vscode-tests/minimal-workspace/databases.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/minimal-workspace/databases.test.ts
@@ -77,7 +77,9 @@ describe('databases', () => {
         },
         resolveDatabase: resolveDatabaseSpy
       } as unknown as CodeQLCliServer,
-      {} as Logger,
+      {
+        log: () => { /**/ }
+      } as unknown as Logger,
     );
 
     // Unfortunately, during a test it is not possible to convert from

--- a/extensions/ql-vscode/src/vscode-tests/minimal-workspace/index.ts
+++ b/extensions/ql-vscode/src/vscode-tests/minimal-workspace/index.ts
@@ -12,3 +12,12 @@ chai.use(sinonChai);
 export function run(): Promise<void> {
   return runTestsInDirectory(__dirname);
 }
+
+process.addListener('unhandledRejection', (reason) => {
+  if (reason instanceof Error && reason.message === 'Canceled') {
+    console.log('Cancellation requested after the test has ended.');
+    process.exit(0);
+  } else {
+    fail(String(reason));
+  }
+});


### PR DESCRIPTION
Also, add stub to logger in tests.

This fixes some occasionally failing tests on main.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->
