### PR TITLE
Rename feature flag

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1294,7 +1294,7 @@
         {
           "id": "codeQLVariantAnalysisRepositories",
           "name": "Variant Analysis Repositories",
-          "when": "config.codeQL.canary && config.codeQL.newQueryRunExperience"
+          "when": "config.codeQL.canary && config.codeQL.variantAnalysis.repositoriesPanel"
         },
         {
           "id": "codeQLQueryHistory",

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -559,16 +559,15 @@ export function isVariantAnalysisLiveResultsEnabled(): boolean {
 }
 
 /**
- * A flag indicating whether to use the new query run experience which involves
- * using a new database panel.
+ * A flag indicating whether to use the new "variant analysis repositories" panel.
  */
-const NEW_QUERY_RUN_EXPERIENCE = new Setting(
+const VARIANT_ANALYSIS_REPOS_PANEL = new Setting(
   "newQueryRunExperience",
   ROOT_SETTING,
 );
 
-export function isNewQueryRunExperienceEnabled(): boolean {
-  return !!NEW_QUERY_RUN_EXPERIENCE.getValue<boolean>();
+export function isVariantAnalysisReposPanelEnabled(): boolean {
+  return !!VARIANT_ANALYSIS_REPOS_PANEL.getValue<boolean>();
 }
 
 // Settings for mocking the GitHub API.

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -562,8 +562,8 @@ export function isVariantAnalysisLiveResultsEnabled(): boolean {
  * A flag indicating whether to use the new "variant analysis repositories" panel.
  */
 const VARIANT_ANALYSIS_REPOS_PANEL = new Setting(
-  "newQueryRunExperience",
-  ROOT_SETTING,
+  "repositoriesPanel",
+  VARIANT_ANALYSIS_SETTING,
 );
 
 export function isVariantAnalysisReposPanelEnabled(): boolean {

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -476,7 +476,7 @@ export const NO_CACHE_AST_VIEWER = new Setting(
 );
 
 // Settings for variant analysis
-const REMOTE_QUERIES_SETTING = new Setting("variantAnalysis", ROOT_SETTING);
+const VARIANT_ANALYSIS_SETTING = new Setting("variantAnalysis", ROOT_SETTING);
 
 /**
  * Lists of GitHub repositories that you want to query remotely via the "Run Variant Analysis" command.
@@ -487,7 +487,7 @@ const REMOTE_QUERIES_SETTING = new Setting("variantAnalysis", ROOT_SETTING);
  */
 const REMOTE_REPO_LISTS = new Setting(
   "repositoryLists",
-  REMOTE_QUERIES_SETTING,
+  VARIANT_ANALYSIS_SETTING,
 );
 
 export function getRemoteRepositoryLists():
@@ -513,7 +513,7 @@ export async function setRemoteRepositoryLists(
  */
 const REPO_LISTS_PATH = new Setting(
   "repositoryListsPath",
-  REMOTE_QUERIES_SETTING,
+  VARIANT_ANALYSIS_SETTING,
 );
 
 export function getRemoteRepositoryListsPath(): string | undefined {
@@ -528,7 +528,7 @@ export function getRemoteRepositoryListsPath(): string | undefined {
  */
 const REMOTE_CONTROLLER_REPO = new Setting(
   "controllerRepo",
-  REMOTE_QUERIES_SETTING,
+  VARIANT_ANALYSIS_SETTING,
 );
 
 export function getRemoteControllerRepo(): string | undefined {
@@ -544,7 +544,7 @@ export async function setRemoteControllerRepo(repo: string | undefined) {
  * Default value is "main".
  * Note: This command is only available for internal users.
  */
-const ACTION_BRANCH = new Setting("actionBranch", REMOTE_QUERIES_SETTING);
+const ACTION_BRANCH = new Setting("actionBranch", VARIANT_ANALYSIS_SETTING);
 
 export function getActionBranch(): string {
   return ACTION_BRANCH.getValue<string>() || "main";

--- a/extensions/ql-vscode/src/databases/db-module.ts
+++ b/extensions/ql-vscode/src/databases/db-module.ts
@@ -6,7 +6,7 @@ import { DbConfigStore } from "./config/db-config-store";
 import { DbManager } from "./db-manager";
 import { DbPanel } from "./ui/db-panel";
 import { DbSelectionDecorationProvider } from "./ui/db-selection-decoration-provider";
-import { isCanary, isNewQueryRunExperienceEnabled } from "../config";
+import { isCanary, isVariantAnalysisReposPanelEnabled } from "../config";
 
 export class DbModule extends DisposableObject {
   public readonly dbManager: DbManager;
@@ -36,7 +36,7 @@ export class DbModule extends DisposableObject {
       return true;
     }
 
-    return isCanary() && isNewQueryRunExperienceEnabled();
+    return isCanary() && isVariantAnalysisReposPanelEnabled();
   }
 
   private async initialize(): Promise<void> {

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -642,7 +642,7 @@ async function activateWithInstalledDistribution(
     cliServer,
     variantAnalysisStorageDir,
     variantAnalysisResultsManager,
-    dbModule?.dbManager, // the dbModule is only needed when the newQueryRunExperience is enabled
+    dbModule?.dbManager, // the dbModule is only needed when variantAnalysisReposPanel is enabled
   );
   ctx.subscriptions.push(variantAnalysisManager);
   ctx.subscriptions.push(variantAnalysisResultsManager);

--- a/extensions/ql-vscode/src/remote-queries/repository-selection.ts
+++ b/extensions/ql-vscode/src/remote-queries/repository-selection.ts
@@ -4,7 +4,7 @@ import { extLogger } from "../common";
 import {
   getRemoteRepositoryLists,
   getRemoteRepositoryListsPath,
-  isNewQueryRunExperienceEnabled,
+  isVariantAnalysisReposPanelEnabled,
 } from "../config";
 import { OWNER_REGEX, REPO_REGEX } from "../pure/helpers-pure";
 import { UserCancellationException } from "../commandRunner";
@@ -36,7 +36,7 @@ interface RepoList {
 export async function getRepositorySelection(
   dbManager?: DbManager,
 ): Promise<RepositorySelection> {
-  if (isNewQueryRunExperienceEnabled()) {
+  if (isVariantAnalysisReposPanelEnabled()) {
     const selectedDbItem = dbManager?.getSelectedDbItem();
     if (selectedDbItem) {
       switch (selectedDbItem.kind) {

--- a/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
@@ -225,7 +225,7 @@ export async function prepareRemoteQueryRun(
   uri: Uri | undefined,
   progress: ProgressCallback,
   token: CancellationToken,
-  dbManager?: DbManager, // the dbManager is only needed when the newQueryRunExperience is enabled
+  dbManager?: DbManager, // the dbManager is only needed when variantAnalysisReposPanel is enabled
 ): Promise<PreparedRemoteQuery> {
   if (!(await cliServer.cliConstraints.supportsRemoteQueries())) {
     throw new Error(

--- a/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/remote-queries/variant-analysis-manager.ts
@@ -61,7 +61,7 @@ import {
 } from "../pure/variant-analysis-filter-sort";
 import { URLSearchParams } from "url";
 import { DbManager } from "../databases/db-manager";
-import { isNewQueryRunExperienceEnabled } from "../config";
+import { isVariantAnalysisReposPanelEnabled } from "../config";
 
 export class VariantAnalysisManager
   extends DisposableObject
@@ -103,7 +103,7 @@ export class VariantAnalysisManager
     private readonly cliServer: CodeQLCliServer,
     private readonly storagePath: string,
     private readonly variantAnalysisResultsManager: VariantAnalysisResultsManager,
-    private readonly dbManager?: DbManager, // the dbManager is only needed when the newQueryRunExperience is enabled
+    private readonly dbManager?: DbManager, // the dbManager is only needed when variantAnalysisReposPanel is enabled
   ) {
     super();
     this.variantAnalysisMonitor = this.push(
@@ -622,7 +622,7 @@ export class VariantAnalysisManager
     }
 
     let text: string[];
-    if (isNewQueryRunExperienceEnabled()) {
+    if (isVariantAnalysisReposPanelEnabled()) {
       text = [
         "{",
         `    "name": "new-repo-list",`,

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/remote-queries/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/remote-queries/variant-analysis-manager.test.ts
@@ -1009,10 +1009,10 @@ describe("Variant Analysis Manager", () => {
         expect(writeTextStub).toBeCalledTimes(1);
       });
 
-      describe("newQueryRunExperience true", () => {
+      describe("variantAnalysisReposPanel true", () => {
         beforeEach(() => {
           jest
-            .spyOn(config, "isNewQueryRunExperienceEnabled")
+            .spyOn(config, "isVariantAnalysisReposPanelEnabled")
             .mockReturnValue(true);
         });
 
@@ -1077,7 +1077,7 @@ describe("Variant Analysis Manager", () => {
           });
         });
       });
-      describe("newQueryRunExperience false", () => {
+      describe("variantAnalysisReposPanel false", () => {
         it("should be valid JSON when put in object", async () => {
           await variantAnalysisManager.copyRepoListToClipboard(
             variantAnalysis.id,

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/remote-queries/repository-selection.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/remote-queries/repository-selection.test.ts
@@ -12,10 +12,10 @@ import {
 } from "../../../../src/databases/db-item";
 
 describe("repository selection", () => {
-  describe("newQueryRunExperience true", () => {
+  describe("variantAnalysisReposPanel true", () => {
     beforeEach(() => {
       jest
-        .spyOn(config, "isNewQueryRunExperienceEnabled")
+        .spyOn(config, "isVariantAnalysisReposPanelEnabled")
         .mockReturnValue(true);
     });
 
@@ -115,7 +115,7 @@ describe("repository selection", () => {
     }
   });
 
-  describe("newQueryRunExperience false", () => {
+  describe("variantAnalysisReposPanel false", () => {
     let quickPickSpy: jest.SpiedFunction<typeof window.showQuickPick>;
     let showInputBoxSpy: jest.SpiedFunction<typeof window.showInputBox>;
 


### PR DESCRIPTION
Renames the `codeQL.newQueryRunExperience` feature flag to `codeQL.variantAnalysis.repositoriesPanel`. 

- The first two commits just rename some internal methods/variables (to make them more consistent with the public names).
- The third commit actually changes the user-facing feature flag in the config.

## Checklist

N/A—internal only 🎨

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
