### PR TITLE
Rename `not_found_repo_nwos` to `not_found_repos`

### DIFF
--- a/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/13-getVariantAnalysis.json
+++ b/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/13-getVariantAnalysis.json
@@ -756,7 +756,7 @@
             }
           ]
         },
-        "not_found_repo_nwos": {
+        "not_found_repos": {
           "repository_count": 110,
           "repository_full_names": [
             "evanw/node-source-map-support",

--- a/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/14-getVariantAnalysis.json
+++ b/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/14-getVariantAnalysis.json
@@ -756,7 +756,7 @@
             }
           ]
         },
-        "not_found_repo_nwos": {
+        "not_found_repos": {
           "repository_count": 110,
           "repository_full_names": [
             "evanw/node-source-map-support",

--- a/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/15-getVariantAnalysis.json
+++ b/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/15-getVariantAnalysis.json
@@ -756,7 +756,7 @@
             }
           ]
         },
-        "not_found_repo_nwos": {
+        "not_found_repos": {
           "repository_count": 110,
           "repository_full_names": [
             "evanw/node-source-map-support",

--- a/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/16-getVariantAnalysis.json
+++ b/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/16-getVariantAnalysis.json
@@ -756,7 +756,7 @@
             }
           ]
         },
-        "not_found_repo_nwos": {
+        "not_found_repos": {
           "repository_count": 110,
           "repository_full_names": [
             "evanw/node-source-map-support",

--- a/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/17-getVariantAnalysis.json
+++ b/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/17-getVariantAnalysis.json
@@ -756,7 +756,7 @@
             }
           ]
         },
-        "not_found_repo_nwos": {
+        "not_found_repos": {
           "repository_count": 110,
           "repository_full_names": [
             "evanw/node-source-map-support",

--- a/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/18-getVariantAnalysis.json
+++ b/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/18-getVariantAnalysis.json
@@ -760,7 +760,7 @@
             }
           ]
         },
-        "not_found_repo_nwos": {
+        "not_found_repos": {
           "repository_count": 110,
           "repository_full_names": [
             "evanw/node-source-map-support",

--- a/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/19-getVariantAnalysis.json
+++ b/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/19-getVariantAnalysis.json
@@ -760,7 +760,7 @@
             }
           ]
         },
-        "not_found_repo_nwos": {
+        "not_found_repos": {
           "repository_count": 110,
           "repository_full_names": [
             "evanw/node-source-map-support",

--- a/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/2-getVariantAnalysis.json
+++ b/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/2-getVariantAnalysis.json
@@ -752,7 +752,7 @@
             }
           ]
         },
-        "not_found_repo_nwos": {
+        "not_found_repos": {
           "repository_count": 110,
           "repository_full_names": [
             "evanw/node-source-map-support",

--- a/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/20-getVariantAnalysis.json
+++ b/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/20-getVariantAnalysis.json
@@ -760,7 +760,7 @@
             }
           ]
         },
-        "not_found_repo_nwos": {
+        "not_found_repos": {
           "repository_count": 110,
           "repository_full_names": [
             "evanw/node-source-map-support",

--- a/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/21-getVariantAnalysis.json
+++ b/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/21-getVariantAnalysis.json
@@ -760,7 +760,7 @@
             }
           ]
         },
-        "not_found_repo_nwos": {
+        "not_found_repos": {
           "repository_count": 110,
           "repository_full_names": [
             "evanw/node-source-map-support",

--- a/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/22-getVariantAnalysis.json
+++ b/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/22-getVariantAnalysis.json
@@ -760,7 +760,7 @@
             }
           ]
         },
-        "not_found_repo_nwos": {
+        "not_found_repos": {
           "repository_count": 110,
           "repository_full_names": [
             "evanw/node-source-map-support",

--- a/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/23-getVariantAnalysis.json
+++ b/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/23-getVariantAnalysis.json
@@ -760,7 +760,7 @@
             }
           ]
         },
-        "not_found_repo_nwos": {
+        "not_found_repos": {
           "repository_count": 110,
           "repository_full_names": [
             "evanw/node-source-map-support",

--- a/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/26-getVariantAnalysis.json
+++ b/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/26-getVariantAnalysis.json
@@ -760,7 +760,7 @@
             }
           ]
         },
