### PR TITLE
Check variant analysis status in isVariantAnalysisComplete

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/shared/variant-analysis.ts
+++ b/extensions/ql-vscode/src/remote-queries/shared/variant-analysis.ts
@@ -165,13 +165,15 @@ export async function isVariantAnalysisComplete(
     repo: VariantAnalysisScannedRepository,
   ) => Promise<boolean>,
 ): Promise<boolean> {
-  // It's only acceptable to have no scanned repos if the variant analysis is not in a final state.
-  // Otherwise it means the analysis hit some kind of internal error or there were no repos to scan.
+  if (!isFinalVariantAnalysisStatus(variantAnalysis.status)) {
+    return false;
+  }
+
   if (
     variantAnalysis.scannedRepos === undefined ||
     variantAnalysis.scannedRepos.length === 0
   ) {
-    return variantAnalysis.status !== VariantAnalysisStatus.InProgress;
+    return true;
   }
 
   return (


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

This allows us to get out of a state where we think that a variant analysis is still in progress but all of its repo tasks are complete. It is possible for the API to return this state in a temporary edge case when the workflow has just finished, but its not permanent and the API will soon start saying the variant analysis is complete. So in this case we want to continue polling, and if VSCode starts up we want to poll for updated state.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
