### PR TITLE
Add GitHub API requests that will be mocked

### DIFF
--- a/extensions/ql-vscode/src/mocks/gh-api-request.ts
+++ b/extensions/ql-vscode/src/mocks/gh-api-request.ts
@@ -1,0 +1,55 @@
+import { Repository } from '../remote-queries/gh-api/repository';
+import { VariantAnalysis, VariantAnalysisRepoTask } from '../remote-queries/gh-api/variant-analysis';
+
+// Types that represent requests/responses from the GitHub API
+// that we need to mock.
+
+export enum RequestKind {
+  GetRepo = 'getRepo',
+  SubmitVariantAnalysis = 'submitVariantAnalysis',
+  GetVariantAnalysis = 'getVariantAnalysis',
+  GetVariantAnalysisRepo = 'getVariantAnalysisRepo',
+  GetVariantAnalysisRepoResult = 'getVariantAnalysisRepoResult',
+}
+
+export interface GetRepoRequest {
+  request: {
+    kind: RequestKind.GetRepo
+  },
+  response: {
+    status: number,
+    body: Repository
+  }
+}
+
+export interface GetVariantAnalysisRequest {
+  request: {
+    kind: RequestKind.GetVariantAnalysis
+  },
+  response: {
+    status: number,
+    body: VariantAnalysis
+  }
+}
+
+export interface GetVariantAnalysisRepoRequest {
+  request: {
+    kind: RequestKind.GetVariantAnalysisRepo,
+    repositoryId: number
+  },
+  response: {
+    status: number,
+    body: VariantAnalysisRepoTask
+  }
+}
+
+export interface GetVariantAnalysisRepoResultRequest {
+  request: {
+    kind: RequestKind.GetVariantAnalysisRepoResult,
+    repositoryId: number
+  },
+  response: {
+    status: number,
+    body: ArrayBuffer
+  }
+}


### PR DESCRIPTION
Paired with: @koesie10 

This adds some types that will be used for recording and replaying HTTP requests.

## Checklist
N/A - testing only.

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
