### PR TITLE
Add new repositories to a highlighted user defined list

### DIFF
--- a/extensions/ql-vscode/src/databases/config/db-config-store.ts
+++ b/extensions/ql-vscode/src/databases/config/db-config-store.ts
@@ -114,11 +114,14 @@ export class DbConfigStore extends DisposableObject {
 
     const config: DbConfig = cloneDbConfig(this.config);
     if (parentList) {
-      config.databases.remote.repositoryLists.forEach((list) => {
-        if (list.name === parentList) {
-          list.repositories.push(repoNwo);
-        }
-      });
+      const parent = config.databases.remote.repositoryLists.find(
+        (list) => list.name === parentList,
+      );
+      if (!parent) {
+        throw Error(`Cannot find parent list '${parentList}'`);
+      } else {
+        parent.repositories.push(repoNwo);
+      }
     } else {
       config.databases.remote.repositories.push(repoNwo);
     }

--- a/extensions/ql-vscode/src/databases/config/db-config-store.ts
+++ b/extensions/ql-vscode/src/databases/config/db-config-store.ts
@@ -94,7 +94,10 @@ export class DbConfigStore extends DisposableObject {
     await this.writeConfig(config);
   }
 
-  public async addRemoteRepo(repoNwo: string): Promise<void> {
+  public async addRemoteRepo(
+    repoNwo: string,
+    parentList?: string,
+  ): Promise<void> {
     if (!this.config) {
       throw Error("Cannot add remote repo if config is not loaded");
     }
@@ -110,8 +113,15 @@ export class DbConfigStore extends DisposableObject {
     }
 
     const config: DbConfig = cloneDbConfig(this.config);
-    config.databases.remote.repositories.push(repoNwo);
-
+    if (parentList) {
+      config.databases.remote.repositoryLists.forEach((list) => {
+        if (list.name === parentList) {
+          list.repositories.push(repoNwo);
+        }
+      });
+    } else {
+      config.databases.remote.repositories.push(repoNwo);
+    }
     await this.writeConfig(config);
   }
 

--- a/extensions/ql-vscode/src/databases/db-manager.ts
+++ b/extensions/ql-vscode/src/databases/db-manager.ts
@@ -79,13 +79,6 @@ export class DbManager {
     nwo: string,
     parentList?: string,
   ): Promise<void> {
-    if (nwo === "") {
-      throw new Error("Repository name cannot be empty");
-    }
-    if (this.dbConfigStore.doesRemoteDbExist(nwo)) {
-      throw new Error(`The repository '${nwo}' already exists`);
-    }
-
     await this.dbConfigStore.addRemoteRepo(nwo, parentList);
   }
 

--- a/extensions/ql-vscode/src/databases/db-manager.ts
+++ b/extensions/ql-vscode/src/databases/db-manager.ts
@@ -75,8 +75,18 @@ export class DbManager {
     await this.dbConfigStore.updateExpandedState(newExpandedItems);
   }
 
-  public async addNewRemoteRepo(nwo: string): Promise<void> {
-    await this.dbConfigStore.addRemoteRepo(nwo);
+  public async addNewRemoteRepo(
+    nwo: string,
+    parentList?: string,
+  ): Promise<void> {
+    if (nwo === "") {
+      throw new Error("Repository name cannot be empty");
+    }
+    if (this.dbConfigStore.doesRemoteDbExist(nwo)) {
+      throw new Error(`The repository '${nwo}' already exists`);
+    }
+
+    await this.dbConfigStore.addRemoteRepo(nwo, parentList);
   }
 
   public async addNewRemoteOwner(owner: string): Promise<void> {

--- a/extensions/ql-vscode/src/databases/ui/db-panel.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-panel.ts
@@ -86,6 +86,11 @@ export class DbPanel extends DisposableObject {
 
     if (highlightedItem?.kind === DbItemKind.RemoteUserDefinedList) {
       await this.addNewRemoteRepo(highlightedItem.listName);
+    } else if (
+      highlightedItem?.kind === DbItemKind.RemoteRepo &&
+      highlightedItem.parentListName
+    ) {
+      await this.addNewRemoteRepo(highlightedItem.parentListName);
     } else {
       const quickPickItems = [
         {

--- a/extensions/ql-vscode/src/vscode-tests/minimal-workspace/databases/db-panel.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/minimal-workspace/databases/db-panel.test.ts
@@ -447,6 +447,91 @@ describe("db panel", () => {
     }
   });
 
+  describe("addNewRemoteRepo", () => {
+    it("should add a new remote repo", async () => {
+      const dbConfig: DbConfig = createDbConfig({
+        remoteRepos: ["owner1/repo1"],
+      });
+
+      await saveDbConfig(dbConfig);
+
+      const dbTreeItems = await dbTreeDataProvider.getChildren();
+
+      expect(dbTreeItems).toBeTruthy();
+      const items = dbTreeItems!;
+
+      const remoteRootNode = items[0];
+      const remoteRepos = remoteRootNode.children.filter(
+        (c) => c.dbItem?.kind === DbItemKind.RemoteRepo,
+      );
+      const repo1 = remoteRootNode.children.find(
+        (c) =>
+          c.dbItem?.kind === DbItemKind.RemoteRepo &&
+          c.dbItem?.repoFullName === "owner1/repo1",
+      );
+
+      expect(remoteRepos.length).toBe(1);
+      expect(remoteRepos[0]).toBe(repo1);
+
+      await dbManager.addNewRemoteRepo("owner2/repo2");
+
+      // Read the workspace databases JSON file directly to check that the new repo has been added.
+      // We can't use the dbConfigStore's `read` function here because it depends on the file watcher
+      // picking up changes, and we don't control the timing of that.
+      const dbConfigFileContents = await readJSON(dbConfigFilePath);
+      expect(dbConfigFileContents.databases.remote.repositories.length).toBe(2);
+      expect(dbConfigFileContents.databases.remote.repositories[1]).toEqual(
+        "owner2/repo2",
+      );
+    });
+
+    it("should add a new remote repo to a user defined list", async () => {
+      const dbConfig: DbConfig = createDbConfig({
+        remoteLists: [
+          {
+            name: "my-list-1",
+            repositories: ["owner1/repo1"],
+          },
+        ],
+      });
+
+      await saveDbConfig(dbConfig);
+
+      const dbTreeItems = await dbTreeDataProvider.getChildren();
+
+      expect(dbTreeItems).toBeTruthy();
+      const items = dbTreeItems!;
+
+      const remoteRootNode = items[0];
+      const remoteUserDefinedLists = remoteRootNode.children.filter(
+        (c) => c.dbItem?.kind === DbItemKind.RemoteUserDefinedList,
+      );
+      const list1 = remoteRootNode.children.find(
+        (c) =>
+          c.dbItem?.kind === DbItemKind.RemoteUserDefinedList &&
+          c.dbItem?.listName === "my-list-1",
+      );
+
+      expect(remoteUserDefinedLists.length).toBe(1);
+      expect(remoteUserDefinedLists[0]).toBe(list1);
+
+      await dbManager.addNewRemoteRepo("owner2/repo2", "my-list-1");
+
+      // Read the workspace databases JSON file directly to check that the new repo has been added.
+      // We can't use the dbConfigStore's `read` function here because it depends on the file watcher
+      // picking up changes, and we don't control the timing of that.
+      const dbConfigFileContents = await readJSON(dbConfigFilePath);
+      expect(dbConfigFileContents.databases.remote.repositoryLists.length).toBe(
+        1,
+      );
+
+      expect(dbConfigFileContents.databases.remote.repositoryLists[0]).toEqual({
+        name: "my-list-1",
+        repositories: ["owner1/repo1", "owner2/repo2"],
+      });
+    });
+  });
+
   describe("addNewList", () => {
     it("should add a new remote list", async () => {
       const dbConfig: DbConfig = createDbConfig({


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

When a remote user defined list is highlighted when pressing the 'Add new Database'-Button we only want to show the option to add a new repository (instead of also adding a new owner) and add the new database to the highlighted list.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
