### PR TITLE
Update `variantAnalyses` and view when "rehydrating" variant analyses

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
@@ -61,10 +61,14 @@ export class VariantAnalysisManager extends DisposableObject implements VariantA
       // In this case, the variant analysis was deleted from disk, most likely because
       // it was purged by another workspace.
       this._onVariantAnalysisRemoved.fire(variantAnalysis);
-    } else if (status === QueryStatus.InProgress) {
-      // In this case, last time we checked, the query was still in progress.
-      // We need to setup the monitor to check for completion.
-      await commands.executeCommand('codeQL.monitorVariantAnalysis', variantAnalysis);
+    } else {
+      this.variantAnalyses.set(variantAnalysis.id, variantAnalysis);
+      await this.getView(variantAnalysis.id)?.updateView(variantAnalysis);
+      if (status === QueryStatus.InProgress) {
+        // In this case, last time we checked, the query was still in progress.
+        // We need to setup the monitor to check for completion.
+        await commands.executeCommand('codeQL.monitorVariantAnalysis', variantAnalysis);
+      }
     }
   }
 


### PR DESCRIPTION
This should fix a bug with opening variant analysis results from the query history. See internal issue!


## Checklist

N/A - internal only 🍌 

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
