### PR TITLE
Fix rename that went too far

### DIFF
--- a/extensions/ql-vscode/src/databases/config/db-config-store.ts
+++ b/extensions/ql-vscode/src/databases/config/db-config-store.ts
@@ -26,7 +26,7 @@ import { ValueResult } from "../../common/value-result";
 import {
   LocalDatabaseDbItem,
   LocalListDbItem,
-  VariantAnalysisUserDefinedListDbItem,
+  RemoteUserDefinedListDbItem,
   DbItem,
   DbItemKind,
 } from "../db-item";
@@ -113,7 +113,7 @@ export class DbConfigStore extends DisposableObject {
       case DbItemKind.LocalList:
         config = removeLocalList(this.config, dbItem.listName);
         break;
-      case DbItemKind.VariantAnalysisUserDefinedList:
+      case DbItemKind.RemoteUserDefinedList:
         config = removeRemoteList(this.config, dbItem.listName);
         break;
       case DbItemKind.LocalDatabase:
@@ -246,7 +246,7 @@ export class DbConfigStore extends DisposableObject {
   }
 
   public async renameRemoteList(
-    currentDbItem: VariantAnalysisUserDefinedListDbItem,
+    currentDbItem: RemoteUserDefinedListDbItem,
     newName: string,
   ) {
     if (!this.config) {

--- a/extensions/ql-vscode/src/databases/db-item-expansion.ts
+++ b/extensions/ql-vscode/src/databases/db-item-expansion.ts
@@ -4,7 +4,7 @@ export type ExpandedDbItem =
   | RootLocalExpandedDbItem
   | LocalUserDefinedListExpandedDbItem
   | RootRemoteExpandedDbItem
-  | VariantAnalysisUserDefinedListExpandedDbItem;
+  | RemoteUserDefinedListExpandedDbItem;
 
 export enum ExpandedDbItemKind {
   RootLocal = "rootLocal",
@@ -26,7 +26,7 @@ export interface RootRemoteExpandedDbItem {
   kind: ExpandedDbItemKind.RootRemote;
 }
 
-export interface VariantAnalysisUserDefinedListExpandedDbItem {
+export interface RemoteUserDefinedListExpandedDbItem {
   kind: ExpandedDbItemKind.RemoteUserDefinedList;
   listName: string;
 }
@@ -89,7 +89,7 @@ function mapDbItemToExpandedDbItem(dbItem: DbItem): ExpandedDbItem {
       };
     case DbItemKind.RootRemote:
       return { kind: ExpandedDbItemKind.RootRemote };
-    case DbItemKind.VariantAnalysisUserDefinedList:
+    case DbItemKind.RemoteUserDefinedList:
       return {
         kind: ExpandedDbItemKind.RemoteUserDefinedList,
         listName: dbItem.listName,
@@ -113,7 +113,7 @@ function isDbItemEqualToExpandedDbItem(
       );
     case DbItemKind.RootRemote:
       return expandedDbItem.kind === ExpandedDbItemKind.RootRemote;
-    case DbItemKind.VariantAnalysisUserDefinedList:
+    case DbItemKind.RemoteUserDefinedList:
       return (
         expandedDbItem.kind === ExpandedDbItemKind.RemoteUserDefinedList &&
         expandedDbItem.listName === dbItem.listName

--- a/extensions/ql-vscode/src/databases/db-item-naming.ts
+++ b/extensions/ql-vscode/src/databases/db-item-naming.ts
@@ -6,7 +6,7 @@ export function getDbItemName(dbItem: DbItem): string | undefined {
     case DbItemKind.RootRemote:
       return undefined;
     case DbItemKind.LocalList:
-    case DbItemKind.VariantAnalysisUserDefinedList:
+    case DbItemKind.RemoteUserDefinedList:
     case DbItemKind.RemoteSystemDefinedList:
       return dbItem.listName;
     case DbItemKind.RemoteOwner:

--- a/extensions/ql-vscode/src/databases/db-item-selection.ts
+++ b/extensions/ql-vscode/src/databases/db-item-selection.ts
@@ -33,7 +33,7 @@ function extractSelected(
         }
       }
       break;
-    case DbItemKind.VariantAnalysisUserDefinedList:
+    case DbItemKind.RemoteUserDefinedList:
       for (const repo of dbItem.repos) {
         if (repo.selected) {
           return repo;
@@ -59,7 +59,7 @@ export function mapDbItemToSelectedDbItem(
         listName: dbItem.listName,
       };
 
-    case DbItemKind.VariantAnalysisUserDefinedList:
+    case DbItemKind.RemoteUserDefinedList:
       return {
         kind: SelectedDbItemKind.VariantAnalysisUserDefinedList,
         listName: dbItem.listName,

--- a/extensions/ql-vscode/src/databases/db-item.ts
+++ b/extensions/ql-vscode/src/databases/db-item.ts
@@ -6,7 +6,7 @@ export enum DbItemKind {
   LocalDatabase = "LocalDatabase",
   RootRemote = "RootRemote",
   RemoteSystemDefinedList = "RemoteSystemDefinedList",
-  VariantAnalysisUserDefinedList = "VariantAnalysisUserDefinedList",
+  RemoteUserDefinedList = "RemoteUserDefinedList",
   RemoteOwner = "RemoteOwner",
   RemoteRepo = "RemoteRepo",
 }
@@ -14,7 +14,7 @@ export enum DbItemKind {
 export const remoteDbKinds = [
   DbItemKind.RootRemote,
   DbItemKind.RemoteSystemDefinedList,
-  DbItemKind.VariantAnalysisUserDefinedList,
+  DbItemKind.RemoteUserDefinedList,
   DbItemKind.RemoteOwner,
   DbItemKind.RemoteRepo,
 ];
@@ -70,7 +70,7 @@ export type DbItem =
 
 export type RemoteDbItem =
   | RemoteSystemDefinedListDbItem
-  | VariantAnalysisUserDefinedListDbItem
+  | RemoteUserDefinedListDbItem
   | RemoteOwnerDbItem
   | RemoteRepoDbItem;
 
@@ -82,8 +82,8 @@ export interface RemoteSystemDefinedListDbItem {
   listDescription: string;
 }
 
-export interface VariantAnalysisUserDefinedListDbItem {
-  kind: DbItemKind.VariantAnalysisUserDefinedList;
+export interface RemoteUserDefinedListDbItem {
+  kind: DbItemKind.RemoteUserDefinedList;
   expanded: boolean;
   selected: boolean;
   listName: string;
@@ -109,10 +109,10 @@ export function isRemoteSystemDefinedListDbItem(
   return dbItem.kind === DbItemKind.RemoteSystemDefinedList;
 }
 
-export function isVariantAnalysisUserDefinedListDbItem(
+export function isRemoteUserDefinedListDbItem(
   dbItem: DbItem,
-): dbItem is VariantAnalysisUserDefinedListDbItem {
-  return dbItem.kind === DbItemKind.VariantAnalysisUserDefinedList;
+): dbItem is RemoteUserDefinedListDbItem {
+  return dbItem.kind === DbItemKind.RemoteUserDefinedList;
 }
 
 export function isRemoteOwnerDbItem(
@@ -145,7 +145,7 @@ const SelectableDbItemKinds = [
   DbItemKind.LocalList,
   DbItemKind.LocalDatabase,
   DbItemKind.RemoteSystemDefinedList,
-  DbItemKind.VariantAnalysisUserDefinedList,
+  DbItemKind.RemoteUserDefinedList,
   DbItemKind.RemoteOwner,
   DbItemKind.RemoteRepo,
 ];
@@ -165,7 +165,7 @@ export function flattenDbItems(dbItems: DbItem[]): DbItem[] {
       case DbItemKind.RootRemote:
         allItems.push(...flattenDbItems(dbItem.children));
         break;
-      case DbItemKind.VariantAnalysisUserDefinedList:
+      case DbItemKind.RemoteUserDefinedList:
         allItems.push(...dbItem.repos);
         break;
       case DbItemKind.LocalDatabase:

--- a/extensions/ql-vscode/src/databases/db-manager.ts
+++ b/extensions/ql-vscode/src/databases/db-manager.ts
@@ -8,7 +8,7 @@ import {
   DbListKind,
   LocalDatabaseDbItem,
   LocalListDbItem,
-  VariantAnalysisUserDefinedListDbItem,
+  RemoteUserDefinedListDbItem,
 } from "./db-item";
 import {
   updateExpandedItem,
@@ -123,14 +123,12 @@ export class DbManager {
   }
 
   public async renameList(
-    currentDbItem: LocalListDbItem | VariantAnalysisUserDefinedListDbItem,
+    currentDbItem: LocalListDbItem | RemoteUserDefinedListDbItem,
     newName: string,
   ): Promise<void> {
     if (currentDbItem.kind === DbItemKind.LocalList) {
       await this.dbConfigStore.renameLocalList(currentDbItem, newName);
-    } else if (
-      currentDbItem.kind === DbItemKind.VariantAnalysisUserDefinedList
-    ) {
+    } else if (currentDbItem.kind === DbItemKind.RemoteUserDefinedList) {
       await this.dbConfigStore.renameRemoteList(currentDbItem, newName);
     }
 

--- a/extensions/ql-vscode/src/databases/db-tree-creator.ts
+++ b/extensions/ql-vscode/src/databases/db-tree-creator.ts
@@ -12,7 +12,7 @@ import {
   RemoteOwnerDbItem,
   RemoteRepoDbItem,
   RemoteSystemDefinedListDbItem,
-  VariantAnalysisUserDefinedListDbItem,
+  RemoteUserDefinedListDbItem,
   RootLocalDbItem,
   RootRemoteDbItem,
 } from "./db-item";
@@ -102,7 +102,7 @@ function createVariantAnalysisUserDefinedList(
   list: RemoteRepositoryList,
   dbConfig: DbConfig,
   expandedItems: ExpandedDbItem[],
-): VariantAnalysisUserDefinedListDbItem {
+): RemoteUserDefinedListDbItem {
   const selected =
     dbConfig.selected &&
     dbConfig.selected.kind ===
@@ -116,7 +116,7 @@ function createVariantAnalysisUserDefinedList(
   );
 
   return {
-    kind: DbItemKind.VariantAnalysisUserDefinedList,
+    kind: DbItemKind.RemoteUserDefinedList,
     listName: list.name,
     repos: list.repositories.map((r) => createRepoItem(r, dbConfig, list.name)),
     selected: !!selected,

--- a/extensions/ql-vscode/src/databases/ui/db-item-mapper.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-item-mapper.ts
@@ -34,7 +34,7 @@ export function mapDbItemToTreeViewItem(dbItem: DbItem): DbTreeViewItem {
         dbItem.listDescription,
       );
 
-    case DbItemKind.VariantAnalysisUserDefinedList:
+    case DbItemKind.RemoteUserDefinedList:
       return createDbTreeViewItemUserDefinedList(
         dbItem,
         dbItem.listName,

--- a/extensions/ql-vscode/src/databases/ui/db-panel.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-panel.ts
@@ -23,7 +23,7 @@ import {
   LocalDatabaseDbItem,
   LocalListDbItem,
   remoteDbKinds,
-  VariantAnalysisUserDefinedListDbItem,
+  RemoteUserDefinedListDbItem,
 } from "../db-item";
 import { getDbItemName } from "../db-item-naming";
 import { DbManager } from "../db-manager";
@@ -124,7 +124,7 @@ export class DbPanel extends DisposableObject {
   private async addNewRemoteDatabase(): Promise<void> {
     const highlightedItem = await this.getHighlightedDbItem();
 
-    if (highlightedItem?.kind === DbItemKind.VariantAnalysisUserDefinedList) {
+    if (highlightedItem?.kind === DbItemKind.RemoteUserDefinedList) {
       await this.addNewRemoteRepo(highlightedItem.listName);
     } else if (
       highlightedItem?.kind === DbItemKind.RemoteRepo &&
@@ -313,7 +313,7 @@ export class DbPanel extends DisposableObject {
       case DbItemKind.LocalDatabase:
         await this.renameLocalDatabaseItem(dbItem, newName);
         break;
-      case DbItemKind.VariantAnalysisUserDefinedList:
+      case DbItemKind.RemoteUserDefinedList:
         await this.renameVariantAnalysisUserDefinedListItem(dbItem, newName);
         break;
       default:
@@ -354,7 +354,7 @@ export class DbPanel extends DisposableObject {
   }
 
   private async renameVariantAnalysisUserDefinedListItem(
-    dbItem: VariantAnalysisUserDefinedListDbItem,
+    dbItem: RemoteUserDefinedListDbItem,
     newName: string,
   ): Promise<void> {
     if (dbItem.listName === newName) {

--- a/extensions/ql-vscode/src/databases/ui/db-tree-view-item-action.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-tree-view-item-action.ts
@@ -27,7 +27,7 @@ export function getDbItemActions(dbItem: DbItem): DbTreeViewItemAction[] {
 
 const dbItemKindsThatCanBeRemoved = [
   DbItemKind.LocalList,
-  DbItemKind.VariantAnalysisUserDefinedList,
+  DbItemKind.RemoteUserDefinedList,
   DbItemKind.LocalDatabase,
   DbItemKind.RemoteRepo,
   DbItemKind.RemoteOwner,
@@ -35,7 +35,7 @@ const dbItemKindsThatCanBeRemoved = [
 
 const dbItemKindsThatCanBeRenamed = [
   DbItemKind.LocalList,
-  DbItemKind.VariantAnalysisUserDefinedList,
+  DbItemKind.RemoteUserDefinedList,
   DbItemKind.LocalDatabase,
 ];
 

--- a/extensions/ql-vscode/src/databases/ui/db-tree-view-item.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-tree-view-item.ts
@@ -7,7 +7,7 @@ import {
   RemoteOwnerDbItem,
   RemoteRepoDbItem,
   RemoteSystemDefinedListDbItem,
-  VariantAnalysisUserDefinedListDbItem,
+  RemoteUserDefinedListDbItem,
   RootLocalDbItem,
   RootRemoteDbItem,
 } from "../db-item";
@@ -97,7 +97,7 @@ export function createDbTreeViewItemSystemDefinedList(
 }
 
 export function createDbTreeViewItemUserDefinedList(
-  dbItem: LocalListDbItem | VariantAnalysisUserDefinedListDbItem,
+  dbItem: LocalListDbItem | RemoteUserDefinedListDbItem,
   listName: string,
   children: DbTreeViewItem[],
 ): DbTreeViewItem {

--- a/extensions/ql-vscode/src/remote-queries/repository-selection.ts
+++ b/extensions/ql-vscode/src/remote-queries/repository-selection.ts
@@ -46,7 +46,7 @@ export async function getRepositorySelection(
           );
         case DbItemKind.RemoteSystemDefinedList:
           return { repositoryLists: [selectedDbItem.listName] };
-        case DbItemKind.VariantAnalysisUserDefinedList:
+        case DbItemKind.RemoteUserDefinedList:
           if (selectedDbItem.repos.length === 0) {
             throw new UserCancellationException(
               "The selected repository list is empty. Please add repositories to it before running a variant analysis.",

--- a/extensions/ql-vscode/test/factories/db-item-factories.ts
+++ b/extensions/ql-vscode/test/factories/db-item-factories.ts
@@ -8,7 +8,7 @@ import {
   RemoteOwnerDbItem,
   RemoteRepoDbItem,
   RemoteSystemDefinedListDbItem,
-  VariantAnalysisUserDefinedListDbItem,
+  RemoteUserDefinedListDbItem,
   RootLocalDbItem,
   RootRemoteDbItem,
 } from "../../src/databases/db-item";
@@ -79,7 +79,7 @@ export function createRemoteSystemDefinedListDbItem({
   };
 }
 
-export function createVariantAnalysisUserDefinedListDbItem({
+export function createRemoteUserDefinedListDbItem({
   expanded = false,
   selected = false,
   listName = `list${faker.datatype.number()}`,
@@ -93,9 +93,9 @@ export function createVariantAnalysisUserDefinedListDbItem({
   expanded?: boolean;
   selected?: boolean;
   repos?: RemoteRepoDbItem[];
-} = {}): VariantAnalysisUserDefinedListDbItem {
+} = {}): RemoteUserDefinedListDbItem {
   return {
-    kind: DbItemKind.VariantAnalysisUserDefinedList,
+    kind: DbItemKind.RemoteUserDefinedList,
     expanded,
     selected,
     listName,

--- a/extensions/ql-vscode/test/unit-tests/databases/config/db-config-store.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/config/db-config-store.test.ts
@@ -16,7 +16,7 @@ import {
   createLocalListDbItem,
   createRemoteOwnerDbItem,
   createRemoteRepoDbItem,
-  createVariantAnalysisUserDefinedListDbItem,
+  createRemoteUserDefinedListDbItem,
 } from "../../../factories/db-item-factories";
 import { createMockApp } from "../../../__mocks__/appMock";
 
@@ -348,7 +348,7 @@ describe("db config store", () => {
       const configStore = await initializeConfig(dbConfig, configPath, app);
 
       // Rename
-      const currentDbItem = createVariantAnalysisUserDefinedListDbItem({
+      const currentDbItem = createRemoteUserDefinedListDbItem({
         listName: "list1",
       });
       await configStore.renameRemoteList(currentDbItem, "listRenamed");
@@ -477,7 +477,7 @@ describe("db config store", () => {
       const configStore = await initializeConfig(dbConfig, configPath, app);
 
       // Rename
-      const currentDbItem = createVariantAnalysisUserDefinedListDbItem({
+      const currentDbItem = createRemoteUserDefinedListDbItem({
         listName: "list1",
       });
       await expect(
@@ -555,7 +555,7 @@ describe("db config store", () => {
       const configStore = await initializeConfig(dbConfig, configPath, app);
 
       // Remove
-      const currentDbItem = createVariantAnalysisUserDefinedListDbItem({
+      const currentDbItem = createRemoteUserDefinedListDbItem({
         listName: "list1",
       });
       await configStore.removeDbItem(currentDbItem);

--- a/extensions/ql-vscode/test/unit-tests/databases/db-item-expansion.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/db-item-expansion.test.ts
@@ -7,7 +7,7 @@ import {
 } from "../../../src/databases/db-item-expansion";
 import {
   createLocalListDbItem,
-  createVariantAnalysisUserDefinedListDbItem,
+  createRemoteUserDefinedListDbItem,
   createRootLocalDbItem,
   createRootRemoteDbItem,
 } from "../../factories/db-item-factories";
@@ -25,7 +25,7 @@ describe("db item expansion", () => {
         },
       ];
 
-      const dbItem = createVariantAnalysisUserDefinedListDbItem({
+      const dbItem = createRemoteUserDefinedListDbItem({
         listName: "list2",
       });
 
@@ -45,7 +45,7 @@ describe("db item expansion", () => {
     });
 
     it("should add an expanded item to an empty list", () => {
-      const dbItem = createVariantAnalysisUserDefinedListDbItem({
+      const dbItem = createRemoteUserDefinedListDbItem({
         listName: "list2",
       });
 
@@ -70,7 +70,7 @@ describe("db item expansion", () => {
         },
       ];
 
-      const dbItem = createVariantAnalysisUserDefinedListDbItem({
+      const dbItem = createRemoteUserDefinedListDbItem({
         listName: "list1",
       });
 
@@ -126,7 +126,7 @@ describe("db item expansion", () => {
         },
       ];
 
-      const currentDbItem = createVariantAnalysisUserDefinedListDbItem({
+      const currentDbItem = createRemoteUserDefinedListDbItem({
         listName: "list1",
       });
 
@@ -184,7 +184,7 @@ describe("db item expansion", () => {
       const dbItems = [
         createRootRemoteDbItem({
           children: [
-            createVariantAnalysisUserDefinedListDbItem({
+            createRemoteUserDefinedListDbItem({
               listName: "list2",
             }),
           ],

--- a/extensions/ql-vscode/test/unit-tests/databases/db-item-naming.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/db-item-naming.test.ts
@@ -5,7 +5,7 @@ import {
   createRemoteOwnerDbItem,
   createRemoteRepoDbItem,
   createRemoteSystemDefinedListDbItem,
-  createVariantAnalysisUserDefinedListDbItem,
+  createRemoteUserDefinedListDbItem,
   createRootLocalDbItem,
   createRootRemoteDbItem,
 } from "../../factories/db-item-factories";
@@ -37,7 +37,7 @@ describe("db item naming", () => {
     });
 
     it("return list name for remote user defined list db item", () => {
-      const dbItem = createVariantAnalysisUserDefinedListDbItem();
+      const dbItem = createRemoteUserDefinedListDbItem();
 
       const name = getDbItemName(dbItem);
 

--- a/extensions/ql-vscode/test/unit-tests/databases/db-item-selection.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/db-item-selection.test.ts
@@ -6,7 +6,7 @@ import {
   createRemoteOwnerDbItem,
   createRemoteRepoDbItem,
   createRemoteSystemDefinedListDbItem,
-  createVariantAnalysisUserDefinedListDbItem,
+  createRemoteUserDefinedListDbItem,
   createRootLocalDbItem,
   createRootRemoteDbItem,
 } from "../../factories/db-item-factories";
@@ -18,7 +18,7 @@ describe("db item selection", () => {
         children: [
           createRemoteSystemDefinedListDbItem(),
           createRemoteOwnerDbItem(),
-          createVariantAnalysisUserDefinedListDbItem(),
+          createRemoteUserDefinedListDbItem(),
         ],
       }),
       createRootLocalDbItem({
@@ -67,7 +67,7 @@ describe("db item selection", () => {
         children: [
           createRemoteSystemDefinedListDbItem(),
           createRemoteOwnerDbItem(),
-          createVariantAnalysisUserDefinedListDbItem({
+          createRemoteUserDefinedListDbItem({
             listName: "my list",
             selected: true,
             repos: [
@@ -80,7 +80,7 @@ describe("db item selection", () => {
     ];
 
     expect(getSelectedDbItem(dbItems)).toEqual({
-      kind: DbItemKind.VariantAnalysisUserDefinedList,
+      kind: DbItemKind.RemoteUserDefinedList,
       expanded: false,
       listName: "my list",
       repos: [
@@ -105,7 +105,7 @@ describe("db item selection", () => {
         children: [
           createRemoteSystemDefinedListDbItem(),
           createRemoteOwnerDbItem(),
-          createVariantAnalysisUserDefinedListDbItem(),
+          createRemoteUserDefinedListDbItem(),
         ],
       }),
       createRemoteSystemDefinedListDbItem({
@@ -131,7 +131,7 @@ describe("db item selection", () => {
         children: [
           createRemoteSystemDefinedListDbItem(),
           createRemoteOwnerDbItem(),
-          createVariantAnalysisUserDefinedListDbItem({
+          createRemoteUserDefinedListDbItem({
             repos: [],
             selected: true,
             listName: "list84",
@@ -141,7 +141,7 @@ describe("db item selection", () => {
     ];
     expect(getSelectedDbItem(dbItems)).toEqual({
       expanded: false,
-      kind: DbItemKind.VariantAnalysisUserDefinedList,
+      kind: DbItemKind.RemoteUserDefinedList,
       listName: "list84",
       repos: [],
       selected: true,

--- a/extensions/ql-vscode/test/unit-tests/databases/db-item.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/db-item.test.ts
@@ -9,7 +9,7 @@ import {
   createRemoteOwnerDbItem,
   createRemoteRepoDbItem,
   createRemoteSystemDefinedListDbItem,
-  createVariantAnalysisUserDefinedListDbItem,
+  createRemoteUserDefinedListDbItem,
   createRootLocalDbItem,
   createRootRemoteDbItem,
 } from "../../factories/db-item-factories";
@@ -22,14 +22,14 @@ describe("DbItem", () => {
           children: [
             createRemoteSystemDefinedListDbItem({ listName: "top10" }),
             createRemoteSystemDefinedListDbItem({ listName: "top100" }),
-            createVariantAnalysisUserDefinedListDbItem({
+            createRemoteUserDefinedListDbItem({
               listName: "remote-list1",
               repos: [
                 createRemoteRepoDbItem({ repoFullName: "owner1/repo1" }),
                 createRemoteRepoDbItem({ repoFullName: "owner1/repo2" }),
               ],
             }),
-            createVariantAnalysisUserDefinedListDbItem({
+            createRemoteUserDefinedListDbItem({
               listName: "remote-list2",
               repos: [
                 createRemoteRepoDbItem({ repoFullName: "owner2/repo1" }),
@@ -82,7 +82,7 @@ describe("DbItem", () => {
       expect(
         items.find(
           (item) =>
-            item.kind === DbItemKind.VariantAnalysisUserDefinedList &&
+            item.kind === DbItemKind.RemoteUserDefinedList &&
             item.listName === name,
         ),
       ).toBeDefined();

--- a/extensions/ql-vscode/test/unit-tests/databases/db-manager.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/db-manager.test.ts
@@ -13,24 +13,24 @@ import {
   isLocalListDbItem,
   isRemoteOwnerDbItem,
   isRemoteRepoDbItem,
-  isVariantAnalysisUserDefinedListDbItem,
+  isRemoteUserDefinedListDbItem,
   LocalDatabaseDbItem,
   LocalListDbItem,
   RemoteOwnerDbItem,
   RemoteRepoDbItem,
-  VariantAnalysisUserDefinedListDbItem,
+  RemoteUserDefinedListDbItem,
 } from "../../../src/databases/db-item";
 import {
   ExpandedDbItem,
   ExpandedDbItemKind,
-  VariantAnalysisUserDefinedListExpandedDbItem,
+  RemoteUserDefinedListExpandedDbItem,
 } from "../../../src/databases/db-item-expansion";
 import { DbManager } from "../../../src/databases/db-manager";
 import {
   createDbConfig,
   createLocalDbConfigItem,
 } from "../../factories/db-config-factories";
-import { createVariantAnalysisUserDefinedListDbItem } from "../../factories/db-item-factories";
+import { createRemoteUserDefinedListDbItem } from "../../factories/db-item-factories";
 import { createMockApp } from "../../__mocks__/appMock";
 
 // Note: Although these are "unit tests" (i.e. not integrating with VS Code), they do
@@ -270,8 +270,7 @@ describe("db manager", () => {
 
       await saveDbConfig(dbConfig);
 
-      const remoteListDbItems =
-        getVariantAnalysisUserDefinedListDbItems("my-list-1");
+      const remoteListDbItems = getRemoteUserDefinedListDbItems("my-list-1");
       expect(remoteListDbItems.length).toEqual(1);
 
       await dbManager.renameList(remoteListDbItems[0], "my-list-2");
@@ -414,8 +413,7 @@ describe("db manager", () => {
     it("should remove remote user-defined list", async () => {
       await saveDbConfig(dbConfig);
 
-      const remoteListDbItems =
-        getVariantAnalysisUserDefinedListDbItems("my-list-1");
+      const remoteListDbItems = getRemoteUserDefinedListDbItems("my-list-1");
       expect(remoteListDbItems.length).toEqual(1);
 
       await dbManager.removeDbItem(remoteListDbItems[0]);
@@ -565,7 +563,7 @@ describe("db manager", () => {
       await saveDbConfig(dbConfig);
 
       // Add item to expanded state
-      const dbItem = createVariantAnalysisUserDefinedListDbItem({
+      const dbItem = createRemoteUserDefinedListDbItem({
         listName,
       });
 
@@ -576,7 +574,7 @@ describe("db manager", () => {
 
       expect(expandedItems?.length).toEqual(1);
       const expandedItem =
-        expandedItems![0] as VariantAnalysisUserDefinedListExpandedDbItem;
+        expandedItems![0] as RemoteUserDefinedListExpandedDbItem;
       expect(expandedItem.listName).toEqual(listName);
     });
 
@@ -593,7 +591,7 @@ describe("db manager", () => {
       ]);
 
       // Remove item from expanded state
-      const dbItem = createVariantAnalysisUserDefinedListDbItem({
+      const dbItem = createRemoteUserDefinedListDbItem({
         listName,
       });
 
@@ -624,7 +622,7 @@ describe("db manager", () => {
       ]);
 
       // Rename item
-      const dbItem = createVariantAnalysisUserDefinedListDbItem({
+      const dbItem = createRemoteUserDefinedListDbItem({
         listName,
       });
 
@@ -635,7 +633,7 @@ describe("db manager", () => {
 
       expect(expandedItems?.length).toEqual(1);
       const expandedItem =
-        expandedItems![0] as VariantAnalysisUserDefinedListExpandedDbItem;
+        expandedItems![0] as RemoteUserDefinedListExpandedDbItem;
       expect(expandedItem.listName).toEqual("new-list-name");
     });
 
@@ -661,7 +659,7 @@ describe("db manager", () => {
       ]);
 
       // Trigger adding an item that is not in the config
-      const dbItem = createVariantAnalysisUserDefinedListDbItem({
+      const dbItem = createRemoteUserDefinedListDbItem({
         listName,
       });
 
@@ -672,7 +670,7 @@ describe("db manager", () => {
 
       expect(expandedItems?.length).toEqual(1);
       const expandedItem =
-        expandedItems![0] as VariantAnalysisUserDefinedListExpandedDbItem;
+        expandedItems![0] as RemoteUserDefinedListExpandedDbItem;
       expect(expandedItem.listName).toEqual("my-list-4");
     });
   });
@@ -742,13 +740,13 @@ describe("db manager", () => {
     return ownerDbItems;
   }
 
-  function getVariantAnalysisUserDefinedListDbItems(
+  function getRemoteUserDefinedListDbItems(
     listName: string,
-  ): VariantAnalysisUserDefinedListDbItem[] {
+  ): RemoteUserDefinedListDbItem[] {
     const dbItemsResult = dbManager.getDbItems();
     const dbItems = flattenDbItems(dbItemsResult.value);
     const listDbItems = dbItems
-      .filter(isVariantAnalysisUserDefinedListDbItem)
+      .filter(isRemoteUserDefinedListDbItem)
       .filter((i) => i.listName === listName);
 
     return listDbItems;

--- a/extensions/ql-vscode/test/unit-tests/databases/db-tree-creator.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/db-tree-creator.test.ts
@@ -6,7 +6,7 @@ import {
   DbItemKind,
   isRemoteOwnerDbItem,
   isRemoteRepoDbItem,
-  isVariantAnalysisUserDefinedListDbItem,
+  isRemoteUserDefinedListDbItem,
 } from "../../../src/databases/db-item";
 import {
   ExpandedDbItem,
@@ -71,12 +71,12 @@ describe("db tree creator", () => {
       expect(dbTreeRoot).toBeTruthy();
       expect(dbTreeRoot.kind).toBe(DbItemKind.RootRemote);
       const repositoryListNodes = dbTreeRoot.children.filter(
-        isVariantAnalysisUserDefinedListDbItem,
+        isRemoteUserDefinedListDbItem,
       );
 
       expect(repositoryListNodes.length).toBe(2);
       expect(repositoryListNodes[0]).toEqual({
-        kind: DbItemKind.VariantAnalysisUserDefinedList,
+        kind: DbItemKind.RemoteUserDefinedList,
         selected: false,
         expanded: false,
         listName: dbConfig.databases.variantAnalysis.repositoryLists[0].name,
@@ -92,7 +92,7 @@ describe("db tree creator", () => {
           ),
       });
       expect(repositoryListNodes[1]).toEqual({
-        kind: DbItemKind.VariantAnalysisUserDefinedList,
+        kind: DbItemKind.RemoteUserDefinedList,
         selected: false,
         expanded: false,
         listName: dbConfig.databases.variantAnalysis.repositoryLists[1].name,
@@ -182,7 +182,7 @@ describe("db tree creator", () => {
         expect(dbTreeRoot).toBeTruthy();
         expect(dbTreeRoot.kind).toBe(DbItemKind.RootRemote);
         const repositoryListNodes = dbTreeRoot.children.filter(
-          (child) => child.kind === DbItemKind.VariantAnalysisUserDefinedList,
+          (child) => child.kind === DbItemKind.RemoteUserDefinedList,
         );
 
         expect(repositoryListNodes.length).toBe(1);
@@ -252,7 +252,7 @@ describe("db tree creator", () => {
         expect(dbTreeRoot).toBeTruthy();
 
         const listNodes = dbTreeRoot.children.filter(
-          isVariantAnalysisUserDefinedListDbItem,
+          isRemoteUserDefinedListDbItem,
         );
 
         expect(listNodes.length).toBe(1);
@@ -304,7 +304,7 @@ describe("db tree creator", () => {
         expect(dbTreeRoot.kind).toBe(DbItemKind.RootRemote);
         expect(dbTreeRoot.expanded).toBe(true);
         const repositoryListNodes = dbTreeRoot.children.filter(
-          isVariantAnalysisUserDefinedListDbItem,
+          isRemoteUserDefinedListDbItem,
         );
 
         expect(repositoryListNodes.length).toBe(1);

--- a/extensions/ql-vscode/test/unit-tests/databases/ui/db-tree-view-item-action.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/ui/db-tree-view-item-action.test.ts
@@ -8,7 +8,7 @@ import {
   createRemoteOwnerDbItem,
   createRemoteRepoDbItem,
   createRemoteSystemDefinedListDbItem,
-  createVariantAnalysisUserDefinedListDbItem,
+  createRemoteUserDefinedListDbItem,
   createRootLocalDbItem,
   createRootRemoteDbItem,
 } from "../../../factories/db-item-factories";
@@ -63,7 +63,7 @@ describe("getDbItemActions", () => {
   });
 
   it("should set canBeSelected, canBeRemoved and canBeRenamed for remote user defined db list", () => {
-    const dbItem = createVariantAnalysisUserDefinedListDbItem();
+    const dbItem = createRemoteUserDefinedListDbItem();
 
     const actions = getDbItemActions(dbItem);
 
@@ -71,7 +71,7 @@ describe("getDbItemActions", () => {
   });
 
   it("should not set canBeSelected for remote user defined db list that is already selected", () => {
-    const dbItem = createVariantAnalysisUserDefinedListDbItem({
+    const dbItem = createRemoteUserDefinedListDbItem({
       selected: true,
     });
 
@@ -135,7 +135,7 @@ describe("getGitHubUrl", () => {
   it("should return undefined for other remote db items", () => {
     const dbItem0 = createRootRemoteDbItem();
     const dbItem1 = createRemoteSystemDefinedListDbItem();
-    const dbItem2 = createVariantAnalysisUserDefinedListDbItem();
+    const dbItem2 = createRemoteUserDefinedListDbItem();
 
     const actualUrl0 = getGitHubUrl(dbItem0);
     const actualUrl1 = getGitHubUrl(dbItem1);

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/databases/db-panel-rendering.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/databases/db-panel-rendering.test.ts
@@ -125,7 +125,7 @@ describe("db panel rendering nodes", () => {
     expect(systemDefinedListItems.length).toBe(3);
 
     const userDefinedListItems = remoteRootNode!.children.filter(
-      (item) => item.dbItem?.kind === DbItemKind.VariantAnalysisUserDefinedList,
+      (item) => item.dbItem?.kind === DbItemKind.RemoteUserDefinedList,
     );
     expect(userDefinedListItems.length).toBe(2);
     checkUserDefinedListItem(userDefinedListItems[0], "my-list-1", [

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/databases/db-panel-selection.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/databases/db-panel-selection.test.ts
@@ -81,12 +81,12 @@ describe("db panel selection", () => {
 
     const list1 = remoteRootNode.children.find(
       (c) =>
-        c.dbItem?.kind === DbItemKind.VariantAnalysisUserDefinedList &&
+        c.dbItem?.kind === DbItemKind.RemoteUserDefinedList &&
         c.dbItem?.listName === "my-list-1",
     );
     const list2 = remoteRootNode.children.find(
       (c) =>
-        c.dbItem?.kind === DbItemKind.VariantAnalysisUserDefinedList &&
+        c.dbItem?.kind === DbItemKind.RemoteUserDefinedList &&
         c.dbItem?.listName === "my-list-2",
     );
 
@@ -129,7 +129,7 @@ describe("db panel selection", () => {
 
     const list2 = remoteRootNode.children.find(
       (c) =>
-        c.dbItem?.kind === DbItemKind.VariantAnalysisUserDefinedList &&
+        c.dbItem?.kind === DbItemKind.RemoteUserDefinedList &&
         c.dbItem?.listName === "my-list-2",
     );
     expect(list2).toBeTruthy();

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/remote-queries/repository-selection.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/remote-queries/repository-selection.test.ts
@@ -42,7 +42,7 @@ describe("repository selection", () => {
 
     it("should log an error when an empty remote user defined list is selected", async () => {
       const dbManager = setUpDbManager({
-        kind: DbItemKind.VariantAnalysisUserDefinedList,
+        kind: DbItemKind.RemoteUserDefinedList,
         repos: [] as RemoteRepoDbItem[],
       } as DbItem);
 
@@ -66,7 +66,7 @@ describe("repository selection", () => {
 
     it("should return correct selection when remote user defined list is selected", async () => {
       const dbManager = setUpDbManager({
-        kind: DbItemKind.VariantAnalysisUserDefinedList,
+        kind: DbItemKind.RemoteUserDefinedList,
         repos: [
           { repoFullName: "owner1/repo1" },
           { repoFullName: "owner1/repo2" },


### PR DESCRIPTION
It looks like I went a bit too far with the `remote -> variantAnalysis` rename (https://github.com/github/vscode-codeql/pull/1960) and accidentally renamed one of the domain entities 🤦  Since all others use `remote`, I decided to roll this one back.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
