### PR TITLE
Refactor: Move `sleep` function to shared module and import it

### DIFF
--- a/extensions/ql-vscode/src/pure/time.ts
+++ b/extensions/ql-vscode/src/pure/time.ts
@@ -87,3 +87,7 @@ function createFormatter(unit: string) {
     unitDisplay: 'long'
   });
 }
+
+export async function sleep(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-monitor.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-monitor.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { Credentials } from '../authentication';
 import { Logger } from '../logging';
+import { sleep } from '../pure/time';
 import { getWorkflowStatus, isArtifactAvailable, RESULT_INDEX_ARTIFACT_NAME } from './gh-api/gh-actions-api-client';
 import { RemoteQuery } from './remote-query';
 import { RemoteQueryWorkflowResult } from './remote-query-workflow-result';
@@ -30,7 +31,7 @@ export class RemoteQueriesMonitor {
     let attemptCount = 0;
 
     while (attemptCount <= RemoteQueriesMonitor.maxAttemptCount) {
-      await this.sleep(RemoteQueriesMonitor.sleepTime);
+      await sleep(RemoteQueriesMonitor.sleepTime);
 
       if (cancellationToken && cancellationToken.isCancellationRequested) {
         return { status: 'Cancelled' };
@@ -69,10 +70,6 @@ export class RemoteQueriesMonitor {
 
     void this.logger.log('Variant analysis monitoring timed out after 2 days');
     return { status: 'Cancelled' };
-  }
-
-  private async sleep(ms: number) {
-    return new Promise(resolve => setTimeout(resolve, ms));
   }
 }
 

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-monitor.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-monitor.ts
@@ -10,6 +10,7 @@ import {
 import { VariantAnalysisMonitorResult } from './shared/variant-analysis-monitor-result';
 import { processUpdatedVariantAnalysis } from './variant-analysis-processor';
 import { DisposableObject } from '../pure/disposable-object';
+import { sleep } from '../pure/time';
 
 export class VariantAnalysisMonitor extends DisposableObject {
   // With a sleep of 5 seconds, the maximum number of attempts takes
@@ -40,7 +41,7 @@ export class VariantAnalysisMonitor extends DisposableObject {
     const scannedReposDownloaded: number[] = [];
 
     while (attemptCount <= VariantAnalysisMonitor.maxAttemptCount) {
-      await this.sleep(VariantAnalysisMonitor.sleepTime);
+      await sleep(VariantAnalysisMonitor.sleepTime);
 
       if (cancellationToken && cancellationToken.isCancellationRequested) {
         return { status: 'Canceled' };
@@ -107,9 +108,5 @@ export class VariantAnalysisMonitor extends DisposableObject {
     });
 
     return downloadedRepos;
-  }
-
-  private async sleep(ms: number) {
-    return new Promise(resolve => setTimeout(resolve, ms));
   }
 }

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/query-results.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/query-results.test.ts
@@ -13,6 +13,7 @@ import { slurpQueryHistory, splatQueryHistory } from '../../query-serialization'
 import { formatLegacyMessage, QueryInProgress } from '../../legacy-query-server/run-queries';
 import { EvaluationResult, QueryResultType } from '../../pure/legacy-messages';
 import Sinon = require('sinon');
+import { sleep } from '../../pure/time';
 
 describe('query-results', () => {
   let disposeSpy: sinon.SinonSpy;
@@ -453,10 +454,6 @@ describe('query-results', () => {
     } catch (e) {
       // ignore
     }
-  }
-
-  async function sleep(ms: number) {
-    return new Promise(resolve => setTimeout(resolve, ms));
   }
 
   function createMockQueryWithResults(


### PR DESCRIPTION
We define a `sleep` function in about 3 different places. This PR adds the `sleep` function to the shared "time" module, so we can re-use the function instead of redefining it. 

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
