### PR TITLE
Use ✓ for db item selection

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -369,8 +369,7 @@
       },
       {
         "command": "codeQLDatabasesExperimental.setSelectedItem",
-        "title": "Select Item",
-        "icon": "$(circle-small-filled)"
+        "title": "✓"
       },
       {
         "command": "codeQLDatabases.chooseDatabaseFolder",

--- a/extensions/ql-vscode/src/databases/ui/db-selection-decoration-provider.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-selection-decoration-provider.ts
@@ -13,7 +13,7 @@ export class DbSelectionDecorationProvider implements FileDecorationProvider {
   ): ProviderResult<FileDecoration> {
     if (uri?.query === "selected=true") {
       return {
-        badge: "●",
+        badge: "✓",
         tooltip: "Currently selected",
       };
     }


### PR DESCRIPTION
Use ✓ for db item selection both in terms of action and decoration.

https://user-images.githubusercontent.com/311693/208654213-a890ba01-e34b-4e09-8d99-4592ec65571e.mov


## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
