### PR TITLE
Handle failed result download in view

### DIFF
--- a/extensions/ql-vscode/src/stories/variant-analysis/RepoRow.stories.tsx
+++ b/extensions/ql-vscode/src/stories/variant-analysis/RepoRow.stories.tsx
@@ -77,6 +77,22 @@ SucceededDownloading.args = {
   downloadStatus: VariantAnalysisScannedRepositoryDownloadStatus.InProgress,
 };
 
+export const SucceededSuccessfulDownload = Template.bind({});
+SucceededSuccessfulDownload.args = {
+  ...Pending.args,
+  status: VariantAnalysisRepoStatus.Succeeded,
+  resultCount: 198,
+  downloadStatus: VariantAnalysisScannedRepositoryDownloadStatus.Succeeded,
+};
+
+export const SucceededFailedDownload = Template.bind({});
+SucceededFailedDownload.args = {
+  ...Pending.args,
+  status: VariantAnalysisRepoStatus.Succeeded,
+  resultCount: 198,
+  downloadStatus: VariantAnalysisScannedRepositoryDownloadStatus.Failed,
+};
+
 export const InterpretedResults = Template.bind({});
 InterpretedResults.args = {
   ...Pending.args,

--- a/extensions/ql-vscode/src/view/variant-analysis/AnalyzedRepoItemContent.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/AnalyzedRepoItemContent.tsx
@@ -3,7 +3,10 @@ import styled from 'styled-components';
 import { AnalysisAlert, AnalysisRawResults } from '../../remote-queries/shared/analysis-result';
 import AnalysisAlertResult from '../remote-queries/AnalysisAlertResult';
 import RawResultsTable from '../remote-queries/RawResultsTable';
-import { VariantAnalysisRepoStatus } from '../../remote-queries/shared/variant-analysis';
+import {
+  VariantAnalysisRepoStatus,
+  VariantAnalysisScannedRepositoryDownloadStatus,
+} from '../../remote-queries/shared/variant-analysis';
 import { Alert } from '../common';
 
 const ContentContainer = styled.div`
@@ -32,7 +35,8 @@ const RawResultsContainer = styled.div`
 `;
 
 export type AnalyzedRepoItemContentProps = {
-  status: VariantAnalysisRepoStatus;
+  status?: VariantAnalysisRepoStatus;
+  downloadStatus?: VariantAnalysisScannedRepositoryDownloadStatus;
 
   interpretedResults?: AnalysisAlert[];
   rawResults?: AnalysisRawResults;
@@ -40,6 +44,7 @@ export type AnalyzedRepoItemContentProps = {
 
 export const AnalyzedRepoItemContent = ({
   status,
+  downloadStatus,
   interpretedResults,
   rawResults,
 }: AnalyzedRepoItemContentProps) => {
@@ -64,6 +69,13 @@ export const AnalyzedRepoItemContent = ({
           type="error"
           title="Canceled"
           message="The variant analysis or this repository was canceled."
+        />
+      </AlertContainer>}
+      {downloadStatus === VariantAnalysisScannedRepositoryDownloadStatus.Failed && <AlertContainer>
+        <Alert
+          type="error"
+          title="Download failed"
+          message="The query was successful on this repository, but the extension failed to download the results for this repository."
         />
       </AlertContainer>}
       {interpretedResults && (

--- a/extensions/ql-vscode/src/view/variant-analysis/__tests__/AnalyzedRepoItemContent.spec.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/__tests__/AnalyzedRepoItemContent.spec.tsx
@@ -1,6 +1,9 @@
 import * as React from 'react';
 import { render as reactRender, screen } from '@testing-library/react';
-import { VariantAnalysisRepoStatus } from '../../../remote-queries/shared/variant-analysis';
+import {
+  VariantAnalysisRepoStatus,
+  VariantAnalysisScannedRepositoryDownloadStatus
+} from '../../../remote-queries/shared/variant-analysis';
 import { AnalyzedRepoItemContent, AnalyzedRepoItemContentProps } from '../AnalyzedRepoItemContent';
 
 describe(AnalyzedRepoItemContent.name, () => {
@@ -111,5 +114,14 @@ describe(AnalyzedRepoItemContent.name, () => {
     });
 
     expect(screen.getByText('Error: Canceled')).toBeInTheDocument();
+  });
+
+  it('renders the failed download state', () => {
+    render({
+      status: VariantAnalysisRepoStatus.Succeeded,
+      downloadStatus: VariantAnalysisScannedRepositoryDownloadStatus.Failed,
+    });
+
+    expect(screen.getByText('Error: Download failed')).toBeInTheDocument();
   });
 });

--- a/extensions/ql-vscode/src/view/variant-analysis/__tests__/RepoRow.spec.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/__tests__/RepoRow.spec.tsx
@@ -104,6 +104,21 @@ describe(RepoRow.name, () => {
     })).toBeEnabled();
   });
 
+  it('renders the succeeded state with failed download status', () => {
+    render({
+      status: VariantAnalysisRepoStatus.Succeeded,
+      resultCount: 178,
+      downloadStatus: VariantAnalysisScannedRepositoryDownloadStatus.Failed,
+    });
+
+    expect(screen.getByRole<HTMLButtonElement>('button', {
+      expanded: false
+    })).toBeEnabled();
+    expect(screen.getByRole('img', {
+      name: 'Failed to download the results',
+    })).toBeInTheDocument();
+  });
+
   it('renders the failed state', () => {
     render({
       status: VariantAnalysisRepoStatus.Failed,


### PR DESCRIPTION
We were not yet showing any errors when a result download had failed. This adds a warning icon to any repositories for which the download has failed and allow expanding the item to show an alert.

![Screenshot 2022-11-08 at 13 42 06](https://user-images.githubusercontent.com/1112623/200566433-89ded0c6-e28e-400f-9175-1d752fab905c.png)


## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
