### PR TITLE
Add opening on GitHub of live results variant analyses

### DIFF
--- a/extensions/ql-vscode/src/query-history-info.ts
+++ b/extensions/ql-vscode/src/query-history-info.ts
@@ -71,3 +71,15 @@ export function buildRepoLabel(item: RemoteQueryHistoryItem | VariantAnalysisHis
     assertNever(item);
   }
 }
+
+export function getActionsWorkflowRunUrl(item: RemoteQueryHistoryItem | VariantAnalysisHistoryItem): string {
+  if (item.t === 'remote') {
+    const { actionsWorkflowRunId: workflowRunId, controllerRepository: { owner, name } } = item.remoteQuery;
+    return `https://github.com/${owner}/${name}/actions/runs/${workflowRunId}`;
+  } else if (item.t === 'variant-analysis') {
+    const { actionsWorkflowRunId, controllerRepo: { fullName } } = item.variantAnalysis;
+    return `https://github.com/${fullName}/actions/runs/${actionsWorkflowRunId}`;
+  } else {
+    assertNever(item);
+  }
+}

--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -1213,7 +1213,6 @@ export class QueryHistoryManager extends DisposableObject {
   ) {
     const { finalSingleItem, finalMultiSelect } = this.determineSelection(singleItem, multiSelect);
 
-    // Remote queries only
     if (!this.assertSingleQuery(finalMultiSelect) || !finalSingleItem) {
       return;
     }

--- a/extensions/ql-vscode/src/remote-queries/shared/variant-analysis.ts
+++ b/extensions/ql-vscode/src/remote-queries/shared/variant-analysis.ts
@@ -3,7 +3,7 @@ import { AnalysisAlert, AnalysisRawResults } from './analysis-result';
 
 export interface VariantAnalysis {
   id: number,
-  controllerRepoId: number,
+  controllerRepo: Repository;
   query: {
     name: string,
     filePath: string,

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-monitor.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-monitor.ts
@@ -51,7 +51,7 @@ export class VariantAnalysisMonitor extends DisposableObject {
 
       variantAnalysisSummary = await ghApiClient.getVariantAnalysis(
         credentials,
-        variantAnalysis.controllerRepoId,
+        variantAnalysis.controllerRepo.id,
         variantAnalysis.id
       );
 

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-processor.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-processor.ts
@@ -52,7 +52,11 @@ export function processUpdatedVariantAnalysis(
 
   const variantAnalysis: VariantAnalysis = {
     id: response.id,
-    controllerRepoId: response.controller_repo.id,
+    controllerRepo: {
+      id: response.controller_repo.id,
+      fullName: response.controller_repo.full_name,
+      private: response.controller_repo.private,
+    },
     query: previousVariantAnalysis.query,
     databases: previousVariantAnalysis.databases,
     executionStartTime: previousVariantAnalysis.executionStartTime,

--- a/extensions/ql-vscode/src/stories/variant-analysis/VariantAnalysis.stories.tsx
+++ b/extensions/ql-vscode/src/stories/variant-analysis/VariantAnalysis.stories.tsx
@@ -24,7 +24,11 @@ const Template: ComponentStory<typeof VariantAnalysisComponent> = (args) => (
 
 const variantAnalysis: VariantAnalysisDomainModel = {
   id: 1,
-  controllerRepoId: 1,
+  controllerRepo: {
+    id: 1,
+    fullName: 'octodemo/variant-analysis-controller',
+    private: false,
+  },
   actionsWorkflowRunId: 789263,
   query: {
     name: 'Example query',

--- a/extensions/ql-vscode/src/stories/variant-analysis/VariantAnalysisAnalyzedRepos.stories.tsx
+++ b/extensions/ql-vscode/src/stories/variant-analysis/VariantAnalysisAnalyzedRepos.stories.tsx
@@ -37,7 +37,11 @@ export const Example = Template.bind({});
 Example.args = {
   variantAnalysis: {
     id: 1,
-    controllerRepoId: 1,
+    controllerRepo: {
+      id: 1,
+      fullName: 'octodemo/variant-analysis-controller',
+      private: false,
+    },
     query: {
       name: 'Query name',
       filePath: 'example.ql',

--- a/extensions/ql-vscode/src/stories/variant-analysis/VariantAnalysisHeader.stories.tsx
+++ b/extensions/ql-vscode/src/stories/variant-analysis/VariantAnalysisHeader.stories.tsx
@@ -68,7 +68,11 @@ const Template: ComponentStory<typeof VariantAnalysisHeader> = (args) => (
 
 const buildVariantAnalysis = (data: Partial<VariantAnalysis>) => ({
   id: 1,
-  controllerRepoId: 1,
+  controllerRepo: {
+    id: 1,
+    fullName: 'octodemo/variant-analysis-controller',
+    private: false,
+  },
   query: {
     name: 'Query name',
     filePath: 'example.ql',

--- a/extensions/ql-vscode/src/stories/variant-analysis/VariantAnalysisOutcomePanels.stories.tsx
+++ b/extensions/ql-vscode/src/stories/variant-analysis/VariantAnalysisOutcomePanels.stories.tsx
@@ -30,7 +30,11 @@ const Template: ComponentStory<typeof VariantAnalysisOutcomePanels> = (args) => 
 
 const buildVariantAnalysis = (data: Partial<VariantAnalysis>) => ({
   id: 1,
-  controllerRepoId: 1,
+  controllerRepo: {
+    id: 1,
+    fullName: 'octodemo/variant-analysis-controller',
+    private: false,
+  },
   query: {
     name: 'Query name',
     filePath: 'example.ql',

--- a/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisAnalyzedRepos.spec.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisAnalyzedRepos.spec.tsx
@@ -11,7 +11,11 @@ import { VariantAnalysisAnalyzedRepos, VariantAnalysisAnalyzedReposProps } from 
 describe(VariantAnalysisAnalyzedRepos.name, () => {
   const defaultVariantAnalysis = {
     id: 1,
-    controllerRepoId: 1,
+    controllerRepo: {
+      id: 1,
+      fullName: 'octodemo/variant-analysis-controller',
+      private: false,
+    },
     actionsWorkflowRunId: 789263,
     query: {
       name: 'Example query',

--- a/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisOutcomePanels.spec.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisOutcomePanels.spec.tsx
@@ -10,7 +10,11 @@ import { VariantAnalysisOutcomePanelProps, VariantAnalysisOutcomePanels } from '
 describe(VariantAnalysisOutcomePanels.name, () => {
   const defaultVariantAnalysis = {
     id: 1,
-    controllerRepoId: 1,
+    controllerRepo: {
+      id: 1,
+      fullName: 'octodemo/variant-analysis-controller',
+      private: false,
+    },
     actionsWorkflowRunId: 789263,
     query: {
       name: 'Example query',

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-processor.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-processor.test.ts
@@ -26,7 +26,11 @@ describe('Variant Analysis processor', function() {
 
     expect(result).to.eql({
       'id': mockApiResponse.id,
-      'controllerRepoId': mockApiResponse.controller_repo.id,
+      'controllerRepo': {
+        'id': mockApiResponse.controller_repo.id,
+        'fullName': mockApiResponse.controller_repo.full_name,
+        'private': mockApiResponse.controller_repo.private
+      },
       'query': {
         'filePath': 'query-file-path',
         'language': VariantAnalysisQueryLanguage.Javascript,

--- a/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/shared/variant-analysis.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/shared/variant-analysis.ts
@@ -16,7 +16,13 @@ export function createMockVariantAnalysis(
 ): VariantAnalysis {
   const variantAnalysis: VariantAnalysis = {
     id: faker.datatype.number(),
-    controllerRepoId: faker.datatype.number(),
+    controllerRepo: {
+      id: faker.datatype.number(),
+      fullName: 'github/' + faker.datatype.hexadecimal({
+        prefix: '',
+      }),
+      private: faker.datatype.boolean(),
+    },
     query: {
       name: 'a-query-name',
       filePath: 'a-query-file-path',

--- a/extensions/ql-vscode/test/pure-tests/query-history-info.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/query-history-info.test.ts
@@ -155,13 +155,21 @@ describe('Query history info', () => {
     it('should get the run url for remote query history items', () => {
       const actionsWorkflowRunUrl = getActionsWorkflowRunUrl(remoteQueryHistoryItem);
 
-      expect(actionsWorkflowRunUrl).to.equal(`https://github.com/${remoteQueryHistoryItem.remoteQuery.controllerRepository.owner}/${remoteQueryHistoryItem.remoteQuery.controllerRepository.name}/actions/runs/${remoteQueryHistoryItem.remoteQuery.actionsWorkflowRunId}`);
+      const remoteQuery = remoteQueryHistoryItem.remoteQuery;
+      const fullName = `${remoteQuery.controllerRepository.owner}/${remoteQuery.controllerRepository.name}`;
+      expect(actionsWorkflowRunUrl).to.equal(
+        `https://github.com/${fullName}/actions/runs/${remoteQuery.actionsWorkflowRunId}`
+      );
     });
 
     it('should get the run url for variant analysis history items', () => {
       const actionsWorkflowRunUrl = getActionsWorkflowRunUrl(variantAnalysisHistoryItem);
 
-      expect(actionsWorkflowRunUrl).to.equal(`https://github.com/${variantAnalysisHistoryItem.variantAnalysis.controllerRepo.fullName}/actions/runs/${variantAnalysisHistoryItem.variantAnalysis.actionsWorkflowRunId}`);
+      const variantAnalysis = variantAnalysisHistoryItem.variantAnalysis;
+      const fullName = variantAnalysis.controllerRepo.fullName;
+      expect(actionsWorkflowRunUrl).to.equal(
+        `https://github.com/${fullName}/actions/runs/${variantAnalysis.actionsWorkflowRunId}`
+      );
     });
   });
 });

--- a/extensions/ql-vscode/test/pure-tests/query-history-info.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/query-history-info.test.ts
@@ -1,7 +1,13 @@
 import { expect } from 'chai';
 
 import { QueryStatus } from '../../src/query-status';
-import { buildRepoLabel, getQueryId, getQueryText, getRawQueryName } from '../../src/query-history-info';
+import {
+  buildRepoLabel,
+  getActionsWorkflowRunUrl,
+  getQueryId,
+  getQueryText,
+  getRawQueryName
+} from '../../src/query-history-info';
 import { VariantAnalysisHistoryItem } from '../../src/remote-queries/variant-analysis-history-item';
 import { createMockVariantAnalysis } from '../../src/vscode-tests/factories/remote-queries/shared/variant-analysis';
 import { createMockScannedRepos } from '../../src/vscode-tests/factories/remote-queries/shared/scanned-repositories';
@@ -142,6 +148,20 @@ describe('Query history info', () => {
 
         expect(repoLabel).to.equal('2/4 repositories');
       });
+    });
+  });
+
+  describe('getActionsWorkflowRunUrl', () => {
+    it('should get the run url for remote query history items', () => {
+      const actionsWorkflowRunUrl = getActionsWorkflowRunUrl(remoteQueryHistoryItem);
+
+      expect(actionsWorkflowRunUrl).to.equal(`https://github.com/${remoteQueryHistoryItem.remoteQuery.controllerRepository.owner}/${remoteQueryHistoryItem.remoteQuery.controllerRepository.name}/actions/runs/${remoteQueryHistoryItem.remoteQuery.actionsWorkflowRunId}`);
+    });
+
+    it('should get the run url for variant analysis history items', () => {
+      const actionsWorkflowRunUrl = getActionsWorkflowRunUrl(variantAnalysisHistoryItem);
+
+      expect(actionsWorkflowRunUrl).to.equal(`https://github.com/${variantAnalysisHistoryItem.variantAnalysis.controllerRepo.fullName}/actions/runs/${variantAnalysisHistoryItem.variantAnalysis.actionsWorkflowRunId}`);
     });
   });
 });


### PR DESCRIPTION
See the two separate commits: this adds the `controllerRepo` to the shared `VariantAnalysis` type and then uses it for constructing the actions workflow run URL.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
