### PR TITLE
Add spinner when loading results

### DIFF
--- a/extensions/ql-vscode/src/view/variant-analysis/RepoRow.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/RepoRow.tsx
@@ -227,7 +227,7 @@ export const RepoRow = ({
     [onSelectedChange, repository],
   );
 
-  const disabled = !canExpand(status, downloadStatus);
+  const disabled = !canExpand(status, downloadStatus) || resultsLoading;
   const expandableContentLoaded = isExpandableContentLoaded(
     status,
     downloadStatus,
@@ -247,11 +247,13 @@ export const RepoRow = ({
           checked={selected}
           disabled={!repository.id || !canSelect(status, downloadStatus)}
         />
-        {isExpanded ? (
+        {isExpanded && (
           <ExpandCollapseCodicon name="chevron-down" label="Collapse" />
-        ) : (
+        )}
+        {!isExpanded && !resultsLoading && (
           <ExpandCollapseCodicon name="chevron-right" label="Expand" />
         )}
+        {resultsLoading && <LoadingIcon label="Results are loading" />}
         <VSCodeBadge>
           {resultCount === undefined ? "-" : formatDecimal(resultCount)}
         </VSCodeBadge>


### PR DESCRIPTION
This will add a spinner to each repo row when the results for a particular repo are loading. It will also disable the row to make clear that it is loading and not clickable.


https://user-images.githubusercontent.com/1112623/205326625-b31369f3-41b1-4d28-ba75-b366494825a3.mov



## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
