### PR TITLE
Add button to open database config from the new databases UI

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -356,7 +356,7 @@
       },
       {
         "command": "codeQLDatabases.openConfigFile",
-        "title": "CodeQL: Open Database Configuration File",
+        "title": "Open Database Configuration File",
         "icon": {
           "light": "media/light/edit.svg",
           "dark": "media/dark/edit.svg"

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -355,7 +355,7 @@
         "title": "CodeQL: Copy Version Information"
       },
       {
-        "command": "codeQLDatabases.openConfigFile",
+        "command": "codeQLDatabasesExperimental.openConfigFile",
         "title": "Open Database Configuration File",
         "icon": {
           "light": "media/light/edit.svg",
@@ -762,7 +762,7 @@
           "group": "navigation"
         },
         {
-          "command": "codeQLDatabases.openConfigFile",
+          "command": "codeQLDatabasesExperimental.openConfigFile",
           "when": "view == codeQLDatabasesExperimental",
           "group": "navigation"
         }
@@ -984,7 +984,7 @@
           "when": "config.codeQL.canary"
         },
         {
-          "command": "codeQLDatabases.openConfigFile",
+          "command": "codeQLDatabasesExperimental.openConfigFile",
           "when": "false"
         },
         {

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -355,6 +355,14 @@
         "title": "CodeQL: Copy Version Information"
       },
       {
+        "command": "codeQLDatabasesExperimental.openConfigFile",
+        "title": "CodeQL: Open Database Configuration File",
+        "icon": {
+          "light": "media/light/edit.svg",
+          "dark": "media/dark/edit.svg"
+        }
+      },
+      {
         "command": "codeQLDatabases.chooseDatabaseFolder",
         "title": "Choose Database from Folder",
         "icon": {
@@ -752,6 +760,11 @@
           "command": "codeQLEvalLogViewer.clear",
           "when": "view == codeQLEvalLogViewer",
           "group": "navigation"
+        },
+        {
+          "command": "codeQLDatabasesExperimental.openConfigFile",
+          "when": "view == codeQLDatabasesExperimental",
+          "group": "navigation"
         }
       ],
       "view/item/context": [
@@ -969,6 +982,10 @@
         {
           "command": "codeQL.chooseDatabaseLgtm",
           "when": "config.codeQL.canary"
+        },
+        {
+          "command": "codeQLDatabasesExperimental.openConfigFile",
+          "when": "false"
         },
         {
           "command": "codeQLDatabases.setCurrentDatabase",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -355,7 +355,7 @@
         "title": "CodeQL: Copy Version Information"
       },
       {
-        "command": "codeQLDatabasesExperimental.openConfigFile",
+        "command": "codeQLDatabases.openConfigFile",
         "title": "CodeQL: Open Database Configuration File",
         "icon": {
           "light": "media/light/edit.svg",
@@ -762,7 +762,7 @@
           "group": "navigation"
         },
         {
-          "command": "codeQLDatabasesExperimental.openConfigFile",
+          "command": "codeQLDatabases.openConfigFile",
           "when": "view == codeQLDatabasesExperimental",
           "group": "navigation"
         }
@@ -984,7 +984,7 @@
           "when": "config.codeQL.canary"
         },
         {
-          "command": "codeQLDatabasesExperimental.openConfigFile",
+          "command": "codeQLDatabases.openConfigFile",
           "when": "false"
         },
         {

--- a/extensions/ql-vscode/src/databases/db-config-store.ts
+++ b/extensions/ql-vscode/src/databases/db-config-store.ts
@@ -32,6 +32,10 @@ export class DbConfigStore extends DisposableObject {
     return cloneDbConfig(this.config);
   }
 
+  public getConfigPath(): string {
+    return this.configPath;
+  }
+
   private async loadConfig(): Promise<void> {
     if (!await fs.pathExists(this.configPath)) {
       await fs.writeJSON(this.configPath, this.createEmptyConfig(), { spaces: 2 });

--- a/extensions/ql-vscode/src/databases/db-manager.ts
+++ b/extensions/ql-vscode/src/databases/db-manager.ts
@@ -19,4 +19,8 @@ export class DbManager {
     // This will be fleshed out in a future change.
     return [];
   }
+
+  public getConfigPath(): string {
+    return this.dbConfigStore.getConfigPath();
+  }
 }

--- a/extensions/ql-vscode/src/databases/db-module.ts
+++ b/extensions/ql-vscode/src/databases/db-module.ts
@@ -29,6 +29,8 @@ export class DbModule extends DisposableObject {
     dbManager.loadDatabases();
 
     const dbPanel = new DbPanel(dbManager);
+    await dbPanel.initialize();
+    extensionContext.subscriptions.push(dbPanel);
 
     this.push(dbPanel);
     this.push(dbConfigStore);

--- a/extensions/ql-vscode/src/databases/ui/db-panel.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-panel.ts
@@ -25,7 +25,7 @@ export class DbPanel extends DisposableObject {
   public async initialize(): Promise<void> {
     this.push(
       commandRunner(
-        'codeQLDatabases.openConfigFile',
+        'codeQLDatabasesExperimental.openConfigFile',
         () => this.openConfigFile(),
       )
     );

--- a/extensions/ql-vscode/src/databases/ui/db-panel.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-panel.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { commandRunner } from '../../commandRunner';
 import { DisposableObject } from '../../pure/disposable-object';
 import { DbManager } from '../db-manager';
 import { DbTreeDataProvider } from './db-tree-data-provider';
@@ -7,7 +8,7 @@ export class DbPanel extends DisposableObject {
   private readonly dataProvider: DbTreeDataProvider;
 
   public constructor(
-    dbManager: DbManager
+    private readonly dbManager: DbManager
   ) {
     super();
 
@@ -19,5 +20,20 @@ export class DbPanel extends DisposableObject {
     });
 
     this.push(treeView);
+  }
+
+  public async initialize(): Promise<void> {
+    this.push(
+      commandRunner(
+        'codeQLDatabasesExperimental.openConfigFile',
+        () => this.openConfigFile(),
+      )
+    );
+  }
+
+  async openConfigFile(): Promise<void> {
+    const configPath = this.dbManager.getConfigPath();
+    const document = await vscode.workspace.openTextDocument(configPath);
+    await vscode.window.showTextDocument(document);
   }
 }

--- a/extensions/ql-vscode/src/databases/ui/db-panel.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-panel.ts
@@ -31,7 +31,7 @@ export class DbPanel extends DisposableObject {
     );
   }
 
-  async openConfigFile(): Promise<void> {
+  private async openConfigFile(): Promise<void> {
     const configPath = this.dbManager.getConfigPath();
     const document = await vscode.workspace.openTextDocument(configPath);
     await vscode.window.showTextDocument(document);

--- a/extensions/ql-vscode/src/databases/ui/db-panel.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-panel.ts
@@ -25,7 +25,7 @@ export class DbPanel extends DisposableObject {
   public async initialize(): Promise<void> {
     this.push(
       commandRunner(
-        'codeQLDatabasesExperimental.openConfigFile',
+        'codeQLDatabases.openConfigFile',
         () => this.openConfigFile(),
       )
     );

--- a/extensions/ql-vscode/test/pure-tests/command-lint.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/command-lint.test.ts
@@ -39,6 +39,7 @@ describe('commands declared in package.json', function() {
     }
     else if (
       command.match(/^codeQLDatabases\./)
+      || command.match(/^codeQLDatabasesExperimental\./)
       || command.match(/^codeQLQueryHistory\./)
       || command.match(/^codeQLAstViewer\./)
       || command.match(/^codeQLEvalLogViewer\./)


### PR DESCRIPTION
Adds a UI icon in the new databases panel to open the `workspace-databases.json` config file.

![pencil icon to open database config file](https://user-images.githubusercontent.com/42641846/200312617-641fb04e-ffca-4311-98f9-efaabcafbef7.png)


~Note: I couldn't quite decide whether to call the command `codeQLDatabases.openConfigFile` or `codeQLDatabasesExperimental.openConfigFile`, so I've gone with the former for now. (Which saves us from adding a case to the [command-lint](https://github.com/github/vscode-codeql/blob/93054e14a27f2001dac4b6230fe2b47870d31aa6/extensions/ql-vscode/test/pure-tests/command-lint.test.ts#L30-L53) test.) Happy to switch over again though~ 🤷🏽 😅  EDIT: switched to `codeQLDatabasesExperimental`.

See internal linked issue for more details!

## Checklist

N/A - internal only 📝 

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
