### PR TITLE
Add remote queries and variant analyses to our serialization tests   

### DIFF
--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-serialization.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-serialization.test.ts
@@ -11,6 +11,11 @@ import { CancellationTokenSource, Uri } from "vscode";
 import { tmpDir } from "../../../src/helpers";
 import { QueryResultType } from "../../../src/pure/legacy-messages";
 import { QueryInProgress } from "../../../src/legacy-query-server/run-queries";
+import { RemoteQueryHistoryItem } from "../../../src/remote-queries/remote-query-history-item";
+import { VariantAnalysisHistoryItem } from "../../../src/remote-queries/variant-analysis-history-item";
+import { QueryHistoryInfo } from "../../../src/query-history-info";
+import { createMockRemoteQueryHistoryItem } from "../../factories/remote-queries/remote-query-history-item";
+import { createMockVariantAnalysisHistoryItem } from "../../factories/remote-queries/variant-analysis-history-item";
 
 describe("serialize and deserialize", () => {
   let infoSuccessRaw: LocalQueryInfo;
@@ -18,7 +23,14 @@ describe("serialize and deserialize", () => {
   let infoEarlyFailure: LocalQueryInfo;
   let infoLateFailure: LocalQueryInfo;
   let infoInprogress: LocalQueryInfo;
-  let allHistory: LocalQueryInfo[];
+
+  let remoteQuery1: RemoteQueryHistoryItem;
+  let remoteQuery2: RemoteQueryHistoryItem;
+
+  let variantAnalysis1: VariantAnalysisHistoryItem;
+  let variantAnalysis2: VariantAnalysisHistoryItem;
+
+  let allHistory: QueryHistoryInfo[];
   let queryPath: string;
   let cnt = 0;
 
@@ -57,12 +69,23 @@ describe("serialize and deserialize", () => {
       ),
     );
     infoInprogress = createMockFullQueryInfo("e");
+
+    remoteQuery1 = createMockRemoteQueryHistoryItem({});
+    remoteQuery2 = createMockRemoteQueryHistoryItem({});
+
+    variantAnalysis1 = createMockVariantAnalysisHistoryItem({});
+    variantAnalysis2 = createMockVariantAnalysisHistoryItem({});
+
     allHistory = [
       infoSuccessRaw,
       infoSuccessInterpreted,
       infoEarlyFailure,
       infoLateFailure,
       infoInprogress,
+      remoteQuery1,
+      remoteQuery2,
+      variantAnalysis1,
+      variantAnalysis2,
     ];
   });
 
@@ -72,6 +95,10 @@ describe("serialize and deserialize", () => {
       infoSuccessRaw,
       infoSuccessInterpreted,
       infoLateFailure,
+      remoteQuery1,
+      remoteQuery2,
+      variantAnalysis1,
+      variantAnalysis2,
     ];
 
     const allHistoryPath = join(tmpDir.name, "workspace-query-history.json");
@@ -98,7 +125,7 @@ describe("serialize and deserialize", () => {
       }
     });
     expectedHistory.forEach((info) => {
-      if (info.completedQuery) {
+      if (info.t == "local" && info.completedQuery) {
         (info.completedQuery as any).dispose = undefined;
       }
     });

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-serialization.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-serialization.test.ts
@@ -22,7 +22,7 @@ describe("serialize and deserialize", () => {
   let infoSuccessInterpreted: LocalQueryInfo;
   let infoEarlyFailure: LocalQueryInfo;
   let infoLateFailure: LocalQueryInfo;
-  let infoInprogress: LocalQueryInfo;
+  let infoInProgress: LocalQueryInfo;
 
   let remoteQuery1: RemoteQueryHistoryItem;
   let remoteQuery2: RemoteQueryHistoryItem;
@@ -68,7 +68,7 @@ describe("serialize and deserialize", () => {
         false,
       ),
     );
-    infoInprogress = createMockFullQueryInfo("e");
+    infoInProgress = createMockFullQueryInfo("e");
 
     remoteQuery1 = createMockRemoteQueryHistoryItem({});
     remoteQuery2 = createMockRemoteQueryHistoryItem({});
@@ -81,7 +81,7 @@ describe("serialize and deserialize", () => {
       infoSuccessInterpreted,
       infoEarlyFailure,
       infoLateFailure,
-      infoInprogress,
+      infoInProgress,
       remoteQuery1,
       remoteQuery2,
       variantAnalysis1,


### PR DESCRIPTION
This was just testing local queries.

Extracted from: https://github.com/github/vscode-codeql/compare/elena/protobuf

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
