### PR TITLE
Handle db validation errors gracefully

### DIFF
--- a/extensions/ql-vscode/src/databases/config/db-config-store.ts
+++ b/extensions/ql-vscode/src/databases/config/db-config-store.ts
@@ -99,6 +99,10 @@ export class DbConfigStore extends DisposableObject {
       throw Error("Cannot add remote repo if config is not loaded");
     }
 
+    if (repoNwo === "") {
+      throw Error("Repository name cannot be empty");
+    }
+
     if (this.doesRemoteDbExist(repoNwo)) {
       throw Error(
         `A remote repository with the name '${repoNwo}' already exists`,
@@ -116,6 +120,10 @@ export class DbConfigStore extends DisposableObject {
       throw Error("Cannot add remote owner if config is not loaded");
     }
 
+    if (owner === "") {
+      throw Error("Owner name cannot be empty");
+    }
+
     if (this.doesRemoteOwnerExist(owner)) {
       throw Error(`A remote owner with the name '${owner}' already exists`);
     }
@@ -129,6 +137,10 @@ export class DbConfigStore extends DisposableObject {
   public async addRemoteList(listName: string): Promise<void> {
     if (!this.config) {
       throw Error("Cannot add remote list if config is not loaded");
+    }
+
+    if (listName === "") {
+      throw Error("List name cannot be empty");
     }
 
     if (this.doesRemoteListExist(listName)) {
@@ -152,6 +164,14 @@ export class DbConfigStore extends DisposableObject {
     return this.config.databases.remote.repositoryLists.some(
       (l) => l.name === listName,
     );
+  }
+
+  public doesLocalListExist(listName: string): boolean {
+    if (!this.config) {
+      throw Error("Cannot check local list existence if config is not loaded");
+    }
+
+    return this.config.databases.local.lists.some((l) => l.name === listName);
   }
 
   public doesRemoteDbExist(dbName: string, listName?: string): boolean {

--- a/extensions/ql-vscode/src/databases/db-item.ts
+++ b/extensions/ql-vscode/src/databases/db-item.ts
@@ -25,6 +25,11 @@ export const localDbKinds = [
   DbItemKind.LocalDatabase,
 ];
 
+export enum DbListKind {
+  Local = "Local",
+  Remote = "Remote",
+}
+
 export interface RootLocalDbItem {
   kind: DbItemKind.RootLocal;
   expanded: boolean;

--- a/extensions/ql-vscode/src/databases/ui/db-panel.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-panel.ts
@@ -128,10 +128,12 @@ export class DbPanel extends DisposableObject {
     const nwo = getNwoFromGitHubUrl(repoName) || repoName;
     if (!isValidGitHubNwo(nwo)) {
       void showAndLogErrorMessage(`Invalid GitHub repository: ${repoName}`);
+      return;
     }
 
     if (this.dbManager.doesRemoteRepoExist(nwo)) {
       void showAndLogErrorMessage(`The repository '${nwo}' already exists`);
+      return;
     }
 
     await this.dbManager.addNewRemoteRepo(nwo);
@@ -151,10 +153,12 @@ export class DbPanel extends DisposableObject {
     const owner = getOwnerFromGitHubUrl(ownerName) || ownerName;
     if (!isValidGitHubOwner(owner)) {
       void showAndLogErrorMessage(`Invalid user or organization: ${owner}`);
+      return;
     }
 
     if (this.dbManager.doesRemoteOwnerExist(owner)) {
       void showAndLogErrorMessage(`The owner '${owner}' already exists`);
+      return;
     }
 
     await this.dbManager.addNewRemoteOwner(owner);
@@ -182,6 +186,7 @@ export class DbPanel extends DisposableObject {
 
     if (this.dbManager.doesListExist(listKind, listName)) {
       void showAndLogErrorMessage(`The list '${listName}' already exists`);
+      return;
     }
 
     await this.dbManager.addNewList(listKind, listName);

--- a/extensions/ql-vscode/src/databases/ui/db-panel.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-panel.ts
@@ -12,8 +12,9 @@ import {
   getOwnerFromGitHubUrl,
   isValidGitHubOwner,
 } from "../../common/github-url-identifier-helper";
+import { showAndLogErrorMessage } from "../../helpers";
 import { DisposableObject } from "../../pure/disposable-object";
-import { DbItem, DbItemKind } from "../db-item";
+import { DbItem, DbItemKind, DbListKind, remoteDbKinds } from "../db-item";
 import { DbManager } from "../db-manager";
 import { DbTreeDataProvider } from "./db-tree-data-provider";
 import { DbTreeViewItem } from "./db-tree-view-item";
@@ -126,7 +127,11 @@ export class DbPanel extends DisposableObject {
 
     const nwo = getNwoFromGitHubUrl(repoName) || repoName;
     if (!isValidGitHubNwo(nwo)) {
-      throw new Error(`Invalid GitHub repository: ${repoName}`);
+      void showAndLogErrorMessage(`Invalid GitHub repository: ${repoName}`);
+    }
+
+    if (this.dbManager.doesRemoteRepoExist(nwo)) {
+      void showAndLogErrorMessage(`The repository '${nwo}' already exists`);
     }
 
     await this.dbManager.addNewRemoteRepo(nwo);
@@ -145,7 +150,11 @@ export class DbPanel extends DisposableObject {
 
     const owner = getOwnerFromGitHubUrl(ownerName) || ownerName;
     if (!isValidGitHubOwner(owner)) {
-      throw new Error(`Invalid user or organization: ${owner}`);
+      void showAndLogErrorMessage(`Invalid user or organization: ${owner}`);
+    }
+
+    if (this.dbManager.doesRemoteOwnerExist(owner)) {
+      void showAndLogErrorMessage(`The owner '${owner}' already exists`);
     }
 
     await this.dbManager.addNewRemoteOwner(owner);
@@ -156,7 +165,7 @@ export class DbPanel extends DisposableObject {
       prompt: "Enter a name for the new list",
       placeHolder: "example-list",
     });
-    if (listName === undefined) {
+    if (listName === undefined || listName === "") {
       return;
     }
 
@@ -166,7 +175,14 @@ export class DbPanel extends DisposableObject {
     // we default to the "RootRemote" kind.
     // In future: if the highlighted item is undefined, we'll show a quick pick where
     // a user can select whether to add a remote or local list.
-    const listKind = highlightedItem?.kind || DbItemKind.RootRemote;
+    const highlightedItemKind = highlightedItem?.kind || DbItemKind.RootRemote;
+    const listKind = remoteDbKinds.includes(highlightedItemKind)
+      ? DbListKind.Remote
+      : DbListKind.Local;
+
+    if (this.dbManager.doesListExist(listKind, listName)) {
+      void showAndLogErrorMessage(`The list '${listName}' already exists`);
+    }
 
     await this.dbManager.addNewList(listKind, listName);
   }

--- a/extensions/ql-vscode/src/vscode-tests/minimal-workspace/databases/db-panel.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/minimal-workspace/databases/db-panel.test.ts
@@ -8,7 +8,11 @@ import {
 import { DbManager } from "../../../databases/db-manager";
 import { DbConfigStore } from "../../../databases/config/db-config-store";
 import { DbTreeDataProvider } from "../../../databases/ui/db-tree-data-provider";
-import { DbItemKind, LocalDatabaseDbItem } from "../../../databases/db-item";
+import {
+  DbItemKind,
+  DbListKind,
+  LocalDatabaseDbItem,
+} from "../../../databases/db-item";
 import { DbTreeViewItem } from "../../../databases/ui/db-tree-view-item";
 import { ExtensionApp } from "../../../common/vscode/vscode-app";
 import { createMockExtensionContext } from "../../factories/extension-context";
@@ -478,7 +482,7 @@ describe("db panel", () => {
       expect(remoteUserDefinedLists.length).toBe(1);
       expect(remoteUserDefinedLists[0]).toBe(list1);
 
-      await dbManager.addNewList(DbItemKind.RootRemote, "my-list-2");
+      await dbManager.addNewList(DbListKind.Remote, "my-list-2");
 
       // Read the workspace databases JSON file directly to check that the new list has been added.
       // We can't use the dbConfigStore's `read` function here because it depends on the file watcher
@@ -497,9 +501,9 @@ describe("db panel", () => {
       const dbConfig: DbConfig = createDbConfig();
       await saveDbConfig(dbConfig);
 
-      await expect(
-        dbManager.addNewList(DbItemKind.RootLocal, ""),
-      ).rejects.toThrow(new Error("Cannot add a local list"));
+      await expect(dbManager.addNewList(DbListKind.Local, "")).rejects.toThrow(
+        new Error("Cannot add a local list"),
+      );
     });
   });
 
@@ -566,9 +570,9 @@ describe("db panel", () => {
 
       await saveDbConfig(dbConfig);
 
-      await expect(
-        dbManager.addNewList(DbItemKind.RootRemote, ""),
-      ).rejects.toThrow(new Error("List name cannot be empty"));
+      await expect(dbManager.addNewList(DbListKind.Remote, "")).rejects.toThrow(
+        new Error("List name cannot be empty"),
+      );
     });
 
     it("should not allow adding a list with duplicate name", async () => {
@@ -584,9 +588,9 @@ describe("db panel", () => {
       await saveDbConfig(dbConfig);
 
       await expect(
-        dbManager.addNewList(DbItemKind.RootRemote, "my-list-1"),
+        dbManager.addNewList(DbListKind.Remote, "my-list-1"),
       ).rejects.toThrow(
-        new Error("A list with the name 'my-list-1' already exists"),
+        new Error("A remote list with the name 'my-list-1' already exists"),
       );
     });
 
@@ -608,7 +612,9 @@ describe("db panel", () => {
       await saveDbConfig(dbConfig);
 
       await expect(dbManager.addNewRemoteRepo("owner1/repo1")).rejects.toThrow(
-        new Error("The repository 'owner1/repo1' already exists"),
+        new Error(
+          "A remote repository with the name 'owner1/repo1' already exists",
+        ),
       );
     });
 
@@ -630,7 +636,7 @@ describe("db panel", () => {
       await saveDbConfig(dbConfig);
 
       await expect(dbManager.addNewRemoteOwner("owner1")).rejects.toThrow(
-        new Error("The owner 'owner1' already exists"),
+        new Error("A remote owner with the name 'owner1' already exists"),
       );
     });
   });


### PR DESCRIPTION
We have a mixture of validation checks and unhandled exceptions in various places. This PR aims to tidy that up so that:
- Validation errors are handled gracefully in the UI (`DbPanel`), using error notifications rather than triggering the global error handler.
- The `DbConfigStore` throws exceptions in the unlikely event that a caller has asked it to do something that would get the config in an invalid state (e.g. to add a list with an empt name).
- The `DbManager` should just pass through without doing the same checks. 

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
