### PR TITLE
Remove deprecated fast compilation option

### DIFF
--- a/extensions/ql-vscode/src/legacy-query-server/run-queries.ts
+++ b/extensions/ql-vscode/src/legacy-query-server/run-queries.ts
@@ -177,7 +177,6 @@ export class QueryInProgress {
         compilationOptions: {
           computeNoLocationUrls: true,
           failOnWarnings: false,
-          fastCompilation: false,
           includeDilInQlo: true,
           localChecking: false,
           noComputeGetUrl: false,

--- a/extensions/ql-vscode/src/pure/legacy-messages.ts
+++ b/extensions/ql-vscode/src/pure/legacy-messages.ts
@@ -97,11 +97,6 @@ export interface CompilationOptions {
    */
   failOnWarnings: boolean;
   /**
-   * Whether to compile as fast as possible, at the expense
-   * of optimization.
-   */
-  fastCompilation: boolean;
-  /**
    * Whether to include dil within qlos.
    */
   includeDilInQlo: boolean;
@@ -150,11 +145,6 @@ export interface ExtraOptions {
  * The DIL compilation options
  */
 export interface DilCompilationOptions {
-  /**
-   * Whether to compile as fast as possible, at the expense
-   * of optimization.
-   */
-  fastCompilation: boolean;
   /**
    * Whether to include dil within qlos.
    */

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/legacy-query.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/legacy-query.test.ts
@@ -190,7 +190,6 @@ describe("using the legacy query server", function () {
           compilationOptions: {
             computeNoLocationUrls: true,
             failOnWarnings: false,
-            fastCompilation: false,
             includeDilInQlo: true,
             localChecking: false,
             noComputeGetUrl: false,

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/run-queries.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/run-queries.test.ts
@@ -201,7 +201,6 @@ describe("run-queries", () => {
           compilationOptions: {
             computeNoLocationUrls: true,
             failOnWarnings: false,
-            fastCompilation: false,
             includeDilInQlo: true,
             localChecking: false,
             noComputeGetUrl: false,


### PR DESCRIPTION
Fast compilation has been deprecated. This PR removes the options associated with fast compilation. 