### PR TITLE
Simplify the credentials class, and clear up impossible error cases

### DIFF
--- a/extensions/ql-vscode/src/authentication.ts
+++ b/extensions/ql-vscode/src/authentication.ts
@@ -34,7 +34,6 @@ export class Credentials {
   ): Promise<Credentials> {
     const c = new Credentials();
     c.registerListeners(context);
-    c.octokit = await c.createOctokit(false);
     return c;
   }
 
@@ -76,7 +75,7 @@ export class Credentials {
     context.subscriptions.push(
       vscode.authentication.onDidChangeSessions(async (e) => {
         if (e.provider.id === GITHUB_AUTH_PROVIDER_ID) {
-          this.octokit = await this.createOctokit(false);
+          this.octokit = undefined;
         }
       }),
     );

--- a/extensions/ql-vscode/src/authentication.ts
+++ b/extensions/ql-vscode/src/authentication.ts
@@ -48,18 +48,13 @@ export class Credentials {
    */
   static async initializeWithToken(overrideToken: string) {
     const c = new Credentials();
-    c.octokit = await c.createOctokit(false, overrideToken);
+    c.octokit = new Octokit.Octokit({ auth: overrideToken, retry });
     return c;
   }
 
   private async createOctokit(
     createIfNone: boolean,
-    overrideToken?: string,
   ): Promise<Octokit.Octokit | undefined> {
-    if (overrideToken) {
-      return new Octokit.Octokit({ auth: overrideToken, retry });
-    }
-
     const session = await vscode.authentication.getSession(
       GITHUB_AUTH_PROVIDER_ID,
       SCOPES,

--- a/extensions/ql-vscode/src/authentication.ts
+++ b/extensions/ql-vscode/src/authentication.ts
@@ -51,23 +51,17 @@ export class Credentials {
     return c;
   }
 
-  private async createOctokit(
-    createIfNone: boolean,
-  ): Promise<Octokit.Octokit | undefined> {
+  private async createOctokit(): Promise<Octokit.Octokit> {
     const session = await vscode.authentication.getSession(
       GITHUB_AUTH_PROVIDER_ID,
       SCOPES,
-      { createIfNone },
+      { createIfNone: true },
     );
 
-    if (session) {
-      return new Octokit.Octokit({
-        auth: session.accessToken,
-        retry,
-      });
-    } else {
-      return undefined;
-    }
+    return new Octokit.Octokit({
+      auth: session.accessToken,
+      retry,
+    });
   }
 
   registerListeners(context: vscode.ExtensionContext): void {
@@ -87,14 +81,8 @@ export class Credentials {
    * @returns An instance of Octokit.
    */
   async getOctokit(): Promise<Octokit.Octokit> {
-    if (this.octokit) {
-      return this.octokit;
-    }
-
-    this.octokit = await this.createOctokit(true);
-
     if (!this.octokit) {
-      throw new Error("Did not initialize Octokit.");
+      this.octokit = await this.createOctokit();
     }
     return this.octokit;
   }

--- a/extensions/ql-vscode/src/authentication.ts
+++ b/extensions/ql-vscode/src/authentication.ts
@@ -27,7 +27,7 @@ export class Credentials {
   /**
    * Initializes a Credentials instance. This will generate octokit instances
    * authenticated as the user. If there is not already an authenticated GitHub
-   * session availabeT then the user will be prompted to log in.
+   * session available then the user will be prompted to log in.
    *
    * @returns An instance of credentials.
    */
@@ -37,8 +37,8 @@ export class Credentials {
 
   /**
    * Initializes an instance of credentials with an octokit instance using
-   * a specific known token. This method is meant to be used non-interactive
-   * environments such as tests.
+   * a specific known token. This method is meant to be used in
+   * non-interactive environments such as tests.
    *
    * @param overrideToken The GitHub token to use for authentication.
    * @returns An instance of credentials.

--- a/extensions/ql-vscode/src/authentication.ts
+++ b/extensions/ql-vscode/src/authentication.ts
@@ -47,7 +47,16 @@ export class Credentials {
     return new Credentials(new Octokit.Octokit({ auth: overrideToken, retry }));
   }
 
-  private async createOctokit(): Promise<Octokit.Octokit> {
+  /**
+   * Creates or returns an instance of Octokit.
+   *
+   * @returns An instance of Octokit.
+   */
+  async getOctokit(): Promise<Octokit.Octokit> {
+    if (this.octokit) {
+      return this.octokit;
+    }
+
     const session = await vscode.authentication.getSession(
       GITHUB_AUTH_PROVIDER_ID,
       SCOPES,
@@ -58,17 +67,5 @@ export class Credentials {
       auth: session.accessToken,
       retry,
     });
-  }
-
-  /**
-   * Creates or returns an instance of Octokit.
-   *
-   * @returns An instance of Octokit.
-   */
-  async getOctokit(): Promise<Octokit.Octokit> {
-    if (this.octokit) {
-      return this.octokit;
-    }
-    return await this.createOctokit();
   }
 }

--- a/extensions/ql-vscode/src/authentication.ts
+++ b/extensions/ql-vscode/src/authentication.ts
@@ -90,24 +90,17 @@ export class Credentials {
   /**
    * Creates or returns an instance of Octokit.
    *
-   * @param requireAuthentication Whether the Octokit instance needs to be authenticated as user.
    * @returns An instance of Octokit.
    */
-  async getOctokit(requireAuthentication = true): Promise<Octokit.Octokit> {
+  async getOctokit(): Promise<Octokit.Octokit> {
     if (this.octokit) {
       return this.octokit;
     }
 
-    this.octokit = await this.createOctokit(requireAuthentication);
+    this.octokit = await this.createOctokit(true);
 
     if (!this.octokit) {
-      if (requireAuthentication) {
-        throw new Error("Did not initialize Octokit.");
-      }
-
-      // We don't want to set this in this.octokit because that would prevent
-      // authenticating when requireCredentials is true.
-      return new Octokit.Octokit({ retry });
+      throw new Error("Did not initialize Octokit.");
     }
     return this.octokit;
   }

--- a/extensions/ql-vscode/src/databaseFetcher.ts
+++ b/extensions/ql-vscode/src/databaseFetcher.ts
@@ -106,7 +106,7 @@ export async function promptImportGithubDatabase(
   }
 
   const octokit = credentials
-    ? await credentials.getOctokit(true)
+    ? await credentials.getOctokit()
     : new Octokit.Octokit({ retry });
 
   const result = await convertGithubNwoToDatabaseUrl(nwo, octokit, progress);

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -591,7 +591,7 @@ async function activateWithInstalledDistribution(
     qs,
     getContextStoragePath(ctx),
     ctx.extensionPath,
-    () => Credentials.initialize(ctx),
+    () => Credentials.initialize(),
   );
   databaseUI.init();
   ctx.subscriptions.push(databaseUI);
@@ -1236,7 +1236,7 @@ async function activateWithInstalledDistribution(
     commandRunner(
       "codeQL.exportRemoteQueryResults",
       async (queryId: string) => {
-        await exportRemoteQueryResults(qhm, rqm, ctx, queryId);
+        await exportRemoteQueryResults(qhm, rqm, queryId);
       },
     ),
   );
@@ -1251,7 +1251,6 @@ async function activateWithInstalledDistribution(
         filterSort?: RepositoriesFilterSortStateWithIds,
       ) => {
         await exportVariantAnalysisResults(
-          ctx,
           variantAnalysisManager,
           variantAnalysisId,
           filterSort,
@@ -1356,7 +1355,7 @@ async function activateWithInstalledDistribution(
       "codeQL.chooseDatabaseGithub",
       async (progress: ProgressCallback, token: CancellationToken) => {
         const credentials = isCanary()
-          ? await Credentials.initialize(ctx)
+          ? await Credentials.initialize()
           : undefined;
         await databaseUI.handleChooseDatabaseGithub(
           credentials,
@@ -1411,7 +1410,7 @@ async function activateWithInstalledDistribution(
        * Credentials for authenticating to GitHub.
        * These are used when making API calls.
        */
-      const credentials = await Credentials.initialize(ctx);
+      const credentials = await Credentials.initialize();
       const octokit = await credentials.getOctokit();
       const userInfo = await octokit.users.getAuthenticated();
       void showAndLogInformationMessage(

--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -397,7 +397,7 @@ export class QueryHistoryManager extends DisposableObject {
     private readonly variantAnalysisManager: VariantAnalysisManager,
     private readonly evalLogViewer: EvalLogViewer,
     private readonly queryStorageDir: string,
-    private readonly ctx: ExtensionContext,
+    ctx: ExtensionContext,
     private readonly queryHistoryConfigListener: QueryHistoryConfig,
     private readonly labelProvider: HistoryItemLabelProvider,
     private readonly doCompareCallback: (
@@ -633,7 +633,7 @@ export class QueryHistoryManager extends DisposableObject {
   }
 
   private getCredentials() {
-    return Credentials.initialize(this.ctx);
+    return Credentials.initialize();
   }
 
   /**

--- a/extensions/ql-vscode/src/remote-queries/analyses-results-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/analyses-results-manager.ts
@@ -1,7 +1,7 @@
 import { pathExists } from "fs-extra";
 import { EOL } from "os";
 import { extname } from "path";
-import { CancellationToken, ExtensionContext } from "vscode";
+import { CancellationToken } from "vscode";
 
 import { Credentials } from "../authentication";
 import { Logger } from "../common";
@@ -26,7 +26,6 @@ export class AnalysesResultsManager {
   private readonly analysesResults: Map<string, AnalysisResults[]>;
 
   constructor(
-    private readonly ctx: ExtensionContext,
     private readonly cliServer: CodeQLCliServer,
     readonly storagePath: string,
     private readonly logger: Logger,
@@ -43,7 +42,7 @@ export class AnalysesResultsManager {
       return;
     }
 
-    const credentials = await Credentials.initialize(this.ctx);
+    const credentials = await Credentials.initialize();
 
     void this.logger.log(
       `Downloading and processing results for ${analysisSummary.nwo}`,
@@ -77,7 +76,7 @@ export class AnalysesResultsManager {
       (x) => !this.isAnalysisInMemory(x),
     );
 
-    const credentials = await Credentials.initialize(this.ctx);
+    const credentials = await Credentials.initialize();
 
     void this.logger.log("Downloading and processing analyses results");
 

--- a/extensions/ql-vscode/src/remote-queries/export-results.ts
+++ b/extensions/ql-vscode/src/remote-queries/export-results.ts
@@ -4,7 +4,6 @@ import { ensureDir, writeFile } from "fs-extra";
 import {
   commands,
   CancellationToken,
-  ExtensionContext,
   Uri,
   ViewColumn,
   window,
@@ -74,7 +73,6 @@ export async function exportSelectedRemoteQueryResults(
 export async function exportRemoteQueryResults(
   queryHistoryManager: QueryHistoryManager,
   remoteQueriesManager: RemoteQueriesManager,
-  ctx: ExtensionContext,
   queryId: string,
 ): Promise<void> {
   const queryHistoryItem = queryHistoryManager.getRemoteQueryById(queryId);
@@ -107,7 +105,6 @@ export async function exportRemoteQueryResults(
   const exportedResultsDirectory = join(exportDirectory, "exported-results");
 
   await exportRemoteQueryAnalysisResults(
-    ctx,
     exportedResultsDirectory,
     query,
     analysesResults,
@@ -116,7 +113,6 @@ export async function exportRemoteQueryResults(
 }
 
 export async function exportRemoteQueryAnalysisResults(
-  ctx: ExtensionContext,
   exportedResultsPath: string,
   query: RemoteQuery,
   analysesResults: AnalysisResults[],
@@ -126,7 +122,6 @@ export async function exportRemoteQueryAnalysisResults(
   const markdownFiles = generateMarkdown(query, analysesResults, exportFormat);
 
   await exportResults(
-    ctx,
     exportedResultsPath,
     description,
     markdownFiles,
@@ -141,7 +136,6 @@ const MAX_VARIANT_ANALYSIS_EXPORT_PROGRESS_STEPS = 2;
  * The user is prompted to select the export format.
  */
 export async function exportVariantAnalysisResults(
-  ctx: ExtensionContext,
   variantAnalysisManager: VariantAnalysisManager,
   variantAnalysisId: number,
   filterSort: RepositoriesFilterSortStateWithIds | undefined,
@@ -255,7 +249,6 @@ export async function exportVariantAnalysisResults(
   );
 
   await exportVariantAnalysisAnalysisResults(
-    ctx,
     exportedResultsDirectory,
     variantAnalysis,
     getAnalysesResults(),
@@ -266,7 +259,6 @@ export async function exportVariantAnalysisResults(
 }
 
 export async function exportVariantAnalysisAnalysisResults(
-  ctx: ExtensionContext,
   exportedResultsPath: string,
   variantAnalysis: VariantAnalysis,
   analysesResults: AsyncIterable<
@@ -297,7 +289,6 @@ export async function exportVariantAnalysisAnalysisResults(
   );
 
   await exportResults(
-    ctx,
     exportedResultsPath,
     description,
     markdownFiles,
@@ -341,7 +332,6 @@ async function determineExportFormat(): Promise<"gist" | "local" | undefined> {
 }
 
 export async function exportResults(
-  ctx: ExtensionContext,
   exportedResultsPath: string,
   description: string,
   markdownFiles: MarkdownFile[],
@@ -354,7 +344,7 @@ export async function exportResults(
   }
 
   if (exportFormat === "gist") {
-    await exportToGist(ctx, description, markdownFiles, progress, token);
+    await exportToGist(description, markdownFiles, progress, token);
   } else if (exportFormat === "local") {
     await exportToLocalMarkdown(
       exportedResultsPath,
@@ -366,7 +356,6 @@ export async function exportResults(
 }
 
 export async function exportToGist(
-  ctx: ExtensionContext,
   description: string,
   markdownFiles: MarkdownFile[],
   progress?: ProgressCallback,
@@ -378,7 +367,7 @@ export async function exportToGist(
     message: "Creating Gist",
   });
 
-  const credentials = await Credentials.initialize(ctx);
+  const credentials = await Credentials.initialize();
 
   if (token?.isCancellationRequested) {
     throw new UserCancellationException("Cancelled");

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-manager.ts
@@ -81,20 +81,19 @@ export class RemoteQueriesManager extends DisposableObject {
   private readonly view: RemoteQueriesView;
 
   constructor(
-    private readonly ctx: ExtensionContext,
+    ctx: ExtensionContext,
     private readonly cliServer: CodeQLCliServer,
     private readonly storagePath: string,
     logger: Logger,
   ) {
     super();
     this.analysesResultsManager = new AnalysesResultsManager(
-      ctx,
       cliServer,
       storagePath,
       logger,
     );
     this.view = new RemoteQueriesView(ctx, logger, this.analysesResultsManager);
-    this.remoteQueriesMonitor = new RemoteQueriesMonitor(ctx, logger);
+    this.remoteQueriesMonitor = new RemoteQueriesMonitor(logger);
 
     this.remoteQueryAddedEventEmitter = this.push(
       new EventEmitter<NewQueryEvent>(),
@@ -160,7 +159,7 @@ export class RemoteQueriesManager extends DisposableObject {
     progress: ProgressCallback,
     token: CancellationToken,
   ): Promise<void> {
-    const credentials = await Credentials.initialize(this.ctx);
+    const credentials = await Credentials.initialize();
 
     const {
       actionBranch,
@@ -218,7 +217,7 @@ export class RemoteQueriesManager extends DisposableObject {
     remoteQuery: RemoteQuery,
     cancellationToken: CancellationToken,
   ): Promise<void> {
-    const credentials = await Credentials.initialize(this.ctx);
+    const credentials = await Credentials.initialize();
 
     const queryWorkflowResult = await this.remoteQueriesMonitor.monitorQuery(
       remoteQuery,

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-monitor.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-monitor.ts
@@ -16,16 +16,13 @@ export class RemoteQueriesMonitor {
   private static readonly maxAttemptCount = 17280;
   private static readonly sleepTime = 5000;
 
-  constructor(
-    private readonly extensionContext: vscode.ExtensionContext,
-    private readonly logger: Logger,
-  ) {}
+  constructor(private readonly logger: Logger) {}
 
   public async monitorQuery(
     remoteQuery: RemoteQuery,
     cancellationToken: vscode.CancellationToken,
   ): Promise<RemoteQueryWorkflowResult> {
-    const credentials = await Credentials.initialize(this.extensionContext);
+    const credentials = await Credentials.initialize();
 
     let attemptCount = 0;
 

--- a/extensions/ql-vscode/src/remote-queries/remote-queries-monitor.ts
+++ b/extensions/ql-vscode/src/remote-queries/remote-queries-monitor.ts
@@ -27,10 +27,6 @@ export class RemoteQueriesMonitor {
   ): Promise<RemoteQueryWorkflowResult> {
     const credentials = await Credentials.initialize(this.extensionContext);
 
-    if (!credentials) {
-      throw Error("Error authenticating with GitHub");
-    }
-
     let attemptCount = 0;
 
     while (attemptCount <= RemoteQueriesMonitor.maxAttemptCount) {

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
@@ -106,7 +106,6 @@ export class VariantAnalysisManager
     super();
     this.variantAnalysisMonitor = this.push(
       new VariantAnalysisMonitor(
-        ctx,
         this.shouldCancelMonitorVariantAnalysis.bind(this),
       ),
     );
@@ -125,7 +124,7 @@ export class VariantAnalysisManager
     progress: ProgressCallback,
     token: CancellationToken,
   ): Promise<void> {
-    const credentials = await Credentials.initialize(this.ctx);
+    const credentials = await Credentials.initialize();
 
     const {
       actionBranch,
@@ -479,7 +478,7 @@ export class VariantAnalysisManager
 
     await this.onRepoStateUpdated(variantAnalysis.id, repoState);
 
-    const credentials = await Credentials.initialize(this.ctx);
+    const credentials = await Credentials.initialize();
 
     if (cancellationToken && cancellationToken.isCancellationRequested) {
       repoState.downloadStatus =
@@ -577,7 +576,7 @@ export class VariantAnalysisManager
       );
     }
 
-    const credentials = await Credentials.initialize(this.ctx);
+    const credentials = await Credentials.initialize();
 
     void showAndLogInformationMessage(
       "Cancelling variant analysis. This may take a while.",

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
@@ -480,9 +480,6 @@ export class VariantAnalysisManager
     await this.onRepoStateUpdated(variantAnalysis.id, repoState);
 
     const credentials = await Credentials.initialize(this.ctx);
-    if (!credentials) {
-      throw Error("Error authenticating with GitHub");
-    }
 
     if (cancellationToken && cancellationToken.isCancellationRequested) {
       repoState.downloadStatus =
@@ -581,9 +578,6 @@ export class VariantAnalysisManager
     }
 
     const credentials = await Credentials.initialize(this.ctx);
-    if (!credentials) {
-      throw Error("Error authenticating with GitHub");
-    }
 
     void showAndLogInformationMessage(
       "Cancelling variant analysis. This may take a while.",

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-monitor.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-monitor.ts
@@ -45,9 +45,6 @@ export class VariantAnalysisMonitor extends DisposableObject {
     cancellationToken: CancellationToken,
   ): Promise<void> {
     const credentials = await Credentials.initialize(this.extensionContext);
-    if (!credentials) {
-      throw Error("Error authenticating with GitHub");
-    }
 
     let attemptCount = 0;
     const scannedReposDownloaded: number[] = [];

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-monitor.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-monitor.ts
@@ -1,9 +1,4 @@
-import {
-  CancellationToken,
-  commands,
-  EventEmitter,
-  ExtensionContext,
-} from "vscode";
+import { CancellationToken, commands, EventEmitter } from "vscode";
 import { Credentials } from "../authentication";
 import { getVariantAnalysis } from "./gh-api/gh-api-client";
 
@@ -32,7 +27,6 @@ export class VariantAnalysisMonitor extends DisposableObject {
   readonly onVariantAnalysisChange = this._onVariantAnalysisChange.event;
 
   constructor(
-    private readonly extensionContext: ExtensionContext,
     private readonly shouldCancelMonitor: (
       variantAnalysisId: number,
     ) => Promise<boolean>,
@@ -44,7 +38,7 @@ export class VariantAnalysisMonitor extends DisposableObject {
     variantAnalysis: VariantAnalysis,
     cancellationToken: CancellationToken,
   ): Promise<void> {
-    const credentials = await Credentials.initialize(this.extensionContext);
+    const credentials = await Credentials.initialize();
 
     let attemptCount = 0;
     const scannedReposDownloaded: number[] = [];

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-monitor.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/variant-analysis-monitor.test.ts
@@ -61,10 +61,7 @@ describe("Variant Analysis Monitor", () => {
         "GitHub.vscode-codeql",
       )!
       .activate();
-    variantAnalysisMonitor = new VariantAnalysisMonitor(
-      extension.ctx,
-      shouldCancelMonitor,
-    );
+    variantAnalysisMonitor = new VariantAnalysisMonitor(shouldCancelMonitor);
     variantAnalysisMonitor.onVariantAnalysisChange(onVariantAnalysisChangeSpy);
 
     variantAnalysisManager = extension.variantAnalysisManager;

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/export-results.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/export-results.test.ts
@@ -1,6 +1,5 @@
 import { join } from "path";
 import { readFile } from "fs-extra";
-import { createMockExtensionContext } from "../index";
 import { Credentials } from "../../../authentication";
 import * as markdownGenerator from "../../../remote-queries/remote-queries-markdown-generation";
 import * as ghApiClient from "../../../remote-queries/gh-api/gh-api-client";
@@ -20,7 +19,6 @@ describe("export results", () => {
         .spyOn(ghApiClient, "createGist")
         .mockResolvedValue(undefined);
 
-      const ctx = createMockExtensionContext();
       const query = JSON.parse(
         await readFile(
           join(
@@ -41,7 +39,6 @@ describe("export results", () => {
       );
 
       await exportRemoteQueryAnalysisResults(
-        ctx,
         "",
         query,
         analysesResults,

--- a/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/remote-query-history.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/no-workspace/remote-queries/remote-query-history.test.ts
@@ -279,7 +279,6 @@ describe("Remote queries and query history manager", () => {
       jest.spyOn(Credentials, "initialize").mockResolvedValue(mockCredentials);
 
       arm = new AnalysesResultsManager(
-        {} as ExtensionContext,
         mockCliServer,
         join(STORAGE_DIR, "queries"),
         mockLogger,


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

The main thing being changed here, is that we remove the illusion that we prompt the user for authorization lazily, and instead we always fetch credentials and construct an authenticated octokit instance when calling `Credentials.initialize()`. I have a suspicion that a lot of the code in `Credentials` was unreachable, because the `octokit` field couldn't actually be undefined.

It's possible I am missing something here and the `Credentials` class really does need to be the way it is. If this is the case I'd like to know, and I'm happy to close or amend this PR as appropriate.

Secondly, and this is what tipped me off to this, we had a few places where we were doing
```typescript
if (!credentials) {
  throw Error("Error authenticating with GitHub");
}
```
but the problem is that `credentials` can never be undefined so this is dead code. The code makes it seem like `credentials.octokit` could be undefined at this point, but I think even this is impossible as I haven't been able to trigger it. I think this misunderstanding comes from the way that the `Credentials` class is written, so I hope this PR makes it clearer.

When removing the above exceptions I also remove some tests that were attempting to cover "when the credentials are invalid", but in reality I think these tests were not covering any code paths that could be hit in production. If there really are no credentials, because the user declined to authenticate the application, then `vscode.authentication.getSession` rejects, and thus we get an exception from the vscode library code. This is perfectly good, and I don't think we need these tests to cover it.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
