### PR TITLE
Track expanded state of db items

### DIFF
--- a/extensions/ql-vscode/src/databases/config/db-config-store.ts
+++ b/extensions/ql-vscode/src/databases/config/db-config-store.ts
@@ -1,6 +1,11 @@
 import { pathExists, writeJSON, readJSON, readJSONSync } from "fs-extra";
 import { join } from "path";
-import { cloneDbConfig, DbConfig, SelectedDbItem } from "./db-config";
+import {
+  cloneDbConfig,
+  DbConfig,
+  ExpandedDbItem,
+  SelectedDbItem,
+} from "./db-config";
 import * as chokidar from "chokidar";
 import { DisposableObject, DisposeHandler } from "../../pure/disposable-object";
 import { DbConfigValidator } from "./db-config-validator";
@@ -72,6 +77,19 @@ export class DbConfigStore extends DisposableObject {
     await this.writeConfig(config);
   }
 
+  public async updateExpandedState(expandedItems: ExpandedDbItem[]) {
+    if (!this.config) {
+      throw Error("Cannot update expansion state if config is not loaded");
+    }
+
+    const config: DbConfig = {
+      ...this.config,
+      expanded: expandedItems,
+    };
+
+    await this.writeConfig(config);
+  }
+
   private async writeConfig(config: DbConfig): Promise<void> {
     await writeJSON(this.configPath, config, {
       spaces: 2,
@@ -137,6 +155,7 @@ export class DbConfigStore extends DisposableObject {
           databases: [],
         },
       },
+      expanded: [],
     };
   }
 }

--- a/extensions/ql-vscode/src/databases/config/db-config.ts
+++ b/extensions/ql-vscode/src/databases/config/db-config.ts
@@ -2,6 +2,7 @@
 
 export interface DbConfig {
   databases: DbConfigDatabases;
+  expanded: ExpandedDbItem[];
   selected?: SelectedDbItem;
 }
 
@@ -87,6 +88,37 @@ export interface LocalDatabase {
   storagePath: string;
 }
 
+export type ExpandedDbItem =
+  | RootLocalExpandedDbItem
+  | LocalUserDefinedListExpandedDbItem
+  | RootRemoteExpandedDbItem
+  | RemoteUserDefinedListExpandedDbItem;
+
+export enum ExpandedDbItemKind {
+  RootLocal = "rootLocal",
+  LocalUserDefinedList = "localUserDefinedList",
+  RootRemote = "rootRemote",
+  RemoteUserDefinedList = "remoteUserDefinedList",
+}
+
+export interface RootLocalExpandedDbItem {
+  kind: ExpandedDbItemKind.RootLocal;
+}
+
+export interface LocalUserDefinedListExpandedDbItem {
+  kind: ExpandedDbItemKind.LocalUserDefinedList;
+  listName: string;
+}
+
+export interface RootRemoteExpandedDbItem {
+  kind: ExpandedDbItemKind.RootRemote;
+}
+
+export interface RemoteUserDefinedListExpandedDbItem {
+  kind: ExpandedDbItemKind.RemoteUserDefinedList;
+  listName: string;
+}
+
 export function cloneDbConfig(config: DbConfig): DbConfig {
   return {
     databases: {
@@ -108,6 +140,7 @@ export function cloneDbConfig(config: DbConfig): DbConfig {
         databases: config.databases.local.databases.map((db) => ({ ...db })),
       },
     },
+    expanded: config.expanded.map(cloneDbConfigExpandedItem),
     selected: config.selected
       ? cloneDbConfigSelectedItem(config.selected)
       : undefined,
@@ -147,6 +180,25 @@ function cloneDbConfigSelectedItem(selected: SelectedDbItem): SelectedDbItem {
         kind: SelectedDbItemKind.RemoteRepository,
         repositoryName: selected.repositoryName,
         listName: selected.listName,
+      };
+  }
+}
+
+function cloneDbConfigExpandedItem(item: ExpandedDbItem): ExpandedDbItem {
+  switch (item.kind) {
+    case ExpandedDbItemKind.RootLocal:
+      return { kind: ExpandedDbItemKind.RootLocal };
+    case ExpandedDbItemKind.LocalUserDefinedList:
+      return {
+        kind: ExpandedDbItemKind.LocalUserDefinedList,
+        listName: item.listName,
+      };
+    case ExpandedDbItemKind.RootRemote:
+      return { kind: ExpandedDbItemKind.RootRemote };
+    case ExpandedDbItemKind.RemoteUserDefinedList:
+      return {
+        kind: ExpandedDbItemKind.RemoteUserDefinedList,
+        listName: item.listName,
       };
   }
 }

