### PR TITLE
Show selected item in new DB panel

### DIFF
--- a/extensions/ql-vscode/src/databases/db-module.ts
+++ b/extensions/ql-vscode/src/databases/db-module.ts
@@ -1,3 +1,4 @@
+import { window } from "vscode";
 import { App, AppMode } from "../common/app";
 import { isCanary, isNewQueryRunExperienceEnabled } from "../config";
 import { extLogger } from "../common";
@@ -5,6 +6,7 @@ import { DisposableObject } from "../pure/disposable-object";
 import { DbConfigStore } from "./config/db-config-store";
 import { DbManager } from "./db-manager";
 import { DbPanel } from "./ui/db-panel";
+import { DbSelectionDecorationProvider } from "./ui/db-selection-decoration-provider";
 
 export class DbModule extends DisposableObject {
   public async initialize(app: App): Promise<void> {
@@ -30,6 +32,10 @@ export class DbModule extends DisposableObject {
 
     this.push(dbPanel);
     this.push(dbConfigStore);
+
+    const dbSelectionDecorationProvider = new DbSelectionDecorationProvider();
+
+    window.registerFileDecorationProvider(dbSelectionDecorationProvider);
   }
 }
 

--- a/extensions/ql-vscode/src/databases/ui/db-selection-decoration-provider.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-selection-decoration-provider.ts
@@ -1,0 +1,22 @@
+import {
+  CancellationToken,
+  FileDecoration,
+  FileDecorationProvider,
+  ProviderResult,
+  Uri,
+} from "vscode";
+
+export class DbSelectionDecorationProvider implements FileDecorationProvider {
+  provideFileDecoration(
+    uri: Uri,
+    _token: CancellationToken,
+  ): ProviderResult<FileDecoration> {
+    if (uri?.query === "selected=true") {
+      return {
+        badge: "✔",
+      };
+    }
+
+    return undefined;
+  }
+}

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -138,7 +138,6 @@ import { VariantAnalysisResultsManager } from "./remote-queries/variant-analysis
 import { initializeDbModule } from "./databases/db-module";
 import { ExtensionApp } from "./common/vscode/vscode-app";
 import { RepositoriesFilterSortStateWithIds } from "./pure/variant-analysis-filter-sort";
-import { DbSelectionDecorationProvider } from "./databases/ui/db-selection-decoration-provider";
 
 /**
  * extension.ts
@@ -1558,10 +1557,6 @@ async function activateWithInstalledDistribution(
   const app = new ExtensionApp(ctx);
   const dbModule = await initializeDbModule(app);
   ctx.subscriptions.push(dbModule);
-
-  const dbSelectionDecorationProvider = new DbSelectionDecorationProvider();
-
-  window.registerFileDecorationProvider(dbSelectionDecorationProvider);
 
   void extLogger.log("Successfully finished extension initialization.");
 

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -138,6 +138,7 @@ import { VariantAnalysisResultsManager } from "./remote-queries/variant-analysis
 import { initializeDbModule } from "./databases/db-module";
 import { ExtensionApp } from "./common/vscode/vscode-app";
 import { RepositoriesFilterSortStateWithIds } from "./pure/variant-analysis-filter-sort";
+import { DbSelectionDecorationProvider } from "./databases/ui/db-selection-decoration-provider";
 
 /**
  * extension.ts
@@ -1557,6 +1558,10 @@ async function activateWithInstalledDistribution(
   const app = new ExtensionApp(ctx);
   const dbModule = await initializeDbModule(app);
   ctx.subscriptions.push(dbModule);
+
+  const dbSelectionDecorationProvider = new DbSelectionDecorationProvider();
+
+  window.registerFileDecorationProvider(dbSelectionDecorationProvider);
 
   void extLogger.log("Successfully finished extension initialization.");
 


### PR DESCRIPTION
Adds a [FileDecorationProvider](https://code.visualstudio.com/api/references/vscode-api#FileDecorationProvider) which displays a ✔ label next to the selected item in the new DB panel. E.g.

![selected item in DB panel](https://user-images.githubusercontent.com/42641846/205273892-9935860e-c390-46bf-917f-1769b594853d.png)

It currently doesn't have any clicky UI actions, but that will come in a follow-up issue! 

Note: I'm not sure if/how to test this "file decoration". I'm wondering whether to wait until we have UI actions too, but I'm open to other suggestions about tests! 

## Checklist

N/A - internal only 🦑 

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
