### PR TITLE
Remove assertion in tests

### DIFF
--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/remote-queries/remote-queries-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/remote-queries/remote-queries-manager.test.ts
@@ -191,7 +191,6 @@ describe("Remote queries", () => {
 
       // check dependencies.
       expect(packNames).toContain("javascript-all");
-      expect(packNames.length).toBeLessThan(3);
     });
 
     it("should run a remote query that is not part of a qlpack", async () => {
@@ -248,7 +247,6 @@ describe("Remote queries", () => {
 
       // check dependencies.
       expect(packNames).toContain("javascript-all");
-      expect(packNames.length).toBeLessThan(3);
     });
 
     it("should run a remote query that is nested inside a qlpack", async () => {
@@ -308,7 +306,6 @@ describe("Remote queries", () => {
 
       // check dependencies.
       expect(packNames).toContain("javascript-all");
-      expect(packNames.length).toBeLessThan(3);
     });
 
     it("should cancel a run before uploading", async () => {


### PR DESCRIPTION
I am removing these assertions so that our internal integration tests can pass. They are currently failing because the number of dependencies of the `codeql/javascript-all` pack has changed. It no longer makes sense to test this value as newer versions of this pack will have more dependencies and we expect this value will continue to go up.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->
