### PR TITLE
Initialize DbManager when newQueryRun is enabled

### DIFF
--- a/extensions/ql-vscode/src/databases/db-module.ts
+++ b/extensions/ql-vscode/src/databases/db-module.ts
@@ -1,6 +1,5 @@
 import { window } from "vscode";
-import { App, AppMode } from "../common/app";
-import { isCanary, isNewQueryRunExperienceEnabled } from "../config";
+import { App } from "../common/app";
 import { extLogger } from "../common";
 import { DisposableObject } from "../pure/disposable-object";
 import { DbConfigStore } from "./config/db-config-store";
@@ -19,18 +18,7 @@ export class DbModule extends DisposableObject {
     this.dbManager = new DbManager(app, this.dbConfigStore);
   }
 
-  public async initialize(app: App): Promise<void> {
-    if (
-      app.mode !== AppMode.Development ||
-      !isCanary() ||
-      !isNewQueryRunExperienceEnabled()
-    ) {
-      // Currently, we only want to expose the new database panel when we
-      // are in development and canary mode and the developer has enabled the
-      // new query run experience.
-      return;
-    }
-
+  public async initialize(): Promise<void> {
     void extLogger.log("Initializing database module");
 
     await this.dbConfigStore.initialize();
@@ -49,6 +37,6 @@ export class DbModule extends DisposableObject {
 
 export async function initializeDbModule(app: App): Promise<DbModule> {
   const dbModule = new DbModule(app);
-  await dbModule.initialize(app);
+  await dbModule.initialize();
   return dbModule;
 }

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
@@ -101,7 +101,7 @@ export class VariantAnalysisManager
     private readonly cliServer: CodeQLCliServer,
     private readonly storagePath: string,
     private readonly variantAnalysisResultsManager: VariantAnalysisResultsManager,
-    private readonly dbManager: DbManager,
+    private readonly dbManager?: DbManager, // the dbManager is only needed when the newQueryRunExperience is enabled
   ) {
     super();
     this.variantAnalysisMonitor = this.push(


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

We need to enable checks to only initialize the DbManager when the respective feature flags are turned on.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
