### PR TITLE
Restructure configuration around mock GitHub API

### DIFF
--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -430,13 +430,24 @@ export function isVariantAnalysisLiveResultsEnabled(): boolean {
   return !!LIVE_RESULTS.getValue<boolean>();
 }
 
+// Settings for mocking the GitHub API.
+const MOCK_GH_API_SERVER = new Setting('mockGitHubApiServer', ROOT_SETTING);
+
 /**
  * A flag indicating whether to enable a mock GitHub API server.
  */
-const MOCK_GH_API_SERVER = new Setting('mockGitHubApiServer', REMOTE_QUERIES_SETTING);
+const MOCK_GH_API_SERVER_ENABLED = new Setting('enabled', MOCK_GH_API_SERVER);
+
+/**
+ * A path to a directory containing test scenarios. If this setting is not set,
+ * the mock server will a default location for test scenarios in dev mode, and 
+ * will show a menu to select a directory in production mode.
+ */
+const MOCK_GH_API_SERVER_SCENARIOS_PATH = new Setting('scenariosPath', MOCK_GH_API_SERVER);
 
 export interface MockGitHubApiConfig {
   mockServerEnabled: boolean;
+  mockScenariosPath: string;
   onDidChangeConfiguration: Event<void>;
 }
 
@@ -446,11 +457,13 @@ export class MockGitHubApiConfigListener extends ConfigListener implements MockG
   }
 
   public get mockServerEnabled(): boolean {
-    return !!MOCK_GH_API_SERVER.getValue<boolean>();
+    return !!MOCK_GH_API_SERVER_ENABLED.getValue<boolean>();
+  }
+
+  public get mockScenariosPath(): string {
+    return MOCK_GH_API_SERVER_SCENARIOS_PATH.getValue<string>();
   }
 }
-
-const MOCK_GH_API_SERVER_SCENARIOS_PATH = new Setting('mockGitHubApiServerScenariosPath', REMOTE_QUERIES_SETTING);
 
 export function getMockGitHubApiServerScenariosPath(): string | undefined {
   return MOCK_GH_API_SERVER_SCENARIOS_PATH.getValue<string>();


### PR DESCRIPTION
Created a top level setting for `mockGitHubApiServer` and moved the two settings related to this inside it.

## Checklist
N/A - internal only:

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
