### PR TITLE
Implement `getQueryText` for variant analysis history items

### DIFF
--- a/extensions/ql-vscode/src/query-history-info.ts
+++ b/extensions/ql-vscode/src/query-history-info.ts
@@ -30,3 +30,16 @@ export function getQueryHistoryItemId(item: QueryHistoryInfo): string {
       assertNever(item);
   }
 }
+
+export function getQueryText(item: QueryHistoryInfo): string {
+  switch (item.t) {
+    case 'local':
+      return item.initialInfo.queryText;
+    case 'remote':
+      return item.remoteQuery.queryText;
+    case 'variant-analysis':
+      return item.variantAnalysis.query.text;
+    default:
+      assertNever(item);
+  }
+}

--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -31,7 +31,7 @@ import { commandRunner } from './commandRunner';
 import { ONE_HOUR_IN_MS, TWO_HOURS_IN_MS } from './pure/time';
 import { assertNever, getErrorMessage, getErrorStack } from './pure/helpers-pure';
 import { CompletedLocalQueryInfo, LocalQueryInfo } from './query-results';
-import { getQueryHistoryItemId, QueryHistoryInfo } from './query-history-info';
+import { getQueryHistoryItemId, getQueryText, QueryHistoryInfo } from './query-history-info';
 import { DatabaseManager } from './databases';
 import { registerQueryHistoryScrubber } from './query-history-scrubber';
 import { QueryStatus } from './query-status';
@@ -1067,7 +1067,7 @@ export class QueryHistoryManager extends DisposableObject {
 
     const params = new URLSearchParams({
       isQuickEval: String(!!(finalSingleItem.t === 'local' && finalSingleItem.initialInfo.quickEvalPosition)),
-      queryText: encodeURIComponent(await this.getQueryText(finalSingleItem)),
+      queryText: encodeURIComponent(getQueryText(finalSingleItem)),
     });
 
     const queryId = getQueryHistoryItemId(finalSingleItem);
@@ -1189,19 +1189,6 @@ export class QueryHistoryManager extends DisposableObject {
     }
 
     await commands.executeCommand('codeQL.copyRepoList', finalSingleItem.queryId);
-  }
-
-  async getQueryText(item: QueryHistoryInfo): Promise<string> {
-    switch (item.t) {
-      case 'local':
-        return item.initialInfo.queryText;
-      case 'remote':
-        return item.remoteQuery.queryText;
-      case 'variant-analysis':
-        return 'TODO';
-      default:
-        assertNever(item);
-    }
   }
 
   async handleExportResults(): Promise<void> {

--- a/extensions/ql-vscode/test/pure-tests/query-history-info.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/query-history-info.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 
 import { QueryStatus } from '../../src/query-status';
-import { getQueryHistoryItemId, getRawQueryName } from '../../src/query-history-info';
+import { getQueryHistoryItemId, getQueryText, getRawQueryName } from '../../src/query-history-info';
 import { VariantAnalysisHistoryItem } from '../../src/remote-queries/variant-analysis-history-item';
 import { createMockVariantAnalysis } from '../../src/vscode-tests/factories/remote-queries/shared/variant-analysis';
 import { createMockLocalQueryInfo } from '../../src/vscode-tests/factories/local-queries/local-query-history-item';
@@ -58,6 +58,26 @@ describe('Query history info', () => {
       const historyItemId = getQueryHistoryItemId(variantAnalysisHistoryItem);
 
       expect(historyItemId).to.equal(variantAnalysisHistoryItem.historyItemId);
+    });
+  });
+
+  describe('getQueryText', () => {
+    it('should get the query text for local history items', () => {
+      const queryText = getQueryText(localQueryHistoryItem);
+
+      expect(queryText).to.equal(localQueryHistoryItem.initialInfo.queryText);
+    });
+
+    it('should get the query text for remote query history items', () => {
+      const queryText = getQueryText(remoteQueryHistoryItem);
+
+      expect(queryText).to.equal(remoteQueryHistoryItem.remoteQuery.queryText);
+    });
+
+    it('should get the query text for variant analysis history items', () => {
+      const queryText = getQueryText(variantAnalysisHistoryItem);
+
+      expect(queryText).to.equal(variantAnalysisHistoryItem.variantAnalysis.query.text);
     });
   });
 });