-        "not_found_repo_nwos": {
+        "not_found_repos": {
           "repository_count": 110,
           "repository_full_names": [
             "evanw/node-source-map-support",

--- a/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/27-getVariantAnalysis.json
+++ b/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/27-getVariantAnalysis.json
@@ -760,7 +760,7 @@
             }
           ]
         },
-        "not_found_repo_nwos": {
+        "not_found_repos": {
           "repository_count": 110,
           "repository_full_names": [
             "evanw/node-source-map-support",

--- a/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/28-getVariantAnalysis.json
+++ b/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/28-getVariantAnalysis.json
@@ -760,7 +760,7 @@
             }
           ]
         },
-        "not_found_repo_nwos": {
+        "not_found_repos": {
           "repository_count": 110,
           "repository_full_names": [
             "evanw/node-source-map-support",

--- a/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/29-getVariantAnalysis.json
+++ b/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/29-getVariantAnalysis.json
@@ -760,7 +760,7 @@
             }
           ]
         },
-        "not_found_repo_nwos": {
+        "not_found_repos": {
           "repository_count": 110,
           "repository_full_names": [
             "evanw/node-source-map-support",

--- a/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/3-getVariantAnalysis.json
+++ b/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/3-getVariantAnalysis.json
@@ -752,7 +752,7 @@
             }
           ]
         },
-        "not_found_repo_nwos": {
+        "not_found_repos": {
           "repository_count": 110,
           "repository_full_names": [
             "evanw/node-source-map-support",

--- a/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/30-getVariantAnalysis.json
+++ b/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/30-getVariantAnalysis.json
@@ -760,7 +760,7 @@
             }
           ]
         },
-        "not_found_repo_nwos": {
+        "not_found_repos": {
           "repository_count": 110,
           "repository_full_names": [
             "evanw/node-source-map-support",

--- a/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/31-getVariantAnalysis.json
+++ b/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/31-getVariantAnalysis.json
@@ -760,7 +760,7 @@
             }
           ]
         },
-        "not_found_repo_nwos": {
+        "not_found_repos": {
           "repository_count": 110,
           "repository_full_names": [
             "evanw/node-source-map-support",

--- a/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/32-getVariantAnalysis.json
+++ b/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/32-getVariantAnalysis.json
@@ -760,7 +760,7 @@
             }
           ]
         },
-        "not_found_repo_nwos": {
+        "not_found_repos": {
           "repository_count": 110,
           "repository_full_names": [
             "evanw/node-source-map-support",

--- a/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/33-getVariantAnalysis.json
+++ b/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/33-getVariantAnalysis.json
@@ -760,7 +760,7 @@
             }
           ]
         },
-        "not_found_repo_nwos": {
+        "not_found_repos": {
           "repository_count": 110,
           "repository_full_names": [
             "evanw/node-source-map-support",

--- a/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/34-getVariantAnalysis.json
+++ b/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/34-getVariantAnalysis.json
@@ -760,7 +760,7 @@
             }
           ]
         },
-        "not_found_repo_nwos": {
+        "not_found_repos": {
           "repository_count": 110,
           "repository_full_names": [
             "evanw/node-source-map-support",

--- a/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/36-getVariantAnalysis.json
+++ b/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/36-getVariantAnalysis.json
@@ -760,7 +760,7 @@
             }
           ]
         },
-        "not_found_repo_nwos": {
+        "not_found_repos": {
           "repository_count": 110,
           "repository_full_names": [
             "evanw/node-source-map-support",

--- a/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/38-getVariantAnalysis.json
+++ b/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/38-getVariantAnalysis.json
@@ -760,7 +760,7 @@
             }
           ]
         },
-        "not_found_repo_nwos": {
+        "not_found_repos": {
           "repository_count": 110,
           "repository_full_names": [
             "evanw/node-source-map-support",

--- a/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/39-getVariantAnalysis.json
+++ b/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/39-getVariantAnalysis.json
@@ -760,7 +760,7 @@
             }
           ]
         },
-        "not_found_repo_nwos": {
+        "not_found_repos": {
           "repository_count": 110,
           "repository_full_names": [
             "evanw/node-source-map-support",

--- a/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/4-getVariantAnalysis.json
+++ b/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/4-getVariantAnalysis.json
@@ -752,7 +752,7 @@
             }
           ]
         },
