### PR TITLE
Add recording of mock scenarios

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -645,6 +645,18 @@
         "command": "codeQL.gotoQL",
         "title": "CodeQL: Go to QL Code",
         "enablement": "codeql.hasQLSource"
+      },
+      {
+        "command": "codeQL.mockGitHubApiServer.startRecording",
+        "title": "CodeQL Mock GitHub API Server: Start Scenario Recording"
+      },
+      {
+        "command": "codeQL.mockGitHubApiServer.saveScenario",
+        "title": "CodeQL Mock GitHub API Server: Save Scenario"
+      },
+      {
+        "command": "codeQL.mockGitHubApiServer.cancelRecording",
+        "title": "CodeQL Mock GitHub API Server: Cancel Scenario"
       }
     ],
     "menus": {
@@ -1104,6 +1116,18 @@
         {
           "command": "codeQLTests.showOutputDifferences",
           "when": "false"
+        },
+        {
+          "command": "codeQL.mockGitHubApiServer.startRecording",
+          "when": "config.codeQL.variantAnalysis.mockGitHubApiServer && !codeQL.mockGitHubApiServer.recording"
+        },
+        {
+          "command": "codeQL.mockGitHubApiServer.saveScenario",
+          "when": "codeQL.mockGitHubApiServer.recording"
+        },
+        {
+          "command": "codeQL.mockGitHubApiServer.cancelRecording",
+          "when": "codeQL.mockGitHubApiServer.recording"
         }
       ],
       "editor/context": [

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -656,7 +656,7 @@
       },
       {
         "command": "codeQLMockGitHubApiServer.cancelRecording",
-        "title": "CodeQL Mock GitHub API Server: Cancel Scenario"
+        "title": "CodeQL Mock GitHub API Server: Cancel Scenario Recording"
       }
     ],
     "menus": {

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -647,15 +647,15 @@
         "enablement": "codeql.hasQLSource"
       },
       {
-        "command": "codeQL.mockGitHubApiServer.startRecording",
+        "command": "codeQLMockGitHubApiServer.startRecording",
         "title": "CodeQL Mock GitHub API Server: Start Scenario Recording"
       },
       {
-        "command": "codeQL.mockGitHubApiServer.saveScenario",
+        "command": "codeQLMockGitHubApiServer.saveScenario",
         "title": "CodeQL Mock GitHub API Server: Save Scenario"
       },
       {
-        "command": "codeQL.mockGitHubApiServer.cancelRecording",
+        "command": "codeQLMockGitHubApiServer.cancelRecording",
         "title": "CodeQL Mock GitHub API Server: Cancel Scenario"
       }
     ],
