### PR TITLE
Add debugging support for Jest integration tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -72,13 +72,10 @@
         "--projects",
         "out/vscode-tests/no-workspace"
       ],
-      "stopOnEntry": false,
       "sourceMaps": true,
-      "outFiles": [
-        "${workspaceRoot}/extensions/ql-vscode/out/**/*.js",
-      ],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
+      "attachSimplePort": 9223,
     },
     {
       "name": "Launch Integration Tests - Minimal Workspace (vscode-codeql)",
@@ -91,13 +88,10 @@
         "--projects",
         "out/vscode-tests/minimal-workspace"
       ],
-      "stopOnEntry": false,
       "sourceMaps": true,
-      "outFiles": [
-        "${workspaceRoot}/extensions/ql-vscode/out/**/*.js",
-      ],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
+      "attachSimplePort": 9223,
     },
     {
       "name": "Launch Integration Tests - With CLI",
@@ -128,13 +122,10 @@
         // available in the workspace for the tests.
         // "TEST_CODEQL_PATH": "${workspaceRoot}/../codeql",
       },
-      "stopOnEntry": false,
       "sourceMaps": true,
-      "outFiles": [
-        "${workspaceRoot}/extensions/ql-vscode/out/**/*.js",
-      ],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
+      "attachSimplePort": 9223,
     },
     {
       "name": "Launch Storybook",

--- a/extensions/ql-vscode/src/vscode-tests/jest-runner-vscode.config.base.ts
+++ b/extensions/ql-vscode/src/vscode-tests/jest-runner-vscode.config.base.ts
@@ -16,4 +16,8 @@ const config: RunnerOptions = {
   extensionDevelopmentPath: rootDir,
 };
 
+if (process.env.VSCODE_INSPECTOR_OPTIONS) {
+  config.launchArgs?.push("--inspect-extensions", "9223");
+}
+
 export default config;


### PR DESCRIPTION
Since we are launching a completely different process for the extension tests than the process that is launched by VSCode, we need to add some special handling for the debugging.

This will let the extension host/VSCode expose a debugging port, which VSCode will then connect to. This is "less desirable than letting the bootloader do its thing", but a packaged VSCode application does not allow using the bootloader (`NODE_OPTIONS=--require=...`). Therefore, we have to fallback to this option.

See: https://github.com/microsoft/vscode-js-debug/blob/47c60558ec31902f42c255abb9b460078df02f9d/src/configuration.ts#L405-L411

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
