### PR TITLE
When adding repo, check whether name exists in specified parent list

### DIFF
--- a/extensions/ql-vscode/src/databases/config/db-config-store.ts
+++ b/extensions/ql-vscode/src/databases/config/db-config-store.ts
@@ -153,7 +153,7 @@ export class DbConfigStore extends DisposableObject {
       throw Error("Repository name cannot be empty");
     }
 
-    if (this.doesRemoteDbExist(repoNwo)) {
+    if (this.doesRemoteDbExist(repoNwo, parentList)) {
       throw Error(
         `A remote repository with the name '${repoNwo}' already exists`,
       );

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/databases/db-panel.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/databases/db-panel.test.ts
@@ -500,6 +500,7 @@ describe("db panel", () => {
             repositories: ["owner1/repo1"],
           },
         ],
+        remoteRepos: ["owner2/repo2"],
       });
 
       await saveDbConfig(dbConfig);


### PR DESCRIPTION
[in the variant analysis repo panel]

Fixes a bug where you couldn't add a repo to list if that name existed, even outside of that list 🐛 

I've now passed in the `parentList` to the method that checks for the repo's existence, so that it knows to check inside the correct list. The tests didn't flag this, so I've tweaked one of the existing tests to cover this behaviour in future 🧪 

## Checklist

N/A—internal only 🦀

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
