### PR TITLE
Integration tests: Accept github/codeql checkouts named `ql`

### DIFF
--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/jest.setup.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/jest.setup.ts
@@ -64,7 +64,9 @@ beforeAll(async () => {
       'No workspace folders found.\nYou will need a local copy of the codeql repo.\nMake sure you specify the path to it in launch.json.\nIt should be something along the lines of "${workspaceRoot}/../codeql" depending on where you have your local copy of the codeql repo.',
     );
   } else {
-    const codeqlFolder = folders.find((folder) => folder.name === "codeql");
+    const codeqlFolder = folders.find((folder) =>
+      ["codeql", "ql"].includes(folder.name),
+    );
     if (!codeqlFolder) {
       throw new Error(
         'No workspace folders found.\nYou will need a local copy of the codeql repo.\nMake sure you specify the path to it in launch.json.\nIt should be something along the lines of "${workspaceRoot}/../codeql" depending on where you have your local copy of the codeql repo.\n\n\n',


### PR DESCRIPTION
Some checkouts of the github/codeql repo, such as the internal submodule, may be named `ql` rather than
`codeql`. Allow this folder name when running tests.

Passing improvement noticed when diagnosing and testing https://github.com/github/vscode-codeql/pull/1932.

## Checklist

- [N/A] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [N/A] Issues have been created for any UI or other user-facing changes made by this pull request.
- [N/A] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
