### PR TITLE
Display pop up message when removing an item from query history

### DIFF
--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -824,11 +824,15 @@ export class QueryHistoryManager extends DisposableObject {
     // Remote queries can be removed locally, but not remotely.
     // The user must cancel the query on GitHub Actions explicitly.
     this.treeDataProvider.remove(item);
-    void logger.log(`Deleted ${this.labelProvider.getLabel(item)}.`);
+
+    let message = 'Remote query has been removed from history.';
+
     if (item.status === QueryStatus.InProgress) {
-      void logger.log('The variant analysis is still running on GitHub Actions. To cancel there, you must go to the workflow run in your browser.');
+      const workflowRunUrl = getActionsWorkflowRunUrl(item);
+      message += ` However, the variant analysis is still running on GitHub Actions. To cancel it, you must go to the [workflow run](${workflowRunUrl}) in your browser.`;
     }
 
+    void showAndLogInformationMessage(message);
     await this.remoteQueriesManager.removeRemoteQuery(item.queryId);
   }
 


### PR DESCRIPTION
Instead of sending this info the logs, we're opening a pop up to let the user know that the remote query has been removed from query history.

![Screenshot 2022-11-17 at 10 16 58](https://user-images.githubusercontent.com/1354439/202423918-440c9d51-aff1-4cd9-9868-2eb6c65f9e13.png)


If the query is still in progress, we also let them know that the GitHub action will also need to be cancelled (and we provide a link to it).

![Screenshot 2022-11-17 at 10 17 39](https://user-images.githubusercontent.com/1354439/202423926-4a89ccd8-5413-42db-970e-a1644253af40.png)

Have asked for feedback from our designer. Waiting to hear back.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
