### PR TITLE
Add db and list rename functionality to db config store

### DIFF
--- a/extensions/ql-vscode/src/databases/config/db-config.ts
+++ b/extensions/ql-vscode/src/databases/config/db-config.ts
@@ -114,6 +114,102 @@ export function cloneDbConfig(config: DbConfig): DbConfig {
   };
 }
 
+export function renameLocalList(
+  originalConfig: DbConfig,
+  currentListName: string,
+  newListName: string,
+): DbConfig {
+  const config = cloneDbConfig(originalConfig);
+
+  const list = config.databases.local.lists.find(
+    (l) => l.name === currentListName,
+  );
+  if (!list) {
+    throw Error(`Cannot find list '${currentListName}' to rename`);
+  }
+  list.name = newListName;
+
+  if (
+    config.selected?.kind === SelectedDbItemKind.LocalUserDefinedList ||
+    config.selected?.kind === SelectedDbItemKind.LocalDatabase
+  ) {
+    if (config.selected.listName === currentListName) {
+      config.selected.listName = newListName;
+    }
+  }
+
+  return config;
+}
+
+export function renameRemoteList(
+  originalConfig: DbConfig,
+  currentListName: string,
+  newListName: string,
+): DbConfig {
+  const config = cloneDbConfig(originalConfig);
+
+  const list = config.databases.remote.repositoryLists.find(
+    (l) => l.name === currentListName,
+  );
+  if (!list) {
+    throw Error(`Cannot find list '${currentListName}' to rename`);
+  }
+  list.name = newListName;
+
+  if (
+    config.selected?.kind === SelectedDbItemKind.RemoteUserDefinedList ||
+    config.selected?.kind === SelectedDbItemKind.RemoteRepository
+  ) {
+    if (config.selected.listName === currentListName) {
+      config.selected.listName = newListName;
+    }
+  }
+
+  return config;
+}
+
+export function renameLocalDb(
+  originalConfig: DbConfig,
+  currentDbName: string,
+  newDbName: string,
+  parentListName?: string,
+): DbConfig {
+  const config = cloneDbConfig(originalConfig);
+
+  if (parentListName) {
+    const list = config.databases.local.lists.find(
+      (l) => l.name === parentListName,
+    );
+    if (!list) {
+      throw Error(`Cannot find parent list '${parentListName}'`);
+    }
+    const dbIndex = list.databases.findIndex((db) => db.name === currentDbName);
+    if (dbIndex === -1) {
+      throw Error(
+        `Cannot find database '${currentDbName}' in list '${parentListName}'`,
+      );
+    }
+    list.databases[dbIndex].name = newDbName;
+  } else {
+    const dbIndex = config.databases.local.databases.findIndex(
+      (db) => db.name === currentDbName,
+    );
+    if (dbIndex === -1) {
+      throw Error(`Cannot find database '${currentDbName}' in local databases`);
+    }
+    config.databases.local.databases[dbIndex].name = newDbName;
+  }
+
+  if (
+    config.selected?.kind === SelectedDbItemKind.LocalDatabase &&
+    config.selected.databaseName === currentDbName
+  ) {
+    config.selected.databaseName = newDbName;
+  }
+
+  return config;
+}
+
 function cloneDbConfigSelectedItem(selected: SelectedDbItem): SelectedDbItem {
   switch (selected.kind) {
     case SelectedDbItemKind.LocalUserDefinedList:

--- a/extensions/ql-vscode/test/unit-tests/databases/config/db-config.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/config/db-config.test.ts
@@ -1,0 +1,363 @@
+import {
+  LocalList,
+  renameLocalDb,
+  renameLocalList,
+  renameRemoteList,
+  SelectedDbItemKind,
+} from "../../../../src/databases/config/db-config";
+import {
+  createDbConfig,
+  createLocalDbConfigItem,
+} from "../../../factories/db-config-factories";
+
+describe("db config", () => {
+  describe("renameLocalList", () => {
+    it("should rename a local list", () => {
+      const originalConfig = createDbConfig({
+        localLists: [
+          {
+            name: "list1",
+            databases: [],
+          },
+          {
+            name: "list2",
+            databases: [],
+          },
+        ],
+      });
+
+      const updatedConfig = renameLocalList(
+        originalConfig,
+        "list1",
+        "listRenamed",
+      );
+
+      expect(updatedConfig.databases.local.lists).toEqual([
+        {
+          name: "listRenamed",
+          databases: [],
+        },
+        {
+          name: "list2",
+          databases: [],
+        },
+      ]);
+    });
+
+    it("should rename a selected local list", () => {
+      const originalConfig = createDbConfig({
+        localLists: [
+          {
+            name: "list1",
+            databases: [],
+          },
+          {
+            name: "list2",
+            databases: [],
+          },
+        ],
+        selected: {
+          kind: SelectedDbItemKind.LocalUserDefinedList,
+          listName: "list1",
+        },
+      });
+
+      const updatedConfig = renameLocalList(
+        originalConfig,
+        "list1",
+        "listRenamed",
+      );
+
+      expect(updatedConfig.databases.local.lists).toEqual([
+        {
+          name: "listRenamed",
+          databases: [],
+        },
+        {
+          name: "list2",
+          databases: [],
+        },
+      ]);
+
+      expect(updatedConfig.selected).toEqual({
+        kind: SelectedDbItemKind.LocalUserDefinedList,
+        listName: "listRenamed",
+      });
+    });
+
+    it("should rename a local list with a db that is selected", () => {
+      const selectedLocalDb = createLocalDbConfigItem();
+      const list1: LocalList = {
+        name: "list1",
+        databases: [
+          createLocalDbConfigItem(),
+          selectedLocalDb,
+          createLocalDbConfigItem(),
+        ],
+      };
+      const list2: LocalList = {
+        name: "list2",
+        databases: [],
+      };
+
+      const originalConfig = createDbConfig({
+        localLists: [list1, list2],
+        selected: {
+          kind: SelectedDbItemKind.LocalDatabase,
+          databaseName: selectedLocalDb.name,
+          listName: list1.name,
+        },
+      });
+
+      const updatedConfig = renameLocalList(
+        originalConfig,
+        list1.name,
+        "listRenamed",
+      );
+
+      expect(updatedConfig.databases.local.lists.length).toEqual(2);
+      expect(updatedConfig.databases.local.lists[0]).toEqual({
+        ...list1,
+        name: "listRenamed",
+      });
+      expect(updatedConfig.databases.local.lists[1]).toEqual(list2);
+
+      expect(updatedConfig.selected).toEqual({
+        kind: SelectedDbItemKind.LocalDatabase,
+        databaseName: selectedLocalDb.name,
+        listName: "listRenamed",
+      });
+    });
+  });
+
+  describe("renameRemoteList", () => {
+    it("should rename a remote list", () => {
+      const originalConfig = createDbConfig({
+        remoteLists: [
+          {
+            name: "list1",
+            repositories: [],
+          },
+          {
+            name: "list2",
+            repositories: [],
+          },
+        ],
+      });
+
+      const updatedConfig = renameRemoteList(
+        originalConfig,
+        "list1",
+        "listRenamed",
+      );
+
+      expect(updatedConfig.databases.remote.repositoryLists).toEqual([
+        {
+          name: "listRenamed",
+          repositories: [],
+        },
+        {
+          name: "list2",
+          repositories: [],
+        },
+      ]);
+    });
+
+    it("should rename a selected remote list", () => {
+      const originalConfig = createDbConfig({
+        remoteLists: [
+          {
+            name: "list1",
+            repositories: [],
+          },
+          {
+            name: "list2",
+            repositories: [],
+          },
+        ],
+        selected: {
+          kind: SelectedDbItemKind.RemoteUserDefinedList,
+          listName: "list1",
+        },
+      });
+
+      const updatedConfig = renameRemoteList(
+        originalConfig,
+        "list1",
+        "listRenamed",
+      );
+
+      expect(updatedConfig.databases.remote.repositoryLists).toEqual([
+        {
+          name: "listRenamed",
+          repositories: [],
+        },
+        {
+          name: "list2",
+          repositories: [],
+        },
+      ]);
+
+      expect(updatedConfig.selected).toEqual({
+        kind: SelectedDbItemKind.RemoteUserDefinedList,
+        listName: "listRenamed",
+      });
+    });
+
+    it("should rename a remote list with a db that is selected", () => {
+      const selectedRemoteRepo = "owner/repo2";
+      const originalConfig = createDbConfig({
+        remoteLists: [
+          {
+            name: "list1",
+            repositories: ["owner1/repo1", selectedRemoteRepo, "owner1/repo3"],
+          },
+          {
+            name: "list2",
+            repositories: [],
+          },
+        ],
+        selected: {
+          kind: SelectedDbItemKind.RemoteRepository,
+          repositoryName: selectedRemoteRepo,
+          listName: "list1",
+        },
+      });
+
+      const updatedConfig = renameRemoteList(
+        originalConfig,
+        "list1",
+        "listRenamed",
+      );
+      const updatedRepositoryLists =
+        updatedConfig.databases.remote.repositoryLists;
+
+      expect(updatedRepositoryLists.length).toEqual(2);
+      expect(updatedRepositoryLists[0]).toEqual({
+        ...originalConfig.databases.remote.repositoryLists[0],
+        name: "listRenamed",
+      });
+      expect(updatedRepositoryLists[1]).toEqual(
+        originalConfig.databases.remote.repositoryLists[1],
+      );
+
+      expect(updatedConfig.selected).toEqual({
+        kind: SelectedDbItemKind.RemoteRepository,
+        repositoryName: selectedRemoteRepo,
+        listName: "listRenamed",
+      });
+    });
+  });
+
+  describe("renameLocalDb", () => {
+    it("should rename a local db", () => {
+      const db1 = createLocalDbConfigItem({ name: "db1" });
+      const db2 = createLocalDbConfigItem({ name: "db2" });
+
+      const originalConfig = createDbConfig({
+        localLists: [
+          {
+            name: "list1",
+            databases: [
+              createLocalDbConfigItem({ name: "db1" }),
+              createLocalDbConfigItem({ name: "db2" }),
+            ],
+          },
+        ],
+        localDbs: [db1, db2],
+      });
+
+      const updatedConfig = renameLocalDb(originalConfig, "db1", "dbRenamed");
+
+      const updatedLocalDbs = updatedConfig.databases.local;
+      const originalLocalDbs = originalConfig.databases.local;
+
+      expect(updatedLocalDbs.lists).toEqual(originalLocalDbs.lists);
+      expect(updatedLocalDbs.databases.length).toEqual(2);
+      expect(updatedLocalDbs.databases[0]).toEqual({
+        ...db1,
+        name: "dbRenamed",
+      });
+      expect(updatedLocalDbs.databases[1]).toEqual(db2);
+    });
+
+    it("should rename a local db inside a list", () => {
+      const db1List1 = createLocalDbConfigItem({ name: "db1" });
+      const db2List1 = createLocalDbConfigItem({ name: "db2" });
+
+      const originalConfig = createDbConfig({
+        localLists: [
+          {
+            name: "list1",
+            databases: [db1List1, db2List1],
+          },
+          {
+            name: "list2",
+            databases: [
+              createLocalDbConfigItem({ name: "db1" }),
+              createLocalDbConfigItem({ name: "db2" }),
+            ],
+          },
+        ],
+        localDbs: [
+          createLocalDbConfigItem({ name: "db1" }),
+          createLocalDbConfigItem({ name: "db2" }),
+        ],
+      });
+
+      const updatedConfig = renameLocalDb(
+        originalConfig,
+        db1List1.name,
+        "dbRenamed",
+        "list1",
+      );
+
+      const updatedLocalDbs = updatedConfig.databases.local;
+      const originalLocalDbs = originalConfig.databases.local;
+      expect(updatedLocalDbs.databases).toEqual(originalLocalDbs.databases);
+      expect(updatedLocalDbs.lists.length).toEqual(2);
+      expect(updatedLocalDbs.lists[0].databases.length).toEqual(2);
+      expect(updatedLocalDbs.lists[0].databases[0]).toEqual({
+        ...db1List1,
+        name: "dbRenamed",
+      });
+      expect(updatedLocalDbs.lists[0].databases[1]).toEqual(db2List1);
+      expect(updatedLocalDbs.lists[1]).toEqual(originalLocalDbs.lists[1]);
+    });
+
+    it("should rename a local db that is selected", () => {
+      const db1 = createLocalDbConfigItem({ name: "db1" });
+      const db2 = createLocalDbConfigItem({ name: "db2" });
+
+      const originalConfig = createDbConfig({
+        localLists: [
+          {
+            name: "list1",
+            databases: [
+              createLocalDbConfigItem({ name: "db1" }),
+              createLocalDbConfigItem({ name: "db2" }),
+            ],
+          },
+        ],
+        localDbs: [db1, db2],
+        selected: {
+          kind: SelectedDbItemKind.LocalDatabase,
+          databaseName: "db1",
+        },
+      });
+
+      const updatedConfig = renameLocalDb(originalConfig, "db1", "dbRenamed");
+
+      const updatedLocalDbs = updatedConfig.databases.local;
+      const originalLocalDbs = originalConfig.databases.local;
+
+      expect(updatedLocalDbs.lists).toEqual(originalLocalDbs.lists);
+      expect(updatedLocalDbs.databases.length).toEqual(2);
+      expect(updatedLocalDbs.databases[0]).toEqual({
+        ...db1,
+        name: "dbRenamed",
+      });
+      expect(updatedLocalDbs.databases[1]).toEqual(db2);
+    });
+  });
+});


### PR DESCRIPTION
This adds some functions to the db config store to allow renaming of dbs and lists. It's not wired up to anything yet as I thought there's quite a bit of code in here already (mainly test code!)

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
