### PR TITLE
Move db item expanded state to workspace storage

### DIFF
--- a/extensions/ql-vscode/src/databases/config/db-config-store.ts
+++ b/extensions/ql-vscode/src/databases/config/db-config-store.ts
@@ -1,11 +1,6 @@
 import { pathExists, outputJSON, readJSON, readJSONSync } from "fs-extra";
 import { join } from "path";
-import {
-  cloneDbConfig,
-  DbConfig,
-  ExpandedDbItem,
-  SelectedDbItem,
-} from "./db-config";
+import { cloneDbConfig, DbConfig, SelectedDbItem } from "./db-config";
 import * as chokidar from "chokidar";
 import { DisposableObject, DisposeHandler } from "../../pure/disposable-object";
 import { DbConfigValidator } from "./db-config-validator";
@@ -76,19 +71,6 @@ export class DbConfigStore extends DisposableObject {
     const config: DbConfig = {
       ...this.config,
       selected: dbItem,
-    };
-
-    await this.writeConfig(config);
-  }
-
-  public async updateExpandedState(expandedItems: ExpandedDbItem[]) {
-    if (!this.config) {
-      throw Error("Cannot update expansion state if config is not loaded");
-    }
-
-    const config: DbConfig = {
-      ...this.config,
-      expanded: expandedItems,
     };
 
     await this.writeConfig(config);
@@ -330,7 +312,6 @@ export class DbConfigStore extends DisposableObject {
           databases: [],
         },
       },
-      expanded: [],
     };
   }
 }

--- a/extensions/ql-vscode/src/databases/config/db-config.ts
+++ b/extensions/ql-vscode/src/databases/config/db-config.ts
@@ -2,7 +2,6 @@
 
 export interface DbConfig {
   databases: DbConfigDatabases;
-  expanded: ExpandedDbItem[];
   selected?: SelectedDbItem;
 }
 
@@ -140,7 +139,6 @@ export function cloneDbConfig(config: DbConfig): DbConfig {
         databases: config.databases.local.databases.map((db) => ({ ...db })),
       },
     },
-    expanded: config.expanded.map(cloneDbConfigExpandedItem),
     selected: config.selected
       ? cloneDbConfigSelectedItem(config.selected)
       : undefined,
@@ -180,20 +178,6 @@ function cloneDbConfigSelectedItem(selected: SelectedDbItem): SelectedDbItem {
         kind: SelectedDbItemKind.RemoteRepository,
         repositoryName: selected.repositoryName,
         listName: selected.listName,
-      };
-  }
-}
-
-function cloneDbConfigExpandedItem(item: ExpandedDbItem): ExpandedDbItem {
-  switch (item.kind) {
-    case ExpandedDbItemKind.RootLocal:
-    case ExpandedDbItemKind.RootRemote:
-      return { kind: item.kind };
-    case ExpandedDbItemKind.LocalUserDefinedList:
-    case ExpandedDbItemKind.RemoteUserDefinedList:
-      return {
-        kind: item.kind,
-        listName: item.listName,
       };
   }
 }

