### PR TITLE
Use constant for selected db item resource uri

### DIFF
--- a/extensions/ql-vscode/src/databases/ui/db-selection-decoration-provider.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-selection-decoration-provider.ts
@@ -5,13 +5,14 @@ import {
   ProviderResult,
   Uri,
 } from "vscode";
+import { SELECTED_DB_ITEM_RESOURCE_URI } from "./db-tree-view-item";
 
 export class DbSelectionDecorationProvider implements FileDecorationProvider {
   provideFileDecoration(
     uri: Uri,
     _token: CancellationToken,
   ): ProviderResult<FileDecoration> {
-    if (uri?.query === "selected=true") {
+    if (uri.toString(true) === SELECTED_DB_ITEM_RESOURCE_URI) {
       return {
         badge: "✓",
         tooltip: "Currently selected",

--- a/extensions/ql-vscode/src/databases/ui/db-tree-view-item.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-tree-view-item.ts
@@ -12,6 +12,8 @@ import {
   RootRemoteDbItem,
 } from "../db-item";
 
+export const SELECTED_DB_ITEM_RESOURCE_URI = "codeql://databases?selected=true";
+
 /**
  * Represents an item in the database tree view. This item could be
  * representing an actual database item or a warning.
@@ -33,7 +35,7 @@ export class DbTreeViewItem extends vscode.TreeItem {
     if (dbItem && isSelectableDbItem(dbItem)) {
       if (dbItem.selected) {
         // Define the resource id to drive the UI to render this item as selected.
-        this.resourceUri = vscode.Uri.parse("codeql://databases?selected=true");
+        this.resourceUri = vscode.Uri.parse(SELECTED_DB_ITEM_RESOURCE_URI);
       } else {
         // Define a context value to drive the UI to show an action to select the item.
         this.contextValue = "selectableDbItem";

--- a/extensions/ql-vscode/src/vscode-tests/minimal-workspace/databases/db-panel.test.ts
+++ b/extensions/ql-vscode/src/vscode-tests/minimal-workspace/databases/db-panel.test.ts
@@ -13,7 +13,10 @@ import {
   DbListKind,
   LocalDatabaseDbItem,
 } from "../../../databases/db-item";
-import { DbTreeViewItem } from "../../../databases/ui/db-tree-view-item";
+import {
+  DbTreeViewItem,
+  SELECTED_DB_ITEM_RESOURCE_URI,
+} from "../../../databases/ui/db-tree-view-item";
 import { ExtensionApp } from "../../../common/vscode/vscode-app";
 import { createMockExtensionContext } from "../../factories/extension-context";
 import { createDbConfig } from "../../factories/db-config-factories";
@@ -831,8 +834,8 @@ describe("db panel", () => {
 
   function isTreeViewItemSelected(treeViewItem: DbTreeViewItem) {
     return (
-      treeViewItem.resourceUri?.query === "selected=true" &&
-      treeViewItem.contextValue === undefined
+      treeViewItem.resourceUri?.toString(true) ===
+        SELECTED_DB_ITEM_RESOURCE_URI && treeViewItem.contextValue === undefined
     );
   }
 });


### PR DESCRIPTION
Without using the constant, it's not clear how the two things (resource URI and decorator) work together.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
