### PR TITLE
Add Storybook story for many results performance

### DIFF
--- a/extensions/ql-vscode/src/stories/variant-analysis/VariantAnalysisAnalyzedRepos.stories.tsx
+++ b/extensions/ql-vscode/src/stories/variant-analysis/VariantAnalysisAnalyzedRepos.stories.tsx
@@ -8,6 +8,7 @@ import { VariantAnalysisContainer } from "../../view/variant-analysis/VariantAna
 import { VariantAnalysisAnalyzedRepos } from "../../view/variant-analysis/VariantAnalysisAnalyzedRepos";
 import {
   VariantAnalysisRepoStatus,
+  VariantAnalysisScannedRepositoryDownloadStatus,
   VariantAnalysisStatus,
 } from "../../remote-queries/shared/variant-analysis";
 import { AnalysisAlert } from "../../remote-queries/shared/analysis-result";
@@ -148,8 +149,8 @@ const manyScannedRepos = Array.from({ length: 1000 }, (_, i) => {
   };
 });
 
-export const PerformanceExample = Template.bind({});
-PerformanceExample.args = {
+export const ManyRepositoriesPerformanceExample = Template.bind({});
+ManyRepositoriesPerformanceExample.args = {
   variantAnalysis: {
     ...createMockVariantAnalysis({
       status: VariantAnalysisStatus.Succeeded,
@@ -161,5 +162,41 @@ PerformanceExample.args = {
     variantAnalysisId: 1,
     repositoryId: repoTask.repository.id,
     interpretedResults: interpretedResultsForRepo("facebook/create-react-app"),
+  })),
+};
+
+const mockAnalysisAlert = interpretedResultsForRepo(
+  "facebook/create-react-app",
+)![0];
+
+const performanceNumbers = [10, 50, 100, 500, 1000, 2000, 5000, 10_000];
+
+export const ManyResultsPerformanceExample = Template.bind({});
+ManyResultsPerformanceExample.args = {
+  variantAnalysis: {
+    ...createMockVariantAnalysis({
+      status: VariantAnalysisStatus.Succeeded,
+      scannedRepos: performanceNumbers.map((resultCount, i) => ({
+        repository: {
+          ...createMockRepositoryWithMetadata(),
+          id: resultCount,
+          fullName: `octodemo/${i}-${resultCount}-results`,
+        },
+        analysisStatus: VariantAnalysisRepoStatus.Succeeded,
+        resultCount,
+      })),
+    }),
+    id: 1,
+  },
+  repositoryStates: performanceNumbers.map((resultCount) => ({
+    repositoryId: resultCount,
+    downloadStatus: VariantAnalysisScannedRepositoryDownloadStatus.Succeeded,
+  })),
+  repositoryResults: performanceNumbers.map((resultCount) => ({
+    variantAnalysisId: 1,
+    repositoryId: resultCount,
+    interpretedResults: Array.from({ length: resultCount }, (_, i) => ({
+      ...mockAnalysisAlert,
+    })),
   })),
 };


### PR DESCRIPTION
This adds a Storybook story for testing the performance of having a large number of results in one repository. This is in addition to the story for testing the performance of having many repositories.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
