### PR TITLE
Add context menu command to open repo/owner on GitHub

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -64,6 +64,7 @@
     "onCommand:codeQLDatabasesExperimental.addNewList",
     "onCommand:codeQLDatabasesExperimental.setSelectedItem",
     "onCommand:codeQLDatabasesExperimental.setSelectedItemContextMenu",
+    "onCommand:codeQLDatabasesExperimental.openOnGitHubContextMenu",
     "onCommand:codeQL.quickQuery",
     "onCommand:codeQL.restartQueryServer",
     "onWebviewPanel:resultsView",
@@ -381,6 +382,10 @@
       {
         "command": "codeQLDatabasesExperimental.setSelectedItemContextMenu",
         "title": "Select"
+      },
+      {
+        "command": "codeQLDatabasesExperimental.openOnGitHubContextMenu",
+        "title": "Open on GitHub"
       },
       {
         "command": "codeQLDatabases.chooseDatabaseFolder",
@@ -786,6 +791,10 @@
           "when": "view == codeQLDatabasesExperimental && viewItem =~ /canBeSelected/"
         },
         {
+          "command": "codeQLDatabasesExperimental.openOnGitHubContextMenu",
+          "when": "view == codeQLDatabasesExperimental && viewItem =~ /canBeOpenedOnGitHub/"
+        },
+        {
           "command": "codeQLDatabases.setCurrentDatabase",
           "group": "inline",
           "when": "view == codeQLDatabases && viewItem != currentDatabase"
@@ -1015,6 +1024,10 @@
         },
         {
           "command": "codeQLDatabasesExperimental.setSelectedItemContextMenu",
+          "when": "false"
+        },
+        {
+          "command": "codeQLDatabasesExperimental.openOnGitHubContextMenu",
           "when": "false"
         },
         {

--- a/extensions/ql-vscode/src/databases/ui/db-tree-view-item-action.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-tree-view-item-action.ts
@@ -59,3 +59,14 @@ function canBeRenamed(dbItem: DbItem): boolean {
 function canBeOpenedOnGitHub(dbItem: DbItem): boolean {
   return dbItemKindsThatCanBeOpenedOnGitHub.includes(dbItem.kind);
 }
+
+export function getGitHubUrl(dbItem: DbItem): string | undefined {
+  switch (dbItem.kind) {
+    case DbItemKind.RemoteOwner:
+      return `https://github.com/${dbItem.ownerName}`;
+    case DbItemKind.RemoteRepo:
+      return `https://github.com/${dbItem.repoFullName}`;
+    default:
+      return undefined;
+  }
+}

--- a/extensions/ql-vscode/test/unit-tests/databases/ui/db-tree-view-item-action.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/ui/db-tree-view-item-action.test.ts
@@ -1,4 +1,7 @@
-import { getDbItemActions } from "../../../../src/databases/ui/db-tree-view-item-action";
+import {
+  getDbItemActions,
+  getGitHubUrl,
+} from "../../../../src/databases/ui/db-tree-view-item-action";
 import {
   createLocalDatabaseDbItem,
   createLocalListDbItem,
@@ -105,5 +108,53 @@ describe("getDbItemActions", () => {
     const actions = getDbItemActions(dbItem);
 
     expect(actions.includes("canBeSelected")).toBeFalsy();
+  });
+});
+
+describe("getGitHubUrl", () => {
+  it("should return the correct url for a remote owner", () => {
+    const dbItem = createRemoteOwnerDbItem();
+
+    const actualUrl = getGitHubUrl(dbItem);
+    const expectedUrl = `https://github.com/${dbItem.ownerName}`;
+
+    expect(actualUrl).toEqual(expectedUrl);
+  });
+
+  it("should return the correct url for a remote repo", () => {
+    const dbItem = createRemoteRepoDbItem();
+
+    const actualUrl = getGitHubUrl(dbItem);
+    const expectedUrl = `https://github.com/${dbItem.repoFullName}`;
+
+    expect(actualUrl).toEqual(expectedUrl);
+  });
+
+  it("should return undefined for other remote db items", () => {
+    const dbItem0 = createRootRemoteDbItem();
+    const dbItem1 = createRemoteSystemDefinedListDbItem();
+    const dbItem2 = createRemoteUserDefinedListDbItem();
+
+    const actualUrl0 = getGitHubUrl(dbItem0);
+    const actualUrl1 = getGitHubUrl(dbItem1);
+    const actualUrl2 = getGitHubUrl(dbItem2);
+
+    expect(actualUrl0).toBeUndefined();
+    expect(actualUrl1).toBeUndefined();
+    expect(actualUrl2).toBeUndefined();
+  });
+
+  it("should return undefined for local db items", () => {
+    const dbItem0 = createRootLocalDbItem();
+    const dbItem1 = createLocalDatabaseDbItem();
+    const dbItem2 = createLocalListDbItem();
+
+    const actualUrl0 = getGitHubUrl(dbItem0);
+    const actualUrl1 = getGitHubUrl(dbItem1);
+    const actualUrl2 = getGitHubUrl(dbItem2);
+
+    expect(actualUrl0).toBeUndefined();
+    expect(actualUrl1).toBeUndefined();
+    expect(actualUrl2).toBeUndefined();
   });
 });


### PR DESCRIPTION
Adds an "Open on GitHub" context menu action for remote repos/owners in the DB panel:
![image](https://user-images.githubusercontent.com/42641846/210410224-00e44d52-8e59-40bc-9fc0-a8cd4a9dcc81.png)



## Checklist

N/A—internal only 🍝

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
