### PR TITLE
MRVA: Fix typo in repo cancellation message

### DIFF
--- a/extensions/ql-vscode/src/view/variant-analysis/AnalyzedRepoItemContent.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/AnalyzedRepoItemContent.tsx
@@ -76,7 +76,7 @@ export const AnalyzedRepoItemContent = ({
           <Alert
             type="error"
             title="Canceled"
-            message="The variant analysis or this repository was canceled."
+            message="The variant analysis for this repository was canceled."
           />
         </AlertContainer>
       )}


### PR DESCRIPTION
Just a teeny typo fix in the MRVA results view!

## Checklist

N/A - internal only 🦏 

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
