### PR TITLE
Make hasInterpretedResults not be async

### DIFF
--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -174,7 +174,7 @@ export class HistoryTreeDataProvider extends DisposableObject implements TreeDat
     // Populate the icon and the context value. We use the context value to
     // control which commands are visible in the context menu.
     treeItem.iconPath = this.getIconPath(element);
-    treeItem.contextValue = await this.getContextValue(element);
+    treeItem.contextValue = this.getContextValue(element);
 
     return treeItem;
   }
@@ -196,7 +196,7 @@ export class HistoryTreeDataProvider extends DisposableObject implements TreeDat
     }
   }
 
-  private async getContextValue(element: QueryHistoryInfo): Promise<string> {
+  private getContextValue(element: QueryHistoryInfo): string {
     switch (element.status) {
       case QueryStatus.InProgress:
         if (element.t === 'local') {
@@ -208,7 +208,7 @@ export class HistoryTreeDataProvider extends DisposableObject implements TreeDat
         }
       case QueryStatus.Completed:
         if (element.t === 'local') {
-          const hasResults = await element.completedQuery?.query.hasInterpretedResults();
+          const hasResults = element.completedQuery?.query.hasInterpretedResults();
           return hasResults
             ? 'interpretedResultsItem'
             : 'rawResultsItem';

--- a/extensions/ql-vscode/src/run-queries-shared.ts
+++ b/extensions/ql-vscode/src/run-queries-shared.ts
@@ -166,8 +166,8 @@ export class QueryEvaluationInfo {
   /**
    * Holds if this query actually has produced interpreted results.
    */
-  async hasInterpretedResults(): Promise<boolean> {
-    return fs.pathExists(this.resultsPaths.interpretedResultsPath);
+  hasInterpretedResults(): boolean {
+    return fs.pathExistsSync(this.resultsPaths.interpretedResultsPath);
   }
 
   /**


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

A tiny improvement I thought of when doing https://github.com/github/vscode-codeql/pull/1697 but didn't / forgot to include in that PR.

This is something I did when trying to pull out the `getContextValue` method and mock things, which didn't turn out well (see comment on that PR) but this small bit could be nice and could make things easier to mock and test in the future.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
