### PR TITLE
Run all unit tests on Linux/macOS

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1278,7 +1278,7 @@
     "watch:webpack": "gulp watchView",
     "watch:files": "gulp watchTestData",
     "test": "npm-run-all -p test:*",
-    "test:unit": "mocha --config .mocharc.json test/pure-tests/**/*.ts",
+    "test:unit": "mocha --config .mocharc.json 'test/pure-tests/**/*.ts'",
     "test:view": "jest",
     "integration": "node ./out/vscode-tests/run-integration-tests.js no-workspace,minimal-workspace",
     "integration:no-workspace": "node ./out/vscode-tests/run-integration-tests.js no-workspace",


### PR DESCRIPTION
It seems like the expansion of the test files pattern is different between Windows and Linux/macOS. This fixes it by allowing Mocha to expand the glob pattern rather than the shell which should fix the inconsistency.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Replace this with a description of the changes your pull request makes.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
