### PR TITLE
Handle canceled status in variant analysis view

### DIFF
--- a/extensions/ql-vscode/src/stories/variant-analysis/VariantAnalysis.stories.tsx
+++ b/extensions/ql-vscode/src/stories/variant-analysis/VariantAnalysis.stories.tsx
@@ -256,3 +256,109 @@ FullExampleWithoutSkipped.args = {
   repoStates,
   repoResults,
 };
+
+export const Canceled = Template.bind({});
+Canceled.args = {
+  variantAnalysis: {
+    ...variantAnalysis,
+    status: VariantAnalysisStatus.Canceled,
+    completedAt: new Date(new Date(variantAnalysis.createdAt).getTime() + 100_000).toISOString(),
+    scannedRepos: [
+      {
+        repository: {
+          ...createMockRepositoryWithMetadata(),
+          id: 1,
+          fullName: 'octodemo/hello-world-1',
+          private: false,
+        },
+        analysisStatus: VariantAnalysisRepoStatus.Succeeded,
+        resultCount: 200,
+      },
+      {
+        repository: {
+          ...createMockRepositoryWithMetadata(),
+          id: 2,
+          fullName: 'octodemo/hello-world-2',
+          private: false,
+        },
+        analysisStatus: VariantAnalysisRepoStatus.Succeeded,
+        resultCount: 10_000,
+      },
+      {
+        repository: {
+          ...createMockRepositoryWithMetadata(),
+          id: 3,
+          fullName: 'octodemo/hello-world-3',
+          private: false,
+        },
+        analysisStatus: VariantAnalysisRepoStatus.Succeeded,
+        resultCount: 500,
+      },
+      {
+        repository: {
+          ...createMockRepositoryWithMetadata(),
+          id: 4,
+          fullName: 'octodemo/hello-world-4',
+          private: false,
+        },
+        analysisStatus: VariantAnalysisRepoStatus.Canceled,
+      },
+      {
+        repository: {
+          ...createMockRepositoryWithMetadata(),
+          id: 5,
+          fullName: 'octodemo/hello-world-5',
+          private: false,
+        },
+        analysisStatus: VariantAnalysisRepoStatus.Failed,
+      },
+      {
+        repository: {
+          ...createMockRepositoryWithMetadata(),
+          id: 6,
+          fullName: 'octodemo/hello-world-6',
+          private: false,
+        },
+        analysisStatus: VariantAnalysisRepoStatus.Canceled,
+      },
+      {
+        repository: {
+          ...createMockRepositoryWithMetadata(),
+          id: 7,
+          fullName: 'octodemo/hello-world-7',
+          private: false,
+        },
+        analysisStatus: VariantAnalysisRepoStatus.Canceled,
+      },
+      {
+        repository: {
+          ...createMockRepositoryWithMetadata(),
+          id: 8,
+          fullName: 'octodemo/hello-world-8',
+          private: false,
+        },
+        analysisStatus: VariantAnalysisRepoStatus.Canceled,
+      },
+      {
+        repository: {
+          ...createMockRepositoryWithMetadata(),
+          id: 9,
+          fullName: 'octodemo/hello-world-9',
+          private: false,
+        },
+        analysisStatus: VariantAnalysisRepoStatus.Canceled,
+      },
+      {
+        repository: {
+          ...createMockRepositoryWithMetadata(),
+          id: 10,
+          fullName: 'octodemo/hello-world-10',
+          private: false,
+        },
+        analysisStatus: VariantAnalysisRepoStatus.Canceled,
+      },
+    ],
+  },
+  repoStates,
+  repoResults,
+};

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisOutcomePanels.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisOutcomePanels.tsx
@@ -6,7 +6,8 @@ import { formatDecimal } from '../../pure/number';
 import {
   VariantAnalysis,
   VariantAnalysisScannedRepositoryResult,
-  VariantAnalysisScannedRepositoryState
+  VariantAnalysisScannedRepositoryState,
+  VariantAnalysisStatus,
 } from '../../remote-queries/shared/variant-analysis';
 import { VariantAnalysisAnalyzedRepos } from './VariantAnalysisAnalyzedRepos';
 import { Alert } from '../common';
@@ -54,6 +55,13 @@ export const VariantAnalysisOutcomePanels = ({
 
   const warnings = (
     <WarningsContainer>
+      {variantAnalysis.status === VariantAnalysisStatus.Canceled && (
+        <Alert
+          type="warning"
+          title="Query manually stopped"
+          message="This query was manually stopped before the analysis completed. Results may be partial."
+        />
+      )}
       {overLimitRepositoryCount > 0 && (
         <Alert
           type="warning"

--- a/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisOutcomePanels.spec.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisOutcomePanels.spec.tsx
@@ -136,6 +136,14 @@ describe(VariantAnalysisOutcomePanels.name, () => {
     expect(screen.getByText('No database')).toBeInTheDocument();
   });
 
+  it('renders warning with canceled variant analysis', () => {
+    render({
+      status: VariantAnalysisStatus.Canceled,
+    });
+
+    expect(screen.getByText('Warning: Query manually stopped')).toBeInTheDocument();
+  });
+
   it('renders warning with access mismatch repos', () => {
     render({
       skippedRepos: {


### PR DESCRIPTION
The variant analysis view was missing an alert when the variant analysis was canceled. This adds it, and also adds a story for checking what the view of a canceled variant analysis looks like.

![Screenshot 2022-11-08 at 13 43 08](https://user-images.githubusercontent.com/1112623/200566748-eac1aa4d-dcc0-4d8f-981c-e09d01f4f052.png)


## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
