### PR TITLE
Implement `openQueryResults` for variant analysis items

### DIFF
--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -1444,7 +1444,7 @@ the file in the file explorer and dragging it into the workspace.`
     } else if (item.t === 'remote') {
       await this.remoteQueriesManager.openRemoteQueryResults(item.queryId);
     } else if (item.t === 'variant-analysis') {
-      await this.variantAnalysisManager.openVariantAnalysisResults(item.variantAnalysis.id);
+      await this.variantAnalysisManager.showView(item.variantAnalysis.id);
     }
   }
 }

--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -912,8 +912,8 @@ export class QueryHistoryManager extends DisposableObject {
       // show original query file on double click
       await this.handleOpenQuery(finalSingleItem, [finalSingleItem]);
     } else {
-      // show results on single click only if query is completed successfully.
-      if (finalSingleItem.status === QueryStatus.Completed) {
+      // show results on single click (if results view is available)
+      if (finalSingleItem.t === 'variant-analysis' || finalSingleItem.status === QueryStatus.Completed) {
         await this.openQueryResults(finalSingleItem);
       }
     }
@@ -1441,9 +1441,10 @@ the file in the file explorer and dragging it into the workspace.`
   private async openQueryResults(item: QueryHistoryInfo) {
     if (item.t === 'local') {
       await this.localQueriesResultsView.showResults(item as CompletedLocalQueryInfo, WebviewReveal.Forced, false);
-    }
-    else if (item.t === 'remote') {
+    } else if (item.t === 'remote') {
       await this.remoteQueriesManager.openRemoteQueryResults(item.queryId);
+    } else if (item.t === 'variant-analysis') {
+      await this.variantAnalysisManager.openVariantAnalysisResults(item.variantAnalysis.id);
     }
   }
 }

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
@@ -73,18 +73,17 @@ export class VariantAnalysisManager extends DisposableObject implements VariantA
   }
 
   public async showView(variantAnalysisId: number): Promise<void> {
-    try{
-      if (!this.views.has(variantAnalysisId)) {
-        // The view will register itself with the manager, so we don't need to do anything here.
-        this.push(new VariantAnalysisView(this.ctx, variantAnalysisId, this));
-      }
-
-      const variantAnalysisView = this.views.get(variantAnalysisId)!;
-      await variantAnalysisView.openView();
-      return;
-    } catch (e) {
-      void showAndLogErrorMessage(`Could not open the results for variant analysis with id: ${variantAnalysisId}. Error: ${getErrorMessage(e)}`);
+    if (!this.variantAnalyses.get(variantAnalysisId)) {
+      void showAndLogErrorMessage(`No variant analysis found with id: ${variantAnalysisId}.`);
     }
+    if (!this.views.has(variantAnalysisId)) {
+      // The view will register itself with the manager, so we don't need to do anything here.
+      this.push(new VariantAnalysisView(this.ctx, variantAnalysisId, this));
+    }
+
+    const variantAnalysisView = this.views.get(variantAnalysisId)!;
+    await variantAnalysisView.openView();
+    return;
   }
 
   public registerView(view: VariantAnalysisView): void {

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
@@ -25,7 +25,7 @@ import { CodeQLCliServer } from '../cli';
 import { getControllerRepo } from './run-remote-query';
 import { processUpdatedVariantAnalysis } from './variant-analysis-processor';
 import PQueue from 'p-queue';
-import { createTimestampFile } from '../helpers';
+import { createTimestampFile, showAndLogErrorMessage } from '../helpers';
 import { QueryStatus } from '../query-status';
 import * as fs from 'fs-extra';
 
@@ -222,6 +222,18 @@ export class VariantAnalysisManager extends DisposableObject implements VariantA
    */
   private async prepareStorageDirectory(variantAnalysisId: number): Promise<void> {
     await createTimestampFile(this.getVariantAnalysisStorageLocation(variantAnalysisId));
+  }
+
+  public async openVariantAnalysisResults(variantAnalysisId: number): Promise<void> {
+    try {
+      const variantAnalysis = this.variantAnalyses.get(variantAnalysisId);
+      if (!variantAnalysis) {
+        void showAndLogErrorMessage(`No variant analysis with id: ${variantAnalysisId}`);
+      }
+      void commands.executeCommand('codeQL.openVariantAnalysisView', variantAnalysisId);
+    } catch (e) {
+      void showAndLogErrorMessage(`Could not open the results for variant analysis with id: ${variantAnalysisId}. Error: ${getErrorMessage(e)}`);
+    }
   }
 
   public async promptOpenVariantAnalysis() {

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
@@ -73,14 +73,18 @@ export class VariantAnalysisManager extends DisposableObject implements VariantA
   }
 
   public async showView(variantAnalysisId: number): Promise<void> {
-    if (!this.views.has(variantAnalysisId)) {
-      // The view will register itself with the manager, so we don't need to do anything here.
-      this.push(new VariantAnalysisView(this.ctx, variantAnalysisId, this));
-    }
+    try{
+      if (!this.views.has(variantAnalysisId)) {
+        // The view will register itself with the manager, so we don't need to do anything here.
+        this.push(new VariantAnalysisView(this.ctx, variantAnalysisId, this));
+      }
 
-    const variantAnalysisView = this.views.get(variantAnalysisId)!;
-    await variantAnalysisView.openView();
-    return;
+      const variantAnalysisView = this.views.get(variantAnalysisId)!;
+      await variantAnalysisView.openView();
+      return;
+    } catch (e) {
+      void showAndLogErrorMessage(`Could not open the results for variant analysis with id: ${variantAnalysisId}. Error: ${getErrorMessage(e)}`);
+    }
   }
 
   public registerView(view: VariantAnalysisView): void {
@@ -222,18 +226,6 @@ export class VariantAnalysisManager extends DisposableObject implements VariantA
    */
   private async prepareStorageDirectory(variantAnalysisId: number): Promise<void> {
     await createTimestampFile(this.getVariantAnalysisStorageLocation(variantAnalysisId));
-  }
-
-  public async openVariantAnalysisResults(variantAnalysisId: number): Promise<void> {
-    try {
-      const variantAnalysis = this.variantAnalyses.get(variantAnalysisId);
-      if (!variantAnalysis) {
-        void showAndLogErrorMessage(`No variant analysis with id: ${variantAnalysisId}`);
-      }
-      void commands.executeCommand('codeQL.openVariantAnalysisView', variantAnalysisId);
-    } catch (e) {
-      void showAndLogErrorMessage(`Could not open the results for variant analysis with id: ${variantAnalysisId}. Error: ${getErrorMessage(e)}`);
-    }
   }
 
   public async promptOpenVariantAnalysis() {


### PR DESCRIPTION
Makes it possible to open the variant analysis results view by single-clicking a query history item: 

![open results view from query history](https://user-images.githubusercontent.com/42641846/197761337-f513da1d-730a-4287-81f7-3cfa62a62b1e.GIF)

See internal issue for context/related work 🔍 


## Checklist

N/A - internal only 🦈 

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
