### PR TITLE
Fix loading results in second opened view

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-results-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-results-manager.ts
@@ -121,6 +121,7 @@ export class VariantAnalysisResultsManager extends DisposableObject {
       createCacheKey(variantAnalysisId, repositoryFullName),
     );
     if (result) {
+      this._onResultLoaded.fire(result);
       return result;
     }
 


### PR DESCRIPTION
When results were already cached in memory and the view requested the result, it would not be loaded because the event would not be fired. This fires the event when the result is loaded from cache as well, to ensure that the view always receives the result.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
