### PR TITLE
Move `createGist` to `gh-api-client`

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/export-results.ts
+++ b/extensions/ql-vscode/src/remote-queries/export-results.ts
@@ -7,7 +7,7 @@ import { UserCancellationException } from '../commandRunner';
 import { showInformationMessageWithAction } from '../helpers';
 import { logger } from '../logging';
 import { QueryHistoryManager } from '../query-history';
-import { createGist } from './gh-api/gh-actions-api-client';
+import { createGist } from './gh-api/gh-api-client';
 import { RemoteQueriesManager } from './remote-queries-manager';
 import { generateMarkdown } from './remote-queries-markdown-generation';
 import { RemoteQuery } from './remote-query';

--- a/extensions/ql-vscode/src/remote-queries/gh-api/gh-actions-api-client.ts
+++ b/extensions/ql-vscode/src/remote-queries/gh-api/gh-actions-api-client.ts
@@ -332,27 +332,6 @@ function getWorkflowError(conclusion: string | null): string {
   return `Unexpected variant analysis execution conclusion: ${conclusion}`;
 }
 
-/**
- * Creates a gist with the given description and files.
- * Returns the URL of the created gist.
- */
-export async function createGist(
-  credentials: Credentials,
-  description: string,
-  files: { [key: string]: { content: string } }
-): Promise<string | undefined> {
-  const octokit = await credentials.getOctokit();
-  const response = await octokit.request('POST /gists', {
-    description,
-    files,
-    public: false,
-  });
-  if (response.status >= 300) {
-    throw new Error(`Error exporting variant analysis results: ${response.status} ${response?.data || ''}`);
-  }
-  return response.data.html_url;
-}
-
 const repositoriesMetadataQuery = `query Stars($repos: String!, $pageSize: Int!, $cursor: String) {
   search(
     query: $repos

--- a/extensions/ql-vscode/src/remote-queries/gh-api/gh-api-client.ts
+++ b/extensions/ql-vscode/src/remote-queries/gh-api/gh-api-client.ts
@@ -94,3 +94,25 @@ export async function getRepositoryFromNwo(
   const response = await octokit.rest.repos.get({ owner, repo });
   return response.data as Repository;
 }
+
+
+/**
+ * Creates a gist with the given description and files.
+ * Returns the URL of the created gist.
+ */
+export async function createGist(
+  credentials: Credentials,
+  description: string,
+  files: { [key: string]: { content: string } }
+): Promise<string | undefined> {
+  const octokit = await credentials.getOctokit();
+  const response = await octokit.request('POST /gists', {
+    description,
+    files,
+    public: false,
+  });
+  if (response.status >= 300) {
+    throw new Error(`Error exporting variant analysis results: ${response.status} ${response?.data || ''}`);
+  }
+  return response.data.html_url;
+}

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/export-results.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/export-results.test.ts
@@ -7,7 +7,7 @@ import { ExtensionContext } from 'vscode';
 import { createMockExtensionContext } from '../index';
 import { Credentials } from '../../../authentication';
 import { MarkdownFile } from '../../../remote-queries/remote-queries-markdown-generation';
-import * as actionsApiClient from '../../../remote-queries/gh-api/gh-actions-api-client';
+import * as ghApiClient from '../../../remote-queries/gh-api/gh-api-client';
 import { exportResultsToGist } from '../../../remote-queries/export-results';
 
 const proxyquire = pq.noPreserveCache();
@@ -41,7 +41,7 @@ describe('export results', async function() {
     });
 
     it('should call the GitHub Actions API with the correct gist title', async function() {
-      mockCreateGist = sinon.stub(actionsApiClient, 'createGist');
+      mockCreateGist = sinon.stub(ghApiClient, 'createGist');
 
       ctx = createMockExtensionContext();
       const query = JSON.parse(await fs.readFile(path.join(__dirname, '../data/remote-queries/query-with-results/query.json'), 'utf8'));


### PR DESCRIPTION
The `createGist` function was part of `gh-actions-api-client`, while it didn't actually involve anything related to the GitHub Actions API. This moves it to the non-Actions-specific `gh-api-client` module.

Another candidate for moving to `gh-api-client` is `getRepositoriesMetadata`, but that one is a bit more involved since it uses `showAndLogErrorMessage`, so depends on the `vscode` module. This means it would not be possible to test in the "pure" tests and we would need to move all our `gh-actions-api` tests to the integration tests. It will not be used for variant analysis queries anymore, so I don't think it's worth moving or refactoring to not depend on `vscode`.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