@@ -1118,16 +1118,16 @@
           "when": "false"
         },
         {
-          "command": "codeQL.mockGitHubApiServer.startRecording",
-          "when": "config.codeQL.variantAnalysis.mockGitHubApiServer && !codeQL.mockGitHubApiServer.recording"
+          "command": "codeQLMockGitHubApiServer.startRecording",
+          "when": "config.codeQL.variantAnalysis.mockGitHubApiServer && !codeQLMockGitHubApiServer.recording"
         },
         {
-          "command": "codeQL.mockGitHubApiServer.saveScenario",
-          "when": "codeQL.mockGitHubApiServer.recording"
+          "command": "codeQLMockGitHubApiServer.saveScenario",
+          "when": "codeQLMockGitHubApiServer.recording"
         },
         {
-          "command": "codeQL.mockGitHubApiServer.cancelRecording",
-          "when": "codeQL.mockGitHubApiServer.recording"
+          "command": "codeQLMockGitHubApiServer.cancelRecording",
+          "when": "codeQLMockGitHubApiServer.recording"
         }
       ],
       "editor/context": [

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1123,11 +1123,11 @@
         },
         {
           "command": "codeQLMockGitHubApiServer.saveScenario",
-          "when": "codeQLMockGitHubApiServer.recording"
+          "when": "config.codeQL.variantAnalysis.mockGitHubApiServer && codeQLMockGitHubApiServer.recording"
         },
         {
           "command": "codeQLMockGitHubApiServer.cancelRecording",
-          "when": "codeQLMockGitHubApiServer.recording"
+          "when": "config.codeQL.variantAnalysis.mockGitHubApiServer && codeQLMockGitHubApiServer.recording"
         }
       ],
       "editor/context": [

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -647,16 +647,16 @@
         "enablement": "codeql.hasQLSource"
       },
       {
-        "command": "codeQLMockGitHubApiServer.startRecording",
-        "title": "CodeQL Mock GitHub API Server: Start Scenario Recording"
+        "command": "codeQL.mockGitHubApiServer.startRecording",
+        "title": "CodeQL: Mock GitHub API Server: Start Scenario Recording"
       },
       {
-        "command": "codeQLMockGitHubApiServer.saveScenario",
-        "title": "CodeQL Mock GitHub API Server: Save Scenario"
+        "command": "codeQL.mockGitHubApiServer.saveScenario",
+        "title": "CodeQL: Mock GitHub API Server: Save Scenario"
       },
       {
-        "command": "codeQLMockGitHubApiServer.cancelRecording",
-        "title": "CodeQL Mock GitHub API Server: Cancel Scenario Recording"
+        "command": "codeQL.mockGitHubApiServer.cancelRecording",
+        "title": "CodeQL: Mock GitHub API Server: Cancel Scenario Recording"
       }
     ],
     "menus": {
@@ -1118,16 +1118,16 @@
           "when": "false"
         },
         {
-          "command": "codeQLMockGitHubApiServer.startRecording",
-          "when": "config.codeQL.variantAnalysis.mockGitHubApiServer && !codeQLMockGitHubApiServer.recording"
+          "command": "codeQL.mockGitHubApiServer.startRecording",
+          "when": "config.codeQL.variantAnalysis.mockGitHubApiServer && !codeQL.mockGitHubApiServer.recording"
         },
         {
-          "command": "codeQLMockGitHubApiServer.saveScenario",
-          "when": "config.codeQL.variantAnalysis.mockGitHubApiServer && codeQLMockGitHubApiServer.recording"
+          "command": "codeQL.mockGitHubApiServer.saveScenario",
+          "when": "config.codeQL.variantAnalysis.mockGitHubApiServer && codeQL.mockGitHubApiServer.recording"
         },
         {
-          "command": "codeQLMockGitHubApiServer.cancelRecording",
-          "when": "config.codeQL.variantAnalysis.mockGitHubApiServer && codeQLMockGitHubApiServer.recording"
+          "command": "codeQL.mockGitHubApiServer.cancelRecording",
+          "when": "config.codeQL.variantAnalysis.mockGitHubApiServer && codeQL.mockGitHubApiServer.recording"
         }
       ],
       "editor/context": [

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -449,3 +449,9 @@ export class MockGitHubApiConfigListener extends ConfigListener implements MockG
     return !!MOCK_GH_API_SERVER.getValue<boolean>();
   }
 }
+
+const MOCK_GH_API_SERVER_SCENARIOS_PATH = new Setting('mockGitHubApiServerScenariosPath', REMOTE_QUERIES_SETTING);
+
+export function getMockGitHubApiServerScenariosPath(): string | undefined {
+  return MOCK_GH_API_SERVER_SCENARIOS_PATH.getValue<string>();
+}

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -1191,7 +1191,7 @@ async function activateWithInstalledDistribution(
     )
   );
 
