### PR TITLE
Rename new db panel to 'Variant Analysis Repositories'

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1293,7 +1293,7 @@
         },
         {
           "id": "codeQLDatabasesExperimental",
-          "name": "Databases",
+          "name": "Variant Analysis Repositories",
           "when": "config.codeQL.canary && config.codeQL.newQueryRunExperience"
         },
         {

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -37,7 +37,7 @@
     "onLanguage:ql",
     "onLanguage:ql-summary",
     "onView:codeQLDatabases",
-    "onView:codeQLDatabasesExperimental",
+    "onView:codeQLVariantAnalysisRepositories",
     "onView:codeQLQueryHistory",
     "onView:codeQLAstViewer",
     "onView:codeQLEvalLogViewer",
@@ -59,14 +59,14 @@
     "onCommand:codeQL.chooseDatabaseGithub",
     "onCommand:codeQLDatabases.chooseDatabase",
     "onCommand:codeQLDatabases.setCurrentDatabase",
-    "onCommand:codeQLDatabasesExperimental.openConfigFile",
-    "onCommand:codeQLDatabasesExperimental.addNewDatabase",
-    "onCommand:codeQLDatabasesExperimental.addNewList",
-    "onCommand:codeQLDatabasesExperimental.setSelectedItem",
-    "onCommand:codeQLDatabasesExperimental.setSelectedItemContextMenu",
-    "onCommand:codeQLDatabasesExperimental.renameItemContextMenu",
-    "onCommand:codeQLDatabasesExperimental.openOnGitHubContextMenu",
-    "onCommand:codeQLDatabasesExperimental.removeItemContextMenu",
+    "onCommand:codeQLVariantAnalysisRepositories.openConfigFile",
+    "onCommand:codeQLVariantAnalysisRepositories.addNewDatabase",
+    "onCommand:codeQLVariantAnalysisRepositories.addNewList",
+    "onCommand:codeQLVariantAnalysisRepositories.setSelectedItem",
+    "onCommand:codeQLVariantAnalysisRepositories.setSelectedItemContextMenu",
+    "onCommand:codeQLVariantAnalysisRepositories.renameItemContextMenu",
+    "onCommand:codeQLVariantAnalysisRepositories.openOnGitHubContextMenu",
+    "onCommand:codeQLVariantAnalysisRepositories.removeItemContextMenu",
     "onCommand:codeQL.quickQuery",
     "onCommand:codeQL.restartQueryServer",
     "onWebviewPanel:resultsView",
@@ -363,38 +363,38 @@
         "title": "CodeQL: Copy Version Information"
       },
       {
-        "command": "codeQLDatabasesExperimental.openConfigFile",
+        "command": "codeQLVariantAnalysisRepositories.openConfigFile",
         "title": "Open Database Configuration File",
         "icon": "$(edit)"
       },
       {
-        "command": "codeQLDatabasesExperimental.addNewDatabase",
+        "command": "codeQLVariantAnalysisRepositories.addNewDatabase",
         "title": "Add new database",
         "icon": "$(add)"
       },
       {
-        "command": "codeQLDatabasesExperimental.addNewList",
+        "command": "codeQLVariantAnalysisRepositories.addNewList",
         "title": "Add new list",
         "icon": "$(new-folder)"
       },
       {
-        "command": "codeQLDatabasesExperimental.setSelectedItem",
+        "command": "codeQLVariantAnalysisRepositories.setSelectedItem",
         "title": "✓"
       },
       {
-        "command": "codeQLDatabasesExperimental.setSelectedItemContextMenu",
+        "command": "codeQLVariantAnalysisRepositories.setSelectedItemContextMenu",
         "title": "Select"
       },
       {
-        "command": "codeQLDatabasesExperimental.renameItemContextMenu",
+        "command": "codeQLVariantAnalysisRepositories.renameItemContextMenu",
         "title": "Rename"
       },
       {
-        "command": "codeQLDatabasesExperimental.openOnGitHubContextMenu",
+        "command": "codeQLVariantAnalysisRepositories.openOnGitHubContextMenu",
         "title": "Open on GitHub"
       },
       {
-        "command": "codeQLDatabasesExperimental.removeItemContextMenu",
+        "command": "codeQLVariantAnalysisRepositories.removeItemContextMenu",
         "title": "Remove"
       },
       {
@@ -780,37 +780,37 @@
           "group": "navigation"
         },
         {
-          "command": "codeQLDatabasesExperimental.openConfigFile",
-          "when": "view == codeQLDatabasesExperimental",
+          "command": "codeQLVariantAnalysisRepositories.openConfigFile",
+          "when": "view == codeQLVariantAnalysisRepositories",
           "group": "navigation"
         },
         {
-          "command": "codeQLDatabasesExperimental.addNewDatabase",
-          "when": "view == codeQLDatabasesExperimental && codeQLDatabasesExperimental.configError == false",
+          "command": "codeQLVariantAnalysisRepositories.addNewDatabase",
+          "when": "view == codeQLVariantAnalysisRepositories && codeQLVariantAnalysisRepositories.configError == false",
           "group": "navigation"
         },
         {
-          "command": "codeQLDatabasesExperimental.addNewList",
-          "when": "view == codeQLDatabasesExperimental && codeQLDatabasesExperimental.configError == false",
+          "command": "codeQLVariantAnalysisRepositories.addNewList",
+          "when": "view == codeQLVariantAnalysisRepositories && codeQLVariantAnalysisRepositories.configError == false",
           "group": "navigation"
         }
       ],
       "view/item/context": [
         {
-          "command": "codeQLDatabasesExperimental.removeItemContextMenu",
-          "when": "view == codeQLDatabasesExperimental && viewItem =~ /canBeRemoved/"
+          "command": "codeQLVariantAnalysisRepositories.removeItemContextMenu",
+          "when": "view == codeQLVariantAnalysisRepositories && viewItem =~ /canBeRemoved/"
         },
         {
-          "command": "codeQLDatabasesExperimental.setSelectedItemContextMenu",
-          "when": "view == codeQLDatabasesExperimental && viewItem =~ /canBeSelected/"
+          "command": "codeQLVariantAnalysisRepositories.setSelectedItemContextMenu",
+          "when": "view == codeQLVariantAnalysisRepositories && viewItem =~ /canBeSelected/"
         },
         {
-          "command": "codeQLDatabasesExperimental.renameItemContextMenu",
-          "when": "view == codeQLDatabasesExperimental && viewItem =~ /canBeRenamed/"
+          "command": "codeQLVariantAnalysisRepositories.renameItemContextMenu",
+          "when": "view == codeQLVariantAnalysisRepositories && viewItem =~ /canBeRenamed/"
         },
         {
-          "command": "codeQLDatabasesExperimental.openOnGitHubContextMenu",
-          "when": "view == codeQLDatabasesExperimental && viewItem =~ /canBeOpenedOnGitHub/"
+          "command": "codeQLVariantAnalysisRepositories.openOnGitHubContextMenu",
+          "when": "view == codeQLVariantAnalysisRepositories && viewItem =~ /canBeOpenedOnGitHub/"
         },
         {
           "command": "codeQLDatabases.setCurrentDatabase",
@@ -838,8 +838,8 @@
           "when": "view == codeQLDatabases"
         },
         {
-          "command": "codeQLDatabasesExperimental.setSelectedItem",
-          "when": "view == codeQLDatabasesExperimental && viewItem =~ /canBeSelected/",
+          "command": "codeQLVariantAnalysisRepositories.setSelectedItem",
+          "when": "view == codeQLVariantAnalysisRepositories && viewItem =~ /canBeSelected/",
           "group": "inline"
         },
         {
@@ -1025,35 +1025,35 @@
           "when": "resourceScheme == codeql-zip-archive && config.codeQL.canary"
         },
         {
-          "command": "codeQLDatabasesExperimental.openConfigFile",
+          "command": "codeQLVariantAnalysisRepositories.openConfigFile",
           "when": "false"
         },
         {
-          "command": "codeQLDatabasesExperimental.addNewDatabase",
+          "command": "codeQLVariantAnalysisRepositories.addNewDatabase",
           "when": "false"
         },
         {
-          "command": "codeQLDatabasesExperimental.addNewList",
+          "command": "codeQLVariantAnalysisRepositories.addNewList",
           "when": "false"
         },
         {
-          "command": "codeQLDatabasesExperimental.setSelectedItem",
+          "command": "codeQLVariantAnalysisRepositories.setSelectedItem",
           "when": "false"
         },
         {
-          "command": "codeQLDatabasesExperimental.setSelectedItemContextMenu",
+          "command": "codeQLVariantAnalysisRepositories.setSelectedItemContextMenu",
           "when": "false"
         },
         {
-          "command": "codeQLDatabasesExperimental.renameItemContextMenu",
+          "command": "codeQLVariantAnalysisRepositories.renameItemContextMenu",
           "when": "false"
         },
         {
-          "command": "codeQLDatabasesExperimental.openOnGitHubContextMenu",
+          "command": "codeQLVariantAnalysisRepositories.openOnGitHubContextMenu",
           "when": "false"
         },
         {
-          "command": "codeQLDatabasesExperimental.removeItemContextMenu",
+          "command": "codeQLVariantAnalysisRepositories.removeItemContextMenu",
           "when": "false"
         },
         {
@@ -1292,7 +1292,7 @@
           "name": "Databases"
         },
         {
-          "id": "codeQLDatabasesExperimental",
+          "id": "codeQLVariantAnalysisRepositories",
           "name": "Variant Analysis Repositories",
           "when": "config.codeQL.canary && config.codeQL.newQueryRunExperience"
         },

--- a/extensions/ql-vscode/src/databases/config/db-config-store.ts
+++ b/extensions/ql-vscode/src/databases/config/db-config-store.ts
@@ -378,14 +378,14 @@ export class DbConfigStore extends DisposableObject {
       this.config = newConfig;
       await this.app.executeCommand(
         "setContext",
-        "codeQLDatabasesExperimental.configError",
+        "codeQLVariantAnalysisRepositories.configError",
         false,
       );
     } else {
       this.config = undefined;
       await this.app.executeCommand(
         "setContext",
-        "codeQLDatabasesExperimental.configError",
+        "codeQLVariantAnalysisRepositories.configError",
         true,
       );
     }
@@ -412,14 +412,14 @@ export class DbConfigStore extends DisposableObject {
       this.config = newConfig;
       void this.app.executeCommand(
         "setContext",
-        "codeQLDatabasesExperimental.configError",
+        "codeQLVariantAnalysisRepositories.configError",
         false,
       );
     } else {
       this.config = undefined;
       void this.app.executeCommand(
         "setContext",
-        "codeQLDatabasesExperimental.configError",
+        "codeQLVariantAnalysisRepositories.configError",
         true,
       );
     }

--- a/extensions/ql-vscode/src/databases/ui/db-panel.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-panel.ts
@@ -48,7 +48,7 @@ export class DbPanel extends DisposableObject {
 
     this.dataProvider = new DbTreeDataProvider(dbManager);
 
-    this.treeView = window.createTreeView("codeQLDatabasesExperimental", {
+    this.treeView = window.createTreeView("codeQLVariantAnalysisRepositories", {
       treeDataProvider: this.dataProvider,
       canSelectMany: false,
     });
@@ -69,47 +69,47 @@ export class DbPanel extends DisposableObject {
 
   public async initialize(): Promise<void> {
     this.push(
-      commandRunner("codeQLDatabasesExperimental.openConfigFile", () =>
+      commandRunner("codeQLVariantAnalysisRepositories.openConfigFile", () =>
         this.openConfigFile(),
       ),
     );
     this.push(
-      commandRunner("codeQLDatabasesExperimental.addNewDatabase", () =>
+      commandRunner("codeQLVariantAnalysisRepositories.addNewDatabase", () =>
         this.addNewRemoteDatabase(),
       ),
     );
     this.push(
-      commandRunner("codeQLDatabasesExperimental.addNewList", () =>
+      commandRunner("codeQLVariantAnalysisRepositories.addNewList", () =>
         this.addNewList(),
       ),
     );
     this.push(
       commandRunner(
-        "codeQLDatabasesExperimental.setSelectedItem",
+        "codeQLVariantAnalysisRepositories.setSelectedItem",
         (treeViewItem: DbTreeViewItem) => this.setSelectedItem(treeViewItem),
       ),
     );
     this.push(
       commandRunner(
-        "codeQLDatabasesExperimental.setSelectedItemContextMenu",
+        "codeQLVariantAnalysisRepositories.setSelectedItemContextMenu",
         (treeViewItem: DbTreeViewItem) => this.setSelectedItem(treeViewItem),
       ),
     );
     this.push(
       commandRunner(
-        "codeQLDatabasesExperimental.openOnGitHubContextMenu",
+        "codeQLVariantAnalysisRepositories.openOnGitHubContextMenu",
         (treeViewItem: DbTreeViewItem) => this.openOnGitHub(treeViewItem),
       ),
     );
     this.push(
       commandRunner(
-        "codeQLDatabasesExperimental.renameItemContextMenu",
+        "codeQLVariantAnalysisRepositories.renameItemContextMenu",
         (treeViewItem: DbTreeViewItem) => this.renameItem(treeViewItem),
       ),
     );
     this.push(
       commandRunner(
-        "codeQLDatabasesExperimental.removeItemContextMenu",
+        "codeQLVariantAnalysisRepositories.removeItemContextMenu",
         (treeViewItem: DbTreeViewItem) => this.removeItem(treeViewItem),
       ),
     );

--- a/extensions/ql-vscode/test/unit-tests/command-lint.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/command-lint.test.ts
@@ -34,7 +34,7 @@ describe("commands declared in package.json", () => {
       commandTitles[command] = title!;
     } else if (
       command.match(/^codeQLDatabases\./) ||
-      command.match(/^codeQLDatabasesExperimental\./) ||
+      command.match(/^codeQLVariantAnalysisRepositories\./) ||
       command.match(/^codeQLQueryHistory\./) ||
       command.match(/^codeQLAstViewer\./) ||
       command.match(/^codeQLEvalLogViewer\./) ||

--- a/extensions/ql-vscode/test/unit-tests/databases/config/db-config-store.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/config/db-config-store.test.ts
@@ -148,7 +148,7 @@ describe("db config store", () => {
       configStore.dispose();
     });
 
-    it("should set codeQLDatabasesExperimental.configError to true when config has error", async () => {
+    it("should set codeQLVariantAnalysisRepositories.configError to true when config has error", async () => {
       const testDataStoragePathInvalid = join(__dirname, "data", "invalid");
 
       const app = createMockApp({
@@ -160,13 +160,13 @@ describe("db config store", () => {
 
       expect(app.executeCommand).toBeCalledWith(
         "setContext",
-        "codeQLDatabasesExperimental.configError",
+        "codeQLVariantAnalysisRepositories.configError",
         true,
       );
       configStore.dispose();
     });
 
-    it("should set codeQLDatabasesExperimental.configError to false when config is valid", async () => {
+    it("should set codeQLVariantAnalysisRepositories.configError to false when config is valid", async () => {
       const app = createMockApp({
         extensionPath,
         workspaceStoragePath: testDataStoragePath,
@@ -176,7 +176,7 @@ describe("db config store", () => {
 
       expect(app.executeCommand).toBeCalledWith(
         "setContext",
-        "codeQLDatabasesExperimental.configError",
+        "codeQLVariantAnalysisRepositories.configError",
         false,
       );
 

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/databases/db-panel.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/databases/db-panel.test.ts
@@ -38,7 +38,9 @@ describe("Db panel UI commands", () => {
       kind: DbListKind.Remote,
     } as AddListQuickPickItem);
     jest.spyOn(window, "showInputBox").mockResolvedValue("my-list-1");
-    await commands.executeCommand("codeQLDatabasesExperimental.addNewList");
+    await commands.executeCommand(
+      "codeQLVariantAnalysisRepositories.addNewList",
+    );
 
     // Check db config
     const dbConfigFilePath = path.join(storagePath, "workspace-databases.json");
@@ -53,7 +55,9 @@ describe("Db panel UI commands", () => {
       kind: DbListKind.Local,
     } as AddListQuickPickItem);
     jest.spyOn(window, "showInputBox").mockResolvedValue("my-list-1");
-    await commands.executeCommand("codeQLDatabasesExperimental.addNewList");
+    await commands.executeCommand(
+      "codeQLVariantAnalysisRepositories.addNewList",
+    );
 
     // Check db config
     const dbConfigFilePath = path.join(storagePath, "workspace-databases.json");
@@ -69,7 +73,9 @@ describe("Db panel UI commands", () => {
     } as RemoteDatabaseQuickPickItem);
 
     jest.spyOn(window, "showInputBox").mockResolvedValue("owner1/repo1");
-    await commands.executeCommand("codeQLDatabasesExperimental.addNewDatabase");
+    await commands.executeCommand(
+      "codeQLVariantAnalysisRepositories.addNewDatabase",
+    );
 
     // Check db config
     const dbConfigFilePath = path.join(storagePath, "workspace-databases.json");
@@ -85,7 +91,9 @@ describe("Db panel UI commands", () => {
     } as RemoteDatabaseQuickPickItem);
 
     jest.spyOn(window, "showInputBox").mockResolvedValue("owner1");
-    await commands.executeCommand("codeQLDatabasesExperimental.addNewDatabase");
+    await commands.executeCommand(
+      "codeQLVariantAnalysisRepositories.addNewDatabase",
+    );
 
     // Check db config
     const dbConfigFilePath = path.join(storagePath, "workspace-databases.json");
@@ -103,7 +111,7 @@ describe("Db panel UI commands", () => {
     );
 
     await commands.executeCommand(
-      "codeQLDatabasesExperimental.setSelectedItemContextMenu",
+      "codeQLVariantAnalysisRepositories.setSelectedItemContextMenu",
       treeViewItem,
     );
 


### PR DESCRIPTION
- Renamed the panel: `Databases` -> `Variant Analysis Repositories` (a21382b05394eab1136cd2465b0674b589b799ae)
- Renamed the panel id: `codeQLDatabasesExperimental` -> `codeQLVariantAnalysisRepositories` (1c3a6154c9220fde1c7cc54fad830d4e58f0e906)

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
