### PR TITLE
Hide DB panel UI actions when config is broken/undefined

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -780,7 +780,7 @@
         },
         {
           "command": "codeQLDatabasesExperimental.addNewList",
-          "when": "view == codeQLDatabasesExperimental",
+          "when": "view == codeQLDatabasesExperimental && codeQLDatabasesExperimental.configError == false",
           "group": "navigation"
         }
       ],

--- a/extensions/ql-vscode/src/databases/config/db-config-store.ts
+++ b/extensions/ql-vscode/src/databases/config/db-config-store.ts
@@ -145,7 +145,16 @@ export class DbConfigStore extends DisposableObject {
       this.configErrors = this.configValidator.validate(newConfig);
     }
 
-    this.config = this.configErrors.length === 0 ? newConfig : undefined;
+    if (this.configErrors.length === 0) {
+      this.config = newConfig;
+      await this.app.executeCommand(
+        "setContext",
+        "codeQLDatabasesExperimental.configError",
+        false,
+      );
+    } else {
+      this.config = undefined;
+    }
   }
 
   private readConfigSync(): void {
@@ -170,8 +179,16 @@ export class DbConfigStore extends DisposableObject {
       this.configErrors = this.configValidator.validate(newConfig);
     }
 
-    this.config = this.configErrors.length === 0 ? newConfig : undefined;
-
+    if (this.configErrors.length === 0) {
+      this.config = newConfig;
+      void this.app.executeCommand(
+        "setContext",
+        "codeQLDatabasesExperimental.configError",
+        false,
+      );
+    } else {
+      this.config = undefined;
+    }
     this.onDidChangeConfigEventEmitter.fire();
   }
 

--- a/extensions/ql-vscode/src/databases/config/db-config-store.ts
+++ b/extensions/ql-vscode/src/databases/config/db-config-store.ts
@@ -28,7 +28,7 @@ export class DbConfigStore extends DisposableObject {
   private configErrors: DbConfigValidationError[];
   private configWatcher: chokidar.FSWatcher | undefined;
 
-  public constructor(app: App) {
+  public constructor(private readonly app: App) {
     super();
 
     const storagePath = app.workspaceStoragePath || app.globalStoragePath;
@@ -134,6 +134,11 @@ export class DbConfigStore extends DisposableObject {
           message: `Failed to read config file: ${this.configPath}`,
         },
       ];
+      await this.app.executeCommand(
+        "setContext",
+        "codeQLDatabasesExperimental.configError",
+        true,
+      );
     }
 
     if (newConfig) {
@@ -154,6 +159,11 @@ export class DbConfigStore extends DisposableObject {
           message: `Failed to read config file: ${this.configPath}`,
         },
       ];
+      void this.app.executeCommand(
+        "setContext",
+        "codeQLDatabasesExperimental.configError",
+        true,
+      );
     }
 
     if (newConfig) {

--- a/extensions/ql-vscode/src/databases/ui/db-panel.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-panel.ts
@@ -58,7 +58,6 @@ export class DbPanel extends DisposableObject {
   }
 
   private async addNewRemoteList(): Promise<void> {
-    // TODO: check that config exists *before* showing the input box
     const listName = await window.showInputBox({
       prompt: "Enter a name for the new list",
       placeHolder: "example-list",


### PR DESCRIPTION
Hides the "Add list" button when the DB config contains errors. Note: We'll need to add this functionality to the upcoming "Add database" button too (see #1870)

I wanted to add a test to check that the context value for `codeQLDatabasesExperimental.configError` had been set to `true`/`false` as appropriate. Annoyingly, I couldn't find a way to access context values in a test 🤔 

## Checklist

N/A - internal only 🦝

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
