### PR TITLE
Add tests for loading results

### DIFF
--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-results-manager.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-results-manager.test.ts
@@ -216,8 +216,8 @@ describe(VariantAnalysisResultsManager.name, () => {
     });
 
     afterEach(async () => {
-      if (fs.existsSync(variantAnalysisStoragePath)) {
-        fs.rmSync(variantAnalysisStoragePath, { recursive: true });
+      if (await fs.pathExists(variantAnalysisStoragePath)) {
+        await fs.remove(variantAnalysisStoragePath);
       }
     });
 
@@ -295,7 +295,7 @@ describe(VariantAnalysisResultsManager.name, () => {
           onResultLoadedSpy.mockClear();
 
           // Delete the directory so it can't read from disk
-          fs.rmSync(variantAnalysisStoragePath, { recursive: true });
+          await fs.remove(variantAnalysisStoragePath);
 
           await expect(
             variantAnalysisResultsManager.loadResults(
@@ -325,7 +325,7 @@ describe(VariantAnalysisResultsManager.name, () => {
           );
 
           // Delete the directory so it can't read from disk
-          fs.rmSync(variantAnalysisStoragePath, { recursive: true });
+          await fs.remove(variantAnalysisStoragePath);
 
           await expect(
             variantAnalysisResultsManager.loadResults(
@@ -347,7 +347,7 @@ describe(VariantAnalysisResultsManager.name, () => {
           );
 
           // Delete the directory so it can't read from disk
-          fs.rmSync(variantAnalysisStoragePath, { recursive: true });
+          await fs.remove(variantAnalysisStoragePath);
 
           await expect(
             variantAnalysisResultsManager.loadResults(


### PR DESCRIPTION
This adds tests for the `loadResults` method of the variant analysis results manager. It tests that SARIF results can be successfully loaded and that the `onResultLoaded` event is fired.

See https://github.com/github/vscode-codeql/pull/1806#issuecomment-1330758936

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
