### PR TITLE
Stop showing warnings for unhandled requests by the mock API server

### DIFF
--- a/extensions/ql-vscode/src/mocks/mock-gh-api-server.ts
+++ b/extensions/ql-vscode/src/mocks/mock-gh-api-server.ts
@@ -30,7 +30,7 @@ export class MockGitHubApiServer extends DisposableObject {
       return;
     }
 
-    this.server.listen();
+    this.server.listen({ onUnhandledRequest: 'bypass' });
     this._isListening = true;
   }
 


### PR DESCRIPTION
Currently we see unhandled requests logged in the debug console which seems to cause confusion so we should turn that off.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
