### PR TITLE
Create remote db tree view items based on the user's db config

### DIFF
--- a/extensions/ql-vscode/src/databases/db-manager.ts
+++ b/extensions/ql-vscode/src/databases/db-manager.ts
@@ -1,6 +1,6 @@
-import { logger } from '../logging';
 import { DbConfigStore } from './db-config-store';
 import { DbItem } from './db-item';
+import { createLocalTree, createRemoteTree } from './db-tree-creator';
 
 export class DbManager {
   constructor(
@@ -8,15 +8,12 @@ export class DbManager {
   ) {
   }
 
-  public loadDatabases(): void {
-    const config = this.dbConfigStore.getConfig();
-    void logger.log(`Loaded databases: ${JSON.stringify(config)}`);
-
-    // This will be fleshed out in a future change.
-  }
-
   public getDbItems(): DbItem[] {
-    // This will be fleshed out in a future change.
-    return [];
+    const config = this.dbConfigStore.getConfig();
+
+    return [
+      createRemoteTree(config),
+      createLocalTree()
+    ];
   }
 }

--- a/extensions/ql-vscode/src/databases/db-module.ts
+++ b/extensions/ql-vscode/src/databases/db-module.ts
@@ -26,8 +26,6 @@ export class DbModule extends DisposableObject {
     await dbConfigStore.initialize();
 
     const dbManager = new DbManager(dbConfigStore);
-    dbManager.loadDatabases();
-
     const dbPanel = new DbPanel(dbManager);
 
     this.push(dbPanel);

--- a/extensions/ql-vscode/src/databases/db-tree-creator.ts
+++ b/extensions/ql-vscode/src/databases/db-tree-creator.ts
@@ -1,0 +1,70 @@
+import { DbConfig, RemoteRepositoryList } from './db-config';
+import {
+  DbItemKind,
+  RemoteOwnerDbItem,
+  RemoteRepoDbItem,
+  RemoteSystemDefinedListDbItem,
+  RemoteUserDefinedListDbItem,
+  RootLocalDbItem,
+  RootRemoteDbItem
+} from './db-item';
+
+export function createRemoteTree(dbConfig: DbConfig): RootRemoteDbItem {
+  const systemDefinedLists = [
+    createSystemDefinedList(10),
+    createSystemDefinedList(100),
+    createSystemDefinedList(1000)
+  ];
+
+  const userDefinedRepoLists = dbConfig.remote.repositoryLists.map(createUserDefinedList);
+  const owners = dbConfig.remote.owners.map(createOwnerItem);
+  const repos = dbConfig.remote.repositories.map(createRepoItem);
+
+  return {
+    kind: DbItemKind.RootRemote,
+    children: [
+      ...systemDefinedLists,
+      ...owners,
+      ...userDefinedRepoLists,
+      ...repos
+    ]
+  };
+}
+
+export function createLocalTree(): RootLocalDbItem {
+  // This will be fleshed out further in the future.
+  return {
+    kind: DbItemKind.RootLocal
+  };
+}
+
+function createSystemDefinedList(n: number): RemoteSystemDefinedListDbItem {
+  return {
+    kind: DbItemKind.RemoteSystemDefinedList,
+    listName: `top_${n}`,
+    listDisplayName: `Top ${n} repositories`,
+    listDescription: `Top ${n} repositories of a language`
+  };
+}
+
+function createUserDefinedList(list: RemoteRepositoryList): RemoteUserDefinedListDbItem {
+  return {
+    kind: DbItemKind.RemoteUserDefinedList,
+    listName: list.name,
+    repos: list.repositories.map((r) => createRepoItem(r))
+  };
+}
+
+function createOwnerItem(owner: string): RemoteOwnerDbItem {
+  return {
+    kind: DbItemKind.RemoteOwner,
+    ownerName: owner
+  };
+}
+
+function createRepoItem(repo: string): RemoteRepoDbItem {
+  return {
+    kind: DbItemKind.RemoteRepo,
+    repoFullName: repo
+  };
+}

--- a/extensions/ql-vscode/src/databases/ui/db-item-mapper.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-item-mapper.ts
@@ -1,0 +1,49 @@
+import { DbItem, DbItemKind } from '../db-item';
+import {
+  createDbTreeViewItemOwner,
+  createDbTreeViewItemRepo,
+  createDbTreeViewItemRoot,
+  createDbTreeViewItemSystemDefinedList,
+  createDbTreeViewItemUserDefinedList,
+  DbTreeViewItem
+} from './db-tree-view-item';
+
+export function mapDbItemToTreeViewItem(dbItem: DbItem): DbTreeViewItem {
+  switch (dbItem.kind) {
+    case DbItemKind.RootLocal:
+      return createDbTreeViewItemRoot(
+        dbItem,
+        'local',
+        'Local databases',
+        []);
+
+    case DbItemKind.RootRemote:
+      return createDbTreeViewItemRoot(
+        dbItem,
+        'remote',
+        'Local databases',
+        dbItem.children.map(c => mapDbItemToTreeViewItem(c)));
+
+    case DbItemKind.RemoteSystemDefinedList:
+      return createDbTreeViewItemSystemDefinedList(
+        dbItem,
+        dbItem.listDisplayName,
+        dbItem.listDescription);
+
+    case DbItemKind.RemoteUserDefinedList:
+      return createDbTreeViewItemUserDefinedList(
+        dbItem,
+        dbItem.listName,
+        dbItem.repos.map(mapDbItemToTreeViewItem));
+
+    case DbItemKind.RemoteOwner:
+      return createDbTreeViewItemOwner(
+        dbItem,
+        dbItem.ownerName);
+
+    case DbItemKind.RemoteRepo:
+      return createDbTreeViewItemRepo(
+        dbItem,
+        dbItem.repoFullName);
+  }
+}

--- a/extensions/ql-vscode/src/databases/ui/db-item-mapper.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-item-mapper.ts
@@ -21,7 +21,7 @@ export function mapDbItemToTreeViewItem(dbItem: DbItem): DbTreeViewItem {
       return createDbTreeViewItemRoot(
         dbItem,
         'remote',
-        'Local databases',
+        'Remote databases',
         dbItem.children.map(c => mapDbItemToTreeViewItem(c)));
 
     case DbItemKind.RemoteSystemDefinedList:

--- a/extensions/ql-vscode/src/databases/ui/db-tree-data-provider.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-tree-data-provider.ts
@@ -1,7 +1,7 @@
-import { logger } from '../../logging';
 import { ProviderResult, TreeDataProvider, TreeItem } from 'vscode';
 import { createDbTreeViewItemWarning, DbTreeViewItem } from './db-tree-view-item';
 import { DbManager } from '../db-manager';
+import { mapDbItemToTreeViewItem } from './db-item-mapper';
 
 export class DbTreeDataProvider implements TreeDataProvider<DbTreeViewItem> {
   private dbTreeItems: DbTreeViewItem[];
@@ -38,15 +38,12 @@ export class DbTreeDataProvider implements TreeDataProvider<DbTreeViewItem> {
   private createTree(): DbTreeViewItem[] {
     const dbItems = this.dbManager.getDbItems();
 
-    // This will be fleshed out in a future change.
-    void logger.log(`Creating database tree with ${dbItems.length} items`);
-
     // Add a sample warning as a proof of concept.
     const warningTreeViewItem = createDbTreeViewItemWarning(
       'There was an error',
       'Fix it'
     );
 
-    return [warningTreeViewItem];
+    return [...dbItems.map(mapDbItemToTreeViewItem), warningTreeViewItem];
   }
 }

--- a/extensions/ql-vscode/src/databases/ui/db-tree-view-item.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-tree-view-item.ts
@@ -1,5 +1,13 @@
 import * as vscode from 'vscode';
-import { DbItem } from '../db-item';
+import {
+  DbItem,
+  RemoteOwnerDbItem,
+  RemoteRepoDbItem,
+  RemoteSystemDefinedListDbItem,
+  RemoteUserDefinedListDbItem,
+  RootLocalDbItem,
+  RootRemoteDbItem
+} from '../db-item';
 
 /**
  * Represents an item in the database tree view. This item could be 
@@ -8,9 +16,9 @@ import { DbItem } from '../db-item';
 export class DbTreeViewItem extends vscode.TreeItem {
   constructor(
     public readonly dbItem: DbItem | undefined,
-    public readonly iconPath: vscode.ThemeIcon,
+    public readonly iconPath: vscode.ThemeIcon | undefined,
     public readonly label: string,
-    public readonly tooltip: string,
+    public readonly tooltip: string | undefined,
     public readonly collapsibleState: vscode.TreeItemCollapsibleState,
     public readonly children: DbTreeViewItem[]
   ) {
@@ -27,4 +35,73 @@ export function createDbTreeViewItemWarning(label: string, tooltip: string): DbT
     vscode.TreeItemCollapsibleState.None,
     []
   );
+}
+
+export function createDbTreeViewItemRoot(
+  dbItem: RootLocalDbItem | RootRemoteDbItem,
+  label: string,
+  tooltip: string,
+  children: DbTreeViewItem[]
+): DbTreeViewItem {
+  return new DbTreeViewItem(
+    dbItem,
+    undefined,
+    label,
+    tooltip,
+    vscode.TreeItemCollapsibleState.Collapsed,
+    children);
+}
+
+export function createDbTreeViewItemSystemDefinedList(
+  dbItem: RemoteSystemDefinedListDbItem,
+  label: string,
+  tooltip: string
+): DbTreeViewItem {
+  return new DbTreeViewItem(
+    dbItem,
+    new vscode.ThemeIcon('github'),
+    label,
+    tooltip,
+    vscode.TreeItemCollapsibleState.None,
+    []);
+}
+
+export function createDbTreeViewItemUserDefinedList(
+  dbItem: RemoteUserDefinedListDbItem,
+  listName: string,
+  children: DbTreeViewItem[]
+): DbTreeViewItem {
+  return new DbTreeViewItem(
+    dbItem,
+    undefined,
+    listName,
+    undefined,
+    vscode.TreeItemCollapsibleState.Collapsed,
+    children);
+}
+
+export function createDbTreeViewItemOwner(
+  dbItem: RemoteOwnerDbItem,
+  ownerName: string,
+): DbTreeViewItem {
+  return new DbTreeViewItem(
+    dbItem,
+    new vscode.ThemeIcon('organization'),
+    ownerName,
+    undefined,
+    vscode.TreeItemCollapsibleState.None,
+    []);
+}
+
+export function createDbTreeViewItemRepo(
+  dbItem: RemoteRepoDbItem,
+  repoName: string,
+): DbTreeViewItem {
+  return new DbTreeViewItem(
+    dbItem,
+    new vscode.ThemeIcon('database'),
+    repoName,
+    undefined,
+    vscode.TreeItemCollapsibleState.None,
+    []);
 }

--- a/extensions/ql-vscode/test/pure-tests/databases/db-tree-creator.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/databases/db-tree-creator.test.ts
@@ -6,7 +6,7 @@ import { createRemoteTree } from '../../../src/databases/db-tree-creator';
 
 describe('db tree creator', () => {
   describe('createRemoteTree', () => {
-    it('should build root node and sytem defined lists', () => {
+    it('should build root node and system defined lists', () => {
       const dbConfig: DbConfig = {
         remote: {
           repositoryLists: [],

--- a/extensions/ql-vscode/test/pure-tests/databases/db-tree-creator.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/databases/db-tree-creator.test.ts
@@ -1,0 +1,163 @@
+import { expect } from 'chai';
+
+import { DbConfig } from '../../../src/databases/db-config';
+import { DbItemKind } from '../../../src/databases/db-item';
+import { createRemoteTree } from '../../../src/databases/db-tree-creator';
+
+describe('db tree creator', () => {
+  describe('createRemoteTree', () => {
+    it('should build root node and sytem defined lists', () => {
+      const dbConfig: DbConfig = {
+        remote: {
+          repositoryLists: [],
+          owners: [],
+          repositories: []
+        }
+      };
+
+      const dbTreeRoot = createRemoteTree(dbConfig);
+
+      expect(dbTreeRoot).to.be.ok;
+      expect(dbTreeRoot.kind).to.equal(DbItemKind.RootRemote);
+      expect(dbTreeRoot.children.length).to.equal(3);
+      expect(dbTreeRoot.children[0]).to.deep.equal({
+        kind: DbItemKind.RemoteSystemDefinedList,
+        listName: 'top_10',
+        listDisplayName: 'Top 10 repositories',
+        listDescription: 'Top 10 repositories of a language'
+      });
+      expect(dbTreeRoot.children[1]).to.deep.equal({
+        kind: DbItemKind.RemoteSystemDefinedList,
+        listName: 'top_100',
+        listDisplayName: 'Top 100 repositories',
+        listDescription: 'Top 100 repositories of a language'
+      });
+      expect(dbTreeRoot.children[2]).to.deep.equal({
+        kind: DbItemKind.RemoteSystemDefinedList,
+        listName: 'top_1000',
+        listDisplayName: 'Top 1000 repositories',
+        listDescription: 'Top 1000 repositories of a language'
+      });
+    });
+
+    it('should create remote user defined list nodes', () => {
+      const dbConfig: DbConfig = {
+        remote: {
+          repositoryLists: [
+            {
+              name: 'my-list-1',
+              repositories: [
+                'owner1/repo1',
+                'owner1/repo2',
+                'owner2/repo1'
+              ]
+            },
+            {
+              name: 'my-list-2',
+              repositories: [
+                'owner3/repo1',
+                'owner3/repo2',
+                'owner4/repo1'
+              ]
+            }
+          ],
+          owners: [],
+          repositories: []
+        }
+      };
+
+      const dbTreeRoot = createRemoteTree(dbConfig);
+
+      expect(dbTreeRoot).to.be.ok;
+      expect(dbTreeRoot.kind).to.equal(DbItemKind.RootRemote);
+      const repositoryListNodes = dbTreeRoot.children.filter(
+        (child) => child.kind === DbItemKind.RemoteUserDefinedList
+      );
+
+      expect(repositoryListNodes.length).to.equal(2);
+      expect(repositoryListNodes[0]).to.deep.equal({
+        kind: DbItemKind.RemoteUserDefinedList,
+        listName: dbConfig.remote.repositoryLists[0].name,
+        repos: dbConfig.remote.repositoryLists[0].repositories.map((repo) => ({
+          kind: DbItemKind.RemoteRepo,
+          repoFullName: repo
+        }))
+      });
+      expect(repositoryListNodes[1]).to.deep.equal({
+        kind: DbItemKind.RemoteUserDefinedList,
+        listName: dbConfig.remote.repositoryLists[1].name,
+        repos: dbConfig.remote.repositoryLists[1].repositories.map((repo) => ({
+          kind: DbItemKind.RemoteRepo,
+          repoFullName: repo
+        }))
+      });
+    });
+
+    it('should create remote owner nodes', () => {
+      const dbConfig: DbConfig = {
+        remote: {
+          repositoryLists: [],
+          owners: [
+            'owner1',
+            'owner2'
+          ],
+          repositories: []
+        }
+      };
+
+      const dbTreeRoot = createRemoteTree(dbConfig);
+
+      expect(dbTreeRoot).to.be.ok;
+      expect(dbTreeRoot.kind).to.equal(DbItemKind.RootRemote);
+      const ownerNodes = dbTreeRoot.children.filter(
+        (child) => child.kind === DbItemKind.RemoteOwner
+      );
+
+      expect(ownerNodes.length).to.equal(2);
+      expect(ownerNodes[0]).to.deep.equal({
+        kind: DbItemKind.RemoteOwner,
+        ownerName: dbConfig.remote.owners[0]
+      });
+      expect(ownerNodes[1]).to.deep.equal({
+        kind: DbItemKind.RemoteOwner,
+        ownerName: dbConfig.remote.owners[1]
+      });
+    });
+
+    it('should create remote repo nodes', () => {
+      const dbConfig: DbConfig = {
+        remote: {
+          repositoryLists: [],
+          owners: [],
+          repositories: [
+            'owner1/repo1',
+            'owner1/repo2',
+            'owner2/repo1'
+          ]
+        }
+      };
+
+      const dbTreeRoot = createRemoteTree(dbConfig);
+
+      expect(dbTreeRoot).to.be.ok;
+      expect(dbTreeRoot.kind).to.equal(DbItemKind.RootRemote);
+      const repoNodes = dbTreeRoot.children.filter(
+        (child) => child.kind === DbItemKind.RemoteRepo
+      );
+
+      expect(repoNodes.length).to.equal(3);
+      expect(repoNodes[0]).to.deep.equal({
+        kind: DbItemKind.RemoteRepo,
+        repoFullName: dbConfig.remote.repositories[0]
+      });
+      expect(repoNodes[1]).to.deep.equal({
+        kind: DbItemKind.RemoteRepo,
+        repoFullName: dbConfig.remote.repositories[1]
+      });
+      expect(repoNodes[2]).to.deep.equal({
+        kind: DbItemKind.RemoteRepo,
+        repoFullName: dbConfig.remote.repositories[2]
+      });
+    });
+  });
+});


### PR DESCRIPTION
Adds some logic to create and render db tree view items based on the user's db config file. Currently only deals with remote dbs.

<img src=https://user-images.githubusercontent.com/311693/199978263-c577dfb5-1779-438f-8e2e-8c4907b4d332.png width=400 />


## Checklist
N/A - internal only.

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
