### PR TITLE
Show error message when running query on empty list

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/repository-selection.ts
+++ b/extensions/ql-vscode/src/remote-queries/repository-selection.ts
@@ -41,13 +41,15 @@ export async function getRepositorySelection(
     if (selectedDbItem) {
       switch (selectedDbItem.kind) {
         case DbItemKind.LocalDatabase || DbItemKind.LocalList:
-          throw new Error("Local databases and lists are not supported yet.");
+          throw new UserCancellationException(
+            "Local databases and lists are not supported yet.",
+          );
         case DbItemKind.RemoteSystemDefinedList:
           return { repositoryLists: [selectedDbItem.listName] };
         case DbItemKind.RemoteUserDefinedList:
           if (selectedDbItem.repos.length === 0) {
-            throw new Error(
-              "The selected repository list is empty. Please add repositories to it before running a query on it.",
+            throw new UserCancellationException(
+              "The selected repository list is empty. Please add repositories to it before running a variant analysis.",
             );
           } else {
             return {
@@ -62,7 +64,7 @@ export async function getRepositorySelection(
           return { repositories: [selectedDbItem.repoFullName] };
       }
     } else {
-      throw new Error(
+      throw new UserCancellationException(
         "Please select a remote database to run the query against.",
       );
     }

--- a/extensions/ql-vscode/src/remote-queries/repository-selection.ts
+++ b/extensions/ql-vscode/src/remote-queries/repository-selection.ts
@@ -45,9 +45,17 @@ export async function getRepositorySelection(
         case DbItemKind.RemoteSystemDefinedList:
           return { repositoryLists: [selectedDbItem.listName] };
         case DbItemKind.RemoteUserDefinedList:
-          return {
-            repositories: selectedDbItem.repos.map((repo) => repo.repoFullName),
-          };
+          if (selectedDbItem.repos.length === 0) {
+            throw new Error(
+              "The selected repository list is empty. Please add repositories to it before running a query on it.",
+            );
+          } else {
+            return {
+              repositories: selectedDbItem.repos.map(
+                (repo) => repo.repoFullName,
+              ),
+            };
+          }
         case DbItemKind.RemoteOwner:
           return { owners: [selectedDbItem.ownerName] };
         case DbItemKind.RemoteRepo:

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/repository-selection.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/repository-selection.test.ts
@@ -5,7 +5,11 @@ import { UserCancellationException } from "../../../commandRunner";
 import * as config from "../../../config";
 import { getRepositorySelection } from "../../../remote-queries/repository-selection";
 import { DbManager } from "../../../databases/db-manager";
-import { DbItem, DbItemKind } from "../../../databases/db-item";
+import {
+  DbItem,
+  DbItemKind,
+  RemoteRepoDbItem,
+} from "../../../databases/db-item";
 
 describe("repository selection", () => {
   describe("newQueryRunExperience true", () => {
@@ -19,30 +23,28 @@ describe("repository selection", () => {
       const dbManager = setUpDbManager(undefined);
 
       await expect(getRepositorySelection(dbManager)).rejects.toThrow(
-        Error("Please select a remote database to run the query against."),
+        "Please select a remote database to run the query against.",
       );
     });
 
-    it("should throw error when local database item is selected", async () => {
+    it("should log error when local database item is selected", async () => {
       const dbManager = setUpDbManager({
         kind: DbItemKind.LocalDatabase,
       } as DbItem);
 
       await expect(getRepositorySelection(dbManager)).rejects.toThrow(
-        Error("Local databases and lists are not supported yet."),
+        "Local databases and lists are not supported yet.",
       );
     });
 
-    it("should throw an error when an empty remote user defined list is selected", async () => {
+    it("should log an error when an empty remote user defined list is selected", async () => {
       const dbManager = setUpDbManager({
         kind: DbItemKind.RemoteUserDefinedList,
-        repos: [],
-      } as any as DbItem);
+        repos: [] as RemoteRepoDbItem[],
+      } as DbItem);
 
       await expect(getRepositorySelection(dbManager)).rejects.toThrow(
-        Error(
-          "The selected repository list is empty. Please add repositories to it before running a query on it.",
-        ),
+        "The selected repository list is empty. Please add repositories to it before running a variant analysis.",
       );
     });
 

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/repository-selection.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/repository-selection.test.ts
@@ -33,6 +33,19 @@ describe("repository selection", () => {
       );
     });
 
+    it("should return throw error when empt remote user defined list is selected", async () => {
+      const dbManager = setUpDbManager({
+        kind: DbItemKind.RemoteUserDefinedList,
+        repos: [],
+      } as any as DbItem);
+
+      await expect(getRepositorySelection(dbManager)).rejects.toThrow(
+        Error(
+          "The selected repository list is empty. Please add repositories to it before running a query on it.",
+        ),
+      );
+    });
+
     it("should return correct selection when remote system defined list is selected", async () => {
       const dbManager = setUpDbManager({
         kind: DbItemKind.RemoteSystemDefinedList,

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/repository-selection.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/repository-selection.test.ts
@@ -33,7 +33,7 @@ describe("repository selection", () => {
       );
     });
 
-    it("should return throw error when empt remote user defined list is selected", async () => {
+    it("should throw an error when an empty remote user defined list is selected", async () => {
       const dbManager = setUpDbManager({
         kind: DbItemKind.RemoteUserDefinedList,
         repos: [],


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->
When creating a new DB List in the panel it will be empty at first. We are now showing an error if one tries to run a query on an empty remote DB list.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
