### PR TITLE
Fix Jest config for view tests

### DIFF
--- a/extensions/ql-vscode/src/view/jest.config.ts
+++ b/extensions/ql-vscode/src/view/jest.config.ts
@@ -171,7 +171,7 @@ const config: Config = {
     "^.+\\.tsx?$": [
       "ts-jest",
       {
-        tsconfig: "src/view/tsconfig.spec.json",
+        tsconfig: "<rootDir>/tsconfig.spec.json",
       },
     ],
     node_modules: [


### PR DESCRIPTION
This will allow running the view tests in `src/view`, rather than only allowing these tests to be run from the root directory.

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
