### PR TITLE
Remove unsupported version constraints

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [UNRELEASED]
 
 - Renamed command "CodeQL: Run Query" to "CodeQL: Run Query on Selected Dababase".
+- Remove support for CodeQL CLI versions older than 2.7.6. [#1788](https://github.com/github/vscode-codeql/pull/1788)
 
 ## 1.7.7 - 13 December 2022
 

--- a/extensions/ql-vscode/src/databaseFetcher.ts
+++ b/extensions/ql-vscode/src/databaseFetcher.ts
@@ -321,7 +321,7 @@ async function readAndUnzip(
     step: 9,
     message: `Unzipping into ${basename(unzipPath)}`,
   });
-  if (cli && (await cli.cliConstraints.supportsDatabaseUnbundle())) {
+  if (cli) {
     // Use the `database unbundle` command if the installed cli version supports it
     await cli.databaseUnbundle(zipFile, unzipPath);
   } else {

--- a/extensions/ql-vscode/src/databases.ts
+++ b/extensions/ql-vscode/src/databases.ts
@@ -990,12 +990,6 @@ export class DatabaseManager extends DisposableObject {
   }
 
   private async getPrimaryLanguage(dbPath: string) {
-    if (!(await this.cli.cliConstraints.supportsLanguageName())) {
-      // return undefined so that we recalculate on restart until the cli is at a version that
-      // supports this feature. This recalculation is cheap since we avoid calling into the cli
-      // unless we know it can return the langauges property.
-      return undefined;
-    }
     const dbInfo = await this.cli.resolveDatabase(dbPath);
     return dbInfo.languages?.[0] || "";
   }

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -33,7 +33,7 @@ import {
   zipArchiveScheme,
 } from "./archive-filesystem-provider";
 import QuickEvalCodeLensProvider from "./quickEvalCodeLensProvider";
-import { CodeQLCliServer, CliVersionConstraint } from "./cli";
+import { CodeQLCliServer } from "./cli";
 import {
   CliConfigListener,
   DistributionConfigListener,
@@ -820,17 +820,9 @@ async function activateWithInstalledDistribution(
     const path =
       selectedQuery?.fsPath || window.activeTextEditor?.document.uri.fsPath;
     if (qs !== undefined && path) {
-      if (await cliServer.cliConstraints.supportsResolveQlref()) {
-        const resolved = await cliServer.resolveQlref(path);
-        const uri = Uri.file(resolved.resolvedPath);
-        await window.showTextDocument(uri, { preview: false });
-      } else {
-        void showAndLogErrorMessage(
-          "Jumping from a .qlref file to the .ql file it references is not " +
-            "supported with the CLI version you are running.\n" +
-            `Please upgrade your CLI to version ${CliVersionConstraint.CLI_VERSION_WITH_RESOLVE_QLREF} or later to use this feature.`,
-        );
-      }
+      const resolved = await cliServer.resolveQlref(path);
+      const uri = Uri.file(resolved.resolvedPath);
+      await window.showTextDocument(uri, { preview: false });
     }
   }
 
@@ -1012,19 +1004,6 @@ async function activateWithInstalledDistribution(
             ...update,
             message,
           });
-        }
-
-        if (
-          queryUris.length > 1 &&
-          !(await cliServer.cliConstraints.supportsNonDestructiveUpgrades())
-        ) {
-          // Try to upgrade the current database before running any queries
-          // so that the user isn't confronted with multiple upgrade
-          // requests for each query to run.
-          // Only do it if running multiple queries since this check is
-          // performed on each query run anyway.
-          // Don't do this with non destructive upgrades as the user won't see anything anyway.
-          await databaseUI.tryUpgradeCurrentDatabase(progress, token);
         }
 
         wrappedProgress({

--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -540,7 +540,6 @@ export class CachedOperation<U> {
  * `cli.CodeQLCliServer.resolveDatabase` and use the first entry in the
  * `languages` property.
  *
- * @see cli.CliVersionConstraint.supportsLanguageName
  * @see cli.CodeQLCliServer.resolveDatabase
  */
 export const dbSchemeToLanguage = {

--- a/extensions/ql-vscode/src/legacy-query-server/legacyRunner.ts
+++ b/extensions/ql-vscode/src/legacy-query-server/legacyRunner.ts
@@ -74,10 +74,7 @@ export class LegacyQueryRunner extends QueryRunner {
     token: CancellationToken,
     dbItem: DatabaseItem,
   ): Promise<void> {
-    if (
-      dbItem.contents &&
-      (await this.qs.cliServer.cliConstraints.supportsDatabaseRegistration())
-    ) {
+    if (dbItem.contents) {
       const databases: Dataset[] = [
         {
           dbDir: dbItem.contents.datasetUri.fsPath,
@@ -97,10 +94,7 @@ export class LegacyQueryRunner extends QueryRunner {
     token: CancellationToken,
     dbItem: DatabaseItem,
   ): Promise<void> {
-    if (
-      dbItem.contents &&
-      (await this.qs.cliServer.cliConstraints.supportsDatabaseRegistration())
-    ) {
+    if (dbItem.contents) {
       const databases: Dataset[] = [
         {
           dbDir: dbItem.contents.datasetUri.fsPath,

--- a/extensions/ql-vscode/src/legacy-query-server/queryserver-client.ts
+++ b/extensions/ql-vscode/src/legacy-query-server/queryserver-client.ts
@@ -141,14 +141,9 @@ export class QueryServerClient extends DisposableObject {
       args.push(this.config.cacheSize.toString());
     }
 
-    if (await this.cliServer.cliConstraints.supportsDatabaseRegistration()) {
-      args.push("--require-db-registration");
-    }
+    args.push("--require-db-registration");
 
-    if (
-      (await this.cliServer.cliConstraints.supportsOldEvalStats()) &&
-      !(await this.cliServer.cliConstraints.supportsPerQueryEvalLog())
-    ) {
+    if (!(await this.cliServer.cliConstraints.supportsPerQueryEvalLog())) {
       args.push("--old-eval-stats");
     }
 

--- a/extensions/ql-vscode/src/legacy-query-server/upgrades.ts
+++ b/extensions/ql-vscode/src/legacy-query-server/upgrades.ts
@@ -37,11 +37,6 @@ export async function compileDatabaseUpgradeSequence(
   ) {
     throw new Error("Database is invalid, and cannot be upgraded.");
   }
-  if (!(await qs.cliServer.cliConstraints.supportsNonDestructiveUpgrades())) {
-    throw new Error(
-      "The version of codeql is too old to run non-destructive upgrades.",
-    );
-  }
   // If possible just compile the upgrade sequence
   return await qs.sendRequest(
     messages.compileUpgradeSequence,

--- a/extensions/ql-vscode/src/packaging.ts
+++ b/extensions/ql-vscode/src/packaging.ts
@@ -1,4 +1,4 @@
-import { CliVersionConstraint, CodeQLCliServer } from "./cli";
+import { CodeQLCliServer } from "./cli";
 import {
   getOnDiskWorkspaceFolders,
   showAndLogErrorMessage,
@@ -30,11 +30,6 @@ export async function handleDownloadPacks(
   cliServer: CodeQLCliServer,
   progress: ProgressCallback,
 ): Promise<void> {
-  if (!(await cliServer.cliConstraints.supportsPackaging())) {
-    throw new Error(
-      `Packaging commands are not supported by this version of CodeQL. Please upgrade to v${CliVersionConstraint.CLI_VERSION_WITH_PACKAGING} or later.`,
-    );
-  }
   progress({
     message: "Choose packs to download",
     step: 1,
@@ -92,11 +87,6 @@ export async function handleInstallPackDependencies(
   cliServer: CodeQLCliServer,
   progress: ProgressCallback,
 ): Promise<void> {
-  if (!(await cliServer.cliConstraints.supportsPackaging())) {
-    throw new Error(
-      `Packaging commands are not supported by this version of CodeQL. Please upgrade to v${CliVersionConstraint.CLI_VERSION_WITH_PACKAGING} or later.`,
-    );
-  }
   progress({
     message: "Choose packs to install dependencies for",
     step: 1,

--- a/extensions/ql-vscode/src/query-server/query-runner.ts
+++ b/extensions/ql-vscode/src/query-server/query-runner.ts
@@ -84,10 +84,7 @@ export class NewQueryRunner extends QueryRunner {
     token: CancellationToken,
     dbItem: DatabaseItem,
   ): Promise<void> {
-    if (
-      dbItem.contents &&
-      (await this.qs.cliServer.cliConstraints.supportsDatabaseRegistration())
-    ) {
+    if (dbItem.contents) {
       const databases: string[] = [dbItem.databaseUri.fsPath];
       await this.qs.sendRequest(
         deregisterDatabases,
@@ -102,10 +99,7 @@ export class NewQueryRunner extends QueryRunner {
     token: CancellationToken,
     dbItem: DatabaseItem,
   ): Promise<void> {
-    if (
-      dbItem.contents &&
-      (await this.qs.cliServer.cliConstraints.supportsDatabaseRegistration())
-    ) {
+    if (dbItem.contents) {
       const databases: string[] = [dbItem.databaseUri.fsPath];
       await this.qs.sendRequest(
         registerDatabases,
@@ -129,7 +123,7 @@ export class NewQueryRunner extends QueryRunner {
     const noItem = { title: "No", isCloseAffordance: true };
     const dialogOptions: vscode.MessageItem[] = [yesItem, noItem];
 
-    const message = `Should the database ${dbItem.databaseUri.fsPath} be destructively upgraded?\n\nThis should not be necessary to run queries 
+    const message = `Should the database ${dbItem.databaseUri.fsPath} be destructively upgraded?\n\nThis should not be necessary to run queries
     as we will non-destructively update it anyway.`;
     const chosenItem = await vscode.window.showInformationMessage(
       message,

--- a/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
@@ -137,7 +137,7 @@ async function generateQueryPack(
       "--no-default-compilation-cache",
       `--compilation-cache=${ccache}`,
     ];
-  } else if (await cliServer.cliConstraints.supportsNoPrecompile()) {
+  } else {
     precompilationOpts = ["--no-precompile"];
   }
 
@@ -227,12 +227,6 @@ export async function prepareRemoteQueryRun(
   token: CancellationToken,
   dbManager?: DbManager, // the dbManager is only needed when variantAnalysisReposPanel is enabled
 ): Promise<PreparedRemoteQuery> {
-  if (!(await cliServer.cliConstraints.supportsRemoteQueries())) {
-    throw new Error(
-      `Variant analysis is not supported by this version of CodeQL. Please upgrade to v${cli.CliVersionConstraint.CLI_VERSION_REMOTE_QUERIES} or later.`,
-    );
-  }
-
   if (!uri?.fsPath.endsWith(".ql")) {
     throw new UserCancellationException("Not a CodeQL query file.");
   }

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/legacy-query.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/legacy-query.test.ts
@@ -154,16 +154,14 @@ describeWithCodeQL()("using the legacy query server", () => {
     const parsedResults = new Checkpoint<void>();
 
     it("should register the database if necessary", async () => {
-      if (await cliServer.cliConstraints.supportsDatabaseRegistration()) {
-        await qs.sendRequest(
-          messages.registerDatabases,
-          { databases: [db] },
-          token,
-          (() => {
-            /**/
-          }) as any,
-        );
-      }
+      await qs.sendRequest(
+        messages.registerDatabases,
+        { databases: [db] },
+        token,
+        (() => {
+          /**/
+        }) as any,
+      );
     });
 
     it(`should be able to compile query ${queryName}`, async () => {

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/databases.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/databases.test.ts
@@ -33,7 +33,6 @@ describe("databases", () => {
   let updateSpy: jest.Mock<Promise<void>, []>;
   let registerSpy: jest.Mock<Promise<void>, []>;
   let deregisterSpy: jest.Mock<Promise<void>, []>;
-  let supportsLanguageNameSpy: jest.Mock<Promise<boolean>, []>;
   let resolveDatabaseSpy: jest.Mock<Promise<DbInfo>, []>;
 
   let dir: tmp.DirResult;
@@ -44,7 +43,6 @@ describe("databases", () => {
     updateSpy = jest.fn(() => Promise.resolve(undefined));
     registerSpy = jest.fn(() => Promise.resolve(undefined));
     deregisterSpy = jest.fn(() => Promise.resolve(undefined));
-    supportsLanguageNameSpy = jest.fn(() => Promise.resolve(true));
     resolveDatabaseSpy = jest.fn(() => Promise.resolve({} as DbInfo));
 
     databaseManager = new DatabaseManager(
@@ -65,10 +63,6 @@ describe("databases", () => {
         },
       } as unknown as QueryRunner,
       {
-        cliConstraints: {
-          supportsLanguageName: supportsLanguageNameSpy,
-          supportsDatabaseRegistration: () => true,
-        },
         resolveDatabase: resolveDatabaseSpy,
       } as unknown as CodeQLCliServer,
       {
@@ -384,15 +378,7 @@ describe("databases", () => {
     });
   });
 
-  it("should not support the primary language", async () => {
-    supportsLanguageNameSpy.mockResolvedValue(false);
-
-    const result = await (databaseManager as any).getPrimaryLanguage("hucairz");
-    expect(result).toBeUndefined();
-  });
-
   it("should get the primary language", async () => {
-    supportsLanguageNameSpy.mockResolvedValue(true);
     resolveDatabaseSpy.mockResolvedValue({
       languages: ["python"],
     } as unknown as DbInfo);
@@ -401,7 +387,6 @@ describe("databases", () => {
   });
 
   it("should handle missing the primary language", async () => {
-    supportsLanguageNameSpy.mockResolvedValue(true);
     resolveDatabaseSpy.mockResolvedValue({
       languages: [],
     } as unknown as DbInfo);

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/contextual/queryResolver.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/contextual/queryResolver.test.ts
@@ -22,9 +22,6 @@ describe("queryResolver", () => {
 
   const mockCli = {
     resolveQueriesInSuite: jest.fn(),
-    cliConstraints: {
-      supportsAllowLibraryPacksInResolveQueries: jest.fn(),
-    },
   };
 
   beforeEach(() => {
@@ -40,10 +37,6 @@ describe("queryResolver", () => {
 
     jest.spyOn(helpers, "getOnDiskWorkspaceFolders").mockReturnValue([]);
     jest.spyOn(helpers, "showAndLogErrorMessage").mockResolvedValue(undefined);
-
-    mockCli.cliConstraints.supportsAllowLibraryPacksInResolveQueries.mockReturnValue(
-      true,
-    );
   });
 
   describe("resolveQueries", () => {
@@ -66,42 +59,6 @@ describe("queryResolver", () => {
       expect(load(await fs.readFile(fileName, "utf-8"))).toEqual([
         {
           from: "my-qlpack",
-          queries: ".",
-          include: {
-            kind: "definitions",
-            "tags contain": "ide-contextual-queries/local-definitions",
-          },
-        },
-      ]);
-    });
-
-    it("should resolve a query from the queries pack if this is an old CLI", async () => {
-      // pretend this is an older CLI
-      mockCli.cliConstraints.supportsAllowLibraryPacksInResolveQueries.mockReturnValue(
-        false,
-      );
-      mockCli.resolveQueriesInSuite.mockReturnValue(["a", "b"]);
-      const result = await resolveQueries(
-        mockCli as unknown as CodeQLCliServer,
-        {
-          dbschemePackIsLibraryPack: true,
-          dbschemePack: "my-qlpack",
-          queryPack: "my-qlpack2",
-        },
-        KeyType.DefinitionQuery,
-      );
-      expect(result).toEqual(["a", "b"]);
-
-      expect(mockCli.resolveQueriesInSuite).toHaveBeenCalledWith(
-        expect.stringMatching(/\.qls$/),
-        [],
-      );
-
-      const fileName = mockCli.resolveQueriesInSuite.mock.calls[0][0];
-
-      expect(load(await fs.readFile(fileName, "utf-8"))).toEqual([
-        {
-          from: "my-qlpack2",
           queries: ".",
           include: {
             kind: "definitions",

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/run-queries.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/run-queries.test.ts
@@ -222,11 +222,7 @@ describe("run-queries", () => {
 
   describe("register", () => {
     it("should register", async () => {
-      const qs = createMockQueryServerClient({
-        cliConstraints: {
-          supportsDatabaseRegistration: () => true,
-        },
-      } as any);
+      const qs = createMockQueryServerClient();
       const runner = new LegacyQueryRunner(qs);
       const mockProgress = "progress-monitor";
       const mockCancel = "cancel-token";
@@ -261,11 +257,7 @@ describe("run-queries", () => {
     });
 
     it("should deregister", async () => {
-      const qs = createMockQueryServerClient({
-        cliConstraints: {
-          supportsDatabaseRegistration: () => true,
-        },
-      } as any);
+      const qs = createMockQueryServerClient();
       const runner = new LegacyQueryRunner(qs);
       const mockProgress = "progress-monitor";
       const mockCancel = "cancel-token";
@@ -297,54 +289,6 @@ describe("run-queries", () => {
         mockCancel,
         mockProgress,
       );
-    });
-
-    it("should not register if unsupported", async () => {
-      const qs = createMockQueryServerClient({
-        cliConstraints: {
-          supportsDatabaseRegistration: () => false,
-        },
-      } as any);
-      const runner = new LegacyQueryRunner(qs);
-      const mockProgress = "progress-monitor";
-      const mockCancel = "cancel-token";
-      const datasetUri = Uri.file("dataset-uri");
-
-      const dbItem: DatabaseItem = {
-        contents: {
-          datasetUri,
-        },
-      } as any;
-      await runner.registerDatabase(
-        mockProgress as any,
-        mockCancel as any,
-        dbItem,
-      );
-      expect(qs.sendRequest).not.toHaveBeenCalled();
-    });
-
-    it("should not deregister if unsupported", async () => {
-      const qs = createMockQueryServerClient({
-        cliConstraints: {
-          supportsDatabaseRegistration: () => false,
-        },
-      } as any);
-      const runner = new LegacyQueryRunner(qs);
-      const mockProgress = "progress-monitor";
-      const mockCancel = "cancel-token";
-      const datasetUri = Uri.file("dataset-uri");
-
-      const dbItem: DatabaseItem = {
-        contents: {
-          datasetUri,
-        },
-      } as any;
-      await runner.registerDatabase(
-        mockProgress as any,
-        mockCancel as any,
-        dbItem,
-      );
-      expect(qs.sendRequest).not.toBeCalled();
     });
   });
 


### PR DESCRIPTION
This removes all CodeQL CLI version constraints for unsupported CLI versions (< 2.7.6). The oldest supported CLI version is 2.7.6 since GHES 3.4 recommends using CodeQL CLI 2.7.6.

I've also removed a constraint on version 2.7.1, but I'm not sure if we still support all 2.7.x versions. 

Please double check that I made the correct transformations in call-sites, especially with regards to if conditions being `true`/`false`.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
