### PR TITLE
Don't show "open on github" link when we don't yet have anything to show

### DIFF
--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -199,7 +199,13 @@ export class HistoryTreeDataProvider extends DisposableObject implements TreeDat
   private async getContextValue(element: QueryHistoryInfo): Promise<string> {
     switch (element.status) {
       case QueryStatus.InProgress:
-        return element.t === 'local' ? 'inProgressResultsItem' : 'inProgressRemoteResultsItem';
+        if (element.t === 'local') {
+          return 'inProgressResultsItem';
+        } else if (element.t === 'variant-analysis' && element.variantAnalysis.actionsWorkflowRunId === undefined) {
+          return 'pendingRemoteResultsItem';
+        } else {
+          return 'inProgressRemoteResultsItem';
+        }
       case QueryStatus.Completed:
         if (element.t === 'local') {
           const hasResults = await element.completedQuery?.query.hasInterpretedResults();

--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -173,33 +173,47 @@ export class HistoryTreeDataProvider extends DisposableObject implements TreeDat
 
     // Populate the icon and the context value. We use the context value to
     // control which commands are visible in the context menu.
-    let hasResults;
+    treeItem.iconPath = this.getIconPath(element);
+    treeItem.contextValue = await this.getContextValue(element);
+
+    return treeItem;
+  }
+
+  private getIconPath(element: QueryHistoryInfo): ThemeIcon | string {
     switch (element.status) {
       case QueryStatus.InProgress:
-        treeItem.iconPath = new ThemeIcon('sync~spin');
-        treeItem.contextValue = element.t === 'local' ? 'inProgressResultsItem' : 'inProgressRemoteResultsItem';
-        break;
+        return new ThemeIcon('sync~spin');
       case QueryStatus.Completed:
         if (element.t === 'local') {
-          hasResults = await element.completedQuery?.query.hasInterpretedResults();
-          treeItem.iconPath = this.localSuccessIconPath;
-          treeItem.contextValue = hasResults
-            ? 'interpretedResultsItem'
-            : 'rawResultsItem';
+          return this.localSuccessIconPath;
         } else {
-          treeItem.iconPath = this.remoteSuccessIconPath;
-          treeItem.contextValue = 'remoteResultsItem';
+          return this.remoteSuccessIconPath;
         }
-        break;
       case QueryStatus.Failed:
-        treeItem.iconPath = this.failedIconPath;
-        treeItem.contextValue = element.t === 'local' ? 'cancelledResultsItem' : 'cancelledRemoteResultsItem';
-        break;
+        return this.failedIconPath;
       default:
         assertNever(element.status);
     }
+  }
 
-    return treeItem;
+  private async getContextValue(element: QueryHistoryInfo): Promise<string> {
+    switch (element.status) {
+      case QueryStatus.InProgress:
+        return element.t === 'local' ? 'inProgressResultsItem' : 'inProgressRemoteResultsItem';
+      case QueryStatus.Completed:
+        if (element.t === 'local') {
+          const hasResults = await element.completedQuery?.query.hasInterpretedResults();
+          return hasResults
+            ? 'interpretedResultsItem'
+            : 'rawResultsItem';
+        } else {
+          return 'remoteResultsItem';
+        }
+      case QueryStatus.Failed:
+        return element.t === 'local' ? 'cancelledResultsItem' : 'cancelledRemoteResultsItem';
+      default:
+        assertNever(element.status);
+    }
   }
 
   getChildren(


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

We were trying to show the "Open variant analysis on github" link before we knew what the actions workflow run ID was, and therefore we were generating links like https://github.com/dsp-testing/qc-controller/actions/runs/undefined

See the individual commits on this PR. The first does some drive-by recfactoring and then the second commit actually implements the change in behaviour. I've tested it manually and it seems to be working as expected.

I went with just pulling `getIconPath` and `getContextValue` out to methods in `query-history.ts` because they unfortunately have references to instance variables and to imports from `vscode`. Otherwise I would have moved them to `query-history-info.ts`, but maybe we can do that in the future. For this PR I just wanted to make an improvement and not get stuck on it.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
