### PR TITLE
Use Webpack in production mode for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,12 @@ jobs:
           name: vscode-codeql-extension
           path: artifacts
 
+      - name: Upload source maps
+        uses: actions/upload-artifact@v3
+        with:
+          name: vscode-codeql-sourcemaps
+          path: dist/vscode-codeql/out/*.map
+
         # TODO Run tests, or check that a test run on the same branch succeeded.
 
       - name: Create release

--- a/extensions/ql-vscode/gulpfile.ts/deploy.ts
+++ b/extensions/ql-vscode/gulpfile.ts/deploy.ts
@@ -8,6 +8,7 @@ import {
   writeFile,
 } from "fs-extra";
 import { resolve, join } from "path";
+import { isDevBuild } from "./dev";
 
 export interface DeployedPackage {
   distPath: string;
@@ -53,8 +54,6 @@ export async function deployPackage(
       await readFile(packageJsonPath, "utf8"),
     );
 
-    // Default to development build; use flag --release to indicate release build.
-    const isDevBuild = !process.argv.includes("--release");
     const distDir = join(__dirname, "../../../dist");
     await mkdirs(distDir);
 

--- a/extensions/ql-vscode/gulpfile.ts/dev.ts
+++ b/extensions/ql-vscode/gulpfile.ts/dev.ts
@@ -1,0 +1,2 @@
+// Default to development build; use flag --release to indicate release build.
+export const isDevBuild = !process.argv.includes("--release");

--- a/extensions/ql-vscode/gulpfile.ts/webpack.config.ts
+++ b/extensions/ql-vscode/gulpfile.ts/webpack.config.ts
@@ -54,6 +54,9 @@ export const config: webpack.Configuration = {
           MiniCssExtractPlugin.loader,
           {
             loader: "css-loader",
+            options: {
+              sourceMap: true,
+            },
           },
         ],
       },

--- a/extensions/ql-vscode/gulpfile.ts/webpack.config.ts
+++ b/extensions/ql-vscode/gulpfile.ts/webpack.config.ts
@@ -1,9 +1,10 @@
 import { resolve } from "path";
 import * as webpack from "webpack";
 import MiniCssExtractPlugin from "mini-css-extract-plugin";
+import { isDevBuild } from "./dev";
 
 export const config: webpack.Configuration = {
-  mode: "development",
+  mode: isDevBuild ? "development" : "production",
   entry: {
     webview: "./src/view/webview.tsx",
   },
@@ -11,7 +12,7 @@ export const config: webpack.Configuration = {
     path: resolve(__dirname, "..", "out"),
     filename: "[name].js",
   },
-  devtool: "inline-source-map",
+  devtool: isDevBuild ? "inline-source-map" : "source-map",
   resolve: {
     extensions: [".js", ".ts", ".tsx", ".json"],
     fallback: {


### PR DESCRIPTION
This will set the `mode` of Webpack to `production` for release builds. It will also stop inlining the sourcemap and instead produce a separate file which is excluded by `.vscodeignore`.

In terms of the bundled extension, this will add 1 file (`out/webview.js.LICENSE.txt`). It decreases the size of the VSIX file from 4.28MB to 1.77MB.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
