### PR TITLE
Fix indentation in exported markdown results

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/remote-queries-markdown-generation.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-markdown-generation.ts
@@ -205,6 +205,7 @@ function generateMarkdownForPathResults(
     const stepCount = codeFlow.threadFlows.length;
     const title = `Path with ${stepCount} steps`;
     for (let i = 0; i < stepCount; i++) {
+      const listNumber = i + 1;
       const threadFlow = codeFlow.threadFlows[i];
       const link = createMarkdownRemoteFileRef(
         threadFlow.fileLink,
@@ -217,8 +218,9 @@ function generateMarkdownForPathResults(
         threadFlow.highlightedRegion
       );
       // Indent the snippet to fit with the numbered list.
-      const codeSnippetIndented = codeSnippet.map((line) => `    ${line}`);
-      pathLines.push(`${i + 1}. ${link}`, ...codeSnippetIndented);
+      // The indentation is "n + 2" where the list number is an n-digit number.
+      const codeSnippetIndented = codeSnippet.map(line => ' '.repeat(listNumber.toString().length + 2) + line);
+      pathLines.push(`${listNumber}. ${link}`, ...codeSnippetIndented);
     }
     lines.push(
       ...buildExpandableMarkdownSection(title, pathLines)

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/path-problem/analyses-results.json
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/path-problem/analyses-results.json
@@ -612,6 +612,74 @@
                 },
                 "highlightedRegion": {
                   "startLine": 259,
+                  "startColumn": 42,
+                  "endLine": 259,
+                  "endColumn": 52
+                }
+              },
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec",
+                  "filePath": "npm-packages/meteor-installer/install.js"
+                },
+                "codeSnippet": {
+                  "startLine": 257,
+                  "endLine": 261,
+                  "text": "  if (isWindows()) {\n    //set for the current session and beyond\n    child_process.execSync(`setx path \"${meteorPath}/;%path%`);\n    return;\n  }\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 259,
+                  "startColumn": 42,
+                  "endLine": 259,
+                  "endColumn": 52
+                }
+              },
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec",
+                  "filePath": "npm-packages/meteor-installer/install.js"
+                },
+                "codeSnippet": {
+                  "startLine": 257,
+                  "endLine": 261,
+                  "text": "  if (isWindows()) {\n    //set for the current session and beyond\n    child_process.execSync(`setx path \"${meteorPath}/;%path%`);\n    return;\n  }\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 259,
+                  "startColumn": 42,
+                  "endLine": 259,
+                  "endColumn": 52
+                }
+              },
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec",
+                  "filePath": "npm-packages/meteor-installer/install.js"
+                },
+                "codeSnippet": {
+                  "startLine": 257,
+                  "endLine": 261,
+                  "text": "  if (isWindows()) {\n    //set for the current session and beyond\n    child_process.execSync(`setx path \"${meteorPath}/;%path%`);\n    return;\n  }\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 259,
+                  "startColumn": 42,
+                  "endLine": 259,
+                  "endColumn": 52
+                }
+              },
+              {
+                "fileLink": {
+                  "fileLinkPrefix": "https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec",
+                  "filePath": "npm-packages/meteor-installer/install.js"
+                },
+                "codeSnippet": {
+                  "startLine": 257,
+                  "endLine": 261,
+                  "text": "  if (isWindows()) {\n    //set for the current session and beyond\n    child_process.execSync(`setx path \"${meteorPath}/;%path%`);\n    return;\n  }\n"
+                },
+                "highlightedRegion": {
+                  "startLine": 259,
                   "startColumn": 28,
                   "endLine": 259,
                   "endColumn": 62

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/path-problem/expected/github-codeql.md
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/path-problem/expected/github-codeql.md
@@ -16,44 +16,44 @@
 <summary>Path with 5 steps</summary>
 
 1. [javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js#L4-L4)
-    <pre><code class="javascript">  path = require("path");
-    function cleanupTemp() {
-      let cmd = "rm -rf " + path.join(<strong>__dirname</strong>, "temp");
-      cp.execSync(cmd); // BAD
-    }
-    </code></pre>
-    
+   <pre><code class="javascript">  path = require("path");
+   function cleanupTemp() {
+     let cmd = "rm -rf " + path.join(<strong>__dirname</strong>, "temp");
+     cp.execSync(cmd); // BAD
+   }
+   </code></pre>
+   
 2. [javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js#L4-L4)
-    <pre><code class="javascript">  path = require("path");
-    function cleanupTemp() {
-      let cmd = "rm -rf " + <strong>path.join(__dirname, "temp")</strong>;
-      cp.execSync(cmd); // BAD
-    }
-    </code></pre>
-    
+   <pre><code class="javascript">  path = require("path");
+   function cleanupTemp() {
+     let cmd = "rm -rf " + <strong>path.join(__dirname, "temp")</strong>;
+     cp.execSync(cmd); // BAD
+   }
+   </code></pre>
+   
 3. [javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js#L4-L4)
-    <pre><code class="javascript">  path = require("path");
-    function cleanupTemp() {
-      let cmd = <strong>"rm -rf " + path.join(__dirname, "temp")</strong>;
-      cp.execSync(cmd); // BAD
-    }
-    </code></pre>
-    
+   <pre><code class="javascript">  path = require("path");
+   function cleanupTemp() {
+     let cmd = <strong>"rm -rf " + path.join(__dirname, "temp")</strong>;
+     cp.execSync(cmd); // BAD
+   }
+   </code></pre>
+   
 4. [javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js#L4-L4)
-    <pre><code class="javascript">  path = require("path");
-    function cleanupTemp() {
-      let <strong>cmd = "rm -rf " + path.join(__dirname, "temp")</strong>;
-      cp.execSync(cmd); // BAD
-    }
-    </code></pre>
-    
+   <pre><code class="javascript">  path = require("path");
+   function cleanupTemp() {
+     let <strong>cmd = "rm -rf " + path.join(__dirname, "temp")</strong>;
+     cp.execSync(cmd); // BAD
+   }
+   </code></pre>
+   
 5. [javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/src/Security/CWE-078/examples/shell-command-injection-from-environment.js#L5-L5)
-    <pre><code class="javascript">function cleanupTemp() {
-      let cmd = "rm -rf " + path.join(__dirname, "temp");
-      cp.execSync(<strong>cmd</strong>); // BAD
-    }
-    </code></pre>
-    
+   <pre><code class="javascript">function cleanupTemp() {
+     let cmd = "rm -rf " + path.join(__dirname, "temp");
+     cp.execSync(<strong>cmd</strong>); // BAD
+   }
+   </code></pre>
+   
 
 </details>
 
@@ -76,29 +76,29 @@
 <summary>Path with 3 steps</summary>
 
 1. [javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L6-L6)
-    <pre><code class="javascript">(function() {
-    	cp.execFileSync('rm',  ['-rf', path.join(__dirname, "temp")]); // GOOD
-    	cp.execSync('rm -rf ' + path.join(<strong>__dirname</strong>, "temp")); // BAD
-    
-    	execa.shell('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
-    </code></pre>
-    
+   <pre><code class="javascript">(function() {
+   	cp.execFileSync('rm',  ['-rf', path.join(__dirname, "temp")]); // GOOD
+   	cp.execSync('rm -rf ' + path.join(<strong>__dirname</strong>, "temp")); // BAD
+   
+   	execa.shell('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
+   </code></pre>
+   
 2. [javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L6-L6)
-    <pre><code class="javascript">(function() {
-    	cp.execFileSync('rm',  ['-rf', path.join(__dirname, "temp")]); // GOOD
-    	cp.execSync('rm -rf ' + <strong>path.join(__dirname, "temp")</strong>); // BAD
-    
-    	execa.shell('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
-    </code></pre>
-    
+   <pre><code class="javascript">(function() {
+   	cp.execFileSync('rm',  ['-rf', path.join(__dirname, "temp")]); // GOOD
+   	cp.execSync('rm -rf ' + <strong>path.join(__dirname, "temp")</strong>); // BAD
+   
+   	execa.shell('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
+   </code></pre>
+   
 3. [javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L6-L6)
-    <pre><code class="javascript">(function() {
-    	cp.execFileSync('rm',  ['-rf', path.join(__dirname, "temp")]); // GOOD
-    	cp.execSync(<strong>'rm -rf ' + path.join(__dirname, "temp")</strong>); // BAD
-    
-    	execa.shell('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
-    </code></pre>
-    
+   <pre><code class="javascript">(function() {
+   	cp.execFileSync('rm',  ['-rf', path.join(__dirname, "temp")]); // GOOD
+   	cp.execSync(<strong>'rm -rf ' + path.join(__dirname, "temp")</strong>); // BAD
+   
+   	execa.shell('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
+   </code></pre>
+   
 
 </details>
 
@@ -121,29 +121,29 @@
 <summary>Path with 3 steps</summary>
 
 1. [javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L8-L8)
-    <pre><code class="javascript">	cp.execSync('rm -rf ' + path.join(__dirname, "temp")); // BAD
-    
-    	execa.shell('rm -rf ' + path.join(<strong>__dirname</strong>, "temp")); // NOT OK
-    	execa.shellSync('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
-    
-    </code></pre>
-    
+   <pre><code class="javascript">	cp.execSync('rm -rf ' + path.join(__dirname, "temp")); // BAD
+   
+   	execa.shell('rm -rf ' + path.join(<strong>__dirname</strong>, "temp")); // NOT OK
+   	execa.shellSync('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
+   
+   </code></pre>
+   
 2. [javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L8-L8)
-    <pre><code class="javascript">	cp.execSync('rm -rf ' + path.join(__dirname, "temp")); // BAD
-    
-    	execa.shell('rm -rf ' + <strong>path.join(__dirname, "temp")</strong>); // NOT OK
-    	execa.shellSync('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
-    
-    </code></pre>
-    
+   <pre><code class="javascript">	cp.execSync('rm -rf ' + path.join(__dirname, "temp")); // BAD
+   
+   	execa.shell('rm -rf ' + <strong>path.join(__dirname, "temp")</strong>); // NOT OK
+   	execa.shellSync('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
+   
+   </code></pre>
+   
 3. [javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L8-L8)
-    <pre><code class="javascript">	cp.execSync('rm -rf ' + path.join(__dirname, "temp")); // BAD
-    
-    	execa.shell(<strong>'rm -rf ' + path.join(__dirname, "temp")</strong>); // NOT OK
-    	execa.shellSync('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
-    
-    </code></pre>
-    
+   <pre><code class="javascript">	cp.execSync('rm -rf ' + path.join(__dirname, "temp")); // BAD
+   
+   	execa.shell(<strong>'rm -rf ' + path.join(__dirname, "temp")</strong>); // NOT OK
+   	execa.shellSync('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
+   
+   </code></pre>
+   
 
 </details>
 
@@ -166,29 +166,29 @@
 <summary>Path with 3 steps</summary>
 
 1. [javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L9-L9)
-    <pre><code class="javascript">
-    	execa.shell('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
-    	execa.shellSync('rm -rf ' + path.join(<strong>__dirname</strong>, "temp")); // NOT OK
-    
-    	const safe = "\"" + path.join(__dirname, "temp") + "\"";
-    </code></pre>
-    
+   <pre><code class="javascript">
+   	execa.shell('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
+   	execa.shellSync('rm -rf ' + path.join(<strong>__dirname</strong>, "temp")); // NOT OK
+   
+   	const safe = "\"" + path.join(__dirname, "temp") + "\"";
+   </code></pre>
+   
 2. [javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L9-L9)
-    <pre><code class="javascript">
-    	execa.shell('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
-    	execa.shellSync('rm -rf ' + <strong>path.join(__dirname, "temp")</strong>); // NOT OK
-    
-    	const safe = "\"" + path.join(__dirname, "temp") + "\"";
-    </code></pre>
-    
+   <pre><code class="javascript">
+   	execa.shell('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
+   	execa.shellSync('rm -rf ' + <strong>path.join(__dirname, "temp")</strong>); // NOT OK
+   
+   	const safe = "\"" + path.join(__dirname, "temp") + "\"";
+   </code></pre>
+   
 3. [javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js](https://github.com/github/codeql/blob/48015e5a2e6202131f2d1062cc066dc33ed69a9b/javascript/ql/test/query-tests/Security/CWE-078/tst_shell-command-injection-from-environment.js#L9-L9)
-    <pre><code class="javascript">
-    	execa.shell('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
-    	execa.shellSync(<strong>'rm -rf ' + path.join(__dirname, "temp")</strong>); // NOT OK
-    
-    	const safe = "\"" + path.join(__dirname, "temp") + "\"";
-    </code></pre>
-    
+   <pre><code class="javascript">
+   	execa.shell('rm -rf ' + path.join(__dirname, "temp")); // NOT OK
+   	execa.shellSync(<strong>'rm -rf ' + path.join(__dirname, "temp")</strong>); // NOT OK
+   
+   	const safe = "\"" + path.join(__dirname, "temp") + "\"";
+   </code></pre>
+   
 
 </details>
 

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/path-problem/expected/meteor-meteor.md
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/markdown-generation/data/interpreted-results/path-problem/expected/meteor-meteor.md
@@ -14,61 +14,93 @@
 #### Paths
 
 <details>
-<summary>Path with 7 steps</summary>
+<summary>Path with 11 steps</summary>
 
 1. [npm-packages/meteor-installer/config.js](https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec/npm-packages/meteor-installer/config.js#L39-L39)
-    <pre><code class="javascript">
-    const meteorLocalFolder = '.meteor';
-    const meteorPath = <strong>path.resolve(rootPath, meteorLocalFolder)</strong>;
-    
-    module.exports = {
-    </code></pre>
-    
+   <pre><code class="javascript">
+   const meteorLocalFolder = '.meteor';
+   const meteorPath = <strong>path.resolve(rootPath, meteorLocalFolder)</strong>;
+   
+   module.exports = {
+   </code></pre>
+   
 2. [npm-packages/meteor-installer/config.js](https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec/npm-packages/meteor-installer/config.js#L39-L39)
-    <pre><code class="javascript">
-    const meteorLocalFolder = '.meteor';
-    const <strong>meteorPath = path.resolve(rootPath, meteorLocalFolder)</strong>;
-    
-    module.exports = {
-    </code></pre>
-    
+   <pre><code class="javascript">
+   const meteorLocalFolder = '.meteor';
+   const <strong>meteorPath = path.resolve(rootPath, meteorLocalFolder)</strong>;
+   
+   module.exports = {
+   </code></pre>
+   
 3. [npm-packages/meteor-installer/config.js](https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec/npm-packages/meteor-installer/config.js#L44-L44)
-    <pre><code class="javascript">  METEOR_LATEST_VERSION,
-      extractPath: rootPath,
-      <strong>meteorPath</strong>,
-      release: process.env.INSTALL_METEOR_VERSION || METEOR_LATEST_VERSION,
-      rootPath,
-    </code></pre>
-    
+   <pre><code class="javascript">  METEOR_LATEST_VERSION,
+     extractPath: rootPath,
+     <strong>meteorPath</strong>,
+     release: process.env.INSTALL_METEOR_VERSION || METEOR_LATEST_VERSION,
+     rootPath,
+   </code></pre>
+   
 4. [npm-packages/meteor-installer/install.js](https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec/npm-packages/meteor-installer/install.js#L12-L12)
-    <pre><code class="javascript">const os = require('os');
-    const {
-      <strong>meteorPath</strong>,
-      release,
-      startedPath,
-    </code></pre>
-    
+   <pre><code class="javascript">const os = require('os');
+   const {
+     <strong>meteorPath</strong>,
+     release,
+     startedPath,
+   </code></pre>
+   
 5. [npm-packages/meteor-installer/install.js](https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec/npm-packages/meteor-installer/install.js#L11-L23)
-    <pre><code class="javascript">const tmp = require('tmp');
-    const os = require('os');
-    const <strong>{</strong>
-    <strong>  meteorPath,</strong>
-    <strong>  release,</strong>
-    <strong>  startedPath,</strong>
-    <strong>  extractPath,</strong>
-    <strong>  isWindows,</strong>
-    <strong>  rootPath,</strong>
-    <strong>  sudoUser,</strong>
-    <strong>  isSudo,</strong>
-    <strong>  isMac,</strong>
-    <strong>  METEOR_LATEST_VERSION,</strong>
-    <strong>  shouldSetupExecPath,</strong>
-    <strong>} = require('./config.js')</strong>;
-    const { uninstall } = require('./uninstall');
-    const {
-    </code></pre>
-    
+   <pre><code class="javascript">const tmp = require('tmp');
+   const os = require('os');
+   const <strong>{</strong>
+   <strong>  meteorPath,</strong>
+   <strong>  release,</strong>
+   <strong>  startedPath,</strong>
+   <strong>  extractPath,</strong>
+   <strong>  isWindows,</strong>
+   <strong>  rootPath,</strong>
+   <strong>  sudoUser,</strong>
+   <strong>  isSudo,</strong>
+   <strong>  isMac,</strong>
+   <strong>  METEOR_LATEST_VERSION,</strong>
+   <strong>  shouldSetupExecPath,</strong>
+   <strong>} = require('./config.js')</strong>;
+   const { uninstall } = require('./uninstall');
+   const {
+   </code></pre>
+   
 6. [npm-packages/meteor-installer/install.js](https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec/npm-packages/meteor-installer/install.js#L259-L259)
+   <pre><code class="javascript">  if (isWindows()) {
+       //set for the current session and beyond
+       child_process.execSync(`setx path "${<strong>meteorPath</strong>}/;%path%`);
+       return;
+     }
+   </code></pre>
+   
+7. [npm-packages/meteor-installer/install.js](https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec/npm-packages/meteor-installer/install.js#L259-L259)
+   <pre><code class="javascript">  if (isWindows()) {
+       //set for the current session and beyond
+       child_process.execSync(`setx path "${<strong>meteorPath</strong>}/;%path%`);
+       return;
+     }
+   </code></pre>
+   
+8. [npm-packages/meteor-installer/install.js](https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec/npm-packages/meteor-installer/install.js#L259-L259)
+   <pre><code class="javascript">  if (isWindows()) {
+       //set for the current session and beyond
+       child_process.execSync(`setx path "${<strong>meteorPath</strong>}/;%path%`);
+       return;
+     }
+   </code></pre>
+   
+9. [npm-packages/meteor-installer/install.js](https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec/npm-packages/meteor-installer/install.js#L259-L259)
+   <pre><code class="javascript">  if (isWindows()) {
+       //set for the current session and beyond
+       child_process.execSync(`setx path "${<strong>meteorPath</strong>}/;%path%`);
+       return;
+     }
+   </code></pre>
+   
+10. [npm-packages/meteor-installer/install.js](https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec/npm-packages/meteor-installer/install.js#L259-L259)
     <pre><code class="javascript">  if (isWindows()) {
         //set for the current session and beyond
         child_process.execSync(`setx path "${<strong>meteorPath</strong>}/;%path%`);
@@ -76,7 +108,7 @@
       }
     </code></pre>
     
-7. [npm-packages/meteor-installer/install.js](https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec/npm-packages/meteor-installer/install.js#L259-L259)
+11. [npm-packages/meteor-installer/install.js](https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec/npm-packages/meteor-installer/install.js#L259-L259)
     <pre><code class="javascript">  if (isWindows()) {
         //set for the current session and beyond
         child_process.execSync(<strong>`setx path "${meteorPath}/;%path%`</strong>);
@@ -91,21 +123,21 @@
 <summary>Path with 2 steps</summary>
 
 1. [npm-packages/meteor-installer/config.js](https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec/npm-packages/meteor-installer/config.js#L39-L39)
-    <pre><code class="javascript">
-    const meteorLocalFolder = '.meteor';
-    const meteorPath = <strong>path.resolve(rootPath, meteorLocalFolder)</strong>;
-    
-    module.exports = {
-    </code></pre>
-    
+   <pre><code class="javascript">
+   const meteorLocalFolder = '.meteor';
+   const meteorPath = <strong>path.resolve(rootPath, meteorLocalFolder)</strong>;
+   
+   module.exports = {
+   </code></pre>
+   
 2. [npm-packages/meteor-installer/install.js](https://github.com/meteor/meteor/blob/73b538fe201cbfe89dd0c709689023f9b3eab1ec/npm-packages/meteor-installer/install.js#L259-L259)
-    <pre><code class="javascript">  if (isWindows()) {
-        //set for the current session and beyond
-        child_process.execSync(<strong>`setx path "${meteorPath}/;%path%`</strong>);
-        return;
-      }
-    </code></pre>
-    
+   <pre><code class="javascript">  if (isWindows()) {
+       //set for the current session and beyond
+       child_process.execSync(<strong>`setx path "${meteorPath}/;%path%`</strong>);
+       return;
+     }
+   </code></pre>
+   
 
 </details>
 


### PR DESCRIPTION
This PR fixes the markdown export for remote query results. Previously, paths with more than 100 steps had their code snippets badly indented, which caused the markdown to render badly on GitHub Gists. 

I've changed the indentation to match the length of the list number, and updated tests to check this variable indentation size.

## Checklist

N/A - this is a private beta feature. See internal issue for more details!

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
