### PR TITLE
Add basic Swift support

### DIFF
--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -551,6 +551,7 @@ export const dbSchemeToLanguage = {
   "semmlecode.csharp.dbscheme": "csharp",
   "go.dbscheme": "go",
   "ruby.dbscheme": "ruby",
+  "swift.dbscheme": "swift",
 };
 
 export const languageToDbScheme = Object.entries(dbSchemeToLanguage).reduce(

--- a/extensions/ql-vscode/src/remote-queries/gh-api/variant-analysis.ts
+++ b/extensions/ql-vscode/src/remote-queries/gh-api/variant-analysis.ts
@@ -16,7 +16,8 @@ export type VariantAnalysisQueryLanguage =
   | "java"
   | "javascript"
   | "python"
-  | "ruby";
+  | "ruby"
+  | "swift";
 
 export interface VariantAnalysis {
   id: number;

--- a/extensions/ql-vscode/src/remote-queries/shared/variant-analysis.ts
+++ b/extensions/ql-vscode/src/remote-queries/shared/variant-analysis.ts
@@ -34,6 +34,7 @@ export enum VariantAnalysisQueryLanguage {
   Javascript = "javascript",
   Python = "python",
   Ruby = "ruby",
+  Swift = "swift",
 }
 
 export function parseVariantAnalysisQueryLanguage(


### PR DESCRIPTION
The extension doesn't actually use anything regarding the language of variant analyses, so this just updates some types.

The actual Swift support is done in the CLI, which is also used for determining which languages are actually supported. So, the environment variable is already used by the CLI for showing supported languages.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
