### PR TITLE
Track parent list name for db items

### DIFF
--- a/extensions/ql-vscode/src/databases/db-item.ts
+++ b/extensions/ql-vscode/src/databases/db-item.ts
@@ -32,6 +32,7 @@ export interface LocalDatabaseDbItem {
   dateAdded: number;
   language: string;
   storagePath: string;
+  parentListName?: string;
 }
 
 export interface RootRemoteDbItem {
@@ -76,6 +77,7 @@ export interface RemoteRepoDbItem {
   kind: DbItemKind.RemoteRepo;
   selected: boolean;
   repoFullName: string;
+  parentListName?: string;
 }
 
 export function isRemoteSystemDefinedListDbItem(

--- a/extensions/ql-vscode/src/databases/db-tree-creator.ts
+++ b/extensions/ql-vscode/src/databases/db-tree-creator.ts
@@ -124,6 +124,7 @@ function createRepoItem(
     kind: DbItemKind.RemoteRepo,
     repoFullName: repo,
     selected: !!selected,
+    parentListName: listName,
   };
 }
 
@@ -159,5 +160,6 @@ function createLocalDb(
     language: db.language,
     storagePath: db.storagePath,
     selected: !!selected,
+    parentListName: listName,
   };
 }

--- a/extensions/ql-vscode/test/pure-tests/databases/db-tree-creator.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/databases/db-tree-creator.test.ts
@@ -100,6 +100,7 @@ describe("db tree creator", () => {
             kind: DbItemKind.RemoteRepo,
             selected: false,
             repoFullName: repo,
+            parentListName: dbConfig.databases.remote.repositoryLists[0].name,
           }),
         ),
       });
@@ -112,6 +113,7 @@ describe("db tree creator", () => {
             kind: DbItemKind.RemoteRepo,
             selected: false,
             repoFullName: repo,
+            parentListName: dbConfig.databases.remote.repositoryLists[1].name,
           }),
         ),
       });
@@ -422,6 +424,7 @@ describe("db tree creator", () => {
           dateAdded: db.dateAdded,
           language: db.language,
           storagePath: db.storagePath,
+          parentListName: dbConfig.databases.local.lists[0].name,
         })),
       });
       expect(localListNodes[1]).toEqual({
@@ -435,6 +438,7 @@ describe("db tree creator", () => {
           dateAdded: db.dateAdded,
           language: db.language,
           storagePath: db.storagePath,
+          parentListName: dbConfig.databases.local.lists[1].name,
         })),
       });
     });


### PR DESCRIPTION
Db items that represent databases inside user defined lists (local or remote), currently don't keep any information about their parent. This makes it a bit difficult to work out the details needed to update the selected db item through the UI. 

In this change we add some knowledge to `LocalDatabaseDbItem` and `RemoteRepoDbItem` to keep track of their parent.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
