### PR TITLE
Restructure variant analysis manager tests

### DIFF
--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-manager.test.ts
@@ -38,6 +38,7 @@ import {
   VariantAnalysis,
   VariantAnalysisScannedRepository,
   VariantAnalysisScannedRepositoryDownloadStatus,
+  VariantAnalysisScannedRepositoryState,
   VariantAnalysisStatus,
 } from "../../../remote-queries/shared/variant-analysis";
 import { createTimestampFile } from "../../../helpers";
@@ -622,26 +623,18 @@ describe("Variant Analysis Manager", () => {
         });
 
         it("should update the repo state correctly", async () => {
-          // To set some initial repo states, we need to mock the correct methods so that the repo states are read in.
-          // The actual tests for these are in rehydrateVariantAnalysis, so we can just mock them here and test that
-          // the methods are called.
-
-          pathExistsStub.mockImplementation(() => true);
-          // This will read in the correct repo states
-          readJsonStub.mockImplementation(() =>
-            Promise.resolve({
-              [scannedRepos[1].repository.id]: {
-                repositoryId: scannedRepos[1].repository.id,
-                downloadStatus:
-                  VariantAnalysisScannedRepositoryDownloadStatus.Succeeded,
-              },
-              [scannedRepos[2].repository.id]: {
-                repositoryId: scannedRepos[2].repository.id,
-                downloadStatus:
-                  VariantAnalysisScannedRepositoryDownloadStatus.InProgress,
-              },
-            }),
-          );
+          mockRepoStates({
+            [scannedRepos[1].repository.id]: {
+              repositoryId: scannedRepos[1].repository.id,
+              downloadStatus:
+                VariantAnalysisScannedRepositoryDownloadStatus.Succeeded,
+            },
+            [scannedRepos[2].repository.id]: {
+              repositoryId: scannedRepos[2].repository.id,
+              downloadStatus:
+                VariantAnalysisScannedRepositoryDownloadStatus.InProgress,
+            },
+          });
 
           await variantAnalysisManager.rehydrateVariantAnalysis(
             variantAnalysis,
@@ -692,6 +685,14 @@ describe("Variant Analysis Manager", () => {
             },
           );
         });
+
+        function mockRepoStates(
+          repoStates: Record<number, VariantAnalysisScannedRepositoryState>,
+        ) {
+          pathExistsStub.mockImplementation(() => true);
+          // This will read in the correct repo states
+          readJsonStub.mockImplementation(() => Promise.resolve(repoStates));
+        }
       });
     });
   });


### PR DESCRIPTION
This restructures the variant analysis manager tests to follow this pattern:
- Class
  - Method
    - Context 
      - Context
        - ...
          - Test

Before, we were only using this pattern for some of the tests and this made it confusing were which method was being tested.

By splitting this off, it will also be easier to move some of these tests out of the cli-integration tests and into the no-workspace or minimal-workspace tests.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
