### PR TITLE
Add event emitter abstraction

### DIFF
--- a/extensions/ql-vscode/src/common/app.ts
+++ b/extensions/ql-vscode/src/common/app.ts
@@ -1,0 +1,5 @@
+import { AppEventEmitter } from './events';
+
+export interface App {
+  createEventEmitter<T>(): AppEventEmitter<T>;
+}

--- a/extensions/ql-vscode/src/common/events.ts
+++ b/extensions/ql-vscode/src/common/events.ts
@@ -1,7 +1,7 @@
 import { Disposable } from '../pure/disposable-object';
 
 export interface AppEvent<T> {
-  (listener: (event: T) => any): Disposable;
+  (listener: (event: T) => void): Disposable;
 }
 
 export interface AppEventEmitter<T> {

--- a/extensions/ql-vscode/src/common/events.ts
+++ b/extensions/ql-vscode/src/common/events.ts
@@ -1,0 +1,10 @@
+import { Disposable } from '../pure/disposable-object';
+
+export interface AppEvent<T> {
+  (listener: (event: T) => any): Disposable;
+}
+
+export interface AppEventEmitter<T> {
+  event: AppEvent<T>;
+  fire(data: T): void;
+}

--- a/extensions/ql-vscode/src/common/vscode/events.ts
+++ b/extensions/ql-vscode/src/common/vscode/events.ts
@@ -1,0 +1,7 @@
+import * as vscode from 'vscode';
+import { AppEventEmitter } from '../events';
+
+export class VSCodeAppEventEmitter<T>
+  extends vscode.EventEmitter<T>
+  implements AppEventEmitter<T> {
+}

--- a/extensions/ql-vscode/src/common/vscode/vscode-app.ts
+++ b/extensions/ql-vscode/src/common/vscode/vscode-app.ts
@@ -1,0 +1,9 @@
+import { App } from '../app';
+import { AppEventEmitter } from '../events';
+import { VSCodeAppEventEmitter } from './events';
+
+export class ExtensionApp implements App {
+  public createEventEmitter<T>(): AppEventEmitter<T> {
+    return new VSCodeAppEventEmitter<T>();
+  }
+}

--- a/extensions/ql-vscode/src/pure/disposable-object.ts
+++ b/extensions/ql-vscode/src/pure/disposable-object.ts
@@ -1,7 +1,7 @@
 
 // Avoid explicitly referencing Disposable type in vscode.
 // This file cannot have dependencies on the vscode API.
-interface Disposable {
+export interface Disposable {
   dispose(): any;
 }
 


### PR DESCRIPTION
Currently, classes/modules that interact with events (raising or catching) have to import [Event](https://code.visualstudio.com/api/references/vscode-api#Event%3CT%3E)/[EventEmitter](https://code.visualstudio.com/api/references/vscode-api#EventEmitter%3CT%3E) which couples them to the VS Code API and as a consequence it means we're no longer able to write unit tests. It pushes us towards writing slow integration tests that require the whole extension host. 

This PR introduces some custom abstractions that we can use instead of bringing in the VS Code API. 

## Checklist
N/A:

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
