### PR TITLE
A new experimental database panel

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -37,6 +37,7 @@
     "onLanguage:ql",
     "onLanguage:ql-summary",
     "onView:codeQLDatabases",
+    "onView:codeQLDatabasesExperimental",
     "onView:codeQLQueryHistory",
     "onView:codeQLAstViewer",
     "onView:codeQLEvalLogViewer",
@@ -1207,6 +1208,11 @@
         {
           "id": "codeQLDatabases",
           "name": "Databases"
+        },
+        {
+          "id": "codeQLDatabasesExperimental",
+          "name": "Databases",
+          "when": "config.codeQL.canary && config.codeQL.newQueryRunExperience"
         },
         {
           "id": "codeQLQueryHistory",

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -438,6 +438,16 @@ export function isVariantAnalysisLiveResultsEnabled(): boolean {
   return !!LIVE_RESULTS.getValue<boolean>();
 }
 
+/**
+ * A flag indicating whether to use the new query run experience which involves
+ * using a new database panel.
+ */
+const NEW_QUERY_RUN_EXPERIENCE = new Setting('newQueryRunExperience', ROOT_SETTING);
+
+export function isNewQueryRunExperienceEnabled(): boolean {
+  return !!NEW_QUERY_RUN_EXPERIENCE.getValue<boolean>();
+}
+
 // Settings for mocking the GitHub API.
 const MOCK_GH_API_SERVER = new Setting('mockGitHubApiServer', ROOT_SETTING);
 


### PR DESCRIPTION
Added new database panel that will be used for the new query run experience. 

The panel is currently empty and is hidden behind a config setting (`codeQL.newQueryRunExperience`).

Paired with @shati-patel. 

## Checklist
N/A - internal only:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
