### PR TITLE
Add script to help with scenario recording

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,6 +181,8 @@ To record a new mock MRVA scenario, follow these steps:
 
 If you want to cancel recording, run the `CodeQL: Mock GitHub API Server: Cancel Scenario Recording` command.
 
+Once the scenario has been recorded, it's often useful to remove some of the requests to speed up the replay, particularly ones that fetch the variant analysis status. Once some of the request files have manually been removed, the [fix-scenario-file-numbering script](./extensions/ql-vscode/scripts/fix-scenario-file-numbering.ts) can be used to update the number of the files. See the script file for details on how to use.
+
 #### Scenario data location
 
 Pre-recorded scenarios are stored in `./src/mocks/scenarios`. However, it's possible to configure the location, by setting the `codeQL.mockGitHubApiServer.scenariosPath` configuration property in the VS Code user settings.

--- a/extensions/ql-vscode/scripts/fix-scenario-file-numbering.ts
+++ b/extensions/ql-vscode/scripts/fix-scenario-file-numbering.ts
@@ -1,0 +1,79 @@
+/**
+ * This scripts helps after recording a scenario to be used for replaying
+ * with the mock GitHub API server.
+ * 
+ * Once the scenario has been recorded, it's often useful to remove some of
+ * the requests to speed up the replay, particularly ones that fetch the 
+ * variant analysis status. Once some of the requests have manually been 
+ * removed, this script can be used to update the numbering of the files.
+ * 
+ * Usage: npx ts-node scripts/fix-scenario-file-numbering.ts <scenario-name>
+ */
+
+import * as fs from 'fs-extra';
+import * as path from 'path';
+
+if (process.argv.length !== 3) {
+  console.error('Expected 1 argument - the scenario name')
+}
+
+const scenarioName = process.argv[2];
+
+const extensionDirectory = path.resolve(__dirname, '..');
+const scenariosDirectory = path.resolve(extensionDirectory, 'src/mocks/scenarios');
+const scenarioDirectory = path.resolve(scenariosDirectory, scenarioName);
+
+async function fixScenarioFiles() {
+  console.log(scenarioDirectory)
+  if (!(await fs.pathExists(scenarioDirectory))) {
+    console.error('Scenario directory does not exist: ' + scenarioDirectory);
+    return;
+  }
+
+  const files = await fs.readdir(scenarioDirectory);
+
+  const orderedFiles = files.sort((a, b) => {
+    const aNum = parseInt(a.split('-')[0]);
+    const bNum = parseInt(b.split('-')[0]);
+    return aNum - bNum;
+  });
+
+  let index = 0;
+  for (let file of orderedFiles) {
+    const ext = path.extname(file);
+    if (ext === '.json') {
+      const fileName = path.basename(file, ext);
+      const fileCurrentIndex = parseInt(fileName.split('-')[0]);
+      const fileNameWithoutIndex = fileName.split('-')[1];
+      if (fileCurrentIndex !== index) {
+        const newFileName = `${index}-${fileNameWithoutIndex}${ext}`;
+        const oldFilePath = path.join(scenarioDirectory, file);
+        const newFilePath = path.join(scenarioDirectory, newFileName);
+        console.log(`Rename: ${oldFilePath} -> ${newFilePath}`);
+        await fs.rename(oldFilePath, newFilePath);
+
+        if (fileNameWithoutIndex === 'getVariantAnalysisRepoResult') {
+          const oldZipFileName = `${fileCurrentIndex}-getVariantAnalysisRepoResult.body.zip`;
+          const newZipFileName = `${index}-getVariantAnalysisRepoResult.body.zip`;
+          const oldZipFilePath = path.join(scenarioDirectory, oldZipFileName);
+          const newZipFilePath = path.join(scenarioDirectory, newZipFileName);
+          console.log(`Rename: ${oldZipFilePath} -> ${newZipFilePath}`);
+          await fs.rename(oldZipFilePath, newZipFilePath);
+
+          const jsonText = await fs.readFile(newFilePath, 'utf8');
+          const json = JSON.parse(jsonText);
+          json.response.body = `file:${newZipFileName}`;
+          console.log(`Response.body change to ${json.response.body}`);
+          await fs.writeFile(newFilePath, JSON.stringify(json, null, 2));
+        }
+      }
+      
+      index++;
+    }
+  }
+}
+
+fixScenarioFiles().catch(e => {
+  console.error(e);
+  process.exit(2);
+});

--- a/extensions/ql-vscode/scripts/fix-scenario-file-numbering.ts
+++ b/extensions/ql-vscode/scripts/fix-scenario-file-numbering.ts
@@ -24,7 +24,7 @@ const scenariosDirectory = path.resolve(extensionDirectory, 'src/mocks/scenarios
 const scenarioDirectory = path.resolve(scenariosDirectory, scenarioName);
 
 async function fixScenarioFiles() {
-  console.log(scenarioDirectory)
+  console.log(scenarioDirectory);
   if (!(await fs.pathExists(scenarioDirectory))) {
     console.error('Scenario directory does not exist: ' + scenarioDirectory);
     return;

--- a/extensions/ql-vscode/scripts/fix-scenario-file-numbering.ts
+++ b/extensions/ql-vscode/scripts/fix-scenario-file-numbering.ts
@@ -60,11 +60,10 @@ async function fixScenarioFiles() {
           console.log(`Rename: ${oldZipFilePath} -> ${newZipFilePath}`);
           await fs.rename(oldZipFilePath, newZipFilePath);
 
-          const jsonText = await fs.readFile(newFilePath, 'utf8');
-          const json = JSON.parse(jsonText);
+          const json = await fs.readJson(newFilePath);
           json.response.body = `file:${newZipFileName}`;
           console.log(`Response.body change to ${json.response.body}`);
-          await fs.writeFile(newFilePath, JSON.stringify(json, null, 2));
+          await fs.writeJSON(newFilePath, json);
         }
       }
       


### PR DESCRIPTION
This is a rather hacky script I put together when collecting test data. I thought it might be useful for others in the future.

## Checklist
N/A - internal only.
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
