### PR TITLE
Move filter and sort tests to pure tests

### DIFF
--- a/extensions/ql-vscode/test/pure-tests/variant-analysis-filter-sort.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/variant-analysis-filter-sort.test.ts
@@ -6,9 +6,8 @@ import {
   filterAndSortRepositoriesWithResultsByName,
   matchesFilter,
   SortKey,
-} from "../../../pure/variant-analysis-filter-sort";
+} from "../../src/pure/variant-analysis-filter-sort";
 
-// TODO: Move this file to the "pure" tests once it has been switched to Jest
 describe(matchesFilter.name, () => {
   const repository = {
     fullName: "github/codeql",


### PR DESCRIPTION
The filter and sort tests were located inside the React tests since they were already using Jest. Now that the pure tests have been switched to Jest, these tests can finally be moved to the "normal" pure tests.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
