### PR TITLE
Add progress notification to exporting results

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -1235,9 +1235,11 @@ async function activateWithInstalledDistribution(
   );
 
   ctx.subscriptions.push(
-    commandRunner(
+    commandRunnerWithProgress(
       "codeQL.exportVariantAnalysisResults",
       async (
+        progress: ProgressCallback,
+        token: CancellationToken,
         variantAnalysisId: number,
         filterSort?: RepositoriesFilterSortStateWithIds,
       ) => {
@@ -1246,7 +1248,13 @@ async function activateWithInstalledDistribution(
           variantAnalysisManager,
           variantAnalysisId,
           filterSort,
+          progress,
+          token,
         );
+      },
+      {
+        title: "Exporting variant analysis results",
+        cancellable: true,
       },
     ),
   );


### PR DESCRIPTION
This will add a progress notification to exporting results to give users feedback about what's happening.

Unfortunately, we need to change some things in how we handle the actions on completion notifications since we want the progress notification to disappear when that notification shows. This results in us having to remove the `await` on the
`showInformationMessageWithAction` calls.


https://user-images.githubusercontent.com/1112623/205052741-89026a7c-2330-40b3-af85-8c9035593981.mov



## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
