### PR TITLE
Set variant analysis view title to query name

### DIFF
--- a/extensions/ql-vscode/src/abstract-webview.ts
+++ b/extensions/ql-vscode/src/abstract-webview.ts
@@ -38,7 +38,7 @@ export abstract class AbstractWebview<ToMessage extends WebviewMessage, FromMess
   public async restoreView(panel: WebviewPanel): Promise<void> {
     this.panel = panel;
     const config = await this.getPanelConfig();
-    await this.setupPanel(panel, config);
+    this.setupPanel(panel, config);
   }
 
   protected get isShowingPanel() {

--- a/extensions/ql-vscode/src/compare/compare-view.ts
+++ b/extensions/ql-vscode/src/compare/compare-view.ts
@@ -46,7 +46,8 @@ export class CompareView extends AbstractWebview<ToCompareViewMessage, FromCompa
     selectedResultSetName?: string
   ) {
     this.comparePair = { from, to };
-    this.getPanel().reveal(undefined, true);
+    const panel = await this.getPanel();
+    panel.reveal(undefined, true);
 
     await this.waitForPanelLoaded();
     const [

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-view.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-view.ts
@@ -49,7 +49,8 @@ export class RemoteQueriesView extends AbstractWebview<ToRemoteQueriesMessage, F
   }
 
   async showResults(query: RemoteQuery, queryResult: RemoteQueryResult) {
-    this.getPanel().reveal(undefined, true);
+    const panel = await this.getPanel();
+    panel.reveal(undefined, true);
 
     await this.waitForPanelLoaded();
     const model = this.buildViewModel(query, queryResult);

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-view.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-view.ts
@@ -41,6 +41,9 @@ export class VariantAnalysisView extends AbstractWebview<ToVariantAnalysisMessag
       t: 'setVariantAnalysis',
       variantAnalysis,
     });
+
+    const panel = await this.getPanel();
+    panel.title = `${variantAnalysis.query.name} - CodeQL Query Results`;
   }
 
   public async updateRepoState(repoState: VariantAnalysisScannedRepositoryState): Promise<void> {
@@ -65,10 +68,12 @@ export class VariantAnalysisView extends AbstractWebview<ToVariantAnalysisMessag
     });
   }
 
-  protected getPanelConfig(): WebviewPanelConfig {
+  protected async getPanelConfig(): Promise<WebviewPanelConfig> {
+    const variantAnalysis = await this.manager.getVariantAnalysis(this.variantAnalysisId);
+
     return {
       viewId: VariantAnalysisView.viewType,
-      title: `CodeQL Query Results for ${this.variantAnalysisId}`,
+      title: variantAnalysis ? `${variantAnalysis.query.name} - CodeQL Query Results` : `Variant analysis ${this.variantAnalysisId} - CodeQL Query Results`,
       viewColumn: ViewColumn.Active,
       preserveFocus: true,
       view: 'variant-analysis',

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-view.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-view.ts
@@ -26,7 +26,8 @@ export class VariantAnalysisView extends AbstractWebview<ToVariantAnalysisMessag
   }
 
   public async openView() {
-    this.getPanel().reveal(undefined, true);
+    const panel = await this.getPanel();
+    panel.reveal(undefined, true);
 
     await this.waitForPanelLoaded();
   }


### PR DESCRIPTION
This sets the title of the variant analysis view to `{queryName} - CodeQL Query Results`. It does so by retrieving the variant analysis in the `getPanelConfig` method and updating the title whenever the variant analysis is updated.

It's probably easiest to review this commit-by-commit. The actual change for setting the view title is quite small, but we first need to allow `getPanelConfig` to return a promise.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