--- a/extensions/ql-vscode/src/databases/config/db-config.ts
+++ b/extensions/ql-vscode/src/databases/config/db-config.ts
@@ -187,17 +187,12 @@ function cloneDbConfigSelectedItem(selected: SelectedDbItem): SelectedDbItem {
 function cloneDbConfigExpandedItem(item: ExpandedDbItem): ExpandedDbItem {
   switch (item.kind) {
     case ExpandedDbItemKind.RootLocal:
-      return { kind: ExpandedDbItemKind.RootLocal };
-    case ExpandedDbItemKind.LocalUserDefinedList:
-      return {
-        kind: ExpandedDbItemKind.LocalUserDefinedList,
-        listName: item.listName,
-      };
     case ExpandedDbItemKind.RootRemote:
-      return { kind: ExpandedDbItemKind.RootRemote };
+      return { kind: item.kind };
+    case ExpandedDbItemKind.LocalUserDefinedList:
     case ExpandedDbItemKind.RemoteUserDefinedList:
       return {
-        kind: ExpandedDbItemKind.RemoteUserDefinedList,
+        kind: item.kind,
         listName: item.listName,
       };
   }

--- a/extensions/ql-vscode/src/databases/db-item-expansion.ts
+++ b/extensions/ql-vscode/src/databases/db-item-expansion.ts
@@ -1,0 +1,66 @@
+import { ExpandedDbItem, ExpandedDbItemKind } from "./config/db-config";
+import { DbItem, DbItemKind } from "./db-item";
+
+export function calculateNewExpandedState(
+  currentExpandedItems: ExpandedDbItem[],
+  dbItem: DbItem,
+  itemExpanded: boolean,
+): ExpandedDbItem[] {
+  if (itemExpanded) {
+    const expandedDbItem = mapDbItemToExpandedDbItem(dbItem);
+    const expandedItems = [...currentExpandedItems];
+    if (!expandedItems.some((i) => isDbItemEqualToExpandedDbItem(dbItem, i))) {
+      expandedItems.push(expandedDbItem);
+    }
+    return expandedItems;
+  } else {
+    return currentExpandedItems.filter(
+      (i) => !isDbItemEqualToExpandedDbItem(dbItem, i),
+    );
+  }
+}
+
+function mapDbItemToExpandedDbItem(dbItem: DbItem): ExpandedDbItem {
+  switch (dbItem.kind) {
+    case DbItemKind.RootLocal:
+      return { kind: ExpandedDbItemKind.RootLocal };
+    case DbItemKind.LocalList:
+      return {
+        kind: ExpandedDbItemKind.LocalUserDefinedList,
+        listName: dbItem.listName,
+      };
+    case DbItemKind.RootRemote:
+      return { kind: ExpandedDbItemKind.RootRemote };
+    case DbItemKind.RemoteUserDefinedList:
+      return {
+        kind: ExpandedDbItemKind.RemoteUserDefinedList,
+        listName: dbItem.listName,
+      };
+    default:
+      throw Error(`Unknown db item kind ${dbItem.kind}`);
+  }
+}
+
+function isDbItemEqualToExpandedDbItem(
+  dbItem: DbItem,
+  expandedDbItem: ExpandedDbItem,
+) {
+  switch (dbItem.kind) {
+    case DbItemKind.RootLocal:
+      return expandedDbItem.kind === ExpandedDbItemKind.RootLocal;
+    case DbItemKind.LocalList:
+      return (
+        expandedDbItem.kind === ExpandedDbItemKind.LocalUserDefinedList &&
+        expandedDbItem.listName === dbItem.listName
+      );
+    case DbItemKind.RootRemote:
+      return expandedDbItem.kind === ExpandedDbItemKind.RootRemote;
+    case DbItemKind.RemoteUserDefinedList:
+      return (
+        expandedDbItem.kind === ExpandedDbItemKind.RemoteUserDefinedList &&
+        expandedDbItem.listName === dbItem.listName
+      );
+    default:
+      throw Error(`Unknown db item kind ${dbItem.kind}`);
+  }
+}

--- a/extensions/ql-vscode/src/databases/db-item.ts
+++ b/extensions/ql-vscode/src/databases/db-item.ts
@@ -13,6 +13,7 @@ export enum DbItemKind {
 
 export interface RootLocalDbItem {
   kind: DbItemKind.RootLocal;
+  expanded: boolean;
   children: LocalDbItem[];
 }
 
@@ -20,6 +21,7 @@ export type LocalDbItem = LocalListDbItem | LocalDatabaseDbItem;
 
 export interface LocalListDbItem {
   kind: DbItemKind.LocalList;
+  expanded: boolean;
   selected: boolean;
   listName: string;
   databases: LocalDatabaseDbItem[];
@@ -37,6 +39,7 @@ export interface LocalDatabaseDbItem {
 
 export interface RootRemoteDbItem {
   kind: DbItemKind.RootRemote;
+  expanded: boolean;
   children: RemoteDbItem[];
 }
 
@@ -62,6 +65,7 @@ export interface RemoteSystemDefinedListDbItem {
 
 export interface RemoteUserDefinedListDbItem {
   kind: DbItemKind.RemoteUserDefinedList;
+  expanded: boolean;
   selected: boolean;
   listName: string;
   repos: RemoteRepoDbItem[];

--- a/extensions/ql-vscode/src/databases/db-manager.ts
+++ b/extensions/ql-vscode/src/databases/db-manager.ts
@@ -3,6 +3,7 @@ import { AppEvent, AppEventEmitter } from "../common/events";
 import { ValueResult } from "../common/value-result";
 import { DbConfigStore } from "./config/db-config-store";
 import { DbItem } from "./db-item";
+import { calculateNewExpandedState } from "./db-item-expansion";
 import {
   getSelectedDbItem,
   mapDbItemToSelectedDbItem,
@@ -53,5 +54,23 @@ export class DbManager {
     if (selectedDbItem) {
       await this.dbConfigStore.setSelectedDbItem(selectedDbItem);
     }
+  }
+
+  public async updateDbItemExpandedState(
+    dbItem: DbItem,
+    itemExpanded: boolean,
+  ): Promise<void> {
+    const configResult = this.dbConfigStore.getConfig();
+    if (configResult.isFailure) {
+      throw Error("Cannot update expanded state if config is not loaded");
+    }
+
+    const newExpandedItems = calculateNewExpandedState(
+      configResult.value.expanded,
+      dbItem,
+      itemExpanded,
+    );
+
+    await this.dbConfigStore.updateExpandedState(newExpandedItems);
   }
 }

--- a/extensions/ql-vscode/src/databases/db-tree-creator.ts
+++ b/extensions/ql-vscode/src/databases/db-tree-creator.ts
@@ -1,5 +1,6 @@
 import {
   DbConfig,
+  ExpandedDbItemKind,
   LocalDatabase,
   LocalList,
   RemoteRepositoryList,
@@ -34,6 +35,10 @@ export function createRemoteTree(dbConfig: DbConfig): RootRemoteDbItem {
     createRepoItem(r, dbConfig),
   );
 
+  const expanded =
+    dbConfig.expanded &&
+    dbConfig.expanded.some((e) => e.kind === ExpandedDbItemKind.RootRemote);
+
   return {
     kind: DbItemKind.RootRemote,
     children: [
@@ -42,6 +47,7 @@ export function createRemoteTree(dbConfig: DbConfig): RootRemoteDbItem {
       ...userDefinedRepoLists,
       ...repos,
     ],
+    expanded: !!expanded,
   };
 }
 
@@ -53,9 +59,14 @@ export function createLocalTree(dbConfig: DbConfig): RootLocalDbItem {
     createLocalDb(l, dbConfig),
   );
 
+  const expanded =
+    dbConfig.expanded &&
+    dbConfig.expanded.some((e) => e.kind === ExpandedDbItemKind.RootLocal);
+
   return {
     kind: DbItemKind.RootLocal,
     children: [...localLists, ...localDbs],
+    expanded: !!expanded,
   };
 }
 
@@ -88,11 +99,20 @@ function createRemoteUserDefinedList(
     dbConfig.selected.kind === SelectedDbItemKind.RemoteUserDefinedList &&
     dbConfig.selected.listName === list.name;
 
+  const expanded =
+    dbConfig.expanded &&
+    dbConfig.expanded.some(
+      (e) =>
+        e.kind === ExpandedDbItemKind.RemoteUserDefinedList &&
+        e.listName === list.name,
+    );
+
   return {
     kind: DbItemKind.RemoteUserDefinedList,
     listName: list.name,
     repos: list.repositories.map((r) => createRepoItem(r, dbConfig, list.name)),
     selected: !!selected,
+    expanded: !!expanded,
   };
 }
 
@@ -134,11 +154,20 @@ function createLocalList(list: LocalList, dbConfig: DbConfig): LocalListDbItem {
     dbConfig.selected.kind === SelectedDbItemKind.LocalUserDefinedList &&
     dbConfig.selected.listName === list.name;
 
+  const expanded =
+    dbConfig.expanded &&
+    dbConfig.expanded.some(
+      (e) =>
+        e.kind === ExpandedDbItemKind.LocalUserDefinedList &&
+        e.listName === list.name,
+    );
+
   return {
     kind: DbItemKind.LocalList,
     listName: list.name,
     databases: list.databases.map((d) => createLocalDb(d, dbConfig, list.name)),
     selected: !!selected,
+    expanded: !!expanded,
   };
 }
 

--- a/extensions/ql-vscode/src/databases/ui/db-panel.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-panel.ts
@@ -1,4 +1,4 @@
-import { window, workspace } from "vscode";
+import { TreeViewExpansionEvent, window, workspace } from "vscode";
 import { commandRunner } from "../../commandRunner";
 import { DisposableObject } from "../../pure/disposable-object";
 import { DbManager } from "../db-manager";
@@ -17,6 +17,9 @@ export class DbPanel extends DisposableObject {
       treeDataProvider: this.dataProvider,
       canSelectMany: false,
     });
+
+    treeView.onDidCollapseElement.bind(this.onDidCollapseElement);
+    treeView.onDidExpandElement.bind(this.onDidExpandElement);
 
     this.push(treeView);
   }
@@ -48,5 +51,27 @@ export class DbPanel extends DisposableObject {
       );
     }
     await this.dbManager.setSelectedDbItem(treeViewItem.dbItem);
+  }
+
+  private async onDidCollapseElement(
+    event: TreeViewExpansionEvent<DbTreeViewItem>,
+  ): Promise<void> {
+    const dbItem = event.element.dbItem;
+    if (!dbItem) {
+      throw Error("Expected a database item.");
+    }
+
+    await this.dbManager.updateDbItemExpandedState(event.element.dbItem, false);
+  }
+
+  private async onDidExpandElement(
+    event: TreeViewExpansionEvent<DbTreeViewItem>,
+  ): Promise<void> {
+    const dbItem = event.element.dbItem;
+    if (!dbItem) {
+      throw Error("Expected a database item.");
+    }
+
+    await this.dbManager.updateDbItemExpandedState(event.element.dbItem, true);
   }
 }

--- a/extensions/ql-vscode/src/databases/ui/db-tree-view-item.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-tree-view-item.ts
@@ -70,7 +70,7 @@ export function createDbTreeViewItemRoot(
     undefined,
     label,
     tooltip,
-    vscode.TreeItemCollapsibleState.Collapsed,
+    getCollapsibleState(dbItem.expanded),
     children,
   );
 }
@@ -100,7 +100,7 @@ export function createDbTreeViewItemUserDefinedList(
     undefined,
     listName,
     undefined,
-    vscode.TreeItemCollapsibleState.Collapsed,
+    getCollapsibleState(dbItem.expanded),
     children,
   );
 }
