### PR TITLE
Create "Add database" button in DB panel 

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -60,6 +60,7 @@
     "onCommand:codeQLDatabases.chooseDatabase",
     "onCommand:codeQLDatabases.setCurrentDatabase",
     "onCommand:codeQLDatabasesExperimental.openConfigFile",
+    "onCommand:codeQLDatabasesExperimental.addNewDatabase",
     "onCommand:codeQLDatabasesExperimental.addNewList",
     "onCommand:codeQLDatabasesExperimental.setSelectedItem",
     "onCommand:codeQL.quickQuery",
@@ -361,6 +362,11 @@
         "command": "codeQLDatabasesExperimental.openConfigFile",
         "title": "Open Database Configuration File",
         "icon": "$(edit)"
+      },
+      {
+        "command": "codeQLDatabasesExperimental.addNewDatabase",
+        "title": "Add new database",
+        "icon": "$(add)"
       },
       {
         "command": "codeQLDatabasesExperimental.addNewList",
@@ -760,6 +766,11 @@
           "group": "navigation"
         },
         {
+          "command": "codeQLDatabasesExperimental.addNewDatabase",
+          "when": "view == codeQLDatabasesExperimental && codeQLDatabasesExperimental.configError == false",
+          "group": "navigation"
+        },
+        {
           "command": "codeQLDatabasesExperimental.addNewList",
           "when": "view == codeQLDatabasesExperimental && codeQLDatabasesExperimental.configError == false",
           "group": "navigation"
@@ -980,6 +991,10 @@
         },
         {
           "command": "codeQLDatabasesExperimental.openConfigFile",
+          "when": "false"
+        },
+        {
+          "command": "codeQLDatabasesExperimental.addNewDatabase",
           "when": "false"
         },
         {

--- a/extensions/ql-vscode/src/common/github-url-identifier-helper.ts
+++ b/extensions/ql-vscode/src/common/github-url-identifier-helper.ts
@@ -5,7 +5,7 @@ import { OWNER_REGEX, REPO_REGEX } from "../pure/helpers-pure";
  * @param identifier The GitHub NWO
  * @returns
  */
-export function validGitHubNwo(identifier: string): boolean {
+export function isValidGitHubNwo(identifier: string): boolean {
   return validGitHubNwoOrOwner(identifier, "nwo");
 }
 
@@ -14,7 +14,7 @@ export function validGitHubNwo(identifier: string): boolean {
  * @param identifier The GitHub owner
  * @returns
  */
-export function validGitHubOwner(identifier: string): boolean {
+export function isValidGitHubOwner(identifier: string): boolean {
   return validGitHubNwoOrOwner(identifier, "owner");
 }
 
@@ -28,7 +28,7 @@ function validGitHubNwoOrOwner(
 }
 
 /**
- * Extracts an NOW from a GitHub URL.
+ * Extracts an NWO from a GitHub URL.
  * @param githubUrl The GitHub repository URL
  * @return The corresponding NWO, or undefined if the URL is not valid
  */

--- a/extensions/ql-vscode/src/databaseFetcher.ts
+++ b/extensions/ql-vscode/src/databaseFetcher.ts
@@ -24,7 +24,7 @@ import { Credentials } from "./authentication";
 import { getErrorMessage } from "./pure/helpers-pure";
 import {
   getNwoFromGitHubUrl,
-  validGitHubNwo,
+  isValidGitHubNwo,
 } from "./common/github-url-identifier-helper";
 
 /**
@@ -101,7 +101,7 @@ export async function promptImportGithubDatabase(
   }
 
   const nwo = getNwoFromGitHubUrl(githubRepo) || githubRepo;
-  if (!validGitHubNwo(nwo)) {
+  if (!isValidGitHubNwo(nwo)) {
     throw new Error(`Invalid GitHub repository: ${githubRepo}`);
   }
 

--- a/extensions/ql-vscode/src/databases/config/db-config-store.ts
+++ b/extensions/ql-vscode/src/databases/config/db-config-store.ts
@@ -94,6 +94,28 @@ export class DbConfigStore extends DisposableObject {
     await this.writeConfig(config);
   }
 
+  public async addRemoteRepo(repoNwo: string): Promise<void> {
+    if (!this.config) {
+      throw Error("Cannot add remote repo if config is not loaded");
+    }
+
+    const config: DbConfig = cloneDbConfig(this.config);
+    config.databases.remote.repositories.push(repoNwo);
+
+    await this.writeConfig(config);
+  }
+
+  public async addRemoteOwner(owner: string): Promise<void> {
+    if (!this.config) {
+      throw Error("Cannot add remote owner if config is not loaded");
+    }
+
+    const config: DbConfig = cloneDbConfig(this.config);
+    config.databases.remote.owners.push(owner);
+
+    await this.writeConfig(config);
+  }
+
   public async addRemoteList(listName: string): Promise<void> {
     if (!this.config) {
       throw Error("Cannot add remote list if config is not loaded");

--- a/extensions/ql-vscode/src/databases/db-manager.ts
+++ b/extensions/ql-vscode/src/databases/db-manager.ts
@@ -75,6 +75,14 @@ export class DbManager {
     await this.dbConfigStore.updateExpandedState(newExpandedItems);
   }
 
+  public async addNewRemoteRepo(nwo: string): Promise<void> {
+    await this.dbConfigStore.addRemoteRepo(nwo);
+  }
+
+  public async addNewRemoteOwner(owner: string): Promise<void> {
+    await this.dbConfigStore.addRemoteOwner(owner);
+  }
+
   public async addNewRemoteList(listName: string): Promise<void> {
     if (listName === "") {
       throw Error("List name cannot be empty");

--- a/extensions/ql-vscode/src/databases/ui/db-panel.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-panel.ts
@@ -7,9 +7,9 @@ import {
 import { commandRunner, UserCancellationException } from "../../commandRunner";
 import {
   getNwoFromGitHubUrl,
-  validGitHubNwo,
+  isValidGitHubNwo,
   getOwnerFromGitHubUrl,
-  validGitHubOwner,
+  isValidGitHubOwner,
 } from "../../common/github-url-identifier-helper";
 import { showAndLogErrorMessage } from "../../helpers";
 import { DisposableObject } from "../../pure/disposable-object";
@@ -123,7 +123,7 @@ export class DbPanel extends DisposableObject {
     }
 
     const nwo = getNwoFromGitHubUrl(repoName) || repoName;
-    if (!validGitHubNwo(nwo)) {
+    if (!isValidGitHubNwo(nwo)) {
       throw new Error(`Invalid GitHub repository: ${repoName}`);
     }
 
@@ -142,7 +142,7 @@ export class DbPanel extends DisposableObject {
     }
 
     const owner = getOwnerFromGitHubUrl(ownerName) || ownerName;
-    if (!validGitHubOwner(owner)) {
+    if (!isValidGitHubOwner(owner)) {
       throw new Error(`Invalid user or organization: ${owner}`);
     }
 

--- a/extensions/ql-vscode/test/pure-tests/common/github-url-identifier-helper.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/common/github-url-identifier-helper.test.ts
@@ -1,23 +1,23 @@
 import {
   getNwoFromGitHubUrl,
   getOwnerFromGitHubUrl,
-  validGitHubNwo,
-  validGitHubOwner,
+  isValidGitHubNwo,
+  isValidGitHubOwner,
 } from "../../../src/common/github-url-identifier-helper";
 
 describe("github url identifier helper", () => {
   describe("valid GitHub Nwo Or Owner method", () => {
     it("should return true for valid owner", () => {
-      expect(validGitHubOwner("github")).toBe(true);
+      expect(isValidGitHubOwner("github")).toBe(true);
     });
     it("should return true for valid NWO", () => {
-      expect(validGitHubNwo("github/codeql")).toBe(true);
+      expect(isValidGitHubNwo("github/codeql")).toBe(true);
     });
     it("should return false for invalid owner", () => {
-      expect(validGitHubOwner("github/codeql")).toBe(false);
+      expect(isValidGitHubOwner("github/codeql")).toBe(false);
     });
     it("should return false for invalid NWO", () => {
-      expect(validGitHubNwo("githubl")).toBe(false);
+      expect(isValidGitHubNwo("githubl")).toBe(false);
     });
   });
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

To add new databases to the new DB panel we want to have an "Add database" button (using the ["add" icon](https://microsoft.github.io/vscode-codicons/dist/codicon.html)), which lets a user add a new database or an owner item through the UI.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
