### PR TITLE
Add 'rename' context menu action for dbs/lists

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -64,6 +64,7 @@
     "onCommand:codeQLDatabasesExperimental.addNewList",
     "onCommand:codeQLDatabasesExperimental.setSelectedItem",
     "onCommand:codeQLDatabasesExperimental.setSelectedItemContextMenu",
+    "onCommand:codeQLDatabasesExperimental.renameItemContextMenu",
     "onCommand:codeQLDatabasesExperimental.openOnGitHubContextMenu",
     "onCommand:codeQL.quickQuery",
     "onCommand:codeQL.restartQueryServer",
@@ -382,6 +383,10 @@
       {
         "command": "codeQLDatabasesExperimental.setSelectedItemContextMenu",
         "title": "Select"
+      },
+      {
+        "command": "codeQLDatabasesExperimental.renameItemContextMenu",
+        "title": "Rename"
       },
       {
         "command": "codeQLDatabasesExperimental.openOnGitHubContextMenu",
@@ -791,6 +796,10 @@
           "when": "view == codeQLDatabasesExperimental && viewItem =~ /canBeSelected/"
         },
         {
+          "command": "codeQLDatabasesExperimental.renameItemContextMenu",
+          "when": "view == codeQLDatabasesExperimental && viewItem =~ /canBeRenamed/"
+        },
+        {
           "command": "codeQLDatabasesExperimental.openOnGitHubContextMenu",
           "when": "view == codeQLDatabasesExperimental && viewItem =~ /canBeOpenedOnGitHub/"
         },
@@ -1024,6 +1033,10 @@
         },
         {
           "command": "codeQLDatabasesExperimental.setSelectedItemContextMenu",
+          "when": "false"
+        },
+        {
+          "command": "codeQLDatabasesExperimental.renameItemContextMenu",
           "when": "false"
         },
         {

--- a/extensions/ql-vscode/src/databases/db-item-expansion.ts
+++ b/extensions/ql-vscode/src/databases/db-item-expansion.ts
@@ -50,6 +50,24 @@ export function updateItemInExpandedState(
   }
 }
 
+export function replaceItemInExpandedState(
+  currentExpandedItems: ExpandedDbItem[],
+  currentDbItem: DbItem,
+  newDbItem: DbItem,
+): ExpandedDbItem[] {
+  const newExpandedItems: ExpandedDbItem[] = [];
+
+  for (const item of currentExpandedItems) {
+    if (isDbItemEqualToExpandedDbItem(currentDbItem, item)) {
+      newExpandedItems.push(mapDbItemToExpandedDbItem(newDbItem));
+    } else {
+      newExpandedItems.push(item);
+    }
+  }
+
+  return newExpandedItems;
+}
+
 function mapDbItemToExpandedDbItem(dbItem: DbItem): ExpandedDbItem {
   switch (dbItem.kind) {
     case DbItemKind.RootLocal:

--- a/extensions/ql-vscode/src/databases/db-item-naming.ts
+++ b/extensions/ql-vscode/src/databases/db-item-naming.ts
@@ -1,0 +1,19 @@
+import { DbItem, DbItemKind } from "./db-item";
+
+export function getDbItemName(dbItem: DbItem): string | undefined {
+  switch (dbItem.kind) {
+    case DbItemKind.RootLocal:
+    case DbItemKind.RootRemote:
+      return undefined;
+    case DbItemKind.LocalList:
+    case DbItemKind.RemoteUserDefinedList:
+    case DbItemKind.RemoteSystemDefinedList:
+      return dbItem.listName;
+    case DbItemKind.RemoteOwner:
+      return dbItem.ownerName;
+    case DbItemKind.LocalDatabase:
+      return dbItem.databaseName;
+    case DbItemKind.RemoteRepo:
+      return dbItem.repoFullName;
+  }
+}

--- a/extensions/ql-vscode/src/databases/ui/db-panel.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-panel.ts
@@ -16,7 +16,15 @@ import {
 } from "../../common/github-url-identifier-helper";
 import { showAndLogErrorMessage } from "../../helpers";
 import { DisposableObject } from "../../pure/disposable-object";
-import { DbItem, DbItemKind, DbListKind, remoteDbKinds } from "../db-item";
+import {
+  DbItem,
+  DbItemKind,
+  DbListKind,
+  LocalDatabaseDbItem,
+  LocalListDbItem,
+  remoteDbKinds,
+  RemoteUserDefinedListDbItem,
+} from "../db-item";
 import { DbManager } from "../db-manager";
 import { DbTreeDataProvider } from "./db-tree-data-provider";
 import { DbTreeViewItem } from "./db-tree-view-item";
@@ -90,6 +98,12 @@ export class DbPanel extends DisposableObject {
       commandRunner(
         "codeQLDatabasesExperimental.openOnGitHubContextMenu",
         (treeViewItem: DbTreeViewItem) => this.openOnGitHub(treeViewItem),
+      ),
+    );
+    this.push(
+      commandRunner(
+        "codeQLDatabasesExperimental.renameItemContextMenu",
+        (treeViewItem: DbTreeViewItem) => this.renameItem(treeViewItem),
       ),
     );
   }
@@ -264,6 +278,85 @@ export class DbPanel extends DisposableObject {
       );
     }
     await this.dbManager.setSelectedDbItem(treeViewItem.dbItem);
