### PR TITLE
Add test for `removeVariantAnalysis`

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
@@ -113,6 +113,10 @@ export class VariantAnalysisManager extends DisposableObject implements VariantA
     return this.variantAnalyses.get(variantAnalysisId);
   }
 
+  public getVariantAnalysesSize(): number {
+    return this.variantAnalyses.size;
+  }
+
   public async loadResults(variantAnalysisId: number, repositoryFullName: string): Promise<void> {
     const variantAnalysis = this.variantAnalyses.get(variantAnalysisId);
     if (!variantAnalysis) {
@@ -127,7 +131,7 @@ export class VariantAnalysisManager extends DisposableObject implements VariantA
     return await fs.pathExists(filePath);
   }
 
-  private async onVariantAnalysisUpdated(variantAnalysis: VariantAnalysis | undefined): Promise<void> {
+  public async onVariantAnalysisUpdated(variantAnalysis: VariantAnalysis | undefined): Promise<void> {
     if (!variantAnalysis) {
       return;
     }

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
@@ -113,7 +113,7 @@ export class VariantAnalysisManager extends DisposableObject implements VariantA
     return this.variantAnalyses.get(variantAnalysisId);
   }
 
-  public getVariantAnalysesSize(): number {
+  public get variantAnalysesSize(): number {
     return this.variantAnalyses.size;
   }
 

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-manager.test.ts
@@ -183,13 +183,13 @@ describe('Variant Analysis Manager', async function() {
 
         it('should remove variant analysis', async () => {
           await variantAnalysisManager.onVariantAnalysisUpdated(dummyVariantAnalysis);
-          expect(variantAnalysisManager.getVariantAnalysesSize()).to.eq(1);
+          expect(variantAnalysisManager.variantAnalysesSize).to.eq(1);
 
           await variantAnalysisManager.removeVariantAnalysis(dummyVariantAnalysis);
 
           expect(removeAnalysisResultsStub).to.have.been.calledOnce;
           expect(removeStorageStub).to.have.been.calledOnce;
-          expect(variantAnalysisManager.getVariantAnalysesSize()).to.equal(0);
+          expect(variantAnalysisManager.variantAnalysesSize).to.equal(0);
         });
       });
     });

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-manager.test.ts
@@ -21,6 +21,8 @@ import { createMockVariantAnalysisRepoTask } from '../../factories/remote-querie
 import { CodeQLCliServer } from '../../../cli';
 import { storagePath } from '../global.helper';
 import { VariantAnalysisResultsManager } from '../../../remote-queries/variant-analysis-results-manager';
+import { VariantAnalysis } from '../../../remote-queries/shared/variant-analysis';
+import { createMockVariantAnalysis } from '../../factories/remote-queries/shared/variant-analysis';
 
 describe('Variant Analysis Manager', async function() {
   let sandbox: sinon.SinonSandbox;
@@ -165,6 +167,29 @@ describe('Variant Analysis Manager', async function() {
 
           expect(variantAnalysisManager.downloadsQueueSize()).to.equal(0);
           expect(getResultsSpy).to.have.been.calledThrice;
+        });
+      });
+
+      describe('removeVariantAnalysis', async () => {
+        let removeAnalysisResultsStub: sinon.SinonStub;
+        let removeStorageStub: sinon.SinonStub;
+        let dummyVariantAnalysis: VariantAnalysis;
+
+        beforeEach(async () => {
+          dummyVariantAnalysis = createMockVariantAnalysis();
+          removeAnalysisResultsStub = sandbox.stub(variantAnalysisResultsManager, 'removeAnalysisResults');
+          removeStorageStub = sandbox.stub(fs, 'remove');
+        });
+
+        it('should remove variant analysis', async () => {
+          await variantAnalysisManager.onVariantAnalysisUpdated(dummyVariantAnalysis);
+          expect(variantAnalysisManager.getVariantAnalysesSize()).to.eq(1);
+
+          await variantAnalysisManager.removeVariantAnalysis(dummyVariantAnalysis);
+
+          expect(removeAnalysisResultsStub).to.have.been.calledOnce;
+          expect(removeStorageStub).to.have.been.calledOnce;
+          expect(variantAnalysisManager.getVariantAnalysesSize()).to.equal(0);
         });
       });
     });


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

We introduced this method in https://github.com/github/vscode-codeql/pull/1656 but didn't add tests.

Thanks to https://github.com/github/vscode-codeql/pull/1657 we can now add a test for this method without having to make the results manager a public property.

Aside from this:
- We are also introducing a helper method to return the size of `variantAnalysisManager.variantAnalyses`. This is something we can check in the test to be able to see the method is doing what it's supposed to without having to reach in and read the private `variantAnalyses` property.
- We've had to make `onVariantAnalysisUpdated` public in order to add a variant analysis in our test setup. This is a much smaller change in terms of privacy (and perhaps harmless?) since:
    - we also have `onVariantAnalysisSubmitted` which is already public
    - the `onVariantAnalysisUpdated` method is already triggered from outside the manager class, from the `variantAnalysisMonitor`

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
