### PR TITLE
Don't show spinner for a failed analysis

### DIFF
--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
@@ -132,6 +132,9 @@ export function VariantAnalysis({
     return <VariantAnalysisLoading />;
   }
 
+  const onViewLogsClick =
+    variantAnalysis.actionsWorkflowRunId === undefined ? undefined : openLogs;
+
   return (
     <>
       <VariantAnalysisHeader
@@ -141,7 +144,7 @@ export function VariantAnalysis({
         onStopQueryClick={stopQuery}
         onCopyRepositoryListClick={copyRepositoryList}
         onExportResultsClick={exportResults}
-        onViewLogsClick={openLogs}
+        onViewLogsClick={onViewLogsClick}
       />
       <VariantAnalysisOutcomePanels
         variantAnalysis={variantAnalysis}

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisHeader.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisHeader.tsx
@@ -24,7 +24,7 @@ export type VariantAnalysisHeaderProps = {
   onCopyRepositoryListClick: () => void;
   onExportResultsClick: () => void;
 
-  onViewLogsClick: () => void;
+  onViewLogsClick?: () => void;
 };
 
 const Container = styled.div`

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisStats.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisStats.tsx
@@ -20,7 +20,7 @@ export type VariantAnalysisStatsProps = {
   createdAt: Date;
   completedAt?: Date | undefined;
 
-  onViewLogsClick: () => void;
+  onViewLogsClick?: () => void;
 };
 
 const Row = styled.div`
@@ -88,6 +88,7 @@ export const VariantAnalysisStats = ({
       </StatItem>
       <StatItem title={completionHeaderName}>
         <VariantAnalysisStatusStats
+          variantAnalysisStatus={variantAnalysisStatus}
           completedAt={completedAt}
           onViewLogsClick={onViewLogsClick}
         />

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisStatusStats.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisStatusStats.tsx
@@ -4,7 +4,7 @@ import { VSCodeLink } from "@vscode/webview-ui-toolkit/react";
 import { formatDate } from "../../pure/date";
 import { VariantAnalysisStatus } from "../../remote-queries/shared/variant-analysis";
 
-type Props = {
+export type VariantAnalysisStatusStatsProps = {
   variantAnalysisStatus: VariantAnalysisStatus;
   completedAt?: Date;
 
@@ -26,7 +26,7 @@ export const VariantAnalysisStatusStats = ({
   variantAnalysisStatus,
   completedAt,
   onViewLogsClick,
-}: Props) => {
+}: VariantAnalysisStatusStatsProps) => {
   if (variantAnalysisStatus === VariantAnalysisStatus.InProgress) {
     return <Icon className="codicon codicon-loading codicon-modifier-spin" />;
   }

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisStatusStats.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisStatusStats.tsx
@@ -2,11 +2,13 @@ import * as React from "react";
 import styled from "styled-components";
 import { VSCodeLink } from "@vscode/webview-ui-toolkit/react";
 import { formatDate } from "../../pure/date";
+import { VariantAnalysisStatus } from "../../remote-queries/shared/variant-analysis";
 
 type Props = {
-  completedAt?: Date | undefined;
+  variantAnalysisStatus: VariantAnalysisStatus;
+  completedAt?: Date;
 
-  onViewLogsClick: () => void;
+  onViewLogsClick?: () => void;
 };
 
 const Container = styled.div`
@@ -21,17 +23,20 @@ const Icon = styled.span`
 `;
 
 export const VariantAnalysisStatusStats = ({
+  variantAnalysisStatus,
   completedAt,
   onViewLogsClick,
 }: Props) => {
-  if (completedAt === undefined) {
+  if (variantAnalysisStatus === VariantAnalysisStatus.InProgress) {
     return <Icon className="codicon codicon-loading codicon-modifier-spin" />;
   }
 
   return (
     <Container>
-      <span>{formatDate(completedAt)}</span>
-      <VSCodeLink onClick={onViewLogsClick}>View logs</VSCodeLink>
+      <span>{completedAt !== undefined ? formatDate(completedAt) : "-"}</span>
+      {onViewLogsClick && (
+        <VSCodeLink onClick={onViewLogsClick}>View logs</VSCodeLink>
+      )}
     </Container>
   );
 };

--- a/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisStatusStats.spec.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisStatusStats.spec.tsx
@@ -1,0 +1,74 @@
+import * as React from "react";
+import { render as reactRender, screen } from "@testing-library/react";
+import { VariantAnalysisStatus } from "../../../remote-queries/shared/variant-analysis";
+import {
+  VariantAnalysisStatusStats,
+  VariantAnalysisStatusStatsProps,
+} from "../VariantAnalysisStatusStats";
+import { formatDate } from "../../../pure/date";
+
+describe(VariantAnalysisStatusStats.name, () => {
+  const onViewLogsClick = jest.fn();
+
+  afterEach(() => {
+    onViewLogsClick.mockReset();
+  });
+
+  const render = (props: Partial<VariantAnalysisStatusStatsProps> = {}) =>
+    reactRender(
+      <VariantAnalysisStatusStats
+        variantAnalysisStatus={VariantAnalysisStatus.InProgress}
+        {...props}
+      />,
+    );
+
+  it("renders an in-progress status correctly", () => {
+    const { container } = render({
+      variantAnalysisStatus: VariantAnalysisStatus.InProgress,
+    });
+
+    expect(
+      container.getElementsByClassName(
+        "codicon codicon-loading codicon-modifier-spin",
+      ).length,
+    ).toEqual(1);
+  });
+
+  it("renders when there is a completedAt date", () => {
+    const completedAt = new Date();
+    render({
+      variantAnalysisStatus: VariantAnalysisStatus.Succeeded,
+      completedAt,
+    });
+
+    expect(screen.getByText(formatDate(completedAt))).toBeInTheDocument();
+    expect(screen.queryByText("-")).not.toBeInTheDocument();
+  });
+
+  it("renders when there isn't a completedAt date", () => {
+    render({
+      variantAnalysisStatus: VariantAnalysisStatus.Succeeded,
+      completedAt: undefined,
+    });
+
+    expect(screen.getByText("-")).toBeInTheDocument();
+  });
+
+  it("renders when there is a viewLogs links", () => {
+    render({
+      variantAnalysisStatus: VariantAnalysisStatus.Succeeded,
+      onViewLogsClick: () => undefined,
+    });
+
+    expect(screen.getByText("View logs")).toBeInTheDocument();
+  });
+
+  it("renders when there isn't a viewLogs links", () => {
+    render({
+      variantAnalysisStatus: VariantAnalysisStatus.Succeeded,
+      onViewLogsClick: undefined,
+    });
+
+    expect(screen.queryByText("View logs")).not.toBeInTheDocument();
+  });
+});

--- a/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisStatusStats.spec.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisStatusStats.spec.tsx
@@ -8,12 +8,6 @@ import {
 import { formatDate } from "../../../pure/date";
 
 describe(VariantAnalysisStatusStats.name, () => {
-  const onViewLogsClick = jest.fn();
-
-  afterEach(() => {
-    onViewLogsClick.mockReset();
-  });
-
   const render = (props: Partial<VariantAnalysisStatusStatsProps> = {}) =>
     reactRender(
       <VariantAnalysisStatusStats

--- a/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisStatusStats.spec.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisStatusStats.spec.tsx
@@ -24,8 +24,8 @@ describe(VariantAnalysisStatusStats.name, () => {
     expect(
       container.getElementsByClassName(
         "codicon codicon-loading codicon-modifier-spin",
-      ).length,
-    ).toEqual(1);
+      )[0],
+    ).toBeInTheDocument();
   });
 
   it("renders when there is a completedAt date", () => {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

This PR avoids showing a spinning spinner when the variant analysis has in fact failed and won't make any more progress.

We're using the `completedAt` field to tell if the analysis is finished or not instead of the variant analysis status. This causes problems when the variant analysis failed to start a workflow because there were no repos to query. In this case it didn't get as far as creating a workflow run, and so there is no `completedAt` value. Possibly we should be setting `completedAt` in the API in this case, but we also can handle this in the extension.

Also, if we just show the non-spinner bit of this component then we start showing the "view logs" link in cases when we shouldn't be. For example when the variant analysis fails before it can start the actions workflow, e.g. if there are no repositories to query. So as part of this I'm also making the "view logs" link option and only populating it when there are logs to link to.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