+  }
+
+  private async renameItem(treeViewItem: DbTreeViewItem): Promise<void> {
+    const dbItem = treeViewItem.dbItem;
+    if (dbItem === undefined) {
+      throw new Error(
+        "Not a database item that can be renamed. Please select a valid item.",
+      );
+    }
+
+    const newName = await window.showInputBox({
+      prompt: "Enter the new name",
+    });
+
+    if (newName === undefined || newName === "") {
+      return;
+    }
+
+    switch (dbItem.kind) {
+      case DbItemKind.LocalList:
+        await this.renameLocalListItem(dbItem, newName);
+        break;
+      case DbItemKind.LocalDatabase:
+        await this.renameLocalDatabaseItem(dbItem, newName);
+        break;
+      case DbItemKind.RemoteUserDefinedList:
+        await this.renameRemoteUserDefinedListItem(dbItem, newName);
+        break;
+      default:
+        throw Error(`Action not allowed for the '${dbItem.kind}' db item kind`);
+    }
+  }
+
+  private async renameLocalListItem(
+    dbItem: LocalListDbItem,
+    newName: string,
+  ): Promise<void> {
+    if (dbItem.listName === newName) {
+      return;
+    }
+
+    if (this.dbManager.doesListExist(DbListKind.Local, newName)) {
+      void showAndLogErrorMessage(`The list '${newName}' already exists`);
+      return;
+    }
+
+    await this.dbManager.renameList(dbItem, newName);
+  }
+
+  private async renameLocalDatabaseItem(
+    dbItem: LocalDatabaseDbItem,
+    newName: string,
+  ): Promise<void> {
+    if (dbItem.databaseName === newName) {
+      return;
+    }
+
+    if (this.dbManager.doesLocalDbExist(newName, dbItem.parentListName)) {
+      void showAndLogErrorMessage(`The database '${newName}' already exists`);
+      return;
+    }
+
+    await this.dbManager.renameLocalDb(dbItem, newName);
+  }
+
+  private async renameRemoteUserDefinedListItem(
+    dbItem: RemoteUserDefinedListDbItem,
+    newName: string,
+  ): Promise<void> {
+    if (dbItem.listName === newName) {
+      return;
+    }
+
+    if (this.dbManager.doesListExist(DbListKind.Remote, newName)) {
+      void showAndLogErrorMessage(`The list '${newName}' already exists`);
+      return;
+    }
+
+    await this.dbManager.renameList(dbItem, newName);
   }
 
   private async onDidCollapseElement(

--- a/extensions/ql-vscode/src/databases/ui/db-panel.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-panel.ts
@@ -25,6 +25,7 @@ import {
   remoteDbKinds,
   RemoteUserDefinedListDbItem,
 } from "../db-item";
+import { getDbItemName } from "../db-item-naming";
 import { DbManager } from "../db-manager";
 import { DbTreeDataProvider } from "./db-tree-data-provider";
 import { DbTreeViewItem } from "./db-tree-view-item";
@@ -288,8 +289,11 @@ export class DbPanel extends DisposableObject {
       );
     }
 
