### PR TITLE
Fix header color of stat item

### DIFF
--- a/extensions/ql-vscode/src/view/variant-analysis/StatItem.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/StatItem.tsx
@@ -12,7 +12,7 @@ const Container = styled.div`
 `;
 
 const Header = styled.div`
-  color: var(--vscode-badge-foreground);
+  color: var(--vscode-editor-foreground);
   font-size: 0.85em;
   font-weight: 800;
   text-transform: uppercase;


### PR DESCRIPTION
The header color of a stat item was using the badge foreground color, but badges can have a different background color than the editor. For some themes, this would result in unreadable text. By using the editor foreground color, the header should be readable in many more themes.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
