### PR TITLE
Telemetry for compare view

### DIFF
--- a/extensions/ql-vscode/src/compare/compare-view.ts
+++ b/extensions/ql-vscode/src/compare/compare-view.ts
@@ -16,9 +16,10 @@ import {
 } from "../pure/bqrs-cli-types";
 import resultsDiff from "./resultsDiff";
 import { CompletedLocalQueryInfo } from "../query-results";
-import { getErrorMessage } from "../pure/helpers-pure";
+import { assertNever, getErrorMessage } from "../pure/helpers-pure";
 import { HistoryItemLabelProvider } from "../history-item-label-provider";
 import { AbstractWebview, WebviewPanelConfig } from "../abstract-webview";
+import { telemetryListener } from "../telemetry";
 
 interface ComparePair {
   from: CompletedLocalQueryInfo;
@@ -118,6 +119,9 @@ export class CompareView extends AbstractWebview<
 
       case "changeCompare":
         await this.changeTable(msg.newResultSetName);
+        telemetryListener?.sendUIInteraction(
+          "compare-view-change-table-to-compare",
+        );
         break;
 
       case "viewSourceFile":
@@ -126,7 +130,17 @@ export class CompareView extends AbstractWebview<
 
       case "openQuery":
         await this.openQuery(msg.kind);
+        telemetryListener?.sendUIInteraction(
+          `compare-view-open-${msg.kind}-query`,
+        );
         break;
+
+      case "telemetry":
+        telemetryListener?.sendUIInteraction(msg.action);
+        break;
+
+      default:
+        assertNever(msg);
     }
   }
 

--- a/extensions/ql-vscode/src/pure/interface-types.ts
+++ b/extensions/ql-vscode/src/pure/interface-types.ts
@@ -306,7 +306,8 @@ export type FromCompareViewMessage =
   | ViewLoadedMsg
   | ChangeCompareMessage
   | ViewSourceFileMsg
-  | OpenQueryMessage;
+  | OpenQueryMessage
+  | TelemetryMessage;
 
 /**
  * Message from the compare view to request opening a query.

--- a/extensions/ql-vscode/src/view/compare/CompareTable.tsx
+++ b/extensions/ql-vscode/src/view/compare/CompareTable.tsx
@@ -6,6 +6,7 @@ import { className } from "../results/result-table-utils";
 import { ResultRow } from "../../pure/bqrs-cli-types";
 import RawTableRow from "../results/RawTableRow";
 import { vscode } from "../vscode-api";
+import { sendTelemetry } from "../common/telemetry";
 
 interface Props {
   comparison: SetComparisonsMessage;
@@ -31,6 +32,9 @@ export default function CompareTable(props: Props) {
             rowIndex={rowIndex}
             row={row}
             databaseUri={databaseUri}
+            onSelected={() => {
+              sendTelemetry("comapre-view-result-clicked");
+            }}
           />
         ))}
       </tbody>


### PR DESCRIPTION
Emits telemetry events for UI interactions in the "compare results" view.

There's not much here so it's quite simple. All the interactions are clicking on links or checkboxes, and some already send messages that we can append extra telemetry to to avoid sending extra messages.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
