### PR TITLE
Create `timestamp` file in variant analysis results directory

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
@@ -280,6 +280,8 @@ export async function runRemoteQuery(
 
       variantAnalysisManager.onVariantAnalysisSubmitted(processedVariantAnalysis);
 
+      await variantAnalysisManager.prepareStorageDirectory(processedVariantAnalysis.id);
+
       void logger.log(`Variant analysis:\n${JSON.stringify(processedVariantAnalysis, null, 2)}`);
 
       void showAndLogInformationMessage(`Variant analysis ${processedVariantAnalysis.query.name} submitted for processing`);

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
@@ -176,6 +176,10 @@ export class VariantAnalysisManager extends DisposableObject implements VariantA
     return this.queue.pending;
   }
 
+  public getVariantAnalysisStorageLocation(variantAnalysisId: number): string {
+    return this.variantAnalysisResultsManager.getStorageDirectory(variantAnalysisId);
+  }
+
   public async promptOpenVariantAnalysis() {
     const credentials = await Credentials.initialize(this.ctx);
     if (!credentials) { throw Error('Error authenticating with GitHub'); }

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
@@ -23,6 +23,7 @@ import { CodeQLCliServer } from '../cli';
 import { getControllerRepo } from './run-remote-query';
 import { processUpdatedVariantAnalysis } from './variant-analysis-processor';
 import PQueue from 'p-queue';
+import { createTimestampFile } from '../helpers';
 
 export class VariantAnalysisManager extends DisposableObject implements VariantAnalysisViewManager<VariantAnalysisView> {
   private readonly _onVariantAnalysisAdded = this.push(new EventEmitter<VariantAnalysis>());
@@ -178,6 +179,16 @@ export class VariantAnalysisManager extends DisposableObject implements VariantA
 
   public getVariantAnalysisStorageLocation(variantAnalysisId: number): string {
     return this.variantAnalysisResultsManager.getStorageDirectory(variantAnalysisId);
+  }
+
+  /**
+   * Prepares a directory for storing results for a variant analysis.
+   * This directory contains a timestamp file, which will be
+   * used by the query history manager to determine when the directory
+   * should be deleted.
+   */
+  public async prepareStorageDirectory(variantAnalysisId: number): Promise<void> {
+    await createTimestampFile(this.getVariantAnalysisStorageLocation(variantAnalysisId));
   }
 
   public async promptOpenVariantAnalysis() {

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-results-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-results-manager.ts
@@ -165,7 +165,7 @@ export class VariantAnalysisResultsManager extends DisposableObject {
     return processedSarif.alerts;
   }
 
-  private getStorageDirectory(variantAnalysisId: number): string {
+  public getStorageDirectory(variantAnalysisId: number): string {
     return path.join(
       this.storagePath,
       `${variantAnalysisId}`


### PR DESCRIPTION
(Split out from #1622)
- Makes the result storage directory accessible from the variant analysis manager
- Creates a `timestamp` file in that directory

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
