### PR TITLE
Add support for adding local db lists

### DIFF
--- a/extensions/ql-vscode/src/databases/config/db-config-store.ts
+++ b/extensions/ql-vscode/src/databases/config/db-config-store.ts
@@ -129,6 +129,28 @@ export class DbConfigStore extends DisposableObject {
     await this.writeConfig(config);
   }
 
+  public async addLocalList(listName: string): Promise<void> {
+    if (!this.config) {
+      throw Error("Cannot add local list if config is not loaded");
+    }
+
+    if (listName === "") {
+      throw Error("List name cannot be empty");
+    }
+
+    if (this.doesLocalListExist(listName)) {
+      throw Error(`A local list with the name '${listName}' already exists`);
+    }
+
+    const config: DbConfig = cloneDbConfig(this.config);
+    config.databases.local.lists.push({
+      name: listName,
+      databases: [],
+    });
+
+    await this.writeConfig(config);
+  }
+
   public async addRemoteList(listName: string): Promise<void> {
     if (!this.config) {
       throw Error("Cannot add remote list if config is not loaded");

--- a/extensions/ql-vscode/src/databases/db-manager.ts
+++ b/extensions/ql-vscode/src/databases/db-manager.ts
@@ -104,8 +104,8 @@ export class DbManager {
   ): Promise<void> {
     switch (listKind) {
       case DbListKind.Local:
-        // Adding a local list is not supported yet.
-        throw Error("Cannot add a local list");
+        await this.dbConfigStore.addLocalList(listName);
+        break;
       case DbListKind.Remote:
         await this.dbConfigStore.addRemoteList(listName);
         break;

--- a/extensions/ql-vscode/src/vscode-tests/cli-integration/databases/db-panel.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/cli-integration/databases/db-panel.test.ts
@@ -4,7 +4,11 @@ import { CodeQLExtensionInterface } from "../../../extension";
 import { readJson } from "fs-extra";
 import * as path from "path";
 import { DbConfig } from "../../../databases/config/db-config";
-import { RemoteDatabaseQuickPickItem } from "../../../databases/ui/db-panel";
+import {
+  AddListQuickPickItem,
+  RemoteDatabaseQuickPickItem,
+} from "../../../databases/ui/db-panel";
+import { DbListKind } from "../../../databases/db-item";
 
 jest.setTimeout(60_000);
 
@@ -25,6 +29,9 @@ describe("Db panel UI commands", () => {
 
   it("should add new remote db list", async () => {
     // Add db list
+    jest.spyOn(window, "showQuickPick").mockResolvedValue({
+      kind: DbListKind.Remote,
+    } as AddListQuickPickItem);
     jest.spyOn(window, "showInputBox").mockResolvedValue("my-list-1");
     await commands.executeCommand("codeQLDatabasesExperimental.addNewList");
 
@@ -33,6 +40,21 @@ describe("Db panel UI commands", () => {
     const dbConfig: DbConfig = await readJson(dbConfigFilePath);
     expect(dbConfig.databases.remote.repositoryLists).toHaveLength(1);
     expect(dbConfig.databases.remote.repositoryLists[0].name).toBe("my-list-1");
+  });
+
+  it("should add new local db list", async () => {
+    // Add db list
+    jest.spyOn(window, "showQuickPick").mockResolvedValue({
+      kind: DbListKind.Local,
+    } as AddListQuickPickItem);
+    jest.spyOn(window, "showInputBox").mockResolvedValue("my-list-1");
+    await commands.executeCommand("codeQLDatabasesExperimental.addNewList");
+
+    // Check db config
+    const dbConfigFilePath = path.join(storagePath, "workspace-databases.json");
+    const dbConfig: DbConfig = await readJson(dbConfigFilePath);
+    expect(dbConfig.databases.local.lists).toHaveLength(1);
+    expect(dbConfig.databases.local.lists[0].name).toBe("my-list-1");
   });
 
   it("should add new remote repository", async () => {


### PR DESCRIPTION
Allows adding a new local db list. It shows a quickpick item to select what kind of list to select if nothing is highlighted.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
