### PR TITLE
Open Actions workflow run when clicking on "View logs"

### DIFF
--- a/extensions/ql-vscode/src/pure/interface-types.ts
+++ b/extensions/ql-vscode/src/pure/interface-types.ts
@@ -477,6 +477,10 @@ export interface OpenQueryTextMessage {
   t: 'openQueryText';
 }
 
+export interface OpenLogsMessage {
+  t: 'openLogs';
+}
+
 export type ToVariantAnalysisMessage =
   | SetVariantAnalysisMessage
   | SetRepoResultsMessage
@@ -487,4 +491,5 @@ export type FromVariantAnalysisMessage =
   | StopVariantAnalysisMessage
   | RequestRepositoryResultsMessage
   | OpenQueryFileMessage
-  | OpenQueryTextMessage;
+  | OpenQueryTextMessage
+  | OpenLogsMessage;

--- a/extensions/ql-vscode/src/query-history-info.ts
+++ b/extensions/ql-vscode/src/query-history-info.ts
@@ -3,7 +3,10 @@ import { VariantAnalysisHistoryItem } from './remote-queries/variant-analysis-hi
 import { LocalQueryInfo } from './query-results';
 import { assertNever } from './pure/helpers-pure';
 import { pluralize } from './pure/word';
-import { hasRepoScanCompleted } from './remote-queries/shared/variant-analysis';
+import {
+  hasRepoScanCompleted,
+  getActionsWorkflowRunUrl as getVariantAnalysisActionsWorkflowRunUrl
+} from './remote-queries/shared/variant-analysis';
 
 export type QueryHistoryInfo = LocalQueryInfo | RemoteQueryHistoryItem | VariantAnalysisHistoryItem;
 
@@ -77,8 +80,7 @@ export function getActionsWorkflowRunUrl(item: RemoteQueryHistoryItem | VariantA
     const { actionsWorkflowRunId: workflowRunId, controllerRepository: { owner, name } } = item.remoteQuery;
     return `https://github.com/${owner}/${name}/actions/runs/${workflowRunId}`;
   } else if (item.t === 'variant-analysis') {
-    const { actionsWorkflowRunId, controllerRepo: { fullName } } = item.variantAnalysis;
-    return `https://github.com/${fullName}/actions/runs/${actionsWorkflowRunId}`;
+    return getVariantAnalysisActionsWorkflowRunUrl(item.variantAnalysis);
   } else {
     assertNever(item);
   }

--- a/extensions/ql-vscode/src/remote-queries/shared/variant-analysis.ts
+++ b/extensions/ql-vscode/src/remote-queries/shared/variant-analysis.ts
@@ -175,3 +175,8 @@ export function getSkippedRepoCount(skippedRepos: VariantAnalysisSkippedReposito
 
   return Object.values(skippedRepos).reduce((acc, group) => acc + group.repositoryCount, 0);
 }
+
+export function getActionsWorkflowRunUrl(variantAnalysis: VariantAnalysis): string {
+  const { actionsWorkflowRunId, controllerRepo: { fullName } } = variantAnalysis;
+  return `https://github.com/${fullName}/actions/runs/${actionsWorkflowRunId}`;
+}

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-view.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-view.ts
@@ -5,6 +5,7 @@ import { logger } from '../logging';
 import { FromVariantAnalysisMessage, ToVariantAnalysisMessage } from '../pure/interface-types';
 import { assertNever } from '../pure/helpers-pure';
 import {
+  getActionsWorkflowRunUrl,
   VariantAnalysis,
   VariantAnalysisScannedRepositoryResult,
   VariantAnalysisScannedRepositoryState,
@@ -96,6 +97,9 @@ export class VariantAnalysisView extends AbstractWebview<ToVariantAnalysisMessag
       case 'openQueryText':
         await this.openQueryText();
         break;
+      case 'openLogs':
+        await this.openLogs();
+        break;
       default:
         assertNever(msg);
     }
@@ -158,5 +162,17 @@ export class VariantAnalysisView extends AbstractWebview<ToVariantAnalysisMessag
     } catch (error) {
       void showAndLogWarningMessage('Could not open variant analysis query text. Failed to open text document.');
     }
+  }
+
+  private async openLogs(): Promise<void> {
+    const variantAnalysis = await this.manager.getVariantAnalysis(this.variantAnalysisId);
+    if (!variantAnalysis) {
+      void showAndLogWarningMessage('Could not open variant analysis logs. Variant analysis not found.');
+      return;
+    }
+
+    const actionsWorkflowRunUrl = getActionsWorkflowRunUrl(variantAnalysis);
+
+    await commands.executeCommand('vscode.open', Uri.parse(actionsWorkflowRunUrl));
   }
 }

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
@@ -30,6 +30,12 @@ const openQueryText = () => {
   });
 };
 
+const openLogs = () => {
+  vscode.postMessage({
+    t: 'openLogs',
+  });
+};
+
 export function VariantAnalysis({
   variantAnalysis: initialVariantAnalysis,
   repoStates: initialRepoStates = [],
@@ -85,7 +91,7 @@ export function VariantAnalysis({
         onStopQueryClick={() => console.log('Stop query')}
         onCopyRepositoryListClick={() => console.log('Copy repository list')}
         onExportResultsClick={() => console.log('Export results')}
-        onViewLogsClick={() => console.log('View logs')}
+        onViewLogsClick={openLogs}
       />
       <VariantAnalysisOutcomePanels
         variantAnalysis={variantAnalysis}

--- a/extensions/ql-vscode/test/pure-tests/variant-analysis.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/variant-analysis.test.ts
@@ -1,5 +1,10 @@
 import { expect } from 'chai';
-import { parseVariantAnalysisQueryLanguage, VariantAnalysisQueryLanguage } from '../../src/remote-queries/shared/variant-analysis';
+import {
+  getActionsWorkflowRunUrl,
+  parseVariantAnalysisQueryLanguage,
+  VariantAnalysisQueryLanguage
+} from '../../src/remote-queries/shared/variant-analysis';
+import { createMockVariantAnalysis } from '../../src/vscode-tests/factories/remote-queries/shared/variant-analysis';
 
 describe('parseVariantAnalysisQueryLanguage', () => {
   it('parses a valid language', () => {
@@ -8,5 +13,15 @@ describe('parseVariantAnalysisQueryLanguage', () => {
 
   it('returns undefined for an valid language', () => {
     expect(parseVariantAnalysisQueryLanguage('rubbish')).to.not.exist;
+  });
+});
+
+describe('getActionsWorkflowRunUrl', () => {
+  it('should get the run url', () => {
+    const variantAnalysis = createMockVariantAnalysis();
+
+    const actionsWorkflowRunUrl = getActionsWorkflowRunUrl(variantAnalysis);
+
+    expect(actionsWorkflowRunUrl).to.equal(`https://github.com/${variantAnalysis.controllerRepo.fullName}/actions/runs/${variantAnalysis.actionsWorkflowRunId}`);
   });
 });


### PR DESCRIPTION
This will hook up the "View logs" link to make it open the variant analysis actions workflow run. The method for creating the actions workflow run URL has been extracted from the query history to make it callable without a history item.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