@@ -146,4 +146,12 @@ export function createDbTreeViewItemLocalDatabase(
     vscode.TreeItemCollapsibleState.None,
     [],
   );
+}
+
+function getCollapsibleState(
+  expanded: boolean,
+): vscode.TreeItemCollapsibleState {
+  return expanded
+    ? vscode.TreeItemCollapsibleState.Expanded
+    : vscode.TreeItemCollapsibleState.Collapsed;
 }

--- a/extensions/ql-vscode/src/vscode-tests/minimal-workspace/databases/db-panel.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/minimal-workspace/databases/db-panel.test.ts
@@ -60,6 +60,7 @@ describe("db panel", () => {
           databases: [],
         },
       },
+      expanded: [],
     };
 
     await saveDbConfig(dbConfig);
@@ -123,6 +124,7 @@ describe("db panel", () => {
           databases: [],
         },
       },
+      expanded: [],
     };
 
     await saveDbConfig(dbConfig);
@@ -174,6 +176,7 @@ describe("db panel", () => {
           databases: [],
         },
       },
+      expanded: [],
     };
 
     await saveDbConfig(dbConfig);
@@ -213,6 +216,7 @@ describe("db panel", () => {
           databases: [],
         },
       },
+      expanded: [],
     };
 
     await saveDbConfig(dbConfig);
