### PR TITLE
Make sorting tests work with remote queries & variant analysis history items

### DIFF
--- a/extensions/ql-vscode/src/stories/variant-analysis/VariantAnalysis.stories.tsx
+++ b/extensions/ql-vscode/src/stories/variant-analysis/VariantAnalysis.stories.tsx
@@ -24,7 +24,7 @@ const Template: ComponentStory<typeof VariantAnalysisComponent> = (args) => (
 );
 
 const variantAnalysis: VariantAnalysisDomainModel = {
-  ...createMockVariantAnalysis(VariantAnalysisStatus.InProgress),
+  ...createMockVariantAnalysis({ status: VariantAnalysisStatus.InProgress }),
   controllerRepo: {
     id: 1,
     fullName: 'octodemo/variant-analysis-controller',

--- a/extensions/ql-vscode/src/stories/variant-analysis/VariantAnalysisAnalyzedRepos.stories.tsx
+++ b/extensions/ql-vscode/src/stories/variant-analysis/VariantAnalysisAnalyzedRepos.stories.tsx
@@ -36,64 +36,67 @@ const interpretedResultsForRepo = (nwo: string): AnalysisAlert[] | undefined => 
 
 export const Example = Template.bind({});
 Example.args = {
-  variantAnalysis: createMockVariantAnalysis(VariantAnalysisStatus.InProgress, [
-    {
-      repository: {
-        ...createMockRepositoryWithMetadata(),
-        id: 63537249,
-        fullName: 'facebook/create-react-app',
-        private: false,
+  variantAnalysis: createMockVariantAnalysis({
+    status: VariantAnalysisStatus.InProgress,
+    scannedRepos: [
+      {
+        repository: {
+          ...createMockRepositoryWithMetadata(),
+          id: 63537249,
+          fullName: 'facebook/create-react-app',
+          private: false,
+        },
+        analysisStatus: VariantAnalysisRepoStatus.Succeeded, resultCount: 198,
       },
-      analysisStatus: VariantAnalysisRepoStatus.Succeeded, resultCount: 198,
-    },
-    {
-      repository: {
-        ...createMockRepositoryWithMetadata(),
-        id: 167174,
-        fullName: 'jquery/jquery',
-        private: false,
+      {
+        repository: {
+          ...createMockRepositoryWithMetadata(),
+          id: 167174,
+          fullName: 'jquery/jquery',
+          private: false,
+        },
+        analysisStatus: VariantAnalysisRepoStatus.Succeeded,
+        resultCount: 67,
       },
-      analysisStatus: VariantAnalysisRepoStatus.Succeeded,
-      resultCount: 67,
-    },
-    {
-      repository: {
-        ...createMockRepositoryWithMetadata(),
-        id: 237159,
-        fullName: 'expressjs/express',
-        private: false,
+      {
+        repository: {
+          ...createMockRepositoryWithMetadata(),
+          id: 237159,
+          fullName: 'expressjs/express',
+          private: false,
+        },
+        analysisStatus: VariantAnalysisRepoStatus.Succeeded,
+        resultCount: 26,
       },
-      analysisStatus: VariantAnalysisRepoStatus.Succeeded,
-      resultCount: 26,
-    },
-    {
-      repository: {
-        ...createMockRepositoryWithMetadata(),
-        id: 15062869,
-        fullName: 'facebook/jest',
-        private: false,
+      {
+        repository: {
+          ...createMockRepositoryWithMetadata(),
+          id: 15062869,
+          fullName: 'facebook/jest',
+          private: false,
+        },
+        analysisStatus: VariantAnalysisRepoStatus.Failed,
       },
-      analysisStatus: VariantAnalysisRepoStatus.Failed,
-    },
-    {
-      repository: {
-        ...createMockRepositoryWithMetadata(),
-        id: 24195339,
-        fullName: 'angular/angular',
-        private: false,
+      {
+        repository: {
+          ...createMockRepositoryWithMetadata(),
+          id: 24195339,
+          fullName: 'angular/angular',
+          private: false,
+        },
+        analysisStatus: VariantAnalysisRepoStatus.InProgress,
       },
-      analysisStatus: VariantAnalysisRepoStatus.InProgress,
-    },
-    {
-      repository: {
-        ...createMockRepositoryWithMetadata(),
-        id: 24560307,
-        fullName: 'babel/babel',
-        private: false,
+      {
+        repository: {
+          ...createMockRepositoryWithMetadata(),
+          id: 24560307,
+          fullName: 'babel/babel',
+          private: false,
+        },
+        analysisStatus: VariantAnalysisRepoStatus.Pending,
       },
-      analysisStatus: VariantAnalysisRepoStatus.Pending,
-    },
-  ]),
+    ]
+  }),
   repositoryResults: [
     {
       variantAnalysisId: 1,

--- a/extensions/ql-vscode/src/stories/variant-analysis/VariantAnalysisHeader.stories.tsx
+++ b/extensions/ql-vscode/src/stories/variant-analysis/VariantAnalysisHeader.stories.tsx
@@ -64,40 +64,46 @@ const Template: ComponentStory<typeof VariantAnalysisHeader> = (args) => (
 
 export const InProgress = Template.bind({});
 InProgress.args = {
-  variantAnalysis: createMockVariantAnalysis(VariantAnalysisStatus.InProgress, [
-    {
-      ...createMockScannedRepo(),
-      analysisStatus: VariantAnalysisRepoStatus.Succeeded,
-      resultCount: 99_999,
-    },
-    {
-      ...createMockScannedRepo(),
-      analysisStatus: VariantAnalysisRepoStatus.Failed,
-    },
-    {
-      ...createMockScannedRepo(),
-      analysisStatus: VariantAnalysisRepoStatus.Succeeded,
-      resultCount: 0,
-    },
-    createMockScannedRepo(),
-    createMockScannedRepo(),
-    createMockScannedRepo(),
-    createMockScannedRepo(),
-    createMockScannedRepo(),
-    createMockScannedRepo(),
-    createMockScannedRepo(),
-  ]),
+  variantAnalysis: createMockVariantAnalysis({
+    status: VariantAnalysisStatus.InProgress,
+    scannedRepos: [
+      {
+        ...createMockScannedRepo(),
+        analysisStatus: VariantAnalysisRepoStatus.Succeeded,
+        resultCount: 99_999,
+      },
+      {
+        ...createMockScannedRepo(),
+        analysisStatus: VariantAnalysisRepoStatus.Failed,
+      },
+      {
+        ...createMockScannedRepo(),
+        analysisStatus: VariantAnalysisRepoStatus.Succeeded,
+        resultCount: 0,
+      },
+      createMockScannedRepo(),
+      createMockScannedRepo(),
+      createMockScannedRepo(),
+      createMockScannedRepo(),
+      createMockScannedRepo(),
+      createMockScannedRepo(),
+      createMockScannedRepo(),
+    ]
+  }),
 };
 
 export const Succeeded = Template.bind({});
 Succeeded.args = {
   ...InProgress.args,
   variantAnalysis: {
-    ...createMockVariantAnalysis(VariantAnalysisStatus.Succeeded, Array.from({ length: 1000 }, (_) => ({
-      ...createMockScannedRepo(),
-      analysisStatus: VariantAnalysisRepoStatus.Succeeded,
-      resultCount: 100,
-    }))),
+    ...createMockVariantAnalysis({
+      status: VariantAnalysisStatus.Succeeded,
+      scannedRepos: Array.from({ length: 1000 }, (_) => ({
+        ...createMockScannedRepo(),
+        analysisStatus: VariantAnalysisRepoStatus.Succeeded,
+        resultCount: 100,
+      }))
+    }),
     createdAt: new Date(1661262726000).toISOString(),
     completedAt: new Date(1661263446000).toISOString(),
   },
@@ -107,7 +113,11 @@ export const Failed = Template.bind({});
 Failed.args = {
   ...InProgress.args,
   variantAnalysis: {
-    ...createMockVariantAnalysis(VariantAnalysisStatus.Failed, [], {}),
+    ...createMockVariantAnalysis({
+      status: VariantAnalysisStatus.Failed,
+      scannedRepos: [],
+      skippedRepos: {}
+    }),
     createdAt: new Date(1661263436000).toISOString(),
     completedAt: new Date(1661263446000).toISOString(),
   },

--- a/extensions/ql-vscode/src/stories/variant-analysis/VariantAnalysisOutcomePanels.stories.tsx
+++ b/extensions/ql-vscode/src/stories/variant-analysis/VariantAnalysisOutcomePanels.stories.tsx
@@ -27,111 +27,118 @@ const Template: ComponentStory<typeof VariantAnalysisOutcomePanels> = (args) => 
 
 export const WithoutSkippedRepos = Template.bind({});
 WithoutSkippedRepos.args = {
-  variantAnalysis: createMockVariantAnalysis(VariantAnalysisStatus.InProgress, [
-    {
-      ...createMockScannedRepo('hello-world-1'),
-      analysisStatus: VariantAnalysisRepoStatus.Succeeded,
-      resultCount: 99_999,
-    },
-    {
-      ...createMockScannedRepo('hello-world-2'),
-      analysisStatus: VariantAnalysisRepoStatus.Failed,
-    },
-    {
-      ...createMockScannedRepo('hello-world-3'),
-      analysisStatus: VariantAnalysisRepoStatus.Succeeded,
-      resultCount: 0,
-    },
-    {
-      ...createMockScannedRepo('hello-world-4'),
-      resultCount: undefined,
-    },
-    {
-      ...createMockScannedRepo('hello-world-5'),
-      resultCount: undefined,
-    },
-    {
-      ...createMockScannedRepo('hello-world-6'),
-      resultCount: undefined,
-    },
-    {
-      ...createMockScannedRepo('hello-world-7'),
-      resultCount: undefined,
-    },
-    {
-      ...createMockScannedRepo('hello-world-8'),
-      resultCount: undefined,
-    },
-    {
-      ...createMockScannedRepo('hello-world-9'),
-      resultCount: undefined,
-    },
-    {
-      ...createMockScannedRepo('hello-world-10'),
-      resultCount: undefined,
-    },
-  ]),
+  variantAnalysis: createMockVariantAnalysis({
+    status: VariantAnalysisStatus.InProgress,
+    scannedRepos: [
+      {
+        ...createMockScannedRepo('hello-world-1'),
+        analysisStatus: VariantAnalysisRepoStatus.Succeeded,
+        resultCount: 99_999,
+      },
+      {
+        ...createMockScannedRepo('hello-world-2'),
+        analysisStatus: VariantAnalysisRepoStatus.Failed,
+      },
+      {
+        ...createMockScannedRepo('hello-world-3'),
+        analysisStatus: VariantAnalysisRepoStatus.Succeeded,
+        resultCount: 0,
+      },
+      {
+        ...createMockScannedRepo('hello-world-4'),
+        resultCount: undefined,
+      },
+      {
+        ...createMockScannedRepo('hello-world-5'),
+        resultCount: undefined,
+      },
+      {
+        ...createMockScannedRepo('hello-world-6'),
+        resultCount: undefined,
+      },
+      {
+        ...createMockScannedRepo('hello-world-7'),
+        resultCount: undefined,
+      },
+      {
+        ...createMockScannedRepo('hello-world-8'),
+        resultCount: undefined,
+      },
+      {
+        ...createMockScannedRepo('hello-world-9'),
+        resultCount: undefined,
+      },
+      {
+        ...createMockScannedRepo('hello-world-10'),
+        resultCount: undefined,
+      },
+    ]
+  }),
 };
 
 export const WithSkippedRepos = Template.bind({});
 WithSkippedRepos.args = {
   ...WithoutSkippedRepos.args,
-  variantAnalysis: createMockVariantAnalysis(VariantAnalysisStatus.InProgress, WithoutSkippedRepos.args.variantAnalysis?.scannedRepos, {
-    notFoundRepos: {
-      repositoryCount: 2,
-      repositories: [
-        {
-          fullName: 'octodemo/hello-globe'
-        },
-        {
-          fullName: 'octodemo/hello-planet'
-        }
-      ]
-    },
-    noCodeqlDbRepos: {
-      repositoryCount: 4,
-      repositories: [
-        {
-          ...createMockRepositoryWithMetadata(),
-          id: 100,
-          fullName: 'octodemo/no-db-1'
-        },
-        {
-          ...createMockRepositoryWithMetadata(),
-          id: 101,
-          fullName: 'octodemo/no-db-2'
-        },
-        {
-          ...createMockRepositoryWithMetadata(),
-          id: 102,
-          fullName: 'octodemo/no-db-3'
-        },
-        {
-          ...createMockRepositoryWithMetadata(),
-          id: 103,
-          fullName: 'octodemo/no-db-4'
-        }
-      ]
-    },
-    overLimitRepos: {
-      repositoryCount: 1,
-      repositories: [
-        {
-          ...createMockRepositoryWithMetadata(),
-          id: 201,
-          fullName: 'octodemo/over-limit-1'
-        }
-      ]
-    },
-    accessMismatchRepos: {
-      repositoryCount: 1,
-      repositories: [
-        {
-          ...createMockRepositoryWithMetadata(),
-          id: 205,
-          fullName: 'octodemo/private'
-        }
-      ]
+  variantAnalysis: createMockVariantAnalysis({
+    status: VariantAnalysisStatus.InProgress,
+    scannedRepos: WithoutSkippedRepos.args.variantAnalysis?.scannedRepos,
+    skippedRepos: {
+      notFoundRepos: {
+        repositoryCount: 2,
+        repositories: [
+          {
+            fullName: 'octodemo/hello-globe'
+          },
+          {
+            fullName: 'octodemo/hello-planet'
+          }
+        ]
+      },
+      noCodeqlDbRepos: {
+        repositoryCount: 4,
+        repositories: [
+          {
+            ...createMockRepositoryWithMetadata(),
+            id: 100,
+            fullName: 'octodemo/no-db-1'
+          },
+          {
+            ...createMockRepositoryWithMetadata(),
+            id: 101,
+            fullName: 'octodemo/no-db-2'
+          },
+          {
+            ...createMockRepositoryWithMetadata(),
+            id: 102,
+            fullName: 'octodemo/no-db-3'
+          },
+          {
+            ...createMockRepositoryWithMetadata(),
+            id: 103,
+            fullName: 'octodemo/no-db-4'
+          }
+        ]
+      },
+      overLimitRepos: {
+        repositoryCount: 1,
+        repositories: [
+          {
+            ...createMockRepositoryWithMetadata(),
+            id: 201,
+            fullName: 'octodemo/over-limit-1'
+          }
+        ]
+      },
+      accessMismatchRepos: {
+        repositoryCount: 1,
+        repositories: [
+          {
+            ...createMockRepositoryWithMetadata(),
+            id: 205,
+            fullName: 'octodemo/private'
+          }
+        ]
+      }
     }
   }),
 };
@@ -139,9 +146,13 @@ WithSkippedRepos.args = {
 export const WithOnlyWarningsSkippedRepos = Template.bind({});
 WithOnlyWarningsSkippedRepos.args = {
   ...WithoutSkippedRepos.args,
-  variantAnalysis: createMockVariantAnalysis(VariantAnalysisStatus.InProgress, WithoutSkippedRepos.args.variantAnalysis?.scannedRepos, {
-    ...WithSkippedRepos.args.variantAnalysis?.skippedRepos,
-    notFoundRepos: undefined,
-    noCodeqlDbRepos: undefined,
+  variantAnalysis: createMockVariantAnalysis({
+    status: VariantAnalysisStatus.InProgress,
+    scannedRepos: WithoutSkippedRepos.args.variantAnalysis?.scannedRepos,
+    skippedRepos: {
+      ...WithSkippedRepos.args.variantAnalysis?.skippedRepos,
+      notFoundRepos: undefined,
+      noCodeqlDbRepos: undefined,
+    }
   }),
 };

--- a/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisAnalyzedRepos.spec.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisAnalyzedRepos.spec.tsx
@@ -11,48 +11,51 @@ import { createMockRepositoryWithMetadata } from '../../../vscode-tests/factorie
 import { createMockScannedRepo } from '../../../vscode-tests/factories/remote-queries/shared/scanned-repositories';
 
 describe(VariantAnalysisAnalyzedRepos.name, () => {
-  const defaultVariantAnalysis = createMockVariantAnalysis(VariantAnalysisStatus.InProgress, [
-    {
-      ...createMockScannedRepo(),
-      repository: {
-        ...createMockRepositoryWithMetadata(),
-        id: 1,
-        fullName: 'octodemo/hello-world-1',
-        private: false,
+  const defaultVariantAnalysis = createMockVariantAnalysis({
+    status: VariantAnalysisStatus.InProgress,
+    scannedRepos: [
+      {
+        ...createMockScannedRepo(),
+        repository: {
+          ...createMockRepositoryWithMetadata(),
+          id: 1,
+          fullName: 'octodemo/hello-world-1',
+          private: false,
+        },
+        analysisStatus: VariantAnalysisRepoStatus.Pending,
       },
-      analysisStatus: VariantAnalysisRepoStatus.Pending,
-    },
-    {
-      ...createMockScannedRepo(),
-      repository: {
-        ...createMockRepositoryWithMetadata(),
-        id: 2,
-        fullName: 'octodemo/hello-world-2',
-        private: false,
+      {
+        ...createMockScannedRepo(),
+        repository: {
+          ...createMockRepositoryWithMetadata(),
+          id: 2,
+          fullName: 'octodemo/hello-world-2',
+          private: false,
+        },
+        analysisStatus: VariantAnalysisRepoStatus.Succeeded,
       },
-      analysisStatus: VariantAnalysisRepoStatus.Succeeded,
-    },
-    {
-      ...createMockScannedRepo(),
-      repository: {
-        ...createMockRepositoryWithMetadata(),
-        id: 3,
-        fullName: 'octodemo/hello-world-3',
-        private: true,
+      {
+        ...createMockScannedRepo(),
+        repository: {
+          ...createMockRepositoryWithMetadata(),
+          id: 3,
+          fullName: 'octodemo/hello-world-3',
+          private: true,
+        },
+        analysisStatus: VariantAnalysisRepoStatus.Failed,
       },
-      analysisStatus: VariantAnalysisRepoStatus.Failed,
-    },
-    {
-      ...createMockScannedRepo(),
-      repository: {
-        ...createMockRepositoryWithMetadata(),
-        id: 4,
-        fullName: 'octodemo/hello-world-4',
-        private: false,
+      {
+        ...createMockScannedRepo(),
+        repository: {
+          ...createMockRepositoryWithMetadata(),
+          id: 4,
+          fullName: 'octodemo/hello-world-4',
+          private: false,
+        },
+        analysisStatus: VariantAnalysisRepoStatus.InProgress,
       },
-      analysisStatus: VariantAnalysisRepoStatus.InProgress,
-    },
-  ]);
+    ]
+  });
 
   const render = (props: Partial<VariantAnalysisAnalyzedReposProps> = {}) => {
     return reactRender(

--- a/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisOutcomePanels.spec.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisOutcomePanels.spec.tsx
@@ -12,7 +12,7 @@ import { createMockScannedRepo } from '../../../vscode-tests/factories/remote-qu
 
 describe(VariantAnalysisOutcomePanels.name, () => {
   const defaultVariantAnalysis = {
-    ...createMockVariantAnalysis(VariantAnalysisStatus.InProgress),
+    ...createMockVariantAnalysis({ status: VariantAnalysisStatus.InProgress }),
     controllerRepo: {
       id: 1,
       fullName: 'octodemo/variant-analysis-controller',

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-manager.test.ts
@@ -178,7 +178,7 @@ describe('Variant Analysis Manager', async function() {
         let dummyVariantAnalysis: VariantAnalysis;
 
         beforeEach(async () => {
-          dummyVariantAnalysis = createMockVariantAnalysis();
+          dummyVariantAnalysis = createMockVariantAnalysis({});
           removeAnalysisResultsStub = sandbox.stub(variantAnalysisResultsManager, 'removeAnalysisResults');
           removeStorageStub = sandbox.stub(fs, 'remove');
         });
@@ -203,7 +203,7 @@ describe('Variant Analysis Manager', async function() {
     let monitorVariantAnalysisCommandSpy: sinon.SinonSpy;
 
     beforeEach(() => {
-      variantAnalysis = createMockVariantAnalysis();
+      variantAnalysis = createMockVariantAnalysis({});
 
       variantAnalysisRemovedSpy = sinon.spy();
       variantAnalysisManager.onVariantAnalysisRemoved(variantAnalysisRemovedSpy);

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-monitor.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-monitor.test.ts
@@ -37,7 +37,7 @@ describe('Variant Analysis Monitor', async function() {
 
     cancellationTokenSource = new CancellationTokenSource();
 
-    variantAnalysis = createMockVariantAnalysis();
+    variantAnalysis = createMockVariantAnalysis({});
 
     try {
       extension = await extensions.getExtension<CodeQLExtensionInterface | Record<string, never>>('GitHub.vscode-codeql')!.activate();

--- a/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/remote-query-history-item.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/remote-query-history-item.ts
@@ -5,15 +5,18 @@ export function createMockRemoteQueryHistoryItem({
   date = new Date('2022-01-01T00:00:00.000Z'),
   status = QueryStatus.InProgress,
   failureReason = undefined,
-  resultCount = 16,
+  resultCount = undefined,
   repositoryCount = 0,
-  userSpecifiedLabel = undefined,
+  executionStartTime = date.getTime(),
+  userSpecifiedLabel = undefined
 }: {
   date?: Date;
   status?: QueryStatus;
   failureReason?: string;
   resultCount?: number;
   repositoryCount?: number;
+  repositories?: string[];
+  executionStartTime?: number;
   userSpecifiedLabel?: string;
 }): RemoteQueryHistoryItem {
   return ({
@@ -32,7 +35,7 @@ export function createMockRemoteQueryHistoryItem({
         owner: 'github',
         name: 'vscode-codeql-integration-tests',
       },
-      executionStartTime: date.getTime(),
+      executionStartTime,
       actionsWorkflowRunId: 1,
       repositoryCount,
     },

--- a/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/shared/variant-analysis.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/shared/variant-analysis.ts
@@ -10,11 +10,17 @@ import { createMockScannedRepos } from './scanned-repositories';
 import { createMockSkippedRepos } from './skipped-repositories';
 import { createMockRepository } from './repository';
 
-export function createMockVariantAnalysis(
-  status: VariantAnalysisStatus = VariantAnalysisStatus.InProgress,
-  scannedRepos: VariantAnalysisScannedRepository[] = createMockScannedRepos(),
-  skippedRepos: VariantAnalysisSkippedRepositories = createMockSkippedRepos()
-): VariantAnalysis {
+export function createMockVariantAnalysis({
+  status = VariantAnalysisStatus.InProgress,
+  scannedRepos = createMockScannedRepos(),
+  skippedRepos = createMockSkippedRepos(),
+  executionStartTime = faker.datatype.number()
+}: {
+  status?: VariantAnalysisStatus,
+  scannedRepos?: VariantAnalysisScannedRepository[],
+  skippedRepos?: VariantAnalysisSkippedRepositories,
+  executionStartTime?: number | undefined
+}): VariantAnalysis {
   const variantAnalysis: VariantAnalysis = {
     id: faker.datatype.number(),
     controllerRepo: {
@@ -32,7 +38,7 @@ export function createMockVariantAnalysis(
     databases: {
       repositories: ['1', '2', '3'],
     },
-    executionStartTime: faker.datatype.number(),
+    executionStartTime,
     createdAt: faker.date.recent().toISOString(),
     updatedAt: faker.date.recent().toISOString(),
     status: status,

--- a/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/variant-analysis-history-item.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/variant-analysis-history-item.ts
@@ -16,7 +16,10 @@ export function createMockVariantAnalysisHistoryItem(
     resultCount,
     status: historyItemStatus,
     completed: false,
-    variantAnalysis: createMockVariantAnalysis(variantAnalysisStatus),
+    variantAnalysis: createMockVariantAnalysis({
+      status: variantAnalysisStatus,
+      executionStartTime: executionStartTime
+    }),
     userSpecifiedLabel,
   });
 }

--- a/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/variant-analysis-history-item.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/variant-analysis-history-item.ts
@@ -3,13 +3,21 @@ import { QueryStatus } from '../../../query-status';
 import { VariantAnalysisStatus } from '../../../remote-queries/shared/variant-analysis';
 import { createMockVariantAnalysis } from './shared/variant-analysis';
 
-export function createMockVariantAnalysisHistoryItem(
-  historyItemStatus: QueryStatus = QueryStatus.InProgress,
-  variantAnalysisStatus: VariantAnalysisStatus = VariantAnalysisStatus.Succeeded,
-  failureReason?: string,
+export function createMockVariantAnalysisHistoryItem({
+  historyItemStatus = QueryStatus.InProgress,
+  variantAnalysisStatus = VariantAnalysisStatus.Succeeded,
+  failureReason = undefined,
+  resultCount = 0,
+  userSpecifiedLabel = 'query-name',
+  executionStartTime = undefined
+}: {
+  historyItemStatus?: QueryStatus,
+  variantAnalysisStatus?: VariantAnalysisStatus,
+  failureReason?: string | undefined,
   resultCount?: number,
-  userSpecifiedLabel?: string
-): VariantAnalysisHistoryItem {
+  userSpecifiedLabel?: string,
+  executionStartTime?: number
+}): VariantAnalysisHistoryItem {
   return ({
     t: 'variant-analysis',
     failureReason,

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/history-item-label-provider.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/history-item-label-provider.test.ts
@@ -4,12 +4,15 @@ import { QueryHistoryConfig } from '../../config';
 import { HistoryItemLabelProvider } from '../../history-item-label-provider';
 import { createMockLocalQueryInfo } from '../factories/local-queries/local-query-history-item';
 import { createMockRemoteQueryHistoryItem } from '../factories/remote-queries/remote-query-history-item';
+import { QueryStatus } from '../../query-status';
 
 describe('HistoryItemLabelProvider', () => {
   let labelProvider: HistoryItemLabelProvider;
   let config: QueryHistoryConfig;
   const date = new Date('2022-01-01T00:00:00.000Z');
   const dateStr = date.toLocaleString(env.language);
+  const executionStartTime = date.getTime();
+  const userSpecifiedLabel = 'user-specified-name';
 
   beforeEach(() => {
     config = {
@@ -20,47 +23,50 @@ describe('HistoryItemLabelProvider', () => {
 
   describe('local queries', () => {
     it('should interpolate query when user specified', () => {
-      const fqi = createMockLocalQueryInfo(dateStr, 'xxx');
+      const fqi = createMockLocalQueryInfo({ startTime: date, userSpecifiedLabel, resultCount: 456, hasMetadata: true });
 
-      expect(labelProvider.getLabel(fqi)).to.eq('xxx');
+      expect(labelProvider.getLabel(fqi)).to.eq('user-specified-name');
 
       fqi.userSpecifiedLabel = '%t %q %d %s %f %r %%';
-      expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name db-name in progress query-file.ql (456 results) %`);
+      expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name db-name finished in 0 seconds query-file.ql (456 results) %`);
 
       fqi.userSpecifiedLabel = '%t %q %d %s %f %r %%::%t %q %d %s %f %r %%';
-      expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name db-name in progress query-file.ql (456 results) %::${dateStr} query-name db-name in progress query-file.ql (456 results) %`);
+      expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name db-name finished in 0 seconds query-file.ql (456 results) %::${dateStr} query-name db-name finished in 0 seconds query-file.ql (456 results) %`);
     });
 
     it('should interpolate query when not user specified', () => {
-      const fqi = createMockLocalQueryInfo(dateStr);
+      const fqi = createMockLocalQueryInfo({ startTime: date, resultCount: 456, hasMetadata: true });
 
       expect(labelProvider.getLabel(fqi)).to.eq('xxx query-name xxx');
 
-
       config.format = '%t %q %d %s %f %r %%';
-      expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name db-name in progress query-file.ql (456 results) %`);
+      expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name db-name finished in 0 seconds query-file.ql (456 results) %`);
 
       config.format = '%t %q %d %s %f %r %%::%t %q %d %s %f %r %%';
-      expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name db-name in progress query-file.ql (456 results) %::${dateStr} query-name db-name in progress query-file.ql (456 results) %`);
+      expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name db-name finished in 0 seconds query-file.ql (456 results) %::${dateStr} query-name db-name finished in 0 seconds query-file.ql (456 results) %`);
     });
 
     it('should get query short label', () => {
-      const fqi = createMockLocalQueryInfo(dateStr, 'xxx');
+      const fqi = createMockLocalQueryInfo({ startTime: date, userSpecifiedLabel, hasMetadata: true, resultCount: 456 });
 
       // fall back on user specified if one exists.
-      expect(labelProvider.getShortLabel(fqi)).to.eq('xxx');
+      expect(labelProvider.getShortLabel(fqi)).to.eq('user-specified-name');
 
       // use query name if no user-specified label exists
-      delete (fqi as any).userSpecifiedLabel;
+      fqi.userSpecifiedLabel = undefined;
       expect(labelProvider.getShortLabel(fqi)).to.eq('query-name');
+
+      // use file name if no user-specified label exists and the query is not yet completed (meaning it has no results)
+      const fqi2 = createMockLocalQueryInfo({ startTime: date, hasMetadata: true });
+      expect(labelProvider.getShortLabel(fqi2)).to.eq('query-file.ql');
     });
   });
 
   describe('remote queries', () => {
     it('should interpolate query when user specified', () => {
-      const fqi = createMockRemoteQueryHistoryItem({ userSpecifiedLabel: 'xxx' });
+      const fqi = createMockRemoteQueryHistoryItem({ userSpecifiedLabel });
 
-      expect(labelProvider.getLabel(fqi)).to.eq('xxx');
+      expect(labelProvider.getLabel(fqi)).to.eq(userSpecifiedLabel);
 
       fqi.userSpecifiedLabel = '%t %q %d %s %%';
       expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name (javascript) github/vscode-codeql-integration-tests in progress %`);
@@ -70,73 +76,73 @@ describe('HistoryItemLabelProvider', () => {
     });
 
     it('should interpolate query when not user-specified', () => {
-      const fqi = createMockRemoteQueryHistoryItem({});
+      const fqi = createMockRemoteQueryHistoryItem({ status: QueryStatus.Completed, executionStartTime, resultCount: 16 });
 
       expect(labelProvider.getLabel(fqi)).to.eq('xxx query-name (javascript) xxx');
 
-
       config.format = '%t %q %d %s %f %r %%';
-      expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name (javascript) github/vscode-codeql-integration-tests in progress query-file.ql (16 results) %`);
+      expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name (javascript) github/vscode-codeql-integration-tests completed query-file.ql (16 results) %`);
 
       config.format = '%t %q %d %s %f %r %%::%t %q %d %s %f %r %%';
-      expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name (javascript) github/vscode-codeql-integration-tests in progress query-file.ql (16 results) %::${dateStr} query-name (javascript) github/vscode-codeql-integration-tests in progress query-file.ql (16 results) %`);
+      expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name (javascript) github/vscode-codeql-integration-tests completed query-file.ql (16 results) %::${dateStr} query-name (javascript) github/vscode-codeql-integration-tests completed query-file.ql (16 results) %`);
     });
 
     it('should use number of repositories instead of controller repo if available', () => {
-      const fqi = createMockRemoteQueryHistoryItem({ repositoryCount: 2 });
+      const fqi = createMockRemoteQueryHistoryItem({ status: QueryStatus.Completed, executionStartTime, resultCount: 16, repositoryCount: 2 });
 
       config.format = '%t %q %d %s %f %r %%';
-      expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name (javascript) 2 repositories in progress query-file.ql (16 results) %`);
+      expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name (javascript) 2 repositories completed query-file.ql (16 results) %`);
     });
 
     it('should get query short label', () => {
-      const fqi = createMockRemoteQueryHistoryItem({ userSpecifiedLabel: 'xxx' });
+      const fqi = createMockRemoteQueryHistoryItem({ status: QueryStatus.Completed, executionStartTime, userSpecifiedLabel });
 
       // fall back on user specified if one exists.
-      expect(labelProvider.getShortLabel(fqi)).to.eq('xxx');
+      expect(labelProvider.getShortLabel(fqi)).to.eq('user-specified-name');
 
       // use query name if no user-specified label exists
-      delete (fqi as any).userSpecifiedLabel;
-      expect(labelProvider.getShortLabel(fqi)).to.eq('query-name');
+      const fqi2 = createMockRemoteQueryHistoryItem({});
+
+      expect(labelProvider.getShortLabel(fqi2)).to.eq('query-name');
     });
 
     describe('when results are present', () => {
       it('should display results if there are any', () => {
-        const fqi = createMockRemoteQueryHistoryItem({ resultCount: 16, repositoryCount: 2 });
+        const fqi = createMockRemoteQueryHistoryItem({ status: QueryStatus.Completed, executionStartTime, resultCount: 16, repositoryCount: 2 });
         config.format = '%t %q %d %s %f %r %%';
-        expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name (javascript) 2 repositories in progress query-file.ql (16 results) %`);
+        expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name (javascript) 2 repositories completed query-file.ql (16 results) %`);
       });
     });
 
     describe('when results are not present', () => {
       it('should skip displaying them', () => {
-        const fqi = createMockRemoteQueryHistoryItem({ resultCount: 0, repositoryCount: 2 });
+        const fqi = createMockRemoteQueryHistoryItem({ status: QueryStatus.Completed, executionStartTime, resultCount: 0, repositoryCount: 2 });
         config.format = '%t %q %d %s %f %r %%';
-        expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name (javascript) 2 repositories in progress query-file.ql %`);
+        expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name (javascript) 2 repositories completed query-file.ql %`);
       });
     });
 
     describe('when extra whitespace is present in the middle of the label', () => {
       it('should squash it down to a single whitespace', () => {
-        const fqi = createMockRemoteQueryHistoryItem({ resultCount: 0, repositoryCount: 2 });
+        const fqi = createMockRemoteQueryHistoryItem({ status: QueryStatus.Completed, executionStartTime, resultCount: 0, repositoryCount: 2 });
         config.format = '%t   %q        %d %s   %f   %r %%';
-        expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name (javascript) 2 repositories in progress query-file.ql %`);
+        expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name (javascript) 2 repositories completed query-file.ql %`);
       });
     });
 
     describe('when extra whitespace is present at the start of the label', () => {
       it('should squash it down to a single whitespace', () => {
-        const fqi = createMockRemoteQueryHistoryItem({ resultCount: 0, repositoryCount: 2 });
+        const fqi = createMockRemoteQueryHistoryItem({ status: QueryStatus.Completed, executionStartTime, resultCount: 0, repositoryCount: 2 });
         config.format = '   %t %q %d %s %f %r %%';
-        expect(labelProvider.getLabel(fqi)).to.eq(` ${dateStr} query-name (javascript) 2 repositories in progress query-file.ql %`);
+        expect(labelProvider.getLabel(fqi)).to.eq(` ${dateStr} query-name (javascript) 2 repositories completed query-file.ql %`);
       });
     });
 
     describe('when extra whitespace is present at the end of the label', () => {
       it('should squash it down to a single whitespace', () => {
-        const fqi = createMockRemoteQueryHistoryItem({ resultCount: 0, repositoryCount: 2 });
+        const fqi = createMockRemoteQueryHistoryItem({ status: QueryStatus.Completed, executionStartTime, resultCount: 0, repositoryCount: 2 });
         config.format = '%t %q %d %s %f %r %%   ';
-        expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name (javascript) 2 repositories in progress query-file.ql % `);
+        expect(labelProvider.getLabel(fqi)).to.eq(`${dateStr} query-name (javascript) 2 repositories completed query-file.ql % `);
       });
     });
   });

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history-info.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history-info.test.ts
@@ -24,15 +24,15 @@ describe('Query history info', () => {
     t: 'variant-analysis',
     status: QueryStatus.InProgress,
     completed: false,
-    variantAnalysis: createMockVariantAnalysis(
-      VariantAnalysisStatus.InProgress,
-      createMockScannedRepos([
+    variantAnalysis: createMockVariantAnalysis({
+      status: VariantAnalysisStatus.InProgress,
+      scannedRepos: createMockScannedRepos([
         VariantAnalysisRepoStatus.Succeeded,
         VariantAnalysisRepoStatus.Pending,
         VariantAnalysisRepoStatus.InProgress,
         VariantAnalysisRepoStatus.Canceled,
       ])
-    ),
+    }),
   };
 
   describe('getRawQueryName', () => {
@@ -117,10 +117,10 @@ describe('Query history info', () => {
           t: 'variant-analysis',
           status: QueryStatus.InProgress,
           completed: false,
-          variantAnalysis: createMockVariantAnalysis(
-            VariantAnalysisStatus.InProgress,
-            createMockScannedRepos([])
-          ),
+          variantAnalysis: createMockVariantAnalysis({
+            status: VariantAnalysisStatus.InProgress,
+            scannedRepos: createMockScannedRepos([])
+          }),
         };
         const repoLabel0 = buildRepoLabel(variantAnalysisHistoryItem0);
 
@@ -131,12 +131,10 @@ describe('Query history info', () => {
           t: 'variant-analysis',
           status: QueryStatus.InProgress,
           completed: false,
-          variantAnalysis: createMockVariantAnalysis(
-            VariantAnalysisStatus.InProgress,
-            createMockScannedRepos([
-              VariantAnalysisRepoStatus.Pending,
-            ])
-          ),
+          variantAnalysis: createMockVariantAnalysis({
+            status: VariantAnalysisStatus.InProgress,
+            scannedRepos: createMockScannedRepos([VariantAnalysisRepoStatus.Pending])
+          }),
         };
 
         const repoLabel1 = buildRepoLabel(variantAnalysisHistoryItem1);

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history-info.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history-info.test.ts
@@ -17,8 +17,7 @@ import { VariantAnalysisRepoStatus, VariantAnalysisStatus } from '../../remote-q
 describe('Query history info', () => {
 
   const date = new Date('2022-01-01T00:00:00.000Z');
-  const dateStr = date.toLocaleString();
-  const localQueryHistoryItem = createMockLocalQueryInfo(dateStr);
+  const localQueryHistoryItem = createMockLocalQueryInfo({ startTime: date });
   const remoteQueryHistoryItem = createMockRemoteQueryHistoryItem({});
   const variantAnalysisHistoryItem: VariantAnalysisHistoryItem = {
     t: 'variant-analysis',

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
@@ -21,13 +21,17 @@ import { EvalLogViewer } from '../../eval-log-viewer';
 import { QueryRunner } from '../../queryRunner';
 import { VariantAnalysisManager } from '../../remote-queries/variant-analysis-manager';
 import { QueryHistoryInfo } from '../../query-history-info';
-import { createMockLocalQuery, createMockQueryWithResults } from '../factories/local-queries/local-query-history-item';
+import {
+  createMockLocalQueryInfo,
+  createMockQueryWithResults
+} from '../factories/local-queries/local-query-history-item';
 import { createMockRemoteQueryHistoryItem } from '../factories/remote-queries/remote-query-history-item';
 import { RemoteQueryHistoryItem } from '../../remote-queries/remote-query-history-item';
 import { shuffleHistoryItems } from '../utils/query-history-helpers';
 import { createMockVariantAnalysisHistoryItem } from '../factories/remote-queries/variant-analysis-history-item';
 import { VariantAnalysisHistoryItem } from '../../remote-queries/variant-analysis-history-item';
 import { QueryStatus } from '../../query-status';
+import { VariantAnalysisStatus } from '../../remote-queries/shared/variant-analysis';
 
 describe('query-history', () => {
   const mockExtensionLocation = path.join(tmpDir.name, 'mock-extension-location');
@@ -88,10 +92,10 @@ describe('query-history', () => {
     } as any as VariantAnalysisManager;
 
     localQueryHistory = [
-      createMockLocalQuery('a', createMockQueryWithResults(sandbox, true)),
-      createMockLocalQuery('b', createMockQueryWithResults(sandbox, true)),
-      createMockLocalQuery('a', createMockQueryWithResults(sandbox, false)),
-      createMockLocalQuery('a', createMockQueryWithResults(sandbox, true)),
+      createMockLocalQueryInfo({ dbName: 'a', queryWithResults: createMockQueryWithResults({ sandbox, didRunSuccessfully: true }) }),
+      createMockLocalQueryInfo({ dbName: 'b', queryWithResults: createMockQueryWithResults({ sandbox, didRunSuccessfully: true }) }),
+      createMockLocalQueryInfo({ dbName: 'a', queryWithResults: createMockQueryWithResults({ sandbox, didRunSuccessfully: false }) }),
+      createMockLocalQueryInfo({ dbName: 'a', queryWithResults: createMockQueryWithResults({ sandbox, didRunSuccessfully: true }) }),
     ];
     remoteQueryHistory = [
       createMockRemoteQueryHistoryItem({ status: QueryStatus.Completed }),
@@ -100,13 +104,24 @@ describe('query-history', () => {
       createMockRemoteQueryHistoryItem({ status: QueryStatus.InProgress })
     ];
     variantAnalysisHistory = [
-      createMockVariantAnalysisHistoryItem(QueryStatus.Completed),
-      createMockVariantAnalysisHistoryItem(QueryStatus.InProgress),
-      createMockVariantAnalysisHistoryItem(QueryStatus.Failed),
-      createMockVariantAnalysisHistoryItem(QueryStatus.InProgress)
+      createMockVariantAnalysisHistoryItem({
+        historyItemStatus: QueryStatus.Completed,
+        variantAnalysisStatus: VariantAnalysisStatus.Succeeded
+      }),
+      createMockVariantAnalysisHistoryItem({
+        historyItemStatus: QueryStatus.InProgress,
+        variantAnalysisStatus: VariantAnalysisStatus.InProgress
+      }),
+      createMockVariantAnalysisHistoryItem({
+        historyItemStatus: QueryStatus.Failed,
+        variantAnalysisStatus: VariantAnalysisStatus.Failed
+      }),
+      createMockVariantAnalysisHistoryItem({
+        historyItemStatus: QueryStatus.InProgress,
+        variantAnalysisStatus: VariantAnalysisStatus.InProgress
+      })
     ];
     allHistory = shuffleHistoryItems([...localQueryHistory, ...remoteQueryHistory, ...variantAnalysisHistory]);
-
   });
 
   afterEach(async () => {
@@ -415,7 +430,7 @@ describe('query-history', () => {
         it('should throw an error when a query is not successful', async () => {
           const thisQuery = localQueryHistory[3];
           queryHistoryManager = await createMockQueryHistory(allHistory);
-          allHistory[0] = createMockLocalQuery('a', createMockQueryWithResults(sandbox, false));
+          allHistory[0] = createMockLocalQueryInfo({ dbName: 'a', queryWithResults: createMockQueryWithResults({ sandbox, didRunSuccessfully: false }) });
 
           try {
             await (queryHistoryManager as any).findOtherQueryToCompare(thisQuery, [thisQuery, allHistory[0]]);
@@ -696,40 +711,45 @@ describe('query-history', () => {
 
     describe('getTreeItem', async () => {
       it('should get a tree item with raw results', async () => {
-        const mockQuery = createMockLocalQuery('a', createMockQueryWithResults(sandbox, true, /* raw results */ false));
-        const treeItem = await historyTreeDataProvider.getTreeItem(mockQuery);
+        const mockQueryWithRawResults = createMockLocalQueryInfo({ dbName: 'a', queryWithResults: createMockQueryWithResults({ sandbox, didRunSuccessfully: true, hasInterpretedResults: false }) });
+
+        const treeItem = await historyTreeDataProvider.getTreeItem(mockQueryWithRawResults);
         expect(treeItem.command).to.deep.eq({
           title: 'Query History Item',
           command: 'codeQLQueryHistory.itemClicked',
-          arguments: [mockQuery],
-          tooltip: labelProvider.getLabel(mockQuery),
+          arguments: [mockQueryWithRawResults],
+          tooltip: labelProvider.getLabel(mockQueryWithRawResults),
         });
-        expect(treeItem.label).to.contain('hucairz');
+        expect(treeItem.label).to.contain('query-file.ql');
         expect(treeItem.contextValue).to.eq('rawResultsItem');
         expect(treeItem.iconPath).to.deep.eq(vscode.Uri.file(mockExtensionLocation + '/media/drive.svg').fsPath);
       });
 
       it('should get a tree item with interpreted results', async () => {
-        const mockQuery = createMockLocalQuery('a', createMockQueryWithResults(sandbox, true, /* interpreted results */ true));
-        const treeItem = await historyTreeDataProvider.getTreeItem(mockQuery);
+        const mockQueryWithInterpretedResults = createMockLocalQueryInfo({ dbName: 'a', queryWithResults: createMockQueryWithResults({ sandbox, didRunSuccessfully: true, hasInterpretedResults: true }) });
+
+        const treeItem = await historyTreeDataProvider.getTreeItem(mockQueryWithInterpretedResults);
         expect(treeItem.contextValue).to.eq('interpretedResultsItem');
         expect(treeItem.iconPath).to.deep.eq(vscode.Uri.file(mockExtensionLocation + '/media/drive.svg').fsPath);
       });
 
       it('should get a tree item that did not complete successfully', async () => {
-        const mockQuery = createMockLocalQuery('a', createMockQueryWithResults(sandbox, false), false);
+        const mockQuery = createMockLocalQueryInfo({ dbName: 'a', failureReason: 'failure reason', queryWithResults: createMockQueryWithResults({ sandbox, didRunSuccessfully: false }) });
+
         const treeItem = await historyTreeDataProvider.getTreeItem(mockQuery);
         expect(treeItem.iconPath).to.eq(vscode.Uri.file(mockExtensionLocation + '/media/red-x.svg').fsPath);
       });
 
       it('should get a tree item that failed before creating any results', async () => {
-        const mockQuery = createMockLocalQuery('a', undefined, true);
+        const mockQuery = createMockLocalQueryInfo({ dbName: 'a', failureReason: 'failure reason' });
+
         const treeItem = await historyTreeDataProvider.getTreeItem(mockQuery);
         expect(treeItem.iconPath).to.eq(vscode.Uri.file(mockExtensionLocation + '/media/red-x.svg').fsPath);
       });
 
       it('should get a tree item that is in progress', async () => {
-        const mockQuery = createMockLocalQuery('a');
+        const mockQuery = createMockLocalQueryInfo({ dbName: 'a' });
+
         const treeItem = await historyTreeDataProvider.getTreeItem(mockQuery);
         expect(treeItem.iconPath).to.deep.eq({
           id: 'sync~spin', color: undefined
@@ -739,7 +759,7 @@ describe('query-history', () => {
 
     describe('getChildren', () => {
       it('fetch children correctly', () => {
-        const mockQuery = createMockLocalQuery();
+        const mockQuery = createMockLocalQueryInfo({});
         historyTreeDataProvider.allHistory.push(mockQuery);
         expect(historyTreeDataProvider.getChildren()).to.deep.eq([mockQuery]);
         expect(historyTreeDataProvider.getChildren(mockQuery)).to.deep.eq([]);

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
@@ -767,12 +767,16 @@ describe('query-history', () => {
 
       describe('sorting', () => {
         const history = [
-          item('a', 2, 'remote', 24),
-          item('b', 10, 'local', 20),
-          item('c', 5, 'local', 30),
-          item('d', 1, 'local', 25),
-          item('e', 6, 'remote', 5),
+          createMockRemoteQueryHistoryItem({ userSpecifiedLabel: 'a', executionStartTime: 2, resultCount: 24, status: QueryStatus.Completed }),
+          createMockLocalQueryInfo({ userSpecifiedLabel: 'b', startTime: new Date(10), resultCount: 20 }),
+          createMockVariantAnalysisHistoryItem({ userSpecifiedLabel: 'c', executionStartTime: 15, resultCount: 456, historyItemStatus: QueryStatus.Completed, variantAnalysisStatus: VariantAnalysisStatus.Succeeded }),
+          createMockLocalQueryInfo({ userSpecifiedLabel: 'd', startTime: new Date(5), resultCount: 30 }),
+          createMockVariantAnalysisHistoryItem({ userSpecifiedLabel: 'e', executionStartTime: 50, resultCount: 15, historyItemStatus: QueryStatus.InProgress, variantAnalysisStatus: VariantAnalysisStatus.InProgress }),
+          createMockLocalQueryInfo({ userSpecifiedLabel: 'f', startTime: new Date(1), resultCount: 13 }),
+          createMockVariantAnalysisHistoryItem({ userSpecifiedLabel: 'g', executionStartTime: 7, resultCount: 30, historyItemStatus: QueryStatus.Failed, variantAnalysisStatus: VariantAnalysisStatus.Failed }),
+          createMockRemoteQueryHistoryItem({ userSpecifiedLabel: 'h', executionStartTime: 6, resultCount: 5, status: QueryStatus.InProgress })
         ];
+
         let treeDataProvider: HistoryTreeDataProvider;
 
         beforeEach(async () => {
@@ -798,7 +802,7 @@ describe('query-history', () => {
         });
 
         it('should get children for date ascending', async () => {
-          const expected = [history[3], history[0], history[2], history[4], history[1]];
+          const expected = [history[5], history[0], history[3], history[7], history[6], history[1], history[2], history[4]];
           treeDataProvider.sortOrder = SortOrder.DateAsc;
 
           const children = await treeDataProvider.getChildren();
@@ -806,7 +810,8 @@ describe('query-history', () => {
         });
 
         it('should get children for date descending', async () => {
-          const expected = [history[3], history[0], history[2], history[4], history[1]].reverse();
+          const expected = [history[5], history[0], history[3], history[7], history[6], history[1], history[2], history[4]].reverse();
+
           treeDataProvider.sortOrder = SortOrder.DateDesc;
 
           const children = await treeDataProvider.getChildren();
@@ -814,35 +819,48 @@ describe('query-history', () => {
         });
 
         it('should get children for result count ascending', async () => {
-          const expected = [history[4], history[1], history[0], history[3], history[2]];
+          const expected = [history[7], history[5], history[4], history[1], history[0], history[3], history[6], history[2]];
           treeDataProvider.sortOrder = SortOrder.CountAsc;
 
           const children = await treeDataProvider.getChildren();
+
           expect(children).to.deep.eq(expected);
         });
 
         it('should get children for result count descending', async () => {
-          const expected = [history[4], history[1], history[0], history[3], history[2]].reverse();
+          const expected = [history[7], history[5], history[4], history[1], history[0], history[3], history[6], history[2]].reverse();
           treeDataProvider.sortOrder = SortOrder.CountDesc;
 
           const children = await treeDataProvider.getChildren();
           expect(children).to.deep.eq(expected);
         });
 
-        it('should get children for result count ascending when there are no results', async () => {
-          // fall back to name
-          const thisHistory = [item('a', 10), item('b', 50), item('c', 1)];
+        it('should fall back to name ascending when there are no results', async () => {
+          const thisHistory = [
+            createMockLocalQueryInfo({ userSpecifiedLabel: 'a', resultCount: 0, startTime: new Date(10) }),
+            createMockLocalQueryInfo({ userSpecifiedLabel: 'b', resultCount: 0, startTime: new Date(1) }),
+            createMockVariantAnalysisHistoryItem({ userSpecifiedLabel: 'c', resultCount: 0, historyItemStatus: QueryStatus.Completed, variantAnalysisStatus: VariantAnalysisStatus.Failed }),
+            createMockRemoteQueryHistoryItem({ userSpecifiedLabel: 'd', resultCount: 0, executionStartTime: 50, status: QueryStatus.Completed }),
+            createMockVariantAnalysisHistoryItem({ userSpecifiedLabel: 'e', resultCount: 0, historyItemStatus: QueryStatus.InProgress, variantAnalysisStatus: VariantAnalysisStatus.Failed }),
+          ];
           (queryHistoryManager!.treeDataProvider as any).history = [...thisHistory];
           const expected = [...thisHistory];
+
           treeDataProvider.sortOrder = SortOrder.CountAsc;
 
           const children = await treeDataProvider.getChildren();
+
           expect(children).to.deep.eq(expected);
         });
 
-        it('should get children for result count descending when there are no results', async () => {
-          // fall back to name
-          const thisHistory = [item('a', 10), item('b', 50), item('c', 1)];
+        it('should fall back to name descending when there are no results', async () => {
+          const thisHistory = [
+            createMockLocalQueryInfo({ userSpecifiedLabel: 'a', resultCount: 0, startTime: new Date(10) }),
+            createMockLocalQueryInfo({ userSpecifiedLabel: 'b', resultCount: 0, startTime: new Date(1) }),
+            createMockVariantAnalysisHistoryItem({ userSpecifiedLabel: 'c', resultCount: 0, historyItemStatus: QueryStatus.Completed, variantAnalysisStatus: VariantAnalysisStatus.Failed }),
+            createMockRemoteQueryHistoryItem({ userSpecifiedLabel: 'd', resultCount: 0, executionStartTime: 50, status: QueryStatus.Completed }),
+            createMockVariantAnalysisHistoryItem({ userSpecifiedLabel: 'e', resultCount: 0, historyItemStatus: QueryStatus.InProgress, variantAnalysisStatus: VariantAnalysisStatus.Failed }),
+          ];
           (queryHistoryManager!.treeDataProvider as any).history = [...thisHistory];
           const expected = [...thisHistory].reverse();
           treeDataProvider.sortOrder = SortOrder.CountDesc;

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/query-history.test.ts
@@ -868,45 +868,6 @@ describe('query-history', () => {
           const children = await treeDataProvider.getChildren();
           expect(children).to.deep.eq(expected);
         });
-
-        function item(label: string, start: number, t = 'local', resultCount?: number) {
-          if (t === 'local') {
-            return {
-              getQueryName() {
-                return label;
-              },
-              getQueryFileName() {
-                return label + '.ql';
-              },
-              initialInfo: {
-                start: new Date(start),
-                databaseInfo: {
-                  name: 'test',
-                }
-              },
-              completedQuery: {
-                resultCount,
-              },
-              t
-            };
-          } else {
-            return {
-              status: 'success',
-              remoteQuery: {
-                queryFilePath: label + '.ql',
-                queryName: label,
-                executionStartTime: start,
-                controllerRepository: {
-                  name: 'test',
-                  owner: 'user',
-                },
-                repositories: []
-              },
-              resultCount,
-              t
-            };
-          }
-        }
       });
     });
   });

--- a/extensions/ql-vscode/test/pure-tests/variant-analysis.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/variant-analysis.test.ts
@@ -18,7 +18,7 @@ describe('isVariantAnalysisComplete', async () => {
   const uncallableArtifactDownloadChecker = () => { throw new Error('Should not be called'); };
 
   beforeEach(() => {
-    variantAnalysis = createMockVariantAnalysis();
+    variantAnalysis = createMockVariantAnalysis({});
   });
 
   describe('when variant analysis status is InProgress', async () => {
@@ -104,7 +104,7 @@ describe('isVariantAnalysisComplete', async () => {
 
 describe('getActionsWorkflowRunUrl', () => {
   it('should get the run url', () => {
-    const variantAnalysis = createMockVariantAnalysis();
+    const variantAnalysis = createMockVariantAnalysis({});
 
     const actionsWorkflowRunUrl = getActionsWorkflowRunUrl(variantAnalysis);
 


### PR DESCRIPTION
🚨 Please review this commit-by-commit.

This is a follow-up to https://github.com/github/vscode-codeql/pull/1688 where we first started converting our query history tests to check all types of history items instead of just local query ones. 

In order to test sorting with local queries, remote queries and variant analyses, we've had to make a few changes:

1. Allow `createMockVariantAnalysis` and `createMockVariantAnalysisHistoryItem` to receive named params so that we can set `resultCount` and `executionStartTime`. We need this in order to test sorting by result and date.
2. We do the same for `createMockRemoteQueryHistoryItem`.
3. We're combining the two existing factory methods for creating a `LocalQueryInfo` into a single `createMockLocalQueryInfo` method.
4. For `createMockLocalQueryInfo` we're now returning a real object instead of typecasting something else. Not having a real object [blocked us][1] from being able to understand which fields we need in our tests and how they interact together.
5. Finally, we change our sorting tests to check all types of history item types, instead of just local queries.

[1]: https://github.com/github/vscode-codeql/pull/1697#discussion_r1011990685

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
