### PR TITLE
Close serialized webview when another view already exists

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-view-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-view-manager.ts
@@ -13,6 +13,7 @@ export interface VariantAnalysisViewManager<
 > {
   registerView(view: T): void;
   unregisterView(view: T): void;
+  getView(variantAnalysisId: number): T | undefined;
 
   getVariantAnalysis(
     variantAnalysisId: number,

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-view-serializer.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-view-serializer.ts
@@ -38,6 +38,15 @@ export class VariantAnalysisViewSerializer implements WebviewPanelSerializer {
 
     const manager = await this.waitForExtensionFullyLoaded();
 
+    const existingView = manager.getView(
+      variantAnalysisState.variantAnalysisId,
+    );
+    if (existingView) {
+      await existingView.openView();
+      webviewPanel.dispose();
+      return;
+    }
+
     const view = new VariantAnalysisView(
       this.ctx,
       variantAnalysisState.variantAnalysisId,


### PR DESCRIPTION
When deserializing a webview, it could happen that a view was already manually opened by the user before the webview was deserialized. This would result in duplicate webview tabs, which is not supported by the manager.

This will close the webview that is being deserialized and focus on the existing view. This should ensure that we never have duplicate loaded webview tabs. There could still be duplicate webview tabs if there are non-deserialized tabs, but once it is opened it should be closed automatically.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