@@ -281,6 +285,7 @@ describe("db panel", () => {
           databases: [],
         },
       },
+      expanded: [],
     };
 
     await saveDbConfig(dbConfig);
@@ -359,6 +364,7 @@ describe("db panel", () => {
           ],
         },
       },
+      expanded: [],
     };
 
     await saveDbConfig(dbConfig);
@@ -421,6 +427,7 @@ describe("db panel", () => {
           databases: [],
         },
       },
+      expanded: [],
       selected: {
         kind: SelectedDbItemKind.RemoteUserDefinedList,
         listName: "my-list-2",
@@ -477,6 +484,7 @@ describe("db panel", () => {
           databases: [],
         },
       },
+      expanded: [],
       selected: {
         kind: SelectedDbItemKind.RemoteRepository,
         repositoryName: "owner1/repo1",

--- a/extensions/ql-vscode/test/factories/db-item-factories.ts
+++ b/extensions/ql-vscode/test/factories/db-item-factories.ts
@@ -1,0 +1,34 @@
+import {
+  DbItemKind,
+  RemoteUserDefinedListDbItem,
+  RootRemoteDbItem,
+} from "../../src/databases/db-item";
+
+export function createRootRemoteDbItem(): RootRemoteDbItem {
+  return {
+    kind: DbItemKind.RootRemote,
+    children: [],
+    expanded: false,
+  };
+}
+
+export function createRemoteUserDefinedListDbItem({
+  name = "list1",
+}: {
+  name: string;
+}): RemoteUserDefinedListDbItem {
+  return {
+    kind: DbItemKind.RemoteUserDefinedList,
+    selected: false,
+    expanded: false,
+    listName: name,
+    repos: [
+      {
+        kind: DbItemKind.RemoteRepo,
+        selected: false,
+        repoFullName: "repo1",
+        parentListName: name,
+      },
+    ],
+  };
+}

--- a/extensions/ql-vscode/test/pure-tests/databases/config/data/without-selected/workspace-databases.json
+++ b/extensions/ql-vscode/test/pure-tests/databases/config/data/without-selected/workspace-databases.json
@@ -9,5 +9,6 @@
       "lists": [],
       "databases": []
     }
-  }
+  },
+  "expanded": []
 }

