### PR TITLE
Set in memory variant analysis on submission

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
@@ -62,8 +62,7 @@ export class VariantAnalysisManager extends DisposableObject implements VariantA
       // it was purged by another workspace.
       this._onVariantAnalysisRemoved.fire(variantAnalysis);
     } else {
-      this.variantAnalyses.set(variantAnalysis.id, variantAnalysis);
-      await this.getView(variantAnalysis.id)?.updateView(variantAnalysis);
+      await this.setVariantAnalysis(variantAnalysis);
       if (status === QueryStatus.InProgress) {
         // In this case, last time we checked, the query was still in progress.
         // We need to setup the monitor to check for completion.
@@ -136,16 +135,21 @@ export class VariantAnalysisManager extends DisposableObject implements VariantA
       return;
     }
 
-    this.variantAnalyses.set(variantAnalysis.id, variantAnalysis);
-
-    await this.getView(variantAnalysis.id)?.updateView(variantAnalysis);
+    await this.setVariantAnalysis(variantAnalysis);
     this._onVariantAnalysisStatusUpdated.fire(variantAnalysis);
   }
 
   public async onVariantAnalysisSubmitted(variantAnalysis: VariantAnalysis): Promise<void> {
+    await this.setVariantAnalysis(variantAnalysis);
+
     await this.prepareStorageDirectory(variantAnalysis.id);
 
     this._onVariantAnalysisAdded.fire(variantAnalysis);
+  }
+
+  private async setVariantAnalysis(variantAnalysis: VariantAnalysis): Promise<void> {
+    this.variantAnalyses.set(variantAnalysis.id, variantAnalysis);
+    await this.getView(variantAnalysis.id)?.updateView(variantAnalysis);
   }
 
   private async onRepoResultLoaded(repositoryResult: VariantAnalysisScannedRepositoryResult): Promise<void> {


### PR DESCRIPTION
We weren't updating the cache as soon as the variant analysis is submitted so I've updated to do that. I've also consolidated the logic into one function. 

## Checklist
N/A - internal only.
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
