### PR TITLE
Emit telemetry for user interactions in the local results view

### DIFF
--- a/extensions/ql-vscode/src/interface.ts
+++ b/extensions/ql-vscode/src/interface.ts
@@ -256,6 +256,7 @@ export class ResultsView extends AbstractWebview<
         }
         case "changeSort":
           await this.changeRawSortState(msg.resultSetName, msg.sortState);
+          telemetryListener?.sendUIInteraction("local-results-column-sorting");
           break;
         case "changeInterpretedSort":
           await this.changeInterpretedSortState(msg.sortState);

--- a/extensions/ql-vscode/src/interface.ts
+++ b/extensions/ql-vscode/src/interface.ts
@@ -65,6 +65,7 @@ import {
 import { AbstractWebview, WebviewPanelConfig } from "./abstract-webview";
 import { PAGE_SIZE } from "./config";
 import { HistoryItemLabelProvider } from "./history-item-label-provider";
+import { telemetryListener } from "./telemetry";
 
 /**
  * interface.ts
@@ -281,6 +282,9 @@ export class ResultsView extends AbstractWebview<
           break;
         case "openFile":
           await this.openFile(msg.filePath);
+          break;
+        case "telemetry":
+          telemetryListener?.sendUIInteraction(msg.action);
           break;
         default:
           assertNever(msg);

--- a/extensions/ql-vscode/src/pure/interface-types.ts
+++ b/extensions/ql-vscode/src/pure/interface-types.ts
@@ -200,7 +200,8 @@ export type FromResultsViewMsg =
   | ChangeInterpretedResultsSortMsg
   | ViewLoadedMsg
   | ChangePage
-  | OpenFileMsg;
+  | OpenFileMsg
+  | TelemetryMessage;
 
 /**
  * Message from the results view to open a database source

--- a/extensions/ql-vscode/src/view/results/RawTableHeader.tsx
+++ b/extensions/ql-vscode/src/view/results/RawTableHeader.tsx
@@ -4,7 +4,6 @@ import { vscode } from "../vscode-api";
 import { RawResultsSortState, SortDirection } from "../../pure/interface-types";
 import { nextSortDirection } from "./result-table-utils";
 import { Column } from "../../pure/bqrs-cli-types";
-import { sendTelemetry } from "../common/telemetry";
 
 interface Props {
   readonly columns: readonly Column[];
@@ -40,7 +39,6 @@ function toggleSortStateForColumn(
     resultSetName: schemaName,
     sortState: nextSortState,
   });
-  sendTelemetry("local-results-column-sorting");
 }
 
 export default function RawTableHeader(props: Props) {

--- a/extensions/ql-vscode/src/view/results/RawTableHeader.tsx
+++ b/extensions/ql-vscode/src/view/results/RawTableHeader.tsx
@@ -4,6 +4,7 @@ import { vscode } from "../vscode-api";
 import { RawResultsSortState, SortDirection } from "../../pure/interface-types";
 import { nextSortDirection } from "./result-table-utils";
 import { Column } from "../../pure/bqrs-cli-types";
+import { sendTelemetry } from "../common/telemetry";
 
 interface Props {
   readonly columns: readonly Column[];
@@ -39,6 +40,7 @@ function toggleSortStateForColumn(
     resultSetName: schemaName,
     sortState: nextSortState,
   });
+  sendTelemetry("local-results-column-sorting");
 }
 
 export default function RawTableHeader(props: Props) {

--- a/extensions/ql-vscode/src/view/results/alert-table.tsx
+++ b/extensions/ql-vscode/src/view/results/alert-table.tsx
@@ -30,6 +30,7 @@ import {
 import { vscode } from "../vscode-api";
 import { isWholeFileLoc, isLineColumnLoc } from "../../pure/bqrs-utils";
 import { ScrollIntoViewHelper } from "./scroll-into-view-helper";
+import { sendTelemetry } from "../common/telemetry";
 
 export type PathTableProps = ResultTableProps & {
   resultSet: InterpretedResultSet<SarifInterpretationData>;
@@ -63,6 +64,9 @@ export class PathTable extends React.Component<PathTableProps, PathTableState> {
         for (const str of keyStrings) {
           expanded.add(str);
         }
+      }
+      if (expanded) {
+        sendTelemetry("local-results-alert-table-path-expanded");
       }
       return { expanded };
     });
@@ -185,6 +189,7 @@ export class PathTable extends React.Component<PathTableProps, PathTableState> {
           ...previousState,
           selectedItem: resultKey,
         }));
+        sendTelemetry("local-results-alert-table-path-selected");
       };
     };
 

--- a/extensions/ql-vscode/src/view/results/raw-results-table.tsx
+++ b/extensions/ql-vscode/src/view/results/raw-results-table.tsx
@@ -18,6 +18,7 @@ import { ResultRow } from "../../pure/bqrs-cli-types";
 import { onNavigation } from "./results";
 import { tryGetResolvableLocation } from "../../pure/bqrs-utils";
 import { ScrollIntoViewHelper } from "./scroll-into-view-helper";
+import { sendTelemetry } from "../common/telemetry";
 
 export type RawTableProps = ResultTableProps & {
   resultSet: RawTableResultSet;
@@ -44,6 +45,7 @@ export class RawTable extends React.Component<RawTableProps, RawTableState> {
       ...prev,
       selectedItem: { row, column },
     }));
+    sendTelemetry("local-results-raw-results-table-selected");
   }
 
   render(): React.ReactNode {

--- a/extensions/ql-vscode/src/view/results/result-table-utils.tsx
+++ b/extensions/ql-vscode/src/view/results/result-table-utils.tsx
@@ -10,6 +10,7 @@ import {
 import { assertNever } from "../../pure/helpers-pure";
 import { vscode } from "../vscode-api";
 import { convertNonPrintableChars } from "../../text-utils";
+import { sendTelemetry } from "../common/telemetry";
 
 export interface ResultTableProps {
   resultSet: ResultSet;
@@ -160,13 +161,20 @@ export function nextSortDirection(
   }
 }
 
+function sendCodeQLLanguageGuidesTelemetry() {
+  sendTelemetry("codeql-language-guides-link");
+}
+
 export function emptyQueryResultsMessage(): JSX.Element {
   return (
     <div className="vscode-codeql__empty-query-message">
       <span>
         This query returned no results. If this isn&apos;t what you were
         expecting, and for effective query-writing tips, check out the{" "}
-        <a href="https://codeql.github.com/docs/codeql-language-guides/">
+        <a
+          href="https://codeql.github.com/docs/codeql-language-guides/"
+          onClick={sendCodeQLLanguageGuidesTelemetry}
+        >
           CodeQL language guides
         </a>
         .

--- a/extensions/ql-vscode/src/view/results/result-tables.tsx
+++ b/extensions/ql-vscode/src/view/results/result-tables.tsx
@@ -154,6 +154,7 @@ export class ResultTables extends React.Component<
       pageNumber: 0,
       selectedTable,
     });
+    sendTelemetry("local-results-table-selection");
   };
 
   private alertTableExtras(): JSX.Element | undefined {
@@ -261,6 +262,7 @@ export class ResultTables extends React.Component<
 
     const openQuery = () => {
       openFile(this.props.queryPath);
+      sendTelemetry("local-results-open-query-file");
     };
     const fileName = FILE_PATH_REGEX.exec(this.props.queryPath)?.[1] || "query";
 

--- a/extensions/ql-vscode/src/view/results/result-tables.tsx
+++ b/extensions/ql-vscode/src/view/results/result-tables.tsx
@@ -26,6 +26,7 @@ import {
   openFile,
 } from "./result-table-utils";
 import { vscode } from "../vscode-api";
+import { sendTelemetry } from "../common/telemetry";
 
 const FILE_PATH_REGEX = /^(?:.+[\\/])*(.+)$/;
 
@@ -165,6 +166,9 @@ export class ResultTables extends React.Component<
       this.setState({
         problemsViewSelected: e.target.checked,
       });
+      if (e.target.checked) {
+        sendTelemetry("local-results-show-results-in-problems-view");
+      }
       if (resultsPath !== undefined) {
         vscode.postMessage({
           t: "toggleDiagnostics",
@@ -199,6 +203,10 @@ export class ResultTables extends React.Component<
     return parsedResultSets.pageNumber * parsedResultSets.pageSize;
   }
 
+  sendResultsPageChangedTelemetry() {
+    sendTelemetry("local-results-alert-table-page-changed");
+  }
+
   renderPageButtons(): JSX.Element {
     const { parsedResultSets } = this.props;
     const selectedTable = this.state.selectedTable;
@@ -217,6 +225,7 @@ export class ResultTables extends React.Component<
 
     const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
       this.setState({ selectedPage: e.target.value });
+      this.sendResultsPageChangedTelemetry();
     };
     const choosePage = (input: string) => {
       const pageNumber = parseInt(input);
@@ -239,6 +248,7 @@ export class ResultTables extends React.Component<
         pageNumber: Math.max(parsedResultSets.pageNumber - 1, 0),
         selectedTable,
       });
+      this.sendResultsPageChangedTelemetry();
     };
     const nextPage = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
       vscode.postMessage({
@@ -246,6 +256,7 @@ export class ResultTables extends React.Component<
         pageNumber: Math.min(parsedResultSets.pageNumber + 1, numPages - 1),
         selectedTable,
       });
+      this.sendResultsPageChangedTelemetry();
     };
 
     const openQuery = () => {
@@ -334,6 +345,7 @@ export class ResultTables extends React.Component<
             nonemptyRawResults={nonemptyRawResults}
             showRawResults={() => {
               this.setState({ selectedTable: SELECT_TABLE_NAME });
+              sendTelemetry("local-results-show-raw-results");
             }}
             offset={this.getOffset()}
           />


### PR DESCRIPTION
This PR adds telemetry for all UI interactions in the local results view.

We use the same telemetry message type that was used for the variant analysis results view, but we have to use a slightly different technique for sending the message when state changes. The local results view is not a modern react component and it uses `setState` rather than `useState`, which means we can't use `useEffect` here and instead have to add a call to the telemetry every time we call `setState`.

I've managed to trigger each of these telemetry events apart from `local-results-show-raw-results`. I can't quite work out the series of conditions that need to happen to be able to trigger this code. But I think if it ever does trigger then telemetry is reasonable.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
