### PR TITLE
Add exporting of in-progress/cancelled results

### DIFF
--- a/extensions/ql-vscode/src/stories/variant-analysis/VariantAnalysis.stories.tsx
+++ b/extensions/ql-vscode/src/stories/variant-analysis/VariantAnalysis.stories.tsx
@@ -43,6 +43,7 @@ const variantAnalysis: VariantAnalysisDomainModel = {
         private: false,
       },
       analysisStatus: VariantAnalysisRepoStatus.Succeeded,
+      resultCount: 100,
     },
     {
       repository: {

--- a/extensions/ql-vscode/src/stories/variant-analysis/VariantAnalysisActions.stories.tsx
+++ b/extensions/ql-vscode/src/stories/variant-analysis/VariantAnalysisActions.stories.tsx
@@ -47,10 +47,24 @@ InProgress.args = {
   variantAnalysisStatus: VariantAnalysisStatus.InProgress,
 };
 
+export const InProgressWithResults = Template.bind({});
+InProgressWithResults.args = {
+  variantAnalysisStatus: VariantAnalysisStatus.InProgress,
+  showResultActions: true,
+};
+
+export const InProgressWithoutDownloadedRepos = Template.bind({});
+InProgressWithoutDownloadedRepos.args = {
+  variantAnalysisStatus: VariantAnalysisStatus.InProgress,
+  showResultActions: true,
+  exportResultsDisabled: true,
+};
+
 export const Succeeded = Template.bind({});
 Succeeded.args = {
   ...InProgress.args,
   variantAnalysisStatus: VariantAnalysisStatus.Succeeded,
+  showResultActions: true,
 };
 
 export const Failed = Template.bind({});

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
@@ -144,6 +144,7 @@ export function VariantAnalysis({
     <>
       <VariantAnalysisHeader
         variantAnalysis={variantAnalysis}
+        repositoryStates={repoStates}
         onOpenQueryFileClick={openQueryFile}
         onViewQueryTextClick={openQueryText}
         onStopQueryClick={stopQuery}

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
@@ -145,6 +145,8 @@ export function VariantAnalysis({
       <VariantAnalysisHeader
         variantAnalysis={variantAnalysis}
         repositoryStates={repoStates}
+        filterSortState={filterSortState}
+        selectedRepositoryIds={selectedRepositoryIds}
         onOpenQueryFileClick={openQueryFile}
         onViewQueryTextClick={openQueryText}
         onStopQueryClick={stopQuery}

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisActions.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisActions.tsx
@@ -12,6 +12,7 @@ export type VariantAnalysisActionsProps = {
   showResultActions?: boolean;
   onCopyRepositoryListClick: () => void;
   onExportResultsClick: () => void;
+  copyRepositoryListDisabled?: boolean;
   exportResultsDisabled?: boolean;
 };
 
@@ -32,13 +33,18 @@ export const VariantAnalysisActions = ({
   showResultActions,
   onCopyRepositoryListClick,
   onExportResultsClick,
+  copyRepositoryListDisabled,
   exportResultsDisabled,
 }: VariantAnalysisActionsProps) => {
   return (
     <Container>
       {showResultActions && (
         <>
-          <Button appearance="secondary" onClick={onCopyRepositoryListClick}>
+          <Button
+            appearance="secondary"
+            onClick={onCopyRepositoryListClick}
+            disabled={copyRepositoryListDisabled}
+          >
             Copy repository list
           </Button>
           <Button

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisActions.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisActions.tsx
@@ -3,14 +3,16 @@ import styled from "styled-components";
 import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
 import { VariantAnalysisStatus } from "../../remote-queries/shared/variant-analysis";
 
-type Props = {
+export type VariantAnalysisActionsProps = {
   variantAnalysisStatus: VariantAnalysisStatus;
 
   onStopQueryClick: () => void;
   stopQueryDisabled?: boolean;
 
+  showResultActions?: boolean;
   onCopyRepositoryListClick: () => void;
   onExportResultsClick: () => void;
+  exportResultsDisabled?: boolean;
 };
 
 const Container = styled.div`
@@ -26,12 +28,28 @@ const Button = styled(VSCodeButton)`
 export const VariantAnalysisActions = ({
   variantAnalysisStatus,
   onStopQueryClick,
+  stopQueryDisabled,
+  showResultActions,
   onCopyRepositoryListClick,
   onExportResultsClick,
-  stopQueryDisabled,
-}: Props) => {
+  exportResultsDisabled,
+}: VariantAnalysisActionsProps) => {
   return (
     <Container>
+      {showResultActions && (
+        <>
+          <Button appearance="secondary" onClick={onCopyRepositoryListClick}>
+            Copy repository list
+          </Button>
+          <Button
+            appearance="primary"
+            onClick={onExportResultsClick}
+            disabled={exportResultsDisabled}
+          >
+            Export results
+          </Button>
+        </>
+      )}
       {variantAnalysisStatus === VariantAnalysisStatus.InProgress && (
         <Button
           appearance="secondary"
@@ -40,16 +58,6 @@ export const VariantAnalysisActions = ({
         >
           Stop query
         </Button>
-      )}
-      {variantAnalysisStatus === VariantAnalysisStatus.Succeeded && (
-        <>
-          <Button appearance="secondary" onClick={onCopyRepositoryListClick}>
-            Copy repository list
-          </Button>
-          <Button appearance="primary" onClick={onExportResultsClick}>
-            Export results
-          </Button>
-        </>
       )}
     </Container>
   );

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisHeader.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisHeader.tsx
@@ -6,6 +6,8 @@ import {
   getTotalResultCount,
   hasRepoScanCompleted,
   VariantAnalysis,
+  VariantAnalysisScannedRepositoryDownloadStatus,
+  VariantAnalysisScannedRepositoryState,
 } from "../../remote-queries/shared/variant-analysis";
 import { QueryDetails } from "./QueryDetails";
 import { VariantAnalysisActions } from "./VariantAnalysisActions";
@@ -15,6 +17,7 @@ import { basename } from "../common/path";
 
 export type VariantAnalysisHeaderProps = {
   variantAnalysis: VariantAnalysis;
+  repositoryStates?: VariantAnalysisScannedRepositoryState[];
 
   onOpenQueryFileClick: () => void;
   onViewQueryTextClick: () => void;
@@ -40,6 +43,7 @@ const Row = styled.div`
 
 export const VariantAnalysisHeader = ({
   variantAnalysis,
+  repositoryStates,
   onOpenQueryFileClick,
   onViewQueryTextClick,
   onStopQueryClick,
@@ -62,6 +66,15 @@ export const VariantAnalysisHeader = ({
   const hasSkippedRepos = useMemo(() => {
     return getSkippedRepoCount(variantAnalysis.skippedRepos) > 0;
   }, [variantAnalysis.skippedRepos]);
+  const hasDownloadedRepos = useMemo(() => {
+    return (
+      repositoryStates?.some(
+        (repo) =>
+          repo.downloadStatus ===
+          VariantAnalysisScannedRepositoryDownloadStatus.Succeeded,
+      ) ?? false
+    );
+  }, [repositoryStates]);
 
   return (
     <Container>
@@ -74,10 +87,12 @@ export const VariantAnalysisHeader = ({
         />
         <VariantAnalysisActions
           variantAnalysisStatus={variantAnalysis.status}
+          showResultActions={(resultCount ?? 0) > 0}
           onStopQueryClick={onStopQueryClick}
           onCopyRepositoryListClick={onCopyRepositoryListClick}
           onExportResultsClick={onExportResultsClick}
           stopQueryDisabled={!variantAnalysis.actionsWorkflowRunId}
+          exportResultsDisabled={!hasDownloadedRepos}
         />
       </Row>
       <VariantAnalysisStats

--- a/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisActions.spec.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisActions.spec.tsx
@@ -2,7 +2,10 @@ import * as React from "react";
 import { render as reactRender, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { VariantAnalysisStatus } from "../../../remote-queries/shared/variant-analysis";
-import { VariantAnalysisActions } from "../VariantAnalysisActions";
+import {
+  VariantAnalysisActions,
+  VariantAnalysisActionsProps,
+} from "../VariantAnalysisActions";
 
 describe(VariantAnalysisActions.name, () => {
   const onStopQueryClick = jest.fn();
@@ -15,51 +18,78 @@ describe(VariantAnalysisActions.name, () => {
     onExportResultsClick.mockReset();
   });
 
-  const render = (variantAnalysisStatus: VariantAnalysisStatus) =>
+  const render = (
+    props: Pick<VariantAnalysisActionsProps, "variantAnalysisStatus"> &
+      Partial<VariantAnalysisActionsProps>,
+  ) =>
     reactRender(
       <VariantAnalysisActions
-        variantAnalysisStatus={variantAnalysisStatus}
         onStopQueryClick={onStopQueryClick}
         onCopyRepositoryListClick={onCopyRepositoryListClick}
         onExportResultsClick={onExportResultsClick}
+        {...props}
       />,
     );
 
   it("renders 1 button when in progress", async () => {
-    const { container } = render(VariantAnalysisStatus.InProgress);
+    const { container } = render({
+      variantAnalysisStatus: VariantAnalysisStatus.InProgress,
+    });
 
     expect(container.querySelectorAll("vscode-button").length).toEqual(1);
   });
 
   it("renders the stop query button when in progress", async () => {
-    render(VariantAnalysisStatus.InProgress);
+    render({
+      variantAnalysisStatus: VariantAnalysisStatus.InProgress,
+    });
 
     await userEvent.click(screen.getByText("Stop query"));
     expect(onStopQueryClick).toHaveBeenCalledTimes(1);
   });
 
+  it("renders 3 buttons when in progress with results", async () => {
+    const { container } = render({
+      variantAnalysisStatus: VariantAnalysisStatus.InProgress,
+      showResultActions: true,
+    });
+
+    expect(container.querySelectorAll("vscode-button").length).toEqual(3);
+  });
+
   it("renders 2 buttons when succeeded", async () => {
-    const { container } = render(VariantAnalysisStatus.Succeeded);
+    const { container } = render({
+      variantAnalysisStatus: VariantAnalysisStatus.Succeeded,
+      showResultActions: true,
+    });
 
     expect(container.querySelectorAll("vscode-button").length).toEqual(2);
   });
 
   it("renders the copy repository list button when succeeded", async () => {
-    render(VariantAnalysisStatus.Succeeded);
+    render({
+      variantAnalysisStatus: VariantAnalysisStatus.Succeeded,
+      showResultActions: true,
+    });
 
     await userEvent.click(screen.getByText("Copy repository list"));
     expect(onCopyRepositoryListClick).toHaveBeenCalledTimes(1);
   });
 
   it("renders the export results button when succeeded", async () => {
-    render(VariantAnalysisStatus.Succeeded);
+    render({
+      variantAnalysisStatus: VariantAnalysisStatus.Succeeded,
+      showResultActions: true,
+    });
 
     await userEvent.click(screen.getByText("Export results"));
     expect(onExportResultsClick).toHaveBeenCalledTimes(1);
   });
 
   it("does not render any buttons when failed", () => {
-    const { container } = render(VariantAnalysisStatus.Failed);
+    const { container } = render({
+      variantAnalysisStatus: VariantAnalysisStatus.Failed,
+    });
 
     expect(container.querySelectorAll("vscode-button").length).toEqual(0);
   });


### PR DESCRIPTION
This will allow exporting results for a variant analysis which is cancelled or in-progress. Repositories for which the results are not yet available or which have not yet been downloaded will not be exported. This will also conditionally disable the buttons, based on whether any results would be exported (based on the filters). Please review this commit-by-commit.

The header of the summary file is incorrect, but this will be fixed in a follow-up PR.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
