### PR TITLE
Rename db config terms to use 'variant analysis' instead of 'remote'

### DIFF
--- a/extensions/ql-vscode/src/databases/config/db-config-store.ts
+++ b/extensions/ql-vscode/src/databases/config/db-config-store.ts
@@ -26,7 +26,7 @@ import { ValueResult } from "../../common/value-result";
 import {
   LocalDatabaseDbItem,
   LocalListDbItem,
-  RemoteUserDefinedListDbItem,
+  VariantAnalysisUserDefinedListDbItem,
   DbItem,
   DbItemKind,
 } from "../db-item";
@@ -111,7 +111,7 @@ export class DbConfigStore extends DisposableObject {
       case DbItemKind.LocalList:
         config = removeLocalList(this.config, dbItem.listName);
         break;
-      case DbItemKind.RemoteUserDefinedList:
+      case DbItemKind.VariantAnalysisUserDefinedList:
         config = removeRemoteList(this.config, dbItem.listName);
         break;
       case DbItemKind.LocalDatabase:
@@ -159,7 +159,7 @@ export class DbConfigStore extends DisposableObject {
 
     const config = cloneDbConfig(this.config);
     if (parentList) {
-      const parent = config.databases.remote.repositoryLists.find(
+      const parent = config.databases.variantAnalysis.repositoryLists.find(
         (list) => list.name === parentList,
       );
       if (!parent) {
@@ -168,7 +168,7 @@ export class DbConfigStore extends DisposableObject {
         parent.repositories.push(repoNwo);
       }
     } else {
-      config.databases.remote.repositories.push(repoNwo);
+      config.databases.variantAnalysis.repositories.push(repoNwo);
     }
     await this.writeConfig(config);
   }
@@ -187,7 +187,7 @@ export class DbConfigStore extends DisposableObject {
     }
 
     const config = cloneDbConfig(this.config);
-    config.databases.remote.owners.push(owner);
+    config.databases.variantAnalysis.owners.push(owner);
 
     await this.writeConfig(config);
   }
@@ -216,7 +216,7 @@ export class DbConfigStore extends DisposableObject {
     this.validateRemoteListName(listName);
 
     const config = cloneDbConfig(this.config);
-    config.databases.remote.repositoryLists.push({
+    config.databases.variantAnalysis.repositoryLists.push({
       name: listName,
       repositories: [],
     });
@@ -244,7 +244,7 @@ export class DbConfigStore extends DisposableObject {
   }
 
   public async renameRemoteList(
-    currentDbItem: RemoteUserDefinedListDbItem,
+    currentDbItem: VariantAnalysisUserDefinedListDbItem,
     newName: string,
   ) {
     if (!this.config) {
@@ -288,7 +288,7 @@ export class DbConfigStore extends DisposableObject {
       throw Error("Cannot check remote list existence if config is not loaded");
     }
 
-    return this.config.databases.remote.repositoryLists.some(
+    return this.config.databases.variantAnalysis.repositoryLists.some(
       (l) => l.name === listName,
     );
   }
@@ -326,12 +326,12 @@ export class DbConfigStore extends DisposableObject {
     }
 
     if (listName) {
-      return this.config.databases.remote.repositoryLists.some(
+      return this.config.databases.variantAnalysis.repositoryLists.some(
         (l) => l.name === listName && l.repositories.includes(dbName),
       );
     }
 
-    return this.config.databases.remote.repositories.includes(dbName);
+    return this.config.databases.variantAnalysis.repositories.includes(dbName);
   }
 
   public doesRemoteOwnerExist(owner: string): boolean {
@@ -341,7 +341,7 @@ export class DbConfigStore extends DisposableObject {
       );
     }
 
-    return this.config.databases.remote.owners.includes(owner);
+    return this.config.databases.variantAnalysis.owners.includes(owner);
   }
 
   private async writeConfig(config: DbConfig): Promise<void> {
@@ -451,7 +451,7 @@ export class DbConfigStore extends DisposableObject {
   private createEmptyConfig(): DbConfig {
     return {
       databases: {
-        remote: {
+        variantAnalysis: {
           repositoryLists: [],
           owners: [],
           repositories: [],

--- a/extensions/ql-vscode/src/databases/config/db-config-validator.ts
+++ b/extensions/ql-vscode/src/databases/config/db-config-validator.ts
@@ -57,7 +57,7 @@ export class DbConfigValidator {
     }
 
     const duplicateRemoteDbLists = findDuplicateStrings(
-      dbConfig.databases.remote.repositoryLists.map((n) => n.name),
+      dbConfig.databases.variantAnalysis.repositoryLists.map((n) => n.name),
     );
     if (duplicateRemoteDbLists.length > 0) {
       errors.push(buildError(duplicateRemoteDbLists));
@@ -83,7 +83,7 @@ export class DbConfigValidator {
     }
 
     const duplicateRemoteDbs = findDuplicateStrings(
-      dbConfig.databases.remote.repositories,
+      dbConfig.databases.variantAnalysis.repositories,
     );
     if (duplicateRemoteDbs.length > 0) {
       errors.push(buildError(duplicateRemoteDbs));
@@ -111,7 +111,7 @@ export class DbConfigValidator {
       }
     }
 
-    for (const list of dbConfig.databases.remote.repositoryLists) {
+    for (const list of dbConfig.databases.variantAnalysis.repositoryLists) {
       const dups = findDuplicateStrings(list.repositories);
       if (dups.length > 0) {
         errors.push(buildError(list.name, dups));
@@ -124,7 +124,9 @@ export class DbConfigValidator {
   private validateOwners(dbConfig: DbConfig): DbConfigValidationError[] {
     const errors: DbConfigValidationError[] = [];
 
-    const dups = findDuplicateStrings(dbConfig.databases.remote.owners);
+    const dups = findDuplicateStrings(
+      dbConfig.databases.variantAnalysis.owners,
+    );
     if (dups.length > 0) {
       errors.push({
         kind: DbConfigValidationErrorKind.DuplicateNames,

--- a/extensions/ql-vscode/src/databases/config/db-config.ts
+++ b/extensions/ql-vscode/src/databases/config/db-config.ts
@@ -6,7 +6,7 @@ export interface DbConfig {
 }
 
 export interface DbConfigDatabases {
-  remote: RemoteDbConfig;
+  variantAnalysis: RemoteDbConfig;
   local: LocalDbConfig;
 }
 
@@ -14,17 +14,17 @@ export type SelectedDbItem =
   | SelectedLocalUserDefinedList
   | SelectedLocalDatabase
   | SelectedRemoteSystemDefinedList
-  | SelectedRemoteUserDefinedList
+  | SelectedVariantAnalysisUserDefinedList
   | SelectedRemoteOwner
   | SelectedRemoteRepository;
 
 export enum SelectedDbItemKind {
   LocalUserDefinedList = "localUserDefinedList",
   LocalDatabase = "localDatabase",
-  RemoteSystemDefinedList = "remoteSystemDefinedList",
-  RemoteUserDefinedList = "remoteUserDefinedList",
-  RemoteOwner = "remoteOwner",
-  RemoteRepository = "remoteRepository",
+  VariantAnalysisSystemDefinedList = "variantAnalysisSystemDefinedList",
+  VariantAnalysisUserDefinedList = "variantAnalysisUserDefinedList",
+  VariantAnalysisOwner = "variantAnalysisOwner",
+  VariantAnalysisRepository = "variantAnalysisRepository",
 }
 
 export interface SelectedLocalUserDefinedList {
@@ -39,22 +39,22 @@ export interface SelectedLocalDatabase {
 }
 
 export interface SelectedRemoteSystemDefinedList {
-  kind: SelectedDbItemKind.RemoteSystemDefinedList;
+  kind: SelectedDbItemKind.VariantAnalysisSystemDefinedList;
   listName: string;
 }
 
-export interface SelectedRemoteUserDefinedList {
-  kind: SelectedDbItemKind.RemoteUserDefinedList;
+export interface SelectedVariantAnalysisUserDefinedList {
+  kind: SelectedDbItemKind.VariantAnalysisUserDefinedList;
   listName: string;
 }
 
 export interface SelectedRemoteOwner {
-  kind: SelectedDbItemKind.RemoteOwner;
+  kind: SelectedDbItemKind.VariantAnalysisOwner;
   ownerName: string;
 }
 
 export interface SelectedRemoteRepository {
-  kind: SelectedDbItemKind.RemoteRepository;
+  kind: SelectedDbItemKind.VariantAnalysisRepository;
   repositoryName: string;
   listName?: string;
 }
@@ -90,15 +90,15 @@ export interface LocalDatabase {
 export function cloneDbConfig(config: DbConfig): DbConfig {
   return {
     databases: {
-      remote: {
-        repositoryLists: config.databases.remote.repositoryLists.map(
+      variantAnalysis: {
+        repositoryLists: config.databases.variantAnalysis.repositoryLists.map(
           (list) => ({
             name: list.name,
             repositories: [...list.repositories],
           }),
         ),
-        owners: [...config.databases.remote.owners],
-        repositories: [...config.databases.remote.repositories],
+        owners: [...config.databases.variantAnalysis.owners],
+        repositories: [...config.databases.variantAnalysis.repositories],
       },
       local: {
         lists: config.databases.local.lists.map((list) => ({
@@ -147,8 +147,9 @@ export function renameRemoteList(
   list.name = newListName;
 
   if (
-    config.selected?.kind === SelectedDbItemKind.RemoteUserDefinedList ||
-    config.selected?.kind === SelectedDbItemKind.RemoteRepository
+    config.selected?.kind ===
+      SelectedDbItemKind.VariantAnalysisUserDefinedList ||
+    config.selected?.kind === SelectedDbItemKind.VariantAnalysisRepository
   ) {
     if (config.selected.listName === currentListName) {
       config.selected.listName = newListName;
@@ -225,17 +226,19 @@ export function removeRemoteList(
 ): DbConfig {
   const config = cloneDbConfig(originalConfig);
 
-  config.databases.remote.repositoryLists =
-    config.databases.remote.repositoryLists.filter(
+  config.databases.variantAnalysis.repositoryLists =
+    config.databases.variantAnalysis.repositoryLists.filter(
       (list) => list.name !== listName,
     );
 
-  if (config.selected?.kind === SelectedDbItemKind.RemoteUserDefinedList) {
+  if (
+    config.selected?.kind === SelectedDbItemKind.VariantAnalysisUserDefinedList
+  ) {
     config.selected = undefined;
   }
 
   if (
-    config.selected?.kind === SelectedDbItemKind.RemoteRepository &&
+    config.selected?.kind === SelectedDbItemKind.VariantAnalysisRepository &&
     config.selected?.listName === listName
   ) {
     config.selected = undefined;
@@ -286,12 +289,14 @@ export function removeRemoteRepo(
       (r) => r !== repoFullName,
     );
   } else {
-    config.databases.remote.repositories =
-      config.databases.remote.repositories.filter((r) => r !== repoFullName);
+    config.databases.variantAnalysis.repositories =
+      config.databases.variantAnalysis.repositories.filter(
+        (r) => r !== repoFullName,
+      );
   }
 
   if (
-    config.selected?.kind === SelectedDbItemKind.RemoteRepository &&
+    config.selected?.kind === SelectedDbItemKind.VariantAnalysisRepository &&
     config.selected?.repositoryName === repoFullName &&
     config.selected?.listName === parentListName
   ) {
@@ -307,12 +312,11 @@ export function removeRemoteOwner(
 ): DbConfig {
   const config = cloneDbConfig(originalConfig);
 
-  config.databases.remote.owners = config.databases.remote.owners.filter(
-    (o) => o !== ownerName,
-  );
+  config.databases.variantAnalysis.owners =
+    config.databases.variantAnalysis.owners.filter((o) => o !== ownerName);
 
   if (
-    config.selected?.kind === SelectedDbItemKind.RemoteOwner &&
+    config.selected?.kind === SelectedDbItemKind.VariantAnalysisOwner &&
     config.selected?.ownerName === ownerName
   ) {
     config.selected = undefined;
@@ -334,24 +338,24 @@ function cloneDbConfigSelectedItem(selected: SelectedDbItem): SelectedDbItem {
         databaseName: selected.databaseName,
         listName: selected.listName,
       };
-    case SelectedDbItemKind.RemoteSystemDefinedList:
+    case SelectedDbItemKind.VariantAnalysisSystemDefinedList:
       return {
-        kind: SelectedDbItemKind.RemoteSystemDefinedList,
+        kind: SelectedDbItemKind.VariantAnalysisSystemDefinedList,
         listName: selected.listName,
       };
-    case SelectedDbItemKind.RemoteUserDefinedList:
+    case SelectedDbItemKind.VariantAnalysisUserDefinedList:
       return {
-        kind: SelectedDbItemKind.RemoteUserDefinedList,
+        kind: SelectedDbItemKind.VariantAnalysisUserDefinedList,
         listName: selected.listName,
       };
-    case SelectedDbItemKind.RemoteOwner:
+    case SelectedDbItemKind.VariantAnalysisOwner:
       return {
-        kind: SelectedDbItemKind.RemoteOwner,
+        kind: SelectedDbItemKind.VariantAnalysisOwner,
         ownerName: selected.ownerName,
       };
-    case SelectedDbItemKind.RemoteRepository:
+    case SelectedDbItemKind.VariantAnalysisRepository:
       return {
-        kind: SelectedDbItemKind.RemoteRepository,
+        kind: SelectedDbItemKind.VariantAnalysisRepository,
         repositoryName: selected.repositoryName,
         listName: selected.listName,
       };
@@ -372,7 +376,7 @@ function getRemoteList(
   config: DbConfig,
   listName: string,
 ): RemoteRepositoryList {
-  const list = config.databases.remote.repositoryLists.find(
+  const list = config.databases.variantAnalysis.repositoryLists.find(
     (l) => l.name === listName,
   );
 

--- a/extensions/ql-vscode/src/databases/db-item-expansion.ts
+++ b/extensions/ql-vscode/src/databases/db-item-expansion.ts
@@ -4,7 +4,7 @@ export type ExpandedDbItem =
   | RootLocalExpandedDbItem
   | LocalUserDefinedListExpandedDbItem
   | RootRemoteExpandedDbItem
-  | RemoteUserDefinedListExpandedDbItem;
+  | VariantAnalysisUserDefinedListExpandedDbItem;
 
 export enum ExpandedDbItemKind {
   RootLocal = "rootLocal",
@@ -26,7 +26,7 @@ export interface RootRemoteExpandedDbItem {
   kind: ExpandedDbItemKind.RootRemote;
 }
 
-export interface RemoteUserDefinedListExpandedDbItem {
+export interface VariantAnalysisUserDefinedListExpandedDbItem {
   kind: ExpandedDbItemKind.RemoteUserDefinedList;
   listName: string;
 }
@@ -89,7 +89,7 @@ function mapDbItemToExpandedDbItem(dbItem: DbItem): ExpandedDbItem {
       };
     case DbItemKind.RootRemote:
       return { kind: ExpandedDbItemKind.RootRemote };
-    case DbItemKind.RemoteUserDefinedList:
+    case DbItemKind.VariantAnalysisUserDefinedList:
       return {
         kind: ExpandedDbItemKind.RemoteUserDefinedList,
         listName: dbItem.listName,
@@ -113,7 +113,7 @@ function isDbItemEqualToExpandedDbItem(
       );
     case DbItemKind.RootRemote:
       return expandedDbItem.kind === ExpandedDbItemKind.RootRemote;
-    case DbItemKind.RemoteUserDefinedList:
+    case DbItemKind.VariantAnalysisUserDefinedList:
       return (
         expandedDbItem.kind === ExpandedDbItemKind.RemoteUserDefinedList &&
         expandedDbItem.listName === dbItem.listName

--- a/extensions/ql-vscode/src/databases/db-item-naming.ts
+++ b/extensions/ql-vscode/src/databases/db-item-naming.ts
@@ -6,7 +6,7 @@ export function getDbItemName(dbItem: DbItem): string | undefined {
     case DbItemKind.RootRemote:
       return undefined;
     case DbItemKind.LocalList:
-    case DbItemKind.RemoteUserDefinedList:
+    case DbItemKind.VariantAnalysisUserDefinedList:
     case DbItemKind.RemoteSystemDefinedList:
       return dbItem.listName;
     case DbItemKind.RemoteOwner:

--- a/extensions/ql-vscode/src/databases/db-item-selection.ts
+++ b/extensions/ql-vscode/src/databases/db-item-selection.ts
@@ -33,7 +33,7 @@ function extractSelected(
         }
       }
       break;
-    case DbItemKind.RemoteUserDefinedList:
+    case DbItemKind.VariantAnalysisUserDefinedList:
       for (const repo of dbItem.repos) {
         if (repo.selected) {
           return repo;
@@ -59,21 +59,21 @@ export function mapDbItemToSelectedDbItem(
         listName: dbItem.listName,
       };
 
-    case DbItemKind.RemoteUserDefinedList:
+    case DbItemKind.VariantAnalysisUserDefinedList:
       return {
-        kind: SelectedDbItemKind.RemoteUserDefinedList,
+        kind: SelectedDbItemKind.VariantAnalysisUserDefinedList,
         listName: dbItem.listName,
       };
 
     case DbItemKind.RemoteSystemDefinedList:
       return {
-        kind: SelectedDbItemKind.RemoteSystemDefinedList,
+        kind: SelectedDbItemKind.VariantAnalysisSystemDefinedList,
         listName: dbItem.listName,
       };
 
     case DbItemKind.RemoteOwner:
       return {
-        kind: SelectedDbItemKind.RemoteOwner,
+        kind: SelectedDbItemKind.VariantAnalysisOwner,
         ownerName: dbItem.ownerName,
       };
 
@@ -86,7 +86,7 @@ export function mapDbItemToSelectedDbItem(
 
     case DbItemKind.RemoteRepo:
       return {
-        kind: SelectedDbItemKind.RemoteRepository,
+        kind: SelectedDbItemKind.VariantAnalysisRepository,
         repositoryName: dbItem.repoFullName,
         listName: dbItem?.parentListName,
       };

--- a/extensions/ql-vscode/src/databases/db-item.ts
+++ b/extensions/ql-vscode/src/databases/db-item.ts
@@ -6,7 +6,7 @@ export enum DbItemKind {
   LocalDatabase = "LocalDatabase",
   RootRemote = "RootRemote",
   RemoteSystemDefinedList = "RemoteSystemDefinedList",
-  RemoteUserDefinedList = "RemoteUserDefinedList",
+  VariantAnalysisUserDefinedList = "VariantAnalysisUserDefinedList",
   RemoteOwner = "RemoteOwner",
   RemoteRepo = "RemoteRepo",
 }
@@ -14,7 +14,7 @@ export enum DbItemKind {
 export const remoteDbKinds = [
   DbItemKind.RootRemote,
   DbItemKind.RemoteSystemDefinedList,
-  DbItemKind.RemoteUserDefinedList,
+  DbItemKind.VariantAnalysisUserDefinedList,
   DbItemKind.RemoteOwner,
   DbItemKind.RemoteRepo,
 ];
@@ -70,7 +70,7 @@ export type DbItem =
 
 export type RemoteDbItem =
   | RemoteSystemDefinedListDbItem
-  | RemoteUserDefinedListDbItem
+  | VariantAnalysisUserDefinedListDbItem
   | RemoteOwnerDbItem
   | RemoteRepoDbItem;
 
@@ -82,8 +82,8 @@ export interface RemoteSystemDefinedListDbItem {
   listDescription: string;
 }
 
-export interface RemoteUserDefinedListDbItem {
-  kind: DbItemKind.RemoteUserDefinedList;
+export interface VariantAnalysisUserDefinedListDbItem {
+  kind: DbItemKind.VariantAnalysisUserDefinedList;
   expanded: boolean;
   selected: boolean;
   listName: string;
@@ -109,10 +109,10 @@ export function isRemoteSystemDefinedListDbItem(
   return dbItem.kind === DbItemKind.RemoteSystemDefinedList;
 }
 
-export function isRemoteUserDefinedListDbItem(
+export function isVariantAnalysisUserDefinedListDbItem(
   dbItem: DbItem,
-): dbItem is RemoteUserDefinedListDbItem {
-  return dbItem.kind === DbItemKind.RemoteUserDefinedList;
+): dbItem is VariantAnalysisUserDefinedListDbItem {
+  return dbItem.kind === DbItemKind.VariantAnalysisUserDefinedList;
 }
 
 export function isRemoteOwnerDbItem(
@@ -145,7 +145,7 @@ const SelectableDbItemKinds = [
   DbItemKind.LocalList,
   DbItemKind.LocalDatabase,
   DbItemKind.RemoteSystemDefinedList,
-  DbItemKind.RemoteUserDefinedList,
+  DbItemKind.VariantAnalysisUserDefinedList,
   DbItemKind.RemoteOwner,
   DbItemKind.RemoteRepo,
 ];
@@ -165,7 +165,7 @@ export function flattenDbItems(dbItems: DbItem[]): DbItem[] {
       case DbItemKind.RootRemote:
         allItems.push(...flattenDbItems(dbItem.children));
         break;
-      case DbItemKind.RemoteUserDefinedList:
+      case DbItemKind.VariantAnalysisUserDefinedList:
         allItems.push(...dbItem.repos);
         break;
       case DbItemKind.LocalDatabase:

--- a/extensions/ql-vscode/src/databases/db-manager.ts
+++ b/extensions/ql-vscode/src/databases/db-manager.ts
@@ -8,7 +8,7 @@ import {
   DbListKind,
   LocalDatabaseDbItem,
   LocalListDbItem,
-  RemoteUserDefinedListDbItem,
+  VariantAnalysisUserDefinedListDbItem,
 } from "./db-item";
 import {
   updateExpandedItem,
@@ -126,12 +126,14 @@ export class DbManager {
   }
 
   public async renameList(
-    currentDbItem: LocalListDbItem | RemoteUserDefinedListDbItem,
+    currentDbItem: LocalListDbItem | VariantAnalysisUserDefinedListDbItem,
     newName: string,
   ): Promise<void> {
     if (currentDbItem.kind === DbItemKind.LocalList) {
       await this.dbConfigStore.renameLocalList(currentDbItem, newName);
-    } else if (currentDbItem.kind === DbItemKind.RemoteUserDefinedList) {
+    } else if (
+      currentDbItem.kind === DbItemKind.VariantAnalysisUserDefinedList
+    ) {
       await this.dbConfigStore.renameRemoteList(currentDbItem, newName);
     }
 

--- a/extensions/ql-vscode/src/databases/db-tree-creator.ts
+++ b/extensions/ql-vscode/src/databases/db-tree-creator.ts
@@ -12,7 +12,7 @@ import {
   RemoteOwnerDbItem,
   RemoteRepoDbItem,
   RemoteSystemDefinedListDbItem,
-  RemoteUserDefinedListDbItem,
+  VariantAnalysisUserDefinedListDbItem,
   RootLocalDbItem,
   RootRemoteDbItem,
 } from "./db-item";
@@ -28,13 +28,14 @@ export function createRemoteTree(
     createSystemDefinedList(1000, dbConfig),
   ];
 
-  const userDefinedRepoLists = dbConfig.databases.remote.repositoryLists.map(
-    (r) => createRemoteUserDefinedList(r, dbConfig, expandedItems),
-  );
-  const owners = dbConfig.databases.remote.owners.map((o) =>
+  const userDefinedRepoLists =
+    dbConfig.databases.variantAnalysis.repositoryLists.map((r) =>
+      createVariantAnalysisUserDefinedList(r, dbConfig, expandedItems),
+    );
+  const owners = dbConfig.databases.variantAnalysis.owners.map((o) =>
     createOwnerItem(o, dbConfig),
   );
-  const repos = dbConfig.databases.remote.repositories.map((r) =>
+  const repos = dbConfig.databases.variantAnalysis.repositories.map((r) =>
     createRepoItem(r, dbConfig),
   );
 
@@ -84,7 +85,8 @@ function createSystemDefinedList(
 
   const selected =
     dbConfig.selected &&
-    dbConfig.selected.kind === SelectedDbItemKind.RemoteSystemDefinedList &&
+    dbConfig.selected.kind ===
+      SelectedDbItemKind.VariantAnalysisSystemDefinedList &&
     dbConfig.selected.listName === listName;
 
   return {
@@ -96,14 +98,15 @@ function createSystemDefinedList(
   };
 }
 
-function createRemoteUserDefinedList(
+function createVariantAnalysisUserDefinedList(
   list: RemoteRepositoryList,
   dbConfig: DbConfig,
   expandedItems: ExpandedDbItem[],
-): RemoteUserDefinedListDbItem {
+): VariantAnalysisUserDefinedListDbItem {
   const selected =
     dbConfig.selected &&
-    dbConfig.selected.kind === SelectedDbItemKind.RemoteUserDefinedList &&
+    dbConfig.selected.kind ===
+      SelectedDbItemKind.VariantAnalysisUserDefinedList &&
     dbConfig.selected.listName === list.name;
 
   const expanded = expandedItems.some(
@@ -113,7 +116,7 @@ function createRemoteUserDefinedList(
   );
 
   return {
-    kind: DbItemKind.RemoteUserDefinedList,
+    kind: DbItemKind.VariantAnalysisUserDefinedList,
     listName: list.name,
     repos: list.repositories.map((r) => createRepoItem(r, dbConfig, list.name)),
     selected: !!selected,
@@ -124,7 +127,7 @@ function createRemoteUserDefinedList(
 function createOwnerItem(owner: string, dbConfig: DbConfig): RemoteOwnerDbItem {
   const selected =
     dbConfig.selected &&
-    dbConfig.selected.kind === SelectedDbItemKind.RemoteOwner &&
+    dbConfig.selected.kind === SelectedDbItemKind.VariantAnalysisOwner &&
     dbConfig.selected.ownerName === owner;
 
   return {
@@ -141,7 +144,7 @@ function createRepoItem(
 ): RemoteRepoDbItem {
   const selected =
     dbConfig.selected &&
-    dbConfig.selected.kind === SelectedDbItemKind.RemoteRepository &&
+    dbConfig.selected.kind === SelectedDbItemKind.VariantAnalysisRepository &&
     dbConfig.selected.repositoryName === repo &&
     dbConfig.selected.listName === listName;
 

--- a/extensions/ql-vscode/src/databases/ui/db-item-mapper.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-item-mapper.ts
@@ -34,7 +34,7 @@ export function mapDbItemToTreeViewItem(dbItem: DbItem): DbTreeViewItem {
         dbItem.listDescription,
       );
 
-    case DbItemKind.RemoteUserDefinedList:
+    case DbItemKind.VariantAnalysisUserDefinedList:
       return createDbTreeViewItemUserDefinedList(
         dbItem,
         dbItem.listName,

--- a/extensions/ql-vscode/src/databases/ui/db-panel.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-panel.ts
@@ -23,7 +23,7 @@ import {
   LocalDatabaseDbItem,
   LocalListDbItem,
   remoteDbKinds,
-  RemoteUserDefinedListDbItem,
+  VariantAnalysisUserDefinedListDbItem,
 } from "../db-item";
 import { getDbItemName } from "../db-item-naming";
 import { DbManager } from "../db-manager";
@@ -124,7 +124,7 @@ export class DbPanel extends DisposableObject {
   private async addNewRemoteDatabase(): Promise<void> {
     const highlightedItem = await this.getHighlightedDbItem();
 
-    if (highlightedItem?.kind === DbItemKind.RemoteUserDefinedList) {
+    if (highlightedItem?.kind === DbItemKind.VariantAnalysisUserDefinedList) {
       await this.addNewRemoteRepo(highlightedItem.listName);
     } else if (
       highlightedItem?.kind === DbItemKind.RemoteRepo &&
@@ -313,8 +313,8 @@ export class DbPanel extends DisposableObject {
       case DbItemKind.LocalDatabase:
         await this.renameLocalDatabaseItem(dbItem, newName);
         break;
-      case DbItemKind.RemoteUserDefinedList:
-        await this.renameRemoteUserDefinedListItem(dbItem, newName);
+      case DbItemKind.VariantAnalysisUserDefinedList:
+        await this.renameVariantAnalysisUserDefinedListItem(dbItem, newName);
         break;
       default:
         throw Error(`Action not allowed for the '${dbItem.kind}' db item kind`);
@@ -353,8 +353,8 @@ export class DbPanel extends DisposableObject {
     await this.dbManager.renameLocalDb(dbItem, newName);
   }
 
-  private async renameRemoteUserDefinedListItem(
-    dbItem: RemoteUserDefinedListDbItem,
+  private async renameVariantAnalysisUserDefinedListItem(
+    dbItem: VariantAnalysisUserDefinedListDbItem,
     newName: string,
   ): Promise<void> {
     if (dbItem.listName === newName) {

--- a/extensions/ql-vscode/src/databases/ui/db-tree-view-item-action.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-tree-view-item-action.ts
@@ -27,7 +27,7 @@ export function getDbItemActions(dbItem: DbItem): DbTreeViewItemAction[] {
 
 const dbItemKindsThatCanBeRemoved = [
   DbItemKind.LocalList,
-  DbItemKind.RemoteUserDefinedList,
+  DbItemKind.VariantAnalysisUserDefinedList,
   DbItemKind.LocalDatabase,
   DbItemKind.RemoteRepo,
   DbItemKind.RemoteOwner,
@@ -35,7 +35,7 @@ const dbItemKindsThatCanBeRemoved = [
 
 const dbItemKindsThatCanBeRenamed = [
   DbItemKind.LocalList,
-  DbItemKind.RemoteUserDefinedList,
+  DbItemKind.VariantAnalysisUserDefinedList,
   DbItemKind.LocalDatabase,
 ];
 

--- a/extensions/ql-vscode/src/databases/ui/db-tree-view-item.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-tree-view-item.ts
@@ -7,7 +7,7 @@ import {
   RemoteOwnerDbItem,
   RemoteRepoDbItem,
   RemoteSystemDefinedListDbItem,
-  RemoteUserDefinedListDbItem,
+  VariantAnalysisUserDefinedListDbItem,
   RootLocalDbItem,
   RootRemoteDbItem,
 } from "../db-item";
@@ -97,7 +97,7 @@ export function createDbTreeViewItemSystemDefinedList(
 }
 
 export function createDbTreeViewItemUserDefinedList(
-  dbItem: LocalListDbItem | RemoteUserDefinedListDbItem,
+  dbItem: LocalListDbItem | VariantAnalysisUserDefinedListDbItem,
   listName: string,
   children: DbTreeViewItem[],
 ): DbTreeViewItem {

--- a/extensions/ql-vscode/src/remote-queries/repository-selection.ts
+++ b/extensions/ql-vscode/src/remote-queries/repository-selection.ts
@@ -46,7 +46,7 @@ export async function getRepositorySelection(
           );
         case DbItemKind.RemoteSystemDefinedList:
           return { repositoryLists: [selectedDbItem.listName] };
-        case DbItemKind.RemoteUserDefinedList:
+        case DbItemKind.VariantAnalysisUserDefinedList:
           if (selectedDbItem.repos.length === 0) {
             throw new UserCancellationException(
               "The selected repository list is empty. Please add repositories to it before running a variant analysis.",

--- a/extensions/ql-vscode/test/factories/db-config-factories.ts
+++ b/extensions/ql-vscode/test/factories/db-config-factories.ts
@@ -24,7 +24,7 @@ export function createDbConfig({
 } = {}): DbConfig {
   return {
     databases: {
-      remote: {
+      variantAnalysis: {
         repositoryLists: remoteLists,
         owners: remoteOwners,
         repositories: remoteRepos,

--- a/extensions/ql-vscode/test/factories/db-item-factories.ts
+++ b/extensions/ql-vscode/test/factories/db-item-factories.ts
@@ -8,7 +8,7 @@ import {
   RemoteOwnerDbItem,
   RemoteRepoDbItem,
   RemoteSystemDefinedListDbItem,
-  RemoteUserDefinedListDbItem,
+  VariantAnalysisUserDefinedListDbItem,
   RootLocalDbItem,
   RootRemoteDbItem,
 } from "../../src/databases/db-item";
@@ -79,7 +79,7 @@ export function createRemoteSystemDefinedListDbItem({
   };
 }
 
-export function createRemoteUserDefinedListDbItem({
+export function createVariantAnalysisUserDefinedListDbItem({
   expanded = false,
   selected = false,
   listName = `list${faker.datatype.number()}`,
@@ -93,9 +93,9 @@ export function createRemoteUserDefinedListDbItem({
   expanded?: boolean;
   selected?: boolean;
   repos?: RemoteRepoDbItem[];
-} = {}): RemoteUserDefinedListDbItem {
+} = {}): VariantAnalysisUserDefinedListDbItem {
   return {
-    kind: DbItemKind.RemoteUserDefinedList,
+    kind: DbItemKind.VariantAnalysisUserDefinedList,
     expanded,
     selected,
     listName,

--- a/extensions/ql-vscode/test/unit-tests/databases/config/data/without-selected/workspace-databases.json
+++ b/extensions/ql-vscode/test/unit-tests/databases/config/data/without-selected/workspace-databases.json
@@ -1,6 +1,6 @@
 {
   "databases": {
-    "remote": {
+    "variantAnalysis": {
       "repositoryLists": [],
       "owners": [],
       "repositories": []

--- a/extensions/ql-vscode/test/unit-tests/databases/config/data/workspace-databases.json
+++ b/extensions/ql-vscode/test/unit-tests/databases/config/data/workspace-databases.json
@@ -1,6 +1,6 @@
 {
   "databases": {
-    "remote": {
+    "variantAnalysis": {
       "repositoryLists": [
         {
           "name": "repoList1",
@@ -46,7 +46,7 @@
     }
   },
   "selected": {
-    "kind": "remoteUserDefinedList",
+    "kind": "variantAnalysisUserDefinedList",
     "listName": "repoList1"
   }
 }

--- a/extensions/ql-vscode/test/unit-tests/databases/config/db-config-store.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/config/db-config-store.test.ts
@@ -16,7 +16,7 @@ import {
   createLocalListDbItem,
   createRemoteOwnerDbItem,
   createRemoteRepoDbItem,
-  createRemoteUserDefinedListDbItem,
+  createVariantAnalysisUserDefinedListDbItem,
 } from "../../../factories/db-item-factories";
 import { createMockApp } from "../../../__mocks__/appMock";
 
@@ -51,9 +51,9 @@ describe("db config store", () => {
       expect(await pathExists(configPath)).toBe(true);
 
       const config = configStore.getConfig().value;
-      expect(config.databases.remote.repositoryLists).toHaveLength(0);
-      expect(config.databases.remote.owners).toHaveLength(0);
-      expect(config.databases.remote.repositories).toHaveLength(0);
+      expect(config.databases.variantAnalysis.repositoryLists).toHaveLength(0);
+      expect(config.databases.variantAnalysis.owners).toHaveLength(0);
+      expect(config.databases.variantAnalysis.repositories).toHaveLength(0);
       expect(config.databases.local.lists).toHaveLength(0);
       expect(config.databases.local.databases).toHaveLength(0);
       expect(config.selected).toBeUndefined();
@@ -70,14 +70,14 @@ describe("db config store", () => {
       await configStore.initialize();
 
       const config = configStore.getConfig().value;
-      expect(config.databases.remote.repositoryLists).toHaveLength(1);
-      expect(config.databases.remote.repositoryLists[0]).toEqual({
+      expect(config.databases.variantAnalysis.repositoryLists).toHaveLength(1);
+      expect(config.databases.variantAnalysis.repositoryLists[0]).toEqual({
         name: "repoList1",
         repositories: ["foo/bar", "foo/baz"],
       });
-      expect(config.databases.remote.owners).toHaveLength(0);
-      expect(config.databases.remote.repositories).toHaveLength(3);
-      expect(config.databases.remote.repositories).toEqual([
+      expect(config.databases.variantAnalysis.owners).toHaveLength(0);
+      expect(config.databases.variantAnalysis.repositories).toHaveLength(3);
+      expect(config.databases.variantAnalysis.repositories).toEqual([
         "owner/repo1",
         "owner/repo2",
         "owner/repo3",
@@ -102,7 +102,7 @@ describe("db config store", () => {
         storagePath: "/path/to/database/",
       });
       expect(config.selected).toEqual({
-        kind: "remoteUserDefinedList",
+        kind: SelectedDbItemKind.VariantAnalysisUserDefinedList,
         listName: "repoList1",
       });
 
@@ -139,12 +139,12 @@ describe("db config store", () => {
       await configStore.initialize();
 
       const config = configStore.getConfig().value;
-      config.databases.remote.repositoryLists = [];
+      config.databases.variantAnalysis.repositoryLists = [];
 
       const reRetrievedConfig = configStore.getConfig().value;
-      expect(reRetrievedConfig.databases.remote.repositoryLists).toHaveLength(
-        1,
-      );
+      expect(
+        reRetrievedConfig.databases.variantAnalysis.repositoryLists,
+      ).toHaveLength(1);
 
       configStore.dispose();
     });
@@ -211,7 +211,7 @@ describe("db config store", () => {
       const updatedDbConfig = (await readJSON(configPath)) as DbConfig;
 
       // Check that the config file has been updated
-      const updatedRemoteDbs = updatedDbConfig.databases.remote;
+      const updatedRemoteDbs = updatedDbConfig.databases.variantAnalysis;
       expect(updatedRemoteDbs.repositories).toHaveLength(1);
       expect(updatedRemoteDbs.repositories).toEqual(["repo1"]);
 
@@ -238,7 +238,7 @@ describe("db config store", () => {
       const updatedDbConfig = (await readJSON(configPath)) as DbConfig;
 
       // Check that the config file has been updated
-      const updatedRemoteDbs = updatedDbConfig.databases.remote;
+      const updatedRemoteDbs = updatedDbConfig.databases.variantAnalysis;
       expect(updatedRemoteDbs.repositories).toHaveLength(0);
       expect(updatedRemoteDbs.repositoryLists).toHaveLength(1);
       expect(updatedRemoteDbs.repositoryLists[0]).toEqual({
@@ -262,7 +262,7 @@ describe("db config store", () => {
       const updatedDbConfig = (await readJSON(configPath)) as DbConfig;
 
       // Check that the config file has been updated
-      const updatedRemoteDbs = updatedDbConfig.databases.remote;
+      const updatedRemoteDbs = updatedDbConfig.databases.variantAnalysis;
       expect(updatedRemoteDbs.owners).toHaveLength(1);
       expect(updatedRemoteDbs.owners).toEqual(["owner1"]);
 
@@ -302,7 +302,7 @@ describe("db config store", () => {
       const updatedDbConfig = (await readJSON(configPath)) as DbConfig;
 
       // Check that the config file has been updated
-      const updatedRemoteDbs = updatedDbConfig.databases.remote;
+      const updatedRemoteDbs = updatedDbConfig.databases.variantAnalysis;
       expect(updatedRemoteDbs.repositoryLists).toHaveLength(1);
       expect(updatedRemoteDbs.repositoryLists[0].name).toEqual("list1");
 
@@ -333,7 +333,7 @@ describe("db config store", () => {
           },
         ],
         selected: {
-          kind: SelectedDbItemKind.RemoteRepository,
+          kind: SelectedDbItemKind.VariantAnalysisRepository,
           repositoryName: "owner/repo2",
           listName: "list1",
         },
@@ -342,7 +342,7 @@ describe("db config store", () => {
       const configStore = await initializeConfig(dbConfig, configPath, app);
 
       // Rename
-      const currentDbItem = createRemoteUserDefinedListDbItem({
+      const currentDbItem = createVariantAnalysisUserDefinedListDbItem({
         listName: "list1",
       });
       await configStore.renameRemoteList(currentDbItem, "listRenamed");
@@ -351,12 +351,12 @@ describe("db config store", () => {
       const updatedDbConfig = (await readJSON(configPath)) as DbConfig;
 
       // Check that the config file has been updated
-      const updatedRemoteDbs = updatedDbConfig.databases.remote;
+      const updatedRemoteDbs = updatedDbConfig.databases.variantAnalysis;
       expect(updatedRemoteDbs.repositoryLists).toHaveLength(1);
       expect(updatedRemoteDbs.repositoryLists[0].name).toEqual("listRenamed");
 
       expect(updatedDbConfig.selected).toEqual({
-        kind: SelectedDbItemKind.RemoteRepository,
+        kind: SelectedDbItemKind.VariantAnalysisRepository,
         repositoryName: "owner/repo2",
         listName: "listRenamed",
       });
@@ -471,7 +471,7 @@ describe("db config store", () => {
       const configStore = await initializeConfig(dbConfig, configPath, app);
 
       // Rename
-      const currentDbItem = createRemoteUserDefinedListDbItem({
+      const currentDbItem = createVariantAnalysisUserDefinedListDbItem({
         listName: "list1",
       });
       await expect(
@@ -500,7 +500,7 @@ describe("db config store", () => {
       const dbConfig = createDbConfig({
         remoteOwners: ["owner1", "owner2"],
         selected: {
-          kind: SelectedDbItemKind.RemoteOwner,
+          kind: SelectedDbItemKind.VariantAnalysisOwner,
           ownerName: "owner1",
         },
       });
@@ -517,7 +517,7 @@ describe("db config store", () => {
       const updatedDbConfig = (await readJSON(configPath)) as DbConfig;
 
       // Check that the config file has been updated
-      const updatedRemoteDbs = updatedDbConfig.databases.remote;
+      const updatedRemoteDbs = updatedDbConfig.databases.variantAnalysis;
       expect(updatedRemoteDbs.owners).toHaveLength(1);
       expect(updatedRemoteDbs.owners[0]).toEqual("owner2");
 
@@ -536,7 +536,7 @@ describe("db config store", () => {
           },
         ],
         selected: {
-          kind: SelectedDbItemKind.RemoteUserDefinedList,
+          kind: SelectedDbItemKind.VariantAnalysisUserDefinedList,
           listName: "list1",
         },
       });
@@ -544,7 +544,7 @@ describe("db config store", () => {
       const configStore = await initializeConfig(dbConfig, configPath, app);
 
       // Remove
-      const currentDbItem = createRemoteUserDefinedListDbItem({
+      const currentDbItem = createVariantAnalysisUserDefinedListDbItem({
         listName: "list1",
       });
       await configStore.removeDbItem(currentDbItem);
@@ -553,7 +553,7 @@ describe("db config store", () => {
       const updatedDbConfig = (await readJSON(configPath)) as DbConfig;
 
       // Check that the config file has been updated
-      const updatedRemoteDbs = updatedDbConfig.databases.remote;
+      const updatedRemoteDbs = updatedDbConfig.databases.variantAnalysis;
       expect(updatedRemoteDbs.repositoryLists).toHaveLength(0);
 
       expect(updatedDbConfig.selected).toEqual(undefined);
@@ -571,7 +571,7 @@ describe("db config store", () => {
           },
         ],
         selected: {
-          kind: SelectedDbItemKind.RemoteRepository,
+          kind: SelectedDbItemKind.VariantAnalysisRepository,
           repositoryName: "owner/repo1",
           listName: "list1",
         },
@@ -590,7 +590,7 @@ describe("db config store", () => {
       const updatedDbConfig = (await readJSON(configPath)) as DbConfig;
 
       // Check that the config file has been updated
-      const updatedRemoteDbs = updatedDbConfig.databases.remote;
+      const updatedRemoteDbs = updatedDbConfig.databases.variantAnalysis;
       expect(updatedRemoteDbs.repositoryLists[0].repositories).toHaveLength(1);
       expect(updatedRemoteDbs.repositoryLists[0].repositories[0]).toEqual(
         "owner/repo2",
@@ -622,7 +622,7 @@ describe("db config store", () => {
 
       // Set selected
       const selectedItem: SelectedDbItem = {
-        kind: SelectedDbItemKind.RemoteOwner,
+        kind: SelectedDbItemKind.VariantAnalysisOwner,
         ownerName: "owner2",
       };
 

--- a/extensions/ql-vscode/test/unit-tests/databases/config/db-config-validator.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/config/db-config-validator.test.ts
@@ -16,7 +16,7 @@ describe("db config validation", () => {
     // like to make sure validation errors are highlighted.
     const dbConfig = {
       databases: {
-        remote: {
+        variantAnalysis: {
           repositoryLists: [
             {
               name: "repoList1",
@@ -39,11 +39,12 @@ describe("db config validation", () => {
     });
     expect(validationOutput[1]).toEqual({
       kind: DbConfigValidationErrorKind.InvalidConfig,
-      message: "/databases/remote must have required property 'owners'",
+      message:
+        "/databases/variantAnalysis must have required property 'owners'",
     });
     expect(validationOutput[2]).toEqual({
       kind: DbConfigValidationErrorKind.InvalidConfig,
-      message: "/databases/remote must NOT have additional properties",
+      message: "/databases/variantAnalysis must NOT have additional properties",
     });
   });
 

--- a/extensions/ql-vscode/test/unit-tests/databases/config/db-config.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/config/db-config.test.ts
@@ -157,7 +157,7 @@ describe("db config", () => {
         "listRenamed",
       );
 
-      expect(updatedConfig.databases.remote.repositoryLists).toEqual([
+      expect(updatedConfig.databases.variantAnalysis.repositoryLists).toEqual([
         {
           name: "listRenamed",
           repositories: [],
@@ -182,7 +182,7 @@ describe("db config", () => {
           },
         ],
         selected: {
-          kind: SelectedDbItemKind.RemoteUserDefinedList,
+          kind: SelectedDbItemKind.VariantAnalysisUserDefinedList,
           listName: "list1",
         },
       });
@@ -193,7 +193,7 @@ describe("db config", () => {
         "listRenamed",
       );
 
-      expect(updatedConfig.databases.remote.repositoryLists).toEqual([
+      expect(updatedConfig.databases.variantAnalysis.repositoryLists).toEqual([
         {
           name: "listRenamed",
           repositories: [],
@@ -205,7 +205,7 @@ describe("db config", () => {
       ]);
 
       expect(updatedConfig.selected).toEqual({
-        kind: SelectedDbItemKind.RemoteUserDefinedList,
+        kind: SelectedDbItemKind.VariantAnalysisUserDefinedList,
         listName: "listRenamed",
       });
     });
@@ -224,7 +224,7 @@ describe("db config", () => {
           },
         ],
         selected: {
-          kind: SelectedDbItemKind.RemoteRepository,
+          kind: SelectedDbItemKind.VariantAnalysisRepository,
           repositoryName: selectedRemoteRepo,
           listName: "list1",
         },
@@ -236,19 +236,19 @@ describe("db config", () => {
         "listRenamed",
       );
       const updatedRepositoryLists =
-        updatedConfig.databases.remote.repositoryLists;
+        updatedConfig.databases.variantAnalysis.repositoryLists;
 
       expect(updatedRepositoryLists.length).toEqual(2);
       expect(updatedRepositoryLists[0]).toEqual({
-        ...originalConfig.databases.remote.repositoryLists[0],
+        ...originalConfig.databases.variantAnalysis.repositoryLists[0],
         name: "listRenamed",
       });
       expect(updatedRepositoryLists[1]).toEqual(
-        originalConfig.databases.remote.repositoryLists[1],
+        originalConfig.databases.variantAnalysis.repositoryLists[1],
       );
 
       expect(updatedConfig.selected).toEqual({
-        kind: SelectedDbItemKind.RemoteRepository,
+        kind: SelectedDbItemKind.VariantAnalysisRepository,
         repositoryName: selectedRemoteRepo,
         listName: "listRenamed",
       });
@@ -471,7 +471,7 @@ describe("db config", () => {
 
       const updatedConfig = removeRemoteList(originalConfig, "list1");
 
-      expect(updatedConfig.databases.remote.repositoryLists).toEqual([
+      expect(updatedConfig.databases.variantAnalysis.repositoryLists).toEqual([
         {
           name: "list2",
           repositories: [],
@@ -492,14 +492,14 @@ describe("db config", () => {
           },
         ],
         selected: {
-          kind: SelectedDbItemKind.RemoteUserDefinedList,
+          kind: SelectedDbItemKind.VariantAnalysisUserDefinedList,
           listName: "list1",
         },
       });
 
       const updatedConfig = removeRemoteList(originalConfig, "list1");
 
-      expect(updatedConfig.databases.remote.repositoryLists).toEqual([
+      expect(updatedConfig.databases.variantAnalysis.repositoryLists).toEqual([
         {
           name: "list2",
           repositories: [],
@@ -523,7 +523,7 @@ describe("db config", () => {
           },
         ],
         selected: {
-          kind: SelectedDbItemKind.RemoteRepository,
+          kind: SelectedDbItemKind.VariantAnalysisRepository,
           repositoryName: selectedRemoteRepo,
           listName: "list1",
         },
@@ -531,11 +531,11 @@ describe("db config", () => {
 
       const updatedConfig = removeRemoteList(originalConfig, "list1");
       const updatedRepositoryLists =
-        updatedConfig.databases.remote.repositoryLists;
+        updatedConfig.databases.variantAnalysis.repositoryLists;
 
       expect(updatedRepositoryLists.length).toEqual(1);
       expect(updatedRepositoryLists[0]).toEqual(
-        originalConfig.databases.remote.repositoryLists[1],
+        originalConfig.databases.variantAnalysis.repositoryLists[1],
       );
       expect(updatedConfig.selected).toBeUndefined();
     });
@@ -661,8 +661,8 @@ describe("db config", () => {
 
       const updatedConfig = removeRemoteRepo(originalConfig, repo1);
 
-      const updatedRemoteDbs = updatedConfig.databases.remote;
-      const originalRemoteDbs = originalConfig.databases.remote;
+      const updatedRemoteDbs = updatedConfig.databases.variantAnalysis;
+      const originalRemoteDbs = originalConfig.databases.variantAnalysis;
       expect(updatedRemoteDbs.repositories.length).toEqual(1);
       expect(updatedRemoteDbs.repositories[0]).toEqual(repo2);
       expect(updatedRemoteDbs.repositoryLists).toEqual(
@@ -689,8 +689,8 @@ describe("db config", () => {
       });
 
       const updatedConfig = removeRemoteRepo(originalConfig, repo1, list1.name);
-      const updatedRemoteDbs = updatedConfig.databases.remote;
-      const originalRemoteDbs = originalConfig.databases.remote;
+      const updatedRemoteDbs = updatedConfig.databases.variantAnalysis;
+      const originalRemoteDbs = originalConfig.databases.variantAnalysis;
       expect(updatedRemoteDbs.repositories).toEqual(
         originalRemoteDbs.repositories,
       );
@@ -719,15 +719,15 @@ describe("db config", () => {
         ],
         remoteRepos: [repo1, repo2],
         selected: {
-          kind: SelectedDbItemKind.RemoteRepository,
+          kind: SelectedDbItemKind.VariantAnalysisRepository,
           repositoryName: repo1,
         },
       });
 
       const updatedConfig = removeRemoteRepo(originalConfig, repo1);
 
-      const updatedRemoteDbs = updatedConfig.databases.remote;
-      const originalRemoteDbs = originalConfig.databases.remote;
+      const updatedRemoteDbs = updatedConfig.databases.variantAnalysis;
+      const originalRemoteDbs = originalConfig.databases.variantAnalysis;
       expect(updatedRemoteDbs.repositories.length).toEqual(1);
       expect(updatedRemoteDbs.repositories[0]).toEqual(repo2);
       expect(updatedRemoteDbs.repositoryLists).toEqual(
@@ -748,7 +748,7 @@ describe("db config", () => {
 
       const updatedConfig = removeRemoteOwner(originalConfig, owner1);
 
-      const updatedRemoteDbs = updatedConfig.databases.remote;
+      const updatedRemoteDbs = updatedConfig.databases.variantAnalysis;
       expect(updatedRemoteDbs.owners).toEqual([owner2]);
     });
 
@@ -759,14 +759,14 @@ describe("db config", () => {
       const originalConfig = createDbConfig({
         remoteOwners: [owner1, owner2],
         selected: {
-          kind: SelectedDbItemKind.RemoteOwner,
+          kind: SelectedDbItemKind.VariantAnalysisOwner,
           ownerName: owner1,
         },
       });
 
       const updatedConfig = removeRemoteOwner(originalConfig, owner1);
 
-      const updatedRemoteDbs = updatedConfig.databases.remote;
+      const updatedRemoteDbs = updatedConfig.databases.variantAnalysis;
       expect(updatedRemoteDbs.owners).toEqual([owner2]);
       expect(updatedConfig.selected).toBeUndefined();
     });

--- a/extensions/ql-vscode/test/unit-tests/databases/db-item-expansion.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/db-item-expansion.test.ts
@@ -7,7 +7,7 @@ import {
 } from "../../../src/databases/db-item-expansion";
 import {
   createLocalListDbItem,
-  createRemoteUserDefinedListDbItem,
+  createVariantAnalysisUserDefinedListDbItem,
   createRootLocalDbItem,
   createRootRemoteDbItem,
 } from "../../factories/db-item-factories";
@@ -25,7 +25,7 @@ describe("db item expansion", () => {
         },
       ];
 
-      const dbItem = createRemoteUserDefinedListDbItem({
+      const dbItem = createVariantAnalysisUserDefinedListDbItem({
         listName: "list2",
       });
 
@@ -45,7 +45,7 @@ describe("db item expansion", () => {
     });
 
     it("should add an expanded item to an empty list", () => {
-      const dbItem = createRemoteUserDefinedListDbItem({
+      const dbItem = createVariantAnalysisUserDefinedListDbItem({
         listName: "list2",
       });
 
@@ -70,7 +70,7 @@ describe("db item expansion", () => {
         },
       ];
 
-      const dbItem = createRemoteUserDefinedListDbItem({
+      const dbItem = createVariantAnalysisUserDefinedListDbItem({
         listName: "list1",
       });
 
@@ -126,7 +126,7 @@ describe("db item expansion", () => {
         },
       ];
 
-      const currentDbItem = createRemoteUserDefinedListDbItem({
+      const currentDbItem = createVariantAnalysisUserDefinedListDbItem({
         listName: "list1",
       });
 
@@ -184,7 +184,7 @@ describe("db item expansion", () => {
       const dbItems = [
         createRootRemoteDbItem({
           children: [
-            createRemoteUserDefinedListDbItem({
+            createVariantAnalysisUserDefinedListDbItem({
               listName: "list2",
             }),
           ],

--- a/extensions/ql-vscode/test/unit-tests/databases/db-item-naming.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/db-item-naming.test.ts
@@ -5,7 +5,7 @@ import {
   createRemoteOwnerDbItem,
   createRemoteRepoDbItem,
   createRemoteSystemDefinedListDbItem,
-  createRemoteUserDefinedListDbItem,
+  createVariantAnalysisUserDefinedListDbItem,
   createRootLocalDbItem,
   createRootRemoteDbItem,
 } from "../../factories/db-item-factories";
@@ -37,7 +37,7 @@ describe("db item naming", () => {
     });
 
     it("return list name for remote user defined list db item", () => {
-      const dbItem = createRemoteUserDefinedListDbItem();
+      const dbItem = createVariantAnalysisUserDefinedListDbItem();
 
       const name = getDbItemName(dbItem);
 

--- a/extensions/ql-vscode/test/unit-tests/databases/db-item-selection.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/db-item-selection.test.ts
@@ -6,7 +6,7 @@ import {
   createRemoteOwnerDbItem,
   createRemoteRepoDbItem,
   createRemoteSystemDefinedListDbItem,
-  createRemoteUserDefinedListDbItem,
+  createVariantAnalysisUserDefinedListDbItem,
   createRootLocalDbItem,
   createRootRemoteDbItem,
 } from "../../factories/db-item-factories";
@@ -18,7 +18,7 @@ describe("db item selection", () => {
         children: [
           createRemoteSystemDefinedListDbItem(),
           createRemoteOwnerDbItem(),
-          createRemoteUserDefinedListDbItem(),
+          createVariantAnalysisUserDefinedListDbItem(),
         ],
       }),
       createRootLocalDbItem({
@@ -67,7 +67,7 @@ describe("db item selection", () => {
         children: [
           createRemoteSystemDefinedListDbItem(),
           createRemoteOwnerDbItem(),
-          createRemoteUserDefinedListDbItem({
+          createVariantAnalysisUserDefinedListDbItem({
             listName: "my list",
             selected: true,
             repos: [
@@ -80,7 +80,7 @@ describe("db item selection", () => {
     ];
 
     expect(getSelectedDbItem(dbItems)).toEqual({
-      kind: DbItemKind.RemoteUserDefinedList,
+      kind: DbItemKind.VariantAnalysisUserDefinedList,
       expanded: false,
       listName: "my list",
       repos: [
@@ -105,7 +105,7 @@ describe("db item selection", () => {
         children: [
           createRemoteSystemDefinedListDbItem(),
           createRemoteOwnerDbItem(),
-          createRemoteUserDefinedListDbItem(),
+          createVariantAnalysisUserDefinedListDbItem(),
         ],
       }),
       createRemoteSystemDefinedListDbItem({
@@ -131,7 +131,7 @@ describe("db item selection", () => {
         children: [
           createRemoteSystemDefinedListDbItem(),
           createRemoteOwnerDbItem(),
-          createRemoteUserDefinedListDbItem({
+          createVariantAnalysisUserDefinedListDbItem({
             repos: [],
             selected: true,
             listName: "list84",
@@ -141,7 +141,7 @@ describe("db item selection", () => {
     ];
     expect(getSelectedDbItem(dbItems)).toEqual({
       expanded: false,
-      kind: DbItemKind.RemoteUserDefinedList,
+      kind: DbItemKind.VariantAnalysisUserDefinedList,
       listName: "list84",
       repos: [],
       selected: true,

--- a/extensions/ql-vscode/test/unit-tests/databases/db-item.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/db-item.test.ts
@@ -9,7 +9,7 @@ import {
   createRemoteOwnerDbItem,
   createRemoteRepoDbItem,
   createRemoteSystemDefinedListDbItem,
-  createRemoteUserDefinedListDbItem,
+  createVariantAnalysisUserDefinedListDbItem,
   createRootLocalDbItem,
   createRootRemoteDbItem,
 } from "../../factories/db-item-factories";
@@ -22,14 +22,14 @@ describe("DbItem", () => {
           children: [
             createRemoteSystemDefinedListDbItem({ listName: "top10" }),
             createRemoteSystemDefinedListDbItem({ listName: "top100" }),
-            createRemoteUserDefinedListDbItem({
+            createVariantAnalysisUserDefinedListDbItem({
               listName: "remote-list1",
               repos: [
                 createRemoteRepoDbItem({ repoFullName: "owner1/repo1" }),
                 createRemoteRepoDbItem({ repoFullName: "owner1/repo2" }),
               ],
             }),
-            createRemoteUserDefinedListDbItem({
+            createVariantAnalysisUserDefinedListDbItem({
               listName: "remote-list2",
               repos: [
                 createRemoteRepoDbItem({ repoFullName: "owner2/repo1" }),
@@ -82,7 +82,7 @@ describe("DbItem", () => {
       expect(
         items.find(
           (item) =>
-            item.kind === DbItemKind.RemoteUserDefinedList &&
+            item.kind === DbItemKind.VariantAnalysisUserDefinedList &&
             item.listName === name,
         ),
       ).toBeDefined();

--- a/extensions/ql-vscode/test/unit-tests/databases/db-manager.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/db-manager.test.ts
@@ -11,12 +11,12 @@ import {
   isLocalListDbItem,
   isRemoteOwnerDbItem,
   isRemoteRepoDbItem,
-  isRemoteUserDefinedListDbItem,
+  isVariantAnalysisUserDefinedListDbItem,
   LocalDatabaseDbItem,
   LocalListDbItem,
   RemoteOwnerDbItem,
   RemoteRepoDbItem,
-  RemoteUserDefinedListDbItem,
+  VariantAnalysisUserDefinedListDbItem,
 } from "../../../src/databases/db-item";
 import { DbManager } from "../../../src/databases/db-manager";
 import {
@@ -78,7 +78,8 @@ describe("db manager", () => {
 
       await saveDbConfig(dbConfig);
 
-      const remoteListDbItems = getRemoteUserDefinedListDbItems("my-list-1");
+      const remoteListDbItems =
+        getVariantAnalysisUserDefinedListDbItems("my-list-1");
       expect(remoteListDbItems.length).toEqual(1);
 
       await dbManager.renameList(remoteListDbItems[0], "my-list-2");
@@ -86,7 +87,8 @@ describe("db manager", () => {
       const dbConfigFileContents = await readDbConfigDirectly();
 
       // Check that the remote list has been renamed
-      const remoteLists = dbConfigFileContents.databases.remote.repositoryLists;
+      const remoteLists =
+        dbConfigFileContents.databases.variantAnalysis.repositoryLists;
       expect(remoteLists.length).toBe(1);
       expect(remoteLists[0]).toEqual({
         name: "my-list-2",
@@ -126,7 +128,8 @@ describe("db manager", () => {
       });
 
       // Check that the remote list has not been renamed
-      const remoteLists = dbConfigFileContents.databases.remote.repositoryLists;
+      const remoteLists =
+        dbConfigFileContents.databases.variantAnalysis.repositoryLists;
       expect(remoteLists.length).toBe(1);
       expect(remoteLists[0]).toEqual({
         name: "my-list-1",
@@ -211,7 +214,7 @@ describe("db manager", () => {
       localLists: [localList],
       localDbs: [localDb],
       selected: {
-        kind: SelectedDbItemKind.RemoteUserDefinedList,
+        kind: SelectedDbItemKind.VariantAnalysisUserDefinedList,
         listName: remoteList.name,
       },
     });
@@ -219,7 +222,8 @@ describe("db manager", () => {
     it("should remove remote user-defined list", async () => {
       await saveDbConfig(dbConfig);
 
-      const remoteListDbItems = getRemoteUserDefinedListDbItems("my-list-1");
+      const remoteListDbItems =
+        getVariantAnalysisUserDefinedListDbItems("my-list-1");
       expect(remoteListDbItems.length).toEqual(1);
 
       await dbManager.removeDbItem(remoteListDbItems[0]);
@@ -228,7 +232,7 @@ describe("db manager", () => {
 
       expect(dbConfigFileContents).toEqual({
         databases: {
-          remote: {
+          variantAnalysis: {
             repositoryLists: [],
             repositories: [remoteRepo1, remoteRepo2],
             owners: [remoteOwner],
@@ -253,7 +257,7 @@ describe("db manager", () => {
 
       expect(dbConfigFileContents).toEqual({
         databases: {
-          remote: {
+          variantAnalysis: {
             repositoryLists: [remoteList],
             repositories: [remoteRepo2],
             owners: [remoteOwner],
@@ -264,7 +268,7 @@ describe("db manager", () => {
           },
         },
         selected: {
-          kind: SelectedDbItemKind.RemoteUserDefinedList,
+          kind: SelectedDbItemKind.VariantAnalysisUserDefinedList,
           listName: remoteList.name,
         },
       });
@@ -282,7 +286,7 @@ describe("db manager", () => {
 
       expect(dbConfigFileContents).toEqual({
         databases: {
-          remote: {
+          variantAnalysis: {
             repositoryLists: [remoteList],
             repositories: [remoteRepo1, remoteRepo2],
             owners: [],
@@ -293,7 +297,7 @@ describe("db manager", () => {
           },
         },
         selected: {
-          kind: SelectedDbItemKind.RemoteUserDefinedList,
+          kind: SelectedDbItemKind.VariantAnalysisUserDefinedList,
           listName: remoteList.name,
         },
       });
@@ -311,7 +315,7 @@ describe("db manager", () => {
 
       expect(dbConfigFileContents).toEqual({
         databases: {
-          remote: {
+          variantAnalysis: {
             repositoryLists: [remoteList],
             repositories: [remoteRepo1, remoteRepo2],
             owners: [remoteOwner],
@@ -322,7 +326,7 @@ describe("db manager", () => {
           },
         },
         selected: {
-          kind: SelectedDbItemKind.RemoteUserDefinedList,
+          kind: SelectedDbItemKind.VariantAnalysisUserDefinedList,
           listName: remoteList.name,
         },
       });
@@ -340,7 +344,7 @@ describe("db manager", () => {
 
       expect(dbConfigFileContents).toEqual({
         databases: {
-          remote: {
+          variantAnalysis: {
             repositoryLists: [remoteList],
             repositories: [remoteRepo1, remoteRepo2],
             owners: [remoteOwner],
@@ -351,7 +355,7 @@ describe("db manager", () => {
           },
         },
         selected: {
-          kind: SelectedDbItemKind.RemoteUserDefinedList,
+          kind: SelectedDbItemKind.VariantAnalysisUserDefinedList,
           listName: remoteList.name,
         },
       });
@@ -423,13 +427,13 @@ describe("db manager", () => {
     return ownerDbItems;
   }
 
-  function getRemoteUserDefinedListDbItems(
+  function getVariantAnalysisUserDefinedListDbItems(
     listName: string,
-  ): RemoteUserDefinedListDbItem[] {
+  ): VariantAnalysisUserDefinedListDbItem[] {
     const dbItemsResult = dbManager.getDbItems();
     const dbItems = flattenDbItems(dbItemsResult.value);
     const listDbItems = dbItems
-      .filter(isRemoteUserDefinedListDbItem)
+      .filter(isVariantAnalysisUserDefinedListDbItem)
       .filter((i) => i.listName === listName);
 
     return listDbItems;

--- a/extensions/ql-vscode/test/unit-tests/databases/db-tree-creator.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/db-tree-creator.test.ts
@@ -6,7 +6,7 @@ import {
   DbItemKind,
   isRemoteOwnerDbItem,
   isRemoteRepoDbItem,
-  isRemoteUserDefinedListDbItem,
+  isVariantAnalysisUserDefinedListDbItem,
 } from "../../../src/databases/db-item";
 import {
   ExpandedDbItem,
@@ -71,37 +71,41 @@ describe("db tree creator", () => {
       expect(dbTreeRoot).toBeTruthy();
       expect(dbTreeRoot.kind).toBe(DbItemKind.RootRemote);
       const repositoryListNodes = dbTreeRoot.children.filter(
-        isRemoteUserDefinedListDbItem,
+        isVariantAnalysisUserDefinedListDbItem,
       );
 
       expect(repositoryListNodes.length).toBe(2);
       expect(repositoryListNodes[0]).toEqual({
-        kind: DbItemKind.RemoteUserDefinedList,
+        kind: DbItemKind.VariantAnalysisUserDefinedList,
         selected: false,
         expanded: false,
-        listName: dbConfig.databases.remote.repositoryLists[0].name,
-        repos: dbConfig.databases.remote.repositoryLists[0].repositories.map(
-          (repo) => ({
-            kind: DbItemKind.RemoteRepo,
-            selected: false,
-            repoFullName: repo,
-            parentListName: dbConfig.databases.remote.repositoryLists[0].name,
-          }),
-        ),
+        listName: dbConfig.databases.variantAnalysis.repositoryLists[0].name,
+        repos:
+          dbConfig.databases.variantAnalysis.repositoryLists[0].repositories.map(
+            (repo) => ({
+              kind: DbItemKind.RemoteRepo,
+              selected: false,
+              repoFullName: repo,
+              parentListName:
+                dbConfig.databases.variantAnalysis.repositoryLists[0].name,
+            }),
+          ),
       });
       expect(repositoryListNodes[1]).toEqual({
-        kind: DbItemKind.RemoteUserDefinedList,
+        kind: DbItemKind.VariantAnalysisUserDefinedList,
         selected: false,
         expanded: false,
-        listName: dbConfig.databases.remote.repositoryLists[1].name,
-        repos: dbConfig.databases.remote.repositoryLists[1].repositories.map(
-          (repo) => ({
-            kind: DbItemKind.RemoteRepo,
-            selected: false,
-            repoFullName: repo,
-            parentListName: dbConfig.databases.remote.repositoryLists[1].name,
-          }),
-        ),
+        listName: dbConfig.databases.variantAnalysis.repositoryLists[1].name,
+        repos:
+          dbConfig.databases.variantAnalysis.repositoryLists[1].repositories.map(
+            (repo) => ({
+              kind: DbItemKind.RemoteRepo,
+              selected: false,
+              repoFullName: repo,
+              parentListName:
+                dbConfig.databases.variantAnalysis.repositoryLists[1].name,
+            }),
+          ),
       });
     });
 
@@ -120,12 +124,12 @@ describe("db tree creator", () => {
       expect(ownerNodes[0]).toEqual({
         kind: DbItemKind.RemoteOwner,
         selected: false,
-        ownerName: dbConfig.databases.remote.owners[0],
+        ownerName: dbConfig.databases.variantAnalysis.owners[0],
       });
       expect(ownerNodes[1]).toEqual({
         kind: DbItemKind.RemoteOwner,
         selected: false,
-        ownerName: dbConfig.databases.remote.owners[1],
+        ownerName: dbConfig.databases.variantAnalysis.owners[1],
       });
     });
 
@@ -144,17 +148,17 @@ describe("db tree creator", () => {
       expect(repoNodes[0]).toEqual({
         kind: DbItemKind.RemoteRepo,
         selected: false,
-        repoFullName: dbConfig.databases.remote.repositories[0],
+        repoFullName: dbConfig.databases.variantAnalysis.repositories[0],
       });
       expect(repoNodes[1]).toEqual({
         kind: DbItemKind.RemoteRepo,
         selected: false,
-        repoFullName: dbConfig.databases.remote.repositories[1],
+        repoFullName: dbConfig.databases.variantAnalysis.repositories[1],
       });
       expect(repoNodes[2]).toEqual({
         kind: DbItemKind.RemoteRepo,
         selected: false,
-        repoFullName: dbConfig.databases.remote.repositories[2],
+        repoFullName: dbConfig.databases.variantAnalysis.repositories[2],
       });
     });
 
@@ -168,7 +172,7 @@ describe("db tree creator", () => {
             },
           ],
           selected: {
-            kind: SelectedDbItemKind.RemoteUserDefinedList,
+            kind: SelectedDbItemKind.VariantAnalysisUserDefinedList,
             listName: "my-list-1",
           },
         });
@@ -178,7 +182,7 @@ describe("db tree creator", () => {
         expect(dbTreeRoot).toBeTruthy();
         expect(dbTreeRoot.kind).toBe(DbItemKind.RootRemote);
         const repositoryListNodes = dbTreeRoot.children.filter(
-          (child) => child.kind === DbItemKind.RemoteUserDefinedList,
+          (child) => child.kind === DbItemKind.VariantAnalysisUserDefinedList,
         );
 
         expect(repositoryListNodes.length).toBe(1);
@@ -189,7 +193,7 @@ describe("db tree creator", () => {
         const dbConfig = createDbConfig({
           remoteOwners: ["owner1", "owner2"],
           selected: {
-            kind: SelectedDbItemKind.RemoteOwner,
+            kind: SelectedDbItemKind.VariantAnalysisOwner,
             ownerName: "owner1",
           },
         });
@@ -211,7 +215,7 @@ describe("db tree creator", () => {
         const dbConfig = createDbConfig({
           remoteRepos: ["owner1/repo1", "owner1/repo2"],
           selected: {
-            kind: SelectedDbItemKind.RemoteRepository,
+            kind: SelectedDbItemKind.VariantAnalysisRepository,
             repositoryName: "owner1/repo2",
           },
         });
@@ -237,7 +241,7 @@ describe("db tree creator", () => {
           ],
           remoteRepos: ["owner1/repo2"],
           selected: {
-            kind: SelectedDbItemKind.RemoteRepository,
+            kind: SelectedDbItemKind.VariantAnalysisRepository,
             listName: "my-list-1",
             repositoryName: "owner1/repo1",
           },
@@ -248,7 +252,7 @@ describe("db tree creator", () => {
         expect(dbTreeRoot).toBeTruthy();
 
         const listNodes = dbTreeRoot.children.filter(
-          isRemoteUserDefinedListDbItem,
+          isVariantAnalysisUserDefinedListDbItem,
         );
 
         expect(listNodes.length).toBe(1);
@@ -300,7 +304,7 @@ describe("db tree creator", () => {
         expect(dbTreeRoot.kind).toBe(DbItemKind.RootRemote);
         expect(dbTreeRoot.expanded).toBe(true);
         const repositoryListNodes = dbTreeRoot.children.filter(
-          isRemoteUserDefinedListDbItem,
+          isVariantAnalysisUserDefinedListDbItem,
         );
 
         expect(repositoryListNodes.length).toBe(1);

--- a/extensions/ql-vscode/test/unit-tests/databases/ui/db-tree-view-item-action.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/ui/db-tree-view-item-action.test.ts
@@ -8,7 +8,7 @@ import {
   createRemoteOwnerDbItem,
   createRemoteRepoDbItem,
   createRemoteSystemDefinedListDbItem,
-  createRemoteUserDefinedListDbItem,
+  createVariantAnalysisUserDefinedListDbItem,
   createRootLocalDbItem,
   createRootRemoteDbItem,
 } from "../../../factories/db-item-factories";
@@ -63,7 +63,7 @@ describe("getDbItemActions", () => {
   });
 
   it("should set canBeSelected, canBeRemoved and canBeRenamed for remote user defined db list", () => {
-    const dbItem = createRemoteUserDefinedListDbItem();
+    const dbItem = createVariantAnalysisUserDefinedListDbItem();
 
     const actions = getDbItemActions(dbItem);
 
@@ -71,7 +71,9 @@ describe("getDbItemActions", () => {
   });
 
   it("should not set canBeSelected for remote user defined db list that is already selected", () => {
-    const dbItem = createRemoteUserDefinedListDbItem({ selected: true });
+    const dbItem = createVariantAnalysisUserDefinedListDbItem({
+      selected: true,
+    });
 
     const actions = getDbItemActions(dbItem);
 
@@ -133,7 +135,7 @@ describe("getGitHubUrl", () => {
   it("should return undefined for other remote db items", () => {
     const dbItem0 = createRootRemoteDbItem();
     const dbItem1 = createRemoteSystemDefinedListDbItem();
-    const dbItem2 = createRemoteUserDefinedListDbItem();
+    const dbItem2 = createVariantAnalysisUserDefinedListDbItem();
 
     const actualUrl0 = getGitHubUrl(dbItem0);
     const actualUrl1 = getGitHubUrl(dbItem1);

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/databases/db-panel.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/databases/db-panel.test.ts
@@ -45,8 +45,10 @@ describe("Db panel UI commands", () => {
     // Check db config
     const dbConfigFilePath = path.join(storagePath, "workspace-databases.json");
     const dbConfig: DbConfig = await readJson(dbConfigFilePath);
-    expect(dbConfig.databases.remote.repositoryLists).toHaveLength(1);
-    expect(dbConfig.databases.remote.repositoryLists[0].name).toBe("my-list-1");
+    expect(dbConfig.databases.variantAnalysis.repositoryLists).toHaveLength(1);
+    expect(dbConfig.databases.variantAnalysis.repositoryLists[0].name).toBe(
+      "my-list-1",
+    );
   });
 
   it("should add new local db list", async () => {
@@ -80,8 +82,10 @@ describe("Db panel UI commands", () => {
     // Check db config
     const dbConfigFilePath = path.join(storagePath, "workspace-databases.json");
     const dbConfig: DbConfig = await readJson(dbConfigFilePath);
-    expect(dbConfig.databases.remote.repositories).toHaveLength(1);
-    expect(dbConfig.databases.remote.repositories[0]).toBe("owner1/repo1");
+    expect(dbConfig.databases.variantAnalysis.repositories).toHaveLength(1);
+    expect(dbConfig.databases.variantAnalysis.repositories[0]).toBe(
+      "owner1/repo1",
+    );
   });
 
   it("should add new remote owner", async () => {
@@ -98,8 +102,8 @@ describe("Db panel UI commands", () => {
     // Check db config
     const dbConfigFilePath = path.join(storagePath, "workspace-databases.json");
     const dbConfig: DbConfig = await readJson(dbConfigFilePath);
-    expect(dbConfig.databases.remote.owners).toHaveLength(1);
-    expect(dbConfig.databases.remote.owners[0]).toBe("owner1");
+    expect(dbConfig.databases.variantAnalysis.owners).toHaveLength(1);
+    expect(dbConfig.databases.variantAnalysis.owners[0]).toBe("owner1");
   });
 
   it("should select db item", async () => {
@@ -120,7 +124,7 @@ describe("Db panel UI commands", () => {
     const dbConfig: DbConfig = await readJson(dbConfigFilePath);
     expect(dbConfig.selected).toBeDefined();
     expect(dbConfig.selected).toEqual({
-      kind: SelectedDbItemKind.RemoteSystemDefinedList,
+      kind: SelectedDbItemKind.VariantAnalysisSystemDefinedList,
       listName,
     });
   });

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/databases/db-panel.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/databases/db-panel.test.ts
@@ -133,7 +133,7 @@ describe("db panel", () => {
     expect(systemDefinedListItems.length).toBe(3);
 
     const userDefinedListItems = remoteRootNode.children.filter(
-      (item) => item.dbItem?.kind === DbItemKind.RemoteUserDefinedList,
+      (item) => item.dbItem?.kind === DbItemKind.VariantAnalysisUserDefinedList,
     );
     expect(userDefinedListItems.length).toBe(2);
     checkUserDefinedListItem(userDefinedListItems[0], "my-list-1", [
@@ -358,7 +358,7 @@ describe("db panel", () => {
         },
       ],
       selected: {
-        kind: SelectedDbItemKind.RemoteUserDefinedList,
+        kind: SelectedDbItemKind.VariantAnalysisUserDefinedList,
         listName: "my-list-2",
       },
     });
@@ -376,12 +376,12 @@ describe("db panel", () => {
 
     const list1 = remoteRootNode.children.find(
       (c) =>
-        c.dbItem?.kind === DbItemKind.RemoteUserDefinedList &&
+        c.dbItem?.kind === DbItemKind.VariantAnalysisUserDefinedList &&
         c.dbItem?.listName === "my-list-1",
     );
     const list2 = remoteRootNode.children.find(
       (c) =>
-        c.dbItem?.kind === DbItemKind.RemoteUserDefinedList &&
+        c.dbItem?.kind === DbItemKind.VariantAnalysisUserDefinedList &&
         c.dbItem?.listName === "my-list-2",
     );
 
@@ -405,7 +405,7 @@ describe("db panel", () => {
       ],
       remoteRepos: ["owner1/repo1"],
       selected: {
-        kind: SelectedDbItemKind.RemoteRepository,
+        kind: SelectedDbItemKind.VariantAnalysisRepository,
         repositoryName: "owner1/repo1",
         listName: "my-list-2",
       },
@@ -424,7 +424,7 @@ describe("db panel", () => {
 
     const list2 = remoteRootNode.children.find(
       (c) =>
-        c.dbItem?.kind === DbItemKind.RemoteUserDefinedList &&
+        c.dbItem?.kind === DbItemKind.VariantAnalysisUserDefinedList &&
         c.dbItem?.listName === "my-list-2",
     );
     expect(list2).toBeTruthy();
@@ -479,10 +479,12 @@ describe("db panel", () => {
       await dbManager.addNewRemoteRepo("owner2/repo2");
 
       const dbConfigFileContents = await readDbConfigDirectly();
-      expect(dbConfigFileContents.databases.remote.repositories.length).toBe(2);
-      expect(dbConfigFileContents.databases.remote.repositories[1]).toEqual(
-        "owner2/repo2",
-      );
+      expect(
+        dbConfigFileContents.databases.variantAnalysis.repositories.length,
+      ).toBe(2);
+      expect(
+        dbConfigFileContents.databases.variantAnalysis.repositories[1],
+      ).toEqual("owner2/repo2");
     });
 
     it("should add a new remote repo to a user defined list", async () => {
@@ -504,11 +506,11 @@ describe("db panel", () => {
 
       const remoteRootNode = items[0];
       const remoteUserDefinedLists = remoteRootNode.children.filter(
-        (c) => c.dbItem?.kind === DbItemKind.RemoteUserDefinedList,
+        (c) => c.dbItem?.kind === DbItemKind.VariantAnalysisUserDefinedList,
       );
       const list1 = remoteRootNode.children.find(
         (c) =>
-          c.dbItem?.kind === DbItemKind.RemoteUserDefinedList &&
+          c.dbItem?.kind === DbItemKind.VariantAnalysisUserDefinedList &&
           c.dbItem?.listName === "my-list-1",
       );
 
@@ -521,11 +523,13 @@ describe("db panel", () => {
       // We can't use the dbConfigStore's `read` function here because it depends on the file watcher
       // picking up changes, and we don't control the timing of that.
       const dbConfigFileContents = await readJSON(dbConfigFilePath);
-      expect(dbConfigFileContents.databases.remote.repositoryLists.length).toBe(
-        1,
-      );
+      expect(
+        dbConfigFileContents.databases.variantAnalysis.repositoryLists.length,
+      ).toBe(1);
 
-      expect(dbConfigFileContents.databases.remote.repositoryLists[0]).toEqual({
+      expect(
+        dbConfigFileContents.databases.variantAnalysis.repositoryLists[0],
+      ).toEqual({
         name: "my-list-1",
         repositories: ["owner1/repo1", "owner2/repo2"],
       });
@@ -542,7 +546,7 @@ describe("db panel", () => {
           },
         ],
         selected: {
-          kind: SelectedDbItemKind.RemoteUserDefinedList,
+          kind: SelectedDbItemKind.VariantAnalysisUserDefinedList,
           listName: "my-list-1",
         },
       });
@@ -556,11 +560,11 @@ describe("db panel", () => {
 
       const remoteRootNode = items[0];
       const remoteUserDefinedLists = remoteRootNode.children.filter(
-        (c) => c.dbItem?.kind === DbItemKind.RemoteUserDefinedList,
+        (c) => c.dbItem?.kind === DbItemKind.VariantAnalysisUserDefinedList,
       );
       const list1 = remoteRootNode.children.find(
         (c) =>
-          c.dbItem?.kind === DbItemKind.RemoteUserDefinedList &&
+          c.dbItem?.kind === DbItemKind.VariantAnalysisUserDefinedList &&
           c.dbItem?.listName === "my-list-1",
       );
 
@@ -570,10 +574,12 @@ describe("db panel", () => {
       await dbManager.addNewList(DbListKind.Remote, "my-list-2");
 
       const dbConfigFileContents = await readDbConfigDirectly();
-      expect(dbConfigFileContents.databases.remote.repositoryLists.length).toBe(
-        2,
-      );
-      expect(dbConfigFileContents.databases.remote.repositoryLists[1]).toEqual({
+      expect(
+        dbConfigFileContents.databases.variantAnalysis.repositoryLists.length,
+      ).toBe(2);
+      expect(
+        dbConfigFileContents.databases.variantAnalysis.repositoryLists[1],
+      ).toEqual({
         name: "my-list-2",
         repositories: [],
       });

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/remote-queries/repository-selection.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/remote-queries/repository-selection.test.ts
@@ -39,7 +39,7 @@ describe("repository selection", () => {
 
     it("should log an error when an empty remote user defined list is selected", async () => {
       const dbManager = setUpDbManager({
-        kind: DbItemKind.RemoteUserDefinedList,
+        kind: DbItemKind.VariantAnalysisUserDefinedList,
         repos: [] as RemoteRepoDbItem[],
       } as DbItem);
 
@@ -63,7 +63,7 @@ describe("repository selection", () => {
 
     it("should return correct selection when remote user defined list is selected", async () => {
       const dbManager = setUpDbManager({
-        kind: DbItemKind.RemoteUserDefinedList,
+        kind: DbItemKind.VariantAnalysisUserDefinedList,
         repos: [
           { repoFullName: "owner1/repo1" },
           { repoFullName: "owner1/repo2" },

--- a/extensions/ql-vscode/workspace-databases-schema.json
+++ b/extensions/ql-vscode/workspace-databases-schema.json
@@ -7,7 +7,7 @@
     "databases": {
       "type": "object",
       "properties": {
-        "remote": {
+        "variantAnalysis": {
           "type": "object",
           "properties": {
             "repositoryLists": {
@@ -125,7 +125,7 @@
           "additionalProperties": false
         }
       },
-      "required": ["remote", "local"],
+      "required": ["variantAnalysis", "local"],
       "additionalProperties": false
     },
     "selected": {
@@ -166,7 +166,7 @@
           "properties": {
             "kind": {
               "type": "string",
-              "enum": ["remoteSystemDefinedList"]
+              "enum": ["variantAnalysisSystemDefinedList"]
             },
             "listName": {
               "type": "string",
@@ -180,7 +180,7 @@
           "properties": {
             "kind": {
               "type": "string",
-              "enum": ["remoteUserDefinedList"]
+              "enum": ["variantAnalysisUserDefinedList"]
             },
             "listName": {
               "type": "string",
@@ -194,7 +194,7 @@
           "properties": {
             "kind": {
               "type": "string",
-              "enum": ["remoteOwner"]
+              "enum": ["variantAnalysisOwner"]
             },
             "ownerName": {
               "type": "string",
@@ -208,7 +208,7 @@
           "properties": {
             "kind": {
               "type": "string",
-              "enum": ["remoteRepository"]
+              "enum": ["variantAnalysisRepository"]
             },
             "repositoryName": {
               "type": "string",


### PR DESCRIPTION
Details in linked internal issue.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
