### PR TITLE
Remove debug log entry

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
@@ -39,7 +39,7 @@ export class VariantAnalysisManager extends DisposableObject implements VariantA
     logger: Logger,
   ) {
     super();
-    this.variantAnalysisMonitor = this.push(new VariantAnalysisMonitor(ctx, logger));
+    this.variantAnalysisMonitor = this.push(new VariantAnalysisMonitor(ctx));
     this.variantAnalysisMonitor.onVariantAnalysisChange(this.onVariantAnalysisUpdated.bind(this));
 
     this.variantAnalysisResultsManager = this.push(new VariantAnalysisResultsManager(cliServer, storagePath, logger));

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-monitor.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-monitor.ts
@@ -1,6 +1,5 @@
 import { ExtensionContext, CancellationToken, commands, EventEmitter } from 'vscode';
 import { Credentials } from '../authentication';
-import { Logger } from '../logging';
 import * as ghApiClient from './gh-api/gh-api-client';
 
 import { VariantAnalysis, VariantAnalysisStatus } from './shared/variant-analysis';
@@ -22,7 +21,6 @@ export class VariantAnalysisMonitor extends DisposableObject {
 
   constructor(
     private readonly extensionContext: ExtensionContext,
-    private readonly logger: Logger
   ) {
     super();
   }
@@ -72,8 +70,6 @@ export class VariantAnalysisMonitor extends DisposableObject {
       variantAnalysis = processUpdatedVariantAnalysis(variantAnalysis, variantAnalysisSummary);
 
       this._onVariantAnalysisChange.fire(variantAnalysis);
-
-      void this.logger.log('****** Retrieved variant analysis' + JSON.stringify(variantAnalysisSummary));
 
       if (variantAnalysisSummary.scanned_repositories) {
         variantAnalysisSummary.scanned_repositories.forEach(scannedRepo => {

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-monitor.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-monitor.test.ts
@@ -2,7 +2,6 @@ import * as sinon from 'sinon';
 import { expect } from 'chai';
 import { CancellationTokenSource, extensions } from 'vscode';
 import { CodeQLExtensionInterface } from '../../../extension';
-import { logger } from '../../../logging';
 import * as config from '../../../config';
 
 import * as ghApiClient from '../../../remote-queries/gh-api/gh-api-client';
@@ -30,7 +29,6 @@ describe('Variant Analysis Monitor', async function() {
 
   beforeEach(async () => {
     sandbox = sinon.createSandbox();
-    sandbox.stub(logger, 'log');
     sandbox.stub(config, 'isVariantAnalysisLiveResultsEnabled').returns(false);
 
     cancellationTokenSource = new CancellationTokenSource();
@@ -39,7 +37,7 @@ describe('Variant Analysis Monitor', async function() {
 
     try {
       const extension = await extensions.getExtension<CodeQLExtensionInterface | Record<string, never>>('GitHub.vscode-codeql')!.activate();
-      variantAnalysisMonitor = new VariantAnalysisMonitor(extension.ctx, logger);
+      variantAnalysisMonitor = new VariantAnalysisMonitor(extension.ctx);
     } catch (e) {
       fail(e as Error);
     }


### PR DESCRIPTION
I believe this log entry was added for debugging purposes and should be removed - we don't want to flood the user's extension log with entries.

## Checklist
N/A - internal only:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
