### PR TITLE
Fix incorrect await for monitor

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
@@ -125,11 +125,7 @@ export class RemoteQueriesManager extends DisposableObject {
     } else if (status === QueryStatus.InProgress) {
       // In this case, last time we checked, the query was still in progress.
       // We need to setup the monitor to check for completion.
-      await commands.executeCommand(
-        "codeQL.monitorRemoteQuery",
-        queryId,
-        query,
-      );
+      void commands.executeCommand("codeQL.monitorRemoteQuery", queryId, query);
     }
   }
 


### PR DESCRIPTION
When rehydrating remote queries, we were awaiting the monitoring command. Since this command may take minutes to hours to complete, it seems like this would block the extension from loading. This is the same issue as in https://github.com/github/vscode-codeql/pull/1698, but for remote queries instead of variant analyses.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
