### PR TITLE
Acknowledge that telemetryListener may be undefined

### DIFF
--- a/extensions/ql-vscode/src/commandRunner.ts
+++ b/extensions/ql-vscode/src/commandRunner.ts
@@ -147,7 +147,7 @@ export function commandRunner(
       return undefined;
     } finally {
       const executionTime = Date.now() - startTime;
-      telemetryListener.sendCommandUsage(commandId, executionTime, error);
+      telemetryListener?.sendCommandUsage(commandId, executionTime, error);
     }
   });
 }
@@ -201,7 +201,7 @@ export function commandRunnerWithProgress<R>(
       return undefined;
     } finally {
       const executionTime = Date.now() - startTime;
-      telemetryListener.sendCommandUsage(commandId, executionTime, error);
+      telemetryListener?.sendCommandUsage(commandId, executionTime, error);
     }
   });
 }

--- a/extensions/ql-vscode/src/telemetry.ts
+++ b/extensions/ql-vscode/src/telemetry.ts
@@ -227,12 +227,15 @@ export class TelemetryListener extends ConfigListener {
 /**
  * The global Telemetry instance
  */
-export let telemetryListener: TelemetryListener;
+export let telemetryListener: TelemetryListener | undefined;
 
 export async function initializeTelemetry(
   extension: Extension<any>,
   ctx: ExtensionContext,
 ): Promise<void> {
+  if (telemetryListener !== undefined) {
+    throw new Error("Telemetry is already initialized");
+  }
   telemetryListener = new TelemetryListener(
     extension.id,
     extension.packageJSON.version,


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Mark the type of `telemetryListener` as `TelemetryListener | undefined` which is more accurate, because it is undefined before `initializeTelemetry` is called. This forces us to use `?.` when logging telemetry of commands, which makes things slightly safer in case a command is accidentally run before `initializeTelemetry` is called.

Also checks that we aren't calling `initializeTelemetry` twice. We shouldn't be because it's only called on extension startup, but it's probably good to check. If it were called twice we wouldn't log telemetry twice, but we might end up doing things like prompting for permission twice.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
