### PR TITLE
Use JSON schemas to validate query history items

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -26,3 +26,6 @@ extensions/ql-vscode/src/stories/remote-queries/data/*.json     linguist-generat
 
 # Always use LF line endings, also on Windows
 * text=auto eol=lf
+
+# Mark JSON schema files as generated so they are not included as part of diffs
+extensions/ql-vscode/src/data-serialization/generated-schemas/*.json     linguist-generated

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,6 +69,7 @@ jobs:
           LATEST=`gh api repos/dsp-testing/codeql-cli-nightlies/releases --jq '.[].tag_name' --method GET --raw-field 'per_page=1'`
           echo "nightly-url=https://github.com/dsp-testing/codeql-cli-nightlies/releases/download/$LATEST" >> "$GITHUB_OUTPUT"
 
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -105,6 +106,11 @@ jobs:
         run: |
           npm run lint:scenarios
 
+      - name: Check generated JSON schemas
+        working-directory: extensions/ql-vscode
+        run: |
+          scripts/check-json-schemas.sh
+
   unit-test:
     name: Unit Test
     runs-on: ${{ matrix.os }}
@@ -133,6 +139,7 @@ jobs:
         working-directory: extensions/ql-vscode
         run: |
           npm run test
+
 
   test:
     name: Test
@@ -183,6 +190,7 @@ jobs:
         run: |
           npm run integration
 
+
   set-matrix:
     name: Set Matrix for cli-test
     runs-on: ubuntu-latest
@@ -194,6 +202,7 @@ jobs:
         run: echo "cli-versions=$(cat ./extensions/ql-vscode/supported_cli_versions.json | jq -rc)" >> $GITHUB_OUTPUT
     outputs:
       cli-versions: ${{ steps.set-variables.outputs.cli-versions }}
+
   cli-test:
     name: CLI Test
     runs-on: ${{ matrix.os }}

--- a/extensions/ql-vscode/.eslintignore
+++ b/extensions/ql-vscode/.eslintignore
@@ -1,6 +1,7 @@
 .vscode-test/
 node_modules/
 out/
+src/data-serialization/generated-schemas/*.json
 
 # Include the Storybook config
 !.storybook

--- a/extensions/ql-vscode/package-lock.json
+++ b/extensions/ql-vscode/package-lock.json
@@ -140,7 +140,7 @@
         "ts-jest": "^29.0.1",
         "ts-json-schema-generator": "^1.2.0",
         "ts-loader": "^8.1.0",
-        "ts-node": "^10.7.0",
+        "ts-node": "^10.9.1",
         "ts-protoc-gen": "^0.9.0",
         "typescript": "^4.5.5",
         "webpack": "^5.62.2",
@@ -2389,25 +2389,26 @@
         "node": ">=0.1.90"
       }
     },
-    "node_modules/@cspotcode/source-map-consumer": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
-      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/@cspotcode/source-map-support": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
-      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "dev": true,
       "dependencies": {
-        "@cspotcode/source-map-consumer": "0.8.0"
+        "@jridgewell/trace-mapping": "0.3.9"
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@design-systems/utils": {
@@ -39021,12 +39022,12 @@
       }
     },
     "node_modules/ts-node": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
-      "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "dev": true,
       "dependencies": {
-        "@cspotcode/source-map-support": "0.7.0",
+        "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
         "@tsconfig/node12": "^1.0.7",
         "@tsconfig/node14": "^1.0.0",
@@ -39037,7 +39038,7 @@
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.0",
+        "v8-compile-cache-lib": "^3.0.1",
         "yn": "3.1.1"
       },
       "bin": {
@@ -40075,9 +40076,9 @@
       "dev": true
     },
     "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz",
-      "integrity": "sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
     "node_modules/v8-to-istanbul": {
@@ -43137,19 +43138,25 @@
       "dev": true,
       "optional": true
     },
-    "@cspotcode/source-map-consumer": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
-      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
-      "dev": true
-    },
     "@cspotcode/source-map-support": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
-      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "dev": true,
       "requires": {
-        "@cspotcode/source-map-consumer": "0.8.0"
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "dependencies": {
+        "@jridgewell/trace-mapping": {
+          "version": "0.3.9",
+          "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+          "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/resolve-uri": "^3.0.3",
+            "@jridgewell/sourcemap-codec": "^1.4.10"
+          }
+        }
       }
     },
     "@design-systems/utils": {
@@ -71403,12 +71410,12 @@
       }
     },
     "ts-node": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
-      "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "dev": true,
       "requires": {
-        "@cspotcode/source-map-support": "0.7.0",
+        "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
         "@tsconfig/node12": "^1.0.7",
         "@tsconfig/node14": "^1.0.0",
@@ -71419,7 +71426,7 @@
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.0",
+        "v8-compile-cache-lib": "^3.0.1",
         "yn": "3.1.1"
       },
       "dependencies": {
@@ -72190,9 +72197,9 @@
       "dev": true
     },
     "v8-compile-cache-lib": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz",
-      "integrity": "sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
     "v8-to-istanbul": {

--- a/extensions/ql-vscode/package-lock.json
+++ b/extensions/ql-vscode/package-lock.json
@@ -138,7 +138,7 @@
         "tar-stream": "^2.2.0",
         "through2": "^4.0.2",
         "ts-jest": "^29.0.1",
-        "ts-json-schema-generator": "^1.1.2",
+        "ts-json-schema-generator": "^1.2.0",
         "ts-loader": "^8.1.0",
         "ts-node": "^10.7.0",
         "ts-protoc-gen": "^0.9.0",
@@ -38765,18 +38765,18 @@
       }
     },
     "node_modules/ts-json-schema-generator": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/ts-json-schema-generator/-/ts-json-schema-generator-1.1.2.tgz",
-      "integrity": "sha512-XMnxvndJFJEYv3NBmW7Po5bGajKdK2qH8Q078eDy60srK9+nEvbT9nLCRKd2IV/RQ7a+oc5FNylvZWveqh7jeQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ts-json-schema-generator/-/ts-json-schema-generator-1.2.0.tgz",
+      "integrity": "sha512-tUMeO3ZvA12d3HHh7T/AK8W5hmUhDRNtqWRHSMN3ZRbUFt+UmV0oX8k1RK4SA+a+BKNHpmW2v06MS49e8Fi3Yg==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.11",
-        "commander": "^9.4.0",
+        "commander": "^9.4.1",
         "glob": "^8.0.3",
         "json5": "^2.2.1",
         "normalize-path": "^3.0.0",
-        "safe-stable-stringify": "^2.4.0",
-        "typescript": "~4.8.3"
+        "safe-stable-stringify": "^2.4.1",
+        "typescript": "~4.9.3"
       },
       "bin": {
         "ts-json-schema-generator": "bin/ts-json-schema-generator"
@@ -38844,19 +38844,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/ts-json-schema-generator/node_modules/typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "node_modules/ts-loader": {
@@ -39382,9 +39369,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -71232,18 +71219,18 @@
       }
     },
     "ts-json-schema-generator": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/ts-json-schema-generator/-/ts-json-schema-generator-1.1.2.tgz",
-      "integrity": "sha512-XMnxvndJFJEYv3NBmW7Po5bGajKdK2qH8Q078eDy60srK9+nEvbT9nLCRKd2IV/RQ7a+oc5FNylvZWveqh7jeQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ts-json-schema-generator/-/ts-json-schema-generator-1.2.0.tgz",
+      "integrity": "sha512-tUMeO3ZvA12d3HHh7T/AK8W5hmUhDRNtqWRHSMN3ZRbUFt+UmV0oX8k1RK4SA+a+BKNHpmW2v06MS49e8Fi3Yg==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.11",
-        "commander": "^9.4.0",
+        "commander": "^9.4.1",
         "glob": "^8.0.3",
         "json5": "^2.2.1",
         "normalize-path": "^3.0.0",
-        "safe-stable-stringify": "^2.4.0",
-        "typescript": "~4.8.3"
+        "safe-stable-stringify": "^2.4.1",
+        "typescript": "~4.9.3"
       },
       "dependencies": {
         "brace-expansion": {
@@ -71288,12 +71275,6 @@
           "requires": {
             "brace-expansion": "^2.0.1"
           }
-        },
-        "typescript": {
-          "version": "4.8.4",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-          "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
-          "dev": true
         }
       }
     },
@@ -71675,9 +71656,9 @@
       }
     },
     "typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
       "dev": true
     },
     "uc.micro": {

--- a/extensions/ql-vscode/package-lock.json
+++ b/extensions/ql-vscode/package-lock.json
@@ -16,7 +16,7 @@
         "@primer/react": "^35.0.0",
         "@vscode/codicons": "^0.0.31",
         "@vscode/webview-ui-toolkit": "^1.0.1",
-        "ajv": "^8.11.0",
+        "ajv": "^8.12.0",
         "child-process-promise": "^2.2.1",
         "chokidar": "^3.5.3",
         "classnames": "~2.2.6",
@@ -15095,9 +15095,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -52995,9 +52995,9 @@
       }
     },
     "ajv": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",

--- a/extensions/ql-vscode/package-lock.json
+++ b/extensions/ql-vscode/package-lock.json
@@ -139,7 +139,7 @@
         "through2": "^4.0.2",
         "ts-jest": "^29.0.1",
         "ts-json-schema-generator": "^1.2.0",
-        "ts-loader": "^8.1.0",
+        "ts-loader": "^8.4.0",
         "ts-node": "^10.9.1",
         "ts-protoc-gen": "^0.9.0",
         "typescript": "^4.5.5",
@@ -38848,9 +38848,9 @@
       }
     },
     "node_modules/ts-loader": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.1.0.tgz",
-      "integrity": "sha512-YiQipGGAFj2zBfqLhp28yUvPP9jUGqHxRzrGYuc82Z2wM27YIHbElXiaZDc93c3x0mz4zvBmS6q/DgExpdj37A==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.4.0.tgz",
+      "integrity": "sha512-6nFY3IZ2//mrPc+ImY3hNWx1vCHyEhl6V+wLmL4CZcm6g1CqX7UKrkc6y0i4FwcfOhxyMPCfaEvh20f4r9GNpw==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.0",
@@ -71286,9 +71286,9 @@
       }
     },
     "ts-loader": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.1.0.tgz",
-      "integrity": "sha512-YiQipGGAFj2zBfqLhp28yUvPP9jUGqHxRzrGYuc82Z2wM27YIHbElXiaZDc93c3x0mz4zvBmS6q/DgExpdj37A==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.4.0.tgz",
+      "integrity": "sha512-6nFY3IZ2//mrPc+ImY3hNWx1vCHyEhl6V+wLmL4CZcm6g1CqX7UKrkc6y0i4FwcfOhxyMPCfaEvh20f4r9GNpw==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1340,7 +1340,7 @@
     "@primer/react": "^35.0.0",
     "@vscode/codicons": "^0.0.31",
     "@vscode/webview-ui-toolkit": "^1.0.1",
-    "ajv": "^8.11.0",
+    "ajv": "^8.12.0",
     "child-process-promise": "^2.2.1",
     "chokidar": "^3.5.3",
     "classnames": "~2.2.6",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1465,7 +1465,7 @@
     "ts-jest": "^29.0.1",
     "ts-json-schema-generator": "^1.2.0",
     "ts-loader": "^8.1.0",
-    "ts-node": "^10.7.0",
+    "ts-node": "^10.9.1",
     "ts-protoc-gen": "^0.9.0",
     "typescript": "^4.5.5",
     "webpack": "^5.62.2",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1462,7 +1462,7 @@
     "tar-stream": "^2.2.0",
     "through2": "^4.0.2",
     "ts-jest": "^29.0.1",
-    "ts-json-schema-generator": "^1.1.2",
+    "ts-json-schema-generator": "^1.2.0",
     "ts-loader": "^8.1.0",
     "ts-node": "^10.7.0",
     "ts-protoc-gen": "^0.9.0",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1464,7 +1464,7 @@
     "through2": "^4.0.2",
     "ts-jest": "^29.0.1",
     "ts-json-schema-generator": "^1.2.0",
-    "ts-loader": "^8.1.0",
+    "ts-loader": "^8.4.0",
     "ts-node": "^10.9.1",
     "ts-protoc-gen": "^0.9.0",
     "typescript": "^4.5.5",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1331,7 +1331,8 @@
     "build-storybook": "build-storybook",
     "lint:scenarios": "ts-node scripts/lint-scenarios.ts",
     "check-types": "find . -type f -name \"tsconfig.json\" -not -path \"./node_modules/*\" | sed -r 's|/[^/]+$||' | sort | uniq | xargs -I {} sh -c \"echo Checking types in {} && cd {} && npx tsc --noEmit\"",
-    "postinstall": "patch-package"
+    "postinstall": "patch-package",
+    "generate:schemas": "rm -rf src/data-serialization/generated-schemas && mkdir src/data-serialization/generated-schemas && ts-node ./src/data-serialization/schema-generator.ts"
   },
   "dependencies": {
     "@octokit/plugin-retry": "^3.0.9",

--- a/extensions/ql-vscode/scripts/check-json-schemas.sh
+++ b/extensions/ql-vscode/scripts/check-json-schemas.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -eu
+
+# Sanity check that repo is clean to start with
+if [ ! -z "$(git status --porcelain)" ]; then
+    # If we get a fail here then this workflow needs attention...
+    >&2 echo "Failed: Repo should be clean before testing!"
+    exit 1
+fi
+
+# Generate the JSON schema files
+npm run generate:schemas
+
+# Check that repo is still clean
+if [ ! -z "$(git status --porcelain)" ]; then
+    # If we get a fail here then the PR needs attention
+    >&2 echo "Failed: JSON schema files are not up to date. Run 'script/generate-json-schemas' to update"
+    git status
+    exit 1
+fi
+echo "Success: JSON schema files are up to date"

--- a/extensions/ql-vscode/src/data-serialization/generated-schemas/RemoteQueryHistoryItem.json
+++ b/extensions/ql-vscode/src/data-serialization/generated-schemas/RemoteQueryHistoryItem.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/RemoteQueryHistoryItem",
+  "definitions": {
+    "RemoteQueryHistoryItem": {
+      "type": "object",
+      "properties": {
+        "t": {
+          "type": "string",
+          "const": "remote"
+        },
+        "failureReason": {
+          "type": "string"
+        },
+        "resultCount": {
+          "type": "number"
+        },
+        "status": {
+          "$ref": "#/definitions/QueryStatus"
+        },
+        "completed": {
+          "type": "boolean"
+        },
+        "queryId": {
+          "type": "string"
+        },
+        "remoteQuery": {
+          "type": "object",
+          "properties": {
+            "queryName": {
+              "type": "string"
+            },
+            "queryFilePath": {
+              "type": "string"
+            },
+            "queryText": {
+              "type": "string"
+            },
+            "language": {
+              "type": "string"
+            },
+            "controllerRepository": {
+              "type": "object",
+              "properties": {
+                "owner": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "owner",
+                "name"
+              ],
+              "additionalProperties": false
+            },
+            "executionStartTime": {
+              "type": "number"
+            },
+            "actionsWorkflowRunId": {
+              "type": "number"
+            },
+            "repositoryCount": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "queryName",
+            "queryFilePath",
+            "queryText",
+            "language",
+            "controllerRepository",
+            "executionStartTime",
+            "actionsWorkflowRunId",
+            "repositoryCount"
+          ],
+          "additionalProperties": false
+        },
+        "userSpecifiedLabel": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "t",
+        "status",
+        "completed",
+        "queryId",
+        "remoteQuery"
+      ],
+      "additionalProperties": false
+    },
+    "QueryStatus": {
+      "type": "string",
+      "enum": [
+        "InProgress",
+        "Completed",
+        "Failed"
+      ]
+    }
+  }
+}

--- a/extensions/ql-vscode/src/data-serialization/generated-schemas/VariantAnalysisHistoryItem.json
+++ b/extensions/ql-vscode/src/data-serialization/generated-schemas/VariantAnalysisHistoryItem.json
@@ -1,0 +1,413 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/definitions/VariantAnalysisHistoryItem",
+  "definitions": {
+    "VariantAnalysisHistoryItem": {
+      "type": "object",
+      "properties": {
+        "t": {
+          "type": "string",
+          "const": "variant-analysis"
+        },
+        "failureReason": {
+          "type": "string"
+        },
+        "resultCount": {
+          "type": "number"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "InProgress",
+            "Completed",
+            "Failed"
+          ]
+        },
+        "completed": {
+          "type": "boolean"
+        },
+        "variantAnalysis": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "number"
+            },
+            "controllerRepo": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "number"
+                },
+                "fullName": {
+                  "type": "string"
+                },
+                "private": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "id",
+                "fullName",
+                "private"
+              ],
+              "additionalProperties": false
+            },
+            "query": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "filePath": {
+                  "type": "string"
+                },
+                "language": {
+                  "type": "string",
+                  "enum": [
+                    "csharp",
+                    "cpp",
+                    "go",
+                    "java",
+                    "javascript",
+                    "python",
+                    "ruby",
+                    "swift"
+                  ]
+                },
+                "text": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "filePath",
+                "language",
+                "text"
+              ],
+              "additionalProperties": false
+            },
+            "databases": {
+              "type": "object",
+              "properties": {
+                "repositories": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "repositoryLists": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "repositoryOwners": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            "createdAt": {
+              "type": "string"
+            },
+            "updatedAt": {
+              "type": "string"
+            },
+            "executionStartTime": {
+              "type": "number"
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "inProgress",
+                "succeeded",
+                "failed",
+                "canceled"
+              ]
+            },
+            "completedAt": {
+              "type": "string"
+            },
+            "actionsWorkflowRunId": {
+              "type": "number"
+            },
+            "failureReason": {
+              "type": "string",
+              "enum": [
+                "noReposQueried",
+                "actionsWorkflowRunFailed",
+                "internalError"
+              ]
+            },
+            "scannedRepos": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "repository": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "number"
+                      },
+                      "fullName": {
+                        "type": "string"
+                      },
+                      "private": {
+                        "type": "boolean"
+                      },
+                      "stargazersCount": {
+                        "type": "number"
+                      },
+                      "updatedAt": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "fullName",
+                      "id",
+                      "private",
+                      "stargazersCount",
+                      "updatedAt"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "analysisStatus": {
+                    "type": "string",
+                    "enum": [
+                      "pending",
+                      "inProgress",
+                      "succeeded",
+                      "failed",
+                      "canceled",
+                      "timedOut"
+                    ]
+                  },
+                  "resultCount": {
+                    "type": "number"
+                  },
+                  "artifactSizeInBytes": {
+                    "type": "number"
+                  },
+                  "failureMessage": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "repository",
+                  "analysisStatus"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "skippedRepos": {
+              "type": "object",
+              "properties": {
+                "accessMismatchRepos": {
+                  "type": "object",
+                  "properties": {
+                    "repositoryCount": {
+                      "type": "number"
+                    },
+                    "repositories": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "number"
+                          },
+                          "fullName": {
+                            "type": "string"
+                          },
+                          "private": {
+                            "type": "boolean"
+                          },
+                          "stargazersCount": {
+                            "type": "number"
+                          },
+                          "updatedAt": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "fullName"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "repositoryCount",
+                    "repositories"
+                  ],
+                  "additionalProperties": false
+                },
+                "notFoundRepos": {
+                  "type": "object",
+                  "properties": {
+                    "repositoryCount": {
+                      "type": "number"
+                    },
+                    "repositories": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "number"
+                          },
+                          "fullName": {
+                            "type": "string"
+                          },
+                          "private": {
+                            "type": "boolean"
+                          },
+                          "stargazersCount": {
+                            "type": "number"
+                          },
+                          "updatedAt": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "fullName"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "repositoryCount",
+                    "repositories"
+                  ],
+                  "additionalProperties": false
+                },
+                "noCodeqlDbRepos": {
+                  "type": "object",
+                  "properties": {
+                    "repositoryCount": {
+                      "type": "number"
+                    },
+                    "repositories": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "number"
+                          },
+                          "fullName": {
+                            "type": "string"
+                          },
+                          "private": {
+                            "type": "boolean"
+                          },
+                          "stargazersCount": {
+                            "type": "number"
+                          },
+                          "updatedAt": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "fullName"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "repositoryCount",
+                    "repositories"
+                  ],
+                  "additionalProperties": false
+                },
+                "overLimitRepos": {
+                  "type": "object",
+                  "properties": {
+                    "repositoryCount": {
+                      "type": "number"
+                    },
+                    "repositories": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "number"
+                          },
+                          "fullName": {
+                            "type": "string"
+                          },
+                          "private": {
+                            "type": "boolean"
+                          },
+                          "stargazersCount": {
+                            "type": "number"
+                          },
+                          "updatedAt": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "fullName"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "repositoryCount",
+                    "repositories"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "id",
+            "controllerRepo",
+            "query",
+            "databases",
+            "createdAt",
+            "updatedAt",
+            "executionStartTime",
+            "status"
+          ],
+          "additionalProperties": false
+        },
+        "userSpecifiedLabel": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "t",
+        "status",
+        "completed",
+        "variantAnalysis"
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/extensions/ql-vscode/src/data-serialization/json-schema-types.ts
+++ b/extensions/ql-vscode/src/data-serialization/json-schema-types.ts
@@ -1,0 +1,4 @@
+export const JsonSchemaTypes = [
+  "RemoteQueryHistoryItem",
+  "VariantAnalysisHistoryItem",
+];

--- a/extensions/ql-vscode/src/data-serialization/json-validator.ts
+++ b/extensions/ql-vscode/src/data-serialization/json-validator.ts
@@ -1,0 +1,50 @@
+import Ajv from "ajv";
+import { JsonSchemaTypes } from "./json-schema-types";
+import * as fs from "fs";
+import { JSONSchema7 as JSONSchema } from "json-schema";
+
+export class JsonValidator {
+  ajv: Ajv;
+  schemaTypes: string[];
+  schemas: { [key: string]: JSONSchema };
+
+  constructor(schemaTypes?: string[]) {
+    this.ajv = new Ajv();
+    this.schemaTypes = schemaTypes || JsonSchemaTypes;
+    this.schemas = this.loadSchemas(this.schemaTypes);
+  }
+
+  public validate(object: unknown, typeName: string) {
+    const validate = this.createValidatorFunction(typeName);
+
+    const valid = validate(object);
+
+    if (!valid) {
+      throw new Error(
+        `Object does not match the "${typeName}" schema: ${validate.errors}`,
+      );
+    }
+    return object;
+  }
+
+  private createValidatorFunction(typeName: string) {
+    const schema = this.loadSchema(typeName);
+    return this.ajv.compile(schema);
+  }
+
+  private loadSchemas(schemaTypes: string[]): { [key: string]: JSONSchema } {
+    const schemaList: { [key: string]: JSONSchema } = {};
+
+    for (const typeName of schemaTypes) {
+      const schemaFilepath = `src/data-serialization/generated-schemas/${typeName}.json`;
+      schemaList[typeName] = JSON.parse(
+        fs.readFileSync(schemaFilepath, "utf-8"),
+      );
+    }
+    return schemaList;
+  }
+
+  private loadSchema(typeName: string): JSONSchema {
+    return this.schemas[typeName];
+  }
+}

--- a/extensions/ql-vscode/src/data-serialization/json-validator.ts
+++ b/extensions/ql-vscode/src/data-serialization/json-validator.ts
@@ -21,7 +21,9 @@ export class JsonValidator {
 
     if (!valid) {
       throw new Error(
-        `Object does not match the "${typeName}" schema: ${validate.errors}`,
+        `Object does not match the "${typeName}" schema: ${this.ajv.errorsText(
+          validate.errors,
+        )}`,
       );
     }
     return object;

--- a/extensions/ql-vscode/src/data-serialization/json-validator.ts
+++ b/extensions/ql-vscode/src/data-serialization/json-validator.ts
@@ -1,4 +1,4 @@
-import Ajv from "ajv";
+import Ajv, { ValidateFunction } from "ajv";
 import { JsonSchemaTypes } from "./json-schema-types";
 import * as fs from "fs";
 import { JSONSchema7 as JSONSchema } from "json-schema";
@@ -7,15 +7,17 @@ export class JsonValidator {
   ajv: Ajv;
   schemaTypes: string[];
   schemas: { [key: string]: JSONSchema };
+  validators: { [key: string]: ValidateFunction };
 
-  constructor(schemaTypes?: string[]) {
+  constructor() {
     this.ajv = new Ajv();
-    this.schemaTypes = schemaTypes || JsonSchemaTypes;
-    this.schemas = this.loadSchemas(this.schemaTypes);
+    this.schemaTypes = JsonSchemaTypes;
+    this.schemas = this.loadSchemas();
+    this.validators = this.loadValidators();
   }
 
   public validate(object: unknown, typeName: string) {
-    const validate = this.createValidatorFunction(typeName);
+    const validate = this.loadValidator(typeName);
 
     const valid = validate(object);
 
@@ -34,10 +36,10 @@ export class JsonValidator {
     return this.ajv.compile(schema);
   }
 
-  private loadSchemas(schemaTypes: string[]): { [key: string]: JSONSchema } {
+  private loadSchemas(): { [key: string]: JSONSchema } {
     const schemaList: { [key: string]: JSONSchema } = {};
 
-    for (const typeName of schemaTypes) {
+    for (const typeName of this.schemaTypes) {
       const schemaFilepath = `src/data-serialization/generated-schemas/${typeName}.json`;
       schemaList[typeName] = JSON.parse(
         fs.readFileSync(schemaFilepath, "utf-8"),
@@ -48,5 +50,18 @@ export class JsonValidator {
 
   private loadSchema(typeName: string): JSONSchema {
     return this.schemas[typeName];
+  }
+
+  private loadValidators(): { [key: string]: ValidateFunction } {
+    const validatorList: { [key: string]: ValidateFunction } = {};
+
+    for (const typeName of this.schemaTypes) {
+      validatorList[typeName] = this.createValidatorFunction(typeName);
+    }
+    return validatorList;
+  }
+
+  private loadValidator(typeName: string): ValidateFunction {
+    return this.validators[typeName];
   }
 }

--- a/extensions/ql-vscode/src/data-serialization/schema-generator.ts
+++ b/extensions/ql-vscode/src/data-serialization/schema-generator.ts
@@ -43,9 +43,7 @@ export class SchemaGenerator {
   public async writeSchema(typeName: string, schemaContents: string) {
     const output_path = `${this.outputFilePath}/${typeName}.json`;
 
-    fs.writeFile(output_path, schemaContents, (err) => {
-      if (err) throw err;
-    });
+    fs.writeFileSync(output_path, schemaContents);
   }
 }
 

--- a/extensions/ql-vscode/src/data-serialization/schema-generator.ts
+++ b/extensions/ql-vscode/src/data-serialization/schema-generator.ts
@@ -1,0 +1,57 @@
+import * as tjsg from "ts-json-schema-generator";
+import * as fs from "fs";
+import { JsonSchemaTypes } from "./json-schema-types";
+
+export class SchemaGenerator {
+  schemaTypes: string[];
+  sourceFilePath: string;
+  outputFilePath: string;
+
+  constructor(
+    schemaTypes?: string[],
+    sourceFilePath?: string,
+    outputFilePath?: string,
+  ) {
+    this.schemaTypes = schemaTypes || JsonSchemaTypes;
+    this.sourceFilePath =
+      sourceFilePath || "src/data-serialization/source-schema-types";
+    this.outputFilePath =
+      outputFilePath || "src/data-serialization/generated-schemas";
+  }
+
+  public async generateSchemas() {
+    for (const typeName of this.schemaTypes) {
+      const schemaContents = await this.generateSchema(typeName);
+      await this.writeSchema(typeName, schemaContents);
+    }
+  }
+
+  public async generateSchema(typeName: string): Promise<string> {
+    console.log(`Generating schema for ${typeName}...`);
+
+    const config = {
+      path: `${this.sourceFilePath}/${typeName}.ts`,
+      tsconfig: "tsconfig.json",
+      type: typeName,
+    };
+
+    const generator = tjsg.createGenerator(config);
+    const schema = generator.createSchema(config.type);
+    return JSON.stringify(schema, null, 2);
+  }
+
+  public async writeSchema(typeName: string, schemaContents: string) {
+    const output_path = `${this.outputFilePath}/${typeName}.json`;
+
+    fs.writeFile(output_path, schemaContents, (err) => {
+      if (err) throw err;
+    });
+  }
+}
+
+const generator = new SchemaGenerator();
+
+generator.generateSchemas().catch((e) => {
+  console.error(e);
+  process.exit(2);
+});

--- a/extensions/ql-vscode/src/data-serialization/schema-generator.ts
+++ b/extensions/ql-vscode/src/data-serialization/schema-generator.ts
@@ -51,7 +51,7 @@ export class SchemaGenerator {
 
 const generator = new SchemaGenerator();
 
-generator.generateSchemas().catch((e) => {
+generator.generateSchemas().catch((e: unknown) => {
   console.error(e);
   process.exit(2);
 });

--- a/extensions/ql-vscode/src/data-serialization/source-schemas-types/remote-query-history-item.ts
+++ b/extensions/ql-vscode/src/data-serialization/source-schemas-types/remote-query-history-item.ts
@@ -1,0 +1,32 @@
+export interface RemoteQueryHistoryItem {
+  readonly t: "remote";
+  failureReason?: string;
+  resultCount?: number;
+  status: QueryStatus;
+  completed: boolean;
+  readonly queryId: string;
+  remoteQuery: RemoteQuery;
+  userSpecifiedLabel?: string;
+}
+
+export enum QueryStatus {
+  InProgress = "InProgress",
+  Completed = "Completed",
+  Failed = "Failed",
+}
+
+interface RemoteQuery {
+  queryName: string;
+  queryFilePath: string;
+  queryText: string;
+  language: string;
+  controllerRepository: RemoteRepository;
+  executionStartTime: number; // Use number here since it needs to be serialized and desserialized.
+  actionsWorkflowRunId: number;
+  repositoryCount: number;
+}
+
+interface RemoteRepository {
+  owner: string;
+  name: string;
+}

--- a/extensions/ql-vscode/src/data-serialization/source-schemas-types/variant-analysis-history-item.ts
+++ b/extensions/ql-vscode/src/data-serialization/source-schemas-types/variant-analysis-history-item.ts
@@ -1,0 +1,112 @@
+export interface VariantAnalysisHistoryItem {
+  readonly t: "variant-analysis";
+  failureReason?: string;
+  resultCount?: number;
+  status: QueryStatus;
+  completed: boolean;
+  variantAnalysis: VariantAnalysis;
+  userSpecifiedLabel?: string;
+}
+
+enum QueryStatus {
+  InProgress = "InProgress",
+  Completed = "Completed",
+  Failed = "Failed",
+}
+
+interface VariantAnalysis {
+  id: number;
+  controllerRepo: Repository;
+  query: {
+    name: string;
+    filePath: string;
+    language: VariantAnalysisQueryLanguage;
+    text: string;
+  };
+  databases: {
+    repositories?: string[];
+    repositoryLists?: string[];
+    repositoryOwners?: string[];
+  };
+  createdAt: string;
+  updatedAt: string;
+  executionStartTime: number;
+  status: VariantAnalysisStatus;
+  completedAt?: string;
+  actionsWorkflowRunId?: number;
+  failureReason?: VariantAnalysisFailureReason;
+  scannedRepos?: VariantAnalysisScannedRepository[];
+  skippedRepos?: VariantAnalysisSkippedRepositories;
+}
+
+interface Repository {
+  id: number;
+  fullName: string;
+  private: boolean;
+}
+
+enum VariantAnalysisQueryLanguage {
+  CSharp = "csharp",
+  Cpp = "cpp",
+  Go = "go",
+  Java = "java",
+  Javascript = "javascript",
+  Python = "python",
+  Ruby = "ruby",
+  Swift = "swift",
+}
+
+enum VariantAnalysisStatus {
+  InProgress = "inProgress",
+  Succeeded = "succeeded",
+  Failed = "failed",
+  Canceled = "canceled",
+}
+
+enum VariantAnalysisFailureReason {
+  NoReposQueried = "noReposQueried",
+  ActionsWorkflowRunFailed = "actionsWorkflowRunFailed",
+  InternalError = "internalError",
+}
+
+enum VariantAnalysisRepoStatus {
+  Pending = "pending",
+  InProgress = "inProgress",
+  Succeeded = "succeeded",
+  Failed = "failed",
+  Canceled = "canceled",
+  TimedOut = "timedOut",
+}
+
+interface VariantAnalysisScannedRepository {
+  repository: RepositoryWithMetadata;
+  analysisStatus: VariantAnalysisRepoStatus;
+  resultCount?: number;
+  artifactSizeInBytes?: number;
+  failureMessage?: string;
+}
+
+interface VariantAnalysisSkippedRepositories {
+  accessMismatchRepos?: VariantAnalysisSkippedRepositoryGroup;
+  notFoundRepos?: VariantAnalysisSkippedRepositoryGroup;
+  noCodeqlDbRepos?: VariantAnalysisSkippedRepositoryGroup;
+  overLimitRepos?: VariantAnalysisSkippedRepositoryGroup;
+}
+
+interface VariantAnalysisSkippedRepositoryGroup {
+  repositoryCount: number;
+  repositories: VariantAnalysisSkippedRepository[];
+}
+
+interface VariantAnalysisSkippedRepository {
+  id?: number;
+  fullName: string;
+  private?: boolean;
+  stargazersCount?: number;
+  updatedAt?: string | null;
+}
+
+interface RepositoryWithMetadata extends Repository {
+  stargazersCount: number;
+  updatedAt: string | null;
+}

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/jest-runner-cli-integration.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/jest-runner-cli-integration.ts
@@ -33,9 +33,8 @@ export default class JestRunnerCliIntegration extends VSCodeTestRunner {
           ?.config as RunnerOptions) ?? {};
 
       const { version, platform } = options;
-      const versionKey = `${version}-${platform}`;
 
-      if (installedOnVsCodeVersions.has(versionKey)) {
+      if (installedOnVsCodeVersions.has(`${version}-${platform}`)) {
         continue;
       }
 
@@ -64,7 +63,7 @@ export default class JestRunnerCliIntegration extends VSCodeTestRunner {
         },
       );
 
-      installedOnVsCodeVersions.add(versionKey);
+      installedOnVsCodeVersions.add(`${version}-${platform}`);
     }
 
     await ensureCli(true);

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/data-serialization/json-validator.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/data-serialization/json-validator.test.ts
@@ -1,0 +1,83 @@
+import { JsonSchemaTypes } from "../../../../src/data-serialization/json-schema-types";
+import { JsonValidator } from "../../../../src/data-serialization/json-validator";
+import {
+  QueryStatus,
+  RemoteQueryHistoryItem,
+} from "../../../../src/data-serialization/source-schemas-types/remote-query-history-item";
+
+describe("JsonValidator", () => {
+  let jsonValidator: JsonValidator;
+
+  beforeAll(() => {
+    jsonValidator = new JsonValidator();
+  });
+
+  for (const typeName of JsonSchemaTypes) {
+    test(`throws error for invalid ${typeName} schema`, () => {
+      const invalidJson = {
+        invalidField: true,
+      };
+
+      const obj = JSON.parse(JSON.stringify(invalidJson));
+
+      expect(() => {
+        jsonValidator.validate(obj, typeName);
+      }).toThrow(`Object does not match the "${typeName}" schema:`);
+    });
+  }
+
+  it("should successfully validate RemoteQueryHistoryItem", () => {
+    const items: RemoteQueryHistoryItem[] = [
+      {
+        t: "remote",
+        status: QueryStatus.InProgress,
+        completed: false,
+        queryId: "123",
+        remoteQuery: {
+          queryName: "query-name1",
+          queryFilePath: "query-file-path1",
+          queryText: "query-text1",
+          language: "Ruby",
+          controllerRepository: {
+            owner: "Matsumoto",
+            name: "ruby/ruby",
+          },
+          executionStartTime: 123,
+          actionsWorkflowRunId: 345,
+          repositoryCount: 6,
+        },
+        userSpecifiedLabel: "a label",
+      },
+      {
+        t: "remote",
+        failureReason: "depression",
+        resultCount: 2,
+        status: QueryStatus.Completed,
+        completed: true,
+        queryId: "345",
+        remoteQuery: {
+          queryName: "query-name2",
+          queryFilePath: "query-file-path2",
+          queryText: "query-text2",
+          language: "Ruby",
+          controllerRepository: {
+            owner: "Shopify",
+            name: "shopify/yjit",
+          },
+          executionStartTime: 678,
+          actionsWorkflowRunId: 901,
+          repositoryCount: 3,
+        },
+        userSpecifiedLabel: "a label",
+      },
+    ];
+
+    expect(jsonValidator.validate(items[0], "RemoteQueryHistoryItem")).toBe(
+      items[0],
+    );
+
+    expect(jsonValidator.validate(items[1], "RemoteQueryHistoryItem")).toBe(
+      items[1],
+    );
+  });
+});

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/data-serialization/schema-generator.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/data-serialization/schema-generator.test.ts
@@ -1,0 +1,107 @@
+import { SchemaGenerator } from "../../../../src/data-serialization/schema-generator";
+
+describe("Schema Generator", () => {
+  let testGenerator: SchemaGenerator;
+
+  beforeAll(async () => {
+    testGenerator = new SchemaGenerator(["RemoteQueryHistoryItem"]);
+  });
+
+  it("should generate schema", async () => {
+    const schemaContents = await testGenerator.generateSchema(
+      "RemoteQueryHistoryItem",
+    );
+
+    const expectedContent = {
+      $schema: "http://json-schema.org/draft-07/schema#",
+      $ref: "#/definitions/RemoteQueryHistoryItem",
+      definitions: {
+        RemoteQueryHistoryItem: {
+          type: "object",
+          properties: {
+            t: {
+              type: "string",
+              const: "remote",
+            },
+            failureReason: {
+              type: "string",
+            },
+            resultCount: {
+              type: "number",
+            },
+            status: {
+              $ref: "#/definitions/QueryStatus",
+            },
+            completed: {
+              type: "boolean",
+            },
+            queryId: {
+              type: "string",
+            },
+            remoteQuery: {
+              type: "object",
+              properties: {
+                queryName: {
+                  type: "string",
+                },
+                queryFilePath: {
+                  type: "string",
+                },
+                queryText: {
+                  type: "string",
+                },
+                language: {
+                  type: "string",
+                },
+                controllerRepository: {
+                  type: "object",
+                  properties: {
+                    owner: {
+                      type: "string",
+                    },
+                    name: {
+                      type: "string",
+                    },
+                  },
+                  required: ["owner", "name"],
+                  additionalProperties: false,
+                },
+                executionStartTime: {
+                  type: "number",
+                },
+                actionsWorkflowRunId: {
+                  type: "number",
+                },
+                repositoryCount: {
+                  type: "number",
+                },
+              },
+              required: [
+                "queryName",
+                "queryFilePath",
+                "queryText",
+                "language",
+                "controllerRepository",
+                "executionStartTime",
+                "actionsWorkflowRunId",
+                "repositoryCount",
+              ],
+              additionalProperties: false,
+            },
+            userSpecifiedLabel: {
+              type: "string",
+            },
+          },
+          required: ["t", "status", "completed", "queryId", "remoteQuery"],
+          additionalProperties: false,
+        },
+        QueryStatus: {
+          type: "string",
+          enum: ["InProgress", "Completed", "Failed"],
+        },
+      },
+    };
+
+    expect(schemaContents).toEqual(JSON.stringify(expectedContent, null, 2));
+  });
+});

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/data/remote-queries/workspace-query-history.json
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/data/remote-queries/workspace-query-history.json
@@ -6,23 +6,19 @@
       "status": "Completed",
       "completed": true,
       "queryId": "MRVA Integration test 1-6sBi6oaky_fxqXW2NA4bx",
-      "label": "MRVA Integration test 1",
+      "userSpecifiedLabel": "MRVA Integration test 1",
       "remoteQuery": {
         "queryName": "MRVA Integration test 1",
         "queryFilePath": "PLACEHOLDER/q0.ql",
         "queryText": "/**\n * @name MRVA Integration test 1\n * @kind problem\n * @problem.severity warning\n * @id javascript/integration-test-1\n */\nimport javascript\n\nfrom MemberDeclaration md\nwhere md.getName() = \"dispose\"\nselect md, \"Dispose method\"\n",
