### PR TITLE
Enable the new query server by default

### DIFF
--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -1427,8 +1427,7 @@ export class CliVersionConstraint {
   }
 
   async supportsNewQueryServer() {
-    // TODO while under development, users _must_ opt-in to the new query server
-    // by setting the `codeql.canaryQueryServer` setting to `true`.
+    // This allows users to explicitly opt-out of the new query server.
     return allowCanaryQueryServer() &&
       this.isVersionAtLeast(CliVersionConstraint.CLI_VERSION_WITH_NEW_QUERY_SERVER);
   }

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -346,9 +346,10 @@ export function isCanary() {
  */
 export const CANARY_QUERY_SERVER = new Setting('canaryQueryServer', ROOT_SETTING);
 
-
+// The default value for this setting is now `true`
 export function allowCanaryQueryServer() {
-  return !!CANARY_QUERY_SERVER.getValue<boolean>();
+  const value = CANARY_QUERY_SERVER.getValue<boolean>();
+  return value === undefined ? true : !!value;
 }
 
 export const JOIN_ORDER_WARNING_THRESHOLD = new Setting('joinOrderWarningThreshold', LOG_INSIGHTS_SETTING);
@@ -458,7 +459,7 @@ const MOCK_GH_API_SERVER_ENABLED = new Setting('enabled', MOCK_GH_API_SERVER);
 
 /**
  * A path to a directory containing test scenarios. If this setting is not set,
- * the mock server will a default location for test scenarios in dev mode, and 
+ * the mock server will a default location for test scenarios in dev mode, and
  * will show a menu to select a directory in production mode.
  */
 const MOCK_GH_API_SERVER_SCENARIOS_PATH = new Setting('scenariosPath', MOCK_GH_API_SERVER);


### PR DESCRIPTION
The new query server is no longer experimental. Enable it by default. We do not remove the old query server code for 2 reasons:

1. We need to support older versions of the CLI
2. We want to give a back door and allow users to explicitly opt-out of the new query server if there is ever a problem.

This is an internal change and does not require a change note.