### PR TITLE
Revert "Rename iconPath to icon"

### DIFF
--- a/extensions/ql-vscode/src/databases/ui/db-tree-view-item.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-tree-view-item.ts
@@ -16,7 +16,7 @@ import {
 export class DbTreeViewItem extends vscode.TreeItem {
   constructor(
     public readonly dbItem: DbItem | undefined,
-    public readonly icon: vscode.ThemeIcon | undefined,
+    public readonly iconPath: vscode.ThemeIcon | undefined,
     public readonly label: string,
     public readonly tooltip: string | undefined,
     public readonly collapsibleState: vscode.TreeItemCollapsibleState,

--- a/extensions/ql-vscode/src/databases/ui/db-tree-view-item.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-tree-view-item.ts
@@ -15,6 +15,9 @@ import {
  */
 export class DbTreeViewItem extends vscode.TreeItem {
   constructor(
+    // iconPath and tooltip must have those names because
+    // they are part of the vscode.TreeItem interface
+
     public readonly dbItem: DbItem | undefined,
     public readonly iconPath: vscode.ThemeIcon | undefined,
     public readonly label: string,

--- a/extensions/ql-vscode/src/vscode-tests/minimal-workspace/databases/db-panel.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/minimal-workspace/databases/db-panel.test.ts
@@ -230,7 +230,7 @@ describe('db panel', async () => {
   ): void {
     expect(item.label).to.equal(`Top ${n} repositories`);
     expect(item.tooltip).to.equal(`Top ${n} repositories of a language`);
-    expect(item.icon).to.deep.equal(new vscode.ThemeIcon('github'));
+    expect(item.iconPath).to.deep.equal(new vscode.ThemeIcon('github'));
     expect(item.collapsibleState).to.equal(vscode.TreeItemCollapsibleState.None);
   }
 
@@ -241,7 +241,7 @@ describe('db panel', async () => {
   ): void {
     expect(item.label).to.equal(listName);
     expect(item.tooltip).to.be.undefined;
-    expect(item.icon).to.be.undefined;
+    expect(item.iconPath).to.be.undefined;
     expect(item.collapsibleState).to.equal(vscode.TreeItemCollapsibleState.Collapsed);
     expect(item.children).to.be.ok;
     expect(item.children.length).to.equal(repos.length);
@@ -257,7 +257,7 @@ describe('db panel', async () => {
   ): void {
     expect(item.label).to.equal(ownerName);
     expect(item.tooltip).to.be.undefined;
-    expect(item.icon).to.deep.equal(new vscode.ThemeIcon('organization'));
+    expect(item.iconPath).to.deep.equal(new vscode.ThemeIcon('organization'));
     expect(item.collapsibleState).to.equal(vscode.TreeItemCollapsibleState.None);
     expect(item.children).to.be.ok;
     expect(item.children.length).to.equal(0);
@@ -269,7 +269,7 @@ describe('db panel', async () => {
   ): void {
     expect(item.label).to.equal(repoName);
     expect(item.tooltip).to.be.undefined;
-    expect(item.icon).to.deep.equal(new vscode.ThemeIcon('database'));
+    expect(item.iconPath).to.deep.equal(new vscode.ThemeIcon('database'));
     expect(item.collapsibleState).to.equal(vscode.TreeItemCollapsibleState.None);
   }
 });


### PR DESCRIPTION
This reverts commit 93b6abeeb4657bbd756ee8807e870b8769182ff0 which has broken the icons in the db panel.

I forgot that we have to use the same name as `vscode.TreeItem`s! 🤦‍♀️ 

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
