### PR TITLE
Make the monitoring command slightly simpler and handle being called on any variant analysis

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/shared/variant-analysis-monitor-result.ts
+++ b/extensions/ql-vscode/src/remote-queries/shared/variant-analysis-monitor-result.ts
@@ -1,16 +1,11 @@
 import { VariantAnalysis } from './variant-analysis';
 
 export type VariantAnalysisMonitorStatus =
-  | 'InProgress'
-  | 'CompletedSuccessfully'
-  | 'CompletedUnsuccessfully'
-  | 'Failed'
-  | 'Cancelled'
-  | 'TimedOut';
+  | 'Completed'
+  | 'Canceled';
 
 export interface VariantAnalysisMonitorResult {
   status: VariantAnalysisMonitorStatus;
-  error?: string;
   scannedReposDownloaded?: number[],
   variantAnalysis?: VariantAnalysis
 }

--- a/extensions/ql-vscode/src/remote-queries/shared/variant-analysis.ts
+++ b/extensions/ql-vscode/src/remote-queries/shared/variant-analysis.ts
@@ -47,6 +47,13 @@ export enum VariantAnalysisStatus {
   Canceled = 'canceled',
 }
 
+export function isFinalVariantAnalysisStatus(status: VariantAnalysisStatus): boolean {
+  return [
+    // All states that indicates the analysis has completed and cannot change status anymore.
+    VariantAnalysisStatus.Succeeded, VariantAnalysisStatus.Failed, VariantAnalysisStatus.Canceled,
+  ].includes(status);
+}
+
 export enum VariantAnalysisFailureReason {
   NoReposQueried = 'noReposQueried',
   InternalError = 'internalError',

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-monitor.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-monitor.ts
@@ -43,7 +43,7 @@ export class VariantAnalysisMonitor extends DisposableObject {
       await this.sleep(VariantAnalysisMonitor.sleepTime);
 
       if (cancellationToken && cancellationToken.isCancellationRequested) {
-        return { status: 'Cancelled', error: 'Variant Analysis was canceled.' };
+        return { status: 'Canceled' };
       }
 
       const variantAnalysisSummary = await ghApiClient.getVariantAnalysis(
@@ -59,22 +59,14 @@ export class VariantAnalysisMonitor extends DisposableObject {
       const downloadedRepos = this.downloadVariantAnalysisResults(variantAnalysisSummary, scannedReposDownloaded);
       scannedReposDownloaded.push(...downloadedRepos);
 
-      if (variantAnalysis.failureReason) {
-        return {
-          status: 'Failed',
-          error: `Variant Analysis has failed: ${variantAnalysis.failureReason}`,
-          variantAnalysis: variantAnalysis
-        };
-      }
-
-      if (isFinalVariantAnalysisStatus(variantAnalysis.status)) {
+      if (isFinalVariantAnalysisStatus(variantAnalysis.status) || variantAnalysis.failureReason) {
         break;
       }
 
       attemptCount++;
     }
 
-    return { status: 'CompletedSuccessfully', scannedReposDownloaded: scannedReposDownloaded };
+    return { status: 'Completed', scannedReposDownloaded, variantAnalysis };
   }
 
   private scheduleForDownload(

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-monitor.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-monitor.ts
@@ -56,6 +56,9 @@ export class VariantAnalysisMonitor extends DisposableObject {
 
       this._onVariantAnalysisChange.fire(variantAnalysis);
 
+      const downloadedRepos = this.downloadVariantAnalysisResults(variantAnalysisSummary, scannedReposDownloaded);
+      scannedReposDownloaded.push(...downloadedRepos);
+
       if (variantAnalysis.failureReason) {
         return {
           status: 'Failed',
@@ -63,9 +66,6 @@ export class VariantAnalysisMonitor extends DisposableObject {
           variantAnalysis: variantAnalysis
         };
       }
-
-      const downloadedRepos = this.downloadVariantAnalysisResults(variantAnalysisSummary, scannedReposDownloaded);
-      scannedReposDownloaded.push(...downloadedRepos);
 
       if (isFinalVariantAnalysisStatus(variantAnalysis.status)) {
         break;

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-processor.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-processor.ts
@@ -62,7 +62,7 @@ export function processUpdatedVariantAnalysis(
     executionStartTime: previousVariantAnalysis.executionStartTime,
     createdAt: response.created_at,
     updatedAt: response.updated_at,
-    status: processApiStatus(response.status),
+    status: processApiStatus(response.status, response.failure_reason),
     completedAt: response.completed_at,
     actionsWorkflowRunId: response.actions_workflow_run_id,
     scannedRepos: scannedRepos,
@@ -158,12 +158,13 @@ function processApiRepoStatus(analysisStatus: ApiVariantAnalysisRepoStatus): Var
   }
 }
 
-function processApiStatus(status: ApiVariantAnalysisStatus): VariantAnalysisStatus {
-  switch (status) {
-    case 'in_progress':
-      return VariantAnalysisStatus.InProgress;
-    case 'completed':
-      return VariantAnalysisStatus.Succeeded;
+function processApiStatus(status: ApiVariantAnalysisStatus, failureReason: string | undefined): VariantAnalysisStatus {
+  if (status === 'in_progress') {
+    return VariantAnalysisStatus.InProgress;
+  } else if (failureReason !== undefined) {
+    return VariantAnalysisStatus.Failed;
+  } else {
+    return VariantAnalysisStatus.Succeeded;
   }
 }
 

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-monitor.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-monitor.test.ts
@@ -83,14 +83,14 @@ describe('Variant Analysis Monitor', async function() {
 
       const result = await variantAnalysisMonitor.monitorVariantAnalysis(variantAnalysis, cancellationTokenSource.token);
 
-      expect(result).to.eql({ status: 'Cancelled', error: 'Variant Analysis was canceled.' });
+      expect(result).to.eql({ status: 'Canceled' });
     });
 
     describe('when the variant analysis fails', async () => {
       let mockFailedApiResponse: VariantAnalysisApiResponse;
 
       beforeEach(async function() {
-        mockFailedApiResponse = createFailedMockApiResponse('in_progress');
+        mockFailedApiResponse = createFailedMockApiResponse();
         mockGetVariantAnalysis = sandbox.stub(ghApiClient, 'getVariantAnalysis').resolves(mockFailedApiResponse);
       });
 
@@ -98,8 +98,7 @@ describe('Variant Analysis Monitor', async function() {
         const result = await variantAnalysisMonitor.monitorVariantAnalysis(variantAnalysis, cancellationTokenSource.token);
 
         expect(mockGetVariantAnalysis.calledOnce).to.be.true;
-        expect(result.status).to.eql('Failed');
-        expect(result.error).to.eql(`Variant Analysis has failed: ${mockFailedApiResponse.failure_reason}`);
+        expect(result.status).to.eql('Completed');
         expect(result.variantAnalysis?.status).to.equal(VariantAnalysisStatus.Failed);
         expect(result.variantAnalysis?.failureReason).to.equal(processFailureReason(mockFailedApiResponse.failure_reason as VariantAnalysisFailureReason));
       });
@@ -130,7 +129,7 @@ describe('Variant Analysis Monitor', async function() {
         it('should succeed and return a list of scanned repo ids', async () => {
           const result = await variantAnalysisMonitor.monitorVariantAnalysis(variantAnalysis, cancellationTokenSource.token);
 
-          expect(result.status).to.equal('CompletedSuccessfully');
+          expect(result.status).to.equal('Completed');
           expect(result.scannedReposDownloaded).to.eql(succeededRepos.map(r => r.repository.id));
         });
 
@@ -173,7 +172,7 @@ describe('Variant Analysis Monitor', async function() {
         it('should succeed and return an empty list of scanned repo ids', async () => {
           const result = await variantAnalysisMonitor.monitorVariantAnalysis(variantAnalysis, cancellationTokenSource.token);
 
-          expect(result.status).to.equal('CompletedSuccessfully');
+          expect(result.status).to.equal('Completed');
           expect(result.scannedReposDownloaded).to.eql([]);
         });
 
@@ -194,7 +193,7 @@ describe('Variant Analysis Monitor', async function() {
         it('should succeed and return an empty list of scanned repo ids', async () => {
           const result = await variantAnalysisMonitor.monitorVariantAnalysis(variantAnalysis, cancellationTokenSource.token);
 
-          expect(result.status).to.equal('CompletedSuccessfully');
+          expect(result.status).to.equal('Completed');
           expect(result.scannedReposDownloaded).to.eql([]);
         });
 

--- a/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/gh-api/variant-analysis-api-response.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/gh-api/variant-analysis-api-response.ts
@@ -39,13 +39,10 @@ export function createMockApiResponse(
 }
 
 export function createFailedMockApiResponse(
-  status: VariantAnalysisStatus = 'in_progress',
   scannedRepos: VariantAnalysisScannedRepository[] = createMockScannedRepos(),
   skippedRepos: VariantAnalysisSkippedRepositories = createMockSkippedRepos(),
 ): VariantAnalysisApiResponse {
-  const variantAnalysis = createMockApiResponse(status, scannedRepos, skippedRepos);
-  variantAnalysis.status = status;
+  const variantAnalysis = createMockApiResponse('completed', scannedRepos, skippedRepos);
   variantAnalysis.failure_reason = 'internal_error';
-
   return variantAnalysis;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

This PR aims to make the variant analysis monitoring command able to handle all states and also be slightly cleaner in its logic. I don't think any of the changes in this PR are critical, but I think they are all improvements.

The changes made are:
- Instead of firing `_onVariantAnalysisChange` from three different places under various conditions, fire it from one place and always fire it in every loop right after getting the updated variant analysis summary.
  - I'm not sure why we fired the event before the loop. This is before we fetched the new updated state so we're just emitting the old state that the monitor was passed when it started up. In the case of rehydrating query history this state could be very old. My only thought is that it's to ensure that the event always fires at least once. Ignoring a HTTP error I think this PR still does that so I think that's fine.
- Try to available download results regardless of if the variant analysis has a failure reason. I'm not sure if this matters as possibly we only set a failure reason for errors that happen before triggering the workflow run, but the idea is to always download available results regardless of other errors. If there are some results available then we should show them to the user.
- Reduces the `VariantAnalysisMonitorResult` to only the cases that we actually use, and make it fit better to the variant analysis summary status.
  - There were various cases in that type that we never used, so it seems sensible to remove them.
  - There were other cases that I didn't really understand. What does it mean for the monitor to "complete unsuccessfully"?
  - This type is only used for this one return value, and in the production code this return value is not used. It's only read from tests as a way of verifying the behaviour of the monitoring command.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
