### PR TITLE
New DB panel: Add UI command to select database item

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -61,6 +61,8 @@
     "onCommand:codeQL.chooseDatabaseLgtm",
     "onCommand:codeQLDatabases.chooseDatabase",
     "onCommand:codeQLDatabases.setCurrentDatabase",
+    "onCommand:codeQLDatabasesExperimental.openConfigFile",
+    "onCommand:codeQLDatabasesExperimental.setSelectedItem",
     "onCommand:codeQL.quickQuery",
     "onCommand:codeQL.restartQueryServer",
     "onWebviewPanel:resultsView",
@@ -363,6 +365,11 @@
           "light": "media/light/edit.svg",
           "dark": "media/dark/edit.svg"
         }
+      },
+      {
+        "command": "codeQLDatabasesExperimental.setSelectedItem",
+        "title": "Select Item",
+        "icon": "$(circle-small-filled)"
       },
       {
         "command": "codeQLDatabases.chooseDatabaseFolder",
@@ -796,6 +803,11 @@
           "when": "view == codeQLDatabases"
         },
         {
+          "command": "codeQLDatabasesExperimental.setSelectedItem",
+          "when": "view == codeQLDatabasesExperimental",
+          "group": "inline"
+        },
+        {
           "command": "codeQLQueryHistory.openQuery",
           "group": "9_qlCommands",
           "when": "view == codeQLQueryHistory"
@@ -983,6 +995,10 @@
         },
         {
           "command": "codeQLDatabasesExperimental.openConfigFile",
+          "when": "false"
+        },
+        {
+          "command": "codeQLDatabasesExperimental.setSelectedItem",
           "when": "false"
         },
         {

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -804,7 +804,7 @@
         },
         {
           "command": "codeQLDatabasesExperimental.setSelectedItem",
-          "when": "view == codeQLDatabasesExperimental",
+          "when": "view == codeQLDatabasesExperimental && viewItem == selectableDbItem",
           "group": "inline"
         },
         {

--- a/extensions/ql-vscode/src/databases/ui/db-panel.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-panel.ts
@@ -3,6 +3,7 @@ import { commandRunner } from "../../commandRunner";
 import { DisposableObject } from "../../pure/disposable-object";
 import { DbManager } from "../db-manager";
 import { DbTreeDataProvider } from "./db-tree-data-provider";
+import { DbTreeViewItem } from "./db-tree-view-item";
 
 export class DbPanel extends DisposableObject {
   private readonly dataProvider: DbTreeDataProvider;
@@ -27,8 +28,9 @@ export class DbPanel extends DisposableObject {
       ),
     );
     this.push(
-      commandRunner("codeQLDatabasesExperimental.setSelectedItem", () =>
-        this.setSelectedItem(),
+      commandRunner(
+        "codeQLDatabasesExperimental.setSelectedItem",
+        (treeViewItem: DbTreeViewItem) => this.setSelectedItem(treeViewItem),
       ),
     );
   }
@@ -38,8 +40,12 @@ export class DbPanel extends DisposableObject {
     const document = await workspace.openTextDocument(configPath);
     await window.showTextDocument(document);
   }
-  private async setSelectedItem(): Promise<void> {
-    // TODO
-    console.log("setSelectedItem");
+  private async setSelectedItem(treeViewItem: DbTreeViewItem): Promise<void> {
+    if (treeViewItem.dbItem === undefined) {
+      throw new Error(
+        "Not a selectable database item. Please select a valid item.",
+      );
+    }
+    await this.dbManager.setSelectedDbItem(treeViewItem.dbItem);
   }
 }

--- a/extensions/ql-vscode/src/databases/ui/db-panel.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-panel.ts
@@ -40,6 +40,7 @@ export class DbPanel extends DisposableObject {
     const document = await workspace.openTextDocument(configPath);
     await window.showTextDocument(document);
   }
+
   private async setSelectedItem(treeViewItem: DbTreeViewItem): Promise<void> {
     if (treeViewItem.dbItem === undefined) {
       throw new Error(

--- a/extensions/ql-vscode/src/databases/ui/db-panel.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-panel.ts
@@ -26,11 +26,20 @@ export class DbPanel extends DisposableObject {
         this.openConfigFile(),
       ),
     );
+    this.push(
+      commandRunner("codeQLDatabasesExperimental.setSelectedItem", () =>
+        this.setSelectedItem(),
+      ),
+    );
   }
 
   private async openConfigFile(): Promise<void> {
     const configPath = this.dbManager.getConfigPath();
     const document = await workspace.openTextDocument(configPath);
     await window.showTextDocument(document);
+  }
+  private async setSelectedItem(): Promise<void> {
+    // TODO
+    console.log("setSelectedItem");
   }
 }

--- a/extensions/ql-vscode/src/databases/ui/db-selection-decoration-provider.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-selection-decoration-provider.ts
@@ -13,7 +13,8 @@ export class DbSelectionDecorationProvider implements FileDecorationProvider {
   ): ProviderResult<FileDecoration> {
     if (uri?.query === "selected=true") {
       return {
-        badge: "✔",
+        badge: "●",
+        tooltip: "Currently selected",
       };
     }
 


### PR DESCRIPTION
Adds a UI action that lets you select a database item. This displays a ⚫ next to the selected item and sets the item as "selected" in the db config file.

![DB panel select](https://user-images.githubusercontent.com/42641846/205913537-b46071e4-7fa6-4b9c-aae7-6ac9fa5184d5.GIF)

See internal issue for more details 🌶️ 

## Checklist

N/A - internal only 🍛 

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
