### PR TITLE
Add theme provider when rendering code flows

### DIFF
--- a/extensions/ql-vscode/src/view/common/CodePaths/CodePaths.tsx
+++ b/extensions/ql-vscode/src/view/common/CodePaths/CodePaths.tsx
@@ -3,7 +3,7 @@ import { useRef, useState } from "react";
 import styled from "styled-components";
 import { VSCodeLink } from "@vscode/webview-ui-toolkit/react";
 
-import { Overlay } from "@primer/react";
+import { Overlay, ThemeProvider } from "@primer/react";
 
 import {
   AnalysisMessage,
@@ -16,7 +16,7 @@ const ShowPathsLink = styled(VSCodeLink)`
   cursor: pointer;
 `;
 
-type Props = {
+export type CodePathsProps = {
   codeFlows: CodeFlow[];
   ruleDescription: string;
   message: AnalysisMessage;
@@ -28,7 +28,7 @@ export const CodePaths = ({
   ruleDescription,
   message,
   severity,
-}: Props) => {
+}: CodePathsProps) => {
   const [isOpen, setIsOpen] = useState(false);
 
   const linkRef = useRef<HTMLAnchorElement>(null);
@@ -41,20 +41,22 @@ export const CodePaths = ({
         Show paths
       </ShowPathsLink>
       {isOpen && (
-        <Overlay
-          returnFocusRef={linkRef}
-          onEscape={closeOverlay}
-          onClickOutside={closeOverlay}
-          anchorSide="outside-top"
-        >
-          <CodePathsOverlay
-            codeFlows={codeFlows}
-            ruleDescription={ruleDescription}
-            message={message}
-            severity={severity}
-            onClose={closeOverlay}
-          />
-        </Overlay>
+        <ThemeProvider colorMode="auto">
+          <Overlay
+            returnFocusRef={linkRef}
+            onEscape={closeOverlay}
+            onClickOutside={closeOverlay}
+            anchorSide="outside-top"
+          >
+            <CodePathsOverlay
+              codeFlows={codeFlows}
+              ruleDescription={ruleDescription}
+              message={message}
+              severity={severity}
+              onClose={closeOverlay}
+            />
+          </Overlay>
+        </ThemeProvider>
       )}
     </>
   );

--- a/extensions/ql-vscode/src/view/common/CodePaths/__tests__/CodePaths.spec.tsx
+++ b/extensions/ql-vscode/src/view/common/CodePaths/__tests__/CodePaths.spec.tsx
@@ -1,0 +1,37 @@
+import * as React from "react";
+import { render as reactRender, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CodePaths, CodePathsProps } from "../CodePaths";
+
+import { createMockCodeFlows } from "../../../../vscode-tests/factories/remote-queries/shared/CodeFlow";
+import { createMockAnalysisMessage } from "../../../../vscode-tests/factories/remote-queries/shared/AnalysisMessage";
+
+describe(CodePaths.name, () => {
+  const render = (props?: CodePathsProps) =>
+    reactRender(
+      <CodePaths
+        codeFlows={createMockCodeFlows()}
+        ruleDescription="Rule description"
+        message={createMockAnalysisMessage()}
+        severity="Recommendation"
+        {...props}
+      />,
+    );
+
+  it("renders correctly when unexpanded", () => {
+    render();
+
+    expect(screen.getByText("Show paths")).toBeInTheDocument();
+    expect(screen.queryByText("Code snippet text")).not.toBeInTheDocument();
+    expect(screen.queryByText("Rule description")).not.toBeInTheDocument();
+  });
+
+  it("renders correctly when expanded", async () => {
+    render();
+
+    await userEvent.click(screen.getByText("Show paths"));
+
+    expect(screen.getByText("Code snippet text")).toBeInTheDocument();
+    expect(screen.getByText("Rule description")).toBeInTheDocument();
+  });
+});

--- a/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/shared/AnalysisMessage.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/shared/AnalysisMessage.ts
@@ -1,0 +1,12 @@
+import { AnalysisMessage } from "../../../../remote-queries/shared/analysis-result";
+
+export function createMockAnalysisMessage(): AnalysisMessage {
+  return {
+    tokens: [
+      {
+        t: "text",
+        text: "Token text",
+      },
+    ],
+  };
+}

--- a/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/shared/CodeFlow.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/remote-queries/shared/CodeFlow.ts
@@ -1,0 +1,23 @@
+import { CodeFlow } from "../../../../remote-queries/shared/analysis-result";
+import { createMockAnalysisMessage } from "./AnalysisMessage";
+
+export function createMockCodeFlows(): CodeFlow[] {
+  return [
+    {
+      threadFlows: [
+        {
+          fileLink: {
+            fileLinkPrefix: "/prefix",
+            filePath: "filePath",
+          },
+          codeSnippet: {
+            startLine: 123,
+            endLine: 456,
+            text: "Code snippet text",
+          },
+          message: createMockAnalysisMessage(),
+        },
+      ],
+    },
+  ];
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

In our push to remove the dependency on Primer we accidentally broke the rendering of paths. This PR adds in a `ThemeProvider` which is what's needed to get it working again. Although this is a slight step in the wrong direction it's probably the best thing to do right now before the release, and then we'll look at doing it properly later on as we continue with the Primer migration.

Also I added some tests as this component. The tests would actually have caught the error when render, so at least this means we won't break it again next time.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
