### PR TITLE
Add additional Storybook VSCode themes

### DIFF
--- a/extensions/ql-vscode/.storybook/vscode-theme-addon/theme.ts
+++ b/extensions/ql-vscode/.storybook/vscode-theme-addon/theme.ts
@@ -1,9 +1,17 @@
 export enum VSCodeTheme {
   Dark = "dark",
   Light = "light",
+  LightHighContrast = "light-high-contrast",
+  DarkHighContrast = "dark-high-contrast",
+  GitHubLightDefault = "github-light-default",
+  GitHubDarkDefault = "github-dark-default",
 }
 
 export const themeNames: { [key in VSCodeTheme]: string } = {
   [VSCodeTheme.Dark]: "Dark+",
   [VSCodeTheme.Light]: "Light+",
+  [VSCodeTheme.LightHighContrast]: "Light High Contrast",
+  [VSCodeTheme.DarkHighContrast]: "Dark High Contrast",
+  [VSCodeTheme.GitHubLightDefault]: "GitHub Light Default",
+  [VSCodeTheme.GitHubDarkDefault]: "GitHub Dark Default",
 };

--- a/extensions/ql-vscode/.storybook/vscode-theme-addon/withTheme.ts
+++ b/extensions/ql-vscode/.storybook/vscode-theme-addon/withTheme.ts
@@ -16,6 +16,22 @@ const themeFiles: { [key in VSCodeTheme]: string } = {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     require("!file-loader?modules!../../src/stories/vscode-theme-light.css")
       .default,
+  [VSCodeTheme.LightHighContrast]:
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    require("!file-loader?modules!../../src/stories/vscode-theme-light-high-contrast.css")
+      .default,
+  [VSCodeTheme.DarkHighContrast]:
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    require("!file-loader?modules!../../src/stories/vscode-theme-dark-high-contrast.css")
+      .default,
+  [VSCodeTheme.GitHubLightDefault]:
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    require("!file-loader?modules!../../src/stories/vscode-theme-github-light-default.css")
+      .default,
+  [VSCodeTheme.GitHubDarkDefault]:
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    require("!file-loader?modules!../../src/stories/vscode-theme-github-dark-default.css")
+      .default,
 };
 
 export const withTheme = (

--- a/extensions/ql-vscode/src/stories/vscode-theme-dark-high-contrast.css
+++ b/extensions/ql-vscode/src/stories/vscode-theme-dark-high-contrast.css
@@ -1,0 +1,577 @@
+/*
+ * These were copied from VSCode Dark High Contrast theme.
+ *
+ * To update these, open a webview in VSCode, open the webview developer tools and find the
+ * iframe hosting the webview. The <html> element will have a style attribute that contains
+ * the CSS variables. Copy these to this file.
+ */
+:root {
+  --vscode-font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+  --vscode-font-weight: normal;
+  --vscode-font-size: 13px;
+  --vscode-editor-font-family: Menlo, Monaco, "Courier New", monospace;
+  --vscode-editor-font-weight: normal;
+  --vscode-editor-font-size: 12px;
+  --vscode-foreground: #ffffff;
+  --vscode-disabledForeground: #a5a5a5;
+  --vscode-errorForeground: #f48771;
+  --vscode-descriptionForeground: rgba(255, 255, 255, 0.7);
+  --vscode-icon-foreground: #ffffff;
+  --vscode-focusBorder: #f38518;
+  --vscode-contrastBorder: #6fc3df;
+  --vscode-contrastActiveBorder: #f38518;
+  --vscode-selection-background: #008000;
+  --vscode-textSeparator-foreground: #000000;
+  --vscode-textLink-foreground: #3794ff;
+  --vscode-textLink-activeForeground: #3794ff;
+  --vscode-textPreformat-foreground: #d7ba7d;
+  --vscode-textBlockQuote-border: #ffffff;
+  --vscode-textCodeBlock-background: #000000;
+  --vscode-input-background: #000000;
+  --vscode-input-foreground: #ffffff;
+  --vscode-input-border: #6fc3df;
+  --vscode-inputOption-activeBorder: #6fc3df;
+  --vscode-inputOption-activeBackground: rgba(0, 0, 0, 0);
+  --vscode-inputOption-activeForeground: #ffffff;
+  --vscode-input-placeholderForeground: rgba(255, 255, 255, 0.7);
+  --vscode-inputValidation-infoBackground: #000000;
+  --vscode-inputValidation-infoBorder: #6fc3df;
+  --vscode-inputValidation-warningBackground: #000000;
+  --vscode-inputValidation-warningBorder: #6fc3df;
+  --vscode-inputValidation-errorBackground: #000000;
+  --vscode-inputValidation-errorBorder: #6fc3df;
+  --vscode-dropdown-background: #000000;
+  --vscode-dropdown-listBackground: #000000;
+  --vscode-dropdown-foreground: #ffffff;
+  --vscode-dropdown-border: #6fc3df;
+  --vscode-button-foreground: #ffffff;
+  --vscode-button-separator: rgba(255, 255, 255, 0.4);
+  --vscode-button-border: #6fc3df;
+  --vscode-button-secondaryForeground: #ffffff;
+  --vscode-badge-background: #000000;
+  --vscode-badge-foreground: #ffffff;
+  --vscode-scrollbarSlider-background: rgba(111, 195, 223, 0.6);
+  --vscode-scrollbarSlider-hoverBackground: rgba(111, 195, 223, 0.8);
+  --vscode-scrollbarSlider-activeBackground: #6fc3df;
+  --vscode-progressBar-background: #6fc3df;
+  --vscode-editorError-foreground: #f48771;
+  --vscode-editorError-border: rgba(228, 119, 119, 0.8);
+  --vscode-editorWarning-foreground: #ff0000;
+  --vscode-editorWarning-border: rgba(255, 204, 0, 0.8);
+  --vscode-editorInfo-foreground: #3794ff;
+  --vscode-editorInfo-border: rgba(55, 148, 255, 0.8);
+  --vscode-editorHint-border: rgba(238, 238, 238, 0.8);
+  --vscode-sash-hoverBorder: #f38518;
+  --vscode-editor-background: #000000;
+  --vscode-editor-foreground: #ffffff;
+  --vscode-editorStickyScroll-background: #000000;
+  --vscode-editorWidget-background: #0c141f;
+  --vscode-editorWidget-foreground: #ffffff;
+  --vscode-editorWidget-border: #6fc3df;
+  --vscode-quickInput-background: #0c141f;
+  --vscode-quickInput-foreground: #ffffff;
+  --vscode-quickInputTitle-background: #000000;
+  --vscode-pickerGroup-foreground: #ffffff;
+  --vscode-pickerGroup-border: #ffffff;
+  --vscode-keybindingLabel-background: rgba(0, 0, 0, 0);
+  --vscode-keybindingLabel-foreground: #ffffff;
+  --vscode-keybindingLabel-border: #6fc3df;
+  --vscode-keybindingLabel-bottomBorder: #6fc3df;
+  --vscode-editor-selectionBackground: #ffffff;
+  --vscode-editor-selectionForeground: #000000;
+  --vscode-editor-inactiveSelectionBackground: rgba(255, 255, 255, 0.7);
+  --vscode-editor-selectionHighlightBorder: #f38518;
+  --vscode-editor-findMatchBorder: #f38518;
+  --vscode-editor-findMatchHighlightBorder: #f38518;
+  --vscode-editor-findRangeHighlightBorder: rgba(243, 133, 24, 0.4);
+  --vscode-searchEditor-findMatchBorder: #f38518;
+  --vscode-editor-hoverHighlightBackground: rgba(173, 214, 255, 0.15);
+  --vscode-editorHoverWidget-background: #0c141f;
+  --vscode-editorHoverWidget-foreground: #ffffff;
+  --vscode-editorHoverWidget-border: #6fc3df;
+  --vscode-editorHoverWidget-statusBarBackground: #0c141f;
+  --vscode-editorLink-activeForeground: #00ffff;
+  --vscode-editorInlayHint-foreground: #000000;
+  --vscode-editorInlayHint-background: #f38518;
+  --vscode-editorInlayHint-typeForeground: #000000;
+  --vscode-editorInlayHint-typeBackground: #f38518;
+  --vscode-editorInlayHint-parameterForeground: #000000;
+  --vscode-editorInlayHint-parameterBackground: #f38518;
+  --vscode-editorLightBulb-foreground: #ffcc00;
+  --vscode-editorLightBulbAutoFix-foreground: #75beff;
+  --vscode-diffEditor-insertedTextBorder: #33ff2e;
+  --vscode-diffEditor-removedTextBorder: #ff008f;
+  --vscode-diffEditor-border: #6fc3df;
+  --vscode-list-focusOutline: #f38518;
+  --vscode-list-highlightForeground: #f38518;
+  --vscode-list-focusHighlightForeground: #f38518;
+  --vscode-list-invalidItemForeground: #b89500;
+  --vscode-listFilterWidget-background: #0c141f;
+  --vscode-listFilterWidget-outline: #f38518;
+  --vscode-listFilterWidget-noMatchesOutline: #6fc3df;
+  --vscode-list-filterMatchBorder: #6fc3df;
+  --vscode-tree-indentGuidesStroke: #a9a9a9;
+  --vscode-list-deemphasizedForeground: #a7a8a9;
+  --vscode-checkbox-background: #000000;
+  --vscode-checkbox-selectBackground: #0c141f;
+  --vscode-checkbox-foreground: #ffffff;
+  --vscode-checkbox-border: #6fc3df;
+  --vscode-checkbox-selectBorder: #0c141f;
+  --vscode-menu-border: #6fc3df;
+  --vscode-menu-foreground: #ffffff;
+  --vscode-menu-background: #000000;
+  --vscode-menu-selectionBorder: #f38518;
+  --vscode-menu-separatorBackground: #6fc3df;
+  --vscode-toolbar-hoverOutline: #f38518;
+  --vscode-editor-snippetTabstopHighlightBackground: rgba(124, 124, 124, 0.3);
+  --vscode-editor-snippetFinalTabstopHighlightBorder: #525252;
+  --vscode-breadcrumb-foreground: rgba(255, 255, 255, 0.8);
+  --vscode-breadcrumb-background: #000000;
+  --vscode-breadcrumb-focusForeground: #ffffff;
+  --vscode-breadcrumb-activeSelectionForeground: #ffffff;
+  --vscode-breadcrumbPicker-background: #0c141f;
+  --vscode-merge-border: #c3df6f;
+  --vscode-editorOverviewRuler-currentContentForeground: #c3df6f;
+  --vscode-editorOverviewRuler-incomingContentForeground: #c3df6f;
+  --vscode-editorOverviewRuler-commonContentForeground: #c3df6f;
+  --vscode-editorOverviewRuler-findMatchForeground: #ab5a00;
+  --vscode-editorOverviewRuler-selectionHighlightForeground: rgba(
+    160,
+    160,
+    160,
+    0.8
+  );
+  --vscode-minimap-findMatchHighlight: #ab5a00;
+  --vscode-minimap-selectionOccurrenceHighlight: #ffffff;
+  --vscode-minimap-selectionHighlight: #ffffff;
+  --vscode-minimap-errorHighlight: #ff3232;
+  --vscode-minimap-warningHighlight: rgba(255, 204, 0, 0.8);
+  --vscode-minimap-foregroundOpacity: #000000;
+  --vscode-minimapSlider-background: rgba(111, 195, 223, 0.3);
+  --vscode-minimapSlider-hoverBackground: rgba(111, 195, 223, 0.4);
+  --vscode-minimapSlider-activeBackground: rgba(111, 195, 223, 0.5);
+  --vscode-problemsErrorIcon-foreground: #f48771;
+  --vscode-problemsWarningIcon-foreground: #ff0000;
+  --vscode-problemsInfoIcon-foreground: #3794ff;
+  --vscode-charts-foreground: #ffffff;
+  --vscode-charts-lines: rgba(255, 255, 255, 0.5);
+  --vscode-charts-red: #f48771;
+  --vscode-charts-blue: #3794ff;
+  --vscode-charts-yellow: #ff0000;
+  --vscode-charts-orange: #ab5a00;
+  --vscode-charts-green: #89d185;
+  --vscode-charts-purple: #b180d7;
+  --vscode-symbolIcon-arrayForeground: #ffffff;
+  --vscode-symbolIcon-booleanForeground: #ffffff;
+  --vscode-symbolIcon-classForeground: #ee9d28;
+  --vscode-symbolIcon-colorForeground: #ffffff;
+  --vscode-symbolIcon-constantForeground: #ffffff;
+  --vscode-symbolIcon-constructorForeground: #b180d7;
+  --vscode-symbolIcon-enumeratorForeground: #ee9d28;
+  --vscode-symbolIcon-enumeratorMemberForeground: #75beff;
+  --vscode-symbolIcon-eventForeground: #ee9d28;
+  --vscode-symbolIcon-fieldForeground: #75beff;
+  --vscode-symbolIcon-fileForeground: #ffffff;
+  --vscode-symbolIcon-folderForeground: #ffffff;
+  --vscode-symbolIcon-functionForeground: #b180d7;
+  --vscode-symbolIcon-interfaceForeground: #75beff;
+  --vscode-symbolIcon-keyForeground: #ffffff;
+  --vscode-symbolIcon-keywordForeground: #ffffff;
+  --vscode-symbolIcon-methodForeground: #b180d7;
+  --vscode-symbolIcon-moduleForeground: #ffffff;
+  --vscode-symbolIcon-namespaceForeground: #ffffff;
+  --vscode-symbolIcon-nullForeground: #ffffff;
+  --vscode-symbolIcon-numberForeground: #ffffff;
+  --vscode-symbolIcon-objectForeground: #ffffff;
+  --vscode-symbolIcon-operatorForeground: #ffffff;
+  --vscode-symbolIcon-packageForeground: #ffffff;
+  --vscode-symbolIcon-propertyForeground: #ffffff;
+  --vscode-symbolIcon-referenceForeground: #ffffff;
+  --vscode-symbolIcon-snippetForeground: #ffffff;
+  --vscode-symbolIcon-stringForeground: #ffffff;
+  --vscode-symbolIcon-structForeground: #ffffff;
+  --vscode-symbolIcon-textForeground: #ffffff;
+  --vscode-symbolIcon-typeParameterForeground: #ffffff;
+  --vscode-symbolIcon-unitForeground: #ffffff;
+  --vscode-symbolIcon-variableForeground: #75beff;
+  --vscode-editor-lineHighlightBorder: #f38518;
+  --vscode-editor-rangeHighlightBorder: #f38518;
+  --vscode-editor-symbolHighlightBorder: #f38518;
+  --vscode-editorCursor-foreground: #ffffff;
+  --vscode-editorWhitespace-foreground: #7c7c7c;
+  --vscode-editorIndentGuide-background: #ffffff;
+  --vscode-editorIndentGuide-activeBackground: #ffffff;
+  --vscode-editorLineNumber-foreground: #ffffff;
+  --vscode-editorActiveLineNumber-foreground: #f38518;
+  --vscode-editorLineNumber-activeForeground: #f38518;
+  --vscode-editorRuler-foreground: #ffffff;
+  --vscode-editorCodeLens-foreground: #999999;
+  --vscode-editorBracketMatch-background: rgba(0, 100, 0, 0.1);
+  --vscode-editorBracketMatch-border: #6fc3df;
+  --vscode-editorOverviewRuler-border: rgba(127, 127, 127, 0.3);
+  --vscode-editorGutter-background: #000000;
+  --vscode-editorUnnecessaryCode-border: rgba(255, 255, 255, 0.8);
+  --vscode-editorGhostText-border: rgba(255, 255, 255, 0.8);
+  --vscode-editorOverviewRuler-rangeHighlightForeground: rgba(0, 122, 204, 0.6);
+  --vscode-editorOverviewRuler-errorForeground: #ff3232;
+  --vscode-editorOverviewRuler-warningForeground: rgba(255, 204, 0, 0.8);
+  --vscode-editorOverviewRuler-infoForeground: rgba(55, 148, 255, 0.8);
+  --vscode-editorBracketHighlight-foreground1: #ffd700;
+  --vscode-editorBracketHighlight-foreground2: #da70d6;
+  --vscode-editorBracketHighlight-foreground3: #87cefa;
+  --vscode-editorBracketHighlight-foreground4: rgba(0, 0, 0, 0);
+  --vscode-editorBracketHighlight-foreground5: rgba(0, 0, 0, 0);
+  --vscode-editorBracketHighlight-foreground6: rgba(0, 0, 0, 0);
+  --vscode-editorBracketHighlight-unexpectedBracket\.foreground: #ff3232;
+  --vscode-editorBracketPairGuide-background1: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-background2: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-background3: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-background4: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-background5: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-background6: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-activeBackground1: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-activeBackground2: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-activeBackground3: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-activeBackground4: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-activeBackground5: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-activeBackground6: rgba(0, 0, 0, 0);
+  --vscode-editorUnicodeHighlight-border: #ff0000;
+  --vscode-editorUnicodeHighlight-background: rgba(0, 0, 0, 0);
+  --vscode-editorHoverWidget-highlightForeground: #f38518;
+  --vscode-editorOverviewRuler-bracketMatchForeground: #a0a0a0;
+  --vscode-editorGutter-foldingControlForeground: #ffffff;
+  --vscode-editor-linkedEditingBackground: rgba(255, 0, 0, 0.3);
+  --vscode-editor-wordHighlightBorder: #f38518;
+  --vscode-editor-wordHighlightStrongBorder: #f38518;
+  --vscode-editorOverviewRuler-wordHighlightForeground: rgba(
+    160,
+    160,
+    160,
+    0.8
+  );
+  --vscode-editorOverviewRuler-wordHighlightStrongForeground: rgba(
+    192,
+    160,
+    192,
+    0.8
+  );
+  --vscode-peekViewTitleLabel-foreground: #ffffff;
+  --vscode-peekViewTitleDescription-foreground: rgba(255, 255, 255, 0.6);
+  --vscode-peekView-border: #6fc3df;
+  --vscode-peekViewResult-background: #000000;
+  --vscode-peekViewResult-lineForeground: #ffffff;
+  --vscode-peekViewResult-fileForeground: #ffffff;
+  --vscode-peekViewResult-selectionForeground: #ffffff;
+  --vscode-peekViewEditor-background: #000000;
+  --vscode-peekViewEditorGutter-background: #000000;
+  --vscode-peekViewEditor-matchHighlightBorder: #f38518;
+  --vscode-editorMarkerNavigationError-background: #6fc3df;
+  --vscode-editorMarkerNavigationWarning-background: #6fc3df;
+  --vscode-editorMarkerNavigationWarning-headerBackground: #0c141f;
+  --vscode-editorMarkerNavigationInfo-background: #6fc3df;
+  --vscode-editorMarkerNavigation-background: #000000;
+  --vscode-editorSuggestWidget-background: #0c141f;
+  --vscode-editorSuggestWidget-border: #6fc3df;
+  --vscode-editorSuggestWidget-foreground: #ffffff;
+  --vscode-editorSuggestWidget-highlightForeground: #f38518;
+  --vscode-editorSuggestWidget-focusHighlightForeground: #f38518;
+  --vscode-editorSuggestWidgetStatus-foreground: rgba(255, 255, 255, 0.5);
+  --vscode-tab-activeBackground: #000000;
+  --vscode-tab-unfocusedActiveBackground: #000000;
+  --vscode-tab-activeForeground: #ffffff;
+  --vscode-tab-inactiveForeground: #ffffff;
+  --vscode-tab-unfocusedActiveForeground: #ffffff;
+  --vscode-tab-unfocusedInactiveForeground: #ffffff;
+  --vscode-tab-border: #6fc3df;
+  --vscode-tab-lastPinnedBorder: #6fc3df;
+  --vscode-tab-inactiveModifiedBorder: #ffffff;
+  --vscode-tab-unfocusedActiveModifiedBorder: #ffffff;
+  --vscode-tab-unfocusedInactiveModifiedBorder: #ffffff;
+  --vscode-editorPane-background: #000000;
+  --vscode-editorGroup-focusedEmptyBorder: #f38518;
+  --vscode-editorGroupHeader-noTabsBackground: #000000;
+  --vscode-editorGroupHeader-border: #6fc3df;
+  --vscode-editorGroup-border: #6fc3df;
+  --vscode-editorGroup-dropIntoPromptForeground: #ffffff;
+  --vscode-editorGroup-dropIntoPromptBackground: #0c141f;
+  --vscode-editorGroup-dropIntoPromptBorder: #6fc3df;
+  --vscode-sideBySideEditor-horizontalBorder: #6fc3df;
+  --vscode-sideBySideEditor-verticalBorder: #6fc3df;
+  --vscode-panel-background: #000000;
+  --vscode-panel-border: #6fc3df;
+  --vscode-panelTitle-activeForeground: #ffffff;
+  --vscode-panelTitle-inactiveForeground: #ffffff;
+  --vscode-panelTitle-activeBorder: #6fc3df;
+  --vscode-panelInput-border: #6fc3df;
+  --vscode-panel-dropBorder: #ffffff;
+  --vscode-panelSectionHeader-border: #6fc3df;
+  --vscode-panelSection-border: #6fc3df;
+  --vscode-banner-iconForeground: #3794ff;
+  --vscode-statusBar-foreground: #ffffff;
+  --vscode-statusBar-noFolderForeground: #ffffff;
+  --vscode-statusBar-border: #6fc3df;
+  --vscode-statusBar-noFolderBorder: #6fc3df;
+  --vscode-statusBarItem-activeBackground: rgba(255, 255, 255, 0.18);
+  --vscode-statusBarItem-hoverBackground: rgba(255, 255, 255, 0.12);
+  --vscode-statusBarItem-compactHoverBackground: rgba(255, 255, 255, 0.2);
+  --vscode-statusBarItem-prominentForeground: #ffffff;
+  --vscode-statusBarItem-prominentBackground: rgba(0, 0, 0, 0.5);
+  --vscode-statusBarItem-prominentHoverBackground: rgba(0, 0, 0, 0.3);
+  --vscode-statusBarItem-errorForeground: #ffffff;
+  --vscode-statusBarItem-warningForeground: #ffffff;
+  --vscode-activityBar-background: #000000;
+  --vscode-activityBar-foreground: #ffffff;
+  --vscode-activityBar-inactiveForeground: #ffffff;
+  --vscode-activityBar-border: #6fc3df;
+  --vscode-activityBarBadge-background: #000000;
+  --vscode-activityBarBadge-foreground: #ffffff;
+  --vscode-activityBarItem-profilesForeground: #ffffff;
+  --vscode-activityBarItem-profilesHoverForeground: #ffffff;
+  --vscode-statusBarItem-remoteBackground: rgba(0, 0, 0, 0);
+  --vscode-statusBarItem-remoteForeground: #ffffff;
+  --vscode-extensionBadge-remoteBackground: #000000;
+  --vscode-extensionBadge-remoteForeground: #ffffff;
+  --vscode-sideBar-background: #000000;
+  --vscode-sideBar-border: #6fc3df;
+  --vscode-sideBarTitle-foreground: #ffffff;
+  --vscode-sideBarSectionHeader-border: #6fc3df;
+  --vscode-titleBar-activeForeground: #ffffff;
+  --vscode-titleBar-activeBackground: #000000;
+  --vscode-titleBar-border: #6fc3df;
+  --vscode-menubar-selectionForeground: #ffffff;
+  --vscode-menubar-selectionBorder: #f38518;
+  --vscode-notificationCenter-border: #6fc3df;
+  --vscode-notificationToast-border: #6fc3df;
+  --vscode-notifications-foreground: #ffffff;
+  --vscode-notifications-background: #0c141f;
+  --vscode-notificationLink-foreground: #3794ff;
+  --vscode-notificationCenterHeader-background: #0c141f;
+  --vscode-notifications-border: #0c141f;
+  --vscode-notificationsErrorIcon-foreground: #f48771;
+  --vscode-notificationsWarningIcon-foreground: #ff0000;
+  --vscode-notificationsInfoIcon-foreground: #3794ff;
+  --vscode-window-activeBorder: #6fc3df;
+  --vscode-window-inactiveBorder: #6fc3df;
+  --vscode-commandCenter-foreground: #ffffff;
+  --vscode-commandCenter-activeForeground: #ffffff;
+  --vscode-commandCenter-border: rgba(255, 255, 255, 0.6);
+  --vscode-commandCenter-activeBorder: #ffffff;
+  --vscode-editorCommentsWidget-resolvedBorder: #6fc3df;
+  --vscode-editorCommentsWidget-unresolvedBorder: #6fc3df;
+  --vscode-editorCommentsWidget-rangeBackground: rgba(111, 195, 223, 0.1);
+  --vscode-editorCommentsWidget-rangeBorder: rgba(111, 195, 223, 0.4);
+  --vscode-editorCommentsWidget-rangeActiveBackground: rgba(111, 195, 223, 0.1);
+  --vscode-editorCommentsWidget-rangeActiveBorder: rgba(111, 195, 223, 0.4);
+  --vscode-editorGutter-commentRangeForeground: #ffffff;
+  --vscode-debugToolBar-background: #000000;
+  --vscode-debugIcon-startForeground: #89d185;
+  --vscode-editor-stackFrameHighlightBackground: rgba(255, 255, 0, 0.2);
+  --vscode-editor-focusedStackFrameHighlightBackground: rgba(
+    122,
+    189,
+    122,
+    0.3
+  );
+  --vscode-mergeEditor-change\.background: rgba(155, 185, 85, 0.2);
+  --vscode-mergeEditor-change\.word\.background: rgba(156, 204, 44, 0.2);
+  --vscode-mergeEditor-changeBase\.background: #4b1818;
+  --vscode-mergeEditor-changeBase\.word\.background: #6f1313;
+  --vscode-mergeEditor-conflict\.unhandledUnfocused\.border: rgba(
+    255,
+    166,
+    0,
+    0.48
+  );
+  --vscode-mergeEditor-conflict\.unhandledFocused\.border: #ffa600;
+  --vscode-mergeEditor-conflict\.handledUnfocused\.border: rgba(
+    134,
+    134,
+    134,
+    0.29
+  );
+  --vscode-mergeEditor-conflict\.handledFocused\.border: rgba(
+    193,
+    193,
+    193,
+    0.8
+  );
+  --vscode-mergeEditor-conflict\.handled\.minimapOverViewRuler: rgba(
+    173,
+    172,
+    168,
+    0.93
+  );
+  --vscode-mergeEditor-conflict\.unhandled\.minimapOverViewRuler: #fcba03;
+  --vscode-mergeEditor-conflictingLines\.background: rgba(255, 234, 0, 0.28);
+  --vscode-settings-headerForeground: #ffffff;
+  --vscode-settings-modifiedItemIndicator: #00497a;
+  --vscode-settings-headerBorder: #6fc3df;
+  --vscode-settings-sashBorder: #6fc3df;
+  --vscode-settings-dropdownBackground: #000000;
+  --vscode-settings-dropdownForeground: #ffffff;
+  --vscode-settings-dropdownBorder: #6fc3df;
+  --vscode-settings-dropdownListBorder: #6fc3df;
+  --vscode-settings-checkboxBackground: #000000;
+  --vscode-settings-checkboxForeground: #ffffff;
+  --vscode-settings-checkboxBorder: #6fc3df;
+  --vscode-settings-textInputBackground: #000000;
+  --vscode-settings-textInputForeground: #ffffff;
+  --vscode-settings-textInputBorder: #6fc3df;
+  --vscode-settings-numberInputBackground: #000000;
+  --vscode-settings-numberInputForeground: #ffffff;
+  --vscode-settings-numberInputBorder: #6fc3df;
+  --vscode-settings-focusedRowBorder: #f38518;
+  --vscode-terminal-foreground: #ffffff;
+  --vscode-terminal-selectionBackground: #ffffff;
+  --vscode-terminal-inactiveSelectionBackground: rgba(255, 255, 255, 0.7);
+  --vscode-terminal-selectionForeground: #000000;
+  --vscode-terminalCommandDecoration-defaultBackground: rgba(
+    255,
+    255,
+    255,
+    0.5
+  );
+  --vscode-terminalCommandDecoration-successBackground: #1b81a8;
+  --vscode-terminalCommandDecoration-errorBackground: #f14c4c;
+  --vscode-terminalOverviewRuler-cursorForeground: rgba(160, 160, 160, 0.8);
+  --vscode-terminal-border: #6fc3df;
+  --vscode-terminal-findMatchBorder: #f38518;
+  --vscode-terminal-findMatchHighlightBorder: #f38518;
+  --vscode-terminalOverviewRuler-findMatchForeground: #f38518;
+  --vscode-testing-iconFailed: #f14c4c;
+  --vscode-testing-iconErrored: #f14c4c;
+  --vscode-testing-iconPassed: #73c991;
+  --vscode-testing-runAction: #73c991;
+  --vscode-testing-iconQueued: #cca700;
+  --vscode-testing-iconUnset: #848484;
+  --vscode-testing-iconSkipped: #848484;
+  --vscode-testing-peekBorder: #6fc3df;
+  --vscode-testing-message\.error\.decorationForeground: #ffffff;
+  --vscode-testing-message\.info\.decorationForeground: rgba(
+    255,
+    255,
+    255,
+    0.5
+  );
+  --vscode-welcomePage-tileBackground: #000000;
+  --vscode-welcomePage-tileBorder: #6fc3df;
+  --vscode-welcomePage-progress\.background: #000000;
+  --vscode-welcomePage-progress\.foreground: #3794ff;
+  --vscode-debugExceptionWidget-border: #a31515;
+  --vscode-debugExceptionWidget-background: #420b0d;
+  --vscode-ports-iconRunningProcessForeground: #ffffff;
+  --vscode-statusBar-debuggingBackground: #ba592c;
+  --vscode-statusBar-debuggingForeground: #ffffff;
+  --vscode-statusBar-debuggingBorder: #6fc3df;
+  --vscode-editor-inlineValuesForeground: rgba(255, 255, 255, 0.5);
+  --vscode-editor-inlineValuesBackground: rgba(255, 200, 0, 0.2);
+  --vscode-editorGutter-modifiedBackground: #1b81a8;
+  --vscode-editorGutter-addedBackground: #487e02;
+  --vscode-editorGutter-deletedBackground: #f48771;
+  --vscode-minimapGutter-modifiedBackground: #1b81a8;
+  --vscode-minimapGutter-addedBackground: #487e02;
+  --vscode-minimapGutter-deletedBackground: #f48771;
+  --vscode-editorOverviewRuler-modifiedForeground: rgba(27, 129, 168, 0.6);
+  --vscode-editorOverviewRuler-addedForeground: rgba(72, 126, 2, 0.6);
+  --vscode-editorOverviewRuler-deletedForeground: rgba(244, 135, 113, 0.6);
+  --vscode-debugIcon-breakpointForeground: #e51400;
+  --vscode-debugIcon-breakpointDisabledForeground: #848484;
+  --vscode-debugIcon-breakpointUnverifiedForeground: #848484;
+  --vscode-debugIcon-breakpointCurrentStackframeForeground: #ffcc00;
+  --vscode-debugIcon-breakpointStackframeForeground: #89d185;
+  --vscode-notebook-cellBorderColor: #6fc3df;
+  --vscode-notebook-focusedEditorBorder: #f38518;
+  --vscode-notebookStatusSuccessIcon-foreground: #89d185;
+  --vscode-notebookStatusErrorIcon-foreground: #f48771;
+  --vscode-notebookStatusRunningIcon-foreground: #ffffff;
+  --vscode-notebook-cellToolbarSeparator: #6fc3df;
+  --vscode-notebook-selectedCellBorder: #6fc3df;
+  --vscode-notebook-inactiveSelectedCellBorder: #f38518;
+  --vscode-notebook-focusedCellBorder: #f38518;
+  --vscode-notebook-inactiveFocusedCellBorder: #6fc3df;
+  --vscode-notebook-cellStatusBarItemHoverBackground: rgba(255, 255, 255, 0.15);
+  --vscode-notebook-cellInsertionIndicator: #f38518;
+  --vscode-notebookScrollbarSlider-background: rgba(111, 195, 223, 0.6);
+  --vscode-notebookScrollbarSlider-hoverBackground: rgba(111, 195, 223, 0.8);
+  --vscode-notebookScrollbarSlider-activeBackground: #6fc3df;
+  --vscode-scm-providerBorder: #6fc3df;
+  --vscode-searchEditor-textInputBorder: #6fc3df;
+  --vscode-debugTokenExpression-name: #ffffff;
+  --vscode-debugTokenExpression-value: #ffffff;
+  --vscode-debugTokenExpression-string: #f48771;
+  --vscode-debugTokenExpression-boolean: #75bdfe;
+  --vscode-debugTokenExpression-number: #89d185;
+  --vscode-debugTokenExpression-error: #f48771;
+  --vscode-debugView-exceptionLabelForeground: #ffffff;
+  --vscode-debugView-exceptionLabelBackground: #6c2022;
+  --vscode-debugView-stateLabelForeground: #ffffff;
+  --vscode-debugView-stateLabelBackground: rgba(136, 136, 136, 0.27);
+  --vscode-debugView-valueChangedHighlight: #569cd6;
+  --vscode-debugConsole-infoForeground: #ffffff;
+  --vscode-debugConsole-warningForeground: #008000;
+  --vscode-debugConsole-errorForeground: #f48771;
+  --vscode-debugConsole-sourceForeground: #ffffff;
+  --vscode-debugConsoleInputIcon-foreground: #ffffff;
+  --vscode-debugIcon-pauseForeground: #75beff;
+  --vscode-debugIcon-stopForeground: #f48771;
+  --vscode-debugIcon-disconnectForeground: #f48771;
+  --vscode-debugIcon-restartForeground: #89d185;
+  --vscode-debugIcon-stepOverForeground: #75beff;
+  --vscode-debugIcon-stepIntoForeground: #75beff;
+  --vscode-debugIcon-stepOutForeground: #75beff;
+  --vscode-debugIcon-continueForeground: #75beff;
+  --vscode-debugIcon-stepBackForeground: #75beff;
+  --vscode-extensionButton-separator: rgba(255, 255, 255, 0.4);
+  --vscode-extensionIcon-starForeground: #ff8e00;
+  --vscode-extensionIcon-verifiedForeground: #3794ff;
+  --vscode-extensionIcon-preReleaseForeground: #1d9271;
+  --vscode-terminal-ansiBlack: #000000;
+  --vscode-terminal-ansiRed: #cd0000;
+  --vscode-terminal-ansiGreen: #00cd00;
+  --vscode-terminal-ansiYellow: #cdcd00;
+  --vscode-terminal-ansiBlue: #0000ee;
+  --vscode-terminal-ansiMagenta: #cd00cd;
+  --vscode-terminal-ansiCyan: #00cdcd;
+  --vscode-terminal-ansiWhite: #e5e5e5;
+  --vscode-terminal-ansiBrightBlack: #7f7f7f;
+  --vscode-terminal-ansiBrightRed: #ff0000;
+  --vscode-terminal-ansiBrightGreen: #00ff00;
+  --vscode-terminal-ansiBrightYellow: #ffff00;
+  --vscode-terminal-ansiBrightBlue: #5c5cff;
+  --vscode-terminal-ansiBrightMagenta: #ff00ff;
+  --vscode-terminal-ansiBrightCyan: #00ffff;
+  --vscode-terminal-ansiBrightWhite: #ffffff;
+  --vscode-interactive-activeCodeBorder: #6fc3df;
+  --vscode-interactive-inactiveCodeBorder: #6fc3df;
+  --vscode-gitDecoration-addedResourceForeground: #a1e3ad;
+  --vscode-gitDecoration-modifiedResourceForeground: #e2c08d;
+  --vscode-gitDecoration-deletedResourceForeground: #c74e39;
+  --vscode-gitDecoration-renamedResourceForeground: #73c991;
+  --vscode-gitDecoration-untrackedResourceForeground: #73c991;
+  --vscode-gitDecoration-ignoredResourceForeground: #a7a8a9;
+  --vscode-gitDecoration-stageModifiedResourceForeground: #e2c08d;
+  --vscode-gitDecoration-stageDeletedResourceForeground: #c74e39;
+  --vscode-gitDecoration-conflictingResourceForeground: #c74e39;
+  --vscode-gitDecoration-submoduleResourceForeground: #8db9e2;
+  --vscode-testExplorer-errorDecorationBackground: #000000;
+}
+
+/**
+ * This is copied in the same way, but from the <body> element
+ */
+body {
+  background-color: transparent;
+  color: var(--vscode-editor-foreground);
+  font-family: var(--vscode-font-family);
+  font-weight: var(--vscode-font-weight);
+  font-size: var(--vscode-font-size);
+  margin: 0;
+  padding: 0 20px;
+}
+
+/**
+ * This is used for setting the background on the Storybook preview.
+ */
+body {
+  background-color: var(--vscode-editor-background);
+}

--- a/extensions/ql-vscode/src/stories/vscode-theme-github-dark-default.css
+++ b/extensions/ql-vscode/src/stories/vscode-theme-github-dark-default.css
@@ -1,0 +1,674 @@
+/*
+ * These were copied from VSCode GitHub Dark Default theme from the
+ * https://marketplace.visualstudio.com/items?itemName=GitHub.github-vscode-theme extension.
+ *
+ * To update these, open a webview in VSCode, open the webview developer tools and find the
+ * iframe hosting the webview. The <html> element will have a style attribute that contains
+ * the CSS variables. Copy these to this file.
+ */
+:root {
+  --vscode-font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+  --vscode-font-weight: normal;
+  --vscode-font-size: 13px;
+  --vscode-editor-font-family: Menlo, Monaco, "Courier New", monospace;
+  --vscode-editor-font-weight: normal;
+  --vscode-editor-font-size: 12px;
+  --vscode-foreground: #c9d1d9;
+  --vscode-disabledForeground: rgba(204, 204, 204, 0.5);
+  --vscode-errorForeground: #f85149;
+  --vscode-descriptionForeground: #8b949e;
+  --vscode-icon-foreground: #8b949e;
+  --vscode-focusBorder: #1f6feb;
+  --vscode-textSeparator-foreground: #21262d;
+  --vscode-textLink-foreground: #58a6ff;
+  --vscode-textLink-activeForeground: #58a6ff;
+  --vscode-textPreformat-foreground: #8b949e;
+  --vscode-textBlockQuote-background: #010409;
+  --vscode-textBlockQuote-border: #30363d;
+  --vscode-textCodeBlock-background: rgba(110, 118, 129, 0.4);
+  --vscode-widget-shadow: rgba(0, 0, 0, 0.36);
+  --vscode-input-background: #0d1117;
+  --vscode-input-foreground: #c9d1d9;
+  --vscode-input-border: #30363d;
+  --vscode-inputOption-activeBorder: rgba(0, 122, 204, 0);
+  --vscode-inputOption-hoverBackground: rgba(90, 93, 94, 0.5);
+  --vscode-inputOption-activeBackground: rgba(31, 111, 235, 0.4);
+  --vscode-inputOption-activeForeground: #ffffff;
+  --vscode-input-placeholderForeground: #484f58;
+  --vscode-inputValidation-infoBackground: #063b49;
+  --vscode-inputValidation-infoBorder: #007acc;
+  --vscode-inputValidation-warningBackground: #352a05;
+  --vscode-inputValidation-warningBorder: #b89500;
+  --vscode-inputValidation-errorBackground: #5a1d1d;
+  --vscode-inputValidation-errorBorder: #be1100;
+  --vscode-dropdown-background: #161b22;
+  --vscode-dropdown-listBackground: #161b22;
+  --vscode-dropdown-foreground: #c9d1d9;
+  --vscode-dropdown-border: #30363d;
+  --vscode-button-foreground: #ffffff;
+  --vscode-button-separator: rgba(255, 255, 255, 0.4);
+  --vscode-button-background: #238636;
+  --vscode-button-hoverBackground: #2ea043;
+  --vscode-button-secondaryForeground: #c9d1d9;
+  --vscode-button-secondaryBackground: #282e33;
+  --vscode-button-secondaryHoverBackground: #30363d;
+  --vscode-badge-background: #1f6feb;
+  --vscode-badge-foreground: #f0f6fc;
+  --vscode-scrollbar-shadow: rgba(72, 79, 88, 0.2);
+  --vscode-scrollbarSlider-background: rgba(110, 118, 129, 0.2);
+  --vscode-scrollbarSlider-hoverBackground: rgba(110, 118, 129, 0.27);
+  --vscode-scrollbarSlider-activeBackground: rgba(110, 118, 129, 0.53);
+  --vscode-progressBar-background: #1f6feb;
+  --vscode-editorError-foreground: #f14c4c;
+  --vscode-editorWarning-foreground: #cca700;
+  --vscode-editorInfo-foreground: #3794ff;
+  --vscode-editorHint-foreground: rgba(238, 238, 238, 0.7);
+  --vscode-sash-hoverBorder: #1f6feb;
+  --vscode-editor-background: #0d1117;
+  --vscode-editor-foreground: #c9d1d9;
+  --vscode-editorStickyScroll-background: #0d1117;
+  --vscode-editorStickyScrollHover-background: #2a2d2e;
+  --vscode-editorWidget-background: #161b22;
+  --vscode-editorWidget-foreground: #c9d1d9;
+  --vscode-editorWidget-border: #454545;
+  --vscode-quickInput-background: #161b22;
+  --vscode-quickInput-foreground: #c9d1d9;
+  --vscode-quickInputTitle-background: rgba(255, 255, 255, 0.1);
+  --vscode-pickerGroup-foreground: #8b949e;
+  --vscode-pickerGroup-border: #30363d;
+  --vscode-keybindingLabel-background: rgba(128, 128, 128, 0.17);
+  --vscode-keybindingLabel-foreground: #c9d1d9;
+  --vscode-keybindingLabel-border: rgba(51, 51, 51, 0.6);
+  --vscode-keybindingLabel-bottomBorder: rgba(68, 68, 68, 0.6);
+  --vscode-editor-selectionBackground: #264f78;
+  --vscode-editor-inactiveSelectionBackground: rgba(38, 79, 120, 0.5);
+  --vscode-editor-selectionHighlightBackground: rgba(63, 185, 80, 0.25);
+  --vscode-editor-findMatchBackground: #9e6a03;
+  --vscode-editor-findMatchHighlightBackground: rgba(242, 204, 96, 0.5);
+  --vscode-editor-findRangeHighlightBackground: rgba(58, 61, 65, 0.4);
+  --vscode-searchEditor-findMatchBackground: rgba(242, 204, 96, 0.33);
+  --vscode-editor-hoverHighlightBackground: rgba(38, 79, 120, 0.25);
+  --vscode-editorHoverWidget-background: #161b22;
+  --vscode-editorHoverWidget-foreground: #c9d1d9;
+  --vscode-editorHoverWidget-border: #454545;
+  --vscode-editorHoverWidget-statusBarBackground: #1a2029;
+  --vscode-editorLink-activeForeground: #4e94ce;
+  --vscode-editorInlayHint-foreground: #8b949e;
+  --vscode-editorInlayHint-background: rgba(139, 148, 158, 0.2);
+  --vscode-editorInlayHint-typeForeground: #8b949e;
+  --vscode-editorInlayHint-typeBackground: rgba(139, 148, 158, 0.2);
+  --vscode-editorInlayHint-parameterForeground: #8b949e;
+  --vscode-editorInlayHint-parameterBackground: rgba(139, 148, 158, 0.2);
+  --vscode-editorLightBulb-foreground: #ffcc00;
+  --vscode-editorLightBulbAutoFix-foreground: #75beff;
+  --vscode-diffEditor-insertedTextBackground: rgba(35, 134, 54, 0.3);
+  --vscode-diffEditor-removedTextBackground: rgba(218, 54, 51, 0.3);
+  --vscode-diffEditor-insertedLineBackground: rgba(35, 134, 54, 0.2);
+  --vscode-diffEditor-removedLineBackground: rgba(218, 54, 51, 0.2);
+  --vscode-diffEditor-diagonalFill: rgba(204, 204, 204, 0.2);
+  --vscode-list-focusBackground: rgba(56, 139, 253, 0.15);
+  --vscode-list-focusForeground: #c9d1d9;
+  --vscode-list-focusOutline: #1f6feb;
+  --vscode-list-activeSelectionBackground: rgba(110, 118, 129, 0.4);
+  --vscode-list-activeSelectionForeground: #c9d1d9;
+  --vscode-list-inactiveSelectionBackground: rgba(110, 118, 129, 0.4);
+  --vscode-list-inactiveSelectionForeground: #c9d1d9;
+  --vscode-list-inactiveFocusBackground: rgba(56, 139, 253, 0.15);
+  --vscode-list-hoverBackground: rgba(110, 118, 129, 0.1);
+  --vscode-list-hoverForeground: #c9d1d9;
+  --vscode-list-dropBackground: #062f4a;
+  --vscode-list-highlightForeground: #58a6ff;
+  --vscode-list-focusHighlightForeground: #58a6ff;
+  --vscode-list-invalidItemForeground: #b89500;
+  --vscode-list-errorForeground: #f88070;
+  --vscode-list-warningForeground: #cca700;
+  --vscode-listFilterWidget-background: #161b22;
+  --vscode-listFilterWidget-outline: rgba(0, 0, 0, 0);
+  --vscode-listFilterWidget-noMatchesOutline: #be1100;
+  --vscode-listFilterWidget-shadow: rgba(0, 0, 0, 0.36);
+  --vscode-list-filterMatchBackground: rgba(242, 204, 96, 0.5);
+  --vscode-tree-indentGuidesStroke: #21262d;
+  --vscode-tree-tableColumnsBorder: rgba(204, 204, 204, 0.13);
+  --vscode-tree-tableOddRowsBackground: rgba(201, 209, 217, 0.04);
+  --vscode-list-deemphasizedForeground: #8c8c8c;
+  --vscode-checkbox-background: #161b22;
+  --vscode-checkbox-selectBackground: #161b22;
+  --vscode-checkbox-foreground: #c9d1d9;
+  --vscode-checkbox-border: #30363d;
+  --vscode-checkbox-selectBorder: #161b22;
+  --vscode-quickInputList-focusForeground: #c9d1d9;
+  --vscode-quickInputList-focusBackground: rgba(110, 118, 129, 0.4);
+  --vscode-menu-foreground: #c9d1d9;
+  --vscode-menu-background: #161b22;
+  --vscode-menu-selectionForeground: #c9d1d9;
+  --vscode-menu-selectionBackground: rgba(110, 118, 129, 0.4);
+  --vscode-menu-separatorBackground: #606060;
+  --vscode-toolbar-hoverBackground: rgba(90, 93, 94, 0.31);
+  --vscode-toolbar-activeBackground: rgba(99, 102, 103, 0.31);
+  --vscode-editor-snippetTabstopHighlightBackground: rgba(124, 124, 124, 0.3);
+  --vscode-editor-snippetFinalTabstopHighlightBorder: #525252;
+  --vscode-breadcrumb-foreground: #8b949e;
+  --vscode-breadcrumb-background: #0d1117;
+  --vscode-breadcrumb-focusForeground: #c9d1d9;
+  --vscode-breadcrumb-activeSelectionForeground: #8b949e;
+  --vscode-breadcrumbPicker-background: #161b22;
+  --vscode-merge-currentHeaderBackground: rgba(64, 200, 174, 0.5);
+  --vscode-merge-currentContentBackground: rgba(64, 200, 174, 0.2);
+  --vscode-merge-incomingHeaderBackground: rgba(64, 166, 255, 0.5);
+  --vscode-merge-incomingContentBackground: rgba(64, 166, 255, 0.2);
+  --vscode-merge-commonHeaderBackground: rgba(96, 96, 96, 0.4);
+  --vscode-merge-commonContentBackground: rgba(96, 96, 96, 0.16);
+  --vscode-editorOverviewRuler-currentContentForeground: rgba(
+    64,
+    200,
+    174,
+    0.5
+  );
+  --vscode-editorOverviewRuler-incomingContentForeground: rgba(
+    64,
+    166,
+    255,
+    0.5
+  );
+  --vscode-editorOverviewRuler-commonContentForeground: rgba(96, 96, 96, 0.4);
+  --vscode-editorOverviewRuler-findMatchForeground: rgba(209, 134, 22, 0.49);
+  --vscode-editorOverviewRuler-selectionHighlightForeground: rgba(
+    160,
+    160,
+    160,
+    0.8
+  );
+  --vscode-minimap-findMatchHighlight: #d18616;
+  --vscode-minimap-selectionOccurrenceHighlight: #676767;
+  --vscode-minimap-selectionHighlight: #264f78;
+  --vscode-minimap-errorHighlight: rgba(255, 18, 18, 0.7);
+  --vscode-minimap-warningHighlight: #cca700;
+  --vscode-minimap-foregroundOpacity: #000000;
+  --vscode-minimapSlider-background: rgba(110, 118, 129, 0.1);
+  --vscode-minimapSlider-hoverBackground: rgba(110, 118, 129, 0.14);
+  --vscode-minimapSlider-activeBackground: rgba(110, 118, 129, 0.27);
+  --vscode-problemsErrorIcon-foreground: #f14c4c;
+  --vscode-problemsWarningIcon-foreground: #cca700;
+  --vscode-problemsInfoIcon-foreground: #3794ff;
+  --vscode-charts-foreground: #c9d1d9;
+  --vscode-charts-lines: rgba(201, 209, 217, 0.5);
+  --vscode-charts-red: #f14c4c;
+  --vscode-charts-blue: #3794ff;
+  --vscode-charts-yellow: #cca700;
+  --vscode-charts-orange: #d18616;
+  --vscode-charts-green: #89d185;
+  --vscode-charts-purple: #b180d7;
+  --vscode-symbolIcon-arrayForeground: #f0883e;
+  --vscode-symbolIcon-booleanForeground: #58a6ff;
+  --vscode-symbolIcon-classForeground: #f0883e;
+  --vscode-symbolIcon-colorForeground: #79c0ff;
+  --vscode-symbolIcon-constantForeground: #c9d1d9;
+  --vscode-symbolIcon-constructorForeground: #d2a8ff;
+  --vscode-symbolIcon-enumeratorForeground: #f0883e;
+  --vscode-symbolIcon-enumeratorMemberForeground: #58a6ff;
+  --vscode-symbolIcon-eventForeground: #6e7681;
+  --vscode-symbolIcon-fieldForeground: #f0883e;
+  --vscode-symbolIcon-fileForeground: #d29922;
+  --vscode-symbolIcon-folderForeground: #d29922;
+  --vscode-symbolIcon-functionForeground: #bc8cff;
+  --vscode-symbolIcon-interfaceForeground: #f0883e;
+  --vscode-symbolIcon-keyForeground: #58a6ff;
+  --vscode-symbolIcon-keywordForeground: #ff7b72;
+  --vscode-symbolIcon-methodForeground: #bc8cff;
+  --vscode-symbolIcon-moduleForeground: #ff7b72;
+  --vscode-symbolIcon-namespaceForeground: #ff7b72;
+  --vscode-symbolIcon-nullForeground: #58a6ff;
+  --vscode-symbolIcon-numberForeground: #3fb950;
+  --vscode-symbolIcon-objectForeground: #f0883e;
+  --vscode-symbolIcon-operatorForeground: #79c0ff;
+  --vscode-symbolIcon-packageForeground: #f0883e;
+  --vscode-symbolIcon-propertyForeground: #f0883e;
+  --vscode-symbolIcon-referenceForeground: #58a6ff;
+  --vscode-symbolIcon-snippetForeground: #58a6ff;
+  --vscode-symbolIcon-stringForeground: #79c0ff;
+  --vscode-symbolIcon-structForeground: #f0883e;
+  --vscode-symbolIcon-textForeground: #79c0ff;
+  --vscode-symbolIcon-typeParameterForeground: #79c0ff;
+  --vscode-symbolIcon-unitForeground: #58a6ff;
+  --vscode-symbolIcon-variableForeground: #f0883e;
+  --vscode-editor-lineHighlightBackground: rgba(110, 118, 129, 0.1);
+  --vscode-editor-lineHighlightBorder: #282828;
+  --vscode-editor-rangeHighlightBackground: rgba(255, 255, 255, 0.04);
+  --vscode-editor-symbolHighlightBackground: rgba(242, 204, 96, 0.5);
+  --vscode-editorCursor-foreground: #58a6ff;
+  --vscode-editorWhitespace-foreground: #484f58;
+  --vscode-editorIndentGuide-background: rgba(201, 209, 217, 0.12);
+  --vscode-editorIndentGuide-activeBackground: rgba(201, 209, 217, 0.24);
+  --vscode-editorLineNumber-foreground: #6e7681;
+  --vscode-editorActiveLineNumber-foreground: #c6c6c6;
+  --vscode-editorLineNumber-activeForeground: #c9d1d9;
+  --vscode-editorRuler-foreground: #5a5a5a;
+  --vscode-editorCodeLens-foreground: #999999;
+  --vscode-editorBracketMatch-background: rgba(63, 185, 80, 0.25);
+  --vscode-editorBracketMatch-border: rgba(63, 185, 80, 0.6);
+  --vscode-editorOverviewRuler-border: #010409;
+  --vscode-editorGutter-background: #0d1117;
+  --vscode-editorUnnecessaryCode-opacity: rgba(0, 0, 0, 0.67);
+  --vscode-editorGhostText-foreground: rgba(255, 255, 255, 0.34);
+  --vscode-editorOverviewRuler-rangeHighlightForeground: rgba(0, 122, 204, 0.6);
+  --vscode-editorOverviewRuler-errorForeground: rgba(255, 18, 18, 0.7);
+  --vscode-editorOverviewRuler-warningForeground: #cca700;
+  --vscode-editorOverviewRuler-infoForeground: #3794ff;
+  --vscode-editorBracketHighlight-foreground1: #79c0ff;
+  --vscode-editorBracketHighlight-foreground2: #56d364;
+  --vscode-editorBracketHighlight-foreground3: #e3b341;
+  --vscode-editorBracketHighlight-foreground4: #ffa198;
+  --vscode-editorBracketHighlight-foreground5: #ff9bce;
+  --vscode-editorBracketHighlight-foreground6: #d2a8ff;
+  --vscode-editorBracketHighlight-unexpectedBracket\.foreground: #8b949e;
+  --vscode-editorBracketPairGuide-background1: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-background2: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-background3: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-background4: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-background5: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-background6: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-activeBackground1: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-activeBackground2: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-activeBackground3: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-activeBackground4: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-activeBackground5: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-activeBackground6: rgba(0, 0, 0, 0);
+  --vscode-editorUnicodeHighlight-border: #bd9b03;
+  --vscode-editorUnicodeHighlight-background: rgba(189, 155, 3, 0.15);
+  --vscode-editorHoverWidget-highlightForeground: #58a6ff;
+  --vscode-editorOverviewRuler-bracketMatchForeground: #a0a0a0;
+  --vscode-editor-foldBackground: rgba(110, 118, 129, 0.1);
+  --vscode-editorGutter-foldingControlForeground: #8b949e;
+  --vscode-editor-linkedEditingBackground: rgba(88, 166, 255, 0.07);
+  --vscode-editor-wordHighlightBackground: rgba(110, 118, 129, 0.5);
+  --vscode-editor-wordHighlightStrongBackground: rgba(110, 118, 129, 0.3);
+  --vscode-editor-wordHighlightBorder: rgba(110, 118, 129, 0.6);
+  --vscode-editor-wordHighlightStrongBorder: rgba(110, 118, 129, 0.6);
+  --vscode-editorOverviewRuler-wordHighlightForeground: rgba(
+    160,
+    160,
+    160,
+    0.8
+  );
+  --vscode-editorOverviewRuler-wordHighlightStrongForeground: rgba(
+    192,
+    160,
+    192,
+    0.8
+  );
+  --vscode-peekViewTitle-background: rgba(55, 148, 255, 0.1);
+  --vscode-peekViewTitleLabel-foreground: #ffffff;
+  --vscode-peekViewTitleDescription-foreground: rgba(204, 204, 204, 0.7);
+  --vscode-peekView-border: #3794ff;
+  --vscode-peekViewResult-background: #0d1117;
+  --vscode-peekViewResult-lineForeground: #bbbbbb;
+  --vscode-peekViewResult-fileForeground: #ffffff;
+  --vscode-peekViewResult-selectionBackground: rgba(51, 153, 255, 0.2);
+  --vscode-peekViewResult-selectionForeground: #ffffff;
+  --vscode-peekViewEditor-background: rgba(110, 118, 129, 0.1);
+  --vscode-peekViewEditorGutter-background: rgba(110, 118, 129, 0.1);
+  --vscode-peekViewResult-matchHighlightBackground: rgba(187, 128, 9, 0.4);
+  --vscode-peekViewEditor-matchHighlightBackground: rgba(187, 128, 9, 0.4);
+  --vscode-editorMarkerNavigationError-background: #f14c4c;
+  --vscode-editorMarkerNavigationError-headerBackground: rgba(241, 76, 76, 0.1);
+  --vscode-editorMarkerNavigationWarning-background: #cca700;
+  --vscode-editorMarkerNavigationWarning-headerBackground: rgba(
+    204,
+    167,
+    0,
+    0.1
+  );
+  --vscode-editorMarkerNavigationInfo-background: #3794ff;
+  --vscode-editorMarkerNavigationInfo-headerBackground: rgba(55, 148, 255, 0.1);
+  --vscode-editorMarkerNavigation-background: #0d1117;
+  --vscode-editorSuggestWidget-background: #161b22;
+  --vscode-editorSuggestWidget-border: #454545;
+  --vscode-editorSuggestWidget-foreground: #c9d1d9;
+  --vscode-editorSuggestWidget-selectedForeground: #c9d1d9;
+  --vscode-editorSuggestWidget-selectedBackground: rgba(110, 118, 129, 0.4);
+  --vscode-editorSuggestWidget-highlightForeground: #58a6ff;
+  --vscode-editorSuggestWidget-focusHighlightForeground: #58a6ff;
+  --vscode-editorSuggestWidgetStatus-foreground: rgba(201, 209, 217, 0.5);
+  --vscode-tab-activeBackground: #0d1117;
+  --vscode-tab-unfocusedActiveBackground: #0d1117;
+  --vscode-tab-inactiveBackground: #010409;
+  --vscode-tab-unfocusedInactiveBackground: #010409;
+  --vscode-tab-activeForeground: #c9d1d9;
+  --vscode-tab-inactiveForeground: #8b949e;
+  --vscode-tab-unfocusedActiveForeground: rgba(201, 209, 217, 0.5);
+  --vscode-tab-unfocusedInactiveForeground: rgba(139, 148, 158, 0.5);
+  --vscode-tab-hoverBackground: #0d1117;
+  --vscode-tab-unfocusedHoverBackground: rgba(110, 118, 129, 0.1);
+  --vscode-tab-border: #30363d;
+  --vscode-tab-lastPinnedBorder: #21262d;
+  --vscode-tab-activeBorder: #0d1117;
+  --vscode-tab-unfocusedActiveBorder: #0d1117;
+  --vscode-tab-activeBorderTop: #f78166;
+  --vscode-tab-unfocusedActiveBorderTop: #30363d;
+  --vscode-tab-activeModifiedBorder: #3399cc;
+  --vscode-tab-inactiveModifiedBorder: rgba(51, 153, 204, 0.5);
+  --vscode-tab-unfocusedActiveModifiedBorder: rgba(51, 153, 204, 0.5);
+  --vscode-tab-unfocusedInactiveModifiedBorder: rgba(51, 153, 204, 0.25);
+  --vscode-editorPane-background: #0d1117;
+  --vscode-editorGroupHeader-tabsBackground: #010409;
+  --vscode-editorGroupHeader-tabsBorder: #30363d;
+  --vscode-editorGroupHeader-noTabsBackground: #0d1117;
+  --vscode-editorGroup-border: #30363d;
+  --vscode-editorGroup-dropBackground: rgba(83, 89, 93, 0.5);
+  --vscode-editorGroup-dropIntoPromptForeground: #c9d1d9;
+  --vscode-editorGroup-dropIntoPromptBackground: #161b22;
+  --vscode-sideBySideEditor-horizontalBorder: #30363d;
+  --vscode-sideBySideEditor-verticalBorder: #30363d;
+  --vscode-panel-background: #010409;
+  --vscode-panel-border: #30363d;
+  --vscode-panelTitle-activeForeground: #c9d1d9;
+  --vscode-panelTitle-inactiveForeground: #8b949e;
+  --vscode-panelTitle-activeBorder: #f78166;
+  --vscode-panelInput-border: #30363d;
+  --vscode-panel-dropBorder: #c9d1d9;
+  --vscode-panelSection-dropBackground: rgba(83, 89, 93, 0.5);
+  --vscode-panelSectionHeader-background: rgba(128, 128, 128, 0.2);
+  --vscode-panelSection-border: #30363d;
+  --vscode-banner-background: rgba(110, 118, 129, 0.4);
+  --vscode-banner-foreground: #c9d1d9;
+  --vscode-banner-iconForeground: #3794ff;
+  --vscode-statusBar-foreground: #8b949e;
+  --vscode-statusBar-noFolderForeground: #8b949e;
+  --vscode-statusBar-background: #0d1117;
+  --vscode-statusBar-noFolderBackground: #0d1117;
+  --vscode-statusBar-border: #30363d;
+  --vscode-statusBar-focusBorder: rgba(31, 111, 235, 0.5);
+  --vscode-statusBar-noFolderBorder: #30363d;
+  --vscode-statusBarItem-activeBackground: rgba(201, 209, 217, 0.12);
+  --vscode-statusBarItem-focusBorder: #1f6feb;
+  --vscode-statusBarItem-hoverBackground: rgba(201, 209, 217, 0.08);
+  --vscode-statusBarItem-compactHoverBackground: rgba(255, 255, 255, 0.2);
+  --vscode-statusBarItem-prominentForeground: #8b949e;
+  --vscode-statusBarItem-prominentBackground: rgba(110, 118, 129, 0.4);
+  --vscode-statusBarItem-prominentHoverBackground: rgba(0, 0, 0, 0.3);
+  --vscode-statusBarItem-errorBackground: #b91007;
+  --vscode-statusBarItem-errorForeground: #ffffff;
+  --vscode-statusBarItem-warningBackground: #7a6400;
+  --vscode-statusBarItem-warningForeground: #ffffff;
+  --vscode-activityBar-background: #0d1117;
+  --vscode-activityBar-foreground: #c9d1d9;
+  --vscode-activityBar-inactiveForeground: #8b949e;
+  --vscode-activityBar-border: #30363d;
+  --vscode-activityBar-activeBorder: #f78166;
+  --vscode-activityBar-dropBorder: #c9d1d9;
+  --vscode-activityBarBadge-background: #1f6feb;
+  --vscode-activityBarBadge-foreground: #f0f6fc;
+  --vscode-activityBarItem-profilesForeground: #8b949e;
+  --vscode-activityBarItem-profilesHoverForeground: #c9d1d9;
+  --vscode-activityBarItem-profilesBackground: #141a23;
+  --vscode-statusBarItem-remoteBackground: #30363d;
+  --vscode-statusBarItem-remoteForeground: #c9d1d9;
+  --vscode-extensionBadge-remoteBackground: #1f6feb;
+  --vscode-extensionBadge-remoteForeground: #f0f6fc;
+  --vscode-sideBar-background: #010409;
+  --vscode-sideBar-foreground: #c9d1d9;
+  --vscode-sideBar-border: #30363d;
+  --vscode-sideBarTitle-foreground: #c9d1d9;
+  --vscode-sideBar-dropBackground: rgba(83, 89, 93, 0.5);
+  --vscode-sideBarSectionHeader-background: #010409;
+  --vscode-sideBarSectionHeader-foreground: #c9d1d9;
+  --vscode-sideBarSectionHeader-border: #30363d;
+  --vscode-titleBar-activeForeground: #8b949e;
+  --vscode-titleBar-inactiveForeground: #8b949e;
+  --vscode-titleBar-activeBackground: #0d1117;
+  --vscode-titleBar-inactiveBackground: #010409;
+  --vscode-titleBar-border: #30363d;
+  --vscode-menubar-selectionForeground: #8b949e;
+  --vscode-menubar-selectionBackground: rgba(90, 93, 94, 0.31);
+  --vscode-notifications-foreground: #c9d1d9;
+  --vscode-notifications-background: #161b22;
+  --vscode-notificationLink-foreground: #58a6ff;
+  --vscode-notificationCenterHeader-foreground: #8b949e;
+  --vscode-notificationCenterHeader-background: #161b22;
+  --vscode-notifications-border: #30363d;
+  --vscode-notificationsErrorIcon-foreground: #f85149;
+  --vscode-notificationsWarningIcon-foreground: #d29922;
+  --vscode-notificationsInfoIcon-foreground: #58a6ff;
+  --vscode-commandCenter-foreground: #8b949e;
+  --vscode-commandCenter-activeForeground: #8b949e;
+  --vscode-commandCenter-inactiveForeground: #8b949e;
+  --vscode-commandCenter-background: rgba(255, 255, 255, 0.05);
+  --vscode-commandCenter-activeBackground: rgba(255, 255, 255, 0.08);
+  --vscode-commandCenter-border: rgba(139, 148, 158, 0.2);
+  --vscode-commandCenter-activeBorder: rgba(139, 148, 158, 0.3);
+  --vscode-commandCenter-inactiveBorder: rgba(139, 148, 158, 0.25);
+  --vscode-editorCommentsWidget-resolvedBorder: rgba(204, 204, 204, 0.5);
+  --vscode-editorCommentsWidget-unresolvedBorder: #3794ff;
+  --vscode-editorCommentsWidget-rangeBackground: rgba(55, 148, 255, 0.1);
+  --vscode-editorCommentsWidget-rangeBorder: rgba(55, 148, 255, 0.4);
+  --vscode-editorCommentsWidget-rangeActiveBackground: rgba(55, 148, 255, 0.1);
+  --vscode-editorCommentsWidget-rangeActiveBorder: rgba(55, 148, 255, 0.4);
+  --vscode-editorGutter-commentRangeForeground: rgba(110, 118, 129, 0.4);
+  --vscode-debugToolBar-background: #161b22;
+  --vscode-debugIcon-startForeground: #89d185;
+  --vscode-editor-stackFrameHighlightBackground: rgba(187, 128, 9, 0.4);
+  --vscode-editor-focusedStackFrameHighlightBackground: rgba(46, 160, 67, 0.4);
+  --vscode-mergeEditor-change\.background: rgba(155, 185, 85, 0.2);
+  --vscode-mergeEditor-change\.word\.background: rgba(156, 204, 44, 0.2);
+  --vscode-mergeEditor-changeBase\.background: #4b1818;
+  --vscode-mergeEditor-changeBase\.word\.background: #6f1313;
+  --vscode-mergeEditor-conflict\.unhandledUnfocused\.border: rgba(
+    255,
+    166,
+    0,
+    0.48
+  );
+  --vscode-mergeEditor-conflict\.unhandledFocused\.border: #ffa600;
+  --vscode-mergeEditor-conflict\.handledUnfocused\.border: rgba(
+    134,
+    134,
+    134,
+    0.29
+  );
+  --vscode-mergeEditor-conflict\.handledFocused\.border: rgba(
+    193,
+    193,
+    193,
+    0.8
+  );
+  --vscode-mergeEditor-conflict\.handled\.minimapOverViewRuler: rgba(
+    173,
+    172,
+    168,
+    0.93
+  );
+  --vscode-mergeEditor-conflict\.unhandled\.minimapOverViewRuler: #fcba03;
+  --vscode-mergeEditor-conflictingLines\.background: rgba(255, 234, 0, 0.28);
+  --vscode-mergeEditor-conflict\.input1\.background: rgba(64, 200, 174, 0.2);
+  --vscode-mergeEditor-conflict\.input2\.background: rgba(64, 166, 255, 0.2);
+  --vscode-settings-headerForeground: #8b949e;
+  --vscode-settings-modifiedItemIndicator: rgba(187, 128, 9, 0.4);
+  --vscode-settings-headerBorder: #30363d;
+  --vscode-settings-sashBorder: #30363d;
+  --vscode-settings-dropdownBackground: #161b22;
+  --vscode-settings-dropdownForeground: #c9d1d9;
+  --vscode-settings-dropdownBorder: #30363d;
+  --vscode-settings-dropdownListBorder: #454545;
+  --vscode-settings-checkboxBackground: #161b22;
+  --vscode-settings-checkboxForeground: #c9d1d9;
+  --vscode-settings-checkboxBorder: #30363d;
+  --vscode-settings-textInputBackground: #0d1117;
+  --vscode-settings-textInputForeground: #c9d1d9;
+  --vscode-settings-textInputBorder: #30363d;
+  --vscode-settings-numberInputBackground: #0d1117;
+  --vscode-settings-numberInputForeground: #c9d1d9;
+  --vscode-settings-numberInputBorder: #30363d;
+  --vscode-settings-focusedRowBackground: rgba(110, 118, 129, 0.06);
+  --vscode-settings-rowHoverBackground: rgba(110, 118, 129, 0.03);
+  --vscode-settings-focusedRowBorder: #1f6feb;
+  --vscode-terminal-foreground: #c9d1d9;
+  --vscode-terminal-selectionBackground: #264f78;
+  --vscode-terminal-inactiveSelectionBackground: rgba(38, 79, 120, 0.5);
+  --vscode-terminalCommandDecoration-defaultBackground: rgba(
+    255,
+    255,
+    255,
+    0.25
+  );
+  --vscode-terminalCommandDecoration-successBackground: #1b81a8;
+  --vscode-terminalCommandDecoration-errorBackground: #f14c4c;
+  --vscode-terminalOverviewRuler-cursorForeground: rgba(160, 160, 160, 0.8);
+  --vscode-terminal-border: #30363d;
+  --vscode-terminal-findMatchBackground: #9e6a03;
+  --vscode-terminal-findMatchHighlightBackground: rgba(242, 204, 96, 0.5);
+  --vscode-terminalOverviewRuler-findMatchForeground: rgba(209, 134, 22, 0.49);
+  --vscode-terminal-dropBackground: rgba(83, 89, 93, 0.5);
+  --vscode-terminal-tab\.activeBorder: #0d1117;
+  --vscode-testing-iconFailed: #f14c4c;
+  --vscode-testing-iconErrored: #f14c4c;
+  --vscode-testing-iconPassed: #73c991;
+  --vscode-testing-runAction: #73c991;
+  --vscode-testing-iconQueued: #cca700;
+  --vscode-testing-iconUnset: #848484;
+  --vscode-testing-iconSkipped: #848484;
+  --vscode-testing-peekBorder: #f14c4c;
+  --vscode-testing-peekHeaderBackground: rgba(241, 76, 76, 0.1);
+  --vscode-testing-message\.error\.decorationForeground: #f14c4c;
+  --vscode-testing-message\.error\.lineBackground: rgba(255, 0, 0, 0.2);
+  --vscode-testing-message\.info\.decorationForeground: rgba(
+    201,
+    209,
+    217,
+    0.5
+  );
+  --vscode-welcomePage-tileBackground: #161b22;
+  --vscode-welcomePage-tileHoverBackground: #1a2029;
+  --vscode-welcomePage-tileBorder: rgba(255, 255, 255, 0.1);
+  --vscode-welcomePage-progress\.background: #0d1117;
+  --vscode-welcomePage-progress\.foreground: #58a6ff;
+  --vscode-walkthrough-stepTitle\.foreground: #ffffff;
+  --vscode-debugExceptionWidget-border: #a31515;
+  --vscode-debugExceptionWidget-background: #420b0d;
+  --vscode-ports-iconRunningProcessForeground: #30363d;
+  --vscode-statusBar-debuggingBackground: #da3633;
+  --vscode-statusBar-debuggingForeground: #f0f6fc;
+  --vscode-statusBar-debuggingBorder: #30363d;
+  --vscode-editor-inlineValuesForeground: rgba(255, 255, 255, 0.5);
+  --vscode-editor-inlineValuesBackground: rgba(255, 200, 0, 0.2);
+  --vscode-editorGutter-modifiedBackground: rgba(187, 128, 9, 0.4);
+  --vscode-editorGutter-addedBackground: rgba(46, 160, 67, 0.4);
+  --vscode-editorGutter-deletedBackground: rgba(248, 81, 73, 0.4);
+  --vscode-minimapGutter-modifiedBackground: rgba(187, 128, 9, 0.4);
+  --vscode-minimapGutter-addedBackground: rgba(46, 160, 67, 0.4);
+  --vscode-minimapGutter-deletedBackground: rgba(248, 81, 73, 0.4);
+  --vscode-editorOverviewRuler-modifiedForeground: rgba(187, 128, 9, 0.24);
+  --vscode-editorOverviewRuler-addedForeground: rgba(46, 160, 67, 0.24);
+  --vscode-editorOverviewRuler-deletedForeground: rgba(248, 81, 73, 0.24);
+  --vscode-debugIcon-breakpointForeground: #f85149;
+  --vscode-debugIcon-breakpointDisabledForeground: #848484;
+  --vscode-debugIcon-breakpointUnverifiedForeground: #848484;
+  --vscode-debugIcon-breakpointCurrentStackframeForeground: #ffcc00;
+  --vscode-debugIcon-breakpointStackframeForeground: #89d185;
+  --vscode-notebook-cellBorderColor: rgba(110, 118, 129, 0.4);
+  --vscode-notebook-focusedEditorBorder: #1f6feb;
+  --vscode-notebookStatusSuccessIcon-foreground: #89d185;
+  --vscode-notebookStatusErrorIcon-foreground: #f85149;
+  --vscode-notebookStatusRunningIcon-foreground: #c9d1d9;
+  --vscode-notebook-cellToolbarSeparator: rgba(128, 128, 128, 0.35);
+  --vscode-notebook-selectedCellBackground: rgba(110, 118, 129, 0.4);
+  --vscode-notebook-selectedCellBorder: rgba(110, 118, 129, 0.4);
+  --vscode-notebook-focusedCellBorder: #1f6feb;
+  --vscode-notebook-inactiveFocusedCellBorder: rgba(110, 118, 129, 0.4);
+  --vscode-notebook-cellStatusBarItemHoverBackground: rgba(255, 255, 255, 0.15);
+  --vscode-notebook-cellInsertionIndicator: #1f6feb;
+  --vscode-notebookScrollbarSlider-background: rgba(110, 118, 129, 0.2);
+  --vscode-notebookScrollbarSlider-hoverBackground: rgba(110, 118, 129, 0.27);
+  --vscode-notebookScrollbarSlider-activeBackground: rgba(110, 118, 129, 0.53);
+  --vscode-notebook-symbolHighlightBackground: rgba(255, 255, 255, 0.04);
+  --vscode-notebook-cellEditorBackground: #010409;
+  --vscode-notebook-editorBackground: #0d1117;
+  --vscode-keybindingTable-headerBackground: rgba(201, 209, 217, 0.04);
+  --vscode-keybindingTable-rowsBackground: rgba(201, 209, 217, 0.04);
+  --vscode-scm-providerBorder: #454545;
+  --vscode-searchEditor-textInputBorder: #30363d;
+  --vscode-debugTokenExpression-name: #79c0ff;
+  --vscode-debugTokenExpression-value: #a5d6ff;
+  --vscode-debugTokenExpression-string: #a5d6ff;
+  --vscode-debugTokenExpression-boolean: #56d364;
+  --vscode-debugTokenExpression-number: #56d364;
+  --vscode-debugTokenExpression-error: #ffa198;
+  --vscode-debugView-exceptionLabelForeground: #c9d1d9;
+  --vscode-debugView-exceptionLabelBackground: #6c2022;
+  --vscode-debugView-stateLabelForeground: #c9d1d9;
+  --vscode-debugView-stateLabelBackground: rgba(136, 136, 136, 0.27);
+  --vscode-debugView-valueChangedHighlight: #569cd6;
+  --vscode-debugConsole-infoForeground: #8b949e;
+  --vscode-debugConsole-warningForeground: #d29922;
+  --vscode-debugConsole-errorForeground: #ffa198;
+  --vscode-debugConsole-sourceForeground: #e3b341;
+  --vscode-debugConsoleInputIcon-foreground: #bc8cff;
+  --vscode-debugIcon-pauseForeground: #75beff;
+  --vscode-debugIcon-stopForeground: #f48771;
+  --vscode-debugIcon-disconnectForeground: #f48771;
+  --vscode-debugIcon-restartForeground: #89d185;
+  --vscode-debugIcon-stepOverForeground: #75beff;
+  --vscode-debugIcon-stepIntoForeground: #75beff;
+  --vscode-debugIcon-stepOutForeground: #75beff;
+  --vscode-debugIcon-continueForeground: #75beff;
+  --vscode-debugIcon-stepBackForeground: #75beff;
+  --vscode-extensionButton-background: #238636;
+  --vscode-extensionButton-foreground: #ffffff;
+  --vscode-extensionButton-hoverBackground: #2ea043;
+  --vscode-extensionButton-separator: rgba(255, 255, 255, 0.4);
+  --vscode-extensionButton-prominentBackground: #238636;
+  --vscode-extensionButton-prominentForeground: #ffffff;
+  --vscode-extensionButton-prominentHoverBackground: #2ea043;
+  --vscode-extensionIcon-starForeground: #ff8e00;
+  --vscode-extensionIcon-verifiedForeground: #58a6ff;
+  --vscode-extensionIcon-preReleaseForeground: #1d9271;
+  --vscode-extensionIcon-sponsorForeground: #d758b3;
+  --vscode-terminal-ansiBlack: #484f58;
+  --vscode-terminal-ansiRed: #ff7b72;
+  --vscode-terminal-ansiGreen: #3fb950;
+  --vscode-terminal-ansiYellow: #d29922;
+  --vscode-terminal-ansiBlue: #58a6ff;
+  --vscode-terminal-ansiMagenta: #bc8cff;
+  --vscode-terminal-ansiCyan: #39c5cf;
+  --vscode-terminal-ansiWhite: #b1bac4;
+  --vscode-terminal-ansiBrightBlack: #6e7681;
+  --vscode-terminal-ansiBrightRed: #ffa198;
+  --vscode-terminal-ansiBrightGreen: #56d364;
+  --vscode-terminal-ansiBrightYellow: #e3b341;
+  --vscode-terminal-ansiBrightBlue: #79c0ff;
+  --vscode-terminal-ansiBrightMagenta: #d2a8ff;
+  --vscode-terminal-ansiBrightCyan: #56d4dd;
+  --vscode-terminal-ansiBrightWhite: #f0f6fc;
+  --vscode-interactive-activeCodeBorder: #3794ff;
+  --vscode-interactive-inactiveCodeBorder: rgba(110, 118, 129, 0.4);
+  --vscode-gitDecoration-addedResourceForeground: #3fb950;
+  --vscode-gitDecoration-modifiedResourceForeground: #d29922;
+  --vscode-gitDecoration-deletedResourceForeground: #f85149;
+  --vscode-gitDecoration-renamedResourceForeground: #73c991;
+  --vscode-gitDecoration-untrackedResourceForeground: #3fb950;
+  --vscode-gitDecoration-ignoredResourceForeground: #484f58;
+  --vscode-gitDecoration-stageModifiedResourceForeground: #e2c08d;
+  --vscode-gitDecoration-stageDeletedResourceForeground: #c74e39;
+  --vscode-gitDecoration-conflictingResourceForeground: #db6d28;
+  --vscode-gitDecoration-submoduleResourceForeground: #8b949e;
+  --vscode-testExplorer-errorDecorationBackground: #5a1d1d;
+}
+
+/**
+ * This is copied in the same way, but from the <body> element
+ */
+body {
+  background-color: transparent;
+  color: var(--vscode-editor-foreground);
+  font-family: var(--vscode-font-family);
+  font-weight: var(--vscode-font-weight);
+  font-size: var(--vscode-font-size);
+  margin: 0;
+  padding: 0 20px;
+}
+
+/**
+ * This is used for setting the background on the Storybook preview.
+ */
+body {
+  background-color: var(--vscode-editor-background);
+}

--- a/extensions/ql-vscode/src/stories/vscode-theme-github-light-default.css
+++ b/extensions/ql-vscode/src/stories/vscode-theme-github-light-default.css
@@ -1,0 +1,659 @@
+/*
+ * These were copied from VSCode GitHub Light Default theme from the
+ * https://marketplace.visualstudio.com/items?itemName=GitHub.github-vscode-theme extension.
+ *
+ * To update these, open a webview in VSCode, open the webview developer tools and find the
+ * iframe hosting the webview. The <html> element will have a style attribute that contains
+ * the CSS variables. Copy these to this file.
+ */
+:root {
+  --vscode-font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+  --vscode-font-weight: normal;
+  --vscode-font-size: 13px;
+  --vscode-editor-font-family: Menlo, Monaco, "Courier New", monospace;
+  --vscode-editor-font-weight: normal;
+  --vscode-editor-font-size: 12px;
+  --vscode-foreground: #24292f;
+  --vscode-disabledForeground: rgba(97, 97, 97, 0.5);
+  --vscode-errorForeground: #cf222e;
+  --vscode-descriptionForeground: #57606a;
+  --vscode-icon-foreground: #57606a;
+  --vscode-focusBorder: #0969da;
+  --vscode-textSeparator-foreground: #d8dee4;
+  --vscode-textLink-foreground: #0969da;
+  --vscode-textLink-activeForeground: #0969da;
+  --vscode-textPreformat-foreground: #57606a;
+  --vscode-textBlockQuote-background: #f6f8fa;
+  --vscode-textBlockQuote-border: #d0d7de;
+  --vscode-textCodeBlock-background: rgba(175, 184, 193, 0.2);
+  --vscode-widget-shadow: rgba(0, 0, 0, 0.16);
+  --vscode-input-background: #ffffff;
+  --vscode-input-foreground: #24292f;
+  --vscode-input-border: #d0d7de;
+  --vscode-inputOption-activeBorder: rgba(0, 122, 204, 0);
+  --vscode-inputOption-hoverBackground: rgba(184, 184, 184, 0.31);
+  --vscode-inputOption-activeBackground: rgba(9, 105, 218, 0.2);
+  --vscode-inputOption-activeForeground: #000000;
+  --vscode-input-placeholderForeground: #6e7781;
+  --vscode-inputValidation-infoBackground: #d6ecf2;
+  --vscode-inputValidation-infoBorder: #007acc;
+  --vscode-inputValidation-warningBackground: #f6f5d2;
+  --vscode-inputValidation-warningBorder: #b89500;
+  --vscode-inputValidation-errorBackground: #f2dede;
+  --vscode-inputValidation-errorBorder: #be1100;
+  --vscode-dropdown-background: #ffffff;
+  --vscode-dropdown-listBackground: #ffffff;
+  --vscode-dropdown-foreground: #24292f;
+  --vscode-dropdown-border: #d0d7de;
+  --vscode-button-foreground: #ffffff;
+  --vscode-button-separator: rgba(255, 255, 255, 0.4);
+  --vscode-button-background: #2da44e;
+  --vscode-button-hoverBackground: #2c974b;
+  --vscode-button-secondaryForeground: #24292f;
+  --vscode-button-secondaryBackground: #ebecf0;
+  --vscode-button-secondaryHoverBackground: #f3f4f6;
+  --vscode-badge-background: #0969da;
+  --vscode-badge-foreground: #ffffff;
+  --vscode-scrollbar-shadow: rgba(110, 119, 129, 0.2);
+  --vscode-scrollbarSlider-background: rgba(140, 149, 159, 0.2);
+  --vscode-scrollbarSlider-hoverBackground: rgba(140, 149, 159, 0.27);
+  --vscode-scrollbarSlider-activeBackground: rgba(140, 149, 159, 0.53);
+  --vscode-progressBar-background: #0969da;
+  --vscode-editorError-foreground: #e51400;
+  --vscode-editorWarning-foreground: #bf8803;
+  --vscode-editorInfo-foreground: #1a85ff;
+  --vscode-editorHint-foreground: #6c6c6c;
+  --vscode-sash-hoverBorder: #0969da;
+  --vscode-editor-background: #ffffff;
+  --vscode-editor-foreground: #24292f;
+  --vscode-editorStickyScroll-background: #ffffff;
+  --vscode-editorStickyScrollHover-background: #f0f0f0;
+  --vscode-editorWidget-background: #ffffff;
+  --vscode-editorWidget-foreground: #24292f;
+  --vscode-editorWidget-border: #c8c8c8;
+  --vscode-quickInput-background: #ffffff;
+  --vscode-quickInput-foreground: #24292f;
+  --vscode-quickInputTitle-background: rgba(0, 0, 0, 0.06);
+  --vscode-pickerGroup-foreground: #57606a;
+  --vscode-pickerGroup-border: #d0d7de;
+  --vscode-keybindingLabel-background: rgba(221, 221, 221, 0.4);
+  --vscode-keybindingLabel-foreground: #24292f;
+  --vscode-keybindingLabel-border: rgba(204, 204, 204, 0.4);
+  --vscode-keybindingLabel-bottomBorder: rgba(187, 187, 187, 0.4);
+  --vscode-editor-selectionBackground: #add6ff;
+  --vscode-editor-inactiveSelectionBackground: rgba(173, 214, 255, 0.5);
+  --vscode-editor-selectionHighlightBackground: rgba(74, 194, 107, 0.25);
+  --vscode-editor-findMatchBackground: #bf8700;
+  --vscode-editor-findMatchHighlightBackground: rgba(250, 225, 125, 0.5);
+  --vscode-editor-findRangeHighlightBackground: rgba(180, 180, 180, 0.3);
+  --vscode-searchEditor-findMatchBackground: rgba(250, 225, 125, 0.33);
+  --vscode-editor-hoverHighlightBackground: rgba(173, 214, 255, 0.15);
+  --vscode-editorHoverWidget-background: #ffffff;
+  --vscode-editorHoverWidget-foreground: #24292f;
+  --vscode-editorHoverWidget-border: #c8c8c8;
+  --vscode-editorHoverWidget-statusBarBackground: #f2f2f2;
+  --vscode-editorLink-activeForeground: #0000ff;
+  --vscode-editorInlayHint-foreground: #57606a;
+  --vscode-editorInlayHint-background: rgba(175, 184, 193, 0.2);
+  --vscode-editorInlayHint-typeForeground: #57606a;
+  --vscode-editorInlayHint-typeBackground: rgba(175, 184, 193, 0.2);
+  --vscode-editorInlayHint-parameterForeground: #57606a;
+  --vscode-editorInlayHint-parameterBackground: rgba(175, 184, 193, 0.2);
+  --vscode-editorLightBulb-foreground: #ddb100;
+  --vscode-editorLightBulbAutoFix-foreground: #007acc;
+  --vscode-diffEditor-insertedTextBackground: rgba(111, 221, 139, 0.4);
+  --vscode-diffEditor-removedTextBackground: rgba(255, 171, 168, 0.4);
+  --vscode-diffEditor-insertedLineBackground: rgba(172, 238, 187, 0.3);
+  --vscode-diffEditor-removedLineBackground: rgba(255, 206, 203, 0.3);
+  --vscode-diffEditor-diagonalFill: rgba(34, 34, 34, 0.2);
+  --vscode-list-focusBackground: #ddf4ff;
+  --vscode-list-focusForeground: #24292f;
+  --vscode-list-focusOutline: #0969da;
+  --vscode-list-activeSelectionBackground: rgba(175, 184, 193, 0.2);
+  --vscode-list-activeSelectionForeground: #24292f;
+  --vscode-list-inactiveSelectionBackground: rgba(175, 184, 193, 0.2);
+  --vscode-list-inactiveSelectionForeground: #24292f;
+  --vscode-list-inactiveFocusBackground: #ddf4ff;
+  --vscode-list-hoverBackground: rgba(234, 238, 242, 0.5);
+  --vscode-list-hoverForeground: #24292f;
+  --vscode-list-dropBackground: #d6ebff;
+  --vscode-list-highlightForeground: #0969da;
+  --vscode-list-focusHighlightForeground: #0969da;
+  --vscode-list-invalidItemForeground: #b89500;
+  --vscode-list-errorForeground: #b01011;
+  --vscode-list-warningForeground: #855f00;
+  --vscode-listFilterWidget-background: #ffffff;
+  --vscode-listFilterWidget-outline: rgba(0, 0, 0, 0);
+  --vscode-listFilterWidget-noMatchesOutline: #be1100;
+  --vscode-listFilterWidget-shadow: rgba(0, 0, 0, 0.16);
+  --vscode-list-filterMatchBackground: rgba(250, 225, 125, 0.5);
+  --vscode-tree-indentGuidesStroke: #d8dee4;
+  --vscode-tree-tableColumnsBorder: rgba(97, 97, 97, 0.13);
+  --vscode-tree-tableOddRowsBackground: rgba(36, 41, 47, 0.04);
+  --vscode-list-deemphasizedForeground: #8e8e90;
+  --vscode-checkbox-background: #f6f8fa;
+  --vscode-checkbox-selectBackground: #ffffff;
+  --vscode-checkbox-foreground: #24292f;
+  --vscode-checkbox-border: #d0d7de;
+  --vscode-checkbox-selectBorder: #ffffff;
+  --vscode-quickInputList-focusForeground: #24292f;
+  --vscode-quickInputList-focusBackground: rgba(175, 184, 193, 0.2);
+  --vscode-menu-foreground: #24292f;
+  --vscode-menu-background: #ffffff;
+  --vscode-menu-selectionForeground: #24292f;
+  --vscode-menu-selectionBackground: rgba(175, 184, 193, 0.2);
+  --vscode-menu-separatorBackground: #d4d4d4;
+  --vscode-toolbar-hoverBackground: rgba(184, 184, 184, 0.31);
+  --vscode-toolbar-activeBackground: rgba(166, 166, 166, 0.31);
+  --vscode-editor-snippetTabstopHighlightBackground: rgba(10, 50, 100, 0.2);
+  --vscode-editor-snippetFinalTabstopHighlightBorder: rgba(10, 50, 100, 0.5);
+  --vscode-breadcrumb-foreground: #57606a;
+  --vscode-breadcrumb-background: #ffffff;
+  --vscode-breadcrumb-focusForeground: #24292f;
+  --vscode-breadcrumb-activeSelectionForeground: #57606a;
+  --vscode-breadcrumbPicker-background: #ffffff;
+  --vscode-merge-currentHeaderBackground: rgba(64, 200, 174, 0.5);
+  --vscode-merge-currentContentBackground: rgba(64, 200, 174, 0.2);
+  --vscode-merge-incomingHeaderBackground: rgba(64, 166, 255, 0.5);
+  --vscode-merge-incomingContentBackground: rgba(64, 166, 255, 0.2);
+  --vscode-merge-commonHeaderBackground: rgba(96, 96, 96, 0.4);
+  --vscode-merge-commonContentBackground: rgba(96, 96, 96, 0.16);
+  --vscode-editorOverviewRuler-currentContentForeground: rgba(
+    64,
+    200,
+    174,
+    0.5
+  );
+  --vscode-editorOverviewRuler-incomingContentForeground: rgba(
+    64,
+    166,
+    255,
+    0.5
+  );
+  --vscode-editorOverviewRuler-commonContentForeground: rgba(96, 96, 96, 0.4);
+  --vscode-editorOverviewRuler-findMatchForeground: rgba(209, 134, 22, 0.49);
+  --vscode-editorOverviewRuler-selectionHighlightForeground: rgba(
+    160,
+    160,
+    160,
+    0.8
+  );
+  --vscode-minimap-findMatchHighlight: #d18616;
+  --vscode-minimap-selectionOccurrenceHighlight: #c9c9c9;
+  --vscode-minimap-selectionHighlight: #add6ff;
+  --vscode-minimap-errorHighlight: rgba(255, 18, 18, 0.7);
+  --vscode-minimap-warningHighlight: #bf8803;
+  --vscode-minimap-foregroundOpacity: #000000;
+  --vscode-minimapSlider-background: rgba(140, 149, 159, 0.1);
+  --vscode-minimapSlider-hoverBackground: rgba(140, 149, 159, 0.14);
+  --vscode-minimapSlider-activeBackground: rgba(140, 149, 159, 0.27);
+  --vscode-problemsErrorIcon-foreground: #e51400;
+  --vscode-problemsWarningIcon-foreground: #bf8803;
+  --vscode-problemsInfoIcon-foreground: #1a85ff;
+  --vscode-charts-foreground: #24292f;
+  --vscode-charts-lines: rgba(36, 41, 47, 0.5);
+  --vscode-charts-red: #e51400;
+  --vscode-charts-blue: #1a85ff;
+  --vscode-charts-yellow: #bf8803;
+  --vscode-charts-orange: #d18616;
+  --vscode-charts-green: #388a34;
+  --vscode-charts-purple: #652d90;
+  --vscode-symbolIcon-arrayForeground: #953800;
+  --vscode-symbolIcon-booleanForeground: #0550ae;
+  --vscode-symbolIcon-classForeground: #953800;
+  --vscode-symbolIcon-colorForeground: #0a3069;
+  --vscode-symbolIcon-constantForeground: #116329;
+  --vscode-symbolIcon-constructorForeground: #3e1f79;
+  --vscode-symbolIcon-enumeratorForeground: #953800;
+  --vscode-symbolIcon-enumeratorMemberForeground: #0550ae;
+  --vscode-symbolIcon-eventForeground: #57606a;
+  --vscode-symbolIcon-fieldForeground: #953800;
+  --vscode-symbolIcon-fileForeground: #7d4e00;
+  --vscode-symbolIcon-folderForeground: #7d4e00;
+  --vscode-symbolIcon-functionForeground: #6639ba;
+  --vscode-symbolIcon-interfaceForeground: #953800;
+  --vscode-symbolIcon-keyForeground: #0550ae;
+  --vscode-symbolIcon-keywordForeground: #a40e26;
+  --vscode-symbolIcon-methodForeground: #6639ba;
+  --vscode-symbolIcon-moduleForeground: #a40e26;
+  --vscode-symbolIcon-namespaceForeground: #a40e26;
+  --vscode-symbolIcon-nullForeground: #0550ae;
+  --vscode-symbolIcon-numberForeground: #116329;
+  --vscode-symbolIcon-objectForeground: #953800;
+  --vscode-symbolIcon-operatorForeground: #0a3069;
+  --vscode-symbolIcon-packageForeground: #953800;
+  --vscode-symbolIcon-propertyForeground: #953800;
+  --vscode-symbolIcon-referenceForeground: #0550ae;
+  --vscode-symbolIcon-snippetForeground: #0550ae;
+  --vscode-symbolIcon-stringForeground: #0a3069;
+  --vscode-symbolIcon-structForeground: #953800;
+  --vscode-symbolIcon-textForeground: #0a3069;
+  --vscode-symbolIcon-typeParameterForeground: #0a3069;
+  --vscode-symbolIcon-unitForeground: #0550ae;
+  --vscode-symbolIcon-variableForeground: #953800;
+  --vscode-editor-lineHighlightBackground: rgba(234, 238, 242, 0.5);
+  --vscode-editor-lineHighlightBorder: #eeeeee;
+  --vscode-editor-rangeHighlightBackground: rgba(253, 255, 0, 0.2);
+  --vscode-editor-symbolHighlightBackground: rgba(250, 225, 125, 0.5);
+  --vscode-editorCursor-foreground: #0969da;
+  --vscode-editorWhitespace-foreground: #afb8c1;
+  --vscode-editorIndentGuide-background: rgba(36, 41, 47, 0.12);
+  --vscode-editorIndentGuide-activeBackground: rgba(36, 41, 47, 0.24);
+  --vscode-editorLineNumber-foreground: #8c959f;
+  --vscode-editorActiveLineNumber-foreground: #0b216f;
+  --vscode-editorLineNumber-activeForeground: #24292f;
+  --vscode-editorRuler-foreground: #d3d3d3;
+  --vscode-editorCodeLens-foreground: #919191;
+  --vscode-editorBracketMatch-background: rgba(74, 194, 107, 0.25);
+  --vscode-editorBracketMatch-border: rgba(74, 194, 107, 0.6);
+  --vscode-editorOverviewRuler-border: #ffffff;
+  --vscode-editorGutter-background: #ffffff;
+  --vscode-editorUnnecessaryCode-opacity: rgba(0, 0, 0, 0.47);
+  --vscode-editorGhostText-foreground: rgba(0, 0, 0, 0.47);
+  --vscode-editorOverviewRuler-rangeHighlightForeground: rgba(0, 122, 204, 0.6);
+  --vscode-editorOverviewRuler-errorForeground: rgba(255, 18, 18, 0.7);
+  --vscode-editorOverviewRuler-warningForeground: #bf8803;
+  --vscode-editorOverviewRuler-infoForeground: #1a85ff;
+  --vscode-editorBracketHighlight-foreground1: #0969da;
+  --vscode-editorBracketHighlight-foreground2: #1a7f37;
+  --vscode-editorBracketHighlight-foreground3: #9a6700;
+  --vscode-editorBracketHighlight-foreground4: #cf222e;
+  --vscode-editorBracketHighlight-foreground5: #bf3989;
+  --vscode-editorBracketHighlight-foreground6: #8250df;
+  --vscode-editorBracketHighlight-unexpectedBracket\.foreground: #57606a;
+  --vscode-editorBracketPairGuide-background1: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-background2: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-background3: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-background4: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-background5: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-background6: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-activeBackground1: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-activeBackground2: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-activeBackground3: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-activeBackground4: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-activeBackground5: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-activeBackground6: rgba(0, 0, 0, 0);
+  --vscode-editorUnicodeHighlight-border: #cea33d;
+  --vscode-editorUnicodeHighlight-background: rgba(206, 163, 61, 0.08);
+  --vscode-editorHoverWidget-highlightForeground: #0969da;
+  --vscode-editorOverviewRuler-bracketMatchForeground: #a0a0a0;
+  --vscode-editor-foldBackground: rgba(110, 119, 129, 0.1);
+  --vscode-editorGutter-foldingControlForeground: #57606a;
+  --vscode-editor-linkedEditingBackground: rgba(9, 105, 218, 0.07);
+  --vscode-editor-wordHighlightBackground: rgba(234, 238, 242, 0.5);
+  --vscode-editor-wordHighlightStrongBackground: rgba(175, 184, 193, 0.3);
+  --vscode-editor-wordHighlightBorder: rgba(175, 184, 193, 0.6);
+  --vscode-editor-wordHighlightStrongBorder: rgba(175, 184, 193, 0.6);
+  --vscode-editorOverviewRuler-wordHighlightForeground: rgba(
+    160,
+    160,
+    160,
+    0.8
+  );
+  --vscode-editorOverviewRuler-wordHighlightStrongForeground: rgba(
+    192,
+    160,
+    192,
+    0.8
+  );
+  --vscode-peekViewTitle-background: rgba(26, 133, 255, 0.1);
+  --vscode-peekViewTitleLabel-foreground: #000000;
+  --vscode-peekViewTitleDescription-foreground: #616161;
+  --vscode-peekView-border: #1a85ff;
+  --vscode-peekViewResult-background: #f3f3f3;
+  --vscode-peekViewResult-lineForeground: #646465;
+  --vscode-peekViewResult-fileForeground: #1e1e1e;
+  --vscode-peekViewResult-selectionBackground: rgba(51, 153, 255, 0.2);
+  --vscode-peekViewResult-selectionForeground: #6c6c6c;
+  --vscode-peekViewEditor-background: #f2f8fc;
+  --vscode-peekViewEditorGutter-background: #f2f8fc;
+  --vscode-peekViewResult-matchHighlightBackground: rgba(234, 92, 0, 0.3);
+  --vscode-peekViewEditor-matchHighlightBackground: rgba(245, 216, 2, 0.87);
+  --vscode-editorMarkerNavigationError-background: #e51400;
+  --vscode-editorMarkerNavigationError-headerBackground: rgba(229, 20, 0, 0.1);
+  --vscode-editorMarkerNavigationWarning-background: #bf8803;
+  --vscode-editorMarkerNavigationWarning-headerBackground: rgba(
+    191,
+    136,
+    3,
+    0.1
+  );
+  --vscode-editorMarkerNavigationInfo-background: #1a85ff;
+  --vscode-editorMarkerNavigationInfo-headerBackground: rgba(26, 133, 255, 0.1);
+  --vscode-editorMarkerNavigation-background: #ffffff;
+  --vscode-editorSuggestWidget-background: #ffffff;
+  --vscode-editorSuggestWidget-border: #c8c8c8;
+  --vscode-editorSuggestWidget-foreground: #24292f;
+  --vscode-editorSuggestWidget-selectedForeground: #24292f;
+  --vscode-editorSuggestWidget-selectedBackground: rgba(175, 184, 193, 0.2);
+  --vscode-editorSuggestWidget-highlightForeground: #0969da;
+  --vscode-editorSuggestWidget-focusHighlightForeground: #0969da;
+  --vscode-editorSuggestWidgetStatus-foreground: rgba(36, 41, 47, 0.5);
+  --vscode-tab-activeBackground: #ffffff;
+  --vscode-tab-unfocusedActiveBackground: #ffffff;
+  --vscode-tab-inactiveBackground: #f6f8fa;
+  --vscode-tab-unfocusedInactiveBackground: #f6f8fa;
+  --vscode-tab-activeForeground: #24292f;
+  --vscode-tab-inactiveForeground: #57606a;
+  --vscode-tab-unfocusedActiveForeground: rgba(36, 41, 47, 0.7);
+  --vscode-tab-unfocusedInactiveForeground: rgba(87, 96, 106, 0.5);
+  --vscode-tab-hoverBackground: #ffffff;
+  --vscode-tab-unfocusedHoverBackground: rgba(234, 238, 242, 0.5);
+  --vscode-tab-border: #d0d7de;
+  --vscode-tab-lastPinnedBorder: #d8dee4;
+  --vscode-tab-activeBorder: #ffffff;
+  --vscode-tab-unfocusedActiveBorder: #ffffff;
+  --vscode-tab-activeBorderTop: #fd8c73;
+  --vscode-tab-unfocusedActiveBorderTop: #d0d7de;
+  --vscode-tab-activeModifiedBorder: #33aaee;
+  --vscode-tab-inactiveModifiedBorder: rgba(51, 170, 238, 0.5);
+  --vscode-tab-unfocusedActiveModifiedBorder: rgba(51, 170, 238, 0.7);
+  --vscode-tab-unfocusedInactiveModifiedBorder: rgba(51, 170, 238, 0.25);
+  --vscode-editorPane-background: #ffffff;
+  --vscode-editorGroupHeader-tabsBackground: #f6f8fa;
+  --vscode-editorGroupHeader-tabsBorder: #d0d7de;
+  --vscode-editorGroupHeader-noTabsBackground: #ffffff;
+  --vscode-editorGroup-border: #d0d7de;
+  --vscode-editorGroup-dropBackground: rgba(38, 119, 203, 0.18);
+  --vscode-editorGroup-dropIntoPromptForeground: #24292f;
+  --vscode-editorGroup-dropIntoPromptBackground: #ffffff;
+  --vscode-sideBySideEditor-horizontalBorder: #d0d7de;
+  --vscode-sideBySideEditor-verticalBorder: #d0d7de;
+  --vscode-panel-background: #f6f8fa;
+  --vscode-panel-border: #d0d7de;
+  --vscode-panelTitle-activeForeground: #24292f;
+  --vscode-panelTitle-inactiveForeground: #57606a;
+  --vscode-panelTitle-activeBorder: #fd8c73;
+  --vscode-panelInput-border: #d0d7de;
+  --vscode-panel-dropBorder: #24292f;
+  --vscode-panelSection-dropBackground: rgba(38, 119, 203, 0.18);
+  --vscode-panelSectionHeader-background: rgba(128, 128, 128, 0.2);
+  --vscode-panelSection-border: #d0d7de;
+  --vscode-banner-background: rgba(113, 129, 145, 0.2);
+  --vscode-banner-foreground: #24292f;
+  --vscode-banner-iconForeground: #1a85ff;
+  --vscode-statusBar-foreground: #57606a;
+  --vscode-statusBar-noFolderForeground: #57606a;
+  --vscode-statusBar-background: #ffffff;
+  --vscode-statusBar-noFolderBackground: #ffffff;
+  --vscode-statusBar-border: #d0d7de;
+  --vscode-statusBar-focusBorder: rgba(9, 105, 218, 0.5);
+  --vscode-statusBar-noFolderBorder: #d0d7de;
+  --vscode-statusBarItem-activeBackground: rgba(36, 41, 47, 0.12);
+  --vscode-statusBarItem-focusBorder: #0969da;
+  --vscode-statusBarItem-hoverBackground: rgba(36, 41, 47, 0.08);
+  --vscode-statusBarItem-compactHoverBackground: rgba(255, 255, 255, 0.2);
+  --vscode-statusBarItem-prominentForeground: #57606a;
+  --vscode-statusBarItem-prominentBackground: rgba(175, 184, 193, 0.2);
+  --vscode-statusBarItem-prominentHoverBackground: rgba(0, 0, 0, 0.3);
+  --vscode-statusBarItem-errorBackground: #7c141b;
+  --vscode-statusBarItem-errorForeground: #ffffff;
+  --vscode-statusBarItem-warningBackground: #725102;
+  --vscode-statusBarItem-warningForeground: #ffffff;
+  --vscode-activityBar-background: #ffffff;
+  --vscode-activityBar-foreground: #24292f;
+  --vscode-activityBar-inactiveForeground: #57606a;
+  --vscode-activityBar-border: #d0d7de;
+  --vscode-activityBar-activeBorder: #fd8c73;
+  --vscode-activityBar-dropBorder: #24292f;
+  --vscode-activityBarBadge-background: #0969da;
+  --vscode-activityBarBadge-foreground: #ffffff;
+  --vscode-activityBarItem-profilesForeground: #57606a;
+  --vscode-activityBarItem-profilesHoverForeground: #24292f;
+  --vscode-activityBarItem-profilesBackground: #e0e0e0;
+  --vscode-statusBarItem-remoteBackground: #eaeef2;
+  --vscode-statusBarItem-remoteForeground: #24292f;
+  --vscode-extensionBadge-remoteBackground: #0969da;
+  --vscode-extensionBadge-remoteForeground: #ffffff;
+  --vscode-sideBar-background: #f6f8fa;
+  --vscode-sideBar-foreground: #24292f;
+  --vscode-sideBar-border: #d0d7de;
+  --vscode-sideBarTitle-foreground: #24292f;
+  --vscode-sideBar-dropBackground: rgba(38, 119, 203, 0.18);
+  --vscode-sideBarSectionHeader-background: #f6f8fa;
+  --vscode-sideBarSectionHeader-foreground: #24292f;
+  --vscode-sideBarSectionHeader-border: #d0d7de;
+  --vscode-titleBar-activeForeground: #57606a;
+  --vscode-titleBar-inactiveForeground: #57606a;
+  --vscode-titleBar-activeBackground: #ffffff;
+  --vscode-titleBar-inactiveBackground: #f6f8fa;
+  --vscode-titleBar-border: #d0d7de;
+  --vscode-menubar-selectionForeground: #57606a;
+  --vscode-menubar-selectionBackground: rgba(184, 184, 184, 0.31);
+  --vscode-notifications-foreground: #24292f;
+  --vscode-notifications-background: #ffffff;
+  --vscode-notificationLink-foreground: #0969da;
+  --vscode-notificationCenterHeader-foreground: #57606a;
+  --vscode-notificationCenterHeader-background: #f6f8fa;
+  --vscode-notifications-border: #d0d7de;
+  --vscode-notificationsErrorIcon-foreground: #cf222e;
+  --vscode-notificationsWarningIcon-foreground: #9a6700;
+  --vscode-notificationsInfoIcon-foreground: #0969da;
+  --vscode-commandCenter-foreground: #57606a;
+  --vscode-commandCenter-activeForeground: #57606a;
+  --vscode-commandCenter-inactiveForeground: #57606a;
+  --vscode-commandCenter-background: rgba(0, 0, 0, 0.05);
+  --vscode-commandCenter-activeBackground: rgba(0, 0, 0, 0.08);
+  --vscode-commandCenter-border: rgba(87, 96, 106, 0.2);
+  --vscode-commandCenter-activeBorder: rgba(87, 96, 106, 0.3);
+  --vscode-commandCenter-inactiveBorder: rgba(87, 96, 106, 0.25);
+  --vscode-editorCommentsWidget-resolvedBorder: rgba(97, 97, 97, 0.5);
+  --vscode-editorCommentsWidget-unresolvedBorder: #1a85ff;
+  --vscode-editorCommentsWidget-rangeBackground: rgba(26, 133, 255, 0.1);
+  --vscode-editorCommentsWidget-rangeBorder: rgba(26, 133, 255, 0.4);
+  --vscode-editorCommentsWidget-rangeActiveBackground: rgba(26, 133, 255, 0.1);
+  --vscode-editorCommentsWidget-rangeActiveBorder: rgba(26, 133, 255, 0.4);
+  --vscode-editorGutter-commentRangeForeground: rgba(165, 175, 185, 0.2);
+  --vscode-debugToolBar-background: #ffffff;
+  --vscode-debugIcon-startForeground: #388a34;
+  --vscode-editor-stackFrameHighlightBackground: rgba(212, 167, 44, 0.4);
+  --vscode-editor-focusedStackFrameHighlightBackground: rgba(74, 194, 107, 0.4);
+  --vscode-mergeEditor-change\.background: rgba(155, 185, 85, 0.2);
+  --vscode-mergeEditor-change\.word\.background: rgba(156, 204, 44, 0.4);
+  --vscode-mergeEditor-changeBase\.background: #ffcccc;
+  --vscode-mergeEditor-changeBase\.word\.background: #ffa3a3;
+  --vscode-mergeEditor-conflict\.unhandledUnfocused\.border: #ffa600;
+  --vscode-mergeEditor-conflict\.unhandledFocused\.border: #ffa600;
+  --vscode-mergeEditor-conflict\.handledUnfocused\.border: rgba(
+    134,
+    134,
+    134,
+    0.29
+  );
+  --vscode-mergeEditor-conflict\.handledFocused\.border: rgba(
+    193,
+    193,
+    193,
+    0.8
+  );
+  --vscode-mergeEditor-conflict\.handled\.minimapOverViewRuler: rgba(
+    173,
+    172,
+    168,
+    0.93
+  );
+  --vscode-mergeEditor-conflict\.unhandled\.minimapOverViewRuler: #fcba03;
+  --vscode-mergeEditor-conflictingLines\.background: rgba(255, 234, 0, 0.28);
+  --vscode-mergeEditor-conflict\.input1\.background: rgba(64, 200, 174, 0.2);
+  --vscode-mergeEditor-conflict\.input2\.background: rgba(64, 166, 255, 0.2);
+  --vscode-settings-headerForeground: #57606a;
+  --vscode-settings-modifiedItemIndicator: rgba(212, 167, 44, 0.4);
+  --vscode-settings-headerBorder: #d0d7de;
+  --vscode-settings-sashBorder: #d0d7de;
+  --vscode-settings-dropdownBackground: #ffffff;
+  --vscode-settings-dropdownForeground: #24292f;
+  --vscode-settings-dropdownBorder: #d0d7de;
+  --vscode-settings-dropdownListBorder: #c8c8c8;
+  --vscode-settings-checkboxBackground: #f6f8fa;
+  --vscode-settings-checkboxForeground: #24292f;
+  --vscode-settings-checkboxBorder: #d0d7de;
+  --vscode-settings-textInputBackground: #ffffff;
+  --vscode-settings-textInputForeground: #24292f;
+  --vscode-settings-textInputBorder: #d0d7de;
+  --vscode-settings-numberInputBackground: #ffffff;
+  --vscode-settings-numberInputForeground: #24292f;
+  --vscode-settings-numberInputBorder: #d0d7de;
+  --vscode-settings-focusedRowBackground: rgba(234, 238, 242, 0.3);
+  --vscode-settings-rowHoverBackground: rgba(234, 238, 242, 0.15);
+  --vscode-settings-focusedRowBorder: #0969da;
+  --vscode-terminal-foreground: #24292f;
+  --vscode-terminal-selectionBackground: #add6ff;
+  --vscode-terminal-inactiveSelectionBackground: rgba(173, 214, 255, 0.5);
+  --vscode-terminalCommandDecoration-defaultBackground: rgba(0, 0, 0, 0.25);
+  --vscode-terminalCommandDecoration-successBackground: #2090d3;
+  --vscode-terminalCommandDecoration-errorBackground: #e51400;
+  --vscode-terminalOverviewRuler-cursorForeground: rgba(160, 160, 160, 0.8);
+  --vscode-terminal-border: #d0d7de;
+  --vscode-terminal-findMatchBackground: #bf8700;
+  --vscode-terminal-findMatchHighlightBackground: rgba(250, 225, 125, 0.5);
+  --vscode-terminalOverviewRuler-findMatchForeground: rgba(209, 134, 22, 0.49);
+  --vscode-terminal-dropBackground: rgba(38, 119, 203, 0.18);
+  --vscode-terminal-tab\.activeBorder: #ffffff;
+  --vscode-testing-iconFailed: #f14c4c;
+  --vscode-testing-iconErrored: #f14c4c;
+  --vscode-testing-iconPassed: #73c991;
+  --vscode-testing-runAction: #73c991;
+  --vscode-testing-iconQueued: #cca700;
+  --vscode-testing-iconUnset: #848484;
+  --vscode-testing-iconSkipped: #848484;
+  --vscode-testing-peekBorder: #e51400;
+  --vscode-testing-peekHeaderBackground: rgba(229, 20, 0, 0.1);
+  --vscode-testing-message\.error\.decorationForeground: #e51400;
+  --vscode-testing-message\.error\.lineBackground: rgba(255, 0, 0, 0.2);
+  --vscode-testing-message\.info\.decorationForeground: rgba(36, 41, 47, 0.5);
+  --vscode-welcomePage-tileBackground: #ffffff;
+  --vscode-welcomePage-tileHoverBackground: #e6e6e6;
+  --vscode-welcomePage-tileBorder: rgba(0, 0, 0, 0.1);
+  --vscode-welcomePage-progress\.background: #ffffff;
+  --vscode-welcomePage-progress\.foreground: #0969da;
+  --vscode-walkthrough-stepTitle\.foreground: #000000;
+  --vscode-debugExceptionWidget-border: #a31515;
+  --vscode-debugExceptionWidget-background: #f1dfde;
+  --vscode-ports-iconRunningProcessForeground: #eaeef2;
+  --vscode-statusBar-debuggingBackground: #cf222e;
+  --vscode-statusBar-debuggingForeground: #ffffff;
+  --vscode-statusBar-debuggingBorder: #d0d7de;
+  --vscode-editor-inlineValuesForeground: rgba(0, 0, 0, 0.5);
+  --vscode-editor-inlineValuesBackground: rgba(255, 200, 0, 0.2);
+  --vscode-editorGutter-modifiedBackground: rgba(212, 167, 44, 0.4);
+  --vscode-editorGutter-addedBackground: rgba(74, 194, 107, 0.4);
+  --vscode-editorGutter-deletedBackground: rgba(255, 129, 130, 0.4);
+  --vscode-minimapGutter-modifiedBackground: rgba(212, 167, 44, 0.4);
+  --vscode-minimapGutter-addedBackground: rgba(74, 194, 107, 0.4);
+  --vscode-minimapGutter-deletedBackground: rgba(255, 129, 130, 0.4);
+  --vscode-editorOverviewRuler-modifiedForeground: rgba(212, 167, 44, 0.24);
+  --vscode-editorOverviewRuler-addedForeground: rgba(74, 194, 107, 0.24);
+  --vscode-editorOverviewRuler-deletedForeground: rgba(255, 129, 130, 0.24);
+  --vscode-debugIcon-breakpointForeground: #cf222e;
+  --vscode-debugIcon-breakpointDisabledForeground: #848484;
+  --vscode-debugIcon-breakpointUnverifiedForeground: #848484;
+  --vscode-debugIcon-breakpointCurrentStackframeForeground: #be8700;
+  --vscode-debugIcon-breakpointStackframeForeground: #89d185;
+  --vscode-notebook-cellBorderColor: rgba(175, 184, 193, 0.2);
+  --vscode-notebook-focusedEditorBorder: #0969da;
+  --vscode-notebookStatusSuccessIcon-foreground: #388a34;
+  --vscode-notebookStatusErrorIcon-foreground: #cf222e;
+  --vscode-notebookStatusRunningIcon-foreground: #24292f;
+  --vscode-notebook-cellToolbarSeparator: rgba(128, 128, 128, 0.35);
+  --vscode-notebook-selectedCellBackground: rgba(175, 184, 193, 0.2);
+  --vscode-notebook-selectedCellBorder: rgba(175, 184, 193, 0.2);
+  --vscode-notebook-focusedCellBorder: #0969da;
+  --vscode-notebook-inactiveFocusedCellBorder: rgba(175, 184, 193, 0.2);
+  --vscode-notebook-cellStatusBarItemHoverBackground: rgba(0, 0, 0, 0.08);
+  --vscode-notebook-cellInsertionIndicator: #0969da;
+  --vscode-notebookScrollbarSlider-background: rgba(140, 149, 159, 0.2);
+  --vscode-notebookScrollbarSlider-hoverBackground: rgba(140, 149, 159, 0.27);
+  --vscode-notebookScrollbarSlider-activeBackground: rgba(140, 149, 159, 0.53);
+  --vscode-notebook-symbolHighlightBackground: rgba(253, 255, 0, 0.2);
+  --vscode-notebook-cellEditorBackground: #f6f8fa;
+  --vscode-notebook-editorBackground: #ffffff;
+  --vscode-keybindingTable-headerBackground: rgba(36, 41, 47, 0.04);
+  --vscode-keybindingTable-rowsBackground: rgba(36, 41, 47, 0.04);
+  --vscode-scm-providerBorder: #c8c8c8;
+  --vscode-searchEditor-textInputBorder: #d0d7de;
+  --vscode-debugTokenExpression-name: #0550ae;
+  --vscode-debugTokenExpression-value: #0a3069;
+  --vscode-debugTokenExpression-string: #0a3069;
+  --vscode-debugTokenExpression-boolean: #116329;
+  --vscode-debugTokenExpression-number: #116329;
+  --vscode-debugTokenExpression-error: #a40e26;
+  --vscode-debugView-exceptionLabelForeground: #ffffff;
+  --vscode-debugView-exceptionLabelBackground: #a31515;
+  --vscode-debugView-stateLabelForeground: #24292f;
+  --vscode-debugView-stateLabelBackground: rgba(136, 136, 136, 0.27);
+  --vscode-debugView-valueChangedHighlight: #569cd6;
+  --vscode-debugConsole-infoForeground: #57606a;
+  --vscode-debugConsole-warningForeground: #7d4e00;
+  --vscode-debugConsole-errorForeground: #cf222e;
+  --vscode-debugConsole-sourceForeground: #9a6700;
+  --vscode-debugConsoleInputIcon-foreground: #6639ba;
+  --vscode-debugIcon-pauseForeground: #007acc;
+  --vscode-debugIcon-stopForeground: #a1260d;
+  --vscode-debugIcon-disconnectForeground: #a1260d;
+  --vscode-debugIcon-restartForeground: #388a34;
+  --vscode-debugIcon-stepOverForeground: #007acc;
+  --vscode-debugIcon-stepIntoForeground: #007acc;
+  --vscode-debugIcon-stepOutForeground: #007acc;
+  --vscode-debugIcon-continueForeground: #007acc;
+  --vscode-debugIcon-stepBackForeground: #007acc;
+  --vscode-extensionButton-background: #2da44e;
+  --vscode-extensionButton-foreground: #ffffff;
+  --vscode-extensionButton-hoverBackground: #2c974b;
+  --vscode-extensionButton-separator: rgba(255, 255, 255, 0.4);
+  --vscode-extensionButton-prominentBackground: #2da44e;
+  --vscode-extensionButton-prominentForeground: #ffffff;
+  --vscode-extensionButton-prominentHoverBackground: #2c974b;
+  --vscode-extensionIcon-starForeground: #df6100;
+  --vscode-extensionIcon-verifiedForeground: #0969da;
+  --vscode-extensionIcon-preReleaseForeground: #1d9271;
+  --vscode-extensionIcon-sponsorForeground: #b51e78;
+  --vscode-terminal-ansiBlack: #24292f;
+  --vscode-terminal-ansiRed: #cf222e;
+  --vscode-terminal-ansiGreen: #116329;
+  --vscode-terminal-ansiYellow: #4d2d00;
+  --vscode-terminal-ansiBlue: #0969da;
+  --vscode-terminal-ansiMagenta: #8250df;
+  --vscode-terminal-ansiCyan: #1b7c83;
+  --vscode-terminal-ansiWhite: #6e7781;
+  --vscode-terminal-ansiBrightBlack: #57606a;
+  --vscode-terminal-ansiBrightRed: #a40e26;
+  --vscode-terminal-ansiBrightGreen: #1a7f37;
+  --vscode-terminal-ansiBrightYellow: #633c01;
+  --vscode-terminal-ansiBrightBlue: #218bff;
+  --vscode-terminal-ansiBrightMagenta: #a475f9;
+  --vscode-terminal-ansiBrightCyan: #3192aa;
+  --vscode-terminal-ansiBrightWhite: #8c959f;
+  --vscode-interactive-activeCodeBorder: #1a85ff;
+  --vscode-interactive-inactiveCodeBorder: rgba(175, 184, 193, 0.2);
+  --vscode-gitDecoration-addedResourceForeground: #1a7f37;
+  --vscode-gitDecoration-modifiedResourceForeground: #9a6700;
+  --vscode-gitDecoration-deletedResourceForeground: #cf222e;
+  --vscode-gitDecoration-renamedResourceForeground: #007100;
+  --vscode-gitDecoration-untrackedResourceForeground: #1a7f37;
+  --vscode-gitDecoration-ignoredResourceForeground: #6e7781;
+  --vscode-gitDecoration-stageModifiedResourceForeground: #895503;
+  --vscode-gitDecoration-stageDeletedResourceForeground: #ad0707;
+  --vscode-gitDecoration-conflictingResourceForeground: #bc4c00;
+  --vscode-gitDecoration-submoduleResourceForeground: #57606a;
+  --vscode-testExplorer-errorDecorationBackground: #f2dede;
+}
+
+/**
+ * This is copied in the same way, but from the <body> element
+ */
+body {
+  background-color: transparent;
+  color: var(--vscode-editor-foreground);
+  font-family: var(--vscode-font-family);
+  font-weight: var(--vscode-font-weight);
+  font-size: var(--vscode-font-size);
+  margin: 0;
+  padding: 0 20px;
+}
+
+/**
+ * This is used for setting the background on the Storybook preview.
+ */
+body {
+  background-color: var(--vscode-editor-background);
+}

--- a/extensions/ql-vscode/src/stories/vscode-theme-light-high-contrast.css
+++ b/extensions/ql-vscode/src/stories/vscode-theme-light-high-contrast.css
@@ -1,0 +1,596 @@
+/*
+ * These were copied from VSCode Light High Contrast theme.
+ *
+ * To update these, open a webview in VSCode, open the webview developer tools and find the
+ * iframe hosting the webview. The <html> element will have a style attribute that contains
+ * the CSS variables. Copy these to this file.
+ */
+:root {
+  --vscode-font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+  --vscode-font-weight: normal;
+  --vscode-font-size: 13px;
+  --vscode-editor-font-family: Menlo, Monaco, "Courier New", monospace;
+  --vscode-editor-font-weight: normal;
+  --vscode-editor-font-size: 12px;
+  --vscode-foreground: #292929;
+  --vscode-disabledForeground: #7f7f7f;
+  --vscode-errorForeground: #b5200d;
+  --vscode-descriptionForeground: rgba(41, 41, 41, 0.7);
+  --vscode-icon-foreground: #292929;
+  --vscode-focusBorder: #0f4a85;
+  --vscode-contrastBorder: #0f4a85;
+  --vscode-contrastActiveBorder: #0f4a85;
+  --vscode-textSeparator-foreground: #292929;
+  --vscode-textLink-foreground: #0f4a85;
+  --vscode-textLink-activeForeground: #0f4a85;
+  --vscode-textPreformat-foreground: #292929;
+  --vscode-textBlockQuote-background: #f2f2f2;
+  --vscode-textBlockQuote-border: #292929;
+  --vscode-textCodeBlock-background: #f2f2f2;
+  --vscode-input-background: #ffffff;
+  --vscode-input-foreground: #292929;
+  --vscode-input-border: #0f4a85;
+  --vscode-inputOption-activeBorder: #0f4a85;
+  --vscode-inputOption-activeBackground: rgba(0, 0, 0, 0);
+  --vscode-inputOption-activeForeground: #292929;
+  --vscode-input-placeholderForeground: rgba(41, 41, 41, 0.7);
+  --vscode-inputValidation-infoBackground: #ffffff;
+  --vscode-inputValidation-infoForeground: #292929;
+  --vscode-inputValidation-infoBorder: #0f4a85;
+  --vscode-inputValidation-warningBackground: #ffffff;
+  --vscode-inputValidation-warningForeground: #292929;
+  --vscode-inputValidation-warningBorder: #0f4a85;
+  --vscode-inputValidation-errorBackground: #ffffff;
+  --vscode-inputValidation-errorForeground: #292929;
+  --vscode-inputValidation-errorBorder: #0f4a85;
+  --vscode-dropdown-background: #ffffff;
+  --vscode-dropdown-listBackground: #ffffff;
+  --vscode-dropdown-foreground: #292929;
+  --vscode-dropdown-border: #0f4a85;
+  --vscode-button-foreground: #ffffff;
+  --vscode-button-separator: rgba(255, 255, 255, 0.4);
+  --vscode-button-background: #0f4a85;
+  --vscode-button-hoverBackground: #0f4a85;
+  --vscode-button-border: #0f4a85;
+  --vscode-button-secondaryForeground: #292929;
+  --vscode-button-secondaryBackground: #ffffff;
+  --vscode-badge-background: #0f4a85;
+  --vscode-badge-foreground: #ffffff;
+  --vscode-scrollbarSlider-background: rgba(15, 74, 133, 0.4);
+  --vscode-scrollbarSlider-hoverBackground: rgba(15, 74, 133, 0.8);
+  --vscode-scrollbarSlider-activeBackground: #0f4a85;
+  --vscode-progressBar-background: #0f4a85;
+  --vscode-editorError-foreground: #b5200d;
+  --vscode-editorError-border: #b5200d;
+  --vscode-editorWarning-foreground: #895503;
+  --vscode-editorWarning-border: #ff0000;
+  --vscode-editorInfo-foreground: #1a85ff;
+  --vscode-editorInfo-border: #292929;
+  --vscode-editorHint-border: #292929;
+  --vscode-sash-hoverBorder: #0f4a85;
+  --vscode-editor-background: #ffffff;
+  --vscode-editor-foreground: #292929;
+  --vscode-editorStickyScroll-background: #ffffff;
+  --vscode-editorStickyScrollHover-background: rgba(15, 74, 133, 0.1);
+  --vscode-editorWidget-background: #ffffff;
+  --vscode-editorWidget-foreground: #292929;
+  --vscode-editorWidget-border: #0f4a85;
+  --vscode-quickInput-background: #ffffff;
+  --vscode-quickInput-foreground: #292929;
+  --vscode-quickInputTitle-background: #ffffff;
+  --vscode-pickerGroup-foreground: #0f4a85;
+  --vscode-pickerGroup-border: #0f4a85;
+  --vscode-keybindingLabel-background: rgba(0, 0, 0, 0);
+  --vscode-keybindingLabel-foreground: #292929;
+  --vscode-keybindingLabel-border: #0f4a85;
+  --vscode-keybindingLabel-bottomBorder: #292929;
+  --vscode-editor-selectionBackground: #0f4a85;
+  --vscode-editor-selectionForeground: #ffffff;
+  --vscode-editor-inactiveSelectionBackground: rgba(15, 74, 133, 0.5);
+  --vscode-editor-selectionHighlightBorder: #0f4a85;
+  --vscode-editor-findMatchBorder: #0f4a85;
+  --vscode-editor-findMatchHighlightBorder: #0f4a85;
+  --vscode-editor-findRangeHighlightBorder: rgba(15, 74, 133, 0.4);
+  --vscode-searchEditor-findMatchBorder: #0f4a85;
+  --vscode-editorHoverWidget-background: #ffffff;
+  --vscode-editorHoverWidget-foreground: #292929;
+  --vscode-editorHoverWidget-border: #0f4a85;
+  --vscode-editorHoverWidget-statusBarBackground: #ffffff;
+  --vscode-editorLink-activeForeground: #292929;
+  --vscode-editorInlayHint-foreground: #ffffff;
+  --vscode-editorInlayHint-background: #0f4a85;
+  --vscode-editorInlayHint-typeForeground: #ffffff;
+  --vscode-editorInlayHint-typeBackground: #0f4a85;
+  --vscode-editorInlayHint-parameterForeground: #ffffff;
+  --vscode-editorInlayHint-parameterBackground: #0f4a85;
+  --vscode-editorLightBulb-foreground: #007acc;
+  --vscode-editorLightBulbAutoFix-foreground: #007acc;
+  --vscode-diffEditor-insertedTextBorder: #374e06;
+  --vscode-diffEditor-removedTextBorder: #ad0707;
+  --vscode-diffEditor-border: #0f4a85;
+  --vscode-list-focusOutline: #0f4a85;
+  --vscode-list-activeSelectionBackground: rgba(15, 74, 133, 0.1);
+  --vscode-list-inactiveSelectionBackground: rgba(15, 74, 133, 0.1);
+  --vscode-list-hoverBackground: rgba(15, 74, 133, 0.1);
+  --vscode-list-highlightForeground: #0f4a85;
+  --vscode-list-focusHighlightForeground: #0f4a85;
+  --vscode-list-invalidItemForeground: #b5200d;
+  --vscode-listFilterWidget-background: #ffffff;
+  --vscode-listFilterWidget-outline: #007acc;
+  --vscode-listFilterWidget-noMatchesOutline: #0f4a85;
+  --vscode-list-filterMatchBorder: #0f4a85;
+  --vscode-tree-indentGuidesStroke: #a5a5a5;
+  --vscode-list-deemphasizedForeground: #666666;
+  --vscode-checkbox-background: #ffffff;
+  --vscode-checkbox-selectBackground: #ffffff;
+  --vscode-checkbox-foreground: #292929;
+  --vscode-checkbox-border: #0f4a85;
+  --vscode-checkbox-selectBorder: #ffffff;
+  --vscode-menu-border: #0f4a85;
+  --vscode-menu-foreground: #292929;
+  --vscode-menu-background: #ffffff;
+  --vscode-menu-selectionBackground: rgba(15, 74, 133, 0.1);
+  --vscode-menu-selectionBorder: #0f4a85;
+  --vscode-menu-separatorBackground: #0f4a85;
+  --vscode-toolbar-hoverOutline: #0f4a85;
+  --vscode-editor-snippetTabstopHighlightBackground: rgba(10, 50, 100, 0.2);
+  --vscode-editor-snippetFinalTabstopHighlightBorder: #292929;
+  --vscode-breadcrumb-foreground: rgba(41, 41, 41, 0.8);
+  --vscode-breadcrumb-background: #ffffff;
+  --vscode-breadcrumb-focusForeground: #2d2d2d;
+  --vscode-breadcrumb-activeSelectionForeground: #2d2d2d;
+  --vscode-breadcrumbPicker-background: #ffffff;
+  --vscode-merge-border: #007acc;
+  --vscode-editorOverviewRuler-currentContentForeground: #007acc;
+  --vscode-editorOverviewRuler-incomingContentForeground: #007acc;
+  --vscode-editorOverviewRuler-commonContentForeground: #007acc;
+  --vscode-editorOverviewRuler-selectionHighlightForeground: rgba(
+    160,
+    160,
+    160,
+    0.8
+  );
+  --vscode-minimap-findMatchHighlight: #0f4a85;
+  --vscode-minimap-selectionOccurrenceHighlight: #0f4a85;
+  --vscode-minimap-selectionHighlight: #0f4a85;
+  --vscode-minimap-errorHighlight: #b5200d;
+  --vscode-minimap-warningHighlight: #ff0000;
+  --vscode-minimap-foregroundOpacity: #000000;
+  --vscode-minimapSlider-background: rgba(15, 74, 133, 0.2);
+  --vscode-minimapSlider-hoverBackground: rgba(15, 74, 133, 0.4);
+  --vscode-minimapSlider-activeBackground: rgba(15, 74, 133, 0.5);
+  --vscode-problemsErrorIcon-foreground: #b5200d;
+  --vscode-problemsWarningIcon-foreground: #895503;
+  --vscode-problemsInfoIcon-foreground: #1a85ff;
+  --vscode-charts-foreground: #292929;
+  --vscode-charts-lines: rgba(41, 41, 41, 0.5);
+  --vscode-charts-red: #b5200d;
+  --vscode-charts-blue: #1a85ff;
+  --vscode-charts-yellow: #895503;
+  --vscode-charts-orange: #0f4a85;
+  --vscode-charts-green: #374e06;
+  --vscode-charts-purple: #652d90;
+  --vscode-symbolIcon-arrayForeground: #292929;
+  --vscode-symbolIcon-booleanForeground: #292929;
+  --vscode-symbolIcon-classForeground: #d67e00;
+  --vscode-symbolIcon-colorForeground: #292929;
+  --vscode-symbolIcon-constantForeground: #292929;
+  --vscode-symbolIcon-constructorForeground: #652d90;
+  --vscode-symbolIcon-enumeratorForeground: #d67e00;
+  --vscode-symbolIcon-enumeratorMemberForeground: #007acc;
+  --vscode-symbolIcon-eventForeground: #d67e00;
+  --vscode-symbolIcon-fieldForeground: #007acc;
+  --vscode-symbolIcon-fileForeground: #292929;
+  --vscode-symbolIcon-folderForeground: #292929;
+  --vscode-symbolIcon-functionForeground: #652d90;
+  --vscode-symbolIcon-interfaceForeground: #007acc;
+  --vscode-symbolIcon-keyForeground: #292929;
+  --vscode-symbolIcon-keywordForeground: #292929;
+  --vscode-symbolIcon-methodForeground: #652d90;
+  --vscode-symbolIcon-moduleForeground: #292929;
+  --vscode-symbolIcon-namespaceForeground: #292929;
+  --vscode-symbolIcon-nullForeground: #292929;
+  --vscode-symbolIcon-numberForeground: #292929;
+  --vscode-symbolIcon-objectForeground: #292929;
+  --vscode-symbolIcon-operatorForeground: #292929;
+  --vscode-symbolIcon-packageForeground: #292929;
+  --vscode-symbolIcon-propertyForeground: #292929;
+  --vscode-symbolIcon-referenceForeground: #292929;
+  --vscode-symbolIcon-snippetForeground: #292929;
+  --vscode-symbolIcon-stringForeground: #292929;
+  --vscode-symbolIcon-structForeground: #292929;
+  --vscode-symbolIcon-textForeground: #292929;
+  --vscode-symbolIcon-typeParameterForeground: #292929;
+  --vscode-symbolIcon-unitForeground: #292929;
+  --vscode-symbolIcon-variableForeground: #007acc;
+  --vscode-editor-lineHighlightBorder: #0f4a85;
+  --vscode-editor-rangeHighlightBorder: #0f4a85;
+  --vscode-editor-symbolHighlightBorder: #0f4a85;
+  --vscode-editorCursor-foreground: #0f4a85;
+  --vscode-editorWhitespace-foreground: #cccccc;
+  --vscode-editorIndentGuide-background: #cccccc;
+  --vscode-editorIndentGuide-activeBackground: #cccccc;
+  --vscode-editorLineNumber-foreground: #292929;
+  --vscode-editorActiveLineNumber-foreground: #0f4a85;
+  --vscode-editorLineNumber-activeForeground: #0f4a85;
+  --vscode-editorRuler-foreground: #292929;
+  --vscode-editorCodeLens-foreground: #292929;
+  --vscode-editorBracketMatch-background: rgba(0, 0, 0, 0);
+  --vscode-editorBracketMatch-border: #0f4a85;
+  --vscode-editorOverviewRuler-border: #666666;
+  --vscode-editorGutter-background: #ffffff;
+  --vscode-editorUnnecessaryCode-border: #0f4a85;
+  --vscode-editorGhostText-border: rgba(41, 41, 41, 0.8);
+  --vscode-editorOverviewRuler-rangeHighlightForeground: rgba(0, 122, 204, 0.6);
+  --vscode-editorOverviewRuler-errorForeground: #b5200d;
+  --vscode-editorOverviewRuler-warningForeground: #ff0000;
+  --vscode-editorOverviewRuler-infoForeground: #292929;
+  --vscode-editorBracketHighlight-foreground1: #0431fa;
+  --vscode-editorBracketHighlight-foreground2: #319331;
+  --vscode-editorBracketHighlight-foreground3: #7b3814;
+  --vscode-editorBracketHighlight-foreground4: rgba(0, 0, 0, 0);
+  --vscode-editorBracketHighlight-foreground5: rgba(0, 0, 0, 0);
+  --vscode-editorBracketHighlight-foreground6: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-background1: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-background2: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-background3: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-background4: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-background5: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-background6: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-activeBackground1: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-activeBackground2: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-activeBackground3: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-activeBackground4: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-activeBackground5: rgba(0, 0, 0, 0);
+  --vscode-editorBracketPairGuide-activeBackground6: rgba(0, 0, 0, 0);
+  --vscode-editorHoverWidget-highlightForeground: #0f4a85;
+  --vscode-editorOverviewRuler-bracketMatchForeground: #a0a0a0;
+  --vscode-editorGutter-foldingControlForeground: #292929;
+  --vscode-editor-linkedEditingBackground: #ffffff;
+  --vscode-editor-wordHighlightBorder: #0f4a85;
+  --vscode-editor-wordHighlightStrongBorder: #0f4a85;
+  --vscode-editorOverviewRuler-wordHighlightForeground: rgba(
+    160,
+    160,
+    160,
+    0.8
+  );
+  --vscode-editorOverviewRuler-wordHighlightStrongForeground: rgba(
+    192,
+    160,
+    192,
+    0.8
+  );
+  --vscode-peekViewTitleLabel-foreground: #292929;
+  --vscode-peekViewTitleDescription-foreground: #292929;
+  --vscode-peekView-border: #0f4a85;
+  --vscode-peekViewResult-background: #ffffff;
+  --vscode-peekViewResult-lineForeground: #292929;
+  --vscode-peekViewResult-fileForeground: #292929;
+  --vscode-peekViewResult-selectionForeground: #292929;
+  --vscode-peekViewEditor-background: #ffffff;
+  --vscode-peekViewEditorGutter-background: #ffffff;
+  --vscode-peekViewEditor-matchHighlightBorder: #0f4a85;
+  --vscode-editorMarkerNavigationError-background: #0f4a85;
+  --vscode-editorMarkerNavigationWarning-background: #0f4a85;
+  --vscode-editorMarkerNavigationWarning-headerBackground: rgba(
+    15,
+    74,
+    133,
+    0.2
+  );
+  --vscode-editorMarkerNavigationInfo-background: #0f4a85;
+  --vscode-editorMarkerNavigation-background: #ffffff;
+  --vscode-editorSuggestWidget-background: #ffffff;
+  --vscode-editorSuggestWidget-border: #0f4a85;
+  --vscode-editorSuggestWidget-foreground: #292929;
+  --vscode-editorSuggestWidget-highlightForeground: #0f4a85;
+  --vscode-editorSuggestWidget-focusHighlightForeground: #0f4a85;
+  --vscode-editorSuggestWidgetStatus-foreground: rgba(41, 41, 41, 0.5);
+  --vscode-tab-activeBackground: #ffffff;
+  --vscode-tab-unfocusedActiveBackground: #ffffff;
+  --vscode-tab-activeForeground: #292929;
+  --vscode-tab-inactiveForeground: #292929;
+  --vscode-tab-unfocusedActiveForeground: #292929;
+  --vscode-tab-unfocusedInactiveForeground: #292929;
+  --vscode-tab-border: #0f4a85;
+  --vscode-tab-lastPinnedBorder: #0f4a85;
+  --vscode-tab-activeBorderTop: #b5200d;
+  --vscode-tab-unfocusedActiveBorderTop: #b5200d;
+  --vscode-tab-unfocusedHoverBorder: #0f4a85;
+  --vscode-tab-activeModifiedBorder: #0f4a85;
+  --vscode-tab-inactiveModifiedBorder: #0f4a85;
+  --vscode-tab-unfocusedActiveModifiedBorder: #0f4a85;
+  --vscode-tab-unfocusedInactiveModifiedBorder: #0f4a85;
+  --vscode-editorPane-background: #ffffff;
+  --vscode-editorGroup-focusedEmptyBorder: #0f4a85;
+  --vscode-editorGroupHeader-noTabsBackground: #ffffff;
+  --vscode-editorGroupHeader-border: #0f4a85;
+  --vscode-editorGroup-border: #0f4a85;
+  --vscode-editorGroup-dropBackground: rgba(15, 74, 133, 0.5);
+  --vscode-editorGroup-dropIntoPromptForeground: #292929;
+  --vscode-editorGroup-dropIntoPromptBackground: #ffffff;
+  --vscode-editorGroup-dropIntoPromptBorder: #0f4a85;
+  --vscode-sideBySideEditor-horizontalBorder: #0f4a85;
+  --vscode-sideBySideEditor-verticalBorder: #0f4a85;
+  --vscode-panel-background: #ffffff;
+  --vscode-panel-border: #0f4a85;
+  --vscode-panelTitle-activeForeground: #292929;
+  --vscode-panelTitle-inactiveForeground: #292929;
+  --vscode-panelTitle-activeBorder: #b5200d;
+  --vscode-panelInput-border: #0f4a85;
+  --vscode-panel-dropBorder: #292929;
+  --vscode-panelSection-dropBackground: rgba(15, 74, 133, 0.5);
+  --vscode-panelSectionHeader-border: #0f4a85;
+  --vscode-panelSection-border: #0f4a85;
+  --vscode-banner-background: rgba(15, 74, 133, 0.1);
+  --vscode-banner-iconForeground: #1a85ff;
+  --vscode-statusBar-foreground: #292929;
+  --vscode-statusBar-noFolderForeground: #292929;
+  --vscode-statusBar-border: #0f4a85;
+  --vscode-statusBar-focusBorder: #292929;
+  --vscode-statusBar-noFolderBorder: #0f4a85;
+  --vscode-statusBarItem-activeBackground: rgba(0, 0, 0, 0.18);
+  --vscode-statusBarItem-focusBorder: #0f4a85;
+  --vscode-statusBarItem-hoverBackground: rgba(0, 0, 0, 0.12);
+  --vscode-statusBarItem-compactHoverBackground: rgba(0, 0, 0, 0.2);
+  --vscode-statusBarItem-prominentForeground: #292929;
+  --vscode-statusBarItem-prominentBackground: rgba(0, 0, 0, 0.5);
+  --vscode-statusBarItem-errorBackground: #b5200d;
+  --vscode-statusBarItem-errorForeground: #ffffff;
+  --vscode-statusBarItem-warningBackground: #895503;
+  --vscode-statusBarItem-warningForeground: #ffffff;
+  --vscode-activityBar-background: #ffffff;
+  --vscode-activityBar-foreground: #292929;
+  --vscode-activityBar-inactiveForeground: #292929;
+  --vscode-activityBar-border: #0f4a85;
+  --vscode-activityBar-activeBorder: #0f4a85;
+  --vscode-activityBar-activeFocusBorder: #b5200d;
+  --vscode-activityBarBadge-background: #0f4a85;
+  --vscode-activityBarBadge-foreground: #ffffff;
+  --vscode-activityBarItem-profilesForeground: #292929;
+  --vscode-activityBarItem-profilesHoverForeground: #292929;
+  --vscode-statusBarItem-remoteBackground: #0f4a85;
+  --vscode-statusBarItem-remoteForeground: #ffffff;
+  --vscode-extensionBadge-remoteBackground: #0f4a85;
+  --vscode-extensionBadge-remoteForeground: #ffffff;
+  --vscode-sideBar-background: #ffffff;
+  --vscode-sideBar-border: #0f4a85;
+  --vscode-sideBar-dropBackground: rgba(15, 74, 133, 0.5);
+  --vscode-sideBarSectionHeader-border: #0f4a85;
+  --vscode-titleBar-activeForeground: #292929;
+  --vscode-titleBar-inactiveForeground: #292929;
+  --vscode-titleBar-activeBackground: #ffffff;
+  --vscode-titleBar-border: #0f4a85;
+  --vscode-menubar-selectionForeground: #292929;
+  --vscode-menubar-selectionBorder: #0f4a85;
+  --vscode-notificationCenter-border: #0f4a85;
+  --vscode-notificationToast-border: #0f4a85;
+  --vscode-notifications-foreground: #292929;
+  --vscode-notifications-background: #ffffff;
+  --vscode-notificationLink-foreground: #0f4a85;
+  --vscode-notificationCenterHeader-background: #ffffff;
+  --vscode-notifications-border: #ffffff;
+  --vscode-notificationsErrorIcon-foreground: #b5200d;
+  --vscode-notificationsWarningIcon-foreground: #895503;
+  --vscode-notificationsInfoIcon-foreground: #1a85ff;
+  --vscode-window-activeBorder: #0f4a85;
+  --vscode-window-inactiveBorder: #0f4a85;
+  --vscode-commandCenter-foreground: #292929;
+  --vscode-commandCenter-activeForeground: #292929;
+  --vscode-commandCenter-inactiveForeground: #292929;
+  --vscode-commandCenter-border: rgba(41, 41, 41, 0.6);
+  --vscode-commandCenter-activeBorder: #292929;
+  --vscode-commandCenter-inactiveBorder: rgba(41, 41, 41, 0.25);
+  --vscode-editorCommentsWidget-resolvedBorder: #0f4a85;
+  --vscode-editorCommentsWidget-unresolvedBorder: #0f4a85;
+  --vscode-editorCommentsWidget-rangeBackground: rgba(15, 74, 133, 0.1);
+  --vscode-editorCommentsWidget-rangeBorder: rgba(15, 74, 133, 0.4);
+  --vscode-editorCommentsWidget-rangeActiveBackground: rgba(15, 74, 133, 0.1);
+  --vscode-editorCommentsWidget-rangeActiveBorder: rgba(15, 74, 133, 0.2);
+  --vscode-editorGutter-commentRangeForeground: #000000;
+  --vscode-debugToolBar-background: #ffffff;
+  --vscode-debugIcon-startForeground: #388a34;
+  --vscode-editor-stackFrameHighlightBackground: rgba(255, 255, 102, 0.45);
+  --vscode-editor-focusedStackFrameHighlightBackground: rgba(
+    206,
+    231,
+    206,
+    0.45
+  );
+  --vscode-mergeEditor-change\.background: rgba(155, 185, 85, 0.2);
+  --vscode-mergeEditor-change\.word\.background: rgba(156, 204, 44, 0.4);
+  --vscode-mergeEditor-changeBase\.background: #ffcccc;
+  --vscode-mergeEditor-changeBase\.word\.background: #ffa3a3;
+  --vscode-mergeEditor-conflict\.unhandledUnfocused\.border: rgba(
+    255,
+    166,
+    0,
+    0.48
+  );
+  --vscode-mergeEditor-conflict\.unhandledFocused\.border: #ffa600;
+  --vscode-mergeEditor-conflict\.handledUnfocused\.border: rgba(
+    134,
+    134,
+    134,
+    0.29
+  );
+  --vscode-mergeEditor-conflict\.handledFocused\.border: rgba(
+    193,
+    193,
+    193,
+    0.8
+  );
+  --vscode-mergeEditor-conflict\.handled\.minimapOverViewRuler: rgba(
+    173,
+    172,
+    168,
+    0.93
+  );
+  --vscode-mergeEditor-conflict\.unhandled\.minimapOverViewRuler: #fcba03;
+  --vscode-mergeEditor-conflictingLines\.background: rgba(255, 234, 0, 0.28);
+  --vscode-settings-headerForeground: #292929;
+  --vscode-settings-modifiedItemIndicator: #66afe0;
+  --vscode-settings-headerBorder: #0f4a85;
+  --vscode-settings-sashBorder: #0f4a85;
+  --vscode-settings-dropdownBackground: #ffffff;
+  --vscode-settings-dropdownForeground: #292929;
+  --vscode-settings-dropdownBorder: #0f4a85;
+  --vscode-settings-dropdownListBorder: #0f4a85;
+  --vscode-settings-checkboxBackground: #ffffff;
+  --vscode-settings-checkboxForeground: #292929;
+  --vscode-settings-checkboxBorder: #0f4a85;
+  --vscode-settings-textInputBackground: #ffffff;
+  --vscode-settings-textInputForeground: #292929;
+  --vscode-settings-textInputBorder: #0f4a85;
+  --vscode-settings-numberInputBackground: #ffffff;
+  --vscode-settings-numberInputForeground: #292929;
+  --vscode-settings-numberInputBorder: #0f4a85;
+  --vscode-settings-focusedRowBorder: #0f4a85;
+  --vscode-terminal-foreground: #292929;
+  --vscode-terminal-selectionBackground: #0f4a85;
+  --vscode-terminal-inactiveSelectionBackground: rgba(15, 74, 133, 0.5);
+  --vscode-terminal-selectionForeground: #ffffff;
+  --vscode-terminalCommandDecoration-defaultBackground: rgba(0, 0, 0, 0.25);
+  --vscode-terminalCommandDecoration-successBackground: #007100;
+  --vscode-terminalCommandDecoration-errorBackground: #b5200d;
+  --vscode-terminalOverviewRuler-cursorForeground: rgba(160, 160, 160, 0.8);
+  --vscode-terminal-border: #0f4a85;
+  --vscode-terminal-findMatchBackground: #0f4a85;
+  --vscode-terminal-findMatchBorder: #0f4a85;
+  --vscode-terminal-findMatchHighlightBorder: #0f4a85;
+  --vscode-terminalOverviewRuler-findMatchForeground: #0f4a85;
+  --vscode-terminal-dropBackground: rgba(15, 74, 133, 0.5);
+  --vscode-testing-iconFailed: #b5200d;
+  --vscode-testing-iconErrored: #b5200d;
+  --vscode-testing-iconPassed: #007100;
+  --vscode-testing-runAction: #007100;
+  --vscode-testing-iconQueued: #cca700;
+  --vscode-testing-iconUnset: #848484;
+  --vscode-testing-iconSkipped: #848484;
+  --vscode-testing-peekBorder: #0f4a85;
+  --vscode-testing-message\.error\.decorationForeground: #292929;
+  --vscode-testing-message\.info\.decorationForeground: rgba(41, 41, 41, 0.5);
+  --vscode-welcomePage-tileBackground: #ffffff;
+  --vscode-welcomePage-tileBorder: #0f4a85;
+  --vscode-welcomePage-progress\.background: #ffffff;
+  --vscode-welcomePage-progress\.foreground: #0f4a85;
+  --vscode-debugExceptionWidget-border: #a31515;
+  --vscode-debugExceptionWidget-background: #f1dfde;
+  --vscode-ports-iconRunningProcessForeground: #0f4a85;
+  --vscode-statusBar-debuggingBackground: #b5200d;
+  --vscode-statusBar-debuggingForeground: #ffffff;
+  --vscode-statusBar-debuggingBorder: #0f4a85;
+  --vscode-editor-inlineValuesForeground: rgba(0, 0, 0, 0.5);
+  --vscode-editor-inlineValuesBackground: rgba(255, 200, 0, 0.2);
+  --vscode-editorGutter-modifiedBackground: #2090d3;
+  --vscode-editorGutter-addedBackground: #48985d;
+  --vscode-editorGutter-deletedBackground: #b5200d;
+  --vscode-minimapGutter-modifiedBackground: #2090d3;
+  --vscode-minimapGutter-addedBackground: #48985d;
+  --vscode-minimapGutter-deletedBackground: #b5200d;
+  --vscode-editorOverviewRuler-modifiedForeground: rgba(32, 144, 211, 0.6);
+  --vscode-editorOverviewRuler-addedForeground: rgba(72, 152, 93, 0.6);
+  --vscode-editorOverviewRuler-deletedForeground: rgba(181, 32, 13, 0.6);
+  --vscode-debugIcon-breakpointForeground: #e51400;
+  --vscode-debugIcon-breakpointDisabledForeground: #848484;
+  --vscode-debugIcon-breakpointUnverifiedForeground: #848484;
+  --vscode-debugIcon-breakpointCurrentStackframeForeground: #be8700;
+  --vscode-debugIcon-breakpointStackframeForeground: #89d185;
+  --vscode-notebook-cellBorderColor: #0f4a85;
+  --vscode-notebook-focusedEditorBorder: #0f4a85;
+  --vscode-notebookStatusSuccessIcon-foreground: #388a34;
+  --vscode-notebookStatusErrorIcon-foreground: #b5200d;
+  --vscode-notebookStatusRunningIcon-foreground: #292929;
+  --vscode-notebook-cellToolbarSeparator: #0f4a85;
+  --vscode-notebook-selectedCellBorder: #0f4a85;
+  --vscode-notebook-inactiveSelectedCellBorder: #0f4a85;
+  --vscode-notebook-focusedCellBorder: #0f4a85;
+  --vscode-notebook-inactiveFocusedCellBorder: #0f4a85;
+  --vscode-notebook-cellStatusBarItemHoverBackground: rgba(0, 0, 0, 0.08);
+  --vscode-notebook-cellInsertionIndicator: #0f4a85;
+  --vscode-notebookScrollbarSlider-background: rgba(15, 74, 133, 0.4);
+  --vscode-notebookScrollbarSlider-hoverBackground: rgba(15, 74, 133, 0.8);
+  --vscode-notebookScrollbarSlider-activeBackground: #0f4a85;
+  --vscode-scm-providerBorder: #0f4a85;
+  --vscode-searchEditor-textInputBorder: #0f4a85;
+  --vscode-debugTokenExpression-name: #292929;
+  --vscode-debugTokenExpression-value: #292929;
+  --vscode-debugTokenExpression-string: #a31515;
+  --vscode-debugTokenExpression-boolean: #0000ff;
+  --vscode-debugTokenExpression-number: #098658;
+  --vscode-debugTokenExpression-error: #e51400;
+  --vscode-debugView-exceptionLabelForeground: #292929;
+  --vscode-debugView-exceptionLabelBackground: #a31515;
+  --vscode-debugView-stateLabelForeground: #292929;
+  --vscode-debugView-stateLabelBackground: rgba(136, 136, 136, 0.27);
+  --vscode-debugView-valueChangedHighlight: #569cd6;
+  --vscode-debugConsole-infoForeground: #292929;
+  --vscode-debugConsole-warningForeground: #895503;
+  --vscode-debugConsole-errorForeground: #b5200d;
+  --vscode-debugConsole-sourceForeground: #292929;
+  --vscode-debugConsoleInputIcon-foreground: #292929;
+  --vscode-debugIcon-pauseForeground: #007acc;
+  --vscode-debugIcon-stopForeground: #a1260d;
+  --vscode-debugIcon-disconnectForeground: #a1260d;
+  --vscode-debugIcon-restartForeground: #388a34;
+  --vscode-debugIcon-stepOverForeground: #007acc;
+  --vscode-debugIcon-stepIntoForeground: #007acc;
+  --vscode-debugIcon-stepOutForeground: #007acc;
+  --vscode-debugIcon-continueForeground: #007acc;
+  --vscode-debugIcon-stepBackForeground: #007acc;
+  --vscode-extensionButton-separator: rgba(255, 255, 255, 0.4);
+  --vscode-extensionIcon-starForeground: #0f4a85;
+  --vscode-extensionIcon-verifiedForeground: #0f4a85;
+  --vscode-extensionIcon-preReleaseForeground: #0f4a85;
+  --vscode-extensionIcon-sponsorForeground: #b51e78;
+  --vscode-terminal-ansiBlack: #292929;
+  --vscode-terminal-ansiRed: #cd3131;
+  --vscode-terminal-ansiGreen: #00bc00;
+  --vscode-terminal-ansiYellow: #949800;
+  --vscode-terminal-ansiBlue: #0451a5;
+  --vscode-terminal-ansiMagenta: #bc05bc;
+  --vscode-terminal-ansiCyan: #ff0000;
+  --vscode-terminal-ansiWhite: #555555;
+  --vscode-terminal-ansiBrightBlack: #666666;
+  --vscode-terminal-ansiBrightRed: #cd3131;
+  --vscode-terminal-ansiBrightGreen: #00bc00;
+  --vscode-terminal-ansiBrightYellow: #b5ba00;
+  --vscode-terminal-ansiBrightBlue: #0451a5;
+  --vscode-terminal-ansiBrightMagenta: #bc05bc;
+  --vscode-terminal-ansiBrightCyan: #0598bc;
+  --vscode-terminal-ansiBrightWhite: #a5a5a5;
+  --vscode-interactive-activeCodeBorder: #0f4a85;
+  --vscode-interactive-inactiveCodeBorder: #0f4a85;
+  --vscode-gitDecoration-addedResourceForeground: #374e06;
+  --vscode-gitDecoration-modifiedResourceForeground: #895503;
+  --vscode-gitDecoration-deletedResourceForeground: #ad0707;
+  --vscode-gitDecoration-renamedResourceForeground: #007100;
+  --vscode-gitDecoration-untrackedResourceForeground: #007100;
+  --vscode-gitDecoration-ignoredResourceForeground: #8e8e90;
+  --vscode-gitDecoration-stageModifiedResourceForeground: #895503;
+  --vscode-gitDecoration-stageDeletedResourceForeground: #ad0707;
+  --vscode-gitDecoration-conflictingResourceForeground: #ad0707;
+  --vscode-gitDecoration-submoduleResourceForeground: #1258a7;
+  --vscode-testExplorer-errorDecorationBackground: #ffffff;
+}
+
+/**
+ * This is copied in the same way, but from the <body> element
+ */
+body {
+  background-color: transparent;
+  color: var(--vscode-editor-foreground);
+  font-family: var(--vscode-font-family);
+  font-weight: var(--vscode-font-weight);
+  font-size: var(--vscode-font-size);
+  margin: 0;
+  padding: 0 20px;
+}
+
+/**
+ * This is used for setting the background on the Storybook preview.
+ */
+body {
+  background-color: var(--vscode-editor-background);
+}


### PR DESCRIPTION
This adds four new VSCode themes to Storybook which will allow us to more easily test these themes in Storybook. These themes were chosen because they are either used for accessibility (the high contrast themes) or are currently not compatible with the variant analysis UI (there are items that are not visible).

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
