### PR TITLE
Fix Gist title in result export

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/export-results.ts
+++ b/extensions/ql-vscode/src/remote-queries/export-results.ts
@@ -20,6 +20,7 @@ import {
   generateMarkdown,
   generateVariantAnalysisMarkdown,
   MarkdownFile,
+  RepositorySummary,
 } from "./remote-queries-markdown-generation";
 import { RemoteQuery } from "./remote-query";
 import { AnalysisResults, sumAnalysesResults } from "./shared/analysis-result";
@@ -235,11 +236,14 @@ export async function exportVariantAnalysisAnalysisResults(
   >,
   exportFormat: "gist" | "local",
 ) {
-  const description = buildVariantAnalysisGistDescription(variantAnalysis);
-  const markdownFiles = await generateVariantAnalysisMarkdown(
+  const { markdownFiles, summaries } = await generateVariantAnalysisMarkdown(
     variantAnalysis,
     analysesResults,
-    "gist",
+    exportFormat,
+  );
+  const description = buildVariantAnalysisGistDescription(
+    variantAnalysis,
+    summaries,
   );
 
   await exportResults(
@@ -345,20 +349,16 @@ const buildGistDescription = (
  */
 const buildVariantAnalysisGistDescription = (
   variantAnalysis: VariantAnalysis,
+  summaries: RepositorySummary[],
 ) => {
-  const resultCount =
-    variantAnalysis.scannedRepos?.reduce(
-      (acc, item) => acc + (item.resultCount ?? 0),
-      0,
-    ) ?? 0;
+  const resultCount = summaries.reduce(
+    (acc, summary) => acc + (summary.resultCount ?? 0),
+    0,
+  );
   const resultLabel = pluralize(resultCount, "result", "results");
 
-  const repositoryLabel = variantAnalysis.scannedRepos?.length
-    ? `(${pluralize(
-        variantAnalysis.scannedRepos.length,
-        "repository",
-        "repositories",
-      )})`
+  const repositoryLabel = summaries.length
+    ? `(${pluralize(summaries.length, "repository", "repositories")})`
     : "";
   return `${variantAnalysis.query.name} (${variantAnalysis.query.language}) ${resultLabel} ${repositoryLabel}`;
 };


### PR DESCRIPTION
The Gist title in the result export didn't take into account the actual number of exported repositories, it only used the scanned, unfiltered, repositories in the variant analysis. This switches it to use the actual exported repositories for determining the result and repository counts.

This is somewhat more complicated than we'd expect it to be since the results are being read in async, so we need to switch the order of operations and store some additional information for being able to compute this information. However, this also makes the code somewhat easier to understand since the summary file is now being created in only 1 location, rather than being split between a method and a for-loop.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
