### PR TITLE
Add db manager tests for "rename" functions

### DIFF
--- a/extensions/ql-vscode/test/unit-tests/databases/db-manager.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/db-manager.test.ts
@@ -67,11 +67,21 @@ describe("db manager", () => {
       await dbManager.renameList(dbItem, "my-list-2");
 
       const dbConfigFileContents = await readDbConfigDirectly();
+
+      // Check that the remote list has been renamed
       const remoteLists = dbConfigFileContents.databases.remote.repositoryLists;
       expect(remoteLists.length).toBe(1);
       expect(remoteLists[0]).toEqual({
         name: "my-list-2",
         repositories: ["owner1/repo1", "owner1/repo2"],
+      });
+
+      // Check that the local list has not been renamed
+      const localLists = dbConfigFileContents.databases.local.lists;
+      expect(localLists.length).toBe(1);
+      expect(localLists[0]).toEqual({
+        name: "my-list-1",
+        databases: [localDb],
       });
     });
 
@@ -88,11 +98,21 @@ describe("db manager", () => {
       await dbManager.renameList(dbItem, "my-list-2");
 
       const dbConfigFileContents = await readDbConfigDirectly();
+
+      // Check that the local list has been renamed
       const localLists = dbConfigFileContents.databases.local.lists;
       expect(localLists.length).toBe(1);
       expect(localLists[0]).toEqual({
         name: "my-list-2",
         databases: [localDb],
+      });
+
+      // Check that the remote list has not been renamed
+      const remoteLists = dbConfigFileContents.databases.remote.repositoryLists;
+      expect(remoteLists.length).toBe(1);
+      expect(remoteLists[0]).toEqual({
+        name: "my-list-1",
+        repositories: ["owner1/repo1", "owner1/repo2"],
       });
     });
 
@@ -109,9 +129,19 @@ describe("db manager", () => {
       await dbManager.renameLocalDb(dbItem, "db2");
 
       const dbConfigFileContents = await readDbConfigDirectly();
+
+      // Check that the db outside of the list has been renamed
       const localDbs = dbConfigFileContents.databases.local.databases;
       expect(localDbs.length).toBe(1);
       expect(localDbs[0].name).toEqual("db2");
+
+      // Check that the db inside the list has not been renamed
+      const localLists = dbConfigFileContents.databases.local.lists;
+      expect(localLists.length).toBe(1);
+      expect(localLists[0]).toEqual({
+        name: "my-list-1",
+        databases: [localDb],
+      });
     });
 
     it("should rename local db inside a list", async () => {
@@ -127,9 +157,17 @@ describe("db manager", () => {
       await dbManager.renameLocalDb(dbItem, "db2");
 
       const dbConfigFileContents = await readDbConfigDirectly();
-      const localDbs = dbConfigFileContents.databases.local.lists[0].databases;
+
+      // Check that the db inside the list has been renamed
+      const localListDbs =
+        dbConfigFileContents.databases.local.lists[0].databases;
+      expect(localListDbs.length).toBe(1);
+      expect(localListDbs[0].name).toEqual("db2");
+
+      // Check that the db outside of the list has not been renamed
+      const localDbs = dbConfigFileContents.databases.local.databases;
       expect(localDbs.length).toBe(1);
-      expect(localDbs[0].name).toEqual("db2");
+      expect(localDbs[0]).toEqual(localDb);
     });
   });
 

