### PR TITLE
Introduce ShowAndLogOptions

### DIFF
--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -44,8 +44,14 @@ export const tmpDirDisposal = {
 };
 
 interface ShowAndLogOptions {
+  /** The output logger that will receive the message. */
   outputLogger?: OutputChannelLogger;
+  /** A set of items that will be rendered as actions in the message. */
   items?: string[];
+  /**
+   * An alternate message that is added to the log, but not displayed in the popup.
+   * This is useful for adding extra detail to the logs that would be too noisy for the popup.
+   */
   fullMessage?: string;
 }
 
@@ -53,11 +59,7 @@ interface ShowAndLogOptions {
  * Show an error message and log it to the console
  *
  * @param message The message to show.
- * @param options.outputLogger The output logger that will receive the message
- * @param options.items A set of items that will be rendered as actions in the message.
- * @param options.fullMessage An alternate message that is added to the log, but not displayed
- *                           in the popup. This is useful for adding extra detail to the logs
- *                           that would be too noisy for the popup.
+ * @param options See indivual fields on `ShowAndLogOptions` type.
  *
  * @return A promise that resolves to the selected item or undefined when being dismissed.
  */
@@ -80,11 +82,7 @@ function dropLinesExceptInitial(message: string, n = 2) {
  * Show a warning message and log it to the console
  *
  * @param message The message to show.
- * @param options.outputLogger The output logger that will receive the message
- * @param options.items A set of items that will be rendered as actions in the message.
- * @param options.fullMessage An alternate message that is added to the log, but not displayed
- *                           in the popup. This is useful for adding extra detail to the logs
- *                           that would be too noisy for the popup.
+ * @param options See indivual fields on `ShowAndLogOptions` type.
  *
  * @return A promise that resolves to the selected item or undefined when being dismissed.
  */
@@ -99,11 +97,7 @@ export async function showAndLogWarningMessage(
  * Show an information message and log it to the console
  *
  * @param message The message to show.
- * @param options.outputLogger The output logger that will receive the message
- * @param options.items A set of items that will be rendered as actions in the message.
- * @param options.fullMessage An alternate message that is added to the log, but not displayed
- *                           in the popup. This is useful for adding extra detail to the logs
- *                           that would be too noisy for the popup.
+ * @param options See indivual fields on `ShowAndLogOptions` type.
  *
  * @return A promise that resolves to the selected item or undefined when being dismissed.
  */


### PR DESCRIPTION
The idea here is to standardise how our `showAndLogXMessage` methods behave. Currently they're each a little different. This PR should mean that the arguments for all the methods stay in sync, and also the default values are only defined in one place instead of multiple places.

I'm also possibly about to introduce another variant of `showAndLogErrorMessage` so I'll want to be able to easily make that consistent too.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
