### PR TITLE
Make query history tests work with remote queries & variant analyses

### DIFF
--- a/extensions/ql-vscode/src/history-item-label-provider.ts
+++ b/extensions/ql-vscode/src/history-item-label-provider.ts
@@ -7,6 +7,7 @@ import { RemoteQueryHistoryItem } from './remote-queries/remote-query-history-it
 import { VariantAnalysisHistoryItem } from './remote-queries/variant-analysis-history-item';
 import { assertNever } from './pure/helpers-pure';
 import { pluralize } from './pure/word';
+import { humanizeQueryStatus } from './query-status';
 
 interface InterpolateReplacements {
   t: string; // Start time
@@ -86,7 +87,7 @@ export class HistoryItemLabelProvider {
       q: `${item.remoteQuery.queryName} (${item.remoteQuery.language})`,
       d: buildRepoLabel(item),
       r: resultCount,
-      s: item.status,
+      s: humanizeQueryStatus(item.status),
       f: path.basename(item.remoteQuery.queryFilePath),
       '%': '%'
     };
@@ -99,7 +100,7 @@ export class HistoryItemLabelProvider {
       q: `${item.variantAnalysis.query.name} (${item.variantAnalysis.query.language})`,
       d: buildRepoLabel(item),
       r: resultCount,
-      s: item.status,
+      s: humanizeQueryStatus(item.status),
       f: path.basename(item.variantAnalysis.query.filePath),
       '%': '%',
     };

--- a/extensions/ql-vscode/src/query-status.ts
+++ b/extensions/ql-vscode/src/query-status.ts
@@ -21,3 +21,16 @@ export function variantAnalysisStatusToQueryStatus(status: VariantAnalysisStatus
       assertNever(status);
   }
 }
+
+export function humanizeQueryStatus(status: QueryStatus): string {
+  switch (status) {
+    case QueryStatus.InProgress:
+      return 'in progress';
+    case QueryStatus.Completed:
+      return 'completed';
+    case QueryStatus.Failed:
+      return 'failed';
+    default:
+      return 'unknown';
+  }
+}

--- a/extensions/ql-vscode/src/vscode-tests/factories/local-queries/local-query-history-item.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/local-queries/local-query-history-item.ts
@@ -4,8 +4,9 @@ import {
   CompletedLocalQueryInfo,
   LocalQueryInfo,
 } from '../../../query-results';
-import { QueryWithResults } from '../../../run-queries-shared';
+import { QueryEvaluationInfo, QueryWithResults } from '../../../run-queries-shared';
 import { CancellationTokenSource } from 'vscode';
+import { QueryResultType } from '../../../pure/legacy-messages';
 
 export function createMockLocalQueryInfo(
   startTime: string,
@@ -63,4 +64,26 @@ export function createMockLocalQuery(
   }
 
   return fqi;
+}
+
+export function createMockQueryWithResults(
+  sandbox: sinon.SinonSandbox,
+  didRunSuccessfully = true,
+  hasInterpretedResults = true
+): QueryWithResults {
+  return {
+    query: {
+      hasInterpretedResults: () => Promise.resolve(hasInterpretedResults),
+      deleteQuery: sandbox.stub(),
+    } as unknown as QueryEvaluationInfo,
+    successful: didRunSuccessfully,
+    message: 'foo',
+    dispose: sandbox.spy(),
+    result: {
+      evaluationTime: 1,
+      queryId: 0,
+      runId: 0,
+      resultType: QueryResultType.SUCCESS,
+    }
+  };
 }

--- a/extensions/ql-vscode/src/vscode-tests/factories/local-queries/local-query-history-item.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/local-queries/local-query-history-item.ts
@@ -4,6 +4,8 @@ import {
   CompletedLocalQueryInfo,
   LocalQueryInfo,
 } from '../../../query-results';
+import { QueryWithResults } from '../../../run-queries-shared';
+import { CancellationTokenSource } from 'vscode';
 
 export function createMockLocalQueryInfo(
   startTime: string,
@@ -30,4 +32,35 @@ export function createMockLocalQueryInfo(
       statusString: 'in progress',
     } as unknown) as CompletedQueryInfo,
   } as unknown) as CompletedLocalQueryInfo;
+}
+
+export function createMockLocalQuery(
+  dbName = 'a',
+  queryWithResults?: QueryWithResults,
+  isFail = false
+): LocalQueryInfo {
+  const initialQueryInfo = {
+    databaseInfo: { name: dbName },
+    start: new Date(),
+    queryPath: 'hucairz'
+  } as InitialQueryInfo;
+
+  const cancellationToken = {
+    dispose: () => { /**/ },
+  } as CancellationTokenSource;
+
+  const fqi = new LocalQueryInfo(
+    initialQueryInfo,
+    cancellationToken,
+  );
+
+  if (queryWithResults) {
+    fqi.completeThisQuery(queryWithResults);
+  }
+
+  if (isFail) {
+    fqi.failureReason = 'failure reason';
+  }
+
+  return fqi;
 }

--- a/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/remote-query-history-item.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/remote-query-history-item.ts
@@ -1,31 +1,39 @@
 import { RemoteQueryHistoryItem } from '../../../remote-queries/remote-query-history-item';
+import { QueryStatus } from '../../../query-status';
 
 export function createMockRemoteQueryHistoryItem({
   date = new Date('2022-01-01T00:00:00.000Z'),
+  failureReason = undefined,
   resultCount = 16,
-  userSpecifiedLabel = undefined,
   repositoryCount = 0,
+  userSpecifiedLabel = undefined,
 }: {
   date?: Date;
+  failureReason?: string;
   resultCount?: number;
-  userSpecifiedLabel?: string;
   repositoryCount?: number;
+  userSpecifiedLabel?: string;
 }): RemoteQueryHistoryItem {
   return ({
     t: 'remote',
-    userSpecifiedLabel,
+    failureReason,
+    resultCount,
+    status: QueryStatus.InProgress,
+    completed: false,
+    queryId: 'queryId',
     remoteQuery: {
-      executionStartTime: date.getTime(),
       queryName: 'query-name',
       queryFilePath: 'query-file.ql',
+      queryText: 'select 1',
+      language: 'javascript',
       controllerRepository: {
         owner: 'github',
         name: 'vscode-codeql-integration-tests',
       },
-      language: 'javascript',
+      executionStartTime: date.getTime(),
+      actionsWorkflowRunId: 1,
       repositoryCount,
     },
-    status: 'in progress',
-    resultCount,
+    userSpecifiedLabel,
   } as unknown) as RemoteQueryHistoryItem;
 }

--- a/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/remote-query-history-item.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/remote-query-history-item.ts
@@ -37,5 +37,5 @@ export function createMockRemoteQueryHistoryItem({
       repositoryCount,
     },
     userSpecifiedLabel,
-  } as unknown) as RemoteQueryHistoryItem;
+  });
 }

