### PR TITLE
Add validation for duplicate names in the db config

### DIFF
--- a/extensions/ql-vscode/src/databases/config/db-config-validator.ts
+++ b/extensions/ql-vscode/src/databases/config/db-config-validator.ts
@@ -99,7 +99,7 @@ export class DbConfigValidator {
 
     const buildError = (listName: string, dups: string[]) => ({
       kind: DbConfigValidationErrorKind.DuplicateNames,
-      message: `There are databases with the same name in the the ${listName} list: ${dups.join(
+      message: `There are databases with the same name in the ${listName} list: ${dups.join(
         ", ",
       )}`,
     });

--- a/extensions/ql-vscode/src/databases/config/db-config-validator.ts
+++ b/extensions/ql-vscode/src/databases/config/db-config-validator.ts
@@ -2,6 +2,11 @@ import { readJsonSync } from "fs-extra";
 import { resolve } from "path";
 import Ajv from "ajv";
 import { DbConfig } from "./db-config";
+import { findDuplicateStrings } from "../../text-utils";
+import {
+  DbConfigValidationError,
+  DbConfigValidationErrorKind,
+} from "../db-validation-errors";
 
 export class DbConfigValidator {
   private readonly schema: any;
@@ -14,16 +19,118 @@ export class DbConfigValidator {
     this.schema = readJsonSync(schemaPath);
   }
 
-  public validate(dbConfig: DbConfig): string[] {
+  public validate(dbConfig: DbConfig): DbConfigValidationError[] {
     const ajv = new Ajv({ allErrors: true });
     ajv.validate(this.schema, dbConfig);
 
     if (ajv.errors) {
-      return ajv.errors.map(
-        (error) => `${error.instancePath} ${error.message}`,
-      );
+      return ajv.errors.map((error) => ({
+        kind: DbConfigValidationErrorKind.InvalidConfig,
+        message: `${error.instancePath} ${error.message}`,
+      }));
     }
 
-    return [];
+    return [
+      ...this.validateDbListNames(dbConfig),
+      ...this.validateDbNames(dbConfig),
+      ...this.validateDbNamesInLists(dbConfig),
+      ...this.validateOwners(dbConfig),
+    ];
+  }
+
+  private validateDbListNames(dbConfig: DbConfig): DbConfigValidationError[] {
+    const errors: DbConfigValidationError[] = [];
+
+    const buildError = (dups: string[]) => ({
+      kind: DbConfigValidationErrorKind.DuplicateNames,
+      message: `There are database lists with the same name: ${dups.join(
+        ", ",
+      )}`,
+    });
+
+    const duplicateLocalDbLists = findDuplicateStrings(
+      dbConfig.databases.local.lists.map((n) => n.name),
+    );
+
+    if (duplicateLocalDbLists.length > 0) {
+      errors.push(buildError(duplicateLocalDbLists));
+    }
+
+    const duplicateRemoteDbLists = findDuplicateStrings(
+      dbConfig.databases.remote.repositoryLists.map((n) => n.name),
+    );
+    if (duplicateRemoteDbLists.length > 0) {
+      errors.push(buildError(duplicateRemoteDbLists));
+    }
+
+    return errors;
+  }
+
+  private validateDbNames(dbConfig: DbConfig): DbConfigValidationError[] {
+    const errors: DbConfigValidationError[] = [];
+
+    const buildError = (dups: string[]) => ({
+      kind: DbConfigValidationErrorKind.DuplicateNames,
+      message: `There are databases with the same name: ${dups.join(", ")}`,
+    });
+
+    const duplicateLocalDbs = findDuplicateStrings(
+      dbConfig.databases.local.databases.map((d) => d.name),
+    );
+
+    if (duplicateLocalDbs.length > 0) {
+      errors.push(buildError(duplicateLocalDbs));
+    }
+
+    const duplicateRemoteDbs = findDuplicateStrings(
+      dbConfig.databases.remote.repositories,
+    );
+    if (duplicateRemoteDbs.length > 0) {
+      errors.push(buildError(duplicateRemoteDbs));
+    }
+
+    return errors;
+  }
+
+  private validateDbNamesInLists(
+    dbConfig: DbConfig,
+  ): DbConfigValidationError[] {
+    const errors: DbConfigValidationError[] = [];
+
+    const buildError = (listName: string, dups: string[]) => ({
+      kind: DbConfigValidationErrorKind.DuplicateNames,
+      message: `There are databases with the same name in the the ${listName} list: ${dups.join(
+        ", ",
+      )}`,
+    });
+
+    for (const list of dbConfig.databases.local.lists) {
+      const dups = findDuplicateStrings(list.databases.map((d) => d.name));
+      if (dups.length > 0) {
+        errors.push(buildError(list.name, dups));
+      }
+    }
+
+    for (const list of dbConfig.databases.remote.repositoryLists) {
+      const dups = findDuplicateStrings(list.repositories);
+      if (dups.length > 0) {
+        errors.push(buildError(list.name, dups));
+      }
+    }
+
+    return errors;
+  }
+
+  private validateOwners(dbConfig: DbConfig): DbConfigValidationError[] {
+    const errors: DbConfigValidationError[] = [];
+
+    const dups = findDuplicateStrings(dbConfig.databases.remote.owners);
+    if (dups.length > 0) {
+      errors.push({
+        kind: DbConfigValidationErrorKind.DuplicateNames,
+        message: `There are owners with the same name: ${dups.join(", ")}`,
+      });
+    }
+    return errors;
   }
 }

--- a/extensions/ql-vscode/src/databases/db-manager.ts
+++ b/extensions/ql-vscode/src/databases/db-manager.ts
@@ -9,6 +9,7 @@ import {
   mapDbItemToSelectedDbItem,
 } from "./db-item-selection";
 import { createLocalTree, createRemoteTree } from "./db-tree-creator";
+import { DbConfigValidationError } from "./db-validation-errors";
 
 export class DbManager {
   public readonly onDbItemsChanged: AppEvent<void>;
@@ -24,16 +25,16 @@ export class DbManager {
   }
 
   public getSelectedDbItem(): DbItem | undefined {
-    const dbItems = this.getDbItems();
+    const dbItemsResult = this.getDbItems();
 
-    if (dbItems.isFailure) {
+    if (dbItemsResult.errors.length > 0) {
       return undefined;
     }
 
-    return getSelectedDbItem(dbItems.value);
+    return getSelectedDbItem(dbItemsResult.value);
   }
 
-  public getDbItems(): ValueResult<DbItem[], string> {
+  public getDbItems(): ValueResult<DbItem[], DbConfigValidationError> {
     const configResult = this.dbConfigStore.getConfig();
     if (configResult.isFailure) {
       return ValueResult.fail(configResult.errors);

--- a/extensions/ql-vscode/src/databases/db-validation-errors.ts
+++ b/extensions/ql-vscode/src/databases/db-validation-errors.ts
@@ -1,0 +1,10 @@
+export enum DbConfigValidationErrorKind {
+  InvalidJson = "InvalidJson",
+  InvalidConfig = "InvalidConfig",
+  DuplicateNames = "DuplicateNames",
+}
+
+export interface DbConfigValidationError {
+  kind: DbConfigValidationErrorKind;
+  message: string;
+}

--- a/extensions/ql-vscode/src/text-utils.ts
+++ b/extensions/ql-vscode/src/text-utils.ts
@@ -31,3 +31,11 @@ export function convertNonPrintableChars(label: string | undefined) {
     return convertedLabelArray.join("");
   }
 }
+
+export function findDuplicateStrings(strings: string[]): string[] {
+  const dups = strings.filter(
+    (string, index, strings) => strings.indexOf(string) !== index,
+  );
+
+  return [...new Set(dups)];
+}

--- a/extensions/ql-vscode/test/factories/db-config-factories.ts
+++ b/extensions/ql-vscode/test/factories/db-config-factories.ts
@@ -1,3 +1,4 @@
+import { faker } from "@faker-js/faker";
 import {
   DbConfig,
   ExpandedDbItem,
@@ -38,5 +39,24 @@ export function createDbConfig({
     },
     expanded,
     selected,
+  };
+}
+
+export function createLocalDbConfigItem({
+  name = `database${faker.datatype.number()}`,
+  dateAdded = faker.date.past().getTime(),
+  language = `language${faker.datatype.number()}`,
+  storagePath = `storagePath${faker.datatype.number()}`,
+}: {
+  name?: string;
+  dateAdded?: number;
+  language?: string;
+  storagePath?: string;
+} = {}): LocalDatabase {
+  return {
+    name,
+    dateAdded,
+    language,
+    storagePath,
   };
 }

--- a/extensions/ql-vscode/test/pure-tests/databases/config/db-config-validator.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/databases/config/db-config-validator.test.ts
@@ -101,7 +101,7 @@ describe("db config validation", () => {
     expect(validationOutput[0]).toEqual({
       kind: DbConfigValidationErrorKind.DuplicateNames,
       message:
-        "There are databases with the same name in the the repoList1 list: owner1/repo2",
+        "There are databases with the same name in the repoList1 list: owner1/repo2",
     });
   });
 
@@ -166,7 +166,7 @@ describe("db config validation", () => {
     expect(validationOutput[0]).toEqual({
       kind: DbConfigValidationErrorKind.DuplicateNames,
       message:
-        "There are databases with the same name in the the dbList1 list: db1",
+        "There are databases with the same name in the dbList1 list: db1",
     });
   });
 });

--- a/extensions/ql-vscode/test/pure-tests/databases/config/db-config-validator.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/databases/config/db-config-validator.test.ts
@@ -1,6 +1,11 @@
 import { join } from "path";
 import { DbConfig } from "../../../../src/databases/config/db-config";
 import { DbConfigValidator } from "../../../../src/databases/config/db-config-validator";
+import { DbConfigValidationErrorKind } from "../../../../src/databases/db-validation-errors";
+import {
+  createDbConfig,
+  createLocalDbConfigItem,
+} from "../../../factories/db-config-factories";
 
 describe("db config validation", () => {
   const extensionPath = join(__dirname, "../../../..");
@@ -29,14 +34,139 @@ describe("db config validation", () => {
 
     expect(validationOutput).toHaveLength(3);
 
-    expect(validationOutput[0]).toEqual(
-      "/databases must have required property 'local'",
-    );
-    expect(validationOutput[1]).toEqual(
-      "/databases/remote must have required property 'owners'",
-    );
-    expect(validationOutput[2]).toEqual(
-      "/databases/remote must NOT have additional properties",
-    );
+    expect(validationOutput[0]).toEqual({
+      kind: DbConfigValidationErrorKind.InvalidConfig,
+      message: "/databases must have required property 'local'",
+    });
+    expect(validationOutput[1]).toEqual({
+      kind: DbConfigValidationErrorKind.InvalidConfig,
+      message: "/databases/remote must have required property 'owners'",
+    });
+    expect(validationOutput[2]).toEqual({
+      kind: DbConfigValidationErrorKind.InvalidConfig,
+      message: "/databases/remote must NOT have additional properties",
+    });
+  });
+
+  it("should return error when there are multiple remote db lists with the same name", async () => {
+    const dbConfig = createDbConfig({
+      remoteLists: [
+        {
+          name: "repoList1",
+          repositories: ["owner1/repo1", "owner1/repo2"],
+        },
+        {
+          name: "repoList1",
+          repositories: ["owner2/repo1", "owner2/repo2"],
+        },
+      ],
+    });
+
+    const validationOutput = configValidator.validate(dbConfig);
+
+    expect(validationOutput).toHaveLength(1);
+    expect(validationOutput[0]).toEqual({
+      kind: DbConfigValidationErrorKind.DuplicateNames,
+      message: "There are database lists with the same name: repoList1",
+    });
+  });
+
+  it("should return error when there are multiple remote dbs with the same name", async () => {
+    const dbConfig = createDbConfig({
+      remoteRepos: ["owner1/repo1", "owner1/repo2", "owner1/repo2"],
+    });
+
+    const validationOutput = configValidator.validate(dbConfig);
+
+    expect(validationOutput).toHaveLength(1);
+    expect(validationOutput[0]).toEqual({
+      kind: DbConfigValidationErrorKind.DuplicateNames,
+      message: "There are databases with the same name: owner1/repo2",
+    });
+  });
+
+  it("should return error when there are multiple remote dbs with the same name in the same list", async () => {
+    const dbConfig = createDbConfig({
+      remoteLists: [
+        {
+          name: "repoList1",
+          repositories: ["owner1/repo1", "owner1/repo2", "owner1/repo2"],
+        },
+      ],
+    });
+
+    const validationOutput = configValidator.validate(dbConfig);
+
+    expect(validationOutput).toHaveLength(1);
+    expect(validationOutput[0]).toEqual({
+      kind: DbConfigValidationErrorKind.DuplicateNames,
+      message:
+        "There are databases with the same name in the the repoList1 list: owner1/repo2",
+    });
+  });
+
+  it("should return error when there are multiple local db lists with the same name", async () => {
+    const dbConfig = createDbConfig({
+      localLists: [
+        {
+          name: "dbList1",
+          databases: [createLocalDbConfigItem()],
+        },
+        {
+          name: "dbList1",
+          databases: [createLocalDbConfigItem()],
+        },
+      ],
+    });
+
+    const validationOutput = configValidator.validate(dbConfig);
+
+    expect(validationOutput).toHaveLength(1);
+    expect(validationOutput[0]).toEqual({
+      kind: DbConfigValidationErrorKind.DuplicateNames,
+      message: "There are database lists with the same name: dbList1",
+    });
+  });
+
+  it("should return error when there are multiple local dbs with the same name", async () => {
+    const dbConfig = createDbConfig({
+      localDbs: [
+        createLocalDbConfigItem({ name: "db1" }),
+        createLocalDbConfigItem({ name: "db2" }),
+        createLocalDbConfigItem({ name: "db1" }),
+      ],
+    });
+
+    const validationOutput = configValidator.validate(dbConfig);
+
+    expect(validationOutput).toHaveLength(1);
+    expect(validationOutput[0]).toEqual({
+      kind: DbConfigValidationErrorKind.DuplicateNames,
+      message: "There are databases with the same name: db1",
+    });
+  });
+
+  it("should return error when there are multiple local dbs with the same name in the same list", async () => {
+    const dbConfig = createDbConfig({
+      localLists: [
+        {
+          name: "dbList1",
+          databases: [
+            createLocalDbConfigItem({ name: "db1" }),
+            createLocalDbConfigItem({ name: "db2" }),
+            createLocalDbConfigItem({ name: "db1" }),
+          ],
+        },
+      ],
+    });
+
+    const validationOutput = configValidator.validate(dbConfig);
+
+    expect(validationOutput).toHaveLength(1);
+    expect(validationOutput[0]).toEqual({
+      kind: DbConfigValidationErrorKind.DuplicateNames,
+      message:
+        "There are databases with the same name in the the dbList1 list: db1",
+    });
   });
 });

--- a/extensions/ql-vscode/test/pure-tests/text-utils.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/text-utils.test.ts
@@ -1,0 +1,15 @@
+import { findDuplicateStrings } from "../../src/text-utils";
+
+describe("findDuplicateStrings", () => {
+  it("should find duplicates strings in an array of strings", () => {
+    const strings = ["a", "b", "c", "a", "aa", "bb"];
+    const duplicates = findDuplicateStrings(strings);
+    expect(duplicates).toEqual(["a"]);
+  });
+
+  it("should not find duplicates strings if there aren't any", () => {
+    const strings = ["a", "b", "c", "aa", "bb"];
+    const duplicates = findDuplicateStrings(strings);
+    expect(duplicates).toEqual([]);
+  });
+});


### PR DESCRIPTION
This PR adds validation for duplicate names in the db config. As part of that we also needed to update the logic that renders errors to allow for 2 different kinds of errors:
a) Ones that the db config is just simply not valid based on the JSON schema
b) Ones that the db config is not valid for other reasons e.g. naming

Please feel free to suggest better names!

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
