### PR TITLE
Hide analyzed panel when it's empty

### DIFF
--- a/extensions/ql-vscode/src/stories/variant-analysis/VariantAnalysis.stories.tsx
+++ b/extensions/ql-vscode/src/stories/variant-analysis/VariantAnalysis.stories.tsx
@@ -385,3 +385,19 @@ Failed.args = {
   repoStates,
   repoResults,
 };
+
+export const FailedInternal = Template.bind({});
+FailedInternal.args = {
+  variantAnalysis: {
+    ...variantAnalysis,
+    status: VariantAnalysisStatus.Failed,
+    failureReason: VariantAnalysisFailureReason.InternalError,
+    completedAt: new Date(
+      new Date(variantAnalysis.createdAt).getTime() + 100_000,
+    ).toISOString(),
+    scannedRepos: [],
+    skippedRepos: {},
+  },
+  repoStates,
+  repoResults,
+};

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisOutcomePanels.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisOutcomePanels.tsx
@@ -110,6 +110,14 @@ export const VariantAnalysisOutcomePanels = ({
     </WarningsContainer>
   );
 
+  const noPanels =
+    scannedReposCount === 0 &&
+    !noCodeqlDbRepos?.repositoryCount &&
+    !notFoundRepos?.repositoryCount;
+  if (noPanels) {
+    return warnings;
+  }
+
   if (!noCodeqlDbRepos?.repositoryCount && !notFoundRepos?.repositoryCount) {
     return (
       <>
@@ -138,12 +146,14 @@ export const VariantAnalysisOutcomePanels = ({
         onChange={setFilterSortState}
       />
       <VSCodePanels>
-        <Tab>
-          Analyzed
-          <VSCodeBadge appearance="secondary">
-            {formatDecimal(variantAnalysis.scannedRepos?.length ?? 0)}
-          </VSCodeBadge>
-        </Tab>
+        {scannedReposCount > 0 && (
+          <Tab>
+            Analyzed
+            <VSCodeBadge appearance="secondary">
+              {formatDecimal(variantAnalysis.scannedRepos?.length ?? 0)}
+            </VSCodeBadge>
+          </Tab>
+        )}
         {notFoundRepos?.repositoryCount && (
           <Tab>
             No access
@@ -160,16 +170,18 @@ export const VariantAnalysisOutcomePanels = ({
             </VSCodeBadge>
           </Tab>
         )}
-        <VSCodePanelView>
-          <VariantAnalysisAnalyzedRepos
-            variantAnalysis={variantAnalysis}
-            repositoryStates={repositoryStates}
-            repositoryResults={repositoryResults}
-            filterSortState={filterSortState}
-            selectedRepositoryIds={selectedRepositoryIds}
-            setSelectedRepositoryIds={setSelectedRepositoryIds}
-          />
-        </VSCodePanelView>
+        {scannedReposCount > 0 && (
+          <VSCodePanelView>
+            <VariantAnalysisAnalyzedRepos
+              variantAnalysis={variantAnalysis}
+              repositoryStates={repositoryStates}
+              repositoryResults={repositoryResults}
+              filterSortState={filterSortState}
+              selectedRepositoryIds={selectedRepositoryIds}
+              setSelectedRepositoryIds={setSelectedRepositoryIds}
+            />
+          </VSCodePanelView>
+        )}
         {notFoundRepos?.repositoryCount && (
           <VSCodePanelView>
             <VariantAnalysisSkippedRepositoriesTab

--- a/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisOutcomePanels.spec.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisOutcomePanels.spec.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { render as reactRender, screen } from "@testing-library/react";
 import {
   VariantAnalysis,
+  VariantAnalysisFailureReason,
   VariantAnalysisRepoStatus,
   VariantAnalysisStatus,
 } from "../../../remote-queries/shared/variant-analysis";
@@ -142,6 +143,36 @@ describe(VariantAnalysisOutcomePanels.name, () => {
     expect(screen.getByText("Analyzed")).toBeInTheDocument();
     expect(screen.getByText("No access")).toBeInTheDocument();
     expect(screen.getByText("No database")).toBeInTheDocument();
+  });
+
+  it("does not render analyzed panel when there are no scanned repos", () => {
+    render({
+      scannedRepos: [],
+      skippedRepos: {
+        notFoundRepos: defaultVariantAnalysis.skippedRepos.notFoundRepos,
+        noCodeqlDbRepos: defaultVariantAnalysis.skippedRepos.noCodeqlDbRepos,
+      },
+    });
+
+    expect(screen.queryByRole("Analyzed")).not.toBeInTheDocument();
+    expect(screen.getByText("No access")).toBeInTheDocument();
+    expect(screen.getByText("No database")).toBeInTheDocument();
+  });
+
+  it("does not render any tabs when there are no repos", () => {
+    render({
+      status: VariantAnalysisStatus.Failed,
+      failureReason: VariantAnalysisFailureReason.InternalError,
+      scannedRepos: [],
+      skippedRepos: {},
+    });
+
+    expect(screen.queryByRole("Analyzed")).not.toBeInTheDocument();
+    expect(screen.queryByRole("No access")).not.toBeInTheDocument();
+    expect(screen.queryByRole("No database")).not.toBeInTheDocument();
+    expect(
+      screen.getByText("Error: Something unexpected happened"),
+    ).toBeInTheDocument();
   });
 
   it("renders warning with canceled variant analysis", () => {


### PR DESCRIPTION
This will hide the "Analyzed" panel when there are no scanned repos and it's completely empty.

When all three panels are empty, this will also hide the search bar and filters, and will skip rendering anything for the panels.

Before:

<img width="1631" alt="Screenshot 2022-12-05 at 12 07 27" src="https://user-images.githubusercontent.com/1112623/205622699-f1d214bd-dc0d-43e5-9e22-bc5aeece5b1e.png">

After:

<img width="1631" alt="Screenshot 2022-12-05 at 12 07 46" src="https://user-images.githubusercontent.com/1112623/205622762-3a24ad17-5591-488b-a940-43b7c28e4372.png">

<img width="1631" alt="Screenshot 2022-12-05 at 14 03 33" src="https://user-images.githubusercontent.com/1112623/205644002-e616fa78-81c0-4e0c-a1b0-32e782160993.png">

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
