### PR TITLE
Stop user from adding a db or owner with the same name

### DIFF
--- a/extensions/ql-vscode/src/databases/config/db-config-store.ts
+++ b/extensions/ql-vscode/src/databases/config/db-config-store.ts
@@ -99,6 +99,12 @@ export class DbConfigStore extends DisposableObject {
       throw Error("Cannot add remote repo if config is not loaded");
     }
 
+    if (this.doesRemoteDbExist(repoNwo)) {
+      throw Error(
+        `A remote repository with the name '${repoNwo}' already exists`,
+      );
+    }
+
     const config: DbConfig = cloneDbConfig(this.config);
     config.databases.remote.repositories.push(repoNwo);
 
@@ -108,6 +114,10 @@ export class DbConfigStore extends DisposableObject {
   public async addRemoteOwner(owner: string): Promise<void> {
     if (!this.config) {
       throw Error("Cannot add remote owner if config is not loaded");
+    }
+
+    if (this.doesRemoteOwnerExist(owner)) {
+      throw Error(`A remote owner with the name '${owner}' already exists`);
     }
 
     const config: DbConfig = cloneDbConfig(this.config);
@@ -142,6 +152,32 @@ export class DbConfigStore extends DisposableObject {
     return this.config.databases.remote.repositoryLists.some(
       (l) => l.name === listName,
     );
+  }
+
+  public doesRemoteDbExist(dbName: string, listName?: string): boolean {
+    if (!this.config) {
+      throw Error(
+        "Cannot check remote database existence if config is not loaded",
+      );
+    }
+
+    if (listName) {
+      return this.config.databases.remote.repositoryLists.some(
+        (l) => l.name === listName && l.repositories.includes(dbName),
+      );
+    }
+
+    return this.config.databases.remote.repositories.includes(dbName);
+  }
+
+  public doesRemoteOwnerExist(owner: string): boolean {
+    if (!this.config) {
+      throw Error(
+        "Cannot check remote onwer existence if config is not loaded",
+      );
+    }
+
+    return this.config.databases.remote.owners.includes(owner);
   }
 
   private async writeConfig(config: DbConfig): Promise<void> {

--- a/extensions/ql-vscode/src/databases/db-manager.ts
+++ b/extensions/ql-vscode/src/databases/db-manager.ts
@@ -76,10 +76,24 @@ export class DbManager {
   }
 
   public async addNewRemoteRepo(nwo: string): Promise<void> {
+    if (nwo === "") {
+      throw new Error("Repository name cannot be empty");
+    }
+    if (this.dbConfigStore.doesRemoteDbExist(nwo)) {
+      throw new Error(`The repository '${nwo}' already exists`);
+    }
+
     await this.dbConfigStore.addRemoteRepo(nwo);
   }
 
   public async addNewRemoteOwner(owner: string): Promise<void> {
+    if (owner === "") {
+      throw Error("Owner name cannot be empty");
+    }
+    if (this.dbConfigStore.doesRemoteOwnerExist(owner)) {
+      throw Error(`The owner '${owner}' already exists`);
+    }
+
     await this.dbConfigStore.addRemoteOwner(owner);
   }
 
@@ -96,9 +110,5 @@ export class DbManager {
     } else {
       throw Error("Cannot add a local list");
     }
-  }
-
-  public doesRemoteListExist(listName: string): boolean {
-    return this.dbConfigStore.doesRemoteListExist(listName);
   }
 }

--- a/extensions/ql-vscode/src/vscode-tests/minimal-workspace/databases/db-panel.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/minimal-workspace/databases/db-panel.test.ts
@@ -589,6 +589,50 @@ describe("db panel", () => {
         new Error("A list with the name 'my-list-1' already exists"),
       );
     });
+
+    it("should not allow adding a new remote db with empty name", async () => {
+      const dbConfig = createDbConfig();
+
+      await saveDbConfig(dbConfig);
+
+      await expect(dbManager.addNewRemoteRepo("")).rejects.toThrow(
+        new Error("Repository name cannot be empty"),
+      );
+    });
+
+    it("should not allow adding a remote db with duplicate name", async () => {
+      const dbConfig = createDbConfig({
+        remoteRepos: ["owner1/repo1"],
+      });
+
+      await saveDbConfig(dbConfig);
+
+      await expect(dbManager.addNewRemoteRepo("owner1/repo1")).rejects.toThrow(
+        new Error("The repository 'owner1/repo1' already exists"),
+      );
+    });
+
+    it("should not allow adding a new remote owner with empty name", async () => {
+      const dbConfig = createDbConfig();
+
+      await saveDbConfig(dbConfig);
+
+      await expect(dbManager.addNewRemoteOwner("")).rejects.toThrow(
+        new Error("Owner name cannot be empty"),
+      );
+    });
+
+    it("should not allow adding a remote owner with duplicate name", async () => {
+      const dbConfig = createDbConfig({
+        remoteOwners: ["owner1"],
+      });
+
+      await saveDbConfig(dbConfig);
+
+      await expect(dbManager.addNewRemoteOwner("owner1")).rejects.toThrow(
+        new Error("The owner 'owner1' already exists"),
+      );
+    });
   });
 
   async function saveDbConfig(dbConfig: DbConfig): Promise<void> {


### PR DESCRIPTION
Follows a similar pattern to the validation checks around db lists.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