-        "not_found_repo_nwos": {
+        "not_found_repos": {
           "repository_count": 110,
           "repository_full_names": [
             "evanw/node-source-map-support",

--- a/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/40-getVariantAnalysis.json
+++ b/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/40-getVariantAnalysis.json
@@ -760,7 +760,7 @@
             }
           ]
         },
-        "not_found_repo_nwos": {
+        "not_found_repos": {
           "repository_count": 110,
           "repository_full_names": [
             "evanw/node-source-map-support",

--- a/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/41-getVariantAnalysis.json
+++ b/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/41-getVariantAnalysis.json
@@ -760,7 +760,7 @@
             }
           ]
         },
-        "not_found_repo_nwos": {
+        "not_found_repos": {
           "repository_count": 110,
           "repository_full_names": [
             "evanw/node-source-map-support",

--- a/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/42-getVariantAnalysis.json
+++ b/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/42-getVariantAnalysis.json
@@ -760,7 +760,7 @@
             }
           ]
         },
-        "not_found_repo_nwos": {
+        "not_found_repos": {
           "repository_count": 110,
           "repository_full_names": [
             "evanw/node-source-map-support",

--- a/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/43-getVariantAnalysis.json
+++ b/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/43-getVariantAnalysis.json
@@ -760,7 +760,7 @@
             }
           ]
         },
-        "not_found_repo_nwos": {
+        "not_found_repos": {
           "repository_count": 110,
           "repository_full_names": [
             "evanw/node-source-map-support",

--- a/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/44-getVariantAnalysis.json
+++ b/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/44-getVariantAnalysis.json
@@ -762,7 +762,7 @@
             }
           ]
         },
-        "not_found_repo_nwos": {
+        "not_found_repos": {
           "repository_count": 110,
           "repository_full_names": [
             "evanw/node-source-map-support",

--- a/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/47-getVariantAnalysis.json
+++ b/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/47-getVariantAnalysis.json
@@ -762,7 +762,7 @@
             }
           ]
         },
-        "not_found_repo_nwos": {
+        "not_found_repos": {
           "repository_count": 110,
           "repository_full_names": [
             "evanw/node-source-map-support",

--- a/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/48-getVariantAnalysis.json
+++ b/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/48-getVariantAnalysis.json
@@ -762,7 +762,7 @@
             }
           ]
         },
-        "not_found_repo_nwos": {
+        "not_found_repos": {
           "repository_count": 110,
           "repository_full_names": [
             "evanw/node-source-map-support",

--- a/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/49-getVariantAnalysis.json
+++ b/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/49-getVariantAnalysis.json
@@ -762,7 +762,7 @@
             }
           ]
         },
-        "not_found_repo_nwos": {
+        "not_found_repos": {
           "repository_count": 110,
           "repository_full_names": [
             "evanw/node-source-map-support",

--- a/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/5-getVariantAnalysis.json
+++ b/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/5-getVariantAnalysis.json
@@ -752,7 +752,7 @@
             }
           ]
         },
-        "not_found_repo_nwos": {
+        "not_found_repos": {
           "repository_count": 110,
           "repository_full_names": [
             "evanw/node-source-map-support",

--- a/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/50-getVariantAnalysis.json
+++ b/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/50-getVariantAnalysis.json
@@ -762,7 +762,7 @@
             }
           ]
         },
-        "not_found_repo_nwos": {
+        "not_found_repos": {
           "repository_count": 110,
           "repository_full_names": [
             "evanw/node-source-map-support",

--- a/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/51-getVariantAnalysis.json
+++ b/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/51-getVariantAnalysis.json
@@ -763,7 +763,7 @@
             }
           ]
         },
-        "not_found_repo_nwos": {
+        "not_found_repos": {
           "repository_count": 110,
           "repository_full_names": [
             "evanw/node-source-map-support",

--- a/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/6-getVariantAnalysis.json
+++ b/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/6-getVariantAnalysis.json
@@ -752,7 +752,7 @@
             }
           ]
         },
