### PR TITLE
Extract remote query preparation to separate method

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
@@ -187,6 +187,17 @@ async function getPackedBundlePath(queryPackDir: string) {
   });
 }
 
+export interface PreparedRemoteQuery {
+  actionBranch: string;
+  base64Pack: string;
+  repoSelection: RepositorySelection;
+  queryFile: string;
+  queryMetadata: QueryMetadata | undefined;
+  controllerRepo: Repository;
+  queryStartTime: number;
+  language: string;
+}
+
 export async function prepareRemoteQueryRun(
   cliServer: cli.CodeQLCliServer,
   credentials: Credentials,
@@ -194,7 +205,7 @@ export async function prepareRemoteQueryRun(
   queryPackDir: string,
   progress: ProgressCallback,
   token: CancellationToken,
-) {
+): Promise<PreparedRemoteQuery> {
   if (!(await cliServer.cliConstraints.supportsRemoteQueries())) {
     throw new Error(`Variant analysis is not supported by this version of CodeQL. Please upgrade to v${cli.CliVersionConstraint.CLI_VERSION_REMOTE_QUERIES
       } or later.`);


### PR DESCRIPTION
There is some common logic between remote queries and the variant analysis flows which deals with parsing the query and asking the user how to run the query. This extracts that part of the logic to a separate method such that the only logic left in the actual `runRemoteQuery` method is related to submitting the query.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
