### PR TITLE
Fix rootDir used in test tsconfig

### DIFF
--- a/extensions/ql-vscode/test/tsconfig.json
+++ b/extensions/ql-vscode/test/tsconfig.json
@@ -5,6 +5,6 @@
   "compilerOptions": {
     "noEmit": true,
     "resolveJsonModule": true,
-    "rootDirs": [".", "../src"]
+    "rootDir": ".."
   }
 }


### PR DESCRIPTION
Turns out [`rootDirs`](https://www.typescriptlang.org/tsconfig#rootDirs) is to do with virtual directories so we should be using [`rootDir`](https://www.typescriptlang.org/tsconfig#rootDir) instead😅 

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