-  const mockServer = new MockGitHubApiServer();
+  const mockServer = new MockGitHubApiServer(ctx);
   ctx.subscriptions.push(mockServer);
   ctx.subscriptions.push(
     commandRunner(

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -1195,19 +1195,19 @@ async function activateWithInstalledDistribution(
   ctx.subscriptions.push(mockServer);
   ctx.subscriptions.push(
     commandRunner(
-      'codeQL.mockGitHubApiServer.startRecording',
+      'codeQLMockGitHubApiServer.startRecording',
       async () => await mockServer.recordScenario(),
     )
   );
   ctx.subscriptions.push(
     commandRunner(
-      'codeQL.mockGitHubApiServer.saveScenario',
+      'codeQLMockGitHubApiServer.saveScenario',
       async () => await mockServer.saveScenario(),
     )
   );
   ctx.subscriptions.push(
     commandRunner(
-      'codeQL.mockGitHubApiServer.cancelRecording',
+      'codeQLMockGitHubApiServer.cancelRecording',
       async () => await mockServer.cancelRecording(),
     )
   );

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -116,6 +116,7 @@ import {
 } from './remote-queries/gh-api/variant-analysis';
 import { VariantAnalysisManager } from './remote-queries/variant-analysis-manager';
 import { createVariantAnalysisContentProvider } from './remote-queries/variant-analysis-content-provider';
+import { MockGitHubApiServer } from './mocks/mock-gh-api-server';
 
 /**
  * extension.ts
@@ -1187,6 +1188,27 @@ async function activateWithInstalledDistribution(
         title: 'Calculating Control Flow Graph',
         cancellable: true
       }
+    )
+  );
+
+  const mockServer = new MockGitHubApiServer();
+  ctx.subscriptions.push(mockServer);
+  ctx.subscriptions.push(
+    commandRunner(
+      'codeQL.mockGitHubApiServer.startRecording',
+      async () => await mockServer.recordScenario(),
+    )
+  );
+  ctx.subscriptions.push(
+    commandRunner(
+      'codeQL.mockGitHubApiServer.saveScenario',
+      async () => await mockServer.saveScenario(),
+    )
+  );
+  ctx.subscriptions.push(
+    commandRunner(
+      'codeQL.mockGitHubApiServer.cancelRecording',
+      async () => await mockServer.cancelRecording(),
     )
   );
 

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -1195,19 +1195,19 @@ async function activateWithInstalledDistribution(
   ctx.subscriptions.push(mockServer);
   ctx.subscriptions.push(
     commandRunner(
-      'codeQLMockGitHubApiServer.startRecording',
+      'codeQL.mockGitHubApiServer.startRecording',
       async () => await mockServer.startRecording(),
     )
   );
   ctx.subscriptions.push(
     commandRunner(
-      'codeQLMockGitHubApiServer.saveScenario',
+      'codeQL.mockGitHubApiServer.saveScenario',
       async () => await mockServer.saveScenario(),
     )
   );
   ctx.subscriptions.push(
     commandRunner(
-      'codeQLMockGitHubApiServer.cancelRecording',
+      'codeQL.mockGitHubApiServer.cancelRecording',
       async () => await mockServer.cancelRecording(),
     )
   );

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -1196,7 +1196,7 @@ async function activateWithInstalledDistribution(
   ctx.subscriptions.push(
     commandRunner(
       'codeQLMockGitHubApiServer.startRecording',
-      async () => await mockServer.recordScenario(),
+      async () => await mockServer.startRecording(),
     )
   );
   ctx.subscriptions.push(

--- a/extensions/ql-vscode/src/mocks/mock-gh-api-server.ts
+++ b/extensions/ql-vscode/src/mocks/mock-gh-api-server.ts
@@ -49,7 +49,7 @@ export class MockGitHubApiServer extends DisposableObject {
     // TODO: Implement logic to list all available scenarios.
   }
 
-  public async recordScenario(): Promise<void> {
+  public async startRecording(): Promise<void> {
     if (this.recorder.isRecording) {
       void window.showErrorMessage('A scenario is already being recorded. Use the "Save Scenario" or "Cancel Scenario" commands to finish recording.');
       return;

--- a/extensions/ql-vscode/src/mocks/mock-gh-api-server.ts
+++ b/extensions/ql-vscode/src/mocks/mock-gh-api-server.ts
@@ -131,7 +131,7 @@ export class MockGitHubApiServer extends DisposableObject {
     }
 
     if (this.ctx.extensionMode === ExtensionMode.Development) {
-      const developmentScenariosPath = Uri.joinPath(this.ctx.extensionUri, 'src/mocks/scenarios').toString();
+      const developmentScenariosPath = Uri.joinPath(this.ctx.extensionUri, 'src/mocks/scenarios').fsPath.toString();
       if (await fs.pathExists(developmentScenariosPath)) {
         return developmentScenariosPath;
       }

--- a/extensions/ql-vscode/src/mocks/mock-gh-api-server.ts
+++ b/extensions/ql-vscode/src/mocks/mock-gh-api-server.ts
@@ -56,7 +56,7 @@ export class MockGitHubApiServer extends DisposableObject {
     }
 
     this.recorder.start();
-    await commands.executeCommand('setContext', 'codeQL.mockGitHubApiServer.recording', true);
+    await commands.executeCommand('setContext', 'codeQLMockGitHubApiServer.recording', true);
 
     await window.showInformationMessage('Recording scenario. To save the scenario, use the "CodeQL Mock GitHub API Server: Save Scenario" command.');
   }
@@ -67,7 +67,7 @@ export class MockGitHubApiServer extends DisposableObject {
       return;
     }
 
-    await commands.executeCommand('setContext', 'codeQL.mockGitHubApiServer.recording', false);
+    await commands.executeCommand('setContext', 'codeQLMockGitHubApiServer.recording', false);
 
     if (!this.recorder.isRecording) {
       void window.showErrorMessage('No scenario is currently being recorded.');
@@ -112,7 +112,7 @@ export class MockGitHubApiServer extends DisposableObject {
   }
 
   private async stopRecording(): Promise<void> {
-    await commands.executeCommand('setContext', 'codeQL.mockGitHubApiServer.recording', false);
+    await commands.executeCommand('setContext', 'codeQLMockGitHubApiServer.recording', false);
 
     await this.recorder.stop();
     await this.recorder.clear();

--- a/extensions/ql-vscode/src/mocks/mock-gh-api-server.ts
+++ b/extensions/ql-vscode/src/mocks/mock-gh-api-server.ts
@@ -1,28 +1,44 @@
 import { MockGitHubApiConfigListener } from '../config';
 
+import { setupServer, SetupServerApi } from 'msw/node';
+import { Recorder } from './recorder';
+import { commands, env, Uri, window } from 'vscode';
+import { DisposableObject } from '../pure/disposable-object';
+import { getMockGitHubApiServerScenariosPath } from '../config';
+
 /**
  * Enables mocking of the GitHub API server via HTTP interception, using msw.
  */
-export class MockGitHubApiServer {
+export class MockGitHubApiServer extends DisposableObject {
   private isListening: boolean;
   private config: MockGitHubApiConfigListener;
 
+  private readonly server: SetupServerApi;
+  private readonly recorder: Recorder;
+
   constructor() {
+    super();
     this.isListening = false;
     this.config = new MockGitHubApiConfigListener();
+
+    this.server = setupServer();
+    this.recorder = this.push(new Recorder(this.server));
+
     this.setupConfigListener();
   }
 
   public startServer(): void {
-    this.isListening = true;
+    if (this.isListening) {
+      return;
+    }
 
-    // TODO: Enable HTTP interception.
+    this.server.listen();
+    this.isListening = true;
   }
 
   public stopServer(): void {
+    this.server.close();
     this.isListening = false;
-
-    // TODO: Disable HTTP interception.
   }
 
   public loadScenario(): void {
@@ -33,8 +49,98 @@ export class MockGitHubApiServer {
     // TODO: Implement logic to list all available scenarios.
   }
 
-  public recordScenario(): void {
-    // TODO: Implement logic to record a new scenario to a directory.
+  public async recordScenario(): Promise<void> {
+    if (this.recorder.isRecording) {
+      void window.showErrorMessage('A scenario is already being recorded. Use the "Save Scenario" or "Cancel Scenario" commands to finish recording.');
+      return;
+    }
+
+    this.recorder.start();
+    await commands.executeCommand('setContext', 'codeQL.mockGitHubApiServer.recording', true);
+
+    await window.showInformationMessage('Recording scenario. To save the scenario, use the "CodeQL Mock GitHub API Server: Save Scenario" command.');
+  }
+
+  public async saveScenario(): Promise<void> {
+    const scenariosDirectory = await this.getScenariosDirectory();
+    if (!scenariosDirectory) {
+      return;
+    }
+
+    await commands.executeCommand('setContext', 'codeQL.mockGitHubApiServer.recording', false);
+
+    if (!this.recorder.isRecording) {
+      void window.showErrorMessage('No scenario is currently being recorded.');
+      return;
+    }
+    if (this.recorder.scenarioRequestCount === 0) {
+      void window.showWarningMessage('No requests were recorded. Cancelling scenario.');
+
+      await this.stopRecording();
+
+      return;
+    }
+
+    const name = await window.showInputBox({
+      title: 'Save scenario',
+      prompt: 'Enter a name for the scenario.',
+      placeHolder: 'successful-run',
+    });
+    if (!name) {
+      return;
+    }
+
+    const filepath = await this.recorder.save(scenariosDirectory, name);
+
+    await this.stopRecording();
+
+    const action = await window.showInformationMessage(`Scenario saved to ${filepath}`, 'Open directory');
+    if (action === 'Open directory') {
+      await env.openExternal(Uri.file(filepath));
+    }
+  }
+
+  public async cancelRecording(): Promise<void> {
+    if (!this.recorder.isRecording) {
+      void window.showErrorMessage('No scenario is currently being recorded.');
+      return;
+    }
+
+    await this.stopRecording();
+
+    void window.showInformationMessage('Recording cancelled.');
+  }
+
+  private async stopRecording(): Promise<void> {
+    await commands.executeCommand('setContext', 'codeQL.mockGitHubApiServer.recording', false);
+
+    await this.recorder.stop();
+    await this.recorder.clear();
+  }
+
+  private async getScenariosDirectory(): Promise<string | undefined> {
+    const scenariosDirectory = getMockGitHubApiServerScenariosPath();
+    if (scenariosDirectory) {
+      return scenariosDirectory;
+    }
+
+    const directories = await window.showOpenDialog({
+      canSelectFolders: true,
+      canSelectFiles: false,
+      canSelectMany: false,
+      openLabel: 'Select scenarios directory',
+      title: 'Select scenarios directory',
+    });
+    if (directories === undefined || directories.length === 0) {
+      void window.showErrorMessage('No scenarios directory selected.');
+      return undefined;
+    }
+
+    // Unfortunately, we cannot save the directory in the configuration because that requires
+    // the configuration to be registered. If we do that, it would be visible to all users; there
+    // is no "when" clause that would allow us to only show it to users who have enabled the feature flag.
+
+    return directories[0].fsPath;
   }
 
   private setupConfigListener(): void {

--- a/extensions/ql-vscode/src/mocks/mock-gh-api-server.ts
+++ b/extensions/ql-vscode/src/mocks/mock-gh-api-server.ts
@@ -56,6 +56,7 @@ export class MockGitHubApiServer extends DisposableObject {
     }
 
     this.recorder.start();
+    // Set a value in the context to track whether we are recording. This allows us to use this to show/hide commands (see package.json)
     await commands.executeCommand('setContext', 'codeQLMockGitHubApiServer.recording', true);
 
     await window.showInformationMessage('Recording scenario. To save the scenario, use the "CodeQL Mock GitHub API Server: Save Scenario" command.');
@@ -67,6 +68,7 @@ export class MockGitHubApiServer extends DisposableObject {
       return;
     }
 
+    // Set a value in the context to track whether we are recording. This allows us to use this to show/hide commands (see package.json)
     await commands.executeCommand('setContext', 'codeQLMockGitHubApiServer.recording', false);
 
     if (!this.recorder.isRecording) {
@@ -112,6 +114,7 @@ export class MockGitHubApiServer extends DisposableObject {
   }
 
   private async stopRecording(): Promise<void> {
+    // Set a value in the context to track whether we are recording. This allows us to use this to show/hide commands (see package.json)
     await commands.executeCommand('setContext', 'codeQLMockGitHubApiServer.recording', false);
 
     await this.recorder.stop();

--- a/extensions/ql-vscode/src/mocks/mock-gh-api-server.ts
+++ b/extensions/ql-vscode/src/mocks/mock-gh-api-server.ts
@@ -157,12 +157,17 @@ export class MockGitHubApiServer extends DisposableObject {
   }
 
   private setupConfigListener(): void {
-    this.config.onDidChangeConfiguration(() => {
-      if (this.config.mockServerEnabled && !this.isListening) {
-        this.startServer();
-      } else if (!this.config.mockServerEnabled && this.isListening) {
-        this.stopServer();
-      }
-    });
+    // The config "changes" from the default at startup, so we need to call onConfigChange() to ensure the server is
+    // started if required.
+    this.onConfigChange();
+    this.config.onDidChangeConfiguration(() => this.onConfigChange());
+  }
+
+  private onConfigChange(): void {
+    if (this.config.mockServerEnabled && !this.isListening) {
+      this.startServer();
+    } else if (!this.config.mockServerEnabled && this.isListening) {
+      this.stopServer();
+    }
   }
 }

--- a/extensions/ql-vscode/src/mocks/mock-gh-api-server.ts
+++ b/extensions/ql-vscode/src/mocks/mock-gh-api-server.ts
@@ -60,7 +60,7 @@ export class MockGitHubApiServer extends DisposableObject {
 
     this.recorder.start();
     // Set a value in the context to track whether we are recording. This allows us to use this to show/hide commands (see package.json)
-    await commands.executeCommand('setContext', 'codeQLMockGitHubApiServer.recording', true);
+    await commands.executeCommand('setContext', 'codeQL.mockGitHubApiServer.recording', true);
 
     await window.showInformationMessage('Recording scenario. To save the scenario, use the "CodeQL Mock GitHub API Server: Save Scenario" command.');
   }
@@ -72,7 +72,7 @@ export class MockGitHubApiServer extends DisposableObject {
     }
 
     // Set a value in the context to track whether we are recording. This allows us to use this to show/hide commands (see package.json)
-    await commands.executeCommand('setContext', 'codeQLMockGitHubApiServer.recording', false);
+    await commands.executeCommand('setContext', 'codeQL.mockGitHubApiServer.recording', false);
 
     if (!this.recorder.isRecording) {
       void window.showErrorMessage('No scenario is currently being recorded.');
@@ -118,7 +118,7 @@ export class MockGitHubApiServer extends DisposableObject {
 
   private async stopRecording(): Promise<void> {
     // Set a value in the context to track whether we are recording. This allows us to use this to show/hide commands (see package.json)
-    await commands.executeCommand('setContext', 'codeQLMockGitHubApiServer.recording', false);
+    await commands.executeCommand('setContext', 'codeQL.mockGitHubApiServer.recording', false);
 
     await this.recorder.stop();
     await this.recorder.clear();

--- a/extensions/ql-vscode/src/mocks/mock-gh-api-server.ts
+++ b/extensions/ql-vscode/src/mocks/mock-gh-api-server.ts
@@ -62,8 +62,8 @@ export class MockGitHubApiServer extends DisposableObject {
   }
 
   public async saveScenario(): Promise<void> {
-    const scenariosDirectory = await this.getScenariosDirectory();
-    if (!scenariosDirectory) {
+    const scenariosPath = await this.getScenariosPath();
+    if (!scenariosPath) {
       return;
     }
 
@@ -73,7 +73,7 @@ export class MockGitHubApiServer extends DisposableObject {
       void window.showErrorMessage('No scenario is currently being recorded.');
       return;
     }
-    if (this.recorder.scenarioRequestCount === 0) {
+    if (!this.recorder.anyRequestsRecorded) {
       void window.showWarningMessage('No requests were recorded. Cancelling scenario.');
 
       await this.stopRecording();
@@ -90,13 +90,13 @@ export class MockGitHubApiServer extends DisposableObject {
       return;
     }
 
-    const filepath = await this.recorder.save(scenariosDirectory, name);
+    const filePath = await this.recorder.save(scenariosPath, name);
 
     await this.stopRecording();
 
-    const action = await window.showInformationMessage(`Scenario saved to ${filepath}`, 'Open directory');
+    const action = await window.showInformationMessage(`Scenario saved to ${filePath}`, 'Open directory');
     if (action === 'Open directory') {
-      await env.openExternal(Uri.file(filepath));
+      await env.openExternal(Uri.file(filePath));
     }
   }
 
@@ -118,10 +118,10 @@ export class MockGitHubApiServer extends DisposableObject {
     await this.recorder.clear();
   }
 
-  private async getScenariosDirectory(): Promise<string | undefined> {
-    const scenariosDirectory = getMockGitHubApiServerScenariosPath();
-    if (scenariosDirectory) {
-      return scenariosDirectory;
+  private async getScenariosPath(): Promise<string | undefined> {
+    const scenariosPath = getMockGitHubApiServerScenariosPath();
+    if (scenariosPath) {
+      return scenariosPath;
     }
 
     const directories = await window.showOpenDialog({

--- a/extensions/ql-vscode/src/mocks/recorder.ts
+++ b/extensions/ql-vscode/src/mocks/recorder.ts
@@ -13,7 +13,7 @@ export class Recorder extends DisposableObject {
   private readonly allRequests = new Map<string, MockedRequest>();
   private currentRecordedScenario: GitHubApiRequest[] = [];
 
-  private _recording = false;
+  private _isRecording = false;
 
   constructor(
     private readonly server: SetupServerApi,
@@ -24,7 +24,7 @@ export class Recorder extends DisposableObject {
   }
 
   public get isRecording(): boolean {
-    return this._recording;
+    return this._isRecording;
   }
 
   public get anyRequestsRecorded(): boolean {
@@ -32,11 +32,11 @@ export class Recorder extends DisposableObject {
   }
 
   public start(): void {
-    if (this._recording) {
+    if (this._isRecording) {
       return;
     }
 
-    this._recording = true;
+    this._isRecording = true;
 
     this.clear();
 
@@ -45,11 +45,11 @@ export class Recorder extends DisposableObject {
   }
 
   public stop(): void {
-    if (!this._recording) {
+    if (!this._isRecording) {
       return;
     }
 
-    this._recording = false;
+    this._isRecording = false;
 
     this.server.events.removeListener('request:start', this.onRequestStart);
     this.server.events.removeListener('response:bypass', this.onResponseBypass);

--- a/extensions/ql-vscode/src/mocks/recorder.ts
+++ b/extensions/ql-vscode/src/mocks/recorder.ts
@@ -1,0 +1,176 @@
+import * as fs from 'fs-extra';
+import * as path from 'path';
+
+import { MockedRequest } from 'msw';
+import { SetupServerApi } from 'msw/node';
+import { IsomorphicResponse } from '@mswjs/interceptors';
+
+import { DisposableObject } from '../pure/disposable-object';
+
+import { GitHubApiRequest, RequestKind } from './gh-api-request';
+
+export class Recorder extends DisposableObject {
+  private readonly allRequests = new Map<string, MockedRequest>();
+  private currentRecordedScenario: GitHubApiRequest[] = [];
+
+  private _recording = false;
+
+  constructor(
+    private readonly server: SetupServerApi,
+  ) {
+    super();
+    this.onRequestStart = this.onRequestStart.bind(this);
+    this.onResponseBypass = this.onResponseBypass.bind(this);
+  }
+
+  public get isRecording(): boolean {
+    return this._recording;
+  }
+
+  public get scenarioRequestCount(): number {
+    return this.currentRecordedScenario.length;
+  }
+
+  public start(): void {
+    if (this._recording) {
+      return;
+    }
+
+    this._recording = true;
+
+    this.clear();
+
+    this.server.events.on('request:start', this.onRequestStart);
+    this.server.events.on('response:bypass', this.onResponseBypass);
+  }
+
+  public stop(): void {
+    if (!this._recording) {
+      return;
+    }
+
+    this._recording = false;
+
+    this.server.events.removeListener('request:start', this.onRequestStart);
+    this.server.events.removeListener('response:bypass', this.onResponseBypass);
+  }
+
+  public clear() {
+    this.currentRecordedScenario = [];
+    this.allRequests.clear();
+  }
+
+  public async save(scenariosDirectory: string, name: string): Promise<string> {
+    const scenarioDirectory = path.join(scenariosDirectory, name);
+
+    await fs.ensureDir(scenarioDirectory);
+
+    for (let i = 0; i < this.currentRecordedScenario.length; i++) {
+      const request = this.currentRecordedScenario[i];
+
+      const fileName = `${i}-${request.request.kind}.json`;
+      const filePath = path.join(scenarioDirectory, fileName);
+      await fs.writeFile(filePath, JSON.stringify(request, null, 2));
+    }
+
+    this.stop();
+
+    return scenarioDirectory;
+  }
+
+  private onRequestStart(request: MockedRequest): void {
+    this.allRequests.set(request.id, request);
+  }
+
+  private onResponseBypass(response: IsomorphicResponse, requestId: string): void {
+    const request = this.allRequests.get(requestId);
+    this.allRequests.delete(requestId);
+    if (!request) {
+      return;
+    }
+
+    if (response.body === undefined) {
+      return;
+    }
+
+    const gitHubApiRequest = createGitHubApiRequest(request.url.toString(), response.status, response.body);
+    if (!gitHubApiRequest) {
+      return;
+    }
+
+    this.currentRecordedScenario.push(gitHubApiRequest);
+  }
+}
+
+function createGitHubApiRequest(url: string, status: number, body: string): GitHubApiRequest | undefined {
+  if (!url) {
+    return undefined;
+  }
+
+  if (url.match(/\/repos\/[a-zA-Z0-9-_.]+\/[a-zA-Z0-9-_.]+$/)) {
+    return {
+      request: {
+        kind: RequestKind.GetRepo,
+      },
+      response: {
+        status,
+        body: JSON.parse(body),
+      },
+    };
+  }
+
+  if (url.match(/\/repositories\/\d+\/code-scanning\/codeql\/variant-analyses$/)) {
+    return {
+      request: {
+        kind: RequestKind.SubmitVariantAnalysis,
+      },
+      response: {
+        status,
+        body: JSON.parse(body),
+      },
+    };
+  }
+
+  if (url.match(/\/repositories\/\d+\/code-scanning\/codeql\/variant-analyses\/\d+$/)) {
+    return {
+      request: {
+        kind: RequestKind.GetVariantAnalysis,
+      },
+      response: {
+        status,
+        body: JSON.parse(body),
+      },
+    };
+  }
+
+  const repoTaskMatch = url.match(/\/repositories\/\d+\/code-scanning\/codeql\/variant-analyses\/\d+\/repositories\/(?<repositoryId>\d+)$/);
+  if (repoTaskMatch?.groups?.repositoryId) {
+    return {
+      request: {
+        kind: RequestKind.GetVariantAnalysisRepo,
+        repositoryId: parseInt(repoTaskMatch.groups.repositoryId, 10),
+      },
+      response: {
+        status,
+        body: JSON.parse(body),
+      },
+    };
+  }
+
+  // if url is a download URL for a variant analysis result, then it's a get-variant-analysis-repoResult.
+  const repoDownloadMatch = url.match(/objects-origin\.githubusercontent\.com\/codeql-query-console\/codeql-variant-analysis-repo-tasks\/\d+\/(?<repositoryId>\d+)/);
+  if (repoDownloadMatch?.groups?.repositoryId) {
+    return {
+      request: {
+        kind: RequestKind.GetVariantAnalysisRepoResult,
+        repositoryId: parseInt(repoDownloadMatch.groups.repositoryId, 10),
+      },
+      response: {
+        status,
+        body: body as unknown as ArrayBuffer,
+      }
+    };
+  }
+
+  return undefined;
+}

--- a/extensions/ql-vscode/src/mocks/recorder.ts
+++ b/extensions/ql-vscode/src/mocks/recorder.ts
@@ -27,8 +27,8 @@ export class Recorder extends DisposableObject {
     return this._recording;
   }
 
-  public get scenarioRequestCount(): number {
-    return this.currentRecordedScenario.length;
+  public get anyRequestsRecorded(): boolean {
+    return this.currentRecordedScenario.length > 0;
   }
 
   public start(): void {
@@ -60,8 +60,8 @@ export class Recorder extends DisposableObject {
     this.allRequests.clear();
   }
 
-  public async save(scenariosDirectory: string, name: string): Promise<string> {
-    const scenarioDirectory = path.join(scenariosDirectory, name);
+  public async save(scenariosPath: string, name: string): Promise<string> {
+    const scenarioDirectory = path.join(scenariosPath, name);
 
     await fs.ensureDir(scenarioDirectory);
 

--- a/extensions/ql-vscode/test/pure-tests/command-lint.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/command-lint.test.ts
@@ -27,9 +27,6 @@ describe('commands declared in package.json', function() {
   const scopedCmds: Set<string> = new Set<string>();
   const commandTitles: { [cmd: string]: string } = {};
 
-  // These are commands which are only used for testing/development
-  const testCmds = new Set<string>();
-
   commands.forEach((commandDecl: CmdDecl) => {
     const { command, title } = commandDecl;
     if (
@@ -48,13 +45,6 @@ describe('commands declared in package.json', function() {
       || command.match(/^codeQLTests\./)
     ) {
       scopedCmds.add(command);
-      expect(title).not.to.be.undefined;
-      commandTitles[command] = title!;
-    }
-    else if (
-      command.match(/^codeQLMockGitHubApiServer\./)
-    ) {
-      testCmds.add(command);
       expect(title).not.to.be.undefined;
       commandTitles[command] = title!;
     }
@@ -92,19 +82,10 @@ describe('commands declared in package.json', function() {
     scopedCmds.forEach(command => {
       expect(commandTitles[command], `command ${command} should not be prefixed with 'CodeQL: ', since it is accessible from an extension-controlled context`).not.to.match(/^CodeQL: /);
     });
-
-    testCmds.forEach(command => {
-      expect(commandTitles[command], `command ${command} should be prefixed with 'CodeQL ', since it is a testing/development command`).to.match(/^CodeQL /);
-      expect(commandTitles[command], `command ${command} should not be prefixed with 'CodeQL: ', since it is a testing/development command`).not.to.match(/^CodeQL: /);
-    });
   });
 
   it('should have the right commands accessible from the command palette', function() {
     paletteCmds.forEach(command => {
-      expect(disabledInPalette.has(command), `command ${command} should be enabled in the command palette`).to.be.false;
-    });
-
-    testCmds.forEach(command => {
       expect(disabledInPalette.has(command), `command ${command} should be enabled in the command palette`).to.be.false;
     });
 

--- a/extensions/ql-vscode/test/pure-tests/command-lint.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/command-lint.test.ts
@@ -27,6 +27,9 @@ describe('commands declared in package.json', function() {
   const scopedCmds: Set<string> = new Set<string>();
   const commandTitles: { [cmd: string]: string } = {};
 
+  // These are commands which are only used for testing/development
+  const testCmds = new Set<string>();
+
   commands.forEach((commandDecl: CmdDecl) => {
     const { command, title } = commandDecl;
     if (
@@ -45,6 +48,13 @@ describe('commands declared in package.json', function() {
       || command.match(/^codeQLTests\./)
     ) {
       scopedCmds.add(command);
+      expect(title).not.to.be.undefined;
+      commandTitles[command] = title!;
+    }
+    else if (
+      command.match(/^codeQLMockGitHubApiServer\./)
+    ) {
+      testCmds.add(command);
       expect(title).not.to.be.undefined;
       commandTitles[command] = title!;
     }
@@ -82,10 +92,19 @@ describe('commands declared in package.json', function() {
     scopedCmds.forEach(command => {
       expect(commandTitles[command], `command ${command} should not be prefixed with 'CodeQL: ', since it is accessible from an extension-controlled context`).not.to.match(/^CodeQL: /);
     });
+
+    testCmds.forEach(command => {
+      expect(commandTitles[command], `command ${command} should be prefixed with 'CodeQL ', since it is a testing/development command`).to.match(/^CodeQL /);
+      expect(commandTitles[command], `command ${command} should not be prefixed with 'CodeQL: ', since it is a testing/development command`).not.to.match(/^CodeQL: /);
+    });
   });
 
   it('should have the right commands accessible from the command palette', function() {
     paletteCmds.forEach(command => {
+      expect(disabledInPalette.has(command), `command ${command} should be enabled in the command palette`).to.be.false;
+    });
+
+    testCmds.forEach(command => {
       expect(disabledInPalette.has(command), `command ${command} should be enabled in the command palette`).to.be.false;
     });
 


### PR DESCRIPTION
This adds three commands for recording mock scenarios:
- "CodeQL Mock GitHub API Server: Start Scenario Recording"
- "CodeQL Mock GitHub API Server: Save Scenario"
- "CodeQL Mock GitHub API Server: Cancel Scenario"

The first one will only be visible when the setting is enabled and you are not yet recording. The latter two will only be visible when recording. On save, it will ask for a scenario save path and a name and will write all files to this directory.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
