### PR TITLE
Create method that returns selected DbItem

### DIFF
--- a/extensions/ql-vscode/src/databases/db-item-selection.ts
+++ b/extensions/ql-vscode/src/databases/db-item-selection.ts
@@ -1,0 +1,40 @@
+import { DbItem, DbItemKind } from "./db-item";
+
+export function getSelectedDbItem(dbItems: DbItem[]): DbItem | undefined {
+  for (const dbItem of dbItems) {
+    if (
+      dbItem.kind === DbItemKind.RootRemote ||
+      dbItem.kind === DbItemKind.RootLocal
+    ) {
+      for (const child of dbItem.children) {
+        switch (child.kind) {
+          case DbItemKind.LocalList:
+            if (child.selected) {
+              return child;
+            }
+            for (const database of child.databases) {
+              if (database.selected) {
+                return database;
+              }
+            }
+            break;
+          case DbItemKind.RemoteUserDefinedList:
+            if (child.selected) {
+              return child;
+            }
+            for (const repo of child.repos) {
+              if (repo.selected) {
+                return repo;
+              }
+            }
+            break;
+          default:
+            if (child.selected) {
+              return child;
+            }
+        }
+      }
+    }
+  }
+  return undefined;
+}

--- a/extensions/ql-vscode/src/databases/db-item-selection.ts
+++ b/extensions/ql-vscode/src/databases/db-item-selection.ts
@@ -1,4 +1,4 @@
-import { DbItem, DbItemKind } from "./db-item";
+import { DbItem, DbItemKind, LocalDbItem, RemoteDbItem } from "./db-item";
 
 export function getSelectedDbItem(dbItems: DbItem[]): DbItem | undefined {
   for (const dbItem of dbItems) {
@@ -7,34 +7,38 @@ export function getSelectedDbItem(dbItems: DbItem[]): DbItem | undefined {
       dbItem.kind === DbItemKind.RootLocal
     ) {
       for (const child of dbItem.children) {
-        switch (child.kind) {
-          case DbItemKind.LocalList:
-            if (child.selected) {
-              return child;
-            }
-            for (const database of child.databases) {
-              if (database.selected) {
-                return database;
-              }
-            }
-            break;
-          case DbItemKind.RemoteUserDefinedList:
-            if (child.selected) {
-              return child;
-            }
-            for (const repo of child.repos) {
-              if (repo.selected) {
-                return repo;
-              }
-            }
-            break;
-          default:
-            if (child.selected) {
-              return child;
-            }
+        const selectedItem = extractSelected(child);
+        if (selectedItem) return selectedItem;
+      }
+    } else {
+      const selectedItem = extractSelected(dbItem);
+      if (selectedItem) return selectedItem;
+    }
+  }
+  return undefined;
+}
+
+function extractSelected(
+  dbItem: RemoteDbItem | LocalDbItem,
+): DbItem | undefined {
+  if (dbItem.selected) {
+    return dbItem;
+  }
+  switch (dbItem.kind) {
+    case DbItemKind.LocalList:
+      for (const database of dbItem.databases) {
+        if (database.selected) {
+          return database;
         }
       }
-    }
+      break;
+    case DbItemKind.RemoteUserDefinedList:
+      for (const repo of dbItem.repos) {
+        if (repo.selected) {
+          return repo;
+        }
+      }
+      break;
   }
   return undefined;
 }

--- a/extensions/ql-vscode/src/databases/db-item.ts
+++ b/extensions/ql-vscode/src/databases/db-item.ts
@@ -124,35 +124,3 @@ const SelectableDbItemKinds = [
   DbItemKind.RemoteOwner,
   DbItemKind.RemoteRepo,
 ];
