### PR TITLE
Fix bug where dbs are lost on restart

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [UNRELEASED]
 
+- Fix a bug where persisted databases may be lost if VS code is restarted while databases are being initialized. [#1638](https://github.com/github/vscode-codeql/pull/1638)
+
 ## 1.7.2 - 14 October 2022
 
 - Fix a bug where results created in older versions were thought to be unsuccessful. [#1605](https://github.com/github/vscode-codeql/pull/1605)

--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [UNRELEASED]
 
-- Fix a bug where persisted databases may be lost if VS code is restarted while databases are being initialized. [#1638](https://github.com/github/vscode-codeql/pull/1638)
+- Fix a bug where databases may be lost if VS Code is restarted while the extension is being started up. [#1638](https://github.com/github/vscode-codeql/pull/1638)
 
 ## 1.7.2 - 14 October 2022
 


### PR DESCRIPTION
If the workspace is restarted while databases are being loaded, this change prevents any from being lost.

The bug was that each time a database was added when rehydrating a db from persisted state on startup, the persisted db list was being updated. Instead of updating the list each time we add a db, on restart, instead update the persisted list only after all are added.

Note that we need to update the persisted list after reading it in since the act of rehydrating a database _may_ change its persisted state. For example, the primary language of the database may be initialized if it was not able to be determined originally.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Fixes https://github.com/github/vscode-codeql/issues/1489

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
