### PR TITLE
QueryHistory: Consume event when variant analysis status is updated

### DIFF
--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -614,18 +614,20 @@ export class QueryHistoryManager extends DisposableObject {
     });
 
     const variantAnalysisStatusUpdateSubscription = this.variantAnalysisManager.onVariantAnalysisStatusUpdated(async (variantAnalysis) => {
-      const item = this.treeDataProvider.allHistory.find(i => i.t === 'variant-analysis' && i.variantAnalysis.id === variantAnalysis.id);
+      const items = this.treeDataProvider.allHistory.filter(i => i.t === 'variant-analysis' && i.variantAnalysis.id === variantAnalysis.id);
       const status = variantAnalysisStatusToQueryStatus(variantAnalysis.status);
 
-      if (item) {
-        const variantAnalysisHistoryItem = item as VariantAnalysisHistoryItem;
-        variantAnalysisHistoryItem.status = status;
-        variantAnalysisHistoryItem.failureReason = variantAnalysis.failureReason;
-        variantAnalysisHistoryItem.resultCount = getTotalResultCount(variantAnalysis.scannedRepos);
-        variantAnalysisHistoryItem.variantAnalysis = variantAnalysis;
-        if (status === QueryStatus.Completed) {
-          variantAnalysisHistoryItem.completed = true;
-        }
+      if (items.length > 0) {
+        items.forEach(async (item) => {
+          const variantAnalysisHistoryItem = item as VariantAnalysisHistoryItem;
+          variantAnalysisHistoryItem.status = status;
+          variantAnalysisHistoryItem.failureReason = variantAnalysis.failureReason;
+          variantAnalysisHistoryItem.resultCount = getTotalResultCount(variantAnalysis.scannedRepos);
+          variantAnalysisHistoryItem.variantAnalysis = variantAnalysis;
+          if (status === QueryStatus.Completed) {
+            variantAnalysisHistoryItem.completed = true;
+          }
+        });
         await this.refreshTreeView();
       } else {
         void logger.log('Variant analysis status update event received for unknown variant analysis');

--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -622,6 +622,7 @@ export class QueryHistoryManager extends DisposableObject {
         variantAnalysisHistoryItem.status = status;
         variantAnalysisHistoryItem.failureReason = variantAnalysis.failureReason;
         variantAnalysisHistoryItem.resultCount = getTotalResultCount(variantAnalysis.scannedRepos);
+        variantAnalysisHistoryItem.variantAnalysis = variantAnalysis;
         if (status === QueryStatus.Completed) {
           variantAnalysisHistoryItem.completed = true;
         }

--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -614,7 +614,7 @@ export class QueryHistoryManager extends DisposableObject {
     });
 
     const variantAnalysisStatusUpdateSubscription = this.variantAnalysisManager.onVariantAnalysisStatusUpdated(async (variantAnalysis) => {
-      const item = this.treeDataProvider.allHistory.find(i => i.t === 'variant-analysis' && i.historyItemId === variantAnalysis.id.toString());
+      const item = this.treeDataProvider.allHistory.find(i => i.t === 'variant-analysis' && i.variantAnalysis.id === variantAnalysis.id);
       const status = variantAnalysisStatusToQueryStatus(variantAnalysis.status);
 
       if (item) {

--- a/extensions/ql-vscode/src/query-status.ts
+++ b/extensions/ql-vscode/src/query-status.ts
@@ -1,5 +1,23 @@
+import { assertNever } from './pure/helpers-pure';
+import { VariantAnalysisStatus } from './remote-queries/shared/variant-analysis';
+
 export enum QueryStatus {
   InProgress = 'InProgress',
   Completed = 'Completed',
   Failed = 'Failed',
+}
+
+export function variantAnalysisStatusToQueryStatus(status: VariantAnalysisStatus): QueryStatus {
+  switch (status) {
+    case VariantAnalysisStatus.Succeeded:
+      return QueryStatus.Completed;
+    case VariantAnalysisStatus.Failed:
+      return QueryStatus.Failed;
+    case VariantAnalysisStatus.InProgress:
+      return QueryStatus.InProgress;
+    case VariantAnalysisStatus.Canceled:
+      return QueryStatus.Completed;
+    default:
+      assertNever(status);
+  }
 }

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
@@ -27,6 +27,8 @@ import PQueue from 'p-queue';
 export class VariantAnalysisManager extends DisposableObject implements VariantAnalysisViewManager<VariantAnalysisView> {
   private readonly _onVariantAnalysisAdded = this.push(new EventEmitter<VariantAnalysis>());
   public readonly onVariantAnalysisAdded = this._onVariantAnalysisAdded.event;
+  private readonly _onVariantAnalysisStatusUpdated = this.push(new EventEmitter<VariantAnalysis>());
+  public readonly onVariantAnalysisStatusUpdated = this._onVariantAnalysisStatusUpdated.event;
 
   private readonly variantAnalysisMonitor: VariantAnalysisMonitor;
   private readonly variantAnalysisResultsManager: VariantAnalysisResultsManager;
@@ -97,6 +99,7 @@ export class VariantAnalysisManager extends DisposableObject implements VariantA
     this.variantAnalyses.set(variantAnalysis.id, variantAnalysis);
 
     await this.getView(variantAnalysis.id)?.updateView(variantAnalysis);
+    this._onVariantAnalysisStatusUpdated.fire(variantAnalysis);
   }
 
   public onVariantAnalysisSubmitted(variantAnalysis: VariantAnalysis): void {

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
@@ -67,7 +67,8 @@ describe('query-history', () => {
     } as any as RemoteQueriesManager;
 
     variantAnalysisManagerStub = {
-      onVariantAnalysisAdded: sandbox.stub()
+      onVariantAnalysisAdded: sandbox.stub(),
+      onVariantAnalysisStatusUpdated: sandbox.stub()
     } as any as VariantAnalysisManager;
   });
 

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/remote-query-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/remote-query-history.test.ts
@@ -77,7 +77,8 @@ describe('Remote queries and query history manager', function() {
     } as any as RemoteQueriesManager;
 
     variantAnalysisManagerStub = {
-      onVariantAnalysisAdded: sandbox.stub()
+      onVariantAnalysisAdded: sandbox.stub(),
+      onVariantAnalysisStatusUpdated: sandbox.stub()
     } as any as VariantAnalysisManager;
   });
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Update the state of a query history item when the status of the variant analysis has changed.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