--- a/extensions/ql-vscode/test/pure-tests/databases/config/data/workspace-databases.json
+++ b/extensions/ql-vscode/test/pure-tests/databases/config/data/workspace-databases.json
@@ -45,6 +45,7 @@
       ]
     }
   },
+  "expanded": [],
   "selected": {
     "kind": "remoteUserDefinedList",
     "listName": "repoList1"

--- a/extensions/ql-vscode/test/pure-tests/databases/config/db-config-validator.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/databases/config/db-config-validator.test.ts
@@ -22,6 +22,7 @@ describe("db config validation", () => {
           somethingElse: "bar",
         },
       },
+      expanded: [],
     } as any as DbConfig;
 
     const validationOutput = configValidator.validate(dbConfig);

--- a/extensions/ql-vscode/test/pure-tests/databases/db-item-expansion.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/databases/db-item-expansion.test.ts
@@ -1,0 +1,109 @@
+import {
+  ExpandedDbItem,
+  ExpandedDbItemKind,
+} from "../../../src/databases/config/db-config";
+import {
+  RemoteUserDefinedListDbItem,
+  RootRemoteDbItem,
+} from "../../../src/databases/db-item";
+import { calculateNewExpandedState } from "../../../src/databases/db-item-expansion";
+import {
+  createRemoteUserDefinedListDbItem,
+  createRootRemoteDbItem,
+} from "../../factories/db-item-factories";
+
+describe("db item expansion", () => {
+  it("should add an expanded item to an existing list", () => {
+    const currentExpandedItems: ExpandedDbItem[] = [
+      {
+        kind: ExpandedDbItemKind.RootRemote,
+      },
+      {
+        kind: ExpandedDbItemKind.RemoteUserDefinedList,
+        listName: "list1",
+      },
+    ];
+
+    const dbItem: RemoteUserDefinedListDbItem =
+      createRemoteUserDefinedListDbItem({
+        name: "list2",
+      });
+
+    const newExpandedItems = calculateNewExpandedState(
+      currentExpandedItems,
+      dbItem,
+      true,
+    );
+
+    expect(newExpandedItems).toEqual([
+      ...currentExpandedItems,
+      {
+        kind: ExpandedDbItemKind.RemoteUserDefinedList,
+        listName: "list2",
+      },
+    ]);
+  });
+
+  it("should add an expanded item to an empty list", () => {
+    const dbItem: RemoteUserDefinedListDbItem =
+      createRemoteUserDefinedListDbItem({
+        name: "list2",
+      });
+
+    const newExpandedItems = calculateNewExpandedState([], dbItem, true);
+
+    expect(newExpandedItems).toEqual([
+      {
+        kind: ExpandedDbItemKind.RemoteUserDefinedList,
+        listName: "list2",
+      },
+    ]);
+  });
+
+  it("should remove a collapsed item from a list", () => {
+    const currentExpandedItems: ExpandedDbItem[] = [
+      {
+        kind: ExpandedDbItemKind.RootRemote,
+      },
+      {
+        kind: ExpandedDbItemKind.RemoteUserDefinedList,
+        listName: "list1",
+      },
+    ];
+
+    const dbItem: RemoteUserDefinedListDbItem =
+      createRemoteUserDefinedListDbItem({
+        name: "list1",
+      });
+
+    const newExpandedItems = calculateNewExpandedState(
+      currentExpandedItems,
+      dbItem,
+      false,
+    );
+
+    expect(newExpandedItems).toEqual([
+      {
+        kind: ExpandedDbItemKind.RootRemote,
+      },
+    ]);
+  });
+
+  it("should remove a collapsed item from a list that becomes empty", () => {
+    const currentExpandedItems: ExpandedDbItem[] = [
+      {
+        kind: ExpandedDbItemKind.RootRemote,
+      },
+    ];
+
+    const dbItem: RootRemoteDbItem = createRootRemoteDbItem();
+
+    const newExpandedItems = calculateNewExpandedState(
+      currentExpandedItems,
+      dbItem,
+      false,
+    );
+
+    expect(newExpandedItems).toEqual([]);
+  });
+});