--- a/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/remote-query-history-item.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/remote-query-history-item.ts
@@ -3,12 +3,14 @@ import { QueryStatus } from '../../../query-status';
 
 export function createMockRemoteQueryHistoryItem({
   date = new Date('2022-01-01T00:00:00.000Z'),
+  status = QueryStatus.InProgress,
   failureReason = undefined,
   resultCount = 16,
   repositoryCount = 0,
   userSpecifiedLabel = undefined,
 }: {
   date?: Date;
+  status?: QueryStatus;
   failureReason?: string;
   resultCount?: number;
   repositoryCount?: number;
@@ -18,7 +20,7 @@ export function createMockRemoteQueryHistoryItem({
     t: 'remote',
     failureReason,
     resultCount,
-    status: QueryStatus.InProgress,
+    status,
     completed: false,
     queryId: 'queryId',
     remoteQuery: {

--- a/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/variant-analysis-history-item.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/variant-analysis-history-item.ts
@@ -18,6 +18,6 @@ export function createMockVariantAnalysisHistoryItem(
     completed: false,
     variantAnalysis: createMockVariantAnalysis(variantAnalysisStatus),
     userSpecifiedLabel,
-  } as unknown) as VariantAnalysisHistoryItem;
+  });
 }
 

--- a/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/variant-analysis-history-item.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/variant-analysis-history-item.ts
@@ -1,7 +1,7 @@
-import { faker } from '@faker-js/faker';
 import { VariantAnalysisHistoryItem } from '../../../remote-queries/variant-analysis-history-item';
 import { QueryStatus } from '../../../query-status';
 import { VariantAnalysisStatus } from '../../../remote-queries/shared/variant-analysis';
+import { createMockVariantAnalysis } from './shared/variant-analysis';
 
 export function createMockVariantAnalysisHistoryItem(
   historyItemStatus: QueryStatus = QueryStatus.InProgress,
@@ -16,24 +16,7 @@ export function createMockVariantAnalysisHistoryItem(
     resultCount,
     status: historyItemStatus,
     completed: false,
-    variantAnalysis: {
-      'id': faker.datatype.number(),
-      'controllerRepoId': faker.datatype.number(),
-      'query': {
-        'name': 'Variant Analysis Query History Item',
-        'filePath': 'PLACEHOLDER/q2.ql',
-        'language': 'ruby',
-        'text': '/**\n * @name Variant Analysis Query History Item\n * @kind problem\n * @problem.severity warning\n * @id ruby/example/empty-block\n */\nimport ruby\n\nfrom Block b\nwhere b.getNumberOfStatements() = 0\nselect b, \'This is an empty block.\'\n'
-      },
-      'databases': {
-        'repositories': ['92384123', '1230871']
-      },
-      'createdAt': faker.date.recent().toISOString(),
-      'updatedAt': faker.date.recent().toISOString(),
-      'executionStartTime': faker.date.recent().toISOString(),
-      'status': variantAnalysisStatus,
-      'actionsWorkflowRunId': faker.datatype.number()
-    },
+    variantAnalysis: createMockVariantAnalysis(variantAnalysisStatus),
     userSpecifiedLabel,
   } as unknown) as VariantAnalysisHistoryItem;
 }

--- a/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/variant-analysis-history-item.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/variant-analysis-history-item.ts
@@ -1,0 +1,40 @@
+import { faker } from '@faker-js/faker';
+import { VariantAnalysisHistoryItem } from '../../../remote-queries/variant-analysis-history-item';
+import { QueryStatus } from '../../../query-status';
+import { VariantAnalysisStatus } from '../../../remote-queries/shared/variant-analysis';
+
+export function createMockVariantAnalysisHistoryItem(
+  historyItemStatus: QueryStatus = QueryStatus.InProgress,
+  variantAnalysisStatus: VariantAnalysisStatus = VariantAnalysisStatus.Succeeded,
+  failureReason?: string,
+  resultCount?: number,
+  userSpecifiedLabel?: string
+): VariantAnalysisHistoryItem {
+  return ({
+    t: 'variant-analysis',
+    failureReason,
+    resultCount,
+    status: historyItemStatus,
+    completed: false,
+    variantAnalysis: {
+      'id': faker.datatype.number(),
+      'controllerRepoId': faker.datatype.number(),
+      'query': {
+        'name': 'Variant Analysis Query History Item',
+        'filePath': 'PLACEHOLDER/q2.ql',
+        'language': 'ruby',
+        'text': '/**\n * @name Variant Analysis Query History Item\n * @kind problem\n * @problem.severity warning\n * @id ruby/example/empty-block\n */\nimport ruby\n\nfrom Block b\nwhere b.getNumberOfStatements() = 0\nselect b, \'This is an empty block.\'\n'
+      },
+      'databases': {
+        'repositories': ['92384123', '1230871']
+      },
+      'createdAt': faker.date.recent().toISOString(),
+      'updatedAt': faker.date.recent().toISOString(),
+      'executionStartTime': faker.date.recent().toISOString(),
+      'status': variantAnalysisStatus,
+      'actionsWorkflowRunId': faker.datatype.number()
+    },
+    userSpecifiedLabel,
+  } as unknown) as VariantAnalysisHistoryItem;
+}
+

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/history-item-label-provider.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/history-item-label-provider.test.ts
@@ -5,9 +5,7 @@ import { HistoryItemLabelProvider } from '../../history-item-label-provider';
 import { createMockLocalQueryInfo } from '../factories/local-queries/local-query-history-item';
 import { createMockRemoteQueryHistoryItem } from '../factories/remote-queries/remote-query-history-item';
 
