### PR TITLE
Stop user from adding a db list with an empty name

### DIFF
--- a/extensions/ql-vscode/src/databases/db-manager.ts
+++ b/extensions/ql-vscode/src/databases/db-manager.ts
@@ -76,6 +76,10 @@ export class DbManager {
   }
 
   public async addNewRemoteList(listName: string): Promise<void> {
+    if (listName === "") {
+      throw Error("List name cannot be empty");
+    }
+
     if (this.dbConfigStore.doesRemoteListExist(listName)) {
       throw Error(`A list with the name '${listName}' already exists`);
     }

--- a/extensions/ql-vscode/src/vscode-tests/minimal-workspace/databases/db-panel.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/minimal-workspace/databases/db-panel.test.ts
@@ -549,6 +549,35 @@ describe("db panel", () => {
     );
   });
 
+  describe("Name validation", () => {
+    it("should not allow adding a new list with empty name", async () => {
+      const dbConfig = createDbConfig();
+
+      await saveDbConfig(dbConfig);
+
+      await expect(dbManager.addNewRemoteList("")).rejects.toThrow(
+        new Error("List name cannot be empty"),
+      );
+    });
+
+    it("should not allow adding a list with duplicate name", async () => {
+      const dbConfig = createDbConfig({
+        remoteLists: [
+          {
+            name: "my-list-1",
+            repositories: ["owner1/repo1", "owner1/repo2"],
+          },
+        ],
+      });
+
+      await saveDbConfig(dbConfig);
+
+      await expect(dbManager.addNewRemoteList("my-list-1")).rejects.toThrow(
+        new Error("A list with the name 'my-list-1' already exists"),
+      );
+    });
+  });
+
   async function saveDbConfig(dbConfig: DbConfig): Promise<void> {
     await writeJson(dbConfigFilePath, dbConfig);
 


### PR DESCRIPTION
This wasn't handled in the UI flow so I've added an extra check, and some tests.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
