### PR TITLE
MRVA: Use QLX to precompile queries

### DIFF
--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -944,16 +944,14 @@ export class CodeQLCliServer implements Disposable {
     return this.runJsonCodeQlCliCommand(['pack', 'install'], args, 'Installing pack dependencies');
   }
 
-  async packBundle(dir: string, workspaceFolders: string[], outputPath: string, precompile = true): Promise<void> {
+  async packBundle(dir: string, workspaceFolders: string[], outputPath: string, moreOptions: string[]): Promise<void> {
     const args = [
       '-o',
       outputPath,
       dir,
+      ...moreOptions,
       ...this.getAdditionalPacksArg(workspaceFolders)
     ];
-    if (!precompile && await this.cliConstraints.supportsNoPrecompile()) {
-      args.push('--no-precompile');
-    }
 
     return this.runJsonCodeQlCliCommand(['pack', 'bundle'], args, 'Bundling pack');
   }
@@ -1289,6 +1287,13 @@ export class CliVersionConstraint {
   public static CLI_VERSION_REMOTE_QUERIES = new SemVer('2.6.3');
 
   /**
+   * CLI version where building QLX packs for remote queries is supported.
+   * (The options were _accepted_ by a few earlier versions, but only from
+   * 2.11.3 will it actually use the existing compilation cache correctly).
+   */
+  public static CLI_VERSION_QLX_REMOTE = new SemVer('2.11.3');
+
+  /**
    * CLI version where the `resolve ml-models` subcommand was introduced.
    */
   public static CLI_VERSION_WITH_RESOLVE_ML_MODELS = new SemVer('2.7.3');
@@ -1381,6 +1386,10 @@ export class CliVersionConstraint {
 
   async supportsRemoteQueries() {
     return this.isVersionAtLeast(CliVersionConstraint.CLI_VERSION_REMOTE_QUERIES);
+  }
+
+  async supportsQlxRemote() {
+    return this.isVersionAtLeast(CliVersionConstraint.CLI_VERSION_QLX_REMOTE);
   }
 
   async supportsResolveMlModels() {


### PR DESCRIPTION
This PR starts using QLX in the packs that are sent to MRVA. Sample run using this [here](https://github.com/edoardopirovano/vscode-codeql-starter/actions/runs/3311989032) which shows the QLX being picked up by MRVA. It would be nice to have an automated test too, but I wasn't sure where to include one: if someone more familiar with this part of the code has any suggestions I'd be keen to hear them.

cc. @hmakholm This code is mostly as you wrote it, with a couple of minor fixes.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
