### PR TITLE
Turn off support for local dbs and remote root 'remote' node from new db panel

### DIFF
--- a/extensions/ql-vscode/databases-schema.json
+++ b/extensions/ql-vscode/databases-schema.json
@@ -48,120 +48,14 @@
           },
           "required": ["repositoryLists", "owners", "repositories"],
           "additionalProperties": false
-        },
-        "local": {
-          "type": "object",
-          "properties": {
-            "lists": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string"
-                  },
-                  "databases": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "name": {
-                          "type": "string",
-                          "minLength": 1
-                        },
-                        "dateAdded": {
-                          "type": "number"
-                        },
-                        "language": {
-                          "type": "string",
-                          "minLength": 1
-                        },
-                        "storagePath": {
-                          "type": "string",
-                          "minLength": 1
-                        }
-                      },
-                      "required": [
-                        "name",
-                        "dateAdded",
-                        "language",
-                        "storagePath"
-                      ],
-                      "additionalProperties": false
-                    }
-                  }
-                },
-                "required": ["name", "databases"],
-                "additionalProperties": false
-              }
-            },
-            "databases": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "dateAdded": {
-                    "type": "number"
-                  },
-                  "language": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "storagePath": {
-                    "type": "string",
-                    "minLength": 1
-                  }
-                },
-                "required": ["name", "dateAdded", "language", "storagePath"],
-                "additionalProperties": false
-              }
-            }
-          },
-          "required": ["lists", "databases"],
-          "additionalProperties": false
         }
       },
