### PR TITLE
Fix flakey test

### DIFF
--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/queries.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/queries.test.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 import * as fs from 'fs-extra';
 import { expect } from 'chai';
 import * as yaml from 'js-yaml';
+import { faker } from '@faker-js/faker';
 
 import { DatabaseItem, DatabaseManager } from '../../databases';
 import { CodeQLExtensionInterface } from '../../extension';
@@ -15,7 +16,6 @@ import { skipIfNoCodeQL } from '../ensureCli';
 import { tmpDir } from '../../helpers';
 import { createInitialQueryInfo } from '../../run-queries-shared';
 import { QueryRunner } from '../../queryRunner';
-
 
 /**
  * Integration tests for queries
@@ -41,7 +41,6 @@ describe('Queries', function() {
   let oldQlpackLockFile: string; // codeql v2.6.3 and earlier
   let qlFile: string;
 
-
   beforeEach(async () => {
     sandbox = sinon.createSandbox();
 
@@ -53,17 +52,13 @@ describe('Queries', function() {
         qs = extension.qs;
         cli.quiet = true;
         ctx = extension.ctx;
-        qlpackFile = `${ctx.storageUri?.fsPath}/quick-queries/qlpack.yml`;
+        qlpackFile = `${ctx.storageUri?.fsPath}/quick-queries/qlpack-${faker.name}.yml`;
         qlpackLockFile = `${ctx.storageUri?.fsPath}/quick-queries/codeql-pack.lock.yml`;
         oldQlpackLockFile = `${ctx.storageUri?.fsPath}/quick-queries/qlpack.lock.yml`;
-        qlFile = `${ctx.storageUri?.fsPath}/quick-queries/quick-query.ql`;
+        qlFile = `${ctx.storageUri?.fsPath}/quick-queries/quick-query-${faker.name}.ql`;
       } else {
         throw new Error('Extension not initialized. Make sure cli is downloaded and installed properly.');
       }
-
-      // Ensure we are starting from a clean slate.
-      safeDel(qlFile);
-      safeDel(qlpackFile);
 
       progress = sandbox.spy();
       token = {} as CancellationToken;


### PR DESCRIPTION
This test has been quite flakey due to timeout errors:

```
1) "before each" hook: beforeEach for "should avoid creating a quick query":
     Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
      at listOnTimeout (node:internal/timers:559:17)
      at processTimers (node:internal/timers:502:7)
```

Since this is an async test, let's attempt to make all file operations use their asynchronous counterparts and see if this allows our test to finish on time.

Normally I'd consider increasing the timeout but the test itself doesn't load massive amounts of data so the culprit seems to be an unresolved promise.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
