### PR TITLE
Update ValueResult to have generic error type

### DIFF
--- a/extensions/ql-vscode/src/common/value-result.ts
+++ b/extensions/ql-vscode/src/common/value-result.ts
@@ -1,13 +1,13 @@
 /**
  * Represents a result that can be either a value or some errors.
  */
-export class ValueResult<TValue> {
+export class ValueResult<TValue, TError> {
   private constructor(
-    private readonly errorMsgs: string[],
+    private readonly errs: TError[],
     private readonly val?: TValue,
   ) {}
 
-  public static ok<TValue>(value: TValue): ValueResult<TValue> {
+  public static ok<TValue, TError>(value: TValue): ValueResult<TValue, TError> {
     if (value === undefined) {
       throw new Error("Value must be set for successful result");
     }
@@ -15,30 +15,30 @@ export class ValueResult<TValue> {
     return new ValueResult([], value);
   }
 
-  public static fail<TValue>(errorMsgs: string[]): ValueResult<TValue> {
-    if (errorMsgs.length === 0) {
-      throw new Error(
-        "At least one error message must be set for a failed result",
-      );
+  public static fail<TValue, TError>(
+    errors: TError[],
+  ): ValueResult<TValue, TError> {
+    if (errors.length === 0) {
+      throw new Error("At least one error must be set for a failed result");
     }
 
-    return new ValueResult<TValue>(errorMsgs, undefined);
+    return new ValueResult<TValue, TError>(errors, undefined);
   }
 
   public get isOk(): boolean {
-    return this.errorMsgs.length === 0;
+    return this.errs.length === 0;
   }
 
   public get isFailure(): boolean {
-    return this.errorMsgs.length > 0;
+    return this.errs.length > 0;
   }
 
-  public get errors(): string[] {
-    if (!this.errorMsgs) {
+  public get errors(): TError[] {
+    if (!this.errs) {
       throw new Error("Cannot get error for successful result");
     }
 
-    return this.errorMsgs;
+    return this.errs;
   }
 
   public get value(): TValue {

--- a/extensions/ql-vscode/src/databases/config/db-config-store.ts
+++ b/extensions/ql-vscode/src/databases/config/db-config-store.ts
@@ -48,7 +48,7 @@ export class DbConfigStore extends DisposableObject {
     this.configWatcher?.unwatch(this.configPath);
   }
 
-  public getConfig(): ValueResult<DbConfig> {
+  public getConfig(): ValueResult<DbConfig, string> {
     if (this.config) {
       // Clone the config so that it's not modified outside of this class.
       return ValueResult.ok(cloneDbConfig(this.config));

--- a/extensions/ql-vscode/src/databases/db-manager.ts
+++ b/extensions/ql-vscode/src/databases/db-manager.ts
@@ -33,7 +33,7 @@ export class DbManager {
     return getSelectedDbItem(dbItems.value);
   }
 
-  public getDbItems(): ValueResult<DbItem[]> {
+  public getDbItems(): ValueResult<DbItem[], string> {
     const configResult = this.dbConfigStore.getConfig();
     if (configResult.isFailure) {
       return ValueResult.fail(configResult.errors);


### PR DESCRIPTION
`ValueResult`s so far only allowed errors of type `string`. This PR makes the type generic so that we can pass different types of errors e.g. objects that are more descriptive than a single message string.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
