### PR TITLE
Close view when variant analyis is deleted from query history

### DIFF
--- a/extensions/ql-vscode/src/abstract-webview.ts
+++ b/extensions/ql-vscode/src/abstract-webview.ts
@@ -9,7 +9,7 @@ import {
 } from 'vscode';
 import * as path from 'path';
 
-import { DisposableObject } from './pure/disposable-object';
+import { DisposableObject, DisposeHandler } from './pure/disposable-object';
 import { tmpDir } from './helpers';
 import { getHtmlForWebview, WebviewMessage, WebviewView } from './interface-utils';
 
@@ -125,5 +125,10 @@ export abstract class AbstractWebview<ToMessage extends WebviewMessage, FromMess
 
   protected postMessage(msg: ToMessage): Thenable<boolean> {
     return this.getPanel().webview.postMessage(msg);
+  }
+
+  public dispose(disposeHandler?: DisposeHandler) {
+    this.panel?.dispose();
+    super.dispose(disposeHandler);
   }
 }


### PR DESCRIPTION
This will close the variant analysis view when the corresponding variant analysis history item is deleted from the query history. This required some extra code to handle `dispose` being called on the view to ensure this actually disposes the panel, but we can now call `dispose()` on the view to close it.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