-
 describe('HistoryItemLabelProvider', () => {
-
   let labelProvider: HistoryItemLabelProvider;
   let config: QueryHistoryConfig;
   const date = new Date('2022-01-01T00:00:00.000Z');

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history-info.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history-info.test.ts
@@ -1,19 +1,18 @@
 import { expect } from 'chai';
-
-import { QueryStatus } from '../../src/query-status';
+import { QueryStatus } from '../../query-status';
 import {
   buildRepoLabel,
   getActionsWorkflowRunUrl,
   getQueryId,
   getQueryText,
   getRawQueryName
-} from '../../src/query-history-info';
-import { VariantAnalysisHistoryItem } from '../../src/remote-queries/variant-analysis-history-item';
-import { createMockVariantAnalysis } from '../../src/vscode-tests/factories/remote-queries/shared/variant-analysis';
-import { createMockScannedRepos } from '../../src/vscode-tests/factories/remote-queries/shared/scanned-repositories';
-import { createMockLocalQueryInfo } from '../../src/vscode-tests/factories/local-queries/local-query-history-item';
-import { createMockRemoteQueryHistoryItem } from '../../src/vscode-tests/factories/remote-queries/remote-query-history-item';
-import { VariantAnalysisRepoStatus, VariantAnalysisStatus } from '../../src/remote-queries/shared/variant-analysis';
+} from '../../query-history-info';
+import { VariantAnalysisHistoryItem } from '../../remote-queries/variant-analysis-history-item';
+import { createMockVariantAnalysis } from '../factories/remote-queries/shared/variant-analysis';
+import { createMockScannedRepos } from '../factories/remote-queries/shared/scanned-repositories';
+import { createMockLocalQueryInfo } from '../factories/local-queries/local-query-history-item';
+import { createMockRemoteQueryHistoryItem } from '../factories/remote-queries/remote-query-history-item';
+import { VariantAnalysisRepoStatus, VariantAnalysisStatus } from '../../remote-queries/shared/variant-analysis';
 
 describe('Query history info', () => {
 

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
@@ -659,44 +659,46 @@ describe('query-history', () => {
       historyTreeDataProvider.dispose();
     });
 
-    it('should get a tree item with raw results', async () => {
-      const mockQuery = createMockLocalQuery('a', createMockQueryWithResults(sandbox, true, /* raw results */ false));
-      const treeItem = await historyTreeDataProvider.getTreeItem(mockQuery);
-      expect(treeItem.command).to.deep.eq({
-        title: 'Query History Item',
-        command: 'codeQLQueryHistory.itemClicked',
-        arguments: [mockQuery],
-        tooltip: labelProvider.getLabel(mockQuery),
+    describe('getTreeItem', async () => {
+      it('should get a tree item with raw results', async () => {
+        const mockQuery = createMockLocalQuery('a', createMockQueryWithResults(sandbox, true, /* raw results */ false));
+        const treeItem = await historyTreeDataProvider.getTreeItem(mockQuery);
+        expect(treeItem.command).to.deep.eq({
+          title: 'Query History Item',
+          command: 'codeQLQueryHistory.itemClicked',
+          arguments: [mockQuery],
+          tooltip: labelProvider.getLabel(mockQuery),
+        });
+        expect(treeItem.label).to.contain('hucairz');
+        expect(treeItem.contextValue).to.eq('rawResultsItem');
+        expect(treeItem.iconPath).to.deep.eq(vscode.Uri.file(mockExtensionLocation + '/media/drive.svg').fsPath);
       });
-      expect(treeItem.label).to.contain('hucairz');
-      expect(treeItem.contextValue).to.eq('rawResultsItem');
-      expect(treeItem.iconPath).to.deep.eq(vscode.Uri.file(mockExtensionLocation + '/media/drive.svg').fsPath);
-    });
 
-    it('should get a tree item with interpreted results', async () => {
-      const mockQuery = createMockLocalQuery('a', createMockQueryWithResults(sandbox, true, /* interpreted results */ true));
-      const treeItem = await historyTreeDataProvider.getTreeItem(mockQuery);
-      expect(treeItem.contextValue).to.eq('interpretedResultsItem');
-      expect(treeItem.iconPath).to.deep.eq(vscode.Uri.file(mockExtensionLocation + '/media/drive.svg').fsPath);
-    });
+      it('should get a tree item with interpreted results', async () => {
+        const mockQuery = createMockLocalQuery('a', createMockQueryWithResults(sandbox, true, /* interpreted results */ true));
+        const treeItem = await historyTreeDataProvider.getTreeItem(mockQuery);
+        expect(treeItem.contextValue).to.eq('interpretedResultsItem');
+        expect(treeItem.iconPath).to.deep.eq(vscode.Uri.file(mockExtensionLocation + '/media/drive.svg').fsPath);
+      });
 
-    it('should get a tree item that did not complete successfully', async () => {
-      const mockQuery = createMockLocalQuery('a', createMockQueryWithResults(sandbox, false), false);
-      const treeItem = await historyTreeDataProvider.getTreeItem(mockQuery);
-      expect(treeItem.iconPath).to.eq(vscode.Uri.file(mockExtensionLocation + '/media/red-x.svg').fsPath);
-    });
+      it('should get a tree item that did not complete successfully', async () => {
+        const mockQuery = createMockLocalQuery('a', createMockQueryWithResults(sandbox, false), false);
+        const treeItem = await historyTreeDataProvider.getTreeItem(mockQuery);
+        expect(treeItem.iconPath).to.eq(vscode.Uri.file(mockExtensionLocation + '/media/red-x.svg').fsPath);
+      });
 
-    it('should get a tree item that failed before creating any results', async () => {
-      const mockQuery = createMockLocalQuery('a', undefined, true);
-      const treeItem = await historyTreeDataProvider.getTreeItem(mockQuery);
-      expect(treeItem.iconPath).to.eq(vscode.Uri.file(mockExtensionLocation + '/media/red-x.svg').fsPath);
-    });
+      it('should get a tree item that failed before creating any results', async () => {
+        const mockQuery = createMockLocalQuery('a', undefined, true);
+        const treeItem = await historyTreeDataProvider.getTreeItem(mockQuery);
+        expect(treeItem.iconPath).to.eq(vscode.Uri.file(mockExtensionLocation + '/media/red-x.svg').fsPath);
+      });
 
-    it('should get a tree item that is in progress', async () => {
-      const mockQuery = createMockLocalQuery('a');
-      const treeItem = await historyTreeDataProvider.getTreeItem(mockQuery);
-      expect(treeItem.iconPath).to.deep.eq({
-        id: 'sync~spin', color: undefined
+      it('should get a tree item that is in progress', async () => {
+        const mockQuery = createMockLocalQuery('a');
+        const treeItem = await historyTreeDataProvider.getTreeItem(mockQuery);
+        expect(treeItem.iconPath).to.deep.eq({
+          id: 'sync~spin', color: undefined
+        });
       });
     });
 

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
@@ -708,133 +708,134 @@ describe('query-history', () => {
       expect(historyTreeDataProvider.getChildren()).to.deep.eq([mockQuery]);
       expect(historyTreeDataProvider.getChildren(mockQuery)).to.deep.eq([]);
     });
-  });
 
-  describe('getChildren', () => {
-    const history = [
-      item('a', 2, 'remote', 24),
-      item('b', 10, 'local', 20),
-      item('c', 5, 'local', 30),
-      item('d', 1, 'local', 25),
-      item('e', 6, 'remote', 5),
-    ];
-    let treeDataProvider: HistoryTreeDataProvider;
+    describe('getChildren', () => {
+      const history = [
+        item('a', 2, 'remote', 24),
+        item('b', 10, 'local', 20),
+        item('c', 5, 'local', 30),
+        item('d', 1, 'local', 25),
+        item('e', 6, 'remote', 5),
+      ];
+      let treeDataProvider: HistoryTreeDataProvider;
 
-    beforeEach(async () => {
-      queryHistoryManager = await createMockQueryHistory(allHistory);
-      (queryHistoryManager.treeDataProvider as any).history = [...history];
-      treeDataProvider = queryHistoryManager.treeDataProvider;
-    });
+      beforeEach(async () => {
+        queryHistoryManager = await createMockQueryHistory(allHistory);
+        (queryHistoryManager.treeDataProvider as any).history = [...history];
+        treeDataProvider = queryHistoryManager.treeDataProvider;
+      });
 
-    it('should get children for name ascending', async () => {
-      const expected = [...history];
-      treeDataProvider.sortOrder = SortOrder.NameAsc;
+      it('should get children for name ascending', async () => {
+        const expected = [...history];
+        treeDataProvider.sortOrder = SortOrder.NameAsc;
 
-      const children = await treeDataProvider.getChildren();
-      expect(children).to.deep.eq(expected);
-    });
+        const children = await treeDataProvider.getChildren();
+        expect(children).to.deep.eq(expected);
+      });
 
-    it('should get children for name descending', async () => {
-      const expected = [...history].reverse();
-      treeDataProvider.sortOrder = SortOrder.NameDesc;
+      it('should get children for name descending', async () => {
+        const expected = [...history].reverse();
+        treeDataProvider.sortOrder = SortOrder.NameDesc;
 
-      const children = await treeDataProvider.getChildren();
-      expect(children).to.deep.eq(expected);
-    });
+        const children = await treeDataProvider.getChildren();
+        expect(children).to.deep.eq(expected);
+      });
 
-    it('should get children for date ascending', async () => {
-      const expected = [history[3], history[0], history[2], history[4], history[1]];
-      treeDataProvider.sortOrder = SortOrder.DateAsc;
+      it('should get children for date ascending', async () => {
+        const expected = [history[3], history[0], history[2], history[4], history[1]];
+        treeDataProvider.sortOrder = SortOrder.DateAsc;
 
-      const children = await treeDataProvider.getChildren();
-      expect(children).to.deep.eq(expected);
-    });
+        const children = await treeDataProvider.getChildren();
+        expect(children).to.deep.eq(expected);
+      });
 
-    it('should get children for date descending', async () => {
-      const expected = [history[3], history[0], history[2], history[4], history[1]].reverse();
-      treeDataProvider.sortOrder = SortOrder.DateDesc;
+      it('should get children for date descending', async () => {
+        const expected = [history[3], history[0], history[2], history[4], history[1]].reverse();
+        treeDataProvider.sortOrder = SortOrder.DateDesc;
 
-      const children = await treeDataProvider.getChildren();
-      expect(children).to.deep.eq(expected);
-    });
+        const children = await treeDataProvider.getChildren();
+        expect(children).to.deep.eq(expected);
+      });
 
-    it('should get children for result count ascending', async () => {
-      const expected = [history[4], history[1], history[0], history[3], history[2]];
-      treeDataProvider.sortOrder = SortOrder.CountAsc;
+      it('should get children for result count ascending', async () => {
+        const expected = [history[4], history[1], history[0], history[3], history[2]];
+        treeDataProvider.sortOrder = SortOrder.CountAsc;
 
-      const children = await treeDataProvider.getChildren();
-      expect(children).to.deep.eq(expected);
-    });
+        const children = await treeDataProvider.getChildren();
+        expect(children).to.deep.eq(expected);
+      });
 
-    it('should get children for result count descending', async () => {
-      const expected = [history[4], history[1], history[0], history[3], history[2]].reverse();
-      treeDataProvider.sortOrder = SortOrder.CountDesc;
+      it('should get children for result count descending', async () => {
+        const expected = [history[4], history[1], history[0], history[3], history[2]].reverse();
+        treeDataProvider.sortOrder = SortOrder.CountDesc;
 
-      const children = await treeDataProvider.getChildren();
-      expect(children).to.deep.eq(expected);
-    });
+        const children = await treeDataProvider.getChildren();
+        expect(children).to.deep.eq(expected);
+      });
 
-    it('should get children for result count ascending when there are no results', async () => {
-      // fall back to name
-      const thisHistory = [item('a', 10), item('b', 50), item('c', 1)];
-      (queryHistoryManager!.treeDataProvider as any).history = [...thisHistory];
-      const expected = [...thisHistory];
-      treeDataProvider.sortOrder = SortOrder.CountAsc;
+      it('should get children for result count ascending when there are no results', async () => {
+        // fall back to name
+        const thisHistory = [item('a', 10), item('b', 50), item('c', 1)];
+        (queryHistoryManager!.treeDataProvider as any).history = [...thisHistory];
+        const expected = [...thisHistory];
+        treeDataProvider.sortOrder = SortOrder.CountAsc;
 
-      const children = await treeDataProvider.getChildren();
-      expect(children).to.deep.eq(expected);
-    });
+        const children = await treeDataProvider.getChildren();
+        expect(children).to.deep.eq(expected);
+      });
 
-    it('should get children for result count descending when there are no results', async () => {
-      // fall back to name
-      const thisHistory = [item('a', 10), item('b', 50), item('c', 1)];
-      (queryHistoryManager!.treeDataProvider as any).history = [...thisHistory];
-      const expected = [...thisHistory].reverse();
-      treeDataProvider.sortOrder = SortOrder.CountDesc;
+      it('should get children for result count descending when there are no results', async () => {
+        // fall back to name
+        const thisHistory = [item('a', 10), item('b', 50), item('c', 1)];
+        (queryHistoryManager!.treeDataProvider as any).history = [...thisHistory];
+        const expected = [...thisHistory].reverse();
+        treeDataProvider.sortOrder = SortOrder.CountDesc;
 
-      const children = await treeDataProvider.getChildren();
-      expect(children).to.deep.eq(expected);
-    });
+        const children = await treeDataProvider.getChildren();
+        expect(children).to.deep.eq(expected);
+      });
 
-    function item(label: string, start: number, t = 'local', resultCount?: number) {
-      if (t === 'local') {
-        return {
-          getQueryName() {
-            return label;
-          },
-          getQueryFileName() {
-            return label + '.ql';
-          },
-          initialInfo: {
-            start: new Date(start),
-            databaseInfo: {
-              name: 'test',
-            }
-          },
-          completedQuery: {
-            resultCount,
-          },
-          t
-        };
-      } else {
-        return {
-          status: 'success',
-          remoteQuery: {
-            queryFilePath: label + '.ql',
-            queryName: label,
-            executionStartTime: start,
-            controllerRepository: {
-              name: 'test',
-              owner: 'user',
+      function item(label: string, start: number, t = 'local', resultCount?: number) {
+        if (t === 'local') {
+          return {
+            getQueryName() {
+              return label;
             },
-            repositories: []
-          },
-          resultCount,
-          t
-        };
+            getQueryFileName() {
+              return label + '.ql';
+            },
+            initialInfo: {
+              start: new Date(start),
+              databaseInfo: {
+                name: 'test',
+              }
+            },
+            completedQuery: {
+              resultCount,
+            },
+            t
+          };
+        } else {
+          return {
+            status: 'success',
+            remoteQuery: {
+              queryFilePath: label + '.ql',
+              queryName: label,
+              executionStartTime: start,
+              controllerRepository: {
+                name: 'test',
+                owner: 'user',
+              },
+              repositories: []
+            },
+            resultCount,
+            t
+          };
+        }
       }
-    }
+    });
   });
+
 
   async function createMockQueryHistory(allHistory: QueryHistoryInfo[]) {
     const qhm = new QueryHistoryManager(

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
@@ -325,77 +325,79 @@ describe('query-history', () => {
     });
   });
 
-  it('should remove an item and not select a new one', async () => {
-    queryHistoryManager = await createMockQueryHistory(allHistory);
-    // initialize the selection
-    await queryHistoryManager.treeView.reveal(allHistory[0], { select: true });
+  describe('handleRemoveHistoryItem', () => {
+    it('should remove an item and not select a new one', async () => {
+      queryHistoryManager = await createMockQueryHistory(allHistory);
+      // initialize the selection
+      await queryHistoryManager.treeView.reveal(allHistory[0], { select: true });
 
-    // deleting the first item when a different item is selected
-    // will not change the selection
-    const toDelete = allHistory[1];
-    const selected = allHistory[3];
+      // deleting the first item when a different item is selected
+      // will not change the selection
+      const toDelete = allHistory[1];
+      const selected = allHistory[3];
 
-    // select the item we want
-    await queryHistoryManager.treeView.reveal(selected, { select: true });
+      // select the item we want
+      await queryHistoryManager.treeView.reveal(selected, { select: true });
 
-    // should be selected
-    expect(queryHistoryManager.treeDataProvider.getCurrent()).to.deep.eq(selected);
+      // should be selected
+      expect(queryHistoryManager.treeDataProvider.getCurrent()).to.deep.eq(selected);
 
-    // remove an item
-    await queryHistoryManager.handleRemoveHistoryItem(toDelete, [toDelete]);
+      // remove an item
+      await queryHistoryManager.handleRemoveHistoryItem(toDelete, [toDelete]);
 
-    if (toDelete.t == 'local') {
-      expect(toDelete.completedQuery!.dispose).to.have.been.calledOnce;
-    } else if (toDelete.t == 'remote') {
-      expect(remoteQueriesManagerStub.removeRemoteQuery).to.have.been.calledOnceWith((toDelete as RemoteQueryHistoryItem).queryId);
-    } else if (toDelete.t == 'variant-analysis') {
-      expect(variantAnalysisManagerStub.removeVariantAnalysis).to.have.been.calledOnceWith((toDelete as VariantAnalysisHistoryItem).variantAnalysis.id);
-    }
+      if (toDelete.t == 'local') {
+        expect(toDelete.completedQuery!.dispose).to.have.been.calledOnce;
+      } else if (toDelete.t == 'remote') {
+        expect(remoteQueriesManagerStub.removeRemoteQuery).to.have.been.calledOnceWith((toDelete as RemoteQueryHistoryItem).queryId);
+      } else if (toDelete.t == 'variant-analysis') {
+        expect(variantAnalysisManagerStub.removeVariantAnalysis).to.have.been.calledOnceWith((toDelete as VariantAnalysisHistoryItem).variantAnalysis.id);
+      }
 
-    // the same item should be selected
-    if (selected.t == 'local') {
-      expect(localQueriesResultsViewStub.showResults).to.have.been.calledOnceWith(selected);
-    } else if (toDelete.t == 'remote') {
-      expect(remoteQueriesManagerStub.openRemoteQueryResults).to.have.been.calledOnceWith((selected as RemoteQueryHistoryItem).queryId);
-    } else if (toDelete.t == 'variant-analysis') {
-      expect(variantAnalysisManagerStub.showView).to.have.been.calledOnceWith((selected as VariantAnalysisHistoryItem).variantAnalysis.id);
-    }
+      // the same item should be selected
+      if (selected.t == 'local') {
+        expect(localQueriesResultsViewStub.showResults).to.have.been.calledOnceWith(selected);
+      } else if (toDelete.t == 'remote') {
+        expect(remoteQueriesManagerStub.openRemoteQueryResults).to.have.been.calledOnceWith((selected as RemoteQueryHistoryItem).queryId);
+      } else if (toDelete.t == 'variant-analysis') {
+        expect(variantAnalysisManagerStub.showView).to.have.been.calledOnceWith((selected as VariantAnalysisHistoryItem).variantAnalysis.id);
+      }
 
-    expect(queryHistoryManager.treeDataProvider.getCurrent()).to.deep.eq(selected);
-    expect(queryHistoryManager.treeDataProvider.allHistory).not.to.contain(toDelete);
-  });
+      expect(queryHistoryManager.treeDataProvider.getCurrent()).to.deep.eq(selected);
+      expect(queryHistoryManager.treeDataProvider.allHistory).not.to.contain(toDelete);
+    });
 
-  it('should remove an item and select a new one', async () => {
-    queryHistoryManager = await createMockQueryHistory(allHistory);
+    it('should remove an item and select a new one', async () => {
+      queryHistoryManager = await createMockQueryHistory(allHistory);
 
-    // deleting the selected item automatically selects next item
-    const toDelete = allHistory[1];
-    const newSelected = allHistory[2];
-    // avoid triggering the callback by setting the field directly
+      // deleting the selected item automatically selects next item
+      const toDelete = allHistory[1];
+      const newSelected = allHistory[2];
+      // avoid triggering the callback by setting the field directly
 
-    // select the item we want
-    await queryHistoryManager.treeView.reveal(toDelete, { select: true });
-    await queryHistoryManager.handleRemoveHistoryItem(toDelete, [toDelete]);
+      // select the item we want
+      await queryHistoryManager.treeView.reveal(toDelete, { select: true });
+      await queryHistoryManager.handleRemoveHistoryItem(toDelete, [toDelete]);
 
-    if (toDelete.t == 'local') {
-      expect(toDelete.completedQuery!.dispose).to.have.been.calledOnce;
-    } else if (toDelete.t == 'remote') {
-      expect(remoteQueriesManagerStub.removeRemoteQuery).to.have.been.calledOnceWith((toDelete as RemoteQueryHistoryItem).queryId);
-    } else if (toDelete.t == 'variant-analysis') {
-      expect(variantAnalysisManagerStub.removeVariantAnalysis).to.have.been.calledOnceWith((toDelete as VariantAnalysisHistoryItem).variantAnalysis.id);
-    }
+      if (toDelete.t == 'local') {
+        expect(toDelete.completedQuery!.dispose).to.have.been.calledOnce;
+      } else if (toDelete.t == 'remote') {
+        expect(remoteQueriesManagerStub.removeRemoteQuery).to.have.been.calledOnceWith((toDelete as RemoteQueryHistoryItem).queryId);
+      } else if (toDelete.t == 'variant-analysis') {
+        expect(variantAnalysisManagerStub.removeVariantAnalysis).to.have.been.calledOnceWith((toDelete as VariantAnalysisHistoryItem).variantAnalysis.id);
+      }
 
-    // the current item should have been selected
-    if (newSelected.t == 'local') {
-      expect(localQueriesResultsViewStub.showResults).to.have.been.calledOnceWith(newSelected);
-    } else if (toDelete.t == 'remote') {
-      expect(remoteQueriesManagerStub.openRemoteQueryResults).to.have.been.calledOnceWith((newSelected as RemoteQueryHistoryItem).queryId);
-    } else if (toDelete.t == 'variant-analysis') {
-      expect(variantAnalysisManagerStub.showView).to.have.been.calledOnceWith((newSelected as VariantAnalysisHistoryItem).variantAnalysis.id);
-    }
+      // the current item should have been selected
+      if (newSelected.t == 'local') {
+        expect(localQueriesResultsViewStub.showResults).to.have.been.calledOnceWith(newSelected);
+      } else if (toDelete.t == 'remote') {
+        expect(remoteQueriesManagerStub.openRemoteQueryResults).to.have.been.calledOnceWith((newSelected as RemoteQueryHistoryItem).queryId);
+      } else if (toDelete.t == 'variant-analysis') {
+        expect(variantAnalysisManagerStub.showView).to.have.been.calledOnceWith((newSelected as VariantAnalysisHistoryItem).variantAnalysis.id);
+      }
 
-    expect(queryHistoryManager.treeDataProvider.getCurrent()).to.eq(newSelected);
-    expect(queryHistoryManager.treeDataProvider.allHistory).not.to.contain(toDelete);
+      expect(queryHistoryManager.treeDataProvider.getCurrent()).to.eq(newSelected);
+      expect(queryHistoryManager.treeDataProvider.allHistory).not.to.contain(toDelete);
+    });
   });
 
   describe('HistoryTreeDataProvider', () => {

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
@@ -263,14 +263,14 @@ describe('query-history', () => {
 
     describe('handleRemoveHistoryItem', () => {
       it('should remove an item and not select a new one', async () => {
-        queryHistoryManager = await createMockQueryHistory(allHistory);
+        queryHistoryManager = await createMockQueryHistory(localQueryHistory);
         // initialize the selection
-        await queryHistoryManager.treeView.reveal(allHistory[0], { select: true });
+        await queryHistoryManager.treeView.reveal(localQueryHistory[0], { select: true });
 
         // deleting the first item when a different item is selected
         // will not change the selection
-        const toDelete = allHistory[1];
-        const selected = allHistory[3];
+        const toDelete = localQueryHistory[1];
+        const selected = localQueryHistory[3];
 
         // select the item we want
         await queryHistoryManager.treeView.reveal(selected, { select: true });
@@ -281,58 +281,32 @@ describe('query-history', () => {
         // remove an item
         await queryHistoryManager.handleRemoveHistoryItem(toDelete, [toDelete]);
 
-        if (toDelete.t == 'local') {
-          expect(toDelete.completedQuery!.dispose).to.have.been.calledOnce;
-        } else if (toDelete.t == 'remote') {
-          expect(remoteQueriesManagerStub.removeRemoteQuery).to.have.been.calledOnceWith((toDelete as RemoteQueryHistoryItem).queryId);
-        } else if (toDelete.t == 'variant-analysis') {
-          expect(variantAnalysisManagerStub.removeVariantAnalysis).to.have.been.calledOnceWith((toDelete as VariantAnalysisHistoryItem).variantAnalysis.id);
-        }
-
-        // the same item should be selected
-        if (selected.t == 'local') {
-          expect(localQueriesResultsViewStub.showResults).to.have.been.calledOnceWith(selected);
-        } else if (toDelete.t == 'remote') {
-          expect(remoteQueriesManagerStub.openRemoteQueryResults).to.have.been.calledOnceWith((selected as RemoteQueryHistoryItem).queryId);
-        } else if (toDelete.t == 'variant-analysis') {
-          expect(variantAnalysisManagerStub.showView).to.have.been.calledOnceWith((selected as VariantAnalysisHistoryItem).variantAnalysis.id);
-        }
-
+        expect(toDelete.completedQuery!.dispose).to.have.been.calledOnce;
         expect(queryHistoryManager.treeDataProvider.getCurrent()).to.deep.eq(selected);
         expect(queryHistoryManager.treeDataProvider.allHistory).not.to.contain(toDelete);
+
+        // the same item should be selected
+        expect(localQueriesResultsViewStub.showResults).to.have.been.calledOnceWith(selected);
       });
 
       it('should remove an item and select a new one', async () => {
-        queryHistoryManager = await createMockQueryHistory(allHistory);
+        queryHistoryManager = await createMockQueryHistory(localQueryHistory);
 
         // deleting the selected item automatically selects next item
-        const toDelete = allHistory[1];
-        const newSelected = allHistory[2];
+        const toDelete = localQueryHistory[1];
+        const newSelected = localQueryHistory[2];
         // avoid triggering the callback by setting the field directly
 
         // select the item we want
         await queryHistoryManager.treeView.reveal(toDelete, { select: true });
         await queryHistoryManager.handleRemoveHistoryItem(toDelete, [toDelete]);
 
-        if (toDelete.t == 'local') {
-          expect(toDelete.completedQuery!.dispose).to.have.been.calledOnce;
-        } else if (toDelete.t == 'remote') {
-          expect(remoteQueriesManagerStub.removeRemoteQuery).to.have.been.calledOnceWith((toDelete as RemoteQueryHistoryItem).queryId);
-        } else if (toDelete.t == 'variant-analysis') {
-          expect(variantAnalysisManagerStub.removeVariantAnalysis).to.have.been.calledOnceWith((toDelete as VariantAnalysisHistoryItem).variantAnalysis.id);
-        }
-
-        // the current item should have been selected
-        if (newSelected.t == 'local') {
-          expect(localQueriesResultsViewStub.showResults).to.have.been.calledOnceWith(newSelected);
-        } else if (toDelete.t == 'remote') {
-          expect(remoteQueriesManagerStub.openRemoteQueryResults).to.have.been.calledOnceWith((newSelected as RemoteQueryHistoryItem).queryId);
-        } else if (toDelete.t == 'variant-analysis') {
-          expect(variantAnalysisManagerStub.showView).to.have.been.calledOnceWith((newSelected as VariantAnalysisHistoryItem).variantAnalysis.id);
-        }
-
+        expect(toDelete.completedQuery!.dispose).to.have.been.calledOnce;
         expect(queryHistoryManager.treeDataProvider.getCurrent()).to.eq(newSelected);
         expect(queryHistoryManager.treeDataProvider.allHistory).not.to.contain(toDelete);
+
+        // the current item should have been selected
+        expect(localQueriesResultsViewStub.showResults).to.have.been.calledOnceWith(newSelected);
       });
     });
 

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
@@ -45,6 +45,11 @@ describe('query-history', () => {
   let tryOpenExternalFile: Function;
   let sandbox: sinon.SinonSandbox;
 
+  let allHistory: QueryHistoryInfo[];
+  let localQueryHistory: LocalQueryInfo[];
+  let remoteQueryHistory: RemoteQueryHistoryItem[];
+  let variantAnalysisHistory: VariantAnalysisHistoryItem[];
+
   beforeEach(() => {
     sandbox = sinon.createSandbox();
 
@@ -80,6 +85,27 @@ describe('query-history', () => {
       removeVariantAnalysis: sandbox.stub(),
       showView: sandbox.stub(),
     } as any as VariantAnalysisManager;
+
+    localQueryHistory = [
+      createMockLocalQuery('a', createMockQueryWithResults(sandbox, true)),
+      createMockLocalQuery('b', createMockQueryWithResults(sandbox, true)),
+      createMockLocalQuery('a', createMockQueryWithResults(sandbox, false)),
+      createMockLocalQuery('a', createMockQueryWithResults(sandbox, true)),
+    ];
+    remoteQueryHistory = [
+      createMockRemoteQueryHistoryItem({}),
+      createMockRemoteQueryHistoryItem({}),
+      createMockRemoteQueryHistoryItem({}),
+      createMockRemoteQueryHistoryItem({})
+    ];
+    variantAnalysisHistory = [
+      createMockVariantAnalysisHistoryItem(),
+      createMockVariantAnalysisHistoryItem(),
+      createMockVariantAnalysisHistoryItem(),
+      createMockVariantAnalysisHistoryItem()
+    ];
+    allHistory = shuffleHistoryItems([...localQueryHistory, ...remoteQueryHistory, ...variantAnalysisHistory]);
+
   });
 
   afterEach(async () => {
@@ -129,33 +155,6 @@ describe('query-history', () => {
         expect(executeCommandSpy).not.to.have.been.called;
       });
     });
-  });
-
-  let allHistory: QueryHistoryInfo[];
-  let localQueryHistory: LocalQueryInfo[];
-  let remoteQueryHistory: RemoteQueryHistoryItem[];
-  let variantAnalysisHistory: VariantAnalysisHistoryItem[];
-
-  beforeEach(() => {
-    localQueryHistory = [
-      createMockLocalQuery('a', createMockQueryWithResults(sandbox, true)),
-      createMockLocalQuery('b', createMockQueryWithResults(sandbox, true)),
-      createMockLocalQuery('a', createMockQueryWithResults(sandbox, false)),
-      createMockLocalQuery('a', createMockQueryWithResults(sandbox, true)),
-    ];
-    remoteQueryHistory = [
-      createMockRemoteQueryHistoryItem({}),
-      createMockRemoteQueryHistoryItem({}),
-      createMockRemoteQueryHistoryItem({}),
-      createMockRemoteQueryHistoryItem({})
-    ];
-    variantAnalysisHistory = [
-      createMockVariantAnalysisHistoryItem(),
-      createMockVariantAnalysisHistoryItem(),
-      createMockVariantAnalysisHistoryItem(),
-      createMockVariantAnalysisHistoryItem()
-    ];
-    allHistory = shuffleHistoryItems([...localQueryHistory, ...remoteQueryHistory, ...variantAnalysisHistory]);
   });
 
   describe('Local Queries', () => {

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
@@ -702,140 +702,141 @@ describe('query-history', () => {
       });
     });
 
-    it('should get children', () => {
-      const mockQuery = createMockLocalQuery();
-      historyTreeDataProvider.allHistory.push(mockQuery);
-      expect(historyTreeDataProvider.getChildren()).to.deep.eq([mockQuery]);
-      expect(historyTreeDataProvider.getChildren(mockQuery)).to.deep.eq([]);
-    });
-
     describe('getChildren', () => {
-      const history = [
-        item('a', 2, 'remote', 24),
-        item('b', 10, 'local', 20),
-        item('c', 5, 'local', 30),
-        item('d', 1, 'local', 25),
-        item('e', 6, 'remote', 5),
-      ];
-      let treeDataProvider: HistoryTreeDataProvider;
-
-      beforeEach(async () => {
-        queryHistoryManager = await createMockQueryHistory(allHistory);
-        (queryHistoryManager.treeDataProvider as any).history = [...history];
-        treeDataProvider = queryHistoryManager.treeDataProvider;
+      it('fetch children correctly', () => {
+        const mockQuery = createMockLocalQuery();
+        historyTreeDataProvider.allHistory.push(mockQuery);
+        expect(historyTreeDataProvider.getChildren()).to.deep.eq([mockQuery]);
+        expect(historyTreeDataProvider.getChildren(mockQuery)).to.deep.eq([]);
       });
 
-      it('should get children for name ascending', async () => {
-        const expected = [...history];
-        treeDataProvider.sortOrder = SortOrder.NameAsc;
+      describe('sorting', () => {
+        const history = [
+          item('a', 2, 'remote', 24),
+          item('b', 10, 'local', 20),
+          item('c', 5, 'local', 30),
+          item('d', 1, 'local', 25),
+          item('e', 6, 'remote', 5),
+        ];
+        let treeDataProvider: HistoryTreeDataProvider;
 
-        const children = await treeDataProvider.getChildren();
-        expect(children).to.deep.eq(expected);
-      });
+        beforeEach(async () => {
+          queryHistoryManager = await createMockQueryHistory(allHistory);
+          (queryHistoryManager.treeDataProvider as any).history = [...history];
+          treeDataProvider = queryHistoryManager.treeDataProvider;
+        });
 
-      it('should get children for name descending', async () => {
-        const expected = [...history].reverse();
-        treeDataProvider.sortOrder = SortOrder.NameDesc;
+        it('should get children for name ascending', async () => {
+          const expected = [...history];
+          treeDataProvider.sortOrder = SortOrder.NameAsc;
 
-        const children = await treeDataProvider.getChildren();
-        expect(children).to.deep.eq(expected);
-      });
+          const children = await treeDataProvider.getChildren();
+          expect(children).to.deep.eq(expected);
+        });
 
-      it('should get children for date ascending', async () => {
-        const expected = [history[3], history[0], history[2], history[4], history[1]];
-        treeDataProvider.sortOrder = SortOrder.DateAsc;
+        it('should get children for name descending', async () => {
+          const expected = [...history].reverse();
+          treeDataProvider.sortOrder = SortOrder.NameDesc;
 
-        const children = await treeDataProvider.getChildren();
-        expect(children).to.deep.eq(expected);
-      });
+          const children = await treeDataProvider.getChildren();
+          expect(children).to.deep.eq(expected);
+        });
 
-      it('should get children for date descending', async () => {
-        const expected = [history[3], history[0], history[2], history[4], history[1]].reverse();
-        treeDataProvider.sortOrder = SortOrder.DateDesc;
+        it('should get children for date ascending', async () => {
+          const expected = [history[3], history[0], history[2], history[4], history[1]];
+          treeDataProvider.sortOrder = SortOrder.DateAsc;
 
-        const children = await treeDataProvider.getChildren();
-        expect(children).to.deep.eq(expected);
-      });
+          const children = await treeDataProvider.getChildren();
+          expect(children).to.deep.eq(expected);
+        });
 
-      it('should get children for result count ascending', async () => {
-        const expected = [history[4], history[1], history[0], history[3], history[2]];
-        treeDataProvider.sortOrder = SortOrder.CountAsc;
+        it('should get children for date descending', async () => {
+          const expected = [history[3], history[0], history[2], history[4], history[1]].reverse();
+          treeDataProvider.sortOrder = SortOrder.DateDesc;
 
-        const children = await treeDataProvider.getChildren();
-        expect(children).to.deep.eq(expected);
-      });
+          const children = await treeDataProvider.getChildren();
+          expect(children).to.deep.eq(expected);
+        });
 
-      it('should get children for result count descending', async () => {
-        const expected = [history[4], history[1], history[0], history[3], history[2]].reverse();
-        treeDataProvider.sortOrder = SortOrder.CountDesc;
+        it('should get children for result count ascending', async () => {
+          const expected = [history[4], history[1], history[0], history[3], history[2]];
+          treeDataProvider.sortOrder = SortOrder.CountAsc;
 
-        const children = await treeDataProvider.getChildren();
-        expect(children).to.deep.eq(expected);
-      });
+          const children = await treeDataProvider.getChildren();
+          expect(children).to.deep.eq(expected);
+        });
 
-      it('should get children for result count ascending when there are no results', async () => {
-        // fall back to name
-        const thisHistory = [item('a', 10), item('b', 50), item('c', 1)];
-        (queryHistoryManager!.treeDataProvider as any).history = [...thisHistory];
-        const expected = [...thisHistory];
-        treeDataProvider.sortOrder = SortOrder.CountAsc;
+        it('should get children for result count descending', async () => {
+          const expected = [history[4], history[1], history[0], history[3], history[2]].reverse();
+          treeDataProvider.sortOrder = SortOrder.CountDesc;
 
-        const children = await treeDataProvider.getChildren();
-        expect(children).to.deep.eq(expected);
-      });
+          const children = await treeDataProvider.getChildren();
+          expect(children).to.deep.eq(expected);
+        });
 
-      it('should get children for result count descending when there are no results', async () => {
-        // fall back to name
-        const thisHistory = [item('a', 10), item('b', 50), item('c', 1)];
-        (queryHistoryManager!.treeDataProvider as any).history = [...thisHistory];
-        const expected = [...thisHistory].reverse();
-        treeDataProvider.sortOrder = SortOrder.CountDesc;
+        it('should get children for result count ascending when there are no results', async () => {
+          // fall back to name
+          const thisHistory = [item('a', 10), item('b', 50), item('c', 1)];
+          (queryHistoryManager!.treeDataProvider as any).history = [...thisHistory];
+          const expected = [...thisHistory];
+          treeDataProvider.sortOrder = SortOrder.CountAsc;
 
-        const children = await treeDataProvider.getChildren();
-        expect(children).to.deep.eq(expected);
-      });
+          const children = await treeDataProvider.getChildren();
+          expect(children).to.deep.eq(expected);
+        });
 
-      function item(label: string, start: number, t = 'local', resultCount?: number) {
-        if (t === 'local') {
-          return {
-            getQueryName() {
-              return label;
-            },
-            getQueryFileName() {
-              return label + '.ql';
-            },
-            initialInfo: {
-              start: new Date(start),
-              databaseInfo: {
-                name: 'test',
-              }
-            },
-            completedQuery: {
-              resultCount,
-            },
-            t
-          };
-        } else {
-          return {
-            status: 'success',
-            remoteQuery: {
-              queryFilePath: label + '.ql',
-              queryName: label,
-              executionStartTime: start,
-              controllerRepository: {
-                name: 'test',
-                owner: 'user',
+        it('should get children for result count descending when there are no results', async () => {
+          // fall back to name
+          const thisHistory = [item('a', 10), item('b', 50), item('c', 1)];
+          (queryHistoryManager!.treeDataProvider as any).history = [...thisHistory];
+          const expected = [...thisHistory].reverse();
+          treeDataProvider.sortOrder = SortOrder.CountDesc;
+
+          const children = await treeDataProvider.getChildren();
+          expect(children).to.deep.eq(expected);
+        });
+
+        function item(label: string, start: number, t = 'local', resultCount?: number) {
+          if (t === 'local') {
+            return {
+              getQueryName() {
+                return label;
               },
-              repositories: []
-            },
-            resultCount,
-            t
-          };
+              getQueryFileName() {
+                return label + '.ql';
+              },
+              initialInfo: {
+                start: new Date(start),
+                databaseInfo: {
+                  name: 'test',
+                }
+              },
+              completedQuery: {
+                resultCount,
+              },
+              t
+            };
+          } else {
+            return {
+              status: 'success',
+              remoteQuery: {
+                queryFilePath: label + '.ql',
+                queryName: label,
+                executionStartTime: start,
+                controllerRepository: {
+                  name: 'test',
+                  owner: 'user',
+                },
+                repositories: []
+              },
+              resultCount,
+              t
+            };
+          }
         }
-      }
+      });
     });
   });
-
 
   async function createMockQueryHistory(allHistory: QueryHistoryInfo[]) {
     const qhm = new QueryHistoryManager(

--- a/extensions/ql-vscode/src/vscode-tests/utils/query-history-helpers.ts
+++ b/extensions/ql-vscode/src/vscode-tests/utils/query-history-helpers.ts
@@ -1,0 +1,5 @@
+import { QueryHistoryInfo } from '../../query-history-info';
+
+export function shuffleHistoryItems(history: QueryHistoryInfo[]) {
+  return history.sort(() => Math.random() - 0.5);
+}


### PR DESCRIPTION
🚨 Please review this PR commit-by-commit.

This PR holds part of the clean-up work to allow us to write more tests for the `QueryHistoryManager` and `HistoryTreeDataProvider` by re-organising tests to make it clear what they're checking and removing
some duplication in the process. This unfortunately results in a lot of noisy diffs as I shuffle things into 
`describe` blocks.

We're also changing part of these tests to work with `RemoteQueryHistoryItem`s and 
`VariantAnalysisHistoryItem`s, instead of just testing local query history items.

The query history now has increased test coverage in terms of how items of different types interact
together, specifically:
- handling an item being clicked / double clicked
- ~~removing and selecting an item~~ this has been reverted, see https://github.com/github/vscode-codeql/pull/1688/commits/5a4015900f1d638781aa6b78dd070bf4d35235de for details 
- showing query results for different item types
- handling single / multi selection

In a future PR we'll also look at:
- sorting results of different types and 
- removing & re-selecting an item

Disclaimer: I don't think these tests are perfect and there's definitely still some duplication between the 
tests in `query-history.test.ts` and the individual history item test files, but they're a step in the right 
direction as they untangle some things that are annoying to deal with in terms of writing/changing 
query history tests.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
