### PR TITLE
Add logging around db config loading

### DIFF
--- a/extensions/ql-vscode/src/databases/config/db-config-store.ts
+++ b/extensions/ql-vscode/src/databases/config/db-config-store.ts
@@ -131,13 +131,13 @@ export class DbConfigStore extends DisposableObject {
   private async loadConfig(): Promise<void> {
     if (!(await pathExists(this.configPath))) {
       void this.app.logger.log(
-        `Creating new db config file at ${this.configPath}`,
+        `Creating new database config file at ${this.configPath}`,
       );
       await this.writeConfig(this.createEmptyConfig());
     }
 
     await this.readConfig();
-    void this.app.logger.log(`Db config loaded from ${this.configPath}`);
+    void this.app.logger.log(`Database config loaded from ${this.configPath}`);
   }
 
   private async readConfig(): Promise<void> {

--- a/extensions/ql-vscode/src/databases/config/db-config-store.ts
+++ b/extensions/ql-vscode/src/databases/config/db-config-store.ts
@@ -130,10 +130,14 @@ export class DbConfigStore extends DisposableObject {
 
   private async loadConfig(): Promise<void> {
     if (!(await pathExists(this.configPath))) {
+      void this.app.logger.log(
+        `Creating new db config file at ${this.configPath}`,
+      );
       await this.writeConfig(this.createEmptyConfig());
     }
 
     await this.readConfig();
+    void this.app.logger.log(`Db config loaded from ${this.configPath}`);
   }
 
   private async readConfig(): Promise<void> {


### PR DESCRIPTION
In order to avoid flooding the log, we only add log messages only for the initial load of the config.

## Checklist
N/A:

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
