### PR TITLE
Don't await the monitoring command

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
@@ -64,7 +64,7 @@ export class VariantAnalysisManager extends DisposableObject implements VariantA
     } else {
       await this.setVariantAnalysis(variantAnalysis);
       if (!await isVariantAnalysisComplete(variantAnalysis, this.makeResultDownloadChecker(variantAnalysis))) {
-        await commands.executeCommand('codeQL.monitorVariantAnalysis', variantAnalysis);
+        void commands.executeCommand('codeQL.monitorVariantAnalysis', variantAnalysis);
       }
     }
   }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Awaiting a command means it waits for the command to finish and gives you its return value. We don't want that in this case because the monitoring command takes a long time.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
