### PR TITLE
Remove `gh-api` usage from variant analysis code

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -109,11 +109,7 @@ import { NewQueryRunner } from './query-server/query-runner';
 import { QueryRunner } from './queryRunner';
 import { VariantAnalysisView } from './remote-queries/variant-analysis-view';
 import { VariantAnalysisViewSerializer } from './remote-queries/variant-analysis-view-serializer';
-import { VariantAnalysis } from './remote-queries/shared/variant-analysis';
-import {
-  VariantAnalysis as VariantAnalysisApiResponse,
-  VariantAnalysisScannedRepository as ApiVariantAnalysisScannedRepository
-} from './remote-queries/gh-api/variant-analysis';
+import { VariantAnalysis, VariantAnalysisScannedRepository } from './remote-queries/shared/variant-analysis';
 import { VariantAnalysisManager } from './remote-queries/variant-analysis-manager';
 import { createVariantAnalysisContentProvider } from './remote-queries/variant-analysis-content-provider';
 import { VSCodeMockGitHubApiServer } from './mocks/vscode-mock-gh-api-server';
@@ -949,8 +945,8 @@ async function activateWithInstalledDistribution(
 
   ctx.subscriptions.push(
     commandRunner('codeQL.autoDownloadVariantAnalysisResult', async (
-      scannedRepo: ApiVariantAnalysisScannedRepository,
-      variantAnalysisSummary: VariantAnalysisApiResponse,
+      scannedRepo: VariantAnalysisScannedRepository,
+      variantAnalysisSummary: VariantAnalysis,
       token: CancellationToken
     ) => {
       await variantAnalysisManager.enqueueDownload(scannedRepo, variantAnalysisSummary, token);

--- a/extensions/ql-vscode/src/remote-queries/shared/variant-analysis.ts
+++ b/extensions/ql-vscode/src/remote-queries/shared/variant-analysis.ts
@@ -76,6 +76,17 @@ export interface VariantAnalysisScannedRepository {
   failureMessage?: string
 }
 
+export interface VariantAnalysisRepositoryTask {
+  repository: Repository,
+  analysisStatus: VariantAnalysisRepoStatus,
+  resultCount?: number,
+  artifactSizeInBytes?: number,
+  failureMessage?: string,
+  databaseCommitSha?: string,
+  sourceLocationPrefix?: string,
+  artifactUrl?: string,
+}
+
 export interface VariantAnalysisSkippedRepositories {
   accessMismatchRepos?: VariantAnalysisSkippedRepositoryGroup,
   notFoundRepos?: VariantAnalysisSkippedRepositoryGroup,

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
@@ -6,13 +6,10 @@ import { DisposableObject } from '../pure/disposable-object';
 import { Credentials } from '../authentication';
 import { VariantAnalysisMonitor } from './variant-analysis-monitor';
 import {
-  VariantAnalysis as VariantAnalysisApiResponse,
-  VariantAnalysisRepoTask,
-  VariantAnalysisScannedRepository as ApiVariantAnalysisScannedRepository
-} from './gh-api/variant-analysis';
-import {
   isVariantAnalysisComplete,
-  VariantAnalysis, VariantAnalysisQueryLanguage,
+  VariantAnalysis,
+  VariantAnalysisQueryLanguage,
+  VariantAnalysisRepositoryTask,
   VariantAnalysisScannedRepository,
   VariantAnalysisScannedRepositoryDownloadStatus,
   VariantAnalysisScannedRepositoryResult,
@@ -23,7 +20,7 @@ import { VariantAnalysisView } from './variant-analysis-view';
 import { VariantAnalysisViewManager } from './variant-analysis-view-manager';
 import { VariantAnalysisResultsManager } from './variant-analysis-results-manager';
 import { getControllerRepo } from './run-remote-query';
-import { processUpdatedVariantAnalysis } from './variant-analysis-processor';
+import { processUpdatedVariantAnalysis, processVariantAnalysisRepositoryTask } from './variant-analysis-processor';
 import PQueue from 'p-queue';
 import { createTimestampFile, showAndLogErrorMessage } from '../helpers';
 import * as fs from 'fs-extra';
@@ -179,8 +176,8 @@ export class VariantAnalysisManager extends DisposableObject implements VariantA
   }
 
   public async autoDownloadVariantAnalysisResult(
-    scannedRepo: ApiVariantAnalysisScannedRepository,
-    variantAnalysisSummary: VariantAnalysisApiResponse,
+    scannedRepo: VariantAnalysisScannedRepository,
+    variantAnalysis: VariantAnalysis,
     cancellationToken: CancellationToken
   ): Promise<void> {
     const repoState = {
@@ -188,48 +185,50 @@ export class VariantAnalysisManager extends DisposableObject implements VariantA
       downloadStatus: VariantAnalysisScannedRepositoryDownloadStatus.Pending,
     };
 
-    await this.onRepoStateUpdated(variantAnalysisSummary.id, repoState);
+    await this.onRepoStateUpdated(variantAnalysis.id, repoState);
 
     const credentials = await Credentials.initialize(this.ctx);
     if (!credentials) { throw Error('Error authenticating with GitHub'); }
 
     if (cancellationToken && cancellationToken.isCancellationRequested) {
       repoState.downloadStatus = VariantAnalysisScannedRepositoryDownloadStatus.Failed;
-      await this.onRepoStateUpdated(variantAnalysisSummary.id, repoState);
+      await this.onRepoStateUpdated(variantAnalysis.id, repoState);
       return;
     }
 
-    let repoTask: VariantAnalysisRepoTask;
+    let repoTask: VariantAnalysisRepositoryTask;
     try {
-      repoTask = await ghApiClient.getVariantAnalysisRepo(
+      const repoTaskResponse = await ghApiClient.getVariantAnalysisRepo(
         credentials,
-        variantAnalysisSummary.controller_repo.id,
-        variantAnalysisSummary.id,
+        variantAnalysis.controllerRepo.id,
+        variantAnalysis.id,
         scannedRepo.repository.id
       );
+
+      repoTask = processVariantAnalysisRepositoryTask(repoTaskResponse);
     } catch (e) {
       repoState.downloadStatus = VariantAnalysisScannedRepositoryDownloadStatus.Failed;
-      await this.onRepoStateUpdated(variantAnalysisSummary.id, repoState);
-      throw new Error(`Could not download the results for variant analysis with id: ${variantAnalysisSummary.id}. Error: ${getErrorMessage(e)}`);
+      await this.onRepoStateUpdated(variantAnalysis.id, repoState);
+      throw new Error(`Could not download the results for variant analysis with id: ${variantAnalysis.id}. Error: ${getErrorMessage(e)}`);
     }
 
-    if (repoTask.artifact_url) {
+    if (repoTask.artifactUrl) {
       repoState.downloadStatus = VariantAnalysisScannedRepositoryDownloadStatus.InProgress;
-      await this.onRepoStateUpdated(variantAnalysisSummary.id, repoState);
+      await this.onRepoStateUpdated(variantAnalysis.id, repoState);
 
-      await this.variantAnalysisResultsManager.download(credentials, variantAnalysisSummary.id, repoTask, this.getVariantAnalysisStorageLocation(variantAnalysisSummary.id));
+      await this.variantAnalysisResultsManager.download(credentials, variantAnalysis.id, repoTask, this.getVariantAnalysisStorageLocation(variantAnalysis.id));
     }
 
     repoState.downloadStatus = VariantAnalysisScannedRepositoryDownloadStatus.Succeeded;
-    await this.onRepoStateUpdated(variantAnalysisSummary.id, repoState);
+    await this.onRepoStateUpdated(variantAnalysis.id, repoState);
   }
 
   public async enqueueDownload(
-    scannedRepo: ApiVariantAnalysisScannedRepository,
-    variantAnalysisSummary: VariantAnalysisApiResponse,
+    scannedRepo: VariantAnalysisScannedRepository,
+    variantAnalysis: VariantAnalysis,
     token: CancellationToken
   ): Promise<void> {
-    await this.queue.add(() => this.autoDownloadVariantAnalysisResult(scannedRepo, variantAnalysisSummary, token));
+    await this.queue.add(() => this.autoDownloadVariantAnalysisResult(scannedRepo, variantAnalysis, token));
   }
 
   public downloadsQueueSize(): number {

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-processor.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-processor.ts
@@ -6,7 +6,8 @@ import {
   VariantAnalysisFailureReason as ApiVariantAnalysisFailureReason,
   VariantAnalysisStatus as ApiVariantAnalysisStatus,
   VariantAnalysisSkippedRepositoryGroup as ApiVariantAnalysisSkippedRepositoryGroup,
-  VariantAnalysisNotFoundRepositoryGroup as ApiVariantAnalysisNotFoundRepositoryGroup
+  VariantAnalysisNotFoundRepositoryGroup as ApiVariantAnalysisNotFoundRepositoryGroup,
+  VariantAnalysisRepoTask as ApiVariantAnalysisRepoTask,
 } from './gh-api/variant-analysis';
 import {
   VariantAnalysis,
@@ -16,7 +17,8 @@ import {
   VariantAnalysisStatus,
   VariantAnalysisRepoStatus,
   VariantAnalysisSubmission,
-  VariantAnalysisSkippedRepositoryGroup
+  VariantAnalysisSkippedRepositoryGroup,
+  VariantAnalysisRepositoryTask
 } from './shared/variant-analysis';
 
 export function processVariantAnalysis(
@@ -76,24 +78,47 @@ export function processUpdatedVariantAnalysis(
   return variantAnalysis;
 }
 
+export function processVariantAnalysisRepositoryTask(
+  response: ApiVariantAnalysisRepoTask
+): VariantAnalysisRepositoryTask {
+  return {
+    repository: {
+      id: response.repository.id,
+      fullName: response.repository.full_name,
+      private: response.repository.private,
+    },
+    analysisStatus: processApiRepoStatus(response.analysis_status),
+    resultCount: response.result_count,
+    artifactSizeInBytes: response.artifact_size_in_bytes,
+    failureMessage: response.failure_message,
+    databaseCommitSha: response.database_commit_sha,
+    sourceLocationPrefix: response.source_location_prefix,
+    artifactUrl: response.artifact_url,
+  };
+}
+
+export function processScannedRepository(
+  scannedRepo: ApiVariantAnalysisScannedRepository
+): VariantAnalysisScannedRepository {
+  return {
+    repository: {
+      id: scannedRepo.repository.id,
+      fullName: scannedRepo.repository.full_name,
+      private: scannedRepo.repository.private,
+      stargazersCount: scannedRepo.repository.stargazers_count,
+      updatedAt: scannedRepo.repository.updated_at,
+    },
+    analysisStatus: processApiRepoStatus(scannedRepo.analysis_status),
+    resultCount: scannedRepo.result_count,
+    artifactSizeInBytes: scannedRepo.artifact_size_in_bytes,
+    failureMessage: scannedRepo.failure_message
+  };
+}
+
 function processScannedRepositories(
   scannedRepos: ApiVariantAnalysisScannedRepository[]
 ): VariantAnalysisScannedRepository[] {
-  return scannedRepos.map(scannedRepo => {
-    return {
-      repository: {
-        id: scannedRepo.repository.id,
-        fullName: scannedRepo.repository.full_name,
-        private: scannedRepo.repository.private,
-        stargazersCount: scannedRepo.repository.stargazers_count,
-        updatedAt: scannedRepo.repository.updated_at,
-      },
-      analysisStatus: processApiRepoStatus(scannedRepo.analysis_status),
-      resultCount: scannedRepo.result_count,
-      artifactSizeInBytes: scannedRepo.artifact_size_in_bytes,
-      failureMessage: scannedRepo.failure_message
-    };
-  });
+  return scannedRepos.map(scannedRepo => processScannedRepository(scannedRepo));
 }
 
 function processSkippedRepositories(

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-monitor.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-monitor.test.ts
@@ -14,7 +14,11 @@ import {
 import { createFailedMockApiResponse, createMockApiResponse } from '../../factories/remote-queries/gh-api/variant-analysis-api-response';
 import { VariantAnalysis, VariantAnalysisStatus } from '../../../remote-queries/shared/variant-analysis';
 import { createMockScannedRepos } from '../../factories/remote-queries/gh-api/scanned-repositories';
-import { processFailureReason } from '../../../remote-queries/variant-analysis-processor';
+import {
+  processFailureReason,
+  processScannedRepository,
+  processUpdatedVariantAnalysis,
+} from '../../../remote-queries/variant-analysis-processor';
 import { Credentials } from '../../../authentication';
 import { createMockVariantAnalysis } from '../../factories/remote-queries/shared/variant-analysis';
 import { VariantAnalysisManager } from '../../../remote-queries/variant-analysis-manager';
@@ -143,8 +147,8 @@ describe('Variant Analysis Monitor', async function() {
 
           succeededRepos.forEach((succeededRepo, index) => {
             expect(commandSpy.getCall(index).args[0]).to.eq('codeQL.autoDownloadVariantAnalysisResult');
-            expect(commandSpy.getCall(index).args[1]).to.eq(succeededRepo);
-            expect(commandSpy.getCall(index).args[2]).to.eq(mockApiResponse);
+            expect(commandSpy.getCall(index).args[1]).to.deep.eq(processScannedRepository(succeededRepo));
+            expect(commandSpy.getCall(index).args[2]).to.deep.eq(processUpdatedVariantAnalysis(variantAnalysis, mockApiResponse));
           });
         });
 
@@ -154,8 +158,8 @@ describe('Variant Analysis Monitor', async function() {
           expect(mockGetDownloadResult).to.have.callCount(succeededRepos.length);
 
           succeededRepos.forEach((succeededRepo, index) => {
-            expect(mockGetDownloadResult.getCall(index).args[0]).to.eq(succeededRepo);
-            expect(mockGetDownloadResult.getCall(index).args[1]).to.eq(mockApiResponse);
+            expect(mockGetDownloadResult.getCall(index).args[0]).to.deep.eq(processScannedRepository(succeededRepo));
+            expect(mockGetDownloadResult.getCall(index).args[1]).to.deep.eq(processUpdatedVariantAnalysis(variantAnalysis, mockApiResponse));
           });
         });
       });

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-results-manager.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-results-manager.test.ts
@@ -8,11 +8,14 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 
 import { VariantAnalysisResultsManager } from '../../../remote-queries/variant-analysis-results-manager';
-import { createMockVariantAnalysisRepoTask } from '../../factories/remote-queries/gh-api/variant-analysis-repo-task';
 import { CodeQLCliServer } from '../../../cli';
 import { storagePath } from '../global.helper';
 import { faker } from '@faker-js/faker';
 import * as ghApiClient from '../../../remote-queries/gh-api/gh-api-client';
+import {
+  createMockVariantAnalysisRepositoryTask
+} from '../../factories/remote-queries/shared/variant-analysis-repo-tasks';
+import { VariantAnalysisRepositoryTask } from '../../../remote-queries/shared/variant-analysis';
 
 describe(VariantAnalysisResultsManager.name, function() {
   this.timeout(10000);
@@ -51,15 +54,15 @@ describe(VariantAnalysisResultsManager.name, function() {
         request: getOctokitStub
       })
     } as unknown as Credentials;
-    let dummyRepoTask = createMockVariantAnalysisRepoTask();
+    let dummyRepoTask: VariantAnalysisRepositoryTask;
     let variantAnalysisStoragePath: string;
     let repoTaskStorageDirectory: string;
 
     beforeEach(async () => {
-      dummyRepoTask = createMockVariantAnalysisRepoTask();
+      dummyRepoTask = createMockVariantAnalysisRepositoryTask();
 
       variantAnalysisStoragePath = path.join(storagePath, variantAnalysisId.toString());
-      repoTaskStorageDirectory = variantAnalysisResultsManager.getRepoStorageDirectory(variantAnalysisStoragePath, dummyRepoTask.repository.full_name);
+      repoTaskStorageDirectory = variantAnalysisResultsManager.getRepoStorageDirectory(variantAnalysisStoragePath, dummyRepoTask.repository.fullName);
     });
 
     afterEach(async () => {
@@ -70,14 +73,14 @@ describe(VariantAnalysisResultsManager.name, function() {
 
     describe('isVariantAnalysisRepoDownloaded', () => {
       it('should return false when no results are downloaded', async () => {
-        expect(await variantAnalysisResultsManager.isVariantAnalysisRepoDownloaded(variantAnalysisStoragePath, dummyRepoTask.repository.full_name)).to.equal(false);
+        expect(await variantAnalysisResultsManager.isVariantAnalysisRepoDownloaded(variantAnalysisStoragePath, dummyRepoTask.repository.fullName)).to.equal(false);
       });
     });
 
     describe('when the artifact_url is missing', async () => {
       it('should not try to download the result', async () => {
-        const dummyRepoTask = createMockVariantAnalysisRepoTask();
-        delete dummyRepoTask.artifact_url;
+        const dummyRepoTask = createMockVariantAnalysisRepositoryTask();
+        delete dummyRepoTask.artifactUrl;
 
         try {
           await variantAnalysisResultsManager.download(
@@ -103,7 +106,7 @@ describe(VariantAnalysisResultsManager.name, function() {
 
         getVariantAnalysisRepoResultStub = sandbox
           .stub(ghApiClient, 'getVariantAnalysisRepoResult')
-          .withArgs(mockCredentials, dummyRepoTask.artifact_url as string)
+          .withArgs(mockCredentials, dummyRepoTask.artifactUrl as string)
           .resolves(arrayBuffer);
       });
 
@@ -149,7 +152,7 @@ describe(VariantAnalysisResultsManager.name, function() {
             variantAnalysisStoragePath
           );
 
-          expect(await variantAnalysisResultsManager.isVariantAnalysisRepoDownloaded(variantAnalysisStoragePath, dummyRepoTask.repository.full_name)).to.equal(true);
+          expect(await variantAnalysisResultsManager.isVariantAnalysisRepoDownloaded(variantAnalysisStoragePath, dummyRepoTask.repository.fullName)).to.equal(true);
         });
       });
     });

--- a/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/shared/variant-analysis-repo-tasks.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/shared/variant-analysis-repo-tasks.ts
@@ -1,0 +1,19 @@
+import { faker } from '@faker-js/faker';
+import {
+  VariantAnalysisRepositoryTask,
+  VariantAnalysisRepoStatus,
+} from '../../../../remote-queries/shared/variant-analysis';
+import { createMockRepositoryWithMetadata } from './repository';
+
+export function createMockVariantAnalysisRepositoryTask(data?: Partial<VariantAnalysisRepositoryTask>): VariantAnalysisRepositoryTask {
+  return {
+    repository: createMockRepositoryWithMetadata(),
+    analysisStatus: VariantAnalysisRepoStatus.Pending,
+    resultCount: faker.datatype.number(),
+    artifactSizeInBytes: faker.datatype.number(),
+    databaseCommitSha: faker.git.commitSha(),
+    sourceLocationPrefix: faker.system.filePath(),
+    artifactUrl: faker.internet.url(),
+    ...data,
+  };
+}

--- a/extensions/ql-vscode/test/pure-tests/remote-queries/variant-analysis-processor.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/remote-queries/variant-analysis-processor.test.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { faker } from '@faker-js/faker';
 import {
   VariantAnalysisScannedRepository as ApiVariantAnalysisScannedRepository
 } from '../../../src/remote-queries/gh-api/variant-analysis';
@@ -7,8 +8,15 @@ import {
   VariantAnalysisScannedRepository,
   VariantAnalysisRepoStatus
 } from '../../../src/remote-queries/shared/variant-analysis';
-import { processVariantAnalysis } from '../../../src/remote-queries/variant-analysis-processor';
-import { createMockScannedRepos } from '../../../src/vscode-tests/factories/remote-queries/gh-api/scanned-repositories';
+import {
+  processScannedRepository,
+  processVariantAnalysis,
+  processVariantAnalysisRepositoryTask
+} from '../../../src/remote-queries/variant-analysis-processor';
+import {
+  createMockScannedRepo,
+  createMockScannedRepos
+} from '../../../src/vscode-tests/factories/remote-queries/gh-api/scanned-repositories';
 import { createMockSkippedRepos } from '../../../src/vscode-tests/factories/remote-queries/gh-api/skipped-repositories';
 import {
   createMockApiResponse
@@ -16,8 +24,11 @@ import {
 import {
   createMockSubmission
 } from '../../../src/vscode-tests/factories/remote-queries/shared/variant-analysis-submission';
+import {
+  createMockVariantAnalysisRepoTask
+} from '../../../src/vscode-tests/factories/remote-queries/gh-api/variant-analysis-repo-task';
 
-describe('Variant Analysis processor', function() {
+describe(processVariantAnalysis.name, function() {
   const scannedRepos = createMockScannedRepos();
   const skippedRepos = createMockSkippedRepos();
   const mockApiResponse = createMockApiResponse('completed', scannedRepos, skippedRepos);
@@ -146,4 +157,45 @@ describe('Variant Analysis processor', function() {
       'resultCount': scannedRepo.result_count
     };
   }
+});
+
+describe(processVariantAnalysisRepositoryTask.name, () => {
+  const mockApiResponse = createMockVariantAnalysisRepoTask();
+
+  it('should return the correct result', () => {
+    expect(processVariantAnalysisRepositoryTask(mockApiResponse)).to.deep.eq({
+      repository: {
+        id: mockApiResponse.repository.id,
+        fullName: mockApiResponse.repository.full_name,
+        private: mockApiResponse.repository.private,
+      },
+      analysisStatus: 'succeeded',
+      resultCount: mockApiResponse.result_count,
+      artifactSizeInBytes: mockApiResponse.artifact_size_in_bytes,
+      failureMessage: mockApiResponse.failure_message,
+      databaseCommitSha: mockApiResponse.database_commit_sha,
+      sourceLocationPrefix: mockApiResponse.source_location_prefix,
+      artifactUrl: mockApiResponse.artifact_url,
+    });
+  });
+});
+
+describe(processScannedRepository.name, () => {
+  const mockApiResponse = createMockScannedRepo(faker.random.word(), faker.datatype.boolean(), VariantAnalysisRepoStatus.Pending);
+
+  it('should return the correct result', () => {
+    expect(processScannedRepository(mockApiResponse)).to.deep.eq({
+      repository: {
+        id: mockApiResponse.repository.id,
+        fullName: mockApiResponse.repository.full_name,
+        private: mockApiResponse.repository.private,
+        stargazersCount: mockApiResponse.repository.stargazers_count,
+        updatedAt: mockApiResponse.repository.updated_at,
+      },
+      analysisStatus: 'pending',
+      resultCount: mockApiResponse.result_count,
+      artifactSizeInBytes: mockApiResponse.artifact_size_in_bytes,
+      failureMessage: mockApiResponse.failure_message,
+    });
+  });
 });


### PR DESCRIPTION
This removes all usages of the `gh-api` types from the variant analysis code by replacing it by the same types defined in `shared`.

This is a breaking change for the query history since the files serialized to disk now also change. However, since this is still behind a feature flag the change should be safe to make now.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
