### PR TITLE
Display modal when removing an item from query history

### DIFF
--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -971,10 +971,6 @@ export class QueryHistoryManager extends DisposableObject {
   private async showToastWithWorkflowRunLink(
     item: VariantAnalysisHistoryItem,
   ): Promise<void> {
-    void extLogger.log(
-      "The variant analysis is still running on GitHub Actions. To cancel there, you must go to the workflow run in your browser.",
-    );
-
     const workflowRunUrl = getActionsWorkflowRunUrl(item);
     const message = `Remote query has been removed from history. However, the variant analysis is still running on GitHub Actions. To cancel it, you must go to the [workflow run](${workflowRunUrl}) in your browser.`;
 

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history.test.ts
@@ -589,98 +589,197 @@ describe("query-history", () => {
       });
 
       describe("when the item is a variant analysis", () => {
-        describe("when the item being removed is not selected", () => {
-          let toDelete: VariantAnalysisHistoryItem;
-          let selected: VariantAnalysisHistoryItem;
+        describe("when in progress", () => {
+          describe("when the item being removed is not selected", () => {
+            let toDelete: VariantAnalysisHistoryItem;
+            let selected: VariantAnalysisHistoryItem;
 
-          beforeEach(async () => {
-            // deleting the first item when a different item is selected
-            // will not change the selection
-            toDelete = variantAnalysisHistory[1];
-            selected = variantAnalysisHistory[3];
+            beforeEach(async () => {
+              // deleting the first item when a different item is selected
+              // will not change the selection
+              toDelete = variantAnalysisHistory[1];
+              selected = variantAnalysisHistory[3];
 
-            queryHistoryManager = await createMockQueryHistory(allHistory);
-            // initialize the selection
-            await queryHistoryManager.treeView.reveal(
-              variantAnalysisHistory[0],
-              {
+              queryHistoryManager = await createMockQueryHistory(allHistory);
+              // initialize the selection
+              await queryHistoryManager.treeView.reveal(
+                variantAnalysisHistory[0],
+                {
+                  select: true,
+                },
+              );
+
+              // select the item we want
+              await queryHistoryManager.treeView.reveal(selected, {
                 select: true,
-              },
-            );
+              });
 
-            // select the item we want
-            await queryHistoryManager.treeView.reveal(selected, {
-              select: true,
+              // should be selected
+              expect(queryHistoryManager.treeDataProvider.getCurrent()).toEqual(
+                selected,
+              );
+
+              // remove an item
+              await queryHistoryManager.handleRemoveHistoryItem(toDelete, [
+                toDelete,
+              ]);
             });
 
-            // should be selected
-            expect(queryHistoryManager.treeDataProvider.getCurrent()).toEqual(
-              selected,
-            );
+            it("should remove the item", () => {
+              expect(
+                variantAnalysisManagerStub.removeVariantAnalysis,
+              ).toHaveBeenCalledWith(toDelete.variantAnalysis);
+              expect(
+                queryHistoryManager.treeDataProvider.allHistory,
+              ).not.toContain(toDelete);
+            });
 
-            // remove an item
-            await queryHistoryManager.handleRemoveHistoryItem(toDelete, [
-              toDelete,
-            ]);
+            it("should not change the selection", () => {
+              expect(queryHistoryManager.treeDataProvider.getCurrent()).toEqual(
+                selected,
+              );
+              expect(variantAnalysisManagerStub.showView).toHaveBeenCalledWith(
+                selected.variantAnalysis.id,
+              );
+            });
           });
 
-          it("should remove the item", () => {
-            expect(
-              variantAnalysisManagerStub.removeVariantAnalysis,
-            ).toHaveBeenCalledWith(toDelete.variantAnalysis);
-            expect(
-              queryHistoryManager.treeDataProvider.allHistory,
-            ).not.toContain(toDelete);
-          });
+          describe("when the item being removed is selected", () => {
+            let toDelete: VariantAnalysisHistoryItem;
+            let newSelected: VariantAnalysisHistoryItem;
 
-          it("should not change the selection", () => {
-            expect(queryHistoryManager.treeDataProvider.getCurrent()).toEqual(
-              selected,
-            );
-            expect(variantAnalysisManagerStub.showView).toHaveBeenCalledWith(
-              selected.variantAnalysis.id,
-            );
+            beforeEach(async () => {
+              // deleting the selected item automatically selects next item
+              toDelete = variantAnalysisHistory[1];
+              newSelected = variantAnalysisHistory[2];
+
+              queryHistoryManager = await createMockQueryHistory(
+                variantAnalysisHistory,
+              );
+
+              // select the item we want
+              await queryHistoryManager.treeView.reveal(toDelete, {
+                select: true,
+              });
+              await queryHistoryManager.handleRemoveHistoryItem(toDelete, [
+                toDelete,
+              ]);
+            });
+
+            it("should remove the item", () => {
+              expect(
+                variantAnalysisManagerStub.removeVariantAnalysis,
+              ).toHaveBeenCalledWith(toDelete.variantAnalysis);
+              expect(
+                queryHistoryManager.treeDataProvider.allHistory,
+              ).not.toContain(toDelete);
+            });
+
+            it.skip("should change the selection", () => {
+              expect(queryHistoryManager.treeDataProvider.getCurrent()).toEqual(
+                newSelected,
+              );
+              expect(variantAnalysisManagerStub.showView).toHaveBeenCalledWith(
+                newSelected.variantAnalysis.id,
+              );
+            });
           });
         });
 
-        describe("when the item being removed is selected", () => {
-          let toDelete: VariantAnalysisHistoryItem;
-          let newSelected: VariantAnalysisHistoryItem;
+        describe("when not in progress", () => {
+          describe("when the item being removed is not selected", () => {
+            let toDelete: VariantAnalysisHistoryItem;
+            let selected: VariantAnalysisHistoryItem;
 
-          beforeEach(async () => {
-            // deleting the selected item automatically selects next item
-            toDelete = variantAnalysisHistory[1];
-            newSelected = variantAnalysisHistory[2];
+            beforeEach(async () => {
+              // deleting the first item when a different item is selected
+              // will not change the selection
+              toDelete = variantAnalysisHistory[2];
+              selected = variantAnalysisHistory[3];
 
-            queryHistoryManager = await createMockQueryHistory(
-              variantAnalysisHistory,
-            );
+              queryHistoryManager = await createMockQueryHistory(allHistory);
+              // initialize the selection
+              await queryHistoryManager.treeView.reveal(
+                variantAnalysisHistory[0],
+                {
+                  select: true,
+                },
+              );
 
-            // select the item we want
-            await queryHistoryManager.treeView.reveal(toDelete, {
-              select: true,
+              // select the item we want
+              await queryHistoryManager.treeView.reveal(selected, {
+                select: true,
+              });
+
+              // should be selected
+              expect(queryHistoryManager.treeDataProvider.getCurrent()).toEqual(
+                selected,
+              );
+
+              // remove an item
+              await queryHistoryManager.handleRemoveHistoryItem(toDelete, [
+                toDelete,
+              ]);
             });
-            await queryHistoryManager.handleRemoveHistoryItem(toDelete, [
-              toDelete,
-            ]);
+
+            it("should remove the item", () => {
+              expect(
+                variantAnalysisManagerStub.removeVariantAnalysis,
+              ).toHaveBeenCalledWith(toDelete.variantAnalysis);
+              expect(
+                queryHistoryManager.treeDataProvider.allHistory,
+              ).not.toContain(toDelete);
+            });
+
+            it("should not change the selection", () => {
+              expect(queryHistoryManager.treeDataProvider.getCurrent()).toEqual(
+                selected,
+              );
+              expect(variantAnalysisManagerStub.showView).toHaveBeenCalledWith(
+                selected.variantAnalysis.id,
+              );
+            });
           });
 
-          it("should remove the item", () => {
-            expect(
-              variantAnalysisManagerStub.removeVariantAnalysis,
-            ).toHaveBeenCalledWith(toDelete.variantAnalysis);
-            expect(
-              queryHistoryManager.treeDataProvider.allHistory,
-            ).not.toContain(toDelete);
-          });
+          describe("when the item being removed is selected", () => {
+            let toDelete: VariantAnalysisHistoryItem;
+            let newSelected: VariantAnalysisHistoryItem;
 
-          it.skip("should change the selection", () => {
-            expect(queryHistoryManager.treeDataProvider.getCurrent()).toEqual(
-              newSelected,
-            );
-            expect(variantAnalysisManagerStub.showView).toHaveBeenCalledWith(
-              newSelected.variantAnalysis.id,
-            );
+            beforeEach(async () => {
+              // deleting the selected item automatically selects next item
+              toDelete = variantAnalysisHistory[0];
+              newSelected = variantAnalysisHistory[2];
+
+              queryHistoryManager = await createMockQueryHistory(
+                variantAnalysisHistory,
+              );
+
+              // select the item we want
+              await queryHistoryManager.treeView.reveal(toDelete, {
+                select: true,
+              });
+              await queryHistoryManager.handleRemoveHistoryItem(toDelete, [
+                toDelete,
+              ]);
+            });
+
+            it("should remove the item", () => {
+              expect(
+                variantAnalysisManagerStub.removeVariantAnalysis,
+              ).toHaveBeenCalledWith(toDelete.variantAnalysis);
+              expect(
+                queryHistoryManager.treeDataProvider.allHistory,
+              ).not.toContain(toDelete);
+            });
+
+            it.skip("should change the selection", () => {
+              expect(queryHistoryManager.treeDataProvider.getCurrent()).toEqual(
+                newSelected,
+              );
+              expect(variantAnalysisManagerStub.showView).toHaveBeenCalledWith(
+                newSelected.variantAnalysis.id,
+              );
+            });
           });
         });
       });


### PR DESCRIPTION
When you attempt to delete a query that's still in progress from your
query history, you get a prompt asking if you're sure.

If you pick "Yes", the item is removed and you see a toast notification
with a link to the GitHub Action.


## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