+    const oldName = getDbItemName(dbItem);
+
     const newName = await window.showInputBox({
       prompt: "Enter the new name",
+      value: oldName,
     });
 
     if (newName === undefined || newName === "") {

--- a/extensions/ql-vscode/test/unit-tests/databases/db-item-expansion.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/db-item-expansion.test.ts
@@ -6,6 +6,7 @@ import {
   updateItemInExpandedState,
   ExpandedDbItem,
   ExpandedDbItemKind,
+  replaceItemInExpandedState,
 } from "../../../src/databases/db-item-expansion";
 import {
   createRemoteUserDefinedListDbItem,
@@ -106,6 +107,61 @@ describe("db item expansion", () => {
       );
 
       expect(newExpandedItems).toEqual([]);
+    });
+  });
+
+  describe("replaceItemInExpandedState", () => {
+    it("should replace the db item", () => {
+      const currentExpandedItems: ExpandedDbItem[] = [
+        {
+          kind: ExpandedDbItemKind.RootRemote,
+        },
+        {
+          kind: ExpandedDbItemKind.RemoteUserDefinedList,
+          listName: "list1",
+        },
+        {
+          kind: ExpandedDbItemKind.RemoteUserDefinedList,
+          listName: "list2",
+        },
+        {
+          kind: ExpandedDbItemKind.LocalUserDefinedList,
+          listName: "list1",
+        },
+      ];
+
+      const currentDbItem = createRemoteUserDefinedListDbItem({
+        listName: "list1",
+      });
+
+      const newDbItem: RemoteUserDefinedListDbItem = {
+        ...currentDbItem,
+        listName: "list1 (renamed)",
+      };
+
+      const newExpandedItems = replaceItemInExpandedState(
+        currentExpandedItems,
+        currentDbItem,
+        newDbItem,
+      );
+
+      expect(newExpandedItems).toEqual([
+        {
+          kind: ExpandedDbItemKind.RootRemote,
+        },
+        {
+          kind: ExpandedDbItemKind.RemoteUserDefinedList,
+          listName: "list1 (renamed)",
+        },
+        {
+          kind: ExpandedDbItemKind.RemoteUserDefinedList,
+          listName: "list2",
+        },
+        {
+          kind: ExpandedDbItemKind.LocalUserDefinedList,
+          listName: "list1",
+        },
+      ]);
     });
   });
 });

--- a/extensions/ql-vscode/test/unit-tests/databases/db-item-naming.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/db-item-naming.test.ts
@@ -1,0 +1,79 @@
+import { getDbItemName } from "../../../src/databases/db-item-naming";
+import {
+  createLocalDatabaseDbItem,
+  createLocalListDbItem,
+  createRemoteOwnerDbItem,
+  createRemoteRepoDbItem,
+  createRemoteSystemDefinedListDbItem,
+  createRemoteUserDefinedListDbItem,
+  createRootLocalDbItem,
+  createRootRemoteDbItem,
+} from "../../factories/db-item-factories";
+
+describe("db item naming", () => {
+  describe("getDbItemName", () => {
+    it("return undefined for root local db item", () => {
+      const dbItem = createRootLocalDbItem();
+
+      const name = getDbItemName(dbItem);
+
+      expect(name).toBeUndefined();
+    });
+
+    it("return undefined for root remote db item", () => {
+      const dbItem = createRootRemoteDbItem();
+
+      const name = getDbItemName(dbItem);
+
+      expect(name).toBeUndefined();
+    });
+
+    it("return list name for local list db item", () => {
+      const dbItem = createLocalListDbItem();
+
+      const name = getDbItemName(dbItem);
+
+      expect(name).toEqual(dbItem.listName);
+    });
+
+    it("return list name for remote user defined list db item", () => {
+      const dbItem = createRemoteUserDefinedListDbItem();
+
+      const name = getDbItemName(dbItem);
+
+      expect(name).toEqual(dbItem.listName);
+    });
+
+    it("return list name for remote system defined list db item", () => {
+      const dbItem = createRemoteSystemDefinedListDbItem();
+
+      const name = getDbItemName(dbItem);
+
+      expect(name).toEqual(dbItem.listName);
+    });
+
+    it("return owner name for owner db item", () => {
+      const dbItem = createRemoteOwnerDbItem();
+
+      const name = getDbItemName(dbItem);
+
+      expect(name).toEqual(dbItem.ownerName);
+    });
+
+    it("return database name for local db item", () => {
+      const dbItem = createLocalDatabaseDbItem();
+
+      const name = getDbItemName(dbItem);
+
+      expect(name).toEqual(dbItem.databaseName);
+    });
+
+    it("return repo name for remote repo db item", () => {
+      const dbItem = createRemoteRepoDbItem();
+
+      const name = getDbItemName(dbItem);
+
+      expect(name).toEqual(dbItem.repoFullName);
+    });
+  });
+});


### PR DESCRIPTION
Implements logic to add "rename" functionality in the db panel as a context menu action.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
