### PR TITLE
Don't focus after delete

### DIFF
--- a/extensions/ql-vscode/src/query-history.ts
+++ b/extensions/ql-vscode/src/query-history.ts
@@ -926,11 +926,6 @@ export class QueryHistoryManager extends DisposableObject {
     );
 
     await this.writeQueryHistory();
-    const current = this.treeDataProvider.getCurrent();
-    if (current !== undefined) {
-      await this.treeView.reveal(current, { select: true });
-      await this.openQueryResults(current);
-    }
   }
 
   private async removeRemoteQuery(item: RemoteQueryHistoryItem): Promise<void> {

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history.test.ts
@@ -669,12 +669,13 @@ describe("query-history", () => {
               await queryHistoryManager.treeView.reveal(toDelete, {
                 select: true,
               });
-              await queryHistoryManager.handleRemoveHistoryItem(toDelete, [
-                toDelete,
-              ]);
             });
 
             it("should remove the item", async () => {
+              await queryHistoryManager.handleRemoveHistoryItem(toDelete, [
+                toDelete,
+              ]);
+
               expect(
                 variantAnalysisManagerStub.removeVariantAnalysis,
               ).toHaveBeenCalledWith(toDelete.variantAnalysis);
@@ -684,6 +685,10 @@ describe("query-history", () => {
             });
 
             it("should show a modal asking 'Are you sure?'", async () => {
+              await queryHistoryManager.handleRemoveHistoryItem(toDelete, [
+                toDelete,
+              ]);
+
               expect(showBinaryChoiceDialogSpy).toHaveBeenCalledWith(
                 "You are about to delete this query: query-name. Are you sure?",
               );
@@ -720,14 +725,14 @@ describe("query-history", () => {
               expect(queryHistoryManager.treeDataProvider.getCurrent()).toEqual(
                 selected,
               );
+            });
 
+            it("should remove the item", async () => {
               // remove an item
               await queryHistoryManager.handleRemoveHistoryItem(toDelete, [
                 toDelete,
               ]);
-            });
 
-            it("should remove the item", async () => {
               expect(
                 variantAnalysisManagerStub.removeVariantAnalysis,
               ).toHaveBeenCalledWith(toDelete.variantAnalysis);
@@ -737,6 +742,11 @@ describe("query-history", () => {
             });
 
             it("should not show a modal asking 'Are you sure?'", async () => {
+              // remove an item
+              await queryHistoryManager.handleRemoveHistoryItem(toDelete, [
+                toDelete,
+              ]);
+
               expect(showBinaryChoiceDialogSpy).not.toHaveBeenCalled();
             });
           });
@@ -756,12 +766,13 @@ describe("query-history", () => {
               await queryHistoryManager.treeView.reveal(toDelete, {
                 select: true,
               });
-              await queryHistoryManager.handleRemoveHistoryItem(toDelete, [
-                toDelete,
-              ]);
             });
 
             it("should remove the item", async () => {
+              await queryHistoryManager.handleRemoveHistoryItem(toDelete, [
+                toDelete,
+              ]);
+
               expect(
                 variantAnalysisManagerStub.removeVariantAnalysis,
               ).toHaveBeenCalledWith(toDelete.variantAnalysis);
@@ -771,6 +782,10 @@ describe("query-history", () => {
             });
 
             it("should not show a modal asking 'Are you sure?'", async () => {
+              await queryHistoryManager.handleRemoveHistoryItem(toDelete, [
+                toDelete,
+              ]);
+
               expect(showBinaryChoiceDialogSpy).not.toHaveBeenCalled();
             });
           });

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history.test.ts
@@ -674,7 +674,7 @@ describe("query-history", () => {
               ]);
             });
 
-            it("should remove the item", () => {
+            it("should remove the item", async () => {
               expect(
                 variantAnalysisManagerStub.removeVariantAnalysis,
               ).toHaveBeenCalledWith(toDelete.variantAnalysis);
@@ -683,7 +683,7 @@ describe("query-history", () => {
               ).not.toContain(toDelete);
             });
 
-            it("should show a modal asking 'Are you sure?'", () => {
+            it("should show a modal asking 'Are you sure?'", async () => {
               expect(showBinaryChoiceDialogSpy).toHaveBeenCalledWith(
                 "You are about to delete this query: query-name. Are you sure?",
               );
@@ -727,7 +727,7 @@ describe("query-history", () => {
               ]);
             });
 
-            it("should remove the item", () => {
+            it("should remove the item", async () => {
               expect(
                 variantAnalysisManagerStub.removeVariantAnalysis,
               ).toHaveBeenCalledWith(toDelete.variantAnalysis);
@@ -736,7 +736,7 @@ describe("query-history", () => {
               ).not.toContain(toDelete);
             });
 
-            it("should not show a modal asking 'Are you sure?'", () => {
+            it("should not show a modal asking 'Are you sure?'", async () => {
               expect(showBinaryChoiceDialogSpy).not.toHaveBeenCalled();
             });
           });
@@ -761,7 +761,7 @@ describe("query-history", () => {
               ]);
             });
 
-            it("should remove the item", () => {
+            it("should remove the item", async () => {
               expect(
                 variantAnalysisManagerStub.removeVariantAnalysis,
               ).toHaveBeenCalledWith(toDelete.variantAnalysis);
@@ -770,7 +770,7 @@ describe("query-history", () => {
               ).not.toContain(toDelete);
             });
 
-            it("should not show a modal asking 'Are you sure?'", () => {
+            it("should not show a modal asking 'Are you sure?'", async () => {
               expect(showBinaryChoiceDialogSpy).not.toHaveBeenCalled();
             });
           });

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history.test.ts
@@ -434,29 +434,14 @@ describe("query-history", () => {
               expect.not.arrayContaining([toDelete]),
             );
           });
-
-          it("should not change the selection", () => {
-            expect(queryHistoryManager.treeDataProvider.getCurrent()).toEqual(
-              selected,
-            );
-
-            expect(
-              localQueriesResultsViewStub.showResults,
-            ).toHaveBeenCalledTimes(1);
-            expect(
-              localQueriesResultsViewStub.showResults,
-            ).toHaveBeenCalledWith(selected, WebviewReveal.Forced, false);
-          });
         });
 
         describe("when the item being removed is selected", () => {
           // deleting the selected item automatically selects next item
           let toDelete: LocalQueryInfo;
-          let newSelected: LocalQueryInfo;
 
           beforeEach(async () => {
             toDelete = localQueryHistory[1];
-            newSelected = localQueryHistory[2];
 
             queryHistoryManager = await createMockQueryHistory(
               localQueryHistory,
@@ -476,19 +461,6 @@ describe("query-history", () => {
             expect(queryHistoryManager.treeDataProvider.allHistory).toEqual(
               expect.not.arrayContaining([toDelete]),
             );
-          });
-
-          it("should change the selection", () => {
-            expect(queryHistoryManager.treeDataProvider.getCurrent()).toBe(
-              newSelected,
-            );
-
-            expect(
-              localQueriesResultsViewStub.showResults,
-            ).toHaveBeenCalledTimes(1);
-            expect(
-              localQueriesResultsViewStub.showResults,
-            ).toHaveBeenCalledWith(newSelected, WebviewReveal.Forced, false);
           });
         });
       });
@@ -535,26 +507,14 @@ describe("query-history", () => {
               queryHistoryManager.treeDataProvider.allHistory,
             ).not.toContain(toDelete);
           });
-
-          it("should not change the selection", () => {
-            expect(queryHistoryManager.treeDataProvider.getCurrent()).toEqual(
-              selected,
-            );
-
-            expect(
-              remoteQueriesManagerStub.openRemoteQueryResults,
-            ).toHaveBeenCalledWith(selected.queryId);
-          });
         });
 
         describe("when the item being removed is selected", () => {
           let toDelete: RemoteQueryHistoryItem;
-          let newSelected: RemoteQueryHistoryItem;
 
           beforeEach(async () => {
             // deleting the selected item automatically selects next item
             toDelete = remoteQueryHistory[1];
-            newSelected = remoteQueryHistory[2];
 
             queryHistoryManager = await createMockQueryHistory(
               remoteQueryHistory,
@@ -576,15 +536,6 @@ describe("query-history", () => {
             expect(
               queryHistoryManager.treeDataProvider.allHistory,
             ).not.toContain(toDelete);
-          });
-
-          it("should change the selection", () => {
-            expect(queryHistoryManager.treeDataProvider.getCurrent()).toEqual(
-              newSelected,
-            );
-            expect(
-              remoteQueriesManagerStub.openRemoteQueryResults,
-            ).toHaveBeenCalledWith(newSelected.queryId);
           });
         });
       });
@@ -654,20 +605,6 @@ describe("query-history", () => {
               ).not.toContain(toDelete);
             });
 
-            it("should not change the selection", async () => {
-              // remove an item
-              await queryHistoryManager.handleRemoveHistoryItem(toDelete, [
-                toDelete,
-              ]);
-
-              expect(queryHistoryManager.treeDataProvider.getCurrent()).toEqual(
-                selected,
-              );
-              expect(variantAnalysisManagerStub.showView).toHaveBeenCalledWith(
-                selected.variantAnalysis.id,
-              );
-            });
-
             it("should show a modal asking 'Are you sure?'", async () => {
               // remove an item
               await queryHistoryManager.handleRemoveHistoryItem(toDelete, [
@@ -719,12 +656,10 @@ describe("query-history", () => {
 
           describe("when the item being removed is selected", () => {
             let toDelete: VariantAnalysisHistoryItem;
-            let newSelected: VariantAnalysisHistoryItem;
 
             beforeEach(async () => {
               // deleting the selected item automatically selects next item
               toDelete = variantAnalysisHistory[1];
-              newSelected = variantAnalysisHistory[2];
 
               queryHistoryManager = await createMockQueryHistory(
                 variantAnalysisHistory,
@@ -746,15 +681,6 @@ describe("query-history", () => {
               expect(
                 queryHistoryManager.treeDataProvider.allHistory,
               ).not.toContain(toDelete);
-            });
-
-            it.skip("should change the selection", () => {
-              expect(queryHistoryManager.treeDataProvider.getCurrent()).toEqual(
-                newSelected,
-              );
-              expect(variantAnalysisManagerStub.showView).toHaveBeenCalledWith(
-                newSelected.variantAnalysis.id,
-              );
             });
 
             it("should show a modal asking 'Are you sure?'", () => {
@@ -810,15 +736,6 @@ describe("query-history", () => {
               ).not.toContain(toDelete);
             });
 
-            it("should not change the selection", () => {
-              expect(queryHistoryManager.treeDataProvider.getCurrent()).toEqual(
-                selected,
-              );
-              expect(variantAnalysisManagerStub.showView).toHaveBeenCalledWith(
-                selected.variantAnalysis.id,
-              );
-            });
-
             it("should not show a modal asking 'Are you sure?'", () => {
               expect(showBinaryChoiceDialogSpy).not.toHaveBeenCalled();
             });
@@ -826,12 +743,10 @@ describe("query-history", () => {
 
           describe("when the item being removed is selected", () => {
             let toDelete: VariantAnalysisHistoryItem;
-            let newSelected: VariantAnalysisHistoryItem;
 
             beforeEach(async () => {
               // deleting the selected item automatically selects next item
               toDelete = variantAnalysisHistory[0];
-              newSelected = variantAnalysisHistory[2];
 
               queryHistoryManager = await createMockQueryHistory(
                 variantAnalysisHistory,
@@ -853,15 +768,6 @@ describe("query-history", () => {
               expect(
                 queryHistoryManager.treeDataProvider.allHistory,
               ).not.toContain(toDelete);
-            });
-
-            it.skip("should change the selection", () => {
-              expect(queryHistoryManager.treeDataProvider.getCurrent()).toEqual(
-                newSelected,
-              );
-              expect(variantAnalysisManagerStub.showView).toHaveBeenCalledWith(
-                newSelected.variantAnalysis.id,
-              );
             });
 
             it("should not show a modal asking 'Are you sure?'", () => {

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/remote-queries/remote-query-history.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/remote-queries/remote-query-history.test.ts
@@ -185,9 +185,6 @@ describe("Remote queries and query history manager", () => {
       rawQueryHistory[1].remoteQuery,
       rawQueryHistory[1].status,
     );
-    expect(openRemoteQueryResultsStub).toHaveBeenCalledWith(
-      rawQueryHistory[1].queryId,
-    );
     expect(qhm.treeDataProvider.allHistory).toEqual(rawQueryHistory.slice(1));
 
     // Add it back


### PR DESCRIPTION
After you delete a query item from history, don't focus on a different item and just close the current query window.

This was requested by our designer when discussing the behaviour of variant analysis queries once a query is deleted. (See feedback in linked internal issue). 

For consistency, I've chosen to do the same for local & remote queries. 

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
