### PR TITLE
Add tests for variant analysis history item

### DIFF
--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/data/variant-analysis/q0.ql
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/data/variant-analysis/q0.ql
@@ -1,0 +1,11 @@
+/**
+ * @name Variant Analysis Integration Test 1
+ * @kind problem
+ * @problem.severity warning
+ * @id javascript/variant-analysis-integration-test-1
+ */
+import javascript
+
+from MemberDeclaration md
+where md.getName() = "dispose"
+select md, "Dispose method"

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/data/variant-analysis/q1.ql
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/data/variant-analysis/q1.ql
@@ -1,0 +1,12 @@
+/**
+ * @name Variant Analysis Integration Test 2
+ * @kind problem
+ * @problem.severity warning
+ * @id ruby/example/empty-block
+ */
+
+import ruby
+
+from Block b
+where b.getNumberOfStatements() = 0
+select b, "This is an empty block."

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/data/variant-analysis/workspace-query-history.json
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/data/variant-analysis/workspace-query-history.json
@@ -5,7 +5,6 @@
       "t": "variant-analysis",
       "status": "Completed",
       "completed": true,
-      "historyItemId": "12349821",
       "variantAnalysis": {
         "id": 98574321397,
         "controllerRepoId": 128321,
@@ -29,7 +28,6 @@
       "t": "variant-analysis",
       "status": "Completed",
       "completed": true,
-      "historyItemId": "12349821",
       "variantAnalysis": {
         "id": 98574321397,
         "controllerRepoId": 128321,

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/data/variant-analysis/workspace-query-history.json
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/data/variant-analysis/workspace-query-history.json
@@ -1,0 +1,53 @@
+{
+  "version": 1,
+  "queries": [
+    {
+      "t": "variant-analysis",
+      "status": "Completed",
+      "completed": true,
+      "historyItemId": "12349821",
+      "variantAnalysis": {
+        "id": 98574321397,
+        "controllerRepoId": 128321,
+        "query": {
+          "name": "Variant Analysis Integration Test 1",
+          "filePath": "PLACEHOLDER/q2.ql",
+          "language": "javascript",
+          "text": "/**\n * @name Variant Analysis Integration Test 1\n * @kind problem\n * @problem.severity warning\n * @id javascript/variant-analysis-integration-test-1\n */\nimport javascript\n\nfrom MemberDeclaration md\nwhere md.getName() = \"dispose\"\nselect md, \"Dispose method\"\n"
+        },
+        "databases": {
+          "repositories": ["234321", "123301"]
+        },
+        "createdAt": "1666688269308",
+        "updatedAt": "1666688869308",
+        "executionStartTime": 1645644973911,
+        "status": "succeeded",
+        "actionsWorkflowRunId": 1889316048
+      }
+    },
+    {
+      "t": "variant-analysis",
+      "status": "Completed",
+      "completed": true,
+      "historyItemId": "12349821",
+      "variantAnalysis": {
+        "id": 98574321397,
+        "controllerRepoId": 128321,
+        "query": {
+          "name": "Variant Analysis Integration Test 2",
+          "filePath": "PLACEHOLDER/q2.ql",
+          "language": "ruby",
+          "text": "/**\n * @name Variant Analysis Integration Test 2\n * @kind problem\n * @problem.severity warning\n * @id ruby/example/empty-block\n */\nimport ruby\n\nfrom Block b\nwhere b.getNumberOfStatements() = 0\nselect b, \"This is an empty block.\"\n"
+        },
+        "databases": {
+          "repositories": ["92384123", "1230871"]
+        },
+        "createdAt": "1666689080847",
+        "updatedAt": "1666689080847",
+        "executionStartTime": 1645644973911,
+        "status": "succeeded",
+        "actionsWorkflowRunId": 1889316048
+      }
+    }
+  ]
+}

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/remote-query-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/remote-query-history.test.ts
@@ -58,6 +58,7 @@ describe('Remote queries and query history manager', function() {
     await copyHistoryState();
 
     sandbox = sinon.createSandbox();
+    disposables = new DisposableBucket();
 
     localQueriesResultsViewStub = {
       showResults: sandbox.stub()
@@ -81,19 +82,6 @@ describe('Remote queries and query history manager', function() {
       onVariantAnalysisStatusUpdated: sandbox.stub(),
       onVariantAnalysisRemoved: sandbox.stub()
     } as any as VariantAnalysisManager;
-  });
-
-  afterEach(function() {
-    // set a higher timeout since recursive delete below may take a while, expecially on Windows.
-    this.timeout(120000);
-    deleteHistoryState();
-    disposables.dispose(testDisposeHandler);
-    sandbox.restore();
-  });
-
-  beforeEach(() => {
-    sandbox = sinon.createSandbox();
-    disposables = new DisposableBucket();
 
     rawQueryHistory = fs.readJSONSync(path.join(STORAGE_DIR, 'workspace-query-history.json')).queries;
     remoteQueryResult0 = fs.readJSONSync(path.join(STORAGE_DIR, 'queries', rawQueryHistory[0].queryId, 'query-result.json'));
@@ -121,6 +109,14 @@ describe('Remote queries and query history manager', function() {
 
     showTextDocumentSpy = sandbox.spy(window, 'showTextDocument');
     openTextDocumentSpy = sandbox.spy(workspace, 'openTextDocument');
+  });
+
+  afterEach(function() {
+    // set a higher timeout since recursive delete below may take a while, expecially on Windows.
+    this.timeout(120000);
+    deleteHistoryState();
+    disposables.dispose(testDisposeHandler);
+    sandbox.restore();
   });
 
   it('should read query history', async () => {

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/remote-query-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/remote-query-history.test.ts
@@ -87,6 +87,8 @@ describe('Remote queries and query history manager', function() {
     // set a higher timeout since recursive delete below may take a while, expecially on Windows.
     this.timeout(120000);
     deleteHistoryState();
+    disposables.dispose(testDisposeHandler);
+    sandbox.restore();
   });
 
   beforeEach(() => {
@@ -119,11 +121,6 @@ describe('Remote queries and query history manager', function() {
 
     showTextDocumentSpy = sandbox.spy(window, 'showTextDocument');
     openTextDocumentSpy = sandbox.spy(workspace, 'openTextDocument');
-  });
-
-  afterEach(() => {
-    disposables.dispose(testDisposeHandler);
-    sandbox.restore();
   });
 
   it('should read query history', async () => {

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/variant-analysis-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/variant-analysis-history.test.ts
@@ -145,6 +145,25 @@ describe('Variant Analyses and QueryHistoryManager', function() {
     expect(qhm.treeDataProvider.allHistory).to.deep.eq([rawQueryHistory[1], rawQueryHistory[0]]);
   });
 
+  it('should remove two queries from history', async () => {
+    await qhm.readQueryHistory();
+
+    // Remove both queries
+    // Just for fun, let's do it in reverse order
+    await qhm.handleRemoveHistoryItem(undefined!, [qhm.treeDataProvider.allHistory[1], qhm.treeDataProvider.allHistory[0]]);
+
+    expect(removeVariantAnalysisStub.callCount).to.eq(2);
+    expect(removeVariantAnalysisStub.getCall(0).args[0]).to.eq(rawQueryHistory[1].historyItemId);
+    expect(removeVariantAnalysisStub.getCall(1).args[0]).to.eq(rawQueryHistory[0].historyItemId);
+    expect(qhm.treeDataProvider.allHistory).to.deep.eq([]);
+
+    // also, both queries should be removed from disk storage
+    expect(fs.readJSONSync(path.join(STORAGE_DIR, 'workspace-query-history.json'))).to.deep.eq({
+      version: 2,
+      queries: []
+    });
+  });
+
   async function copyHistoryState() {
     fs.ensureDirSync(STORAGE_DIR);
     fs.copySync(

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/variant-analysis-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/variant-analysis-history.test.ts
@@ -136,17 +136,6 @@ describe('Variant Analyses and QueryHistoryManager', function() {
     // Remove the first variant analysis
     await qhm.handleRemoveHistoryItem(qhm.treeDataProvider.allHistory[0]);
 
-    expect(removeVariantAnalysisStub).calledOnceWithExactly(rawQueryHistory[0].variantAnalysis);
-    expect(rehydrateVariantAnalysisStub).to.have.callCount(2);
-
-    expect(rehydrateVariantAnalysisStub.getCall(0).args[0]).to.deep.eq(rawQueryHistory[0].variantAnalysis);
-    expect(rehydrateVariantAnalysisStub.getCall(0).args[1]).to.deep.eq(rawQueryHistory[0].status);
-
-    expect(rehydrateVariantAnalysisStub.getCall(1).args[0]).to.deep.eq(rawQueryHistory[1].variantAnalysis);
-    expect(rehydrateVariantAnalysisStub.getCall(1).args[1]).to.deep.eq(rawQueryHistory[1].status);
-
-    expect(qhm.treeDataProvider.allHistory).to.deep.eq(rawQueryHistory.slice(1));
-
     // Add it back to the history
     qhm.addQuery(rawQueryHistory[0]);
     expect(removeVariantAnalysisStub).to.have.callCount(1);

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/variant-analysis-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/variant-analysis-history.test.ts
@@ -44,7 +44,6 @@ describe('Variant Analyses and QueryHistoryManager', function() {
   let showTextDocumentSpy: sinon.SinonSpy;
   let openTextDocumentSpy: sinon.SinonSpy;
 
-  let openRemoteQueryResultsStub: sinon.SinonStub;
   let rehydrateVariantAnalysisStub: sinon.SinonStub;
   let removeVariantAnalysisStub: sinon.SinonStub;
   let showViewStub: sinon.SinonStub;
@@ -66,14 +65,14 @@ describe('Variant Analyses and QueryHistoryManager', function() {
 
     rehydrateVariantAnalysisStub = sandbox.stub();
     removeVariantAnalysisStub = sandbox.stub();
-    openRemoteQueryResultsStub = sandbox.stub();
+    showViewStub = sandbox.stub();
 
     remoteQueriesManagerStub = {
       onRemoteQueryAdded: sandbox.stub(),
       onRemoteQueryRemoved: sandbox.stub(),
       onRemoteQueryStatusUpdate: sandbox.stub(),
       rehydrateRemoteQuery: sandbox.stub(),
-      openRemoteQueryResults: openRemoteQueryResultsStub
+      openRemoteQueryResults: sandbox.stub()
     } as any as RemoteQueriesManager;
 
     variantAnalysisManagerStub = {
@@ -137,7 +136,7 @@ describe('Variant Analyses and QueryHistoryManager', function() {
     // Remove the first variant analysis
     await qhm.handleRemoveHistoryItem(qhm.treeDataProvider.allHistory[0]);
 
-    expect(removeVariantAnalysisStub).calledOnceWithExactly(rawQueryHistory[0].variantAnalysis.id.toString());
+    expect(removeVariantAnalysisStub).calledOnceWithExactly(rawQueryHistory[0].variantAnalysis);
     expect(rehydrateVariantAnalysisStub).to.have.callCount(2);
 
     expect(rehydrateVariantAnalysisStub.getCall(0).args[0]).to.deep.eq(rawQueryHistory[0].variantAnalysis);
@@ -146,7 +145,6 @@ describe('Variant Analyses and QueryHistoryManager', function() {
     expect(rehydrateVariantAnalysisStub.getCall(1).args[0]).to.deep.eq(rawQueryHistory[1].variantAnalysis);
     expect(rehydrateVariantAnalysisStub.getCall(1).args[1]).to.deep.eq(rawQueryHistory[1].status);
 
-    expect(openRemoteQueryResultsStub).calledOnceWithExactly(rawQueryHistory[1].variantAnalysis.id.toString());
     expect(qhm.treeDataProvider.allHistory).to.deep.eq(rawQueryHistory.slice(1));
 
     // Add it back to the history
@@ -164,8 +162,8 @@ describe('Variant Analyses and QueryHistoryManager', function() {
     await qhm.handleRemoveHistoryItem(undefined!, [qhm.treeDataProvider.allHistory[1], qhm.treeDataProvider.allHistory[0]]);
 
     expect(removeVariantAnalysisStub.callCount).to.eq(2);
-    expect(removeVariantAnalysisStub.getCall(0).args[0]).to.eq(rawQueryHistory[1].variantAnalysis);
-    expect(removeVariantAnalysisStub.getCall(1).args[0]).to.eq(rawQueryHistory[0].variantAnalysis);
+    expect(removeVariantAnalysisStub.getCall(0).args[0]).to.deep.eq(rawQueryHistory[1].variantAnalysis);
+    expect(removeVariantAnalysisStub.getCall(1).args[0]).to.deep.eq(rawQueryHistory[0].variantAnalysis);
     expect(qhm.treeDataProvider.allHistory).to.deep.eq([]);
 
     // also, both queries should be removed from disk storage
@@ -179,7 +177,7 @@ describe('Variant Analyses and QueryHistoryManager', function() {
     await qhm.readQueryHistory();
 
     await qhm.handleItemClicked(qhm.treeDataProvider.allHistory[0], []);
-    expect(showViewStub).calledOnceWithExactly(rawQueryHistory[0].variantAnalysis.id.toString());
+    expect(showViewStub).calledOnceWithExactly(rawQueryHistory[0].variantAnalysis.id);
   });
 
   it('should get the query text', async () => {

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/variant-analysis-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/variant-analysis-history.test.ts
@@ -47,6 +47,7 @@ describe('Variant Analyses and QueryHistoryManager', function() {
   let openRemoteQueryResultsStub: sinon.SinonStub;
   let rehydrateVariantAnalysisStub: sinon.SinonStub;
   let removeVariantAnalysisStub: sinon.SinonStub;
+  let showViewStub: sinon.SinonStub;
 
   beforeEach(async function() {
     // set a higher timeout since recursive delete below may take a while, expecially on Windows.
@@ -78,9 +79,10 @@ describe('Variant Analyses and QueryHistoryManager', function() {
     variantAnalysisManagerStub = {
       onVariantAnalysisAdded: sandbox.stub(),
       onVariantAnalysisRemoved: sandbox.stub(),
-      removeRemoteQuery: removeVariantAnalysisStub,
+      removeVariantAnalysis: removeVariantAnalysisStub,
       rehydrateVariantAnalysis: rehydrateVariantAnalysisStub,
-      onVariantAnalysisStatusUpdated: sandbox.stub()
+      onVariantAnalysisStatusUpdated: sandbox.stub(),
+      showView: showViewStub
     } as any as VariantAnalysisManager;
 
     rawQueryHistory = fs.readJSONSync(path.join(STORAGE_DIR, 'workspace-query-history.json')).queries;
@@ -162,8 +164,8 @@ describe('Variant Analyses and QueryHistoryManager', function() {
     await qhm.handleRemoveHistoryItem(undefined!, [qhm.treeDataProvider.allHistory[1], qhm.treeDataProvider.allHistory[0]]);
 
     expect(removeVariantAnalysisStub.callCount).to.eq(2);
-    expect(removeVariantAnalysisStub.getCall(0).args[0]).to.eq(rawQueryHistory[1].variantAnalysis.id.toString());
-    expect(removeVariantAnalysisStub.getCall(1).args[0]).to.eq(rawQueryHistory[0].variantAnalysis.id.toString());
+    expect(removeVariantAnalysisStub.getCall(0).args[0]).to.eq(rawQueryHistory[1].variantAnalysis);
+    expect(removeVariantAnalysisStub.getCall(1).args[0]).to.eq(rawQueryHistory[0].variantAnalysis);
     expect(qhm.treeDataProvider.allHistory).to.deep.eq([]);
 
     // also, both queries should be removed from disk storage
@@ -177,7 +179,7 @@ describe('Variant Analyses and QueryHistoryManager', function() {
     await qhm.readQueryHistory();
 
     await qhm.handleItemClicked(qhm.treeDataProvider.allHistory[0], []);
-    expect(openRemoteQueryResultsStub).calledOnceWithExactly(rawQueryHistory[0].variantAnalysis.id.toString());
+    expect(showViewStub).calledOnceWithExactly(rawQueryHistory[0].variantAnalysis.id.toString());
   });
 
   it('should get the query text', async () => {

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/variant-analysis-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/variant-analysis-history.test.ts
@@ -164,6 +164,13 @@ describe('Variant Analyses and QueryHistoryManager', function() {
     });
   });
 
+  it('should handle a click', async () => {
+    await qhm.readQueryHistory();
+
+    await qhm.handleItemClicked(qhm.treeDataProvider.allHistory[0], []);
+    expect(openRemoteQueryResultsStub).calledOnceWithExactly(rawQueryHistory[0].historyItemId);
+  });
+
   async function copyHistoryState() {
     fs.ensureDirSync(STORAGE_DIR);
     fs.copySync(

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/variant-analysis-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/variant-analysis-history.test.ts
@@ -1,0 +1,153 @@
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import * as sinon from 'sinon';
+import { expect } from 'chai';
+
+import {
+  ExtensionContext,
+  Uri,
+} from 'vscode';
+import { QueryHistoryConfig } from '../../../config';
+import { DatabaseManager } from '../../../databases';
+import { tmpDir } from '../../../helpers';
+import { QueryHistoryManager } from '../../../query-history';
+import { DisposableBucket } from '../../disposable-bucket';
+import { testDisposeHandler } from '../../test-dispose-handler';
+import { walkDirectory } from '../../../helpers';
+import { HistoryItemLabelProvider } from '../../../history-item-label-provider';
+import { RemoteQueriesManager } from '../../../remote-queries/remote-queries-manager';
+import { ResultsView } from '../../../interface';
+import { EvalLogViewer } from '../../../eval-log-viewer';
+import { QueryRunner } from '../../../queryRunner';
+import { VariantAnalysisManager } from '../../../remote-queries/variant-analysis-manager';
+
+/**
+ * Tests for variant analyses and how they interact with the query history manager.
+ */
+
+describe('Variant Analyses and QueryHistoryManager', function() {
+  const EXTENSION_PATH = path.join(__dirname, '../../../../');
+  const STORAGE_DIR = Uri.file(path.join(tmpDir.name, 'variant-analysis')).fsPath;
+  const asyncNoop = async () => {
+    /** noop */
+  };
+
+  let sandbox: sinon.SinonSandbox;
+  let qhm: QueryHistoryManager;
+  let localQueriesResultsViewStub: ResultsView;
+  let remoteQueriesManagerStub: RemoteQueriesManager;
+  let variantAnalysisManagerStub: VariantAnalysisManager;
+  let rawQueryHistory: any;
+  let disposables: DisposableBucket;
+  let openRemoteQueryResultsStub: sinon.SinonStub;
+  let rehydrateVariantAnalysisStub: sinon.SinonStub;
+  let removeVariantAnalysisStub: sinon.SinonStub;
+
+  beforeEach(async function() {
+    // set a higher timeout since recursive delete below may take a while, expecially on Windows.
+    this.timeout(120000);
+
+    // Since these tests change the state of the query history manager, we need to copy the original
+    // to a temporary folder where we can manipulate it for tests
+    await copyHistoryState();
+
+    sandbox = sinon.createSandbox();
+    disposables = new DisposableBucket();
+
+    localQueriesResultsViewStub = {
+      showResults: sandbox.stub()
+    } as any as ResultsView;
+
+    rehydrateVariantAnalysisStub = sandbox.stub();
+    removeVariantAnalysisStub = sandbox.stub();
+    openRemoteQueryResultsStub = sandbox.stub();
+
+    remoteQueriesManagerStub = {
+      onRemoteQueryAdded: sandbox.stub(),
+      onRemoteQueryRemoved: sandbox.stub(),
+      onRemoteQueryStatusUpdate: sandbox.stub(),
+      rehydrateRemoteQuery: sandbox.stub(),
+      openRemoteQueryResults: openRemoteQueryResultsStub
+    } as any as RemoteQueriesManager;
+
+    variantAnalysisManagerStub = {
+      onVariantAnalysisAdded: sandbox.stub(),
+      onVariantAnalysisRemoved: sandbox.stub(),
+      removeRemoteQuery: removeVariantAnalysisStub,
+      rehydrateVariantAnalysis: rehydrateVariantAnalysisStub
+    } as any as VariantAnalysisManager;
+
+    rawQueryHistory = fs.readJSONSync(path.join(STORAGE_DIR, 'workspace-query-history.json')).queries;
+
+    qhm = new QueryHistoryManager(
+      {} as QueryRunner,
+      {} as DatabaseManager,
+      localQueriesResultsViewStub,
+      remoteQueriesManagerStub,
+      variantAnalysisManagerStub,
+      {} as EvalLogViewer,
+      STORAGE_DIR,
+      {
+        globalStorageUri: Uri.file(STORAGE_DIR),
+        extensionPath: EXTENSION_PATH
+      } as ExtensionContext,
+      {
+        onDidChangeConfiguration: () => new DisposableBucket(),
+      } as unknown as QueryHistoryConfig,
+      new HistoryItemLabelProvider({} as QueryHistoryConfig),
+      asyncNoop
+    );
+    disposables.push(qhm);
+  });
+
+  afterEach(function() {
+    deleteHistoryState();
+    disposables.dispose(testDisposeHandler);
+    sandbox.restore();
+  });
+
+  it('should read query history that has variant analysis history items', async () => {
+    await qhm.readQueryHistory();
+
+    expect(rehydrateVariantAnalysisStub).to.have.callCount(2);
+    expect(rehydrateVariantAnalysisStub.getCall(0).args[0]).to.deep.eq(rawQueryHistory[0].variantAnalysis);
+    expect(rehydrateVariantAnalysisStub.getCall(0).args[1]).to.deep.eq(rawQueryHistory[0].status);
+    expect(rehydrateVariantAnalysisStub.getCall(1).args[0]).to.deep.eq(rawQueryHistory[1].variantAnalysis);
+    expect(rehydrateVariantAnalysisStub.getCall(1).args[1]).to.deep.eq(rawQueryHistory[1].status);
+
+    expect(qhm.treeDataProvider.allHistory[0]).to.deep.eq(rawQueryHistory[0]);
+    expect(qhm.treeDataProvider.allHistory[1]).to.deep.eq(rawQueryHistory[1]);
+    expect(qhm.treeDataProvider.allHistory.length).to.eq(2);
+  });
+
+  async function copyHistoryState() {
+    fs.ensureDirSync(STORAGE_DIR);
+    fs.copySync(
+      path.join(__dirname, '../data/variant-analysis/'),
+      path.join(tmpDir.name, 'variant-analysis')
+    );
+
+    // also, replace the files with 'PLACEHOLDER' so that they have the correct directory
+    for await (const p of walkDirectory(STORAGE_DIR)) {
+      replacePlaceholder(path.join(p));
+    }
+  }
+
+  function replacePlaceholder(filePath: string) {
+    if (filePath.endsWith('.json')) {
+      const newContents = fs
+        .readFileSync(filePath, 'utf8')
+        .replaceAll('PLACEHOLDER', STORAGE_DIR.replaceAll('\\', '/'));
+      fs.writeFileSync(filePath, newContents, 'utf8');
+    }
+  }
+
+  function deleteHistoryState() {
+    fs.rmSync(STORAGE_DIR, {
+      recursive: true,
+      force: true,
+      maxRetries: 10,
+      retryDelay: 100
+    });
+  }
+});

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/variant-analysis-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/variant-analysis-history.test.ts
@@ -79,7 +79,8 @@ describe('Variant Analyses and QueryHistoryManager', function() {
       onVariantAnalysisAdded: sandbox.stub(),
       onVariantAnalysisRemoved: sandbox.stub(),
       removeRemoteQuery: removeVariantAnalysisStub,
-      rehydrateVariantAnalysis: rehydrateVariantAnalysisStub
+      rehydrateVariantAnalysis: rehydrateVariantAnalysisStub,
+      onVariantAnalysisStatusUpdated: sandbox.stub()
     } as any as VariantAnalysisManager;
 
     rawQueryHistory = fs.readJSONSync(path.join(STORAGE_DIR, 'workspace-query-history.json')).queries;
@@ -134,7 +135,7 @@ describe('Variant Analyses and QueryHistoryManager', function() {
     // Remove the first variant analysis
     await qhm.handleRemoveHistoryItem(qhm.treeDataProvider.allHistory[0]);
 
-    expect(removeVariantAnalysisStub).calledOnceWithExactly(rawQueryHistory[0].historyItemId);
+    expect(removeVariantAnalysisStub).calledOnceWithExactly(rawQueryHistory[0].variantAnalysis.id.toString());
     expect(rehydrateVariantAnalysisStub).to.have.callCount(2);
 
     expect(rehydrateVariantAnalysisStub.getCall(0).args[0]).to.deep.eq(rawQueryHistory[0].variantAnalysis);
@@ -143,7 +144,7 @@ describe('Variant Analyses and QueryHistoryManager', function() {
     expect(rehydrateVariantAnalysisStub.getCall(1).args[0]).to.deep.eq(rawQueryHistory[1].variantAnalysis);
     expect(rehydrateVariantAnalysisStub.getCall(1).args[1]).to.deep.eq(rawQueryHistory[1].status);
 
-    expect(openRemoteQueryResultsStub).calledOnceWithExactly(rawQueryHistory[1].historyItemId);
+    expect(openRemoteQueryResultsStub).calledOnceWithExactly(rawQueryHistory[1].variantAnalysis.id.toString());
     expect(qhm.treeDataProvider.allHistory).to.deep.eq(rawQueryHistory.slice(1));
 
     // Add it back to the history
@@ -161,8 +162,8 @@ describe('Variant Analyses and QueryHistoryManager', function() {
     await qhm.handleRemoveHistoryItem(undefined!, [qhm.treeDataProvider.allHistory[1], qhm.treeDataProvider.allHistory[0]]);
 
     expect(removeVariantAnalysisStub.callCount).to.eq(2);
-    expect(removeVariantAnalysisStub.getCall(0).args[0]).to.eq(rawQueryHistory[1].historyItemId);
-    expect(removeVariantAnalysisStub.getCall(1).args[0]).to.eq(rawQueryHistory[0].historyItemId);
+    expect(removeVariantAnalysisStub.getCall(0).args[0]).to.eq(rawQueryHistory[1].variantAnalysis.id.toString());
+    expect(removeVariantAnalysisStub.getCall(1).args[0]).to.eq(rawQueryHistory[0].variantAnalysis.id.toString());
     expect(qhm.treeDataProvider.allHistory).to.deep.eq([]);
 
     // also, both queries should be removed from disk storage
@@ -176,7 +177,7 @@ describe('Variant Analyses and QueryHistoryManager', function() {
     await qhm.readQueryHistory();
 
     await qhm.handleItemClicked(qhm.treeDataProvider.allHistory[0], []);
-    expect(openRemoteQueryResultsStub).calledOnceWithExactly(rawQueryHistory[0].historyItemId);
+    expect(openRemoteQueryResultsStub).calledOnceWithExactly(rawQueryHistory[0].variantAnalysis.id.toString());
   });
 
   it('should get the query text', async () => {

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/variant-analysis-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/variant-analysis-history.test.ts
@@ -120,6 +120,31 @@ describe('Variant Analyses and QueryHistoryManager', function() {
     expect(qhm.treeDataProvider.allHistory.length).to.eq(2);
   });
 
+  it('should remove the variant analysis history item', async () => {
+    await qhm.readQueryHistory();
+
+    // Remove the first variant analysis
+    await qhm.handleRemoveHistoryItem(qhm.treeDataProvider.allHistory[0]);
+
+    expect(removeVariantAnalysisStub).calledOnceWithExactly(rawQueryHistory[0].historyItemId);
+    expect(rehydrateVariantAnalysisStub).to.have.callCount(2);
+
+    expect(rehydrateVariantAnalysisStub.getCall(0).args[0]).to.deep.eq(rawQueryHistory[0].variantAnalysis);
+    expect(rehydrateVariantAnalysisStub.getCall(0).args[1]).to.deep.eq(rawQueryHistory[0].status);
+
+    expect(rehydrateVariantAnalysisStub.getCall(1).args[0]).to.deep.eq(rawQueryHistory[1].variantAnalysis);
+    expect(rehydrateVariantAnalysisStub.getCall(1).args[1]).to.deep.eq(rawQueryHistory[1].status);
+
+    expect(openRemoteQueryResultsStub).calledOnceWithExactly(rawQueryHistory[1].historyItemId);
+    expect(qhm.treeDataProvider.allHistory).to.deep.eq(rawQueryHistory.slice(1));
+
+    // Add it back to the history
+    qhm.addQuery(rawQueryHistory[0]);
+    expect(removeVariantAnalysisStub).to.have.callCount(1);
+    expect(rehydrateVariantAnalysisStub).to.have.callCount(2);
+    expect(qhm.treeDataProvider.allHistory).to.deep.eq([rawQueryHistory[1], rawQueryHistory[0]]);
+  });
+
   async function copyHistoryState() {
     fs.ensureDirSync(STORAGE_DIR);
     fs.copySync(


### PR DESCRIPTION
🚨 Please review this PR commit-by-commit.

We're repeating what we've done for the `RemoteQueryHistoryItem` tests for now.

Separately we'll think about setting up tests that check for both remote queries and variant analysis in the query history.

At the moment we'd like to focus on just adding some test coverage for `VariantAnalysisHistoryItem`.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
