### PR TITLE
Decouple VariantAnalysisManager from VariantAnalysisResultsManager

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -117,6 +117,7 @@ import {
 import { VariantAnalysisManager } from './remote-queries/variant-analysis-manager';
 import { createVariantAnalysisContentProvider } from './remote-queries/variant-analysis-content-provider';
 import { MockGitHubApiServer } from './mocks/mock-gh-api-server';
+import { VariantAnalysisResultsManager } from './remote-queries/variant-analysis-results-manager';
 
 /**
  * extension.ts
@@ -490,8 +491,10 @@ async function activateWithInstalledDistribution(
   void logger.log('Initializing variant analysis manager.');
   const variantAnalysisStorageDir = path.join(ctx.globalStorageUri.fsPath, 'variant-analyses');
   await fs.ensureDir(variantAnalysisStorageDir);
-  const variantAnalysisManager = new VariantAnalysisManager(ctx, cliServer, variantAnalysisStorageDir, logger);
+  const variantAnalysisResultsManager = new VariantAnalysisResultsManager(cliServer, logger);
+  const variantAnalysisManager = new VariantAnalysisManager(ctx, variantAnalysisStorageDir, variantAnalysisResultsManager);
   ctx.subscriptions.push(variantAnalysisManager);
+  ctx.subscriptions.push(variantAnalysisResultsManager);
   ctx.subscriptions.push(workspace.registerTextDocumentContentProvider('codeql-variant-analysis', createVariantAnalysisContentProvider(variantAnalysisManager)));
 
   void logger.log('Initializing remote queries manager.');

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
@@ -52,7 +52,7 @@ export class VariantAnalysisManager extends DisposableObject implements VariantA
     this.variantAnalysisMonitor = this.push(new VariantAnalysisMonitor(ctx));
     this.variantAnalysisMonitor.onVariantAnalysisChange(this.onVariantAnalysisUpdated.bind(this));
 
-    this.variantAnalysisResultsManager = this.push(variantAnalysisResultsManager);
+    this.variantAnalysisResultsManager = variantAnalysisResultsManager;
     this.variantAnalysisResultsManager.onResultLoaded(this.onRepoResultLoaded.bind(this));
   }
 

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/run-remote-query.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/run-remote-query.test.ts
@@ -24,6 +24,7 @@ import { createMockApiResponse } from '../../factories/remote-queries/gh-api/var
 import { createMockExtensionContext } from '../../no-workspace';
 import { VariantAnalysisManager } from '../../../remote-queries/variant-analysis-manager';
 import { OutputChannelLogger } from '../../../logging';
+import { VariantAnalysisResultsManager } from '../../../remote-queries/variant-analysis-results-manager';
 
 describe('Remote queries', function() {
   const baseDir = path.join(__dirname, '../../../../src/vscode-tests/cli-integration');
@@ -43,6 +44,7 @@ describe('Remote queries', function() {
   let ctx: ExtensionContext;
   let logger: any;
   let variantAnalysisManager: VariantAnalysisManager;
+  let variantAnalysisResultsManager: VariantAnalysisResultsManager;
 
   // use `function` so we have access to `this`
   beforeEach(async function() {
@@ -57,7 +59,8 @@ describe('Remote queries', function() {
 
     ctx = createMockExtensionContext();
     logger = new OutputChannelLogger('test-logger');
-    variantAnalysisManager = new VariantAnalysisManager(ctx, cli, 'fake-storage-dir', logger);
+    variantAnalysisResultsManager = new VariantAnalysisResultsManager(cli, logger);
+    variantAnalysisManager = new VariantAnalysisManager(ctx, 'fake-storage-dir', variantAnalysisResultsManager);
 
     if (!(await cli.cliConstraints.supportsRemoteQueries())) {
       console.log(`Remote queries are not supported on CodeQL CLI v${CliVersionConstraint.CLI_VERSION_REMOTE_QUERIES

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-manager.test.ts
@@ -20,6 +20,7 @@ import { createMockScannedRepos } from '../../factories/remote-queries/gh-api/sc
 import { createMockVariantAnalysisRepoTask } from '../../factories/remote-queries/gh-api/variant-analysis-repo-task';
 import { CodeQLCliServer } from '../../../cli';
 import { storagePath } from '../global.helper';
+import { VariantAnalysisResultsManager } from '../../../remote-queries/variant-analysis-results-manager';
 
 describe('Variant Analysis Manager', async function() {
   let sandbox: sinon.SinonSandbox;
@@ -30,6 +31,7 @@ describe('Variant Analysis Manager', async function() {
   let scannedRepos: ApiVariantAnalysisScannedRepository[];
   let getVariantAnalysisRepoStub: sinon.SinonStub;
   let getVariantAnalysisRepoResultStub: sinon.SinonStub;
+  let variantAnalysisResultsManager: VariantAnalysisResultsManager;
 
   beforeEach(async () => {
     sandbox = sinon.createSandbox();
@@ -46,7 +48,8 @@ describe('Variant Analysis Manager', async function() {
     try {
       const extension = await extensions.getExtension<CodeQLExtensionInterface | Record<string, never>>('GitHub.vscode-codeql')!.activate();
       cli = extension.cliServer;
-      variantAnalysisManager = new VariantAnalysisManager(extension.ctx, cli, storagePath, logger);
+      variantAnalysisResultsManager = new VariantAnalysisResultsManager(cli, logger);
+      variantAnalysisManager = new VariantAnalysisManager(extension.ctx, storagePath, variantAnalysisResultsManager);
     } catch (e) {
       fail(e as Error);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

At the moment we create the results manager as a private property on the `VariantAnalysisManager`. 

If we instead created it at the extension level and passed it to the `VariantAnalysisManager`, we would have more freedom to write unit tests for the `VariantAnalysisManager` without needing to reach into a private results manager property.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