-
-export function getSelectedDbItem(dbItems: DbItem[]): DbItem | undefined {
-  for (const dbItem of dbItems) {
-    if (
-      dbItem.kind === DbItemKind.RootRemote ||
-      dbItem.kind === DbItemKind.RootLocal
-    ) {
-      for (const child of dbItem.children) {
-        switch (child.kind) {
-          case DbItemKind.LocalList:
-            for (const database of child.databases) {
-              if (database.selected) {
-                return database;
-              }
-            }
-            break;
-          case DbItemKind.RemoteUserDefinedList:
-            for (const repo of child.repos) {
-              if (repo.selected) {
-                return repo;
-              }
-            }
-            break;
-          default:
-            if (child.selected) {
-              return child;
-            }
-        }
-      }
-    }
-  }
-}

--- a/extensions/ql-vscode/src/databases/db-item.ts
+++ b/extensions/ql-vscode/src/databases/db-item.ts
@@ -124,3 +124,35 @@ const SelectableDbItemKinds = [
   DbItemKind.RemoteOwner,
   DbItemKind.RemoteRepo,
 ];
+
+export function getSelectedDbItem(dbItems: DbItem[]): DbItem | undefined {
+  for (const dbItem of dbItems) {
+    if (
+      dbItem.kind === DbItemKind.RootRemote ||
+      dbItem.kind === DbItemKind.RootLocal
+    ) {
+      for (const child of dbItem.children) {
+        switch (child.kind) {
+          case DbItemKind.LocalList:
+            for (const database of child.databases) {
+              if (database.selected) {
+                return database;
+              }
+            }
+            break;
+          case DbItemKind.RemoteUserDefinedList:
+            for (const repo of child.repos) {
+              if (repo.selected) {
+                return repo;
+              }
+            }
+            break;
+          default:
+            if (child.selected) {
+              return child;
+            }
+        }
+      }
+    }
+  }
+}

--- a/extensions/ql-vscode/src/databases/db-manager.ts
+++ b/extensions/ql-vscode/src/databases/db-manager.ts
@@ -2,7 +2,7 @@ import { App } from "../common/app";
 import { AppEvent, AppEventEmitter } from "../common/events";
 import { ValueResult } from "../common/value-result";
 import { DbConfigStore } from "./config/db-config-store";
