### PR TITLE
Avoid race condition requesting telemetry permissions

### DIFF
--- a/extensions/ql-vscode/src/telemetry.ts
+++ b/extensions/ql-vscode/src/telemetry.ts
@@ -95,10 +95,8 @@ export class TelemetryListener extends ConfigListener {
       CANARY_FEATURES.getValue() &&
       !ENABLE_TELEMETRY.getValue()
     ) {
-      await Promise.all([
-        this.setTelemetryRequested(false),
-        this.requestTelemetryPermission(),
-      ]);
+      await this.setTelemetryRequested(false);
+      await this.requestTelemetryPermission();
     }
   }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

I think this is a race condition, because `setTelemetryRequested` is setting `telemetry-request-viewed` to false but `requestTelemetryPermission` is checking `telemetry-request-viewed`. So this could get the value false or it could get whatever the existing value is.

My understanding of the intention of this code is that if the user has canary mode enabled but not telemetry then we always want to prompt them to enable telemetry and we want to ignore if they've already been prompted. So therefore the intention is to set `telemetry-request-viewed` to false first and the use of `Promise.all` seems like a bug.

It's been this way all the way since 292e695646186d5b2d700aac1fc8dcdd0fbf08f2 when telemetry was first added.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
