### PR TITLE
Update dependencies in workflow files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
   - package-ecosystem: "github-actions"
-    directory: ".github"
+    directory: "/"
     schedule:
       interval: "weekly"
       day: "thursday" # Thursday is arbitrary


### PR DESCRIPTION
I'd expect dependabot to update dependencies in our actions workflows (specifically, I noticed that we're using an old version of https://github.com/peter-evans/create-pull-request in our [release workflow](https://github.com/github/vscode-codeql/blob/082d4b8c78236c82dbeab7ad1377e1c2d740fa71/.github/workflows/release.yml#L119), which has an outdated version of `node` and outdated `set-output` syntax. See warnings [here](https://github.com/github/vscode-codeql/actions/runs/3685687906).)

It looks like our dependabot configuration for `github-actions` was wrong: we need to set the directory to `"/"` instead of `".github"`. (Found this in the docs [here](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#directory)!)



## Checklist

No user impact

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
