### PR TITLE
Make use of asError instead of reimplementing

### DIFF
--- a/extensions/ql-vscode/src/commandRunner.ts
+++ b/extensions/ql-vscode/src/commandRunner.ts
@@ -8,7 +8,7 @@ import {
 } from "vscode";
 import { showAndLogErrorMessage, showAndLogWarningMessage } from "./helpers";
 import { extLogger } from "./common";
-import { getErrorMessage, getErrorStack } from "./pure/helpers-pure";
+import { asError, getErrorMessage, getErrorStack } from "./pure/helpers-pure";
 import { telemetryListener } from "./telemetry";
 
 export class UserCancellationException extends Error {
@@ -126,7 +126,7 @@ export function commandRunner(
       return await task(...args);
     } catch (e) {
       const errorMessage = `${getErrorMessage(e) || e} (${commandId})`;
-      error = e instanceof Error ? e : new Error(errorMessage);
+      error = asError(e);
       const errorStack = getErrorStack(e);
       if (e instanceof UserCancellationException) {
         // User has cancelled this action manually
@@ -179,7 +179,7 @@ export function commandRunnerWithProgress<R>(
       return await withProgress(progressOptionsWithDefaults, task, ...args);
     } catch (e) {
       const errorMessage = `${getErrorMessage(e) || e} (${commandId})`;
-      error = e instanceof Error ? e : new Error(errorMessage);
+      error = asError(e);
       const errorStack = getErrorStack(e);
       if (e instanceof UserCancellationException) {
         // User has cancelled this action manually

--- a/extensions/ql-vscode/src/databases.ts
+++ b/extensions/ql-vscode/src/databases.ts
@@ -19,7 +19,7 @@ import {
 } from "./archive-filesystem-provider";
 import { DisposableObject } from "./pure/disposable-object";
 import { Logger, extLogger } from "./common";
-import { getErrorMessage } from "./pure/helpers-pure";
+import { asError, getErrorMessage } from "./pure/helpers-pure";
 import { QueryRunner } from "./queryRunner";
 import { pathsEqual } from "./pure/files";
 
@@ -370,7 +370,7 @@ export class DatabaseItemImpl implements DatabaseItem {
         this._error = undefined;
       } catch (e) {
         this._contents = undefined;
-        this._error = e instanceof Error ? e : new Error(String(e));
+        this._error = asError(e);
         throw e;
       }
     } finally {

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -73,7 +73,7 @@ import {
   showInformationMessageWithAction,
   tmpDir,
 } from "./helpers";
-import { assertNever, getErrorMessage } from "./pure/helpers-pure";
+import { asError, assertNever, getErrorMessage } from "./pure/helpers-pure";
 import { spawnIdeServer } from "./ide-server";
 import { ResultsView } from "./interface";
 import { WebviewReveal } from "./interface-utils";
@@ -771,7 +771,9 @@ async function activateWithInstalledDistribution(
         // Note we must update the query history view after showing results as the
         // display and sorting might depend on the number of results
       } catch (e) {
-        item.failureReason = `Error running query: ${getErrorMessage(e)}`;
+        const err = asError(e);
+        err.message = `Error running query: ${err.message}`;
+        item.failureReason = err.message;
         throw e;
       } finally {
         await qhm.refreshTreeView();

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -73,7 +73,7 @@ import {
   showInformationMessageWithAction,
   tmpDir,
 } from "./helpers";
-import { asError, assertNever, getErrorMessage } from "./pure/helpers-pure";
+import { assertNever, getErrorMessage } from "./pure/helpers-pure";
 import { spawnIdeServer } from "./ide-server";
 import { ResultsView } from "./interface";
 import { WebviewReveal } from "./interface-utils";
@@ -771,9 +771,7 @@ async function activateWithInstalledDistribution(
         // Note we must update the query history view after showing results as the
         // display and sorting might depend on the number of results
       } catch (e) {
-        const err = asError(e);
-        err.message = `Error running query: ${err.message}`;
-        item.failureReason = err.message;
+        item.failureReason = `Error running query: ${getErrorMessage(e)}`;
         throw e;
       } finally {
         await qhm.refreshTreeView();

--- a/extensions/ql-vscode/src/pure/helpers-pure.ts
+++ b/extensions/ql-vscode/src/pure/helpers-pure.ts
@@ -46,14 +46,14 @@ export const REPO_REGEX = /^[a-zA-Z0-9-_\.]+\/[a-zA-Z0-9-_\.]+$/;
  */
 export const OWNER_REGEX = /^[a-zA-Z0-9-_\.]+$/;
 
-export function getErrorMessage(e: any) {
+export function getErrorMessage(e: unknown) {
   return e instanceof Error ? e.message : String(e);
 }
 
-export function getErrorStack(e: any) {
+export function getErrorStack(e: unknown) {
   return e instanceof Error ? e.stack ?? "" : "";
 }
 
-export function asError(e: any): Error {
+export function asError(e: unknown): Error {
   return e instanceof Error ? e : new Error(String(e));
 }

--- a/extensions/ql-vscode/src/run-queries-shared.ts
+++ b/extensions/ql-vscode/src/run-queries-shared.ts
@@ -33,7 +33,7 @@ import { DatabaseManager } from "./databases";
 import { DecodedBqrsChunk } from "./pure/bqrs-cli-types";
 import { extLogger, Logger } from "./common";
 import { generateSummarySymbolsFile } from "./log-insights/summary-parser";
-import { asError } from "./pure/helpers-pure";
+import { getErrorMessage } from "./pure/helpers-pure";
 
 /**
  * run-queries.ts
@@ -270,9 +270,10 @@ export class QueryEvaluationInfo {
       );
       return this.evalLogSummaryPath;
     } catch (e) {
-      const err = asError(e);
       void showAndLogWarningMessage(
-        `Failed to generate human-readable structured evaluator log summary. Reason: ${err.message}`,
+        `Failed to generate human-readable structured evaluator log summary. Reason: ${getErrorMessage(
+          e,
+        )}`,
       );
       return undefined;
     }


### PR DESCRIPTION
This PR updates a few places that were doing their own `e instanceOf Error` check to instead use `asError` or `getErrorMessage` as appropriate.

Also updates the types of the helper methods to be more restrictive, as I believe using `unknown` instead of `any` where possible is generally best practice. I haven't gone any further than this with annotating things as `unknown` to avoid going down too much of a rabbit hole.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
