### PR TITLE
Increase timeout for "variant analysis submission" test

### DIFF
--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/remote-queries/variant-analysis-submission-integration.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/remote-queries/variant-analysis-submission-integration.test.ts
@@ -16,7 +16,7 @@ import { CodeQLExtensionInterface } from "../../../../src/extension";
 import { Credentials } from "../../../../src/authentication";
 import { MockGitHubApiServer } from "../../../../src/mocks/mock-gh-api-server";
 
-jest.setTimeout(10_000);
+jest.setTimeout(30_000);
 
 const mockServer = new MockGitHubApiServer();
 beforeAll(() => mockServer.startServer());


### PR DESCRIPTION
This test consistently times out for me locally, and sometimes times out on CI too (e.g. [here](https://github.com/github/vscode-codeql/actions/runs/3901556902/jobs/6663550979#step:8:133)). The timeout of 30s works for me, and will hopefully reduce some CI flakiness.



## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