-import { DbItem } from "./db-item";
+import { DbItem, getSelectedDbItem } from "./db-item";
 import { createLocalTree, createRemoteTree } from "./db-tree-creator";
 
 export class DbManager {
@@ -16,6 +16,16 @@ export class DbManager {
     this.dbConfigStore.onDidChangeConfig(() => {
       this.onDbItemsChangesEventEmitter.fire();
     });
+  }
+
+  public selectedDbItem(): DbItem | undefined {
+    const dbItems = this.getDbItems();
+
+    if (dbItems.isFailure) {
+      return undefined;
+    }
+
+    return getSelectedDbItem(dbItems.value);
   }
 
   public getDbItems(): ValueResult<DbItem[]> {

--- a/extensions/ql-vscode/src/databases/db-manager.ts
+++ b/extensions/ql-vscode/src/databases/db-manager.ts
@@ -2,7 +2,8 @@ import { App } from "../common/app";
 import { AppEvent, AppEventEmitter } from "../common/events";
 import { ValueResult } from "../common/value-result";
 import { DbConfigStore } from "./config/db-config-store";
-import { DbItem, getSelectedDbItem } from "./db-item";
+import { DbItem } from "./db-item";
+import { getSelectedDbItem } from "./db-item-selection";
 import { createLocalTree, createRemoteTree } from "./db-tree-creator";
 
 export class DbManager {

--- a/extensions/ql-vscode/src/databases/db-manager.ts
+++ b/extensions/ql-vscode/src/databases/db-manager.ts
@@ -19,7 +19,7 @@ export class DbManager {
     });
   }
 
-  public selectedDbItem(): DbItem | undefined {
+  public getSelectedDbItem(): DbItem | undefined {
     const dbItems = this.getDbItems();
 
     if (dbItems.isFailure) {

--- a/extensions/ql-vscode/test/pure-tests/databases/db-item-selection.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/databases/db-item-selection.test.ts
@@ -1,7 +1,7 @@
 import { DbItem, DbItemKind } from "../../../src/databases/db-item";
 import { getSelectedDbItem } from "../../../src/databases/db-item-selection";
 describe("db item selection", () => {
-  it("dhoulf return undefined if no item is selected", () => {
+  it("should return undefined if no item is selected", () => {
     const dbItems: DbItem[] = [
       {
         kind: DbItemKind.RootRemote,

--- a/extensions/ql-vscode/test/pure-tests/databases/db-item-selection.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/databases/db-item-selection.test.ts
@@ -1,0 +1,215 @@
+import { DbItem, DbItemKind } from "../../../src/databases/db-item";
+import { getSelectedDbItem } from "../../../src/databases/db-item-selection";
+describe("db item selection", () => {
+  it("return undefined if no item is selected", () => {
+    const dbItems: DbItem[] = [
+      {
+        kind: DbItemKind.RootRemote,
+        children: [
+          {
+            kind: DbItemKind.RemoteSystemDefinedList,
+            listName: "top_10",
+            listDisplayName: "Top 10 repositories",
+            listDescription: "Top 10 repositories of a language",
+            selected: false,
+          },
+          {
+            kind: DbItemKind.RemoteSystemDefinedList,
+            listName: "top_100",
+            listDisplayName: "Top 100 repositories",
+            listDescription: "Top 100 repositories of a language",
+            selected: false,
+          },
+          {
+            kind: DbItemKind.RemoteSystemDefinedList,
+            listName: "top_1000",
+            listDisplayName: "Top 1000 repositories",
+            listDescription: "Top 1000 repositories of a language",
+            selected: false,
+          },
+          {
+            kind: DbItemKind.RemoteOwner,
+            ownerName: "github",
+            selected: false,
+          },
+          {
+            kind: DbItemKind.RemoteUserDefinedList,
+            listName: "my list",
+            repos: [
+              {
+                kind: DbItemKind.RemoteRepo,
+                repoFullName: "owner1/repo2",
+                selected: false,
+              },
+              {
+                kind: DbItemKind.RemoteRepo,
+                repoFullName: "owner1/repo3",
+                selected: false,
+              },
+            ],
+            selected: false,
+          },
+        ],
+      },
+      {
+        kind: DbItemKind.RootLocal,
+        children: [
+          {
+            kind: DbItemKind.LocalList,
+            listName: "list-1",
+            databases: [
+              {
+                kind: DbItemKind.LocalDatabase,
+                databaseName: "db1",
+                dateAdded: 1234,
+                language: "javascript",
+                storagePath: "/foo/bar",
+                selected: false,
+              },
+              {
+                kind: DbItemKind.LocalDatabase,
+                databaseName: "db2",
+                dateAdded: 1234,
+                language: "javascript",
+                storagePath: "/foo/bar",
+                selected: false,
+              },
+            ],
+            selected: false,
+          },
+          {
+            kind: DbItemKind.LocalDatabase,
+            databaseName: "db3",
+            dateAdded: 1234,
+            language: "javascript",
+            storagePath: "/foo/bar",
+            selected: false,
+          },
+        ],
+      },
+    ];
+
+    expect(getSelectedDbItem(dbItems)).toBeUndefined();
+  });
+
+  it("return correct local database item from DbItem list", () => {
+    const dbItems: DbItem[] = [
+      {
+        kind: DbItemKind.RootLocal,
+        children: [
+          {
+            kind: DbItemKind.LocalList,
+            listName: "list-1",
+            databases: [
+              {
+                kind: DbItemKind.LocalDatabase,
+                databaseName: "db1",
+                dateAdded: 1234,
+                language: "javascript",
+                storagePath: "/foo/bar",
+                selected: false,
+              },
+              {
+                kind: DbItemKind.LocalDatabase,
+                databaseName: "db2",
+                dateAdded: 1234,
+                language: "javascript",
+                storagePath: "/foo/bar",
+                selected: true,
+              },
+            ],
+            selected: false,
+          },
+          {
+            kind: DbItemKind.LocalDatabase,
+            databaseName: "db3",
+            dateAdded: 1234,
+            language: "javascript",
+            storagePath: "/foo/bar",
+            selected: false,
+          },
+        ],
+      },
+    ];
+
+    expect(getSelectedDbItem(dbItems)).toEqual({
+      kind: DbItemKind.LocalDatabase,
+      databaseName: "db2",
+      dateAdded: 1234,
+      language: "javascript",
+      storagePath: "/foo/bar",
+      selected: true,
+    });
+  });
+
+  it("return correct remote database list item from DbItem list", () => {
+    const dbItems: DbItem[] = [
+      {
+        kind: DbItemKind.RootRemote,
+        children: [
+          {
+            kind: DbItemKind.RemoteSystemDefinedList,
+            listName: "top_10",
+            listDisplayName: "Top 10 repositories",
+            listDescription: "Top 10 repositories of a language",
+            selected: false,
+          },
+          {
+            kind: DbItemKind.RemoteSystemDefinedList,
+            listName: "top_100",
+            listDisplayName: "Top 100 repositories",
+            listDescription: "Top 100 repositories of a language",
+            selected: false,
+          },
+          {
+            kind: DbItemKind.RemoteSystemDefinedList,
+            listName: "top_1000",
+            listDisplayName: "Top 1000 repositories",
+            listDescription: "Top 1000 repositories of a language",
+            selected: false,
+          },
+          {
+            kind: DbItemKind.RemoteOwner,
+            ownerName: "github",
+            selected: false,
+          },
+          {
+            kind: DbItemKind.RemoteUserDefinedList,
+            listName: "my list",
+            repos: [
+              {
+                kind: DbItemKind.RemoteRepo,
+                repoFullName: "owner1/repo2",
+                selected: false,
+              },
+              {
+                kind: DbItemKind.RemoteRepo,
+                repoFullName: "owner1/repo3",
+                selected: false,
+              },
+            ],
+            selected: true,
+          },
+        ],
+      },
+    ];
+
+    expect(getSelectedDbItem(dbItems)).toEqual({
+      kind: DbItemKind.RemoteUserDefinedList,
+      listName: "my list",
+      repos: [
+        {
+          kind: DbItemKind.RemoteRepo,
+          repoFullName: "owner1/repo2",
+          selected: false,
+        },
+        {
+          kind: DbItemKind.RemoteRepo,
+          repoFullName: "owner1/repo3",
+          selected: false,
+        },
+      ],
+      selected: true,
+    });
+  });
+});

--- a/extensions/ql-vscode/test/pure-tests/databases/db-item-selection.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/databases/db-item-selection.test.ts
@@ -191,4 +191,88 @@ describe("db item selection", () => {
       selected: true,
     });
   });
+
+  it("should handle arbitrary list of db items", () => {
+    const dbItems: DbItem[] = [
+      {
+        kind: DbItemKind.RootRemote,
+        children: [
+          {
+            kind: DbItemKind.RemoteSystemDefinedList,
+            listName: "top_10",
+            listDisplayName: "Top 10 repositories",
+            listDescription: "Top 10 repositories of a language",
+            selected: false,
+          },
+          {
+            kind: DbItemKind.RemoteOwner,
+            ownerName: "github",
+            selected: false,
+          },
+          {
+            kind: DbItemKind.RemoteUserDefinedList,
+            listName: "my list",
+            repos: [
+              {
+                kind: DbItemKind.RemoteRepo,
+                repoFullName: "owner1/repo2",
+                selected: false,
+              },
+              {
+                kind: DbItemKind.RemoteRepo,
+                repoFullName: "owner1/repo3",
+                selected: false,
+              },
+            ],
+            selected: false,
+          },
+        ],
+      },
+      {
+        kind: DbItemKind.RemoteSystemDefinedList,
+        listName: "top_10",
+        listDisplayName: "Top 10 repositories",
+        listDescription: "Top 10 repositories of a language",
+        selected: true,
+      },
+    ];
+
+    expect(getSelectedDbItem(dbItems)).toEqual({
+      kind: DbItemKind.RemoteSystemDefinedList,
+      listName: "top_10",
+      listDisplayName: "Top 10 repositories",
+      listDescription: "Top 10 repositories of a language",
+      selected: true,
+    });
+  });
+
+  it("should handle empty db item lists", () => {
+    const dbItems: DbItem[] = [
+      {
+        kind: DbItemKind.RootRemote,
+        children: [
+          {
+            kind: DbItemKind.RemoteSystemDefinedList,
+            listName: "top_10",
+            listDisplayName: "Top 10 repositories",
+            listDescription: "Top 10 repositories of a language",
+            selected: false,
+          },
+          {
+            kind: DbItemKind.RemoteOwner,
+            ownerName: "github",
+            selected: false,
+          },
+          {
+            kind: DbItemKind.RemoteUserDefinedList,
+            listName: "my list",
+            repos: [],
+            selected: false,
+          },
+        ],
+      },
+    ];
+
+    expect(getSelectedDbItem(dbItems)).toBeUndefined();
+  });
 });

--- a/extensions/ql-vscode/test/pure-tests/databases/db-item-selection.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/databases/db-item-selection.test.ts
@@ -1,7 +1,7 @@
 import { DbItem, DbItemKind } from "../../../src/databases/db-item";
 import { getSelectedDbItem } from "../../../src/databases/db-item-selection";
 describe("db item selection", () => {
-  it("return undefined if no item is selected", () => {
+  it("dhoulf return undefined if no item is selected", () => {
     const dbItems: DbItem[] = [
       {
         kind: DbItemKind.RootRemote,
@@ -18,13 +18,6 @@ describe("db item selection", () => {
             listName: "top_100",
             listDisplayName: "Top 100 repositories",
             listDescription: "Top 100 repositories of a language",
-            selected: false,
-          },
-          {
-            kind: DbItemKind.RemoteSystemDefinedList,
-            listName: "top_1000",
-            listDisplayName: "Top 1000 repositories",
-            listDescription: "Top 1000 repositories of a language",
             selected: false,
           },
           {
@@ -92,7 +85,7 @@ describe("db item selection", () => {
     expect(getSelectedDbItem(dbItems)).toBeUndefined();
   });
 
-  it("return correct local database item from DbItem list", () => {
+  it("should return correct local database item from DbItem list", () => {
     const dbItems: DbItem[] = [
       {
         kind: DbItemKind.RootLocal,
@@ -142,7 +135,7 @@ describe("db item selection", () => {
     });
   });
 
-  it("return correct remote database list item from DbItem list", () => {
+  it("should return correct remote database list item from DbItem list", () => {
     const dbItems: DbItem[] = [
       {
         kind: DbItemKind.RootRemote,
@@ -152,20 +145,6 @@ describe("db item selection", () => {
             listName: "top_10",
             listDisplayName: "Top 10 repositories",
             listDescription: "Top 10 repositories of a language",
-            selected: false,
-          },
-          {
-            kind: DbItemKind.RemoteSystemDefinedList,
-            listName: "top_100",
-            listDisplayName: "Top 100 repositories",
-            listDescription: "Top 100 repositories of a language",
-            selected: false,
-          },
-          {
-            kind: DbItemKind.RemoteSystemDefinedList,
-            listName: "top_1000",
-            listDisplayName: "Top 1000 repositories",
-            listDescription: "Top 1000 repositories of a language",
             selected: false,
           },
           {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

When running a query we need to know which DbItem is selected in the new DB panel. This PR adds a method to the DbManager that returns the currently selected item.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
