### PR TITLE
Added logic to clean expanded state when it's updated

### DIFF
--- a/extensions/ql-vscode/src/databases/db-item-expansion.ts
+++ b/extensions/ql-vscode/src/databases/db-item-expansion.ts
@@ -1,4 +1,4 @@
-import { DbItem, DbItemKind } from "./db-item";
+import { DbItem, DbItemKind, flattenDbItems } from "./db-item";
 
 export type ExpandedDbItem =
   | RootLocalExpandedDbItem
@@ -66,6 +66,16 @@ export function replaceExpandedItem(
   }
 
   return newExpandedItems;
+}
+
+export function cleanNonExistentExpandedItems(
+  currentExpandedItems: ExpandedDbItem[],
+  dbItems: DbItem[],
+): ExpandedDbItem[] {
+  const flattenedDbItems = flattenDbItems(dbItems);
+  return currentExpandedItems.filter((i) =>
+    flattenedDbItems.some((dbItem) => isDbItemEqualToExpandedDbItem(dbItem, i)),
+  );
 }
 
 function mapDbItemToExpandedDbItem(dbItem: DbItem): ExpandedDbItem {

--- a/extensions/ql-vscode/src/databases/db-item.ts
+++ b/extensions/ql-vscode/src/databases/db-item.ts
@@ -149,3 +149,32 @@ const SelectableDbItemKinds = [
   DbItemKind.RemoteOwner,
   DbItemKind.RemoteRepo,
 ];
+
+export function flattenDbItems(dbItems: DbItem[]): DbItem[] {
+  const allItems: DbItem[] = [];
+
+  for (const dbItem of dbItems) {
+    allItems.push(dbItem);
+    switch (dbItem.kind) {
+      case DbItemKind.RootLocal:
+        allItems.push(...flattenDbItems(dbItem.children));
+        break;
+      case DbItemKind.LocalList:
+        allItems.push(...flattenDbItems(dbItem.databases));
+        break;
+      case DbItemKind.RootRemote:
+        allItems.push(...flattenDbItems(dbItem.children));
+        break;
+      case DbItemKind.RemoteUserDefinedList:
+        allItems.push(...dbItem.repos);
+        break;
+      case DbItemKind.LocalDatabase:
+      case DbItemKind.RemoteSystemDefinedList:
+      case DbItemKind.RemoteOwner:
+      case DbItemKind.RemoteRepo:
+        break;
+    }
+  }
+
+  return allItems;
+}

--- a/extensions/ql-vscode/test/unit-tests/databases/db-item-expansion.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/db-item-expansion.test.ts
@@ -3,9 +3,12 @@ import {
   ExpandedDbItem,
   ExpandedDbItemKind,
   replaceExpandedItem,
+  cleanNonExistentExpandedItems,
 } from "../../../src/databases/db-item-expansion";
 import {
+  createLocalListDbItem,
   createRemoteUserDefinedListDbItem,
+  createRootLocalDbItem,
   createRootRemoteDbItem,
 } from "../../factories/db-item-factories";
 
@@ -145,6 +148,64 @@ describe("db item expansion", () => {
         {
           kind: ExpandedDbItemKind.RemoteUserDefinedList,
           listName: "list1 (renamed)",
+        },
+        {
+          kind: ExpandedDbItemKind.RemoteUserDefinedList,
+          listName: "list2",
+        },
+        {
+          kind: ExpandedDbItemKind.LocalUserDefinedList,
+          listName: "list1",
+        },
+      ]);
+    });
+  });
+
+  describe("cleanNonExistentExpandedItems", () => {
+    it("should remove non-existent items", () => {
+      const currentExpandedItems: ExpandedDbItem[] = [
+        {
+          kind: ExpandedDbItemKind.RootRemote,
+        },
+        {
+          kind: ExpandedDbItemKind.RemoteUserDefinedList,
+          listName: "list1",
+        },
+        {
+          kind: ExpandedDbItemKind.RemoteUserDefinedList,
+          listName: "list2",
+        },
+        {
+          kind: ExpandedDbItemKind.LocalUserDefinedList,
+          listName: "list1",
+        },
+      ];
+
+      const dbItems = [
+        createRootRemoteDbItem({
+          children: [
+            createRemoteUserDefinedListDbItem({
+              listName: "list2",
+            }),
+          ],
+        }),
+        createRootLocalDbItem({
+          children: [
+            createLocalListDbItem({
+              listName: "list1",
+            }),
+          ],
+        }),
+      ];
+
+      const newExpandedItems = cleanNonExistentExpandedItems(
+        currentExpandedItems,
+        dbItems,
+      );
+
+      expect(newExpandedItems).toEqual([
+        {
+          kind: ExpandedDbItemKind.RootRemote,
         },
         {
           kind: ExpandedDbItemKind.RemoteUserDefinedList,

--- a/extensions/ql-vscode/test/unit-tests/databases/db-item.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/db-item.test.ts
@@ -1,0 +1,144 @@
+import {
+  DbItem,
+  DbItemKind,
+  flattenDbItems,
+} from "../../../src/databases/db-item";
+import {
+  createLocalDatabaseDbItem,
+  createLocalListDbItem,
+  createRemoteOwnerDbItem,
+  createRemoteRepoDbItem,
+  createRemoteSystemDefinedListDbItem,
+  createRemoteUserDefinedListDbItem,
+  createRootLocalDbItem,
+  createRootRemoteDbItem,
+} from "../../factories/db-item-factories";
+
+describe("DbItem", () => {
+  describe("flattenDbItems", () => {
+    it("should flatten a list of DbItems", () => {
+      const dbItems = [
+        createRootRemoteDbItem({
+          children: [
+            createRemoteSystemDefinedListDbItem({ listName: "top10" }),
+            createRemoteSystemDefinedListDbItem({ listName: "top100" }),
+            createRemoteUserDefinedListDbItem({
+              listName: "remote-list1",
+              repos: [
+                createRemoteRepoDbItem({ repoFullName: "owner1/repo1" }),
+                createRemoteRepoDbItem({ repoFullName: "owner1/repo2" }),
+              ],
+            }),
+            createRemoteUserDefinedListDbItem({
+              listName: "remote-list2",
+              repos: [
+                createRemoteRepoDbItem({ repoFullName: "owner2/repo1" }),
+                createRemoteRepoDbItem({ repoFullName: "owner2/repo2" }),
+              ],
+            }),
+            createRemoteOwnerDbItem({ ownerName: "owner1" }),
+            createRemoteRepoDbItem({ repoFullName: "owner3/repo3" }),
+          ],
+        }),
+        createRootLocalDbItem({
+          children: [
+            createLocalListDbItem({
+              listName: "local-list1",
+              databases: [
+                createLocalDatabaseDbItem({ databaseName: "local-db1" }),
+              ],
+            }),
+            createLocalDatabaseDbItem({ databaseName: "local-db2" }),
+          ],
+        }),
+      ];
+
+      const flattenedItems = flattenDbItems(dbItems);
+
+      expect(flattenedItems.length).toEqual(15);
+      checkRootRemoteExists(flattenedItems);
+      checkSystemDefinedListExists(flattenedItems, "top10");
+      checkSystemDefinedListExists(flattenedItems, "top100");
+      checkUserDefinedListExists(flattenedItems, "remote-list1");
+      checkRemoteRepoExists(flattenedItems, "owner1/repo1");
+      checkRemoteRepoExists(flattenedItems, "owner1/repo2");
+      checkRemoteRepoExists(flattenedItems, "owner2/repo1");
+      checkRemoteRepoExists(flattenedItems, "owner2/repo2");
+      checkRemoteOwnerExists(flattenedItems, "owner1");
+      checkRemoteRepoExists(flattenedItems, "owner3/repo3");
+      checkRootLocalExists(flattenedItems);
+      checkLocalListExists(flattenedItems, "local-list1");
+      checkLocalDbExists(flattenedItems, "local-db1");
+      checkLocalDbExists(flattenedItems, "local-db2");
+    });
+
+    function checkRootRemoteExists(items: DbItem[]): void {
+      expect(
+        items.find((item) => item.kind === DbItemKind.RootRemote),
+      ).toBeDefined();
+    }
+
+    function checkUserDefinedListExists(items: DbItem[], name: string): void {
+      expect(
+        items.find(
+          (item) =>
+            item.kind === DbItemKind.RemoteUserDefinedList &&
+            item.listName === name,
+        ),
+      ).toBeDefined();
+    }
+
+    function checkSystemDefinedListExists(items: DbItem[], name: string): void {
+      expect(
+        items.find(
+          (item) =>
+            item.kind === DbItemKind.RemoteSystemDefinedList &&
+            item.listName === name,
+        ),
+      ).toBeDefined();
+    }
+
+    function checkRemoteOwnerExists(items: DbItem[], name: string): void {
+      expect(
+        items.find(
+          (item) =>
+            item.kind === DbItemKind.RemoteOwner && item.ownerName === name,
+        ),
+      ).toBeDefined();
+    }
+
+    function checkRemoteRepoExists(items: DbItem[], name: string): void {
+      expect(
+        items.find(
+          (item) =>
+            item.kind === DbItemKind.RemoteRepo && item.repoFullName === name,
+        ),
+      ).toBeDefined();
+    }
+
+    function checkRootLocalExists(items: DbItem[]): void {
+      expect(
+        items.find((item) => item.kind === DbItemKind.RootLocal),
+      ).toBeDefined();
+    }
+
+    function checkLocalListExists(items: DbItem[], name: string): void {
+      expect(
+        items.find(
+          (item) =>
+            item.kind === DbItemKind.LocalList && item.listName === name,
+        ),
+      ).toBeDefined();
+    }
+
+    function checkLocalDbExists(items: DbItem[], name: string): void {
+      expect(
+        items.find(
+          (item) =>
+            item.kind === DbItemKind.LocalDatabase &&
+            item.databaseName === name,
+        ),
+      ).toBeDefined();
+    }
+  });
+});


### PR DESCRIPTION
Added logic to remove non existent expanded items every time expanded state is updated. 

As part of this I added a `flattenDbItems` function that turns a tree of DbItems into a flat list. We can use that in other places if we want (e.g. tests).

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
