### PR TITLE
Support new DB config format in "copy repo list" function

### DIFF
--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
@@ -60,6 +60,7 @@ import {
 } from "../pure/variant-analysis-filter-sort";
 import { URLSearchParams } from "url";
 import { DbManager } from "../databases/db-manager";
+import { isNewQueryRunExperienceEnabled } from "../config";
 
 export class VariantAnalysisManager
   extends DisposableObject
@@ -605,12 +606,25 @@ export class VariantAnalysisManager
       return;
     }
 
-    const text = [
-      '"new-repo-list": [',
-      ...fullNames.slice(0, -1).map((repo) => `    "${repo}",`),
-      `    "${fullNames[fullNames.length - 1]}"`,
-      "]",
-    ];
+    let text: string[];
+    if (isNewQueryRunExperienceEnabled()) {
+      text = [
+        "{",
+        `    "name": "new-repo-list",`,
+        `    "repositories": [`,
+        ...fullNames.slice(0, -1).map((repo) => `        "${repo}",`),
+        `        "${fullNames[fullNames.length - 1]}"`,
+        `    ]`,
+        "}",
+      ];
+    } else {
+      text = [
+        '"new-repo-list": [',
+        ...fullNames.slice(0, -1).map((repo) => `    "${repo}",`),
+        `    "${fullNames[fullNames.length - 1]}"`,
+        "]",
+      ];
+    }
 
     await env.clipboard.writeText(text.join(EOL));
   }

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/remote-queries/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/remote-queries/variant-analysis-manager.test.ts
@@ -1009,61 +1009,131 @@ describe("Variant Analysis Manager", () => {
         expect(writeTextStub).toBeCalledTimes(1);
       });
 
-      it("should be valid JSON when put in object", async () => {
-        await variantAnalysisManager.copyRepoListToClipboard(
-          variantAnalysis.id,
-        );
+      describe("newQueryRunExperience true", () => {
+        beforeEach(() => {
+          jest
+            .spyOn(config, "isNewQueryRunExperienceEnabled")
+            .mockReturnValue(true);
+        });
 
-        const text = writeTextStub.mock.calls[0][0];
+        it("should be valid JSON when put in object", async () => {
+          await variantAnalysisManager.copyRepoListToClipboard(
+            variantAnalysis.id,
+          );
 
-        const parsed = JSON.parse(`{${text}}`);
+          const text = writeTextStub.mock.calls[0][0];
 
-        expect(parsed).toEqual({
-          "new-repo-list": [
-            scannedRepos[4].repository.fullName,
-            scannedRepos[2].repository.fullName,
-            scannedRepos[0].repository.fullName,
-          ],
+          const parsed = JSON.parse(`${text}`);
+
+          expect(parsed).toEqual({
+            name: "new-repo-list",
+            repositories: [
+              scannedRepos[4].repository.fullName,
+              scannedRepos[2].repository.fullName,
+              scannedRepos[0].repository.fullName,
+            ],
+          });
+        });
+
+        it("should use the sort key", async () => {
+          await variantAnalysisManager.copyRepoListToClipboard(
+            variantAnalysis.id,
+            {
+              ...defaultFilterSortState,
+              sortKey: SortKey.ResultsCount,
+            },
+          );
+
+          const text = writeTextStub.mock.calls[0][0];
+
+          const parsed = JSON.parse(`${text}`);
+
+          expect(parsed).toEqual({
+            name: "new-repo-list",
+            repositories: [
+              scannedRepos[2].repository.fullName,
+              scannedRepos[0].repository.fullName,
+              scannedRepos[4].repository.fullName,
+            ],
+          });
+        });
+
+        it("should use the search value", async () => {
+          await variantAnalysisManager.copyRepoListToClipboard(
+            variantAnalysis.id,
+            {
+              ...defaultFilterSortState,
+              searchValue: "ban",
+            },
+          );
+
+          const text = writeTextStub.mock.calls[0][0];
+
+          const parsed = JSON.parse(`${text}`);
+
+          expect(parsed).toEqual({
+            name: "new-repo-list",
+            repositories: [scannedRepos[4].repository.fullName],
+          });
         });
       });
+      describe("newQueryRunExperience false", () => {
+        it("should be valid JSON when put in object", async () => {
+          await variantAnalysisManager.copyRepoListToClipboard(
+            variantAnalysis.id,
+          );
 
-      it("should use the sort key", async () => {
-        await variantAnalysisManager.copyRepoListToClipboard(
-          variantAnalysis.id,
-          {
-            ...defaultFilterSortState,
-            sortKey: SortKey.ResultsCount,
-          },
-        );
+          const text = writeTextStub.mock.calls[0][0];
 
-        const text = writeTextStub.mock.calls[0][0];
+          const parsed = JSON.parse(`{${text}}`);
 
-        const parsed = JSON.parse(`{${text}}`);
-
-        expect(parsed).toEqual({
-          "new-repo-list": [
-            scannedRepos[2].repository.fullName,
-            scannedRepos[0].repository.fullName,
-            scannedRepos[4].repository.fullName,
-          ],
+          expect(parsed).toEqual({
+            "new-repo-list": [
+              scannedRepos[4].repository.fullName,
+              scannedRepos[2].repository.fullName,
+              scannedRepos[0].repository.fullName,
+            ],
+          });
         });
-      });
 
-      it("should use the search value", async () => {
-        await variantAnalysisManager.copyRepoListToClipboard(
-          variantAnalysis.id,
-          {
-            ...defaultFilterSortState,
-            searchValue: "ban",
-          },
-        );
+        it("should use the sort key", async () => {
+          await variantAnalysisManager.copyRepoListToClipboard(
+            variantAnalysis.id,
+            {
+              ...defaultFilterSortState,
+              sortKey: SortKey.ResultsCount,
+            },
+          );
 
-        const text = writeTextStub.mock.calls[0][0];
+          const text = writeTextStub.mock.calls[0][0];
 
-        const parsed = JSON.parse(`{${text}}`);
+          const parsed = JSON.parse(`{${text}}`);
 
-        expect(parsed).toEqual({
-          "new-repo-list": [scannedRepos[4].repository.fullName],
+          expect(parsed).toEqual({
+            "new-repo-list": [
+              scannedRepos[2].repository.fullName,
+              scannedRepos[0].repository.fullName,
+              scannedRepos[4].repository.fullName,
+            ],
+          });
+        });
+
+        it("should use the search value", async () => {
+          await variantAnalysisManager.copyRepoListToClipboard(
+            variantAnalysis.id,
+            {
+              ...defaultFilterSortState,
+              searchValue: "ban",
+            },
+          );
+
+          const text = writeTextStub.mock.calls[0][0];
+
+          const parsed = JSON.parse(`{${text}}`);
+
+          expect(parsed).toEqual({
+            "new-repo-list": [scannedRepos[4].repository.fullName],
+          });
         });
       });
     });


### PR DESCRIPTION
The "Copy Repository List" command lets you copy the list of repos with results, for a MRVA run. If you're using the new experimental query run experience (i.e. with the new DB panel), that command should return the list in a slightly different format.

Old format:
```json
"new-repo-list": [
    "foo/bar",
    "foo/baz"
],
```

New format (if you have `newQueryRunExperience` enabled):
```json
{
    "name": "new-repo-list",
    "repositories": [
        "foo/bar",
        "foo/baz"
    ]
}
```

## Checklist

N/A—internal only 🎠

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
