### PR TITLE
Add mode and subscriptions to App container

### DIFF
--- a/extensions/ql-vscode/src/common/app.ts
+++ b/extensions/ql-vscode/src/common/app.ts
@@ -1,8 +1,17 @@
+import { Disposable } from '../pure/disposable-object';
 import { AppEventEmitter } from './events';
 
 export interface App {
   createEventEmitter<T>(): AppEventEmitter<T>;
+  mode: AppMode;
+  subscriptions: Disposable[];
   extensionPath: string;
   globalStoragePath: string;
   workspaceStoragePath?: string;
+}
+
+export enum AppMode {
+  Production = 1,
+  Development = 2,
+  Test = 3,
 }

--- a/extensions/ql-vscode/src/common/vscode/vscode-app.ts
+++ b/extensions/ql-vscode/src/common/vscode/vscode-app.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
-import { App } from '../app';
+import { Disposable } from '../../pure/disposable-object';
+import { App, AppMode } from '../app';
 import { AppEventEmitter } from '../events';
 import { VSCodeAppEventEmitter } from './events';
 
@@ -19,6 +20,21 @@ export class ExtensionApp implements App {
 
   public get workspaceStoragePath(): string | undefined {
     return this.extensionContext.storageUri?.fsPath;
+  }
+
+  public get subscriptions(): Disposable[] {
+    return this.extensionContext.subscriptions;
+  }
+
+  public get mode(): AppMode {
+    switch (this.extensionContext.extensionMode) {
+      case vscode.ExtensionMode.Development:
+        return AppMode.Development;
+      case vscode.ExtensionMode.Test:
+        return AppMode.Test;
+      default:
+        return AppMode.Production;
+    }
   }
 
   public createEventEmitter<T>(): AppEventEmitter<T> {

--- a/extensions/ql-vscode/src/databases/db-module.ts
+++ b/extensions/ql-vscode/src/databases/db-module.ts
@@ -1,5 +1,4 @@
-import * as vscode from 'vscode';
-import { ExtensionApp } from '../common/vscode/vscode-app';
+import { App, AppMode } from '../common/app';
 import { isCanary, isNewQueryRunExperienceEnabled } from '../config';
 import { logger } from '../logging';
 import { DisposableObject } from '../pure/disposable-object';
@@ -8,10 +7,8 @@ import { DbManager } from './db-manager';
 import { DbPanel } from './ui/db-panel';
 
 export class DbModule extends DisposableObject {
-  public async initialize(
-    extensionContext: vscode.ExtensionContext
-  ): Promise<void> {
-    if (extensionContext.extensionMode !== vscode.ExtensionMode.Development ||
+  public async initialize(app: App): Promise<void> {
+    if (app.mode !== AppMode.Development ||
       !isCanary() ||
       !isNewQueryRunExperienceEnabled()) {
       // Currently, we only want to expose the new database panel when we
@@ -22,25 +19,21 @@ export class DbModule extends DisposableObject {
 
     void logger.log('Initializing database module');
 
-    const app = new ExtensionApp(extensionContext);
-
     const dbConfigStore = new DbConfigStore(app);
     await dbConfigStore.initialize();
 
     const dbManager = new DbManager(dbConfigStore);
     const dbPanel = new DbPanel(dbManager);
     await dbPanel.initialize();
-    extensionContext.subscriptions.push(dbPanel);
+    app.subscriptions.push(dbPanel);
 
     this.push(dbPanel);
     this.push(dbConfigStore);
   }
 }
 
-export async function initializeDbModule(
-  extensionContext: vscode.ExtensionContext
-): Promise<DbModule> {
+export async function initializeDbModule(app: App): Promise<DbModule> {
   const dbModule = new DbModule();
-  await dbModule.initialize(extensionContext);
+  await dbModule.initialize(app);
   return dbModule;
 }

--- a/extensions/ql-vscode/src/databases/db-module.ts
+++ b/extensions/ql-vscode/src/databases/db-module.ts
@@ -25,7 +25,6 @@ export class DbModule extends DisposableObject {
     const dbManager = new DbManager(dbConfigStore);
     const dbPanel = new DbPanel(dbManager);
     await dbPanel.initialize();
-    app.subscriptions.push(dbPanel);
 
     this.push(dbPanel);
     this.push(dbConfigStore);

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -116,6 +116,7 @@ import { createVariantAnalysisContentProvider } from './remote-queries/variant-a
 import { VSCodeMockGitHubApiServer } from './mocks/vscode-mock-gh-api-server';
 import { VariantAnalysisResultsManager } from './remote-queries/variant-analysis-results-manager';
 import { initializeDbModule } from './databases/db-module';
+import { ExtensionApp } from './common/vscode/vscode-app';
 
 /**
  * extension.ts
@@ -1250,7 +1251,8 @@ async function activateWithInstalledDistribution(
   void logger.log('Reading query history');
   await qhm.readQueryHistory();
 
-  const dbModule = await initializeDbModule(ctx);
+  const app = new ExtensionApp(ctx);
+  const dbModule = await initializeDbModule(app);
   ctx.subscriptions.push(dbModule);
 
   void logger.log('Successfully finished extension initialization.');

--- a/extensions/ql-vscode/test/__mocks__/appMock.ts
+++ b/extensions/ql-vscode/test/__mocks__/appMock.ts
@@ -1,4 +1,4 @@
-import { App } from '../../src/common/app';
+import { App, AppMode } from '../../src/common/app';
 import { AppEvent, AppEventEmitter } from '../../src/common/events';
 import { Disposable } from '../../src/pure/disposable-object';
 
@@ -6,7 +6,7 @@ export function createMockApp({
   extensionPath = '/mock/extension/path',
   workspaceStoragePath = '/mock/workspace/storage/path',
   globalStoragePath = '/mock/global/storage/path',
-  createEventEmitter = <T>() => new MockAppEventEmitter<T>()
+  createEventEmitter = <T>() => new MockAppEventEmitter<T>(),
 }: {
   extensionPath?: string,
   workspaceStoragePath?: string,
@@ -14,10 +14,12 @@ export function createMockApp({
   createEventEmitter?: <T>() => AppEventEmitter<T>
 }): App {
   return {
-    createEventEmitter,
+    mode: AppMode.Test,
+    subscriptions: [],
     extensionPath,
     workspaceStoragePath,
-    globalStoragePath
+    globalStoragePath,
+    createEventEmitter,
   };
 }
 


### PR DESCRIPTION
Adds two more pieces of information to the App container:
- The mode we're running in
- Any subscriptions for objects that need to be disposed.

I then took advantage of that in the `DbModule`. I also released that we were registering the `DbPanel` to be disposed twice so I removed that (see second commit).

## Checklist

N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
