### PR TITLE
Implement `handleRemoveHistoryItem` for variant analysis history items - take two

### DIFF
--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -813,7 +813,7 @@ export class QueryHistoryManager extends DisposableObject {
   }
 
   private async removeVariantAnalysis(item: VariantAnalysisHistoryItem): Promise<void> {
-    // Remote queries can be removed locally, but not remotely.
+    // We can remove a Variant Analysis locally, but not remotely.
     // The user must cancel the query on GitHub Actions explicitly.
     this.treeDataProvider.remove(item);
     void logger.log(`Deleted ${this.labelProvider.getLabel(item)}.`);

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
@@ -72,6 +72,17 @@ export class VariantAnalysisManager extends DisposableObject implements VariantA
     }
   }
 
+  public async removeVariantAnalysis(variantAnalysis: VariantAnalysis) {
+    this.variantAnalysisResultsManager.removeAnalysesResults(variantAnalysis);
+    await this.removeStorageDirectory(variantAnalysis.id);
+    this.variantAnalyses.delete(variantAnalysis.id);
+  }
+
+  private async removeStorageDirectory(variantAnalysisId: number) {
+    const storageLocation = this.getVariantAnalysisStorageLocation(variantAnalysisId);
+    await fs.remove(storageLocation);
+  }
+
   public async showView(variantAnalysisId: number): Promise<void> {
     if (!this.variantAnalyses.get(variantAnalysisId)) {
       void showAndLogErrorMessage(`No variant analysis found with id: ${variantAnalysisId}.`);

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
@@ -73,7 +73,7 @@ export class VariantAnalysisManager extends DisposableObject implements VariantA
   }
 
   public async removeVariantAnalysis(variantAnalysis: VariantAnalysis) {
-    this.variantAnalysisResultsManager.removeAnalysesResults(variantAnalysis);
+    this.variantAnalysisResultsManager.removeAnalysisResults(variantAnalysis);
     await this.removeStorageDirectory(variantAnalysis.id);
     this.variantAnalyses.delete(variantAnalysis.id);
   }

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-results-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-results-manager.ts
@@ -179,7 +179,7 @@ export class VariantAnalysisResultsManager extends DisposableObject {
     return `https://github.com/${fullName}/blob/${sha}`;
   }
 
-  public removeAnalysesResults(variantAnalysis: VariantAnalysis) {
+  public removeAnalysisResults(variantAnalysis: VariantAnalysis) {
     const scannedRepos = variantAnalysis.scannedRepos;
 
     if (scannedRepos) {

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-results-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-results-manager.ts
@@ -9,7 +9,7 @@ import { sarifParser } from '../sarif-parser';
 import { extractAnalysisAlerts } from './sarif-processing';
 import { CodeQLCliServer } from '../cli';
 import { extractRawResults } from './bqrs-processing';
-import { VariantAnalysisScannedRepositoryResult } from './shared/variant-analysis';
+import { VariantAnalysis, VariantAnalysisScannedRepositoryResult } from './shared/variant-analysis';
 import { DisposableObject, DisposeHandler } from '../pure/disposable-object';
 import { VariantAnalysisRepoTask } from './gh-api/variant-analysis';
 import * as ghApiClient from './gh-api/gh-api-client';
@@ -177,6 +177,19 @@ export class VariantAnalysisResultsManager extends DisposableObject {
 
   private createGitHubDotcomFileLinkPrefix(fullName: string, sha: string): string {
     return `https://github.com/${fullName}/blob/${sha}`;
+  }
+
+  public removeAnalysesResults(variantAnalysis: VariantAnalysis) {
+    const scannedRepos = variantAnalysis.scannedRepos;
+
+    if (scannedRepos) {
+      scannedRepos.forEach(scannedRepo => {
+        const cacheKey = createCacheKey(variantAnalysis.id, scannedRepo.repository.fullName);
+        if (this.cachedResults.get(cacheKey)) {
+          this.cachedResults.delete(cacheKey);
+        }
+      });
+    }
   }
 
   public dispose(disposeHandler?: DisposeHandler) {


### PR DESCRIPTION
Previous attempt: https://github.com/github/vscode-codeql/pull/1655

At the moment we have a no-op placeholder for when we try to remove 
a variant analysis from our query history.

This adds the actual implementation by:
- removing the item from the query history list
- cleaning up any existing result files attached to the variant analysis

NB: For remote queries, we would store all their results in a single folder.
For variant analyses, we store results per repo. The folder names are 
generated using a `cacheKey` which is built from the variant analysis ID and
the repo name. The resulting `cacheKeys` are stored in `cachedResults`.

Since we need to know the repo name when we want to delete a results 
folder,  we've had to pass in the full variant analysis object to the manager 
and call `cacheResults.delete()` for each of its scanned repos.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->


## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