-        "not_found_repo_nwos": {
+        "not_found_repos": {
           "repository_count": 110,
           "repository_full_names": [
             "evanw/node-source-map-support",

--- a/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/7-getVariantAnalysis.json
+++ b/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/7-getVariantAnalysis.json
@@ -752,7 +752,7 @@
             }
           ]
         },
-        "not_found_repo_nwos": {
+        "not_found_repos": {
           "repository_count": 110,
           "repository_full_names": [
             "evanw/node-source-map-support",

--- a/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/8-getVariantAnalysis.json
+++ b/extensions/ql-vscode/src/mocks/scenarios/problem-query-warnings/8-getVariantAnalysis.json
@@ -756,7 +756,7 @@
             }
           ]
         },
-        "not_found_repo_nwos": {
+        "not_found_repos": {
           "repository_count": 110,
           "repository_full_names": [
             "evanw/node-source-map-support",

--- a/extensions/ql-vscode/src/remote-queries/gh-api/variant-analysis.ts
+++ b/extensions/ql-vscode/src/remote-queries/gh-api/variant-analysis.ts
@@ -79,7 +79,7 @@ export interface VariantAnalysisRepoTask {
 
 export interface VariantAnalysisSkippedRepositories {
   access_mismatch_repos?: VariantAnalysisSkippedRepositoryGroup,
-  not_found_repo_nwos?: VariantAnalysisNotFoundRepositoryGroup,
+  not_found_repos?: VariantAnalysisNotFoundRepositoryGroup,
   no_codeql_db_repos?: VariantAnalysisSkippedRepositoryGroup,
   over_limit_repos?: VariantAnalysisSkippedRepositoryGroup
 }

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-processor.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-processor.ts
@@ -100,7 +100,7 @@ function processSkippedRepositories(
 
   return {
     accessMismatchRepos: processRepoGroup(skippedRepos.access_mismatch_repos),
-    notFoundRepos: processNotFoundRepoGroup(skippedRepos.not_found_repo_nwos),
+    notFoundRepos: processNotFoundRepoGroup(skippedRepos.not_found_repos),
     noCodeqlDbRepos: processRepoGroup(skippedRepos.no_codeql_db_repos),
     overLimitRepos: processRepoGroup(skippedRepos.over_limit_repos)
   };

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-processor.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-processor.test.ts
@@ -22,7 +22,7 @@ describe('Variant Analysis processor', function() {
   it('should process an API response and return a variant analysis', () => {
     const result = processVariantAnalysis(mockSubmission, mockApiResponse);
 
-    const { access_mismatch_repos, no_codeql_db_repos, not_found_repo_nwos, over_limit_repos } = skippedRepos;
+    const { access_mismatch_repos, no_codeql_db_repos, not_found_repos, over_limit_repos } = skippedRepos;
 
     expect(result).to.eql({
       'id': mockApiResponse.id,
@@ -81,13 +81,13 @@ describe('Variant Analysis processor', function() {
         'notFoundRepos': {
           'repositories': [
             {
-              'fullName': not_found_repo_nwos?.repository_full_names[0]
+              'fullName': not_found_repos?.repository_full_names[0]
             },
             {
-              'fullName': not_found_repo_nwos?.repository_full_names[1]
+              'fullName': not_found_repos?.repository_full_names[1]
             }
           ],
-          'repositoryCount': not_found_repo_nwos?.repository_count
+          'repositoryCount': not_found_repos?.repository_count
         },
         'overLimitRepos': {
           'repositories': [

--- a/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/gh-api/skipped-repositories.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/gh-api/skipped-repositories.ts
@@ -9,7 +9,7 @@ export function createMockSkippedRepos(): VariantAnalysisSkippedRepositories {
   return {
     access_mismatch_repos: createMockSkippedRepoGroup(),
     no_codeql_db_repos: createMockSkippedRepoGroup(),
-    not_found_repo_nwos: createMockNotFoundSkippedRepoGroup(),
+    not_found_repos: createMockNotFoundSkippedRepoGroup(),
     over_limit_repos: createMockSkippedRepoGroup()
   };
 }


### PR DESCRIPTION
The `not_found_repo_nwos` field doesn't actually exist (anymore?) on the GitHub API. The correct name is `not_found_repos`, so this renames the field on the type and in the scenarios.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
