### PR TITLE
Remove variant analysis monitor return value

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/shared/variant-analysis-monitor-result.ts
+++ b/extensions/ql-vscode/src/remote-queries/shared/variant-analysis-monitor-result.ts
@@ -1,9 +1,0 @@
-import { VariantAnalysis } from "./variant-analysis";
-
-export type VariantAnalysisMonitorStatus = "Completed" | "Canceled";
-
-export interface VariantAnalysisMonitorResult {
-  status: VariantAnalysisMonitorStatus;
-  scannedReposDownloaded?: number[];
-  variantAnalysis?: VariantAnalysis;
-}

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-monitor.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-monitor.ts
@@ -13,7 +13,6 @@ import {
   VariantAnalysis,
   VariantAnalysisScannedRepository,
 } from "./shared/variant-analysis";
-import { VariantAnalysisMonitorResult } from "./shared/variant-analysis-monitor-result";
 import { processUpdatedVariantAnalysis } from "./variant-analysis-processor";
 import { DisposableObject } from "../pure/disposable-object";
 import { sleep } from "../pure/time";
@@ -36,7 +35,7 @@ export class VariantAnalysisMonitor extends DisposableObject {
   public async monitorVariantAnalysis(
     variantAnalysis: VariantAnalysis,
     cancellationToken: CancellationToken,
-  ): Promise<VariantAnalysisMonitorResult> {
+  ): Promise<void> {
     const credentials = await Credentials.initialize(this.extensionContext);
     if (!credentials) {
       throw Error("Error authenticating with GitHub");
@@ -49,7 +48,7 @@ export class VariantAnalysisMonitor extends DisposableObject {
       await sleep(VariantAnalysisMonitor.sleepTime);
 
       if (cancellationToken && cancellationToken.isCancellationRequested) {
-        return { status: "Canceled" };
+        return;
       }
 
       const variantAnalysisSummary = await ghApiClient.getVariantAnalysis(
@@ -77,8 +76,6 @@ export class VariantAnalysisMonitor extends DisposableObject {
 
       attemptCount++;
     }
-
-    return { status: "Completed", scannedReposDownloaded, variantAnalysis };
   }
 
   private scheduleForDownload(


### PR DESCRIPTION
The monitor return value was only used in tests, but we can also assert the correct behavior using the calls it makes, rather than using the result of the monitor.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
