### PR TITLE
Move loading query history to after registering commands

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -525,9 +525,6 @@ async function activateWithInstalledDistribution(
   ctx.subscriptions.push(logScannerService);
   ctx.subscriptions.push(logScannerService.scanners.registerLogScannerProvider(new JoinOrderScannerProvider(() => joinOrderWarningThreshold())));
 
-  void logger.log('Reading query history');
-  await qhm.readQueryHistory();
-
   void logger.log('Initializing compare view.');
   const compareView = new CompareView(
     ctx,
@@ -1228,6 +1225,9 @@ async function activateWithInstalledDistribution(
   );
 
   await commands.executeCommand('codeQLDatabases.removeOrphanedDatabases');
+
+  void logger.log('Reading query history');
+  await qhm.readQueryHistory();
 
   void logger.log('Successfully finished extension initialization.');
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

We have a problem that rehydrating the query history can lead to triggering the `codeQL.monitorVariantAnalysis` command.  This is a problem because we start loading the query history before we register the `codeQL.monitorVariantAnalysis` command with the extension. This leads to the following error:
```
Activating extension 'GitHub.vscode-codeql' failed: command 'codeQL.monitorVariantAnalysis' not found
```

So this PR moves the query history loading to be right at the end of the extension-loading process. I've confirmed locally that doing this allows me to open the extension when there is a variant analysis in progress.

Is there any problem of moving this to be the last thing in the method? @aeisenberg, do you have any thoughts?

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
