### PR TITLE
Fix failing tests on VSCode 1.74.0

### DIFF
--- a/extensions/ql-vscode/patches/jest-runner-vscode+3.0.1.patch
+++ b/extensions/ql-vscode/patches/jest-runner-vscode+3.0.1.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/jest-runner-vscode/dist/child/environment.js b/node_modules/jest-runner-vscode/dist/child/environment.js
-index 1ac28d5..52665c7 100644
+index 1ac28d5..f91f216 100644
 --- a/node_modules/jest-runner-vscode/dist/child/environment.js
 +++ b/node_modules/jest-runner-vscode/dist/child/environment.js
-@@ -10,6 +10,14 @@ const wrap_io_1 = __importDefault(require("./wrap-io"));
+@@ -10,6 +10,21 @@ const wrap_io_1 = __importDefault(require("./wrap-io"));
  const load_pnp_1 = __importDefault(require("./load-pnp"));
  const ipc = new ipc_client_1.default('env');
  class VSCodeEnvironment extends jest_environment_node_1.default {
@@ -11,7 +11,14 @@ index 1ac28d5..52665c7 100644
 +        // The _VSCODE_NODE_MODULES is a proxy which will require a module if any property
 +        // on it is accessed. This is a workaround for the fact that jest will call
 +        // _isMockFunction on the module, which will cause that function to be required.
-+        delete this.global._VSCODE_NODE_MODULES;
++        this.global._VSCODE_NODE_MODULES = new Proxy(this.global._VSCODE_NODE_MODULES, {
++          get(target, prop) {
++            if (prop === '_isMockFunction') {
++              return undefined;
++            }
++            return target[prop];
++          },
++        });
 +    }
 +
      async setup() {


### PR DESCRIPTION
This fixes the tests on VSCode 1.74.0. The issue is as follows:

1. Jest wil try reset all mocks after each test, as it should.
2. When Jest does this, it will loop over all global variables and check if they are mocks.
3. One of the global variables it checks is _VSCODE_NODE_MODULES, which is a proxy object.
4. When Jest checks whether it is a proxy by getting _isMockFunction on it, the `get` function on the proxy object will be called.
5. This will in turn call require, which will try to load the non-existing `_isMockFunction` module. This throws the error we are seeing.

By removing the `_VSCODE_NODE_MODULES` property from the global object in the Jest environment, Jest will not try to reset it, and the tests should work again.

See: https://github.com/facebook/jest/blob/41bf2300895a2c00d0525d21260f0a392819871f/packages/jest-runtime/src/index.ts#L1173-L1186
See: https://github.com/microsoft/vscode/blob/ed442a9e99ff68a3bb9e4953081305766862f450/src/bootstrap-amd.js#L15

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
