### PR TITLE
Ensure remote queries can handle codeql-pack.yml files

### DIFF
--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/data-remote-qlpack-nested/codeql-pack.yml
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/data-remote-qlpack-nested/codeql-pack.yml
@@ -1,5 +1,4 @@
 name: github/remote-query-pack
 version: 0.0.0
 dependencies:
-  # The workspace reference will be removed before creating the MRVA pack.
   codeql/javascript-all: '*'

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/data-remote-qlpack/qlpack.yml
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/data-remote-qlpack/qlpack.yml
@@ -1,4 +1,4 @@
 name: github/remote-query-pack
 version: 0.0.0
 dependencies:
-  codeql/javascript-all: '${workspace}'
+  codeql/javascript-all: ${workspace}

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/remote-queries/remote-queries-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/remote-queries/remote-queries-manager.test.ts
@@ -277,7 +277,7 @@ describe("Remote queries", () => {
 
       // check a few files that we know should exist and others that we know should not
       expect(packFS.fileExists("subfolder/in-pack.ql")).toBe(true);
-      expect(packFS.fileExists("qlpack.yml")).toBe(true);
+      expect(packFS.fileExists("codeql-pack.yml")).toBe(true);
       // depending on the cli version, we should have one of these files
       expect(
         packFS.fileExists("qlpack.lock.yml") ||
@@ -289,13 +289,13 @@ describe("Remote queries", () => {
       // the compiled pack
       verifyQlPack(
         "subfolder/in-pack.ql",
-        packFS.fileContents("qlpack.yml"),
+        packFS.fileContents("codeql-pack.yml"),
         "0.0.0",
       );
 
       // should have generated a correct qlpack file
       const qlpackContents: any = load(
-        packFS.fileContents("qlpack.yml").toString("utf-8"),
+        packFS.fileContents("codeql-pack.yml").toString("utf-8"),
       );
       expect(qlpackContents.name).toBe("codeql-remote/query");
       expect(qlpackContents.version).toBe("0.0.0");
@@ -333,22 +333,27 @@ describe("Remote queries", () => {
     // don't check the build metadata since it is variable
     delete (qlPack as any).buildMetadata;
 
-    expect(qlPack).toEqual({
-      name: "codeql-remote/query",
-      version: packVersion,
-      dependencies: {
-        "codeql/javascript-all": "*",
-      },
-      library: false,
-      defaultSuite: [
-        {
-          description: "Query suite for variant analysis",
+    expect(qlPack).toEqual(
+      expect.objectContaining({
+        name: "codeql-remote/query",
+        version: packVersion,
+        dependencies: {
+          "codeql/javascript-all": "*",
         },
-        {
-          query: queryPath,
-        },
-      ],
-    });
+        defaultSuite: [
+          {
+            description: "Query suite for variant analysis",
+          },
+          {
+            query: queryPath,
+          },
+        ],
+      }),
+    );
+
+    // v2.11.6 and later set this to false.
+    // Earlier versions don't set it at all.
+    expect(qlPack.library).toBeFalsy();
   }
 
   function getFile(file: string): Uri {


### PR DESCRIPTION
This updates one of our integration tests so that it uses `codeql-pack.yml` instead of `qlpack.yml`.