--- a/extensions/ql-vscode/test/pure-tests/databases/db-item-selection.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/databases/db-item-selection.test.ts
@@ -1,10 +1,12 @@
 import { DbItem, DbItemKind } from "../../../src/databases/db-item";
 import { getSelectedDbItem } from "../../../src/databases/db-item-selection";
+
 describe("db item selection", () => {
   it("should return undefined if no item is selected", () => {
     const dbItems: DbItem[] = [
       {
         kind: DbItemKind.RootRemote,
+        expanded: false,
         children: [
           {
             kind: DbItemKind.RemoteSystemDefinedList,
@@ -27,6 +29,7 @@ describe("db item selection", () => {
           },
           {
             kind: DbItemKind.RemoteUserDefinedList,
+            expanded: false,
             listName: "my list",
             repos: [
               {
@@ -46,9 +49,11 @@ describe("db item selection", () => {
       },
       {
         kind: DbItemKind.RootLocal,
+        expanded: false,
         children: [
           {
             kind: DbItemKind.LocalList,
+            expanded: false,
             listName: "list-1",
             databases: [
               {
@@ -89,9 +94,11 @@ describe("db item selection", () => {
     const dbItems: DbItem[] = [
       {
         kind: DbItemKind.RootLocal,
+        expanded: false,
         children: [
           {
             kind: DbItemKind.LocalList,
+            expanded: false,
             listName: "list-1",
             databases: [
               {
@@ -139,6 +146,7 @@ describe("db item selection", () => {
     const dbItems: DbItem[] = [
       {
         kind: DbItemKind.RootRemote,
+        expanded: false,
         children: [
           {
             kind: DbItemKind.RemoteSystemDefinedList,
@@ -154,6 +162,7 @@ describe("db item selection", () => {
           },
           {
             kind: DbItemKind.RemoteUserDefinedList,
+            expanded: false,
             listName: "my list",
             repos: [
               {
@@ -175,6 +184,7 @@ describe("db item selection", () => {
 
     expect(getSelectedDbItem(dbItems)).toEqual({
       kind: DbItemKind.RemoteUserDefinedList,
+      expanded: false,
       listName: "my list",
       repos: [
         {
@@ -196,6 +206,7 @@ describe("db item selection", () => {
     const dbItems: DbItem[] = [
       {
         kind: DbItemKind.RootRemote,
+        expanded: false,
         children: [
           {
             kind: DbItemKind.RemoteSystemDefinedList,
@@ -211,6 +222,7 @@ describe("db item selection", () => {
           },
           {
             kind: DbItemKind.RemoteUserDefinedList,
+            expanded: false,
             listName: "my list",
             repos: [
               {
@@ -250,6 +262,7 @@ describe("db item selection", () => {
     const dbItems: DbItem[] = [
       {
         kind: DbItemKind.RootRemote,
+        expanded: false,
         children: [
           {
             kind: DbItemKind.RemoteSystemDefinedList,
@@ -265,6 +278,7 @@ describe("db item selection", () => {
           },
           {
             kind: DbItemKind.RemoteUserDefinedList,
+            expanded: false,
             listName: "my list",
             repos: [],
             selected: false,

--- a/extensions/ql-vscode/test/pure-tests/databases/db-tree-creator.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/databases/db-tree-creator.test.ts
@@ -1,5 +1,6 @@
 import {
   DbConfig,
+  ExpandedDbItemKind,
   SelectedDbItemKind,
 } from "../../../src/databases/config/db-config";
 import {
@@ -28,12 +29,14 @@ describe("db tree creator", () => {
             databases: [],
           },
         },
+        expanded: [],
       };
 
       const dbTreeRoot = createRemoteTree(dbConfig);
 
       expect(dbTreeRoot).toBeTruthy();
       expect(dbTreeRoot.kind).toBe(DbItemKind.RootRemote);
+      expect(dbTreeRoot.expanded).toBe(false);
       expect(dbTreeRoot.children.length).toBe(3);
       expect(dbTreeRoot.children[0]).toEqual({
         kind: DbItemKind.RemoteSystemDefinedList,
@@ -80,6 +83,7 @@ describe("db tree creator", () => {
             databases: [],
           },
         },
+        expanded: [],
       };
 
       const dbTreeRoot = createRemoteTree(dbConfig);
@@ -94,6 +98,7 @@ describe("db tree creator", () => {
       expect(repositoryListNodes[0]).toEqual({
         kind: DbItemKind.RemoteUserDefinedList,
         selected: false,
+        expanded: false,
         listName: dbConfig.databases.remote.repositoryLists[0].name,
         repos: dbConfig.databases.remote.repositoryLists[0].repositories.map(
           (repo) => ({
@@ -107,6 +112,7 @@ describe("db tree creator", () => {
       expect(repositoryListNodes[1]).toEqual({
         kind: DbItemKind.RemoteUserDefinedList,
         selected: false,
+        expanded: false,
         listName: dbConfig.databases.remote.repositoryLists[1].name,
         repos: dbConfig.databases.remote.repositoryLists[1].repositories.map(
           (repo) => ({
@@ -132,6 +138,7 @@ describe("db tree creator", () => {
             databases: [],
           },
         },
+        expanded: [],
       };
 
       const dbTreeRoot = createRemoteTree(dbConfig);
@@ -166,6 +173,7 @@ describe("db tree creator", () => {
             databases: [],
           },
         },
+        expanded: [],
       };
 
       const dbTreeRoot = createRemoteTree(dbConfig);
@@ -215,6 +223,7 @@ describe("db tree creator", () => {
               databases: [],
             },
           },
+          expanded: [],
           selected: {
             kind: SelectedDbItemKind.RemoteUserDefinedList,
             listName: "my-list-1",
@@ -246,6 +255,7 @@ describe("db tree creator", () => {
               databases: [],
             },
           },
+          expanded: [],
           selected: {
             kind: SelectedDbItemKind.RemoteOwner,
             ownerName: "owner1",
@@ -278,6 +288,7 @@ describe("db tree creator", () => {
               databases: [],
             },
           },
+          expanded: [],
           selected: {
             kind: SelectedDbItemKind.RemoteRepository,
             repositoryName: "owner1/repo2",
@@ -313,6 +324,7 @@ describe("db tree creator", () => {
               databases: [],
             },
           },
+          expanded: [],
           selected: {
             kind: SelectedDbItemKind.RemoteRepository,
             listName: "my-list-1",
@@ -335,6 +347,81 @@ describe("db tree creator", () => {
         expect(listNodes[0].repos[0].selected).toBe(true);
       });
     });
+
+    describe("expanded db items", () => {
+      it("should allow expanding the root remote list node", () => {
+        const dbConfig: DbConfig = {
+          databases: {
+            remote: {
+              repositoryLists: [],
+              owners: [],
+              repositories: [],
+            },
+            local: {
+              lists: [],
+              databases: [],
+            },
+          },
+          expanded: [
+            {
+              kind: ExpandedDbItemKind.RootRemote,
+            },
+          ],
+        };
+
+        const dbTreeRoot = createRemoteTree(dbConfig);
+
+        expect(dbTreeRoot).toBeTruthy();
+        expect(dbTreeRoot.kind).toBe(DbItemKind.RootRemote);
+        expect(dbTreeRoot.expanded).toBe(true);
+      });
+
+      it("should allow expanding a remote user defined list node", () => {
+        const dbConfig: DbConfig = {
+          databases: {
+            remote: {
+              repositoryLists: [
+                {
+                  name: "my-list-1",
+                  repositories: [
+                    "owner1/repo1",
+                    "owner1/repo2",
+                    "owner2/repo1",
+                  ],
+                },
+              ],
+              owners: [],
+              repositories: [],
+            },
+            local: {
+              lists: [],
+              databases: [],
+            },
+          },
+          expanded: [
+            {
+              kind: ExpandedDbItemKind.RootRemote,
+            },
+            {
+              kind: ExpandedDbItemKind.RemoteUserDefinedList,
+              listName: "my-list-1",
+            },
+          ],
+        };
+
+        const dbTreeRoot = createRemoteTree(dbConfig);
+
+        expect(dbTreeRoot).toBeTruthy();
+        expect(dbTreeRoot.kind).toBe(DbItemKind.RootRemote);
+        expect(dbTreeRoot.expanded).toBe(true);
+        const repositoryListNodes = dbTreeRoot.children.filter(
+          isRemoteUserDefinedListDbItem,
+        );
+
+        expect(repositoryListNodes.length).toBe(1);
+        expect(repositoryListNodes[0].expanded).toEqual(true);
+      });
+    });
   });
 
   describe("createLocalTree", () => {
@@ -351,12 +438,14 @@ describe("db tree creator", () => {
             databases: [],
           },
         },
+        expanded: [],
       };
 
       const dbTreeRoot = createLocalTree(dbConfig);
 
       expect(dbTreeRoot).toBeTruthy();
       expect(dbTreeRoot.kind).toBe(DbItemKind.RootLocal);
+      expect(dbTreeRoot.expanded).toBe(false);
       expect(dbTreeRoot.children.length).toBe(0);
     });
 
@@ -402,6 +491,7 @@ describe("db tree creator", () => {
             databases: [],
           },
         },
+        expanded: [],
       };
 
       const dbTreeRoot = createLocalTree(dbConfig);
@@ -415,6 +505,7 @@ describe("db tree creator", () => {
       expect(localListNodes.length).toBe(2);
       expect(localListNodes[0]).toEqual({
         kind: DbItemKind.LocalList,
+        expanded: false,
         selected: false,
         listName: dbConfig.databases.local.lists[0].name,
         databases: dbConfig.databases.local.lists[0].databases.map((db) => ({
@@ -429,6 +520,7 @@ describe("db tree creator", () => {
       });
       expect(localListNodes[1]).toEqual({
         kind: DbItemKind.LocalList,
+        expanded: false,
         selected: false,
         listName: dbConfig.databases.local.lists[1].name,
         databases: dbConfig.databases.local.lists[1].databases.map((db) => ({
@@ -469,6 +561,7 @@ describe("db tree creator", () => {
             ],
           },
         },
+        expanded: [],
       };
 
       const dbTreeRoot = createLocalTree(dbConfig);

--- a/extensions/ql-vscode/workspace-databases-schema.json
+++ b/extensions/ql-vscode/workspace-databases-schema.json
@@ -121,6 +121,60 @@
       "required": ["remote", "local"],
       "additionalProperties": false
     },
+    "expanded": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "oneOf": [
+          {
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": ["rootLocal"]
+              }
+            },
+            "required": ["kind"],
+            "additionalProperties": false
+          },
+          {
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": ["localUserDefinedList"]
+              },
+              "listName": {
+                "type": "string"
+              }
+            },
+            "required": ["kind", "listName"],
+            "additionalProperties": false
+          },
+          {
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": ["rootRemote"]
+              }
+            },
+            "required": ["kind"],
+            "additionalProperties": false
+          },
+          {
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": ["remoteUserDefinedList"]
+              },
+              "listName": {
+                "type": "string"
+              }
+            },
+            "required": ["kind", "listName"],
+            "additionalProperties": false
+          }
+        ]
+      }
+    },
     "selected": {
       "type": "object",
       "oneOf": [
@@ -211,6 +265,6 @@
       ]
     }
   },
-  "required": ["databases"],
+  "required": ["databases", "expanded"],
   "additionalProperties": false
 }


### PR DESCRIPTION
Adds logic to track expanded state for db items:
- Adds an `expanded` property in the db config, which contains an array of items that are expanded
- Adds an `expanded` property on some kinds of db items
- Updates to db item creation to look at the `expanded` property in the db config and set the db item's `expanded` property where appropriate.
- Adds `expanded` to a lot of test data

## Checklist
N/A:

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