--- a/extensions/ql-vscode/test/pure-tests/query-history-info.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/query-history-info.test.ts
@@ -8,71 +8,56 @@ import { createMockLocalQueryInfo } from '../../src/vscode-tests/factories/local
 import { createMockRemoteQueryHistoryItem } from '../../src/vscode-tests/factories/remote-queries/remote-query-history-item';
 
 describe('Query history info', () => {
+
+  const date = new Date('2022-01-01T00:00:00.000Z');
+  const dateStr = date.toLocaleString();
+  const localQueryHistoryItem = createMockLocalQueryInfo(dateStr);
+  const remoteQueryHistoryItem = createMockRemoteQueryHistoryItem({});
+  const variantAnalysisHistoryItem: VariantAnalysisHistoryItem = {
+    t: 'variant-analysis',
+    status: QueryStatus.InProgress,
+    completed: false,
+    historyItemId: 'abc123',
+    variantAnalysis: createMockVariantAnalysis()
+  };
+
   describe('getRawQueryName', () => {
     it('should get the name for local history items', () => {
-      const date = new Date('2022-01-01T00:00:00.000Z');
-      const dateStr = date.toLocaleString();
+      const queryName = getRawQueryName(localQueryHistoryItem);
 
-      const queryHistoryItem = createMockLocalQueryInfo(dateStr);
-
-      const queryName = getRawQueryName(queryHistoryItem);
-
-      expect(queryName).to.equal(queryHistoryItem.getQueryName());
+      expect(queryName).to.equal(localQueryHistoryItem.getQueryName());
     });
 
     it('should get the name for remote query history items', () => {
-      const queryHistoryItem = createMockRemoteQueryHistoryItem({});
-      const queryName = getRawQueryName(queryHistoryItem);
+      const queryName = getRawQueryName(remoteQueryHistoryItem);
 
-      expect(queryName).to.equal(queryHistoryItem.remoteQuery.queryName);
+      expect(queryName).to.equal(remoteQueryHistoryItem.remoteQuery.queryName);
     });
 
     it('should get the name for variant analysis history items', () => {
-      const queryHistoryItem: VariantAnalysisHistoryItem = {
-        t: 'variant-analysis',
-        status: QueryStatus.InProgress,
-        completed: false,
-        historyItemId: 'abc123',
-        variantAnalysis: createMockVariantAnalysis()
-      };
+      const queryName = getRawQueryName(variantAnalysisHistoryItem);
 
-      const queryName = getRawQueryName(queryHistoryItem);
-
-      expect(queryName).to.equal(queryHistoryItem.variantAnalysis.query.name);
+      expect(queryName).to.equal(variantAnalysisHistoryItem.variantAnalysis.query.name);
     });
   });
 
   describe('getQueryHistoryItemId', () => {
     it('should get the ID for local history items', () => {
-      const date = new Date('2022-01-01T00:00:00.000Z');
-      const dateStr = date.toLocaleString();
+      const historyItemId = getQueryHistoryItemId(localQueryHistoryItem);
 
-      const queryHistoryItem = createMockLocalQueryInfo(dateStr);
-
-      const historyItemId = getQueryHistoryItemId(queryHistoryItem);
-
-      expect(historyItemId).to.equal(queryHistoryItem.initialInfo.id);
+      expect(historyItemId).to.equal(localQueryHistoryItem.initialInfo.id);
     });
 
     it('should get the ID for remote query history items', () => {
-      const queryHistoryItem = createMockRemoteQueryHistoryItem({});
-      const historyItemId = getQueryHistoryItemId(queryHistoryItem);
+      const historyItemId = getQueryHistoryItemId(remoteQueryHistoryItem);
 
-      expect(historyItemId).to.equal(queryHistoryItem.queryId);
+      expect(historyItemId).to.equal(remoteQueryHistoryItem.queryId);
     });
 
     it('should get the ID for variant analysis history items', () => {
-      const queryHistoryItem: VariantAnalysisHistoryItem = {
-        t: 'variant-analysis',
-        status: QueryStatus.InProgress,
-        completed: false,
-        historyItemId: 'abc123',
-        variantAnalysis: createMockVariantAnalysis()
-      };
+      const historyItemId = getQueryHistoryItemId(variantAnalysisHistoryItem);
 
-      const historyItemId = getQueryHistoryItemId(queryHistoryItem);
-
-      expect(historyItemId).to.equal(queryHistoryItem.historyItemId);
+      expect(historyItemId).to.equal(variantAnalysisHistoryItem.historyItemId);
     });
   });
 });


### PR DESCRIPTION
Implements `getQueryText` for variant analysis history items, and moves the function into the `query-history-info` helper file 📝 

I've also slightly cleaned up the `query-history-info` test file (in https://github.com/github/vscode-codeql/commit/6ed9c24326da41c7b1a64153a24846bf66870607) by pulling the query history items to the start of the file instead of recreating them in each test 🧹  https://github.com/github/vscode-codeql/commit/c8f2ba5cc1a06b32007899225e47db8132fc617d actually adds the new test 🧪 

Internal linked issue has more context and remaining work! 🦏 

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
