### PR TITLE
Fix missing DIL for new query server

### DIFF
--- a/extensions/ql-vscode/src/query-server/run-queries.ts
+++ b/extensions/ql-vscode/src/query-server/run-queries.ts
@@ -78,6 +78,7 @@ export async function compileAndRunQueryAgainstDatabase(
     singletonExternalInputs: templates || {},
     outputPath: query.resultsPaths.resultsPath,
     queryPath: initialInfo.queryPath,
+    dilPath: query.dilPath,
     logPath,
     target,
   };

--- a/extensions/ql-vscode/src/run-queries-shared.ts
+++ b/extensions/ql-vscode/src/run-queries-shared.ts
@@ -198,7 +198,7 @@ export class QueryEvaluationInfo {
         // This could be from the new query server
         // in which case we expect the qlo to be missing so we should ignore it
         throw new Error(
-          `DIL was not found. ${this.dilPath}`
+          `DIL was not found. Expected location: '${this.dilPath}'`
         );
       } else {
         throw new Error(

--- a/extensions/ql-vscode/src/run-queries-shared.ts
+++ b/extensions/ql-vscode/src/run-queries-shared.ts
@@ -198,7 +198,7 @@ export class QueryEvaluationInfo {
         // This could be from the new query server
         // in which case we expect the qlo to be missing so we should ignore it
         throw new Error(
-          `DIL was not found. ${compiledQuery}`
+          `DIL was not found. ${this.dilPath}`
         );
       } else {
         throw new Error(


### PR DESCRIPTION
This makes the new queryserver write the DIL to the DIL path which should make it work. It also fixes the error message to report the DIL location.

I can't get extension development to work currently so I can't test this so whoever reviews this should test it.