### PR TITLE
Save scroll position before opening code paths

### DIFF
--- a/extensions/ql-vscode/src/view/common/CodePaths/CodePaths.tsx
+++ b/extensions/ql-vscode/src/view/common/CodePaths/CodePaths.tsx
@@ -31,13 +31,24 @@ export const CodePaths = ({
 }: CodePathsProps) => {
   const [isOpen, setIsOpen] = useState(false);
 
+  const [scrollPosition, setScrollPosition] = useState({ x: 0, y: 0 });
+  React.useEffect(() => {
+    window.scrollTo(scrollPosition.x, scrollPosition.y);
+  }, [scrollPosition]);
+
   const linkRef = useRef<HTMLAnchorElement>(null);
 
   const closeOverlay = () => setIsOpen(false);
 
   return (
     <>
-      <ShowPathsLink onClick={() => setIsOpen(true)} ref={linkRef}>
+      <ShowPathsLink
+        onClick={() => {
+          setScrollPosition({ x: window.scrollX, y: window.scrollY });
+          setIsOpen(true);
+        }}
+        ref={linkRef}
+      >
         Show paths
       </ShowPathsLink>
       {isOpen && (


### PR DESCRIPTION
This is so that the user doesn't lose their place in the results view.

https://user-images.githubusercontent.com/311693/212700041-573ea61d-582b-4a76-b07d-3237e957f74c.mov

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
