### PR TITLE
Implement `handleRemoveHistoryItem` for variant analysis history items

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
@@ -114,12 +114,8 @@ export class VariantAnalysisManager extends DisposableObject implements VariantA
     return this.variantAnalyses.get(variantAnalysisId);
   }
 
-  public getVariantAnalyses(): Map<number, VariantAnalysis> {
-    return this.variantAnalyses;
-  }
-
-  public async setVariantAnalysis(variantAnalysis: VariantAnalysis): Promise<void> {
-    this.variantAnalyses.set(variantAnalysis.id, variantAnalysis);
+  public getVariantAnalysesSize(): number {
+    return this.variantAnalyses.size;
   }
 
   public async loadResults(variantAnalysisId: number, repositoryFullName: string): Promise<void> {
@@ -136,7 +132,7 @@ export class VariantAnalysisManager extends DisposableObject implements VariantA
     return await fs.pathExists(filePath);
   }
 
-  private async onVariantAnalysisUpdated(variantAnalysis: VariantAnalysis | undefined): Promise<void> {
+  public async onVariantAnalysisUpdated(variantAnalysis: VariantAnalysis | undefined): Promise<void> {
     if (!variantAnalysis) {
       return;
     }

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
@@ -38,7 +38,7 @@ export class VariantAnalysisManager extends DisposableObject implements VariantA
   public readonly onVariantAnalysisRemoved = this._onVariantAnalysisRemoved.event;
 
   private readonly variantAnalysisMonitor: VariantAnalysisMonitor;
-  private readonly variantAnalysisResultsManager: VariantAnalysisResultsManager;
+  public readonly variantAnalysisResultsManager: VariantAnalysisResultsManager;
   private readonly variantAnalyses = new Map<number, VariantAnalysis>();
   private readonly views = new Map<number, VariantAnalysisView>();
   private static readonly maxConcurrentDownloads = 3;
@@ -110,6 +110,14 @@ export class VariantAnalysisManager extends DisposableObject implements VariantA
 
   public async getVariantAnalysis(variantAnalysisId: number): Promise<VariantAnalysis | undefined> {
     return this.variantAnalyses.get(variantAnalysisId);
+  }
+
+  public getVariantAnalyses(): Map<number, VariantAnalysis> {
+    return this.variantAnalyses;
+  }
+
+  public async setVariantAnalysis(variantAnalysis: VariantAnalysis): Promise<void> {
+    this.variantAnalyses.set(variantAnalysis.id, variantAnalysis);
   }
 
   public async loadResults(variantAnalysisId: number, repositoryFullName: string): Promise<void> {

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
@@ -70,6 +70,17 @@ export class VariantAnalysisManager extends DisposableObject implements VariantA
     }
   }
 
+  public async removeVariantAnalysis(variantAnalysis: VariantAnalysis) {
+    this.variantAnalysisResultsManager.removeAnalysesResults(variantAnalysis);
+    await this.removeStorageDirectory(variantAnalysis.id);
+    this.variantAnalyses.delete(variantAnalysis.id);
+  }
+
+  private async removeStorageDirectory(variantAnalysisId: number) {
+    const storageLocation = this.getVariantAnalysisStorageLocation(variantAnalysisId);
+    await fs.remove(storageLocation);
+  }
+
   public async showView(variantAnalysisId: number): Promise<void> {
     if (!this.views.has(variantAnalysisId)) {
       // The view will register itself with the manager, so we don't need to do anything here.

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-results-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-results-manager.ts
@@ -29,7 +29,7 @@ export class VariantAnalysisResultsManager extends DisposableObject {
   private static readonly REPO_TASK_FILENAME = 'repo_task.json';
   private static readonly RESULTS_DIRECTORY = 'results';
 
-  public readonly cachedResults: Map<CacheKey, VariantAnalysisScannedRepositoryResult>;
+  private readonly cachedResults: Map<CacheKey, VariantAnalysisScannedRepositoryResult>;
 
   private readonly _onResultDownloaded = this.push(new EventEmitter<ResultDownloadedEvent>());
   readonly onResultDownloaded = this._onResultDownloaded.event;
@@ -90,7 +90,7 @@ export class VariantAnalysisResultsManager extends DisposableObject {
     return result ?? await this.loadResultsIntoMemory(variantAnalysisId, variantAnalysisStoragePath, repositoryFullName);
   }
 
-  public async loadResultsIntoMemory(
+  private async loadResultsIntoMemory(
     variantAnalysisId: number,
     variantAnalysisStoragePath: string,
     repositoryFullName: string,
@@ -190,6 +190,10 @@ export class VariantAnalysisResultsManager extends DisposableObject {
         }
       });
     }
+  }
+
+  public getCachedResultsSize() {
+    return this.cachedResults.size;
   }
 
   public dispose(disposeHandler?: DisposeHandler) {

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-results-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-results-manager.ts
@@ -9,7 +9,7 @@ import { sarifParser } from '../sarif-parser';
 import { extractAnalysisAlerts } from './sarif-processing';
 import { CodeQLCliServer } from '../cli';
 import { extractRawResults } from './bqrs-processing';
-import { VariantAnalysisScannedRepositoryResult } from './shared/variant-analysis';
+import { VariantAnalysis, VariantAnalysisScannedRepositoryResult } from './shared/variant-analysis';
 import { DisposableObject, DisposeHandler } from '../pure/disposable-object';
 import { VariantAnalysisRepoTask } from './gh-api/variant-analysis';
 import * as ghApiClient from './gh-api/gh-api-client';
@@ -177,6 +177,19 @@ export class VariantAnalysisResultsManager extends DisposableObject {
 
   private createGitHubDotcomFileLinkPrefix(fullName: string, sha: string): string {
     return `https://github.com/${fullName}/blob/${sha}`;
+  }
+
+  public removeAnalysesResults(variantAnalysis: VariantAnalysis) {
+    const scannedRepos = variantAnalysis.scannedRepos;
+
+    if (scannedRepos) {
+      scannedRepos.forEach(scannedRepo => {
+        const cacheKey = createCacheKey(variantAnalysis.id, scannedRepo.repository.fullName);
+        if (this.cachedResults.get(cacheKey)) {
+          this.cachedResults.delete(cacheKey);
+        }
+      });
+    }
   }
 
   public dispose(disposeHandler?: DisposeHandler) {

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-results-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-results-manager.ts
@@ -29,7 +29,7 @@ export class VariantAnalysisResultsManager extends DisposableObject {
   private static readonly REPO_TASK_FILENAME = 'repo_task.json';
   private static readonly RESULTS_DIRECTORY = 'results';
 
-  private readonly cachedResults: Map<CacheKey, VariantAnalysisScannedRepositoryResult>;
+  public readonly cachedResults: Map<CacheKey, VariantAnalysisScannedRepositoryResult>;
 
   private readonly _onResultDownloaded = this.push(new EventEmitter<ResultDownloadedEvent>());
   readonly onResultDownloaded = this._onResultDownloaded.event;
@@ -90,7 +90,7 @@ export class VariantAnalysisResultsManager extends DisposableObject {
     return result ?? await this.loadResultsIntoMemory(variantAnalysisId, variantAnalysisStoragePath, repositoryFullName);
   }
 
-  private async loadResultsIntoMemory(
+  public async loadResultsIntoMemory(
     variantAnalysisId: number,
     variantAnalysisStoragePath: string,
     repositoryFullName: string,
@@ -101,7 +101,7 @@ export class VariantAnalysisResultsManager extends DisposableObject {
     return result;
   }
 
-  private async loadResultsFromStorage(
+  public async loadResultsFromStorage(
     variantAnalysisId: number,
     variantAnalysisStoragePath: string,
     repositoryFullName: string,

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-manager.test.ts
@@ -118,47 +118,51 @@ describe('Variant Analysis Manager', async function() {
         getVariantAnalysisRepoResultStub = sandbox.stub(ghApiClient, 'getVariantAnalysisRepoResult').resolves(arrayBuffer);
       });
 
-      it('should return early if variant analysis is cancelled', async () => {
-        cancellationTokenSource.cancel();
+      describe('autoDownloadVariantAnalysisResult', async () => {
+        it('should return early if variant analysis is cancelled', async () => {
+          cancellationTokenSource.cancel();
 
-        await variantAnalysisManager.autoDownloadVariantAnalysisResult(
-          scannedRepos[0],
-          variantAnalysis,
-          cancellationTokenSource.token
-        );
+          await variantAnalysisManager.autoDownloadVariantAnalysisResult(
+            scannedRepos[0],
+            variantAnalysis,
+            cancellationTokenSource.token
+          );
 
-        expect(getVariantAnalysisRepoStub.notCalled).to.be.true;
+          expect(getVariantAnalysisRepoStub.notCalled).to.be.true;
+        });
+
+        it('should fetch a repo task', async () => {
+          await variantAnalysisManager.autoDownloadVariantAnalysisResult(
+            scannedRepos[0],
+            variantAnalysis,
+            cancellationTokenSource.token
+          );
+
+          expect(getVariantAnalysisRepoStub.calledOnce).to.be.true;
+        });
+
+        it('should fetch a repo result', async () => {
+          await variantAnalysisManager.autoDownloadVariantAnalysisResult(
+            scannedRepos[0],
+            variantAnalysis,
+            cancellationTokenSource.token
+          );
+
+          expect(getVariantAnalysisRepoResultStub.calledOnce).to.be.true;
+        });
       });
 
-      it('should fetch a repo task', async () => {
-        await variantAnalysisManager.autoDownloadVariantAnalysisResult(
-          scannedRepos[0],
-          variantAnalysis,
-          cancellationTokenSource.token
-        );
+      describe('enqueueDownload', async () => {
+        it('should pop download tasks off the queue', async () => {
+          const getResultsSpy = sandbox.spy(variantAnalysisManager, 'autoDownloadVariantAnalysisResult');
 
-        expect(getVariantAnalysisRepoStub.calledOnce).to.be.true;
-      });
+          await variantAnalysisManager.enqueueDownload(scannedRepos[0], variantAnalysis, cancellationTokenSource.token);
+          await variantAnalysisManager.enqueueDownload(scannedRepos[1], variantAnalysis, cancellationTokenSource.token);
+          await variantAnalysisManager.enqueueDownload(scannedRepos[2], variantAnalysis, cancellationTokenSource.token);
 
-      it('should fetch a repo result', async () => {
-        await variantAnalysisManager.autoDownloadVariantAnalysisResult(
-          scannedRepos[0],
-          variantAnalysis,
-          cancellationTokenSource.token
-        );
-
-        expect(getVariantAnalysisRepoResultStub.calledOnce).to.be.true;
-      });
-
-      it('should pop download tasks off the queue', async () => {
-        const getResultsSpy = sandbox.spy(variantAnalysisManager, 'autoDownloadVariantAnalysisResult');
-
-        await variantAnalysisManager.enqueueDownload(scannedRepos[0], variantAnalysis, cancellationTokenSource.token);
-        await variantAnalysisManager.enqueueDownload(scannedRepos[1], variantAnalysis, cancellationTokenSource.token);
-        await variantAnalysisManager.enqueueDownload(scannedRepos[2], variantAnalysis, cancellationTokenSource.token);
-
-        expect(variantAnalysisManager.downloadsQueueSize()).to.equal(0);
-        expect(getResultsSpy).to.have.been.calledThrice;
+          expect(variantAnalysisManager.downloadsQueueSize()).to.equal(0);
+          expect(getResultsSpy).to.have.been.calledThrice;
+        });
       });
     });
   });

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-manager.test.ts
@@ -174,19 +174,20 @@ describe('Variant Analysis Manager', async function() {
 
         beforeEach(async () => {
           dummyVariantAnalysis = createMockVariantAnalysis();
-          await variantAnalysisManager.setVariantAnalysis(dummyVariantAnalysis);
           const resultsManager = variantAnalysisManager.variantAnalysisResultsManager;
           removeVariantAnalysisStub = sandbox.stub(resultsManager, 'removeAnalysesResults');
           removeStorageStub = sandbox.stub(fs, 'remove');
         });
 
         it('should remove variant analysis', async () => {
-          expect(variantAnalysisManager.getVariantAnalyses().size).to.eq(1);
+          await variantAnalysisManager.onVariantAnalysisUpdated(dummyVariantAnalysis);
+          expect(variantAnalysisManager.getVariantAnalysesSize()).to.eq(1);
+
           await variantAnalysisManager.removeVariantAnalysis(dummyVariantAnalysis);
 
           expect(removeVariantAnalysisStub).to.have.been.calledOnce;
           expect(removeStorageStub).to.have.been.calledOnce;
-          expect(variantAnalysisManager.getVariantAnalyses().size).to.equal(0);
+          expect(variantAnalysisManager.getVariantAnalysesSize()).to.equal(0);
         });
       });
     });

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-manager.test.ts
@@ -20,6 +20,8 @@ import { createMockScannedRepos } from '../../factories/remote-queries/gh-api/sc
 import { createMockVariantAnalysisRepoTask } from '../../factories/remote-queries/gh-api/variant-analysis-repo-task';
 import { CodeQLCliServer } from '../../../cli';
 import { storagePath } from '../global.helper';
+import { VariantAnalysis } from '../../../remote-queries/shared/variant-analysis';
+import { createMockVariantAnalysis } from '../../factories/remote-queries/shared/variant-analysis';
 
 describe('Variant Analysis Manager', async function() {
   let sandbox: sinon.SinonSandbox;
@@ -162,6 +164,29 @@ describe('Variant Analysis Manager', async function() {
 
           expect(variantAnalysisManager.downloadsQueueSize()).to.equal(0);
           expect(getResultsSpy).to.have.been.calledThrice;
+        });
+      });
+
+      describe('removeVariantAnalysis', async () => {
+        let removeVariantAnalysisStub: sinon.SinonStub;
+        let removeStorageStub: sinon.SinonStub;
+        let dummyVariantAnalysis: VariantAnalysis;
+
+        beforeEach(async () => {
+          dummyVariantAnalysis = createMockVariantAnalysis();
+          await variantAnalysisManager.setVariantAnalysis(dummyVariantAnalysis);
+          const resultsManager = variantAnalysisManager.variantAnalysisResultsManager;
+          removeVariantAnalysisStub = sandbox.stub(resultsManager, 'removeAnalysesResults');
+          removeStorageStub = sandbox.stub(fs, 'remove');
+        });
+
+        it('should remove variant analysis', async () => {
+          expect(variantAnalysisManager.getVariantAnalyses().size).to.eq(1);
+          await variantAnalysisManager.removeVariantAnalysis(dummyVariantAnalysis);
+
+          expect(removeVariantAnalysisStub).to.have.been.calledOnce;
+          expect(removeStorageStub).to.have.been.calledOnce;
+          expect(variantAnalysisManager.getVariantAnalyses().size).to.equal(0);
         });
       });
     });

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-results-manager.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-results-manager.test.ts
@@ -140,7 +140,7 @@ describe(VariantAnalysisResultsManager.name, function() {
     });
   });
 
-  describe('loadResultsIntoMemory', () => {
+  describe('loadResults', () => {
     let variantAnalysisStoragePath: string;
     let dummyVariantAnalysis: VariantAnalysis;
     let repoFullName1: string;
@@ -162,19 +162,21 @@ describe(VariantAnalysisResultsManager.name, function() {
     });
 
     it('should load results into memory', async () => {
-      await variantAnalysisResultsManager.loadResultsIntoMemory(
+      expect(variantAnalysisResultsManager.getCachedResultsSize()).to.eq(0);
+
+      await variantAnalysisResultsManager.loadResults(
         dummyVariantAnalysis.id,
         variantAnalysisStoragePath,
         repoFullName1
       );
 
-      await variantAnalysisResultsManager.loadResultsIntoMemory(
+      await variantAnalysisResultsManager.loadResults(
         dummyVariantAnalysis.id,
         variantAnalysisStoragePath,
         repoFullName2
       );
 
-      expect(variantAnalysisResultsManager.cachedResults.size).to.eq(2);
+      expect(variantAnalysisResultsManager.getCachedResultsSize()).to.eq(2);
     });
   });
 
@@ -198,13 +200,13 @@ describe(VariantAnalysisResultsManager.name, function() {
       const result = createMockScannedRepoResult();
       sandbox.stub(variantAnalysisResultsManager, 'loadResultsFromStorage').resolves(result);
 
-      await variantAnalysisResultsManager.loadResultsIntoMemory(
+      await variantAnalysisResultsManager.loadResults(
         dummyVariantAnalysis.id,
         variantAnalysisStoragePath,
         repoFullName1
       );
 
-      await variantAnalysisResultsManager.loadResultsIntoMemory(
+      await variantAnalysisResultsManager.loadResults(
         dummyVariantAnalysis.id,
         variantAnalysisStoragePath,
         repoFullName2
@@ -212,11 +214,11 @@ describe(VariantAnalysisResultsManager.name, function() {
     });
 
     it('should remove all cached results related to a variant analysis', async () => {
-      expect(variantAnalysisResultsManager.cachedResults.size).to.eq(2);
+      expect(variantAnalysisResultsManager.getCachedResultsSize()).to.eq(2);
 
       await variantAnalysisResultsManager.removeAnalysesResults(dummyVariantAnalysis);
 
-      expect(variantAnalysisResultsManager.cachedResults.size).to.eq(0);
+      expect(variantAnalysisResultsManager.getCachedResultsSize()).to.eq(0);
     });
 
   });

--- a/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/shared/scanned-repo-result.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/shared/scanned-repo-result.ts
@@ -1,0 +1,9 @@
+import { faker } from '@faker-js/faker';
+import { VariantAnalysisScannedRepositoryResult } from '../../../../remote-queries/shared/variant-analysis';
+
+export function createMockScannedRepoResult(): VariantAnalysisScannedRepositoryResult {
+  return {
+    variantAnalysisId: faker.datatype.number(),
+    repositoryId: faker.datatype.number()
+  };
+}


### PR DESCRIPTION
🚨 Please review this PR commit-by-commit.

We had previously added a no-op placeholder for when we attempt
to remove a variant analysis from our query history.

This adds the implementation by:
- removing the item from the query history
- cleaning up any existing result files attached to the variant analysis

NB: For remote queries, we would store all their results in a single folder.
For variant analyses, we store results per repo. The folder names are 
generated using a `cacheKey` which is built from the variant analysis ID and
the repo name. The resulting `cacheKeys` are stored in `cachedResults`.

Since we need to know the repo name when we want to delete a results 
folder,  we've had to pass in the full variant analysis object to the manager 
and call `cacheResults.delete()` for each of its scanned repos.

Also we're adding tests, because we need more of them. ❤️ 

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
