### PR TITLE
Fix missing error message on repository selection

### DIFF
--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/repository-selection.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/repository-selection.test.ts
@@ -65,6 +65,28 @@ describe("repository selection", () => {
       expect(repoSelection.owners).toBeUndefined();
       expect(repoSelection.repositories).toEqual(["foo/bar", "foo/baz"]);
     });
+
+    it("should return an error for an empty repository list", async () => {
+      // Fake return values
+      quickPickSpy.mockResolvedValue({
+        repositories: [],
+      } as unknown as QuickPickItem);
+      getRemoteRepositoryListsSpy.mockReturnValue({
+        list1: ["foo/bar", "foo/baz"],
+        list2: [],
+      });
+
+      await expect(getRepositorySelection()).rejects.toThrow(
+        "No repositories selected",
+      );
+      await expect(getRepositorySelection()).rejects.toThrow(
+        UserCancellationException,
+      );
+      await expect(getRepositorySelection()).rejects.toHaveProperty(
+        "silent",
+        false,
+      );
+    });
   });
 
   describe("system level repo lists", () => {
@@ -149,6 +171,10 @@ describe("repository selection", () => {
       await expect(getRepositorySelection()).rejects.toThrow(
         UserCancellationException,
       );
+      await expect(getRepositorySelection()).rejects.toHaveProperty(
+        "silent",
+        true,
+      );
     });
   });
 
@@ -218,6 +244,10 @@ describe("repository selection", () => {
       );
       await expect(getRepositorySelection()).rejects.toThrow(
         UserCancellationException,
+      );
+      await expect(getRepositorySelection()).rejects.toHaveProperty(
+        "silent",
+        true,
       );
     });
   });
@@ -312,5 +342,21 @@ describe("repository selection", () => {
       expect(repoSelection.owners).toBeUndefined();
       expect(repoSelection.repositories).toEqual(["owner3/repo3"]);
     });
+  });
+
+  it("should allow the user to cancel", async () => {
+    // Fake return values
+    quickPickSpy.mockResolvedValue(undefined);
+
+    await expect(getRepositorySelection()).rejects.toThrow(
+      "No repositories selected",
+    );
+    await expect(getRepositorySelection()).rejects.toThrow(
+      UserCancellationException,
+    );
+    await expect(getRepositorySelection()).rejects.toHaveProperty(
+      "silent",
+      true,
+    );
   });
 });


### PR DESCRIPTION
The repository selection was structured such that you would get in the `else` case if there was nothing selected, but this case would also be used if for some other reason the selected item was not valid.

This restructures the conditions to first check whether the user cancelled out of the operation and will silently return in that case. In other cases where it cannot determine the repositories, it will now show a user-visible error.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