+        "language": "Ruby",
         "controllerRepository": {
           "owner": "dsp-testing",
           "name": "qc-run2"
         },
-        "repositories": [
-          {
-            "owner": "github",
-            "name": "vscode-codeql"
-          }
-        ],
         "executionStartTime": 1645644967533,
-        "actionsWorkflowRunId": 1889315769
+        "actionsWorkflowRunId": 1889315769,
+        "repositoryCount": 2
       }
     },
     {
@@ -30,23 +26,19 @@
       "status": "Completed",
       "completed": true,
       "queryId": "MRVA Integration test 2-UL-vbKAjP8ffObxjsp7hN",
-      "label": "MRVA Integration test 2",
+      "userSpecifiedLabel": "MRVA Integration test 2",
       "remoteQuery": {
         "queryName": "MRVA Integration test 2",
         "queryFilePath": "PLACEHOLDER/q1.ql",
         "queryText": "/**\n * @name MRVA Integration test 2\n * @kind problem\n * @problem.severity warning\n * @id javascript/integration-test-2\n */\nimport javascript\n\nfrom MemberDeclaration md\nwhere md.getName() = \"refresh\"\nselect md, \"Refresh method\"\n",
+        "language": "Ruby",
         "controllerRepository": {
           "owner": "dsp-testing",
           "name": "qc-run2"
         },
-        "repositories": [
-          {
-            "owner": "github",
-            "name": "vscode-codeql"
-          }
-        ],
         "executionStartTime": 1645644973911,
-        "actionsWorkflowRunId": 1889316048
+        "actionsWorkflowRunId": 1889316048,
+        "repositoryCount": 2
       }
     }
   ]

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/data/variant-analysis/workspace-query-history.json
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/data/variant-analysis/workspace-query-history.json
@@ -7,7 +7,11 @@
       "completed": true,
       "variantAnalysis": {
         "id": 98574321397,
-        "controllerRepoId": 128321,
+        "controllerRepo": {
+          "id": 128321,
+          "fullName": "test/repo",
+          "private": false
+        },
         "query": {
           "name": "Variant Analysis Integration Test 1",
           "filePath": "PLACEHOLDER/q2.ql",
@@ -30,7 +34,11 @@
       "completed": true,
       "variantAnalysis": {
         "id": 98574321397,
-        "controllerRepoId": 128321,
+        "controllerRepo": {
+          "id": 128321,
+          "fullName": "test/repo2",
+          "private": false
+        },
         "query": {
           "name": "Variant Analysis Integration Test 2",
           "filePath": "PLACEHOLDER/q2.ql",


### PR DESCRIPTION
Introduces:
- a separate set of types for the data we want to read from/write to disk (in `data-serialization/source-schema-types`)
- a `SchemaGenerator` which takes those types and converts them into JSON schemas (in `data-serialization/generated-schemas`). I've tried to make it configurable so that we can re-use it in other parts of the extension where we read/write data. That may or may not be overkill.
- a `JsonValidator` which reads the JSON schemas and checks whether provided data is valid.

We then use the JsonValidator in our `query-serialization.ts` code to validate remote queries and variant analyses when we read/write from disk. This decouples our code from our existing types as we're now using the types defined in `data-serialization/source-schema-types`.

We could expand this further by:
1. using this validator for local query history items
2. re-using this pattern in other parts of the code where we read/write data (e.g. database panel config, query results)
3. think about versioning

While these would be nice to have, the immediate issue we want to solve is decoupling our types from the data we read/write for query history so that we're able to make changes to our types without making the data we've already written to disk unreadable. See internal issue for details. 

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
