### PR TITLE
Make query text and file commands consistent

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -1274,6 +1274,24 @@ async function activateWithInstalledDistribution(
   );
 
   ctx.subscriptions.push(
+    commandRunner(
+      "codeQL.openVariantAnalysisQueryText",
+      async (variantAnalysisId: number) => {
+        await variantAnalysisManager.openQueryText(variantAnalysisId);
+      },
+    ),
+  );
+
+  ctx.subscriptions.push(
+    commandRunner(
+      "codeQL.openVariantAnalysisQueryFile",
+      async (variantAnalysisId: number) => {
+        await variantAnalysisManager.openQueryFile(variantAnalysisId);
+      },
+    ),
+  );
+
+  ctx.subscriptions.push(
     commandRunner("codeQL.openReferencedFile", openReferencedFile),
   );
 

--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -826,6 +826,14 @@ export class QueryHistoryManager extends DisposableObject {
       return;
     }
 
+    if (finalSingleItem.t === "variant-analysis") {
+      await commands.executeCommand(
+        "codeQL.openVariantAnalysisQueryFile",
+        finalSingleItem.variantAnalysis.id,
+      );
+      return;
+    }
+
     let queryPath: string;
     switch (finalSingleItem.t) {
       case "local":
@@ -833,9 +841,6 @@ export class QueryHistoryManager extends DisposableObject {
         break;
       case "remote":
         queryPath = finalSingleItem.remoteQuery.queryFilePath;
-        break;
-      case "variant-analysis":
-        queryPath = finalSingleItem.variantAnalysis.query.filePath;
         break;
       default:
         assertNever(finalSingleItem);
@@ -1337,6 +1342,14 @@ export class QueryHistoryManager extends DisposableObject {
     );
 
     if (!this.assertSingleQuery(finalMultiSelect) || !finalSingleItem) {
+      return;
+    }
+
+    if (finalSingleItem.t === "variant-analysis") {
+      await commands.executeCommand(
+        "codeQL.openVariantAnalysisQueryText",
+        finalSingleItem.variantAnalysis.id,
+      );
       return;
     }
 

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-view.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-view.ts
@@ -1,12 +1,4 @@
-import {
-  commands,
-  ExtensionContext,
-  Uri,
-  ViewColumn,
-  window as Window,
-  workspace,
-} from "vscode";
-import { URLSearchParams } from "url";
+import { commands, ExtensionContext, Uri, ViewColumn } from "vscode";
 import { AbstractWebview, WebviewPanelConfig } from "../abstract-webview";
 import { extLogger } from "../common";
 import {
@@ -129,10 +121,16 @@ export class VariantAnalysisView
         );
         break;
       case "openQueryFile":
-        await this.openQueryFile();
+        void commands.executeCommand(
+          "codeQL.openVariantAnalysisQueryFile",
+          this.variantAnalysisId,
+        );
         break;
       case "openQueryText":
-        await this.openQueryText();
+        void commands.executeCommand(
+          "codeQL.openVariantAnalysisQueryText",
+          this.variantAnalysisId,
+        );
         break;
       case "copyRepositoryList":
         void commands.executeCommand(
@@ -184,61 +182,6 @@ export class VariantAnalysisView
       t: "setRepoStates",
       repoStates,
     });
-  }
-
-  private async openQueryFile(): Promise<void> {
-    const variantAnalysis = await this.manager.getVariantAnalysis(
-      this.variantAnalysisId,
-    );
-
-    if (!variantAnalysis) {
-      void showAndLogWarningMessage(
-        "Could not open variant analysis query file",
-      );
-      return;
-    }
-
-    try {
-      const textDocument = await workspace.openTextDocument(
-        variantAnalysis.query.filePath,
-      );
-      await Window.showTextDocument(textDocument, ViewColumn.One);
-    } catch (error) {
-      void showAndLogWarningMessage(
-        `Could not open file: ${variantAnalysis.query.filePath}`,
-      );
-    }
-  }
-
-  private async openQueryText(): Promise<void> {
-    const variantAnalysis = await this.manager.getVariantAnalysis(
-      this.variantAnalysisId,
-    );
-    if (!variantAnalysis) {
-      void showAndLogWarningMessage(
-        "Could not open variant analysis query text. Variant analysis not found.",
-      );
-      return;
-    }
-
-    const filename = variantAnalysis.query.filePath;
-
-    try {
-      const params = new URLSearchParams({
-        variantAnalysisId: variantAnalysis.id.toString(),
-      });
-      const uri = Uri.from({
-        scheme: "codeql-variant-analysis",
-        path: filename,
-        query: params.toString(),
-      });
-      const doc = await workspace.openTextDocument(uri);
-      await Window.showTextDocument(doc, { preview: false });
-    } catch (error) {
-      void showAndLogWarningMessage(
-        "Could not open variant analysis query text. Failed to open text document.",
-      );
-    }
   }
 
   private async openLogs(): Promise<void> {


### PR DESCRIPTION
We were using two different implementations for opening the query file and query text between the query history and the results view. This moves the better implementation in the view to a command and uses these commands for opening the query text/file in the query history and view. This results in consistent error messages and behaviour between the two different views.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
