### PR TITLE
Add basic integration test for 'add db list' functionality

### DIFF
--- a/extensions/ql-vscode/src/databases/config/db-config-store.ts
+++ b/extensions/ql-vscode/src/databases/config/db-config-store.ts
@@ -1,4 +1,4 @@
-import { pathExists, writeJSON, readJSON, readJSONSync } from "fs-extra";
+import { pathExists, outputJSON, readJSON, readJSONSync } from "fs-extra";
 import { join } from "path";
 import {
   cloneDbConfig,
@@ -123,7 +123,7 @@ export class DbConfigStore extends DisposableObject {
   }
 
   private async writeConfig(config: DbConfig): Promise<void> {
-    await writeJSON(this.configPath, config, {
+    await outputJSON(this.configPath, config, {
       spaces: 2,
     });
   }

--- a/extensions/ql-vscode/src/databases/db-module.ts
+++ b/extensions/ql-vscode/src/databases/db-module.ts
@@ -20,20 +20,23 @@ export class DbModule extends DisposableObject {
   }
 
   public static async initialize(app: App): Promise<DbModule | undefined> {
-    if (
-      isCanary() &&
-      isNewQueryRunExperienceEnabled() &&
-      app.mode === AppMode.Development
-    ) {
+    if (DbModule.shouldEnableModule(app.mode)) {
       const dbModule = new DbModule(app);
       app.subscriptions.push(dbModule);
 
       await dbModule.initialize();
-
       return dbModule;
     }
 
     return undefined;
+  }
+
+  private static shouldEnableModule(app: AppMode): boolean {
+    if (app === AppMode.Development || app === AppMode.Test) {
+      return true;
+    }
+
+    return isCanary() && isNewQueryRunExperienceEnabled();
   }
 
   private async initialize(): Promise<void> {

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/databases/db-panel.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/databases/db-panel.test.ts
@@ -5,6 +5,8 @@ import { readJson } from "fs-extra";
 import * as path from "path";
 import { DbConfig } from "../../../databases/config/db-config";
 
+jest.setTimeout(10_000);
+
 describe("Db panel UI commands", () => {
   let extension: CodeQLExtensionInterface | Record<string, never>;
   let storagePath: string;

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/databases/db-panel.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/databases/db-panel.test.ts
@@ -5,7 +5,7 @@ import { readJson } from "fs-extra";
 import * as path from "path";
 import { DbConfig } from "../../../databases/config/db-config";
 
-jest.setTimeout(10_000);
+jest.setTimeout(60_000);
 
 describe("Db panel UI commands", () => {
   let extension: CodeQLExtensionInterface | Record<string, never>;

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/databases/db-panel.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/databases/db-panel.test.ts
@@ -1,0 +1,34 @@
+import { commands, extensions, window } from "vscode";
+
+import { CodeQLExtensionInterface } from "../../../extension";
+import { readJson } from "fs-extra";
+import * as path from "path";
+import { DbConfig } from "../../../databases/config/db-config";
+
+describe("Db panel UI commands", () => {
+  let extension: CodeQLExtensionInterface | Record<string, never>;
+  let storagePath: string;
+
+  beforeEach(async () => {
+    extension = await extensions
+      .getExtension<CodeQLExtensionInterface | Record<string, never>>(
+        "GitHub.vscode-codeql",
+      )!
+      .activate();
+
+    storagePath =
+      extension.ctx.storageUri?.fsPath || extension.ctx.globalStorageUri.fsPath;
+  });
+
+  it("should add new remote db list", async () => {
+    // Add db list
+    jest.spyOn(window, "showInputBox").mockResolvedValue("my-list-1");
+    await commands.executeCommand("codeQLDatabasesExperimental.addNewList");
+
+    // Check db config
+    const dbConfigFilePath = path.join(storagePath, "workspace-databases.json");
+    const dbConfig: DbConfig = await readJson(dbConfigFilePath);
+    expect(dbConfig.databases.remote.repositoryLists).toHaveLength(1);
+    expect(dbConfig.databases.remote.repositoryLists[0].name).toBe("my-list-1");
+  });
+});


### PR DESCRIPTION
In order to be able to write this test I had to allow for the `DbModule` to be initialized so I've changed the conditions in which its initiatialized. See 8d52e8b14a188d51b7a082822c2b427268380f95 for details.

I wrote a simple test in 9b6c4410f4e664da87ceea090502f78dcb6a33f6. I've tried writing some more complex tests but kept hitting issues/tech-debt.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
