### PR TITLE
Store binary scenario bodies as files

### DIFF
--- a/extensions/ql-vscode/src/mocks/gh-api-request.ts
+++ b/extensions/ql-vscode/src/mocks/gh-api-request.ts
@@ -64,7 +64,8 @@ export interface GetVariantAnalysisRepoResultRequest {
   },
   response: {
     status: number,
-    body?: ArrayBuffer
+    body?: Buffer | string,
+    contentType: string,
   }
 }
 

--- a/extensions/ql-vscode/src/mocks/request-handlers.ts
+++ b/extensions/ql-vscode/src/mocks/request-handlers.ts
@@ -144,6 +144,7 @@ function createGetVariantAnalysisRepoResultRequestHandler(requests: GitHubApiReq
       if (scenarioRequest.response.body) {
         return res(
           ctx.status(scenarioRequest.response.status),
+          ctx.set('Content-Type', scenarioRequest.response.contentType),
           ctx.body(scenarioRequest.response.body),
         );
       } else {

--- a/extensions/ql-vscode/src/mocks/request-handlers.ts
+++ b/extensions/ql-vscode/src/mocks/request-handlers.ts
@@ -39,8 +39,17 @@ async function readRequestFiles(scenarioDirPath: string): Promise<GitHubApiReque
 
   const requests: GitHubApiRequest[] = [];
   for (const file of orderedFiles) {
+    if (!file.endsWith('.json')) {
+      continue;
+    }
+
     const filePath = path.join(scenarioDirPath, file);
     const request: GitHubApiRequest = await fs.readJson(filePath, { encoding: 'utf8' });
+
+    if (typeof request.response.body === 'string' && request.response.body.startsWith('file:')) {
+      request.response.body = await fs.readFile(path.join(scenarioDirPath, request.response.body.substring(5)));
+    }
+
     requests.push(request);
   }
 


### PR DESCRIPTION
This will store binary scenario bodies as files. It will create a separate file `4-getVariantAnalysisRepoResult.body.zip` for the request `4-getVariantAnalysisRepoResult.json` which contains the file. The request JSON will then refer to this file:

```json5
{
  "request": {
    "kind": "getVariantAnalysisRepoResult",
    "repositoryId": ...
  },
  "response": {
    "status": 200,
    "body": "file:4-getVariantAnalysisRepoResult.body.zip",
    "contentType": "application/zip"
  }
}
```

There are some workarounds because msw for Node doesn't support seem to support binary response bodies, so we need to fetch the file separately instead.

It's probably easiest to review this commit-by-commit.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
