### PR TITLE
Allow synthetic variant analysis packs to handle `${workspace}`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ artifacts/
 # Visual Studio workspace state
 .vs/
 
-# Rush files
-/common/temp/**
-package-deps.json
-**/.rush/temp
+# CodeQL metadata
+.cache/
+.codeql/

--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -1605,6 +1605,11 @@ export class CliVersionConstraint {
    */
   public static CLI_VERSION_WITH_NEW_QUERY_SERVER = new SemVer("2.11.1");
 
+  /**
+   * CLI version that supports `${workspace}` references in qlpack.yml files.
+   */
+  public static CLI_VERSION_WITH_WORKSPACE_RFERENCES = new SemVer("2.11.3");
+
   constructor(private readonly cli: CodeQLCliServer) {
     /**/
   }
@@ -1732,6 +1737,12 @@ export class CliVersionConstraint {
   async supportsNewQueryServerForTests() {
     return this.isVersionAtLeast(
       CliVersionConstraint.CLI_VERSION_WITH_NEW_QUERY_SERVER,
+    );
+  }
+
+  async supportsWorkspaceReferences() {
+    return this.isVersionAtLeast(
+      CliVersionConstraint.CLI_VERSION_WITH_WORKSPACE_RFERENCES,
     );
   }
 }

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/data-remote-qlpack-nested/qlpack.yml
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/data-remote-qlpack-nested/qlpack.yml
@@ -1,4 +1,5 @@
 name: github/remote-query-pack
 version: 0.0.0
 dependencies:
+  # The workspace reference will be removed before creating the MRVA pack.
   codeql/javascript-all: '*'

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/data-remote-qlpack/qlpack.yml
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/data-remote-qlpack/qlpack.yml
@@ -1,4 +1,4 @@
 name: github/remote-query-pack
 version: 0.0.0
 dependencies:
-  codeql/javascript-all: '*'
+  codeql/javascript-all: '${workspace}'

--- a/extensions/ql-vscode/src/vscode-tests/test-config.ts
+++ b/extensions/ql-vscode/src/vscode-tests/test-config.ts
@@ -106,9 +106,11 @@ export const getTestSetting = (
 };
 
 export const testConfigHelper = async (mocha: Mocha) => {
+  // Allow extra time to read settings. Sometimes this can time out.
+  mocha.timeout(20000);
+
   // Read in all current settings
   await Promise.all(TEST_SETTINGS.map((setting) => setting.initialSetup()));
-
   mocha.rootHooks({
     async beforeEach() {
       // Reset the settings to their initial values before each test


### PR DESCRIPTION
`${workspace}` references are new in CLI version 2.11.3. These mean that
the version depended upon in a pack must be the version available in the
current codeql workspace.

When generating a variant analysis pack, however, we copy the target
query and generate a synthetic pack with the original dependencies.
This breaks workspace references since the synthetic pack is no longer
in the same workspace.

A simple workaround is to replace `${workspace}` with `*` references.

I wanted to ensure the tests exercise this feature, so I altered one of our test qlpacks to use the `${workspace}` reference. This will work on CLI v2.11.3 and later. For earlier versions, I needed to change that reference to a `*` reference.

I also fixed a problem I was having locally where the CLI tests were timing out. By bumping the timeout to 20s in the `testConfigHelper`, I got around that error.

## Checklist

- [n/a] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [n/a] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
