### PR TITLE
Limit SARIF code snippet size

### DIFF
--- a/extensions/ql-vscode/src/pure/sarif-utils.ts
+++ b/extensions/ql-vscode/src/pure/sarif-utils.ts
@@ -1,5 +1,5 @@
 import * as Sarif from "sarif";
-import { HighlightedRegion } from "../remote-queries/shared/analysis-result";
+import type { HighlightedRegion } from "../remote-queries/shared/analysis-result";
 import { ResolvableLocationValue } from "./bqrs-cli-types";
 
 export interface SarifLink {

--- a/extensions/ql-vscode/src/remote-queries/sarif-processing.ts
+++ b/extensions/ql-vscode/src/remote-queries/sarif-processing.ts
@@ -19,7 +19,7 @@ import {
 // A line of more than 8k characters is probably generated.
 const CODE_SNIPPET_LARGE_LINE_SIZE_LIMIT = 8192;
 // If less than 1% of the line is highlighted, we consider it a small snippet.
-const CODE_SNIPPET_HIGHLIGHTED_REGION_MINIMUM_PERCENTAGE = 0.01;
+const CODE_SNIPPET_HIGHLIGHTED_REGION_MINIMUM_RATIO = 0.01;
 
 const defaultSeverity = "Warning";
 
@@ -194,15 +194,14 @@ function getCodeSnippet(
       return parseHighlightedLine(line, startLine + index, highlightedRegion);
     });
 
-    const highlightedCharactersCount = highlightedLines
-      .map((line) => line.highlightedSection.length)
-      .reduce((a, b) => a + b, 0);
+    const highlightedCharactersCount = highlightedLines.reduce(
+      (a, line) => a + line.highlightedSection.length,
+      0,
+    );
 
-    const highlightedPercentage = highlightedCharactersCount / text.length;
+    const highlightedRatio = highlightedCharactersCount / text.length;
 
-    if (
-      highlightedPercentage < CODE_SNIPPET_HIGHLIGHTED_REGION_MINIMUM_PERCENTAGE
-    ) {
+    if (highlightedRatio < CODE_SNIPPET_HIGHLIGHTED_REGION_MINIMUM_RATIO) {
       // If not enough is highlighted and the snippet is large, it's probably generated or bundled code and
       // we don't want to show it.
       return undefined;


### PR DESCRIPTION
This adds a new filtering on SARIF code snippets for very large code snippets (defined as 8KB or more). If less than 1% of such a snippet is highlighted, it will not include the code snippet in the analysed results, and it will thus not be shown in the UI.

This is to avoid very large SARIF files that can cause the extension host to crash when the analysis results are send to the UI. I don't think any of these snippets would ever be useful to show, so it should be fine to just not include them.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
