### PR TITLE
Convert opening variant analysis logs to a command

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -1166,6 +1166,15 @@ async function activateWithInstalledDistribution(
 
   ctx.subscriptions.push(
     commandRunner(
+      "codeQL.openVariantAnalysisLogs",
+      async (variantAnalysisId: number) => {
+        await variantAnalysisManager.openVariantAnalysisLogs(variantAnalysisId);
+      },
+    ),
+  );
+
+  ctx.subscriptions.push(
+    commandRunner(
       "codeQL.copyVariantAnalysisRepoList",
       async (
         variantAnalysisId: number,

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
@@ -19,6 +19,7 @@ import { DisposableObject } from "../pure/disposable-object";
 import { Credentials } from "../authentication";
 import { VariantAnalysisMonitor } from "./variant-analysis-monitor";
 import {
+  getActionsWorkflowRunUrl,
   isVariantAnalysisComplete,
   parseVariantAnalysisQueryLanguage,
   VariantAnalysis,
@@ -583,6 +584,20 @@ export class VariantAnalysisManager
       "Cancelling variant analysis. This may take a while.",
     );
     await cancelVariantAnalysis(credentials, variantAnalysis);
+  }
+
+  public async openVariantAnalysisLogs(variantAnalysisId: number) {
+    const variantAnalysis = this.variantAnalyses.get(variantAnalysisId);
+    if (!variantAnalysis) {
+      throw new Error(`No variant analysis with id: ${variantAnalysisId}`);
+    }
+
+    const actionsWorkflowRunUrl = getActionsWorkflowRunUrl(variantAnalysis);
+
+    await commands.executeCommand(
+      "vscode.open",
+      Uri.parse(actionsWorkflowRunUrl),
+    );
   }
 
   public async copyRepoListToClipboard(

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-view.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-view.ts
@@ -1,4 +1,4 @@
-import { commands, ExtensionContext, Uri, ViewColumn } from "vscode";
+import { commands, ExtensionContext, ViewColumn } from "vscode";
 import { AbstractWebview, WebviewPanelConfig } from "../abstract-webview";
 import { extLogger } from "../common";
 import {
@@ -7,7 +7,6 @@ import {
 } from "../pure/interface-types";
 import { assertNever } from "../pure/helpers-pure";
 import {
-  getActionsWorkflowRunUrl,
   VariantAnalysis,
   VariantAnalysisScannedRepositoryResult,
   VariantAnalysisScannedRepositoryState,
@@ -147,7 +146,10 @@ export class VariantAnalysisView
         );
         break;
       case "openLogs":
-        await this.openLogs();
+        await commands.executeCommand(
+          "codeQL.openVariantAnalysisLogs",
+          this.variantAnalysisId,
+        );
         break;
       default:
         assertNever(msg);
@@ -182,24 +184,5 @@ export class VariantAnalysisView
       t: "setRepoStates",
       repoStates,
     });
-  }
-
-  private async openLogs(): Promise<void> {
-    const variantAnalysis = await this.manager.getVariantAnalysis(
-      this.variantAnalysisId,
-    );
-    if (!variantAnalysis) {
-      void showAndLogWarningMessage(
-        "Could not open variant analysis logs. Variant analysis not found.",
-      );
-      return;
-    }
-
-    const actionsWorkflowRunUrl = getActionsWorkflowRunUrl(variantAnalysis);
-
-    await commands.executeCommand(
-      "vscode.open",
-      Uri.parse(actionsWorkflowRunUrl),
-    );
   }
 }


### PR DESCRIPTION
Moves the work for opening the logs for a variant analysis into a command. The primary motivation here is to get telemetry logged for it. The alternative would be outputting telemetry explicitly, but using a command seems cleaner, and makes the code more reusable.

This only affects when opening the logs from the variant analysis results webview. The query history has its own implementation. We could look at unifying these implementations but I think we should wait until the remote queries code has been deleted first.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
