### PR TITLE
Add mock GitHub API config listener

### DIFF
--- a/extensions/ql-vscode/src/mocks/mock-gh-api-server.ts
+++ b/extensions/ql-vscode/src/mocks/mock-gh-api-server.ts
@@ -1,13 +1,28 @@
+import { MockGitHubApiConfigListener } from '../config';
+
 /**
  * Enables mocking of the GitHub API server via HTTP interception, using msw.
  */
 export class MockGitHubApiServer {
+  private isListening: boolean;
+  private config: MockGitHubApiConfigListener;
+
+  constructor() {
+    this.isListening = false;
+    this.config = new MockGitHubApiConfigListener();
+    this.setupConfigListener();
+  }
+
   public startServer(): void {
+    this.isListening = true;
+
     // TODO: Enable HTTP interception.
   }
 
   public stopServer(): void {
-    // Disable HTTP interception.
+    this.isListening = false;
+
+    // TODO: Disable HTTP interception.
   }
 
   public loadScenario(): void {
@@ -20,5 +35,15 @@ export class MockGitHubApiServer {
 
   public recordScenario(): void {
     // TODO: Implement logic to record a new scenario to a directory.
+  }
+
+  private setupConfigListener(): void {
+    this.config.onDidChangeConfiguration(() => {
+      if (this.config.mockServerEnabled && !this.isListening) {
+        this.startServer();
+      } else if (!this.config.mockServerEnabled && this.isListening) {
+        this.stopServer();
+      }
+    });
   }
 }


### PR DESCRIPTION
Set up a config listener to start and stop the mock server.

## Checklist
N/A - internal only:

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