--- a/extensions/ql-vscode/src/databases/db-tree-creator.ts
+++ b/extensions/ql-vscode/src/databases/db-tree-creator.ts
@@ -1,5 +1,6 @@
 import {
   DbConfig,
+  ExpandedDbItem,
   ExpandedDbItemKind,
   LocalDatabase,
   LocalList,
@@ -18,7 +19,10 @@ import {
   RootRemoteDbItem,
 } from "./db-item";
 
-export function createRemoteTree(dbConfig: DbConfig): RootRemoteDbItem {
+export function createRemoteTree(
+  dbConfig: DbConfig,
+  expandedItems: ExpandedDbItem[],
+): RootRemoteDbItem {
   const systemDefinedLists = [
     createSystemDefinedList(10, dbConfig),
     createSystemDefinedList(100, dbConfig),
@@ -26,7 +30,7 @@ export function createRemoteTree(dbConfig: DbConfig): RootRemoteDbItem {
   ];
 
   const userDefinedRepoLists = dbConfig.databases.remote.repositoryLists.map(
-    (r) => createRemoteUserDefinedList(r, dbConfig),
+    (r) => createRemoteUserDefinedList(r, dbConfig, expandedItems),
   );
   const owners = dbConfig.databases.remote.owners.map((o) =>
     createOwnerItem(o, dbConfig),
@@ -35,9 +39,9 @@ export function createRemoteTree(dbConfig: DbConfig): RootRemoteDbItem {
     createRepoItem(r, dbConfig),
   );
 
-  const expanded =
-    dbConfig.expanded &&
-    dbConfig.expanded.some((e) => e.kind === ExpandedDbItemKind.RootRemote);
+  const expanded = expandedItems.some(
+    (e) => e.kind === ExpandedDbItemKind.RootRemote,
+  );
 
   return {
     kind: DbItemKind.RootRemote,
@@ -51,17 +55,20 @@ export function createRemoteTree(dbConfig: DbConfig): RootRemoteDbItem {
   };
 }
 
-export function createLocalTree(dbConfig: DbConfig): RootLocalDbItem {
+export function createLocalTree(
+  dbConfig: DbConfig,
+  expandedItems: ExpandedDbItem[],
+): RootLocalDbItem {
   const localLists = dbConfig.databases.local.lists.map((l) =>
-    createLocalList(l, dbConfig),
+    createLocalList(l, dbConfig, expandedItems),
   );
   const localDbs = dbConfig.databases.local.databases.map((l) =>
     createLocalDb(l, dbConfig),
   );
 
-  const expanded =
-    dbConfig.expanded &&
-    dbConfig.expanded.some((e) => e.kind === ExpandedDbItemKind.RootLocal);
+  const expanded = expandedItems.some(
+    (e) => e.kind === ExpandedDbItemKind.RootLocal,
+  );
 
   return {
     kind: DbItemKind.RootLocal,
@@ -93,19 +100,18 @@ function createSystemDefinedList(
 function createRemoteUserDefinedList(
   list: RemoteRepositoryList,
   dbConfig: DbConfig,
+  expandedItems: ExpandedDbItem[],
 ): RemoteUserDefinedListDbItem {
   const selected =
     dbConfig.selected &&
     dbConfig.selected.kind === SelectedDbItemKind.RemoteUserDefinedList &&
     dbConfig.selected.listName === list.name;
 
-  const expanded =
-    dbConfig.expanded &&
-    dbConfig.expanded.some(
-      (e) =>
-        e.kind === ExpandedDbItemKind.RemoteUserDefinedList &&
-        e.listName === list.name,
-    );
+  const expanded = expandedItems.some(
+    (e) =>
+      e.kind === ExpandedDbItemKind.RemoteUserDefinedList &&
+      e.listName === list.name,
+  );
 
   return {
     kind: DbItemKind.RemoteUserDefinedList,
@@ -148,19 +154,21 @@ function createRepoItem(
   };
 }
 
-function createLocalList(list: LocalList, dbConfig: DbConfig): LocalListDbItem {
+function createLocalList(
+  list: LocalList,
+  dbConfig: DbConfig,
+  expandedItems: ExpandedDbItem[],
+): LocalListDbItem {
   const selected =
     dbConfig.selected &&
     dbConfig.selected.kind === SelectedDbItemKind.LocalUserDefinedList &&
     dbConfig.selected.listName === list.name;
 
-  const expanded =
-    dbConfig.expanded &&
-    dbConfig.expanded.some(
-      (e) =>
-        e.kind === ExpandedDbItemKind.LocalUserDefinedList &&
-        e.listName === list.name,
-    );
+  const expanded = expandedItems.some(
+    (e) =>
+      e.kind === ExpandedDbItemKind.LocalUserDefinedList &&
+      e.listName === list.name,
+  );
 
   return {
     kind: DbItemKind.LocalList,

--- a/extensions/ql-vscode/src/vscode-tests/factories/db-config-factories.ts
+++ b/extensions/ql-vscode/src/vscode-tests/factories/db-config-factories.ts
@@ -1,7 +1,6 @@
 import { faker } from "@faker-js/faker";
 import {
   DbConfig,
-  ExpandedDbItem,
   LocalDatabase,
   LocalList,
   RemoteRepositoryList,
@@ -15,7 +14,6 @@ export function createDbConfig({
   localLists = [],
   localDbs = [],
   selected = undefined,
-  expanded = [],
 }: {
   remoteLists?: RemoteRepositoryList[];
   remoteOwners?: string[];
@@ -23,7 +21,6 @@ export function createDbConfig({
   localLists?: LocalList[];
   localDbs?: LocalDatabase[];
   selected?: SelectedDbItem;
-  expanded?: ExpandedDbItem[];
 } = {}): DbConfig {
   return {
     databases: {
@@ -37,7 +34,6 @@ export function createDbConfig({
         databases: localDbs,
       },
     },
-    expanded,
     selected,
   };
 }

--- a/extensions/ql-vscode/test/pure-tests/databases/config/data/without-selected/workspace-databases.json
+++ b/extensions/ql-vscode/test/pure-tests/databases/config/data/without-selected/workspace-databases.json
@@ -9,6 +9,5 @@
       "lists": [],
       "databases": []
     }
-  },
-  "expanded": []
+  }
 }

--- a/extensions/ql-vscode/test/pure-tests/databases/config/data/workspace-databases.json
+++ b/extensions/ql-vscode/test/pure-tests/databases/config/data/workspace-databases.json
@@ -45,7 +45,6 @@
       ]
     }
   },
-  "expanded": [],
   "selected": {
     "kind": "remoteUserDefinedList",
     "listName": "repoList1"

--- a/extensions/ql-vscode/test/pure-tests/databases/config/db-config-validator.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/databases/config/db-config-validator.test.ts
@@ -27,7 +27,6 @@ describe("db config validation", () => {
           somethingElse: "bar",
         },
       },
-      expanded: [],
     } as any as DbConfig;
 
     const validationOutput = configValidator.validate(dbConfig);

--- a/extensions/ql-vscode/test/pure-tests/databases/db-tree-creator.test.ts
+++ b/extensions/ql-vscode/test/pure-tests/databases/db-tree-creator.test.ts
@@ -1,5 +1,6 @@
 import {
   DbConfig,
+  ExpandedDbItem,
   ExpandedDbItemKind,
   SelectedDbItemKind,
 } from "../../../src/databases/config/db-config";
@@ -20,7 +21,7 @@ describe("db tree creator", () => {
     it("should build root node and system defined lists", () => {
       const dbConfig = createDbConfig();
 
-      const dbTreeRoot = createRemoteTree(dbConfig);
+      const dbTreeRoot = createRemoteTree(dbConfig, []);
 
       expect(dbTreeRoot).toBeTruthy();
       expect(dbTreeRoot.kind).toBe(DbItemKind.RootRemote);
@@ -63,7 +64,7 @@ describe("db tree creator", () => {
         ],
       });
 
-      const dbTreeRoot = createRemoteTree(dbConfig);
+      const dbTreeRoot = createRemoteTree(dbConfig, []);
 
       expect(dbTreeRoot).toBeTruthy();
       expect(dbTreeRoot.kind).toBe(DbItemKind.RootRemote);
@@ -107,7 +108,7 @@ describe("db tree creator", () => {
         remoteOwners: ["owner1", "owner2"],
       });
 
-      const dbTreeRoot = createRemoteTree(dbConfig);
+      const dbTreeRoot = createRemoteTree(dbConfig, []);
 
       expect(dbTreeRoot).toBeTruthy();
       expect(dbTreeRoot.kind).toBe(DbItemKind.RootRemote);
@@ -131,7 +132,7 @@ describe("db tree creator", () => {
         remoteRepos: ["owner1/repo1", "owner1/repo2", "owner2/repo1"],
       });
 
-      const dbTreeRoot = createRemoteTree(dbConfig);
+      const dbTreeRoot = createRemoteTree(dbConfig, []);
 
       expect(dbTreeRoot).toBeTruthy();
       expect(dbTreeRoot.kind).toBe(DbItemKind.RootRemote);
@@ -170,7 +171,7 @@ describe("db tree creator", () => {
           },
         });
 
-        const dbTreeRoot = createRemoteTree(dbConfig);
+        const dbTreeRoot = createRemoteTree(dbConfig, []);
 
         expect(dbTreeRoot).toBeTruthy();
         expect(dbTreeRoot.kind).toBe(DbItemKind.RootRemote);
@@ -191,7 +192,7 @@ describe("db tree creator", () => {
           },
         });
 
-        const dbTreeRoot = createRemoteTree(dbConfig);
+        const dbTreeRoot = createRemoteTree(dbConfig, []);
 
         expect(dbTreeRoot).toBeTruthy();
         expect(dbTreeRoot.kind).toBe(DbItemKind.RootRemote);
@@ -213,7 +214,7 @@ describe("db tree creator", () => {
           },
         });
 
-        const dbTreeRoot = createRemoteTree(dbConfig);
+        const dbTreeRoot = createRemoteTree(dbConfig, []);
 
         expect(dbTreeRoot).toBeTruthy();
         expect(dbTreeRoot.kind).toBe(DbItemKind.RootRemote);
@@ -240,7 +241,7 @@ describe("db tree creator", () => {
           },
         });
 
-        const dbTreeRoot = createRemoteTree(dbConfig);
+        const dbTreeRoot = createRemoteTree(dbConfig, []);
 
         expect(dbTreeRoot).toBeTruthy();
 
@@ -258,15 +259,14 @@ describe("db tree creator", () => {
 
     describe("expanded db items", () => {
       it("should allow expanding the root remote list node", () => {
-        const dbConfig = createDbConfig({
-          expanded: [
-            {
-              kind: ExpandedDbItemKind.RootRemote,
-            },
-          ],
-        });
+        const dbConfig = createDbConfig();
+        const expanded: ExpandedDbItem[] = [
+          {
+            kind: ExpandedDbItemKind.RootRemote,
+          },
+        ];
 
-        const dbTreeRoot = createRemoteTree(dbConfig);
+        const dbTreeRoot = createRemoteTree(dbConfig, expanded);
 
         expect(dbTreeRoot).toBeTruthy();
         expect(dbTreeRoot.kind).toBe(DbItemKind.RootRemote);
@@ -281,18 +281,18 @@ describe("db tree creator", () => {
               repositories: ["owner1/repo1", "owner1/repo2", "owner2/repo1"],
             },
           ],
-          expanded: [
-            {
-              kind: ExpandedDbItemKind.RootRemote,
-            },
-            {
-              kind: ExpandedDbItemKind.RemoteUserDefinedList,
-              listName: "my-list-1",
-            },
-          ],
         });
+        const expanded: ExpandedDbItem[] = [
+          {
+            kind: ExpandedDbItemKind.RootRemote,
+          },
+          {
+            kind: ExpandedDbItemKind.RemoteUserDefinedList,
+            listName: "my-list-1",
+          },
+        ];
 
-        const dbTreeRoot = createRemoteTree(dbConfig);
+        const dbTreeRoot = createRemoteTree(dbConfig, expanded);
 
         expect(dbTreeRoot).toBeTruthy();
         expect(dbTreeRoot.kind).toBe(DbItemKind.RootRemote);
@@ -311,7 +311,7 @@ describe("db tree creator", () => {
     it("should build root node", () => {
       const dbConfig = createDbConfig();
 
-      const dbTreeRoot = createLocalTree(dbConfig);
+      const dbTreeRoot = createLocalTree(dbConfig, []);
 
       expect(dbTreeRoot).toBeTruthy();
       expect(dbTreeRoot.kind).toBe(DbItemKind.RootLocal);
@@ -353,7 +353,7 @@ describe("db tree creator", () => {
         ],
       });
 
-      const dbTreeRoot = createLocalTree(dbConfig);
+      const dbTreeRoot = createLocalTree(dbConfig, []);
 
       expect(dbTreeRoot).toBeTruthy();
       expect(dbTreeRoot.kind).toBe(DbItemKind.RootLocal);
@@ -412,7 +412,7 @@ describe("db tree creator", () => {
         ],
       });
 
-      const dbTreeRoot = createLocalTree(dbConfig);
+      const dbTreeRoot = createLocalTree(dbConfig, []);
 
       expect(dbTreeRoot).toBeTruthy();
       expect(dbTreeRoot.kind).toBe(DbItemKind.RootLocal);

--- a/extensions/ql-vscode/workspace-databases-schema.json
+++ b/extensions/ql-vscode/workspace-databases-schema.json
@@ -128,62 +128,6 @@
       "required": ["remote", "local"],
       "additionalProperties": false
     },
-    "expanded": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "oneOf": [
-          {
-            "properties": {
-              "kind": {
-                "type": "string",
-                "enum": ["rootLocal"]
-              }
-            },
-            "required": ["kind"],
-            "additionalProperties": false
-          },
-          {
-            "properties": {
-              "kind": {
-                "type": "string",
-                "enum": ["localUserDefinedList"]
-              },
-              "listName": {
-                "type": "string",
-                "minLength": 1
-              }
-            },
-            "required": ["kind", "listName"],
-            "additionalProperties": false
-          },
-          {
-            "properties": {
-              "kind": {
-                "type": "string",
-                "enum": ["rootRemote"]
-              }
-            },
-            "required": ["kind"],
-            "additionalProperties": false
-          },
-          {
-            "properties": {
-              "kind": {
-                "type": "string",
-                "enum": ["remoteUserDefinedList"]
-              },
-              "listName": {
-                "type": "string",
-                "minLength": 1
-              }
-            },
-            "required": ["kind", "listName"],
-            "additionalProperties": false
-          }
-        ]
-      }
-    },
     "selected": {
       "type": "object",
       "oneOf": [
@@ -281,6 +225,6 @@
       ]
     }
   },
-  "required": ["databases", "expanded"],
+  "required": ["databases"],
   "additionalProperties": false
 }


### PR DESCRIPTION
We're moving the db item expanded state out of the db config file and into workspace storage. To do that we have to:
- Update the db config and db config schema to remove expanded state
- Update the logic to store and retrieve state around expanded items from the workspace state instead of the db config

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
