### PR TITLE
Implement query history "cancel" option

### DIFF
--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -40,7 +40,7 @@ import * as fs from 'fs-extra';
 import { CliVersionConstraint } from './cli';
 import { HistoryItemLabelProvider } from './history-item-label-provider';
 import { Credentials } from './authentication';
-import { cancelRemoteQuery } from './remote-queries/gh-api/gh-actions-api-client';
+import { cancelRemoteQuery, cancelVariantAnalysis } from './remote-queries/gh-api/gh-actions-api-client';
 import { RemoteQueriesManager } from './remote-queries/remote-queries-manager';
 import { RemoteQueryHistoryItem } from './remote-queries/remote-query-history-item';
 import { ResultsView } from './interface';
@@ -1109,6 +1109,7 @@ export class QueryHistoryManager extends DisposableObject {
     const { finalSingleItem, finalMultiSelect } = this.determineSelection(singleItem, multiSelect);
 
     const selected = finalMultiSelect || [finalSingleItem];
+
     const results = selected.map(async item => {
       if (item.status === QueryStatus.InProgress) {
         if (item.t === 'local') {
@@ -1117,6 +1118,10 @@ export class QueryHistoryManager extends DisposableObject {
           void showAndLogInformationMessage('Cancelling variant analysis. This may take a while.');
           const credentials = await this.getCredentials();
           await cancelRemoteQuery(credentials, item.remoteQuery);
+        } else if (item.t === 'variant-analysis') {
+          void showAndLogInformationMessage('Cancelling variant analysis. This may take a while.');
+          const credentials = await this.getCredentials();
+          await cancelVariantAnalysis(credentials, item.variantAnalysis);
         }
       }
     });

--- a/extensions/ql-vscode/src/remote-queries/gh-api/gh-actions-api-client.ts
+++ b/extensions/ql-vscode/src/remote-queries/gh-api/gh-actions-api-client.ts
@@ -9,6 +9,7 @@ import { RemoteQuery } from '../remote-query';
 import { RemoteQueryFailureIndexItem, RemoteQueryResultIndex, RemoteQuerySuccessIndexItem } from '../remote-query-result-index';
 import { getErrorMessage } from '../../pure/helpers-pure';
 import { unzipFile } from '../../pure/zip';
+import { VariantAnalysis } from '../shared/variant-analysis';
 
 export const RESULT_INDEX_ARTIFACT_NAME = 'result-index';
 
@@ -89,6 +90,18 @@ export async function cancelRemoteQuery(
   const octokit = await credentials.getOctokit();
   const { actionsWorkflowRunId, controllerRepository: { owner, name } } = remoteQuery;
   const response = await octokit.request(`POST /repos/${owner}/${name}/actions/runs/${actionsWorkflowRunId}/cancel`);
+  if (response.status >= 300) {
+    throw new Error(`Error cancelling variant analysis: ${response.status} ${response?.data?.message || ''}`);
+  }
+}
+
+export async function cancelVariantAnalysis(
+  credentials: Credentials,
+  variantAnalysis: VariantAnalysis
+): Promise<void> {
+  const octokit = await credentials.getOctokit();
+  const { actionsWorkflowRunId, controllerRepo: { fullName } } = variantAnalysis;
+  const response = await octokit.request(`POST /repos/${fullName}/actions/runs/${actionsWorkflowRunId}/cancel`);
   if (response.status >= 300) {
     throw new Error(`Error cancelling variant analysis: ${response.status} ${response?.data?.message || ''}`);
   }

--- a/extensions/ql-vscode/src/vscode-tests/factories/local-queries/local-query-history-item.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/local-queries/local-query-history-item.ts
@@ -47,6 +47,7 @@ export function createMockLocalQueryInfo({
   const localQuery = new LocalQueryInfo(initialQueryInfo, cancellationToken);
 
   localQuery.failureReason = failureReason;
+  localQuery.cancel = () => { /**/ };
 
   if (queryWithResults) {
     localQuery.completeThisQuery(queryWithResults);

--- a/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/shared/variant-analysis.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/shared/variant-analysis.ts
@@ -21,7 +21,7 @@ export function createMockVariantAnalysis({
   skippedRepos?: VariantAnalysisSkippedRepositories,
   executionStartTime?: number | undefined
 }): VariantAnalysis {
-  const variantAnalysis: VariantAnalysis = {
+  return {
     id: faker.datatype.number(),
     controllerRepo: {
       ...createMockRepository(),
@@ -46,6 +46,4 @@ export function createMockVariantAnalysis({
     scannedRepos: scannedRepos,
     skippedRepos: skippedRepos
   };
-
-  return variantAnalysis;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

This makes it possible to cancel a variant analysis from the query history by right-clicking on it. This will trigger a request to the GitHub API to cancel the workflow run. Once that happens, the variant analysis will be updated via the monitor with a `canceled` state.

NB: We only attempt to cancel if the item is in progress. 

While we're here we're also adding tests for cancelling local queries and remote queries. 

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
