### PR TITLE
Renamed selectable context value

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -803,7 +803,7 @@
         },
         {
           "command": "codeQLDatabasesExperimental.setSelectedItem",
-          "when": "view == codeQLDatabasesExperimental && viewItem == selectableDbItem",
+          "when": "view == codeQLDatabasesExperimental && viewItem == canBeSelected",
           "group": "inline"
         },
         {

--- a/extensions/ql-vscode/src/databases/ui/db-tree-view-item.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-tree-view-item.ts
@@ -38,7 +38,7 @@ export class DbTreeViewItem extends vscode.TreeItem {
         this.resourceUri = vscode.Uri.parse(SELECTED_DB_ITEM_RESOURCE_URI);
       } else {
         // Define a context value to drive the UI to show an action to select the item.
-        this.contextValue = "selectableDbItem";
+        this.contextValue = "canBeSelected";
       }
     }
   }

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/databases/db-panel.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/databases/db-panel.test.ts
@@ -852,7 +852,7 @@ describe("db panel", () => {
   function isTreeViewItemSelectable(treeViewItem: DbTreeViewItem) {
     return (
       treeViewItem.resourceUri === undefined &&
-      treeViewItem.contextValue === "selectableDbItem"
+      treeViewItem.contextValue === "canBeSelected"
     );
   }
 


### PR DESCRIPTION
Renamed context value `selectableDbItem` -> `canBeSelected` in preparation for adding more actions.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