-      "required": ["variantAnalysis", "local"],
+      "required": ["variantAnalysis"],
       "additionalProperties": false
     },
     "selected": {
       "type": "object",
       "oneOf": [
-        {
-          "properties": {
-            "kind": {
-              "type": "string",
-              "enum": ["localUserDefinedList"]
-            },
-            "listName": {
-              "type": "string",
-              "minLength": 1
-            }
-          },
-          "required": ["kind", "listName"],
-          "additionalProperties": false
-        },
-        {
-          "properties": {
-            "kind": {
-              "type": "string",
-              "enum": ["localDatabase"]
-            },
-            "databaseName": {
-              "type": "string"
-            },
-            "listName": {
-              "type": "string",
-              "minLength": 1
-            }
-          },
-          "required": ["kind", "databaseName"],
-          "additionalProperties": false
-        },
         {
           "properties": {
             "kind": {

--- a/extensions/ql-vscode/src/databases/config/db-config-store.ts
+++ b/extensions/ql-vscode/src/databases/config/db-config-store.ts
@@ -1,8 +1,10 @@
 import { pathExists, outputJSON, readJSON, readJSONSync } from "fs-extra";
 import { join } from "path";
 import {
+  clearLocalDbConfig,
   cloneDbConfig,
   DbConfig,
+  initializeLocalDbConfig,
   removeLocalDb,
   removeLocalList,
   removeRemoteList,
@@ -349,6 +351,7 @@ export class DbConfigStore extends DisposableObject {
   }
 
   private async writeConfig(config: DbConfig): Promise<void> {
+    clearLocalDbConfig(config);
     await outputJSON(this.configPath, config, {
       spaces: 2,
     });
@@ -380,6 +383,7 @@ export class DbConfigStore extends DisposableObject {
     }
 
     if (newConfig) {
+      initializeLocalDbConfig(newConfig);
       this.configErrors = this.configValidator.validate(newConfig);
     }
 
@@ -414,6 +418,7 @@ export class DbConfigStore extends DisposableObject {
     }
 
     if (newConfig) {
+      initializeLocalDbConfig(newConfig);
       this.configErrors = this.configValidator.validate(newConfig);
     }
 

--- a/extensions/ql-vscode/src/databases/config/db-config.ts
+++ b/extensions/ql-vscode/src/databases/config/db-config.ts
@@ -325,6 +325,38 @@ export function removeRemoteOwner(
   return config;
 }
 
+/**
+ * Removes local db config from a db config object, if one is set.
+ * We do this because we don't want to expose this feature to users
+ * yet (since it's only partially implemented), but we also don't want
+ * to remove all the code we've already implemented.
+ * @param config The config object to change.
+ * @returns Any removed local db config.
+ */
+export function clearLocalDbConfig(
+  config: DbConfig,
+): LocalDbConfig | undefined {
+  let localDbs = undefined;
+
+  if (config && config.databases && config.databases.local) {
+    localDbs = config.databases.local;
+    delete (config.databases as any).local;
+  }
+
+  return localDbs;
+}
+
+/**
+ * Initializes the local db config, if the config object contains
+ * database configuration.
+ * @param config The config object to change.
+ */
+export function initializeLocalDbConfig(config: DbConfig): void {
+  if (config.databases) {
+    config.databases.local = { lists: [], databases: [] };
+  }
+}
+
 function cloneDbConfigSelectedItem(selected: SelectedDbItem): SelectedDbItem {
   switch (selected.kind) {
     case SelectedDbItemKind.LocalUserDefinedList:

--- a/extensions/ql-vscode/src/databases/db-manager.ts
+++ b/extensions/ql-vscode/src/databases/db-manager.ts
@@ -20,7 +20,7 @@ import {
   getSelectedDbItem,
   mapDbItemToSelectedDbItem,
 } from "./db-item-selection";
-import { createLocalTree, createRemoteTree } from "./db-tree-creator";
+import { createRemoteTree } from "./db-tree-creator";
 import { DbConfigValidationError } from "./db-validation-errors";
 
 export class DbManager {
@@ -60,7 +60,6 @@ export class DbManager {
 
     return ValueResult.ok([
       createRemoteTree(configResult.value, expandedItems),
-      createLocalTree(configResult.value, expandedItems),
     ]);
   }
 

--- a/extensions/ql-vscode/src/databases/db-manager.ts
+++ b/extensions/ql-vscode/src/databases/db-manager.ts
@@ -58,9 +58,8 @@ export class DbManager {
 
     const expandedItems = this.getExpandedItems();
 
-    return ValueResult.ok([
-      createRemoteTree(configResult.value, expandedItems),
-    ]);
+    const remoteTree = createRemoteTree(configResult.value, expandedItems);
+    return ValueResult.ok(remoteTree.children);
   }
 
   public getConfigPath(): string {

--- a/extensions/ql-vscode/src/databases/ui/db-panel.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-panel.ts
@@ -22,7 +22,6 @@ import {
   DbListKind,
   LocalDatabaseDbItem,
   LocalListDbItem,
-  remoteDbKinds,
   RemoteUserDefinedListDbItem,
 } from "../db-item";
 import { getDbItemName } from "../db-item-naming";
@@ -219,7 +218,7 @@ export class DbPanel extends DisposableObject {
   }
 
   private async addNewList(): Promise<void> {
-    const listKind = await this.getAddNewListKind();
+    const listKind = DbListKind.Remote;
 
     const listName = await window.showInputBox({
       prompt: "Enter a name for the new list",
@@ -235,47 +234,6 @@ export class DbPanel extends DisposableObject {
     }
 
     await this.dbManager.addNewList(listKind, listName);
-  }
-
-  private async getAddNewListKind(): Promise<DbListKind> {
-    const highlightedItem = await this.getHighlightedDbItem();
-    if (highlightedItem) {
-      return remoteDbKinds.includes(highlightedItem.kind)
-        ? DbListKind.Remote
-        : DbListKind.Local;
-    } else {
-      const quickPickItems = [
-        {
-          label: "$(cloud) Variant Analysis",
-          detail: "Add a repository from GitHub",
-          alwaysShow: true,
-          kind: DbListKind.Remote,
-        },
-        {
-          label: "$(database) Local",
-          detail: "Import a database from the cloud or a local file",
-          alwaysShow: true,
-          kind: DbListKind.Local,
-        },
-      ];
-      const selectedOption = await window.showQuickPick<AddListQuickPickItem>(
-        quickPickItems,
-        {
-          title: "Add a new database",
-          ignoreFocusOut: true,
-        },
-      );
-      if (!selectedOption) {
-        // We don't need to display a warning pop-up in this case, since the user just escaped out of the operation.
-        // We set 'true' to make this a silent exception.
-        throw new UserCancellationException(
-          "No database list kind selected",
-          true,
-        );
-      }
-
-      return selectedOption.kind;
-    }
   }
 
   private async setSelectedItem(treeViewItem: DbTreeViewItem): Promise<void> {

--- a/extensions/ql-vscode/test/unit-tests/databases/config/data/databases.json
+++ b/extensions/ql-vscode/test/unit-tests/databases/config/data/databases.json
@@ -9,40 +9,6 @@
       ],
       "owners": [],
       "repositories": ["owner/repo1", "owner/repo2", "owner/repo3"]
-    },
-    "local": {
-      "lists": [
-        {
-          "name": "localList1",
-          "databases": [
-            {
-              "name": "foo/bar",
-              "dateAdded": 1668096745193,
-              "language": "go",
-              "storagePath": "/path/to/database/"
-            }
-          ]
-        },
-        {
-          "name": "localList2",
-          "databases": [
-            {
-              "name": "foo/baz",
-              "dateAdded": 1668096760848,
-              "language": "javascript",
-              "storagePath": "/path/to/database/"
-            }
-          ]
-        }
-      ],
-      "databases": [
-        {
-          "name": "example-db",
-          "dateAdded": 1668096927267,
-          "language": "ruby",
-          "storagePath": "/path/to/database/"
-        }
-      ]
     }
   },
   "selected": {

--- a/extensions/ql-vscode/test/unit-tests/databases/config/data/without-selected/databases.json
+++ b/extensions/ql-vscode/test/unit-tests/databases/config/data/without-selected/databases.json
@@ -4,10 +4,6 @@
       "repositoryLists": [],
       "owners": [],
       "repositories": []
-    },
-    "local": {
-      "lists": [],
-      "databases": []
     }
   }
 }

--- a/extensions/ql-vscode/test/unit-tests/databases/config/db-config-store.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/config/db-config-store.test.ts
@@ -82,25 +82,6 @@ describe("db config store", () => {
         "owner/repo2",
         "owner/repo3",
       ]);
-      expect(config.databases.local.lists).toHaveLength(2);
-      expect(config.databases.local.lists[0]).toEqual({
-        name: "localList1",
-        databases: [
-          {
-            name: "foo/bar",
-            dateAdded: 1668096745193,
-            language: "go",
-            storagePath: "/path/to/database/",
-          },
-        ],
-      });
-      expect(config.databases.local.databases).toHaveLength(1);
-      expect(config.databases.local.databases[0]).toEqual({
-        name: "example-db",
-        dateAdded: 1668096927267,
-        language: "ruby",
-        storagePath: "/path/to/database/",
-      });
       expect(config.selected).toEqual({
         kind: SelectedDbItemKind.VariantAnalysisUserDefinedList,
         listName: "repoList1",
@@ -272,7 +253,7 @@ describe("db config store", () => {
       configStore.dispose();
     });
 
-    it("should add a local list", async () => {
+    it.skip("should add a local list", async () => {
       // Initial set up
       const dbConfig = createDbConfig();
 
@@ -370,7 +351,7 @@ describe("db config store", () => {
       configStore.dispose();
     });
 
-    it("should allow renaming a local list", async () => {
+    it.skip("should allow renaming a local list", async () => {
       // Initial set up
       const dbConfig = createDbConfig({
         localLists: [
@@ -413,7 +394,7 @@ describe("db config store", () => {
       configStore.dispose();
     });
 
-    it("should allow renaming of a local db", async () => {
+    it.skip("should allow renaming of a local db", async () => {
       // Initial set up
       const dbConfig = createDbConfig({
         localLists: [
@@ -723,7 +704,7 @@ describe("db config store", () => {
       configStore.dispose();
     });
 
-    it("should return true if a local db and local list exists", async () => {
+    it.skip("should return true if a local db and local list exists", async () => {
       // Initial set up
       const dbConfig = createDbConfig({
         localLists: [
@@ -772,8 +753,11 @@ describe("db config store", () => {
     configPath: string,
     app: App,
   ): Promise<DbConfigStore> {
+    if (dbConfig && dbConfig.databases && dbConfig.databases.local) {
+      delete (dbConfig.databases as any).local;
+    }
+    // const config = clearLocalDbs(dbConfig);
     await writeJSON(configPath, dbConfig);
-
     const configStore = new DbConfigStore(app, false);
     await configStore.initialize();
 

--- a/extensions/ql-vscode/test/unit-tests/databases/config/db-config-validator.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/config/db-config-validator.test.ts
@@ -31,18 +31,14 @@ describe("db config validation", () => {
 
     const validationOutput = configValidator.validate(dbConfig);
 
-    expect(validationOutput).toHaveLength(3);
+    expect(validationOutput).toHaveLength(2);
 
     expect(validationOutput[0]).toEqual({
-      kind: DbConfigValidationErrorKind.InvalidConfig,
-      message: "/databases must have required property 'local'",
-    });
-    expect(validationOutput[1]).toEqual({
       kind: DbConfigValidationErrorKind.InvalidConfig,
       message:
         "/databases/variantAnalysis must have required property 'owners'",
     });
-    expect(validationOutput[2]).toEqual({
+    expect(validationOutput[1]).toEqual({
       kind: DbConfigValidationErrorKind.InvalidConfig,
       message: "/databases/variantAnalysis must NOT have additional properties",
     });

--- a/extensions/ql-vscode/test/unit-tests/databases/db-manager.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/db-manager.test.ts
@@ -173,7 +173,7 @@ describe("db manager", () => {
         });
       });
 
-      it("should throw error when adding a new list to a local node", async () => {
+      it.skip("should add a new local list", async () => {
         const dbConfig: DbConfig = createDbConfig({
           localLists: [
             {
@@ -285,17 +285,9 @@ describe("db manager", () => {
         name: "my-list-2",
         repositories: ["owner1/repo1", "owner1/repo2"],
       });
-
-      // Check that the local list has not been renamed
-      const localLists = dbConfigFileContents.databases.local.lists;
-      expect(localLists.length).toBe(1);
-      expect(localLists[0]).toEqual({
-        name: "my-list-1",
-        databases: [localDb],
-      });
     });
 
-    it("should rename local db list", async () => {
+    it.skip("should rename local db list", async () => {
       const dbConfig = createDbConfig({
         remoteLists: [remoteList],
         localLists: [localList],
@@ -328,7 +320,7 @@ describe("db manager", () => {
       });
     });
 
-    it("should rename local db outside a list", async () => {
+    it.skip("should rename local db outside a list", async () => {
       const dbConfig = createDbConfig({
         localLists: [localList],
         localDbs: [localDb],
@@ -357,7 +349,7 @@ describe("db manager", () => {
       });
     });
 
-    it("should rename local db inside a list", async () => {
+    it.skip("should rename local db inside a list", async () => {
       const dbConfig = createDbConfig({
         localLists: [localList],
         localDbs: [localDb],
@@ -427,10 +419,6 @@ describe("db manager", () => {
             repositories: [remoteRepo1, remoteRepo2],
             owners: [remoteOwner],
           },
-          local: {
-            lists: [localList],
-            databases: [localDb],
-          },
         },
       });
     });
@@ -451,10 +439,6 @@ describe("db manager", () => {
             repositoryLists: [remoteList],
             repositories: [remoteRepo2],
             owners: [remoteOwner],
-          },
-          local: {
-            lists: [localList],
-            databases: [localDb],
           },
         },
         selected: {
@@ -481,10 +465,6 @@ describe("db manager", () => {
             repositories: [remoteRepo1, remoteRepo2],
             owners: [],
           },
-          local: {
-            lists: [localList],
-            databases: [localDb],
-          },
         },
         selected: {
           kind: SelectedDbItemKind.VariantAnalysisUserDefinedList,
@@ -493,7 +473,7 @@ describe("db manager", () => {
       });
     });
 
-    it("should remove local db list", async () => {
+    it.skip("should remove local db list", async () => {
       await saveDbConfig(dbConfig);
 
       const localListDbItems = getLocalListDbItems("my-list-1");
@@ -522,7 +502,7 @@ describe("db manager", () => {
       });
     });
 
-    it("should remove local database", async () => {
+    it.skip("should remove local database", async () => {
       await saveDbConfig(dbConfig);
 
       const localDbItems = getLocalDatabaseDbItems("db1");

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/databases/db-panel.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/databases/db-panel.test.ts
@@ -35,9 +35,6 @@ describe("Db panel UI commands", () => {
 
   it("should add new remote db list", async () => {
     // Add db list
-    jest.spyOn(window, "showQuickPick").mockResolvedValue({
-      kind: DbListKind.Remote,
-    } as AddListQuickPickItem);
     jest.spyOn(window, "showInputBox").mockResolvedValue("my-list-1");
     await commands.executeCommand(
       "codeQLVariantAnalysisRepositories.addNewList",
@@ -55,7 +52,7 @@ describe("Db panel UI commands", () => {
     );
   });
 
-  it("should add new local db list", async () => {
+  it.skip("should add new local db list", async () => {
     // Add db list
     jest.spyOn(window, "showQuickPick").mockResolvedValue({
       kind: DbListKind.Local,

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/databases/db-panel-rendering.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/databases/db-panel-rendering.test.ts
@@ -48,7 +48,7 @@ describe("db panel rendering nodes", () => {
     await remove(workspaceStoragePath);
   });
 
-  it("should render default local and remote nodes when the config is empty", async () => {
+  it("should render default remote nodes when the config is empty", async () => {
     const dbConfig: DbConfig = createDbConfig();
 
     await saveDbConfig(dbConfig);
@@ -57,7 +57,7 @@ describe("db panel rendering nodes", () => {
 
     expect(dbTreeItems).toBeTruthy();
     const items = dbTreeItems!;
-    expect(items.length).toBe(2);
+    expect(items.length).toBe(1);
 
     const remoteRootNode = items[0];
     expect(remoteRootNode.dbItem).toBeTruthy();
@@ -77,17 +77,6 @@ describe("db panel rendering nodes", () => {
     checkRemoteSystemDefinedListItem(systemDefinedListItems[0], 10);
     checkRemoteSystemDefinedListItem(systemDefinedListItems[1], 100);
     checkRemoteSystemDefinedListItem(systemDefinedListItems[2], 1000);
-
-    const localRootNode = items[1];
-    expect(localRootNode.dbItem).toBeTruthy();
-    expect(localRootNode.dbItem?.kind).toBe(DbItemKind.RootLocal);
-    expect(localRootNode.label).toBe("local");
-    expect(localRootNode.tooltip).toBe("Local databases");
-    expect(localRootNode.collapsibleState).toBe(
-      TreeItemCollapsibleState.Collapsed,
-    );
-    expect(localRootNode.children).toBeTruthy();
-    expect(localRootNode.children.length).toBe(0);
   });
 
   it("should render remote repository list nodes", async () => {
@@ -199,7 +188,7 @@ describe("db panel rendering nodes", () => {
     checkRemoteRepoItem(repoItems[1], "owner1/repo2");
   });
 
-  it("should render local list nodes", async () => {
+  it.skip("should render local list nodes", async () => {
     const dbConfig: DbConfig = createDbConfig({
       localLists: [
         {
@@ -284,7 +273,7 @@ describe("db panel rendering nodes", () => {
     ]);
   });
 
-  it("should render local database nodes", async () => {
+  it.skip("should render local database nodes", async () => {
     const dbConfig: DbConfig = createDbConfig({
       localDbs: [
         {

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/databases/db-panel-rendering.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/databases/db-panel-rendering.test.ts
@@ -57,26 +57,11 @@ describe("db panel rendering nodes", () => {
 
     expect(dbTreeItems).toBeTruthy();
     const items = dbTreeItems!;
-    expect(items.length).toBe(1);
+    expect(items.length).toBe(3);
 
-    const remoteRootNode = items[0];
-    expect(remoteRootNode.dbItem).toBeTruthy();
-    expect(remoteRootNode.dbItem?.kind).toBe(DbItemKind.RootRemote);
-    expect(remoteRootNode.label).toBe("remote");
-    expect(remoteRootNode.tooltip).toBe("Remote databases");
-    expect(remoteRootNode.collapsibleState).toBe(
-      TreeItemCollapsibleState.Collapsed,
-    );
-    expect(remoteRootNode.children).toBeTruthy();
-    expect(remoteRootNode.children.length).toBe(3);
-
-    const systemDefinedListItems = remoteRootNode.children.filter(
-      (item) => item.dbItem?.kind === DbItemKind.RemoteSystemDefinedList,
-    );
-    expect(systemDefinedListItems.length).toBe(3);
-    checkRemoteSystemDefinedListItem(systemDefinedListItems[0], 10);
-    checkRemoteSystemDefinedListItem(systemDefinedListItems[1], 100);
-    checkRemoteSystemDefinedListItem(systemDefinedListItems[2], 1000);
+    checkRemoteSystemDefinedListItem(items[0], 10);
+    checkRemoteSystemDefinedListItem(items[1], 100);
+    checkRemoteSystemDefinedListItem(items[2], 1000);
   });
 
   it("should render remote repository list nodes", async () => {
@@ -98,22 +83,12 @@ describe("db panel rendering nodes", () => {
     const dbTreeItems = await dbTreeDataProvider.getChildren();
     expect(dbTreeItems).toBeTruthy();
 
-    const remoteRootNode = dbTreeItems?.find(
-      (i) => i.dbItem?.kind === DbItemKind.RootRemote,
-    );
-    expect(remoteRootNode).toBeTruthy();
-    expect(remoteRootNode!.collapsibleState).toBe(
-      TreeItemCollapsibleState.Collapsed,
-    );
-    expect(remoteRootNode!.children).toBeTruthy();
-    expect(remoteRootNode!.children.length).toBe(5);
-
-    const systemDefinedListItems = remoteRootNode!.children.filter(
+    const systemDefinedListItems = dbTreeItems!.filter(
       (item) => item.dbItem?.kind === DbItemKind.RemoteSystemDefinedList,
     );
     expect(systemDefinedListItems.length).toBe(3);
 
-    const userDefinedListItems = remoteRootNode!.children.filter(
+    const userDefinedListItems = dbTreeItems!.filter(
       (item) => item.dbItem?.kind === DbItemKind.RemoteUserDefinedList,
     );
     expect(userDefinedListItems.length).toBe(2);
@@ -137,20 +112,9 @@ describe("db panel rendering nodes", () => {
 
     const dbTreeItems = await dbTreeDataProvider.getChildren();
     expect(dbTreeItems).toBeTruthy();
+    expect(dbTreeItems?.length).toBe(5);
 
-    const remoteRootNode = dbTreeItems?.find(
-      (i) => i.dbItem?.kind === DbItemKind.RootRemote,
-    );
-    expect(remoteRootNode).toBeTruthy();
-
-    expect(remoteRootNode!.dbItem).toBeTruthy();
-    expect(remoteRootNode!.collapsibleState).toBe(
-      TreeItemCollapsibleState.Collapsed,
-    );
-    expect(remoteRootNode!.children).toBeTruthy();
-    expect(remoteRootNode!.children.length).toBe(5);
-
-    const ownerListItems = remoteRootNode!.children.filter(
+    const ownerListItems = dbTreeItems!.filter(
       (item) => item.dbItem?.kind === DbItemKind.RemoteOwner,
     );
     expect(ownerListItems.length).toBe(2);
@@ -167,20 +131,9 @@ describe("db panel rendering nodes", () => {
 
     const dbTreeItems = await dbTreeDataProvider.getChildren();
     expect(dbTreeItems).toBeTruthy();
+    expect(dbTreeItems!.length).toBe(5);
 
-    const remoteRootNode = dbTreeItems?.find(
-      (i) => i.dbItem?.kind === DbItemKind.RootRemote,
-    );
-    expect(remoteRootNode).toBeTruthy();
-
-    expect(remoteRootNode!.dbItem).toBeTruthy();
-    expect(remoteRootNode!.collapsibleState).toBe(
-      TreeItemCollapsibleState.Collapsed,
-    );
-    expect(remoteRootNode!.children).toBeTruthy();
-    expect(remoteRootNode!.children.length).toBe(5);
-
-    const repoItems = remoteRootNode!.children.filter(
+    const repoItems = dbTreeItems!.filter(
       (item) => item.dbItem?.kind === DbItemKind.RemoteRepo,
     );
     expect(repoItems.length).toBe(2);

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/databases/db-panel-selection.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/databases/db-panel-selection.test.ts
@@ -75,16 +75,12 @@ describe("db panel selection", () => {
     expect(dbTreeItems).toBeTruthy();
     const items = dbTreeItems!;
 
-    const remoteRootNode = items[0];
-    expect(remoteRootNode.dbItem).toBeTruthy();
-    expect(remoteRootNode.dbItem?.kind).toEqual(DbItemKind.RootRemote);
-
-    const list1 = remoteRootNode.children.find(
+    const list1 = items.find(
       (c) =>
         c.dbItem?.kind === DbItemKind.RemoteUserDefinedList &&
         c.dbItem?.listName === "my-list-1",
     );
-    const list2 = remoteRootNode.children.find(
+    const list2 = items.find(
       (c) =>
         c.dbItem?.kind === DbItemKind.RemoteUserDefinedList &&
         c.dbItem?.listName === "my-list-2",
@@ -123,11 +119,7 @@ describe("db panel selection", () => {
     expect(dbTreeItems).toBeTruthy();
     const items = dbTreeItems!;
 
-    const remoteRootNode = items[0];
-    expect(remoteRootNode.dbItem).toBeTruthy();
-    expect(remoteRootNode.dbItem?.kind).toEqual(DbItemKind.RootRemote);
-
-    const list2 = remoteRootNode.children.find(
+    const list2 = items.find(
       (c) =>
         c.dbItem?.kind === DbItemKind.RemoteUserDefinedList &&
         c.dbItem?.listName === "my-list-2",
@@ -150,7 +142,7 @@ describe("db panel selection", () => {
     expect(repo2Node).toBeTruthy();
     expect(isTreeViewItemSelectable(repo2Node!)).toBeTruthy();
 
-    for (const item of remoteRootNode.children) {
+    for (const item of items) {
       expect(isTreeViewItemSelectable(item)).toBeTruthy();
     }
   });


### PR DESCRIPTION
Since support for local dbs is only partially implemented in the new panel, we've decided to turn it off for now. In this PR we:
- [Turn off support for local dbs in new panel](https://github.com/github/vscode-codeql/commit/65623c07a247c9466b0998a2a2fb7609e4c4084a)
- [Remove root 'remote' node](https://github.com/github/vscode-codeql/commit/526c4f3ab7fa004e40b3010fd1c7f384110836e3)

As part of this it means that we have to mark a few tests as skipped. 

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
