### PR TITLE
Don't show pending state when analysis has failed

### DIFF
--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
@@ -17,7 +17,7 @@ import {
   RepositoriesFilterSortState,
 } from "../../pure/variant-analysis-filter-sort";
 
-type Props = {
+export type VariantAnalysisProps = {
   variantAnalysis?: VariantAnalysisDomainModel;
   repoStates?: VariantAnalysisScannedRepositoryState[];
   repoResults?: VariantAnalysisScannedRepositoryResult[];
@@ -51,7 +51,7 @@ export function VariantAnalysis({
   variantAnalysis: initialVariantAnalysis,
   repoStates: initialRepoStates = [],
   repoResults: initialRepoResults = [],
-}: Props): JSX.Element {
+}: VariantAnalysisProps): JSX.Element {
   const [variantAnalysis, setVariantAnalysis] = useState<
     VariantAnalysisDomainModel | undefined
   >(initialVariantAnalysis);

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
@@ -5,6 +5,7 @@ import {
   VariantAnalysis as VariantAnalysisDomainModel,
   VariantAnalysisScannedRepositoryResult,
   VariantAnalysisScannedRepositoryState,
+  VariantAnalysisStatus,
 } from "../../remote-queries/shared/variant-analysis";
 import { VariantAnalysisHeader } from "./VariantAnalysisHeader";
 import { VariantAnalysisOutcomePanels } from "./VariantAnalysisOutcomePanels";
@@ -128,7 +129,11 @@ export function VariantAnalysis({
     });
   }, [filterSortState, selectedRepositoryIds]);
 
-  if (variantAnalysis?.actionsWorkflowRunId === undefined) {
+  if (
+    variantAnalysis === undefined ||
+    (variantAnalysis.status === VariantAnalysisStatus.InProgress &&
+      variantAnalysis.actionsWorkflowRunId === undefined)
+  ) {
     return <VariantAnalysisLoading />;
   }
 

--- a/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysis.spec.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysis.spec.tsx
@@ -1,0 +1,49 @@
+import * as React from "react";
+import { render as reactRender, screen } from "@testing-library/react";
+import {
+  VariantAnalysisFailureReason,
+  VariantAnalysisStatus,
+} from "../../../remote-queries/shared/variant-analysis";
+import { VariantAnalysis, VariantAnalysisProps } from "../VariantAnalysis";
+import { createMockVariantAnalysis } from "../../../vscode-tests/factories/remote-queries/shared/variant-analysis";
+
+describe(VariantAnalysis.name, () => {
+  const render = (props: Partial<VariantAnalysisProps> = {}) =>
+    reactRender(
+      <VariantAnalysis
+        variantAnalysis={createMockVariantAnalysis({})}
+        {...props}
+      />,
+    );
+
+  it("renders a pending analysis", () => {
+    const variantAnalysis = createMockVariantAnalysis({
+      status: VariantAnalysisStatus.InProgress,
+    });
+    variantAnalysis.actionsWorkflowRunId = undefined;
+    render({ variantAnalysis });
+
+    expect(
+      screen.getByText("We are getting everything ready"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders an analysis where there were no repos to analyse", () => {
+    const variantAnalysis = createMockVariantAnalysis({
+      status: VariantAnalysisStatus.Failed,
+    });
+    variantAnalysis.failureReason = VariantAnalysisFailureReason.NoReposQueried;
+    variantAnalysis.actionsWorkflowRunId = undefined;
+    render({ variantAnalysis });
+
+    expect(
+      screen.queryByText("We are getting everything ready"),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.getByText(
+        "No repositories available after processing. No repositories were analyzed.",
+      ),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

If a variant analysis fails because there are no repos to query (or the repos don't have databases) then it doesn't get as far as creating an actions workflow. This means that using the presence of that field alone is problematic for determining the status of a variant analysis.

This PR will avoid cases like:
<img width="756" alt="Screenshot 2022-11-25 at 16 29 11" src="https://user-images.githubusercontent.com/3749000/204564873-cf820341-5a86-49c2-8ce9-6133a058e0d8.png">


## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
