### PR TITLE
Add copying of repository list to view

### DIFF
--- a/extensions/ql-vscode/src/pure/interface-types.ts
+++ b/extensions/ql-vscode/src/pure/interface-types.ts
@@ -472,6 +472,10 @@ export interface OpenQueryTextMessage {
   t: 'openQueryText';
 }
 
+export interface CopyRepositoryListMessage {
+  t: 'copyRepositoryList';
+}
+
 export interface OpenLogsMessage {
   t: 'openLogs';
 }
@@ -490,5 +494,6 @@ export type FromVariantAnalysisMessage =
   | RequestRepositoryResultsMessage
   | OpenQueryFileMessage
   | OpenQueryTextMessage
+  | CopyRepositoryListMessage
   | OpenLogsMessage
   | CancelVariantAnalysisMessage;

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-view.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-view.ts
@@ -103,6 +103,9 @@ export class VariantAnalysisView extends AbstractWebview<ToVariantAnalysisMessag
       case 'openQueryText':
         await this.openQueryText();
         break;
+      case 'copyRepositoryList':
+        void commands.executeCommand('codeQL.copyVariantAnalysisRepoList', this.variantAnalysisId);
+        break;
       case 'openLogs':
         await this.openLogs();
         break;

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
@@ -36,6 +36,12 @@ const stopQuery = () => {
   });
 };
 
+const copyRepositoryList = () => {
+  vscode.postMessage({
+    t: 'copyRepositoryList',
+  });
+};
+
 const openLogs = () => {
   vscode.postMessage({
     t: 'openLogs',
@@ -95,7 +101,7 @@ export function VariantAnalysis({
         onOpenQueryFileClick={openQueryFile}
         onViewQueryTextClick={openQueryText}
         onStopQueryClick={stopQuery}
-        onCopyRepositoryListClick={() => console.log('Copy repository list')}
+        onCopyRepositoryListClick={copyRepositoryList}
         onExportResultsClick={() => console.log('Export results')}
         onViewLogsClick={openLogs}
       />


### PR DESCRIPTION
This will allow a user to use the "Copy repository list" button in the view to copy a repository list.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
