### PR TITLE
Check for duplicate repo within parent list

### DIFF
--- a/extensions/ql-vscode/src/databases/config/db-config-store.ts
+++ b/extensions/ql-vscode/src/databases/config/db-config-store.ts
@@ -206,7 +206,7 @@ export class DbConfigStore extends DisposableObject {
   public doesRemoteOwnerExist(owner: string): boolean {
     if (!this.config) {
       throw Error(
-        "Cannot check remote onwer existence if config is not loaded",
+        "Cannot check remote owner existence if config is not loaded",
       );
     }
 

--- a/extensions/ql-vscode/src/databases/ui/db-panel.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-panel.ts
@@ -145,7 +145,7 @@ export class DbPanel extends DisposableObject {
       return;
     }
 
-    if (this.dbManager.doesRemoteRepoExist(nwo)) {
+    if (this.dbManager.doesRemoteRepoExist(nwo, parentList)) {
       void showAndLogErrorMessage(`The repository '${nwo}' already exists`);
       return;
     }


### PR DESCRIPTION
Found a small bug where we previously allowed duplicate repos within the same list. Fixed by passing in the `parentList` to `doesRemoteRepoExist`. 

(https://github.com/github/vscode-codeql/commit/161e342ff2deb5a9442d6b0546f12fcc7b027dc1 is an unrelated typo fix)

## Checklist

N/A - internal only 🥦 

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
