### PR TITLE
Add missing request type for mock GitHub API

### DIFF
--- a/extensions/ql-vscode/src/mocks/gh-api-request.ts
+++ b/extensions/ql-vscode/src/mocks/gh-api-request.ts
@@ -22,6 +22,16 @@ export interface GetRepoRequest {
   }
 }
 
+export interface SubmitVariantAnalysisRequest {
+  request: {
+    kind: RequestKind.SubmitVariantAnalysis
+  },
+  response: {
+    status: number,
+    body: VariantAnalysis
+  }
+}
+
 export interface GetVariantAnalysisRequest {
   request: {
     kind: RequestKind.GetVariantAnalysis
@@ -53,3 +63,10 @@ export interface GetVariantAnalysisRepoResultRequest {
     body: ArrayBuffer
   }
 }
+
+export type GitHubApiRequest =
+  | GetRepoRequest
+  | SubmitVariantAnalysisRequest
+  | GetVariantAnalysisRequest
+  | GetVariantAnalysisRepoRequest
+  | GetVariantAnalysisRepoResultRequest;


### PR DESCRIPTION
We were still missing the `SubmitVariantAnalysisRequest` type and a type to represent the union of all request types. This adds both of them.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
