### PR TITLE
Allow multiple query history items for a single variant analysis

### DIFF
--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -635,10 +635,10 @@ export class QueryHistoryManager extends DisposableObject {
     });
 
     const variantAnalysisRemovedSubscription = this.variantAnalysisManager.onVariantAnalysisRemoved(async (variantAnalysis) => {
-      const item = this.treeDataProvider.allHistory.find(i => i.t === 'variant-analysis' && i.variantAnalysis.id === variantAnalysis.id);
-      if (item) {
+      const items = this.treeDataProvider.allHistory.filter(i => i.t === 'variant-analysis' && i.variantAnalysis.id === variantAnalysis.id);
+      items.forEach(async (item) => {
         await this.removeRemoteQuery(item as RemoteQueryHistoryItem);
-      }
+      });
     });
 
     this.push(variantAnalysisAddedSubscription);


### PR DESCRIPTION
We decided to allow having multiple query history items for the same variant analysis. This PR ensures that all places in the code deal with this possibility. 

## Checklist
N/A - internal only.
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
