### PR TITLE
Use stdin for supplying auth to CodeQL

### DIFF
--- a/extensions/ql-vscode/src/authentication.ts
+++ b/extensions/ql-vscode/src/authentication.ts
@@ -4,10 +4,11 @@ import { retry } from "@octokit/plugin-retry";
 
 const GITHUB_AUTH_PROVIDER_ID = "github";
 
-// We need 'repo' scope for triggering workflows and 'gist' scope for exporting results to Gist.
+// We need 'repo' scope for triggering workflows, 'gist' scope for exporting results to Gist,
+// and 'read:packages' for reading private CodeQL packages.
 // For a comprehensive list of scopes, see:
 // https://docs.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps
-const SCOPES = ["repo", "gist"];
+const SCOPES = ["repo", "gist", "read:packages"];
 
 /**
  * Handles authentication to GitHub, using the VS Code [authentication API](https://code.visualstudio.com/api/references/vscode-api#authentication).
@@ -57,15 +58,31 @@ export class Credentials {
       return this.octokit;
     }
 
+    const accessToken = await this.getAccessToken();
+
+    return new Octokit.Octokit({
+      auth: accessToken,
+      retry,
+    });
+  }
+
+  async getAccessToken(): Promise<string> {
     const session = await vscode.authentication.getSession(
       GITHUB_AUTH_PROVIDER_ID,
       SCOPES,
       { createIfNone: true },
     );
 
-    return new Octokit.Octokit({
-      auth: session.accessToken,
-      retry,
-    });
+    return session.accessToken;
+  }
+
+  async getExistingAccessToken(): Promise<string | undefined> {
+    const session = await vscode.authentication.getSession(
+      GITHUB_AUTH_PROVIDER_ID,
+      SCOPES,
+      { createIfNone: false },
+    );
+
+    return session?.accessToken;
   }
 }

--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -619,7 +619,17 @@ export class CodeQLCliServer implements Disposable {
       progressReporter,
       async (line) => {
         if (line.startsWith("Enter value for --github-auth-stdin")) {
-          return credentials.getAccessToken();
+          try {
+            return await credentials.getAccessToken();
+          } catch (e) {
+            // If the user cancels the authentication prompt, we still need to give a value to the CLI.
+            // By giving a potentially invalid value, the user will just get a 401/403 when they try to access a
+            // private package and the access token is invalid.
+            // This code path is very rare to hit. It would only be hit if the user is logged in when
+            // starting the command, then logging out before the getAccessToken() is called again and
+            // then cancelling the authentication prompt.
+            return accessToken;
+          }
         }
 
         return undefined;

--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -549,7 +549,7 @@ export class CodeQLCliServer implements Disposable {
   }
 
   /**
-   * Runs a CodeQL CLI command, returning the output as JSON.
+   * Runs a CodeQL CLI command, parsing the output as JSON.
    * @param command The `codeql` command to be run, provided as an array of command/subcommand names.
    * @param commandArgs The arguments to pass to the `codeql` command.
    * @param description Description of the action being run, to be shown in log and error messages.
@@ -590,7 +590,20 @@ export class CodeQLCliServer implements Disposable {
   }
 
   /**
-   * Runs a CodeQL CLI command, returning the output as JSON.
+   * Runs a CodeQL CLI command with authentication, parsing the output as JSON.
+   *
+   * This method is intended for use with commands that accept a `--github-auth-stdin` argument. This
+   * will be added to the command line arguments automatically if an access token is available.
+   *
+   * When the argument is given to the command, the CLI server will prompt for the access token on
+   * stdin. This method will automatically respond to the prompt with the access token.
+   *
+   * There are a few race conditions that can potentially happen:
+   * 1. The user logs in after the command has started. In this case, no access token will be given.
+   * 2. The user logs out after the command has started. In this case, the user will be prompted
+   *   to login again. If they cancel the login, the old access token that was present before the
+   *   command was started will be used.
+   *
    * @param command The `codeql` command to be run, provided as an array of command/subcommand names.
    * @param commandArgs The arguments to pass to the `codeql` command.
    * @param description Description of the action being run, to be shown in log and error messages.


### PR DESCRIPTION
This will supply the GitHub access token to certain CodeQL CLI commands such that private packages can be resolved. It will only do so if the user has an existing auth session. If they don't, they will now get a prompt to login. However, this will only happen for commands which actually use authentication, which is limited to packaging commands.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
