### PR TITLE
Minor refactoring of the db config store and tests

### DIFF
--- a/extensions/ql-vscode/src/databases/config/db-config-store.ts
+++ b/extensions/ql-vscode/src/databases/config/db-config-store.ts
@@ -134,9 +134,7 @@ export class DbConfigStore extends DisposableObject {
       throw Error("Cannot add local list if config is not loaded");
     }
 
-    if (listName === "") {
-      throw Error("List name cannot be empty");
-    }
+    this.validateLocalListName(listName);
 
     if (this.doesLocalListExist(listName)) {
       throw Error(`A local list with the name '${listName}' already exists`);
@@ -156,9 +154,7 @@ export class DbConfigStore extends DisposableObject {
       throw Error("Cannot add remote list if config is not loaded");
     }
 
-    if (listName === "") {
-      throw Error("List name cannot be empty");
-    }
+    this.validateRemoteListName(listName);
 
     if (this.doesRemoteListExist(listName)) {
       throw Error(`A remote list with the name '${listName}' already exists`);
@@ -335,5 +331,25 @@ export class DbConfigStore extends DisposableObject {
         },
       },
     };
+  }
+
+  private validateLocalListName(listName: string): void {
+    if (listName === "") {
+      throw Error("List name cannot be empty");
+    }
+
+    if (this.doesLocalListExist(listName)) {
+      throw Error(`A local list with the name '${listName}' already exists`);
+    }
+  }
+
+  private validateRemoteListName(listName: string): void {
+    if (listName === "") {
+      throw Error("List name cannot be empty");
+    }
+
+    if (this.doesRemoteListExist(listName)) {
+      throw Error(`A remote list with the name '${listName}' already exists`);
+    }
   }
 }

--- a/extensions/ql-vscode/src/databases/config/db-config-store.ts
+++ b/extensions/ql-vscode/src/databases/config/db-config-store.ts
@@ -94,7 +94,7 @@ export class DbConfigStore extends DisposableObject {
       );
     }
 
-    const config: DbConfig = cloneDbConfig(this.config);
+    const config = cloneDbConfig(this.config);
     if (parentList) {
       const parent = config.databases.remote.repositoryLists.find(
         (list) => list.name === parentList,
@@ -123,7 +123,7 @@ export class DbConfigStore extends DisposableObject {
       throw Error(`A remote owner with the name '${owner}' already exists`);
     }
 
-    const config: DbConfig = cloneDbConfig(this.config);
+    const config = cloneDbConfig(this.config);
     config.databases.remote.owners.push(owner);
 
     await this.writeConfig(config);
@@ -142,7 +142,7 @@ export class DbConfigStore extends DisposableObject {
       throw Error(`A local list with the name '${listName}' already exists`);
     }
 
-    const config: DbConfig = cloneDbConfig(this.config);
+    const config = cloneDbConfig(this.config);
     config.databases.local.lists.push({
       name: listName,
       databases: [],
@@ -164,7 +164,7 @@ export class DbConfigStore extends DisposableObject {
       throw Error(`A remote list with the name '${listName}' already exists`);
     }
 
-    const config: DbConfig = cloneDbConfig(this.config);
+    const config = cloneDbConfig(this.config);
     config.databases.remote.repositoryLists.push({
       name: listName,
       repositories: [],

--- a/extensions/ql-vscode/src/databases/config/db-config-store.ts
+++ b/extensions/ql-vscode/src/databases/config/db-config-store.ts
@@ -136,10 +136,6 @@ export class DbConfigStore extends DisposableObject {
 
     this.validateLocalListName(listName);
 
-    if (this.doesLocalListExist(listName)) {
-      throw Error(`A local list with the name '${listName}' already exists`);
-    }
-
     const config = cloneDbConfig(this.config);
     config.databases.local.lists.push({
       name: listName,
@@ -155,10 +151,6 @@ export class DbConfigStore extends DisposableObject {
     }
 
     this.validateRemoteListName(listName);
-
-    if (this.doesRemoteListExist(listName)) {
-      throw Error(`A remote list with the name '${listName}' already exists`);
-    }
 
     const config = cloneDbConfig(this.config);
     config.databases.remote.repositoryLists.push({


### PR DESCRIPTION
This change tidies up code around the db config store. Please check the individual commits for details.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
