### PR TITLE
Minor polish to the "bump CLI" automation

### DIFF
--- a/.github/actions/create-pr/action.yml
+++ b/.github/actions/create-pr/action.yml
@@ -75,7 +75,7 @@ runs:
           echo "Found existing open PR: $PR_NUMBERS"
           exit 0
         fi
-        gh pr create --head "$HEAD_BRANCH" --base "$BASE_BRANCH" --title "$TITLE" --body "$BODY" --assignee ${{ github.actor }}
+        gh pr create --head "$HEAD_BRANCH" --base "$BASE_BRANCH" --title "$TITLE" --body "$BODY" --assignee ${{ github.actor }} --draft
         if [[ $? -ne 0 ]]; then
           echo "Failed to create new PR."
           exit 1

--- a/extensions/ql-vscode/.prettierignore
+++ b/extensions/ql-vscode/.prettierignore
@@ -2,5 +2,9 @@
 node_modules/
 out/
 
+# This file gets written by an actions workflow.
+# Don't try to format it.
+supported_cli_versions.json
+
 # Include the Storybook config
 !.storybook


### PR DESCRIPTION
We took @tjgurwara99's new `bump-cli` workflow for its first test run in #1995, which worked great! 🙏🏽 🎉 

This PR polished a few minor things noticed during testing: 💅🏽 
- Tell Prettier to ignore `supported_cli_versions.json` when linting/formatting
- Open the generated PR as a draft: CI doesn't run on PRs opened by the github-actions bot, so we need a human to manually prod them. Our existing approach (e.g. in the [releases workflow](https://github.com/github/vscode-codeql/blob/bd74b410f651ab5254f3f1efa281c2dbfe9def12/.github/workflows/release.yml#L134)) is to open the bot PR as a draft, and then [run CI](https://github.com/github/vscode-codeql/blob/b0168aa04a6763eb41897c6989933aef7e9a51ea/.github/workflows/main.yml#L5) when a human marks it as ready-for-review.


## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