--- a/extensions/ql-vscode/test/unit-tests/databases/db-manager.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/db-manager.test.ts
@@ -47,6 +47,7 @@ describe("db manager", () => {
 
   afterEach(async () => {
     await remove(tempWorkspaceStoragePath);
+    dbConfigStore.dispose();
   });
 
   describe("renaming items", () => {

--- a/extensions/ql-vscode/test/unit-tests/databases/db-manager.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/db-manager.test.ts
@@ -1,0 +1,134 @@
+import { ensureDir, readJSON, remove, writeJson } from "fs-extra";
+import { join } from "path";
+import { DbConfig } from "../../../src/databases/config/db-config";
+import { DbConfigStore } from "../../../src/databases/config/db-config-store";
+import {
+  flattenDbItems,
+  isLocalListDbItem,
+  isRemoteUserDefinedListDbItem,
+  LocalListDbItem,
+  RemoteUserDefinedListDbItem,
+} from "../../../src/databases/db-item";
+import { DbManager } from "../../../src/databases/db-manager";
+import {
+  createDbConfig,
+  createLocalDbConfigItem,
+} from "../../factories/db-config-factories";
+import { createMockApp } from "../../__mocks__/appMock";
+
+// Note: Although these are "unit tests" (i.e. not integrating with VS Code), they do
+// test the interaction/"integration" between the DbManager and the DbConfigStore.
+describe("db manager", () => {
+  const extensionPath = join(__dirname, "../../..");
+  const tempWorkspaceStoragePath = join(__dirname, "test-workspace");
+  const app = createMockApp({
+    extensionPath,
+    workspaceStoragePath: tempWorkspaceStoragePath,
+  });
+  const dbConfigStore = new DbConfigStore(app);
+  const dbManager = new DbManager(app, dbConfigStore);
+
+  beforeEach(async () => {
+    await ensureDir(tempWorkspaceStoragePath);
+  });
+
+  afterEach(async () => {
+    await remove(tempWorkspaceStoragePath);
+  });
+
+  const dbConfigFilePath = join(
+    tempWorkspaceStoragePath,
+    "workspace-databases.json",
+  );
+
+  describe("renaming items", () => {
+    it("should rename remote db list", async () => {
+      const dbConfig = createDbConfig({
+        remoteLists: [
+          {
+            name: "my-list-1",
+            repositories: ["owner1/repo1", "owner1/repo2"],
+          },
+        ],
+      });
+
+      await saveDbConfig(dbConfig);
+
+      const dbItem = getRemoteUserDefinedListDbItem("my-list-1");
+
+      await dbManager.renameList(dbItem, "my-list-2");
+
+      const dbConfigFileContents = await readDbConfigDirectly();
+      const remoteLists = dbConfigFileContents.databases.remote.repositoryLists;
+      expect(remoteLists.length).toBe(1);
+      expect(remoteLists[0]).toEqual({
+        name: "my-list-2",
+        repositories: ["owner1/repo1", "owner1/repo2"],
+      });
+
+      function getRemoteUserDefinedListDbItem(
+        listName: string,
+      ): RemoteUserDefinedListDbItem {
+        const dbItemsResult = dbManager.getDbItems();
+        const dbItems = flattenDbItems(dbItemsResult.value);
+        const listDbItems = dbItems
+          .filter(isRemoteUserDefinedListDbItem)
+          .filter((i) => i.listName === listName);
+
+        expect(listDbItems.length).toEqual(1);
+        return listDbItems[0];
+      }
+    });
+
+    it("should rename local db list", async () => {
+      const localDb = createLocalDbConfigItem();
+      const dbConfig = createDbConfig({
+        localLists: [
+          {
+            name: "my-list-1",
+            databases: [localDb],
+          },
+        ],
+      });
+
+      await saveDbConfig(dbConfig);
+
+      const dbItem = getLocalListDbItem("my-list-1");
+
+      await dbManager.renameList(dbItem, "my-list-2");
+
+      const dbConfigFileContents = await readDbConfigDirectly();
+      const localLists = dbConfigFileContents.databases.local.lists;
+      expect(localLists.length).toBe(1);
+      expect(localLists[0]).toEqual({
+        name: "my-list-2",
+        databases: [localDb],
+      });
+
+      function getLocalListDbItem(listName: string): LocalListDbItem {
+        const dbItemsResult = dbManager.getDbItems();
+        const dbItems = flattenDbItems(dbItemsResult.value);
+        const listDbItems = dbItems
+          .filter(isLocalListDbItem)
+          .filter((i) => i.listName === listName);
+
+        expect(listDbItems.length).toEqual(1);
+        return listDbItems[0];
+      }
+    });
+  });
+
+  async function saveDbConfig(dbConfig: DbConfig): Promise<void> {
+    await writeJson(dbConfigFilePath, dbConfig);
+
+    // Ideally we would just initialize the db config store at the start
+    // of each test and then rely on the file watcher to update the config.
+    // However, this requires adding sleep to the tests to allow for the
+    // file watcher to catch up, so we instead initialize the config store here.
+    await dbConfigStore.initialize();
+  }
+
+  async function readDbConfigDirectly(): Promise<DbConfig> {
+    return (await readJSON(dbConfigFilePath)) as DbConfig;
+  }
+});

--- a/extensions/ql-vscode/test/unit-tests/databases/db-manager.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/db-manager.test.ts
@@ -44,14 +44,20 @@ describe("db manager", () => {
   );
 
   describe("renaming items", () => {
+    const remoteList = {
+      name: "my-list-1",
+      repositories: ["owner1/repo1", "owner1/repo2"],
+    };
+    const localDb = createLocalDbConfigItem({ name: "db1" });
+    const localList = {
+      name: "my-list-1",
+      databases: [localDb],
+    };
+
     it("should rename remote db list", async () => {
       const dbConfig = createDbConfig({
-        remoteLists: [
-          {
-            name: "my-list-1",
-            repositories: ["owner1/repo1", "owner1/repo2"],
-          },
-        ],
+        remoteLists: [remoteList],
+        localLists: [localList],
       });
 
       await saveDbConfig(dbConfig);
@@ -70,14 +76,9 @@ describe("db manager", () => {
     });
 
     it("should rename local db list", async () => {
-      const localDb = createLocalDbConfigItem();
       const dbConfig = createDbConfig({
-        localLists: [
-          {
-            name: "my-list-1",
-            databases: [localDb],
-          },
-        ],
+        remoteLists: [remoteList],
+        localLists: [localList],
       });
 
       await saveDbConfig(dbConfig);
@@ -96,8 +97,8 @@ describe("db manager", () => {
     });
 
     it("should rename local db outside a list", async () => {
-      const localDb = createLocalDbConfigItem({ name: "db1" });
       const dbConfig = createDbConfig({
+        localLists: [localList],
         localDbs: [localDb],
       });
 
@@ -114,14 +115,9 @@ describe("db manager", () => {
     });
 
     it("should rename local db inside a list", async () => {
-      const localDb = createLocalDbConfigItem({ name: "db1" });
       const dbConfig = createDbConfig({
-        localLists: [
-          {
-            name: "my-list-1",
-            databases: [localDb],
-          },
-        ],
+        localLists: [localList],
+        localDbs: [localDb],
       });
 
       await saveDbConfig(dbConfig);

--- a/extensions/ql-vscode/test/unit-tests/databases/db-manager.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/db-manager.test.ts
@@ -21,27 +21,33 @@ import { createMockApp } from "../../__mocks__/appMock";
 // Note: Although these are "unit tests" (i.e. not integrating with VS Code), they do
 // test the interaction/"integration" between the DbManager and the DbConfigStore.
 describe("db manager", () => {
-  const extensionPath = join(__dirname, "../../..");
-  const tempWorkspaceStoragePath = join(__dirname, "test-workspace");
-  const app = createMockApp({
-    extensionPath,
-    workspaceStoragePath: tempWorkspaceStoragePath,
-  });
-  const dbConfigStore = new DbConfigStore(app);
-  const dbManager = new DbManager(app, dbConfigStore);
+  let dbManager: DbManager;
+  let dbConfigStore: DbConfigStore;
+  let tempWorkspaceStoragePath: string;
+  let dbConfigFilePath: string;
 
   beforeEach(async () => {
+    tempWorkspaceStoragePath = join(__dirname, "test-workspace");
+
+    const extensionPath = join(__dirname, "../../..");
+    const app = createMockApp({
+      extensionPath,
+      workspaceStoragePath: tempWorkspaceStoragePath,
+    });
+
+    dbConfigStore = new DbConfigStore(app);
+    dbManager = new DbManager(app, dbConfigStore);
     await ensureDir(tempWorkspaceStoragePath);
+
+    dbConfigFilePath = join(
+      tempWorkspaceStoragePath,
+      "workspace-databases.json",
+    );
   });
 
   afterEach(async () => {
     await remove(tempWorkspaceStoragePath);
   });
-
-  const dbConfigFilePath = join(
-    tempWorkspaceStoragePath,
-    "workspace-databases.json",
-  );
 
   describe("renaming items", () => {
     const remoteList = {


### PR DESCRIPTION
Follow-up to https://github.com/github/vscode-codeql/pull/1928 to add some "integration" tests (specifically testing the integration between the db manager and db config store).

These tests check renaming lists and local databases.

## Checklist

N/A—internal only 🎭

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
