### PR TITLE
Change remote queries to test against submitted data

### DIFF
--- a/extensions/ql-vscode/package-lock.json
+++ b/extensions/ql-vscode/package-lock.json
@@ -137,6 +137,7 @@
         "proxyquire": "~2.1.3",
         "sinon": "~14.0.0",
         "sinon-chai": "~3.5.0",
+        "tar-stream": "^2.2.0",
         "through2": "^4.0.2",
         "ts-jest": "^29.0.1",
         "ts-json-schema-generator": "^1.1.2",

--- a/extensions/ql-vscode/package-lock.json
+++ b/extensions/ql-vscode/package-lock.json
@@ -96,6 +96,7 @@
         "@types/sinon-chai": "~3.2.3",
         "@types/stream-chain": "~2.0.1",
         "@types/stream-json": "~1.7.1",
+        "@types/tar-stream": "^2.2.2",
         "@types/through2": "^2.0.36",
         "@types/tmp": "^0.1.0",
         "@types/unzipper": "~0.10.1",
@@ -13516,6 +13517,15 @@
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.8.tgz",
       "integrity": "sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ==",
       "dev": true
+    },
+    "node_modules/@types/tar-stream": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@types/tar-stream/-/tar-stream-2.2.2.tgz",
+      "integrity": "sha512-1AX+Yt3icFuU6kxwmPakaiGrJUwG44MpuiqPg4dSolRFk6jmvs4b3IbUol9wKDLIgU76gevn3EwE8y/DkSJCZQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/testing-library__jest-dom": {
       "version": "5.14.5",
@@ -50621,6 +50631,15 @@
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.8.tgz",
       "integrity": "sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ==",
       "dev": true
+    },
+    "@types/tar-stream": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@types/tar-stream/-/tar-stream-2.2.2.tgz",
+      "integrity": "sha512-1AX+Yt3icFuU6kxwmPakaiGrJUwG44MpuiqPg4dSolRFk6jmvs4b3IbUol9wKDLIgU76gevn3EwE8y/DkSJCZQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/testing-library__jest-dom": {
       "version": "5.14.5",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1380,6 +1380,7 @@
     "@types/sinon-chai": "~3.2.3",
     "@types/stream-chain": "~2.0.1",
     "@types/stream-json": "~1.7.1",
+    "@types/tar-stream": "^2.2.2",
     "@types/through2": "^2.0.36",
     "@types/tmp": "^0.1.0",
     "@types/unzipper": "~0.10.1",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1421,6 +1421,7 @@
     "proxyquire": "~2.1.3",
     "sinon": "~14.0.0",
     "sinon-chai": "~3.5.0",
+    "tar-stream": "^2.2.0",
     "through2": "^4.0.2",
     "ts-jest": "^29.0.1",
     "ts-json-schema-generator": "^1.1.2",

--- a/extensions/ql-vscode/src/remote-queries/gh-api/gh-api-client.ts
+++ b/extensions/ql-vscode/src/remote-queries/gh-api/gh-api-client.ts
@@ -1,5 +1,6 @@
 import { Credentials } from '../../authentication';
 import { OctokitResponse } from '@octokit/types/dist-types';
+import { RemoteQueriesSubmission } from '../shared/remote-queries';
 import { VariantAnalysisSubmission } from '../shared/variant-analysis';
 import {
   VariantAnalysis,
@@ -7,6 +8,7 @@ import {
   VariantAnalysisSubmissionRequest
 } from './variant-analysis';
 import { Repository } from './repository';
+import { RemoteQueriesResponse, RemoteQueriesSubmissionRequest } from './remote-queries';
 
 export async function submitVariantAnalysis(
   credentials: Credentials,
@@ -115,4 +117,32 @@ export async function createGist(
     throw new Error(`Error exporting variant analysis results: ${response.status} ${response?.data || ''}`);
   }
   return response.data.html_url;
+}
+
+export async function submitRemoteQueries(
+  credentials: Credentials,
+  submissionDetails: RemoteQueriesSubmission
+): Promise<RemoteQueriesResponse> {
+  const octokit = await credentials.getOctokit();
+
+  const { ref, language, repositories, repositoryLists, repositoryOwners, queryPack, controllerRepoId } = submissionDetails;
+
+  const data: RemoteQueriesSubmissionRequest = {
+    ref,
+    language,
+    repositories,
+    repository_lists: repositoryLists,
+    repository_owners: repositoryOwners,
+    query_pack: queryPack,
+  };
+
+  const response: OctokitResponse<RemoteQueriesResponse> = await octokit.request(
+    'POST /repositories/:controllerRepoId/code-scanning/codeql/queries',
+    {
+      controllerRepoId,
+      data
+    }
+  );
+
+  return response.data;
 }

--- a/extensions/ql-vscode/src/remote-queries/gh-api/remote-queries.ts
+++ b/extensions/ql-vscode/src/remote-queries/gh-api/remote-queries.ts
@@ -1,0 +1,20 @@
+export interface RemoteQueriesSubmissionRequest {
+  ref: string;
+  language: string;
+  repositories?: string[];
+  repository_lists?: string[];
+  repository_owners?: string[];
+  query_pack: string;
+}
+
+export interface RemoteQueriesResponse {
+  workflow_run_id: number,
+  errors?: {
+    invalid_repositories?: string[],
+    repositories_without_database?: string[],
+    private_repositories?: string[],
+    cutoff_repositories?: string[],
+    cutoff_repositories_count?: number,
+  },
+  repositories_queried: string[],
+}

--- a/extensions/ql-vscode/src/remote-queries/shared/remote-queries.ts
+++ b/extensions/ql-vscode/src/remote-queries/shared/remote-queries.ts
@@ -1,0 +1,10 @@
+export interface RemoteQueriesSubmission {
+  ref: string;
+  language: string;
+  repositories?: string[];
+  repositoryLists?: string[];
+  repositoryOwners?: string[];
+  queryPack: string;
+
+  controllerRepoId: number;
+}

--- a/extensions/ql-vscode/src/vscode-tests/utils/bundled-pack-helpers.ts
+++ b/extensions/ql-vscode/src/vscode-tests/utils/bundled-pack-helpers.ts
@@ -1,0 +1,76 @@
+import { Readable } from 'stream';
+import * as tar from 'tar-stream';
+import { Headers } from 'tar-stream';
+import { pipeline } from 'stream/promises';
+import { createGunzip } from 'zlib';
+
+export interface QueryPackFS {
+  fileExists: (name: string) => boolean;
+  fileContents: (name: string) => Buffer;
+  directoryContents: (name: string) => string[];
+}
+
+export const readBundledPack = async (base64Pack: string): Promise<QueryPackFS> => {
+  const buffer = Buffer.from(base64Pack, 'base64');
+  const stream = Readable.from(buffer);
+
+  const extract = tar.extract();
+
+  const files: Record<string, {
+    headers: Headers,
+    contents: Buffer,
+  }> = {};
+
+  extract.on('entry', function(headers: Headers, stream, next) {
+    const buffers: Buffer[] = [];
+
+    stream.on('data', chunk => buffers.push(chunk));
+    stream.on('end', () => {
+      files[headers.name] = {
+        headers,
+        contents: Buffer.concat(buffers),
+      };
+
+      next();
+    });
+    stream.on('error', err => {
+      console.error(err);
+      next();
+    });
+  });
+
+  await pipeline(stream, createGunzip(), extract);
+
+  const directories: Record<string, number> = {};
+  for (let file of Object.keys(files)) {
+    while (file.indexOf('/') > 0) {
+      const directory = file.substring(0, file.lastIndexOf('/'));
+      if (!(directory in directories)) {
+        directories[directory] = 0;
+      }
+
+      directories[directory]++;
+
+      file = directory;
+    }
+  }
+
+  return {
+    fileExists: (name: string) => {
+      return files[name]?.headers.type === 'file';
+    },
+    fileContents: (name: string): Buffer => {
+      const file = files[name];
+      if (file?.headers.type === 'file') {
+        return file.contents;
+      }
+
+      throw new Error(`File ${name} does not exist`);
+    },
+    directoryContents: (name: string): string[] => {
+      return Object.keys(directories)
+        .filter(dir => dir.startsWith(name) && dir !== name && dir.substring(name.length + 1).split('/').length === 1)
+        .map(dir => dir.substring(name.length + 1));
+    },
+  };
+};

--- a/extensions/ql-vscode/src/vscode-tests/utils/bundled-pack-helpers.ts
+++ b/extensions/ql-vscode/src/vscode-tests/utils/bundled-pack-helpers.ts
@@ -10,7 +10,7 @@ export interface QueryPackFS {
   directoryContents: (name: string) => string[];
 }
 
-export const readBundledPack = async (base64Pack: string): Promise<QueryPackFS> => {
+export async function readBundledPack(base64Pack: string): Promise<QueryPackFS> {
   const buffer = Buffer.from(base64Pack, 'base64');
   const stream = Readable.from(buffer);
 
@@ -73,4 +73,4 @@ export const readBundledPack = async (base64Pack: string): Promise<QueryPackFS> 
         .map(dir => dir.substring(name.length + 1));
     },
   };
-};
+}


### PR DESCRIPTION
The remote queries tests were testing the data on the filesystem, rather than the data submitted to the server. This required using a `dryRun` parameter to prevent deleting the temporary directory, while we can actually just test against the submitted data.

This will create an in-memory filesystem of the submitted query pack by un-tar-gz'ing the query pack into memory and using that to test the existence of certain files.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
