### PR TITLE
Reduce nesting in `runRemoteQuery`

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
@@ -46,6 +46,11 @@ export interface QlPack {
  */
 const QUERY_PACK_NAME = 'codeql-remote/query';
 
+export interface GeneratedQueryPack {
+  base64Pack: string,
+  language: string
+}
+
 /**
  * Two possibilities:
  * 1. There is no qlpack.yml in this directory. Assume this is a lone query and generate a synthetic qlpack for it.
@@ -53,10 +58,7 @@ const QUERY_PACK_NAME = 'codeql-remote/query';
  *
  * @returns the entire qlpack as a base64 string.
  */
-async function generateQueryPack(cliServer: cli.CodeQLCliServer, queryFile: string, queryPackDir: string): Promise<{
-  base64Pack: string,
-  language: string
-}> {
+async function generateQueryPack(cliServer: cli.CodeQLCliServer, queryFile: string, queryPackDir: string): Promise<GeneratedQueryPack> {
   const originalPackRoot = await findPackRoot(queryFile);
   const packRelativePath = path.relative(originalPackRoot, queryFile);
   const targetQueryFileName = path.join(queryPackDir, packRelativePath);
@@ -226,7 +228,7 @@ export async function prepareRemoteQueryRun(
 
   const { remoteQueryDir, queryPackDir } = await createRemoteQueriesTempDirectory();
 
-  let pack: Awaited<ReturnType<typeof generateQueryPack>>;
+  let pack: GeneratedQueryPack;
 
   try {
     pack = await generateQueryPack(cliServer, queryFile, queryPackDir);


### PR DESCRIPTION
Now that we do not have a dry run mode, we can create and clean up the temporary directory in the same function. This allows us to remove the complete `try`..`finally` block inside `runRemoteQuery` and move it to a much more local spot.

It's easiest to review this by hiding whitespace, this should only show the actual changes.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
