### PR TITLE
Extract github nwo helper functions

### DIFF
--- a/extensions/ql-vscode/src/databaseFetcher.ts
+++ b/extensions/ql-vscode/src/databaseFetcher.ts
@@ -21,7 +21,11 @@ import { showAndLogInformationMessage, tmpDir } from "./helpers";
 import { reportStreamProgress, ProgressCallback } from "./commandRunner";
 import { extLogger } from "./common";
 import { Credentials } from "./authentication";
-import { REPO_REGEX, getErrorMessage } from "./pure/helpers-pure";
+import { getErrorMessage } from "./pure/helpers-pure";
+import {
+  convertGitHubUrlToNwo,
+  looksLikeGithubRepo,
+} from "./databases/github-nwo";
 
 /**
  * Prompts a user to fetch a database from a remote location. Database is assumed to be an archive file.
@@ -507,55 +511,6 @@ export async function findDirWithFile(
     }
   }
   return;
-}
-
-/**
- * The URL pattern is https://github.com/{owner}/{name}/{subpages}.
- *
- * This function accepts any URL that matches the pattern above. It also accepts just the
- * name with owner (NWO): `<owner>/<repo>`.
- *
- * @param githubRepo The GitHub repository URL or NWO
- *
- * @return true if this looks like a valid GitHub repository URL or NWO
- */
-export function looksLikeGithubRepo(
-  githubRepo: string | undefined,
-): githubRepo is string {
-  if (!githubRepo) {
-    return false;
-  }
-  if (REPO_REGEX.test(githubRepo) || convertGitHubUrlToNwo(githubRepo)) {
-    return true;
-  }
-  return false;
-}
-
-/**
- * Converts a GitHub repository URL to the corresponding NWO.
- * @param githubUrl The GitHub repository URL
- * @return The corresponding NWO, or undefined if the URL is not valid
- */
-function convertGitHubUrlToNwo(githubUrl: string): string | undefined {
-  try {
-    const uri = Uri.parse(githubUrl, true);
-    if (uri.scheme !== "https") {
-      return;
-    }
-    if (uri.authority !== "github.com" && uri.authority !== "www.github.com") {
-      return;
-    }
-    const paths = uri.path.split("/").filter((segment: string) => segment);
-    const nwo = `${paths[0]}/${paths[1]}`;
-    if (REPO_REGEX.test(nwo)) {
-      return nwo;
-    }
-    return;
-  } catch (e) {
-    // Ignore the error here, since we catch failures at a higher level.
-    // In particular: returning undefined leads to an error in 'promptImportGithubDatabase'.
-    return;
-  }
 }
 
 export async function convertGithubNwoToDatabaseUrl(

--- a/extensions/ql-vscode/src/databases/github-nwo.ts
+++ b/extensions/ql-vscode/src/databases/github-nwo.ts
@@ -1,0 +1,51 @@
+import { Uri } from "vscode";
+import { REPO_REGEX } from "../pure/helpers-pure";
+
+/**
+ * The URL pattern is https://github.com/{owner}/{name}/{subpages}.
+ *
+ * This function accepts any URL that matches the pattern above. It also accepts just the
+ * name with owner (NWO): `<owner>/<repo>`.
+ *
+ * @param githubRepo The GitHub repository URL or NWO
+ *
+ * @return true if this looks like a valid GitHub repository URL or NWO
+ */
+export function looksLikeGithubRepo(
+  githubRepo: string | undefined,
+): githubRepo is string {
+  if (!githubRepo) {
+    return false;
+  }
+  if (REPO_REGEX.test(githubRepo) || convertGitHubUrlToNwo(githubRepo)) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Converts a GitHub repository URL to the corresponding NWO.
+ * @param githubUrl The GitHub repository URL
+ * @return The corresponding NWO, or undefined if the URL is not valid
+ */
+export function convertGitHubUrlToNwo(githubUrl: string): string | undefined {
+  try {
+    const uri = Uri.parse(githubUrl, true);
+    if (uri.scheme !== "https") {
+      return;
+    }
+    if (uri.authority !== "github.com" && uri.authority !== "www.github.com") {
+      return;
+    }
+    const paths = uri.path.split("/").filter((segment: string) => segment);
+    const nwo = `${paths[0]}/${paths[1]}`;
+    if (REPO_REGEX.test(nwo)) {
+      return nwo;
+    }
+    return;
+  } catch (e) {
+    // Ignore the error here, since we catch failures at a higher level.
+    // In particular: returning undefined leads to an error in 'promptImportGithubDatabase'.
+    return;
+  }
+}

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/databaseFetcher.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/databaseFetcher.test.ts
@@ -8,9 +8,9 @@ import {
   convertLgtmUrlToDatabaseUrl,
   looksLikeLgtmUrl,
   findDirWithFile,
-  looksLikeGithubRepo,
 } from "../../databaseFetcher";
 import * as Octokit from "@octokit/rest";
+import { looksLikeGithubRepo } from "../../databases/github-nwo";
 
 // These tests make API calls and may need extra time to complete.
 jest.setTimeout(10000);


### PR DESCRIPTION
Moves the `looksLikeGithubRepo` and `convertGitHubUrlToNwo` functions into a separate helper file. We plan to use these helpers in the new database panel, so let's put them in a shared location 🗺️ 

## Checklist

N/A: not user-visible

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
