### PR TITLE
Show welcome view when controller repo is not setup

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1310,6 +1310,11 @@
       {
         "view": "codeQLEvalLogViewer",
         "contents": "Run the 'Show Evaluator Log (UI)' command on a CodeQL query run in the Query History view."
+      },
+      {
+        "view": "codeQLVariantAnalysisRepositories",
+        "contents": "Set up a controller repository to start using variant analysis.\n[Set up controller repository](command:codeQLVariantAnalysisRepositories.setupControllerRepository)",
+        "when": "!config.codeQL.variantAnalysis.controllerRepo"
       }
     ]
   },

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -539,6 +539,27 @@ export async function setRemoteControllerRepo(repo: string | undefined) {
   await REMOTE_CONTROLLER_REPO.updateValue(repo, ConfigurationTarget.Global);
 }
 
+export interface VariantAnalysisConfig {
+  controllerRepo: string | undefined;
+  onDidChangeConfiguration?: Event<void>;
+}
+
+export class VariantAnalysisConfigListener
+  extends ConfigListener
+  implements VariantAnalysisConfig
+{
+  protected handleDidChangeConfiguration(e: ConfigurationChangeEvent): void {
+    this.handleDidChangeConfigurationForRelevantSettings(
+      [VARIANT_ANALYSIS_SETTING],
+      e,
+    );
+  }
+
+  public get controllerRepo(): string | undefined {
+    return getRemoteControllerRepo();
+  }
+}
+
 /**
  * The branch of "github/codeql-variant-analysis-action" to use with the "Run Variant Analysis" command.
  * Default value is "main".

--- a/extensions/ql-vscode/src/databases/db-module.ts
+++ b/extensions/ql-vscode/src/databases/db-module.ts
@@ -24,7 +24,7 @@ export class DbModule extends DisposableObject {
       const dbModule = new DbModule(app);
       app.subscriptions.push(dbModule);
 
-      await dbModule.initialize();
+      await dbModule.initialize(app);
       return dbModule;
     }
 
@@ -39,12 +39,12 @@ export class DbModule extends DisposableObject {
     return isCanary() && isVariantAnalysisReposPanelEnabled();
   }
 
-  private async initialize(): Promise<void> {
+  private async initialize(app: App): Promise<void> {
     void extLogger.log("Initializing database module");
 
     await this.dbConfigStore.initialize();
 
-    const dbPanel = new DbPanel(this.dbManager);
+    const dbPanel = new DbPanel(this.dbManager, app.credentials);
     await dbPanel.initialize();
 
     this.push(dbPanel);

--- a/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
@@ -376,10 +376,10 @@ export async function getControllerRepo(
     );
     controllerRepoNwo = await window.showInputBox({
       title:
-        "Controller repository in which to run the GitHub Actions workflow for this variant analysis",
+        "Controller repository in which to run GitHub Actions workflows for variant analyses",
       placeHolder: "<owner>/<repo>",
       prompt:
-        "Enter the name of a GitHub repository in the format <owner>/<repo>",
+        "Enter the name of a GitHub repository in the format <owner>/<repo>. You can change this in the extension settings.",
       ignoreFocusOut: true,
     });
     if (!controllerRepoNwo) {

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/remote-queries/variant-analysis-submission-integration.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/remote-queries/variant-analysis-submission-integration.test.ts
@@ -12,6 +12,7 @@ import {
 
 import { CodeQLExtensionInterface } from "../../../../src/extension";
 import { MockGitHubApiServer } from "../../../../src/mocks/mock-gh-api-server";
+import { mockConfiguration } from "../../utils/configuration-helpers";
 
 jest.setTimeout(30_000);
 
@@ -35,50 +36,17 @@ describe("Variant Analysis Submission Integration", () => {
   let showErrorMessageSpy: jest.SpiedFunction<typeof window.showErrorMessage>;
 
   beforeEach(async () => {
-    const originalGetConfiguration = workspace.getConfiguration;
-
-    jest
-      .spyOn(workspace, "getConfiguration")
-      .mockImplementation((section, scope) => {
-        const configuration = originalGetConfiguration(section, scope);
-
-        return {
-          get(key: string, defaultValue?: unknown) {
-            if (section === "codeQL.variantAnalysis" && key === "liveResults") {
-              return true;
-            }
-            if (section === "codeQL" && key == "canary") {
-              return true;
-            }
-            if (
-              section === "codeQL.variantAnalysis" &&
-              key === "controllerRepo"
-            ) {
-              return "github/vscode-codeql";
-            }
-            return configuration.get(key, defaultValue);
-          },
-          has(key: string) {
-            return configuration.has(key);
-          },
-          inspect(key: string) {
-            return configuration.inspect(key);
-          },
-          update(
-            key: string,
-            value: unknown,
-            configurationTarget?: boolean,
-            overrideInLanguage?: boolean,
-          ) {
-            return configuration.update(
-              key,
-              value,
-              configurationTarget,
-              overrideInLanguage,
-            );
-          },
-        };
-      });
+    mockConfiguration({
+      values: {
+        codeQL: {
+          canary: true,
+        },
+        "codeQL.variantAnalysis": {
+          liveResults: true,
+          controllerRepo: "github/vscode-codeql",
+        },
+      },
+    });
 
     jest.spyOn(authentication, "getSession").mockResolvedValue({
       id: "test",

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/databases/db-panel-rendering.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/databases/db-panel-rendering.test.ts
@@ -13,6 +13,7 @@ import { DbTreeViewItem } from "../../../../src/databases/ui/db-tree-view-item";
 import { ExtensionApp } from "../../../../src/common/vscode/vscode-app";
 import { createMockExtensionContext } from "../../../factories/extension-context";
 import { createDbConfig } from "../../../factories/db-config-factories";
+import { mockConfiguration } from "../../utils/configuration-helpers";
 
 describe("db panel rendering nodes", () => {
   const workspaceStoragePath = join(__dirname, "test-workspace-storage");
@@ -42,6 +43,14 @@ describe("db panel rendering nodes", () => {
 
   beforeEach(async () => {
     await ensureDir(workspaceStoragePath);
+
+    mockConfiguration({
+      values: {
+        "codeQL.variantAnalysis": {
+          controllerRepo: "github/codeql",
+        },
+      },
+    });
   });
 
   afterEach(async () => {

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/databases/db-panel-rendering.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/databases/db-panel-rendering.test.ts
@@ -43,252 +43,287 @@ describe("db panel rendering nodes", () => {
 
   beforeEach(async () => {
     await ensureDir(workspaceStoragePath);
-
-    mockConfiguration({
-      values: {
-        "codeQL.variantAnalysis": {
-          controllerRepo: "github/codeql",
-        },
-      },
-    });
   });
 
   afterEach(async () => {
     await remove(workspaceStoragePath);
   });
 
-  it("should render default remote nodes when the config is empty", async () => {
-    const dbConfig: DbConfig = createDbConfig();
-
-    await saveDbConfig(dbConfig);
-
-    const dbTreeItems = await dbTreeDataProvider.getChildren();
-
-    expect(dbTreeItems).toBeTruthy();
-    const items = dbTreeItems!;
-    expect(items.length).toBe(3);
-
-    checkRemoteSystemDefinedListItem(items[0], 10);
-    checkRemoteSystemDefinedListItem(items[1], 100);
-    checkRemoteSystemDefinedListItem(items[2], 1000);
-  });
-
-  it("should render remote repository list nodes", async () => {
-    const dbConfig: DbConfig = createDbConfig({
-      remoteLists: [
-        {
-          name: "my-list-1",
-          repositories: ["owner1/repo1", "owner1/repo2"],
+  describe("when controller repo is not set", () => {
+    mockConfiguration({
+      values: {
+        "codeQL.variantAnalysis": {
+          controllerRepo: undefined,
         },
-        {
-          name: "my-list-2",
-          repositories: ["owner1/repo1", "owner2/repo1", "owner2/repo2"],
-        },
-      ],
+      },
     });
 
-    await saveDbConfig(dbConfig);
+    it("should not have any items", async () => {
+      const dbConfig: DbConfig = createDbConfig({
+        remoteLists: [
+          {
+            name: "my-list-1",
+            repositories: ["owner1/repo1", "owner1/repo2"],
+          },
+          {
+            name: "my-list-2",
+            repositories: ["owner2/repo1", "owner2/repo2"],
+          },
+        ],
+      });
 
-    const dbTreeItems = await dbTreeDataProvider.getChildren();
-    expect(dbTreeItems).toBeTruthy();
+      await saveDbConfig(dbConfig);
 
-    const systemDefinedListItems = dbTreeItems!.filter(
-      (item) => item.dbItem?.kind === DbItemKind.RemoteSystemDefinedList,
-    );
-    expect(systemDefinedListItems.length).toBe(3);
+      const dbTreeItems = await dbTreeDataProvider.getChildren();
 
-    const userDefinedListItems = dbTreeItems!.filter(
-      (item) => item.dbItem?.kind === DbItemKind.RemoteUserDefinedList,
-    );
-    expect(userDefinedListItems.length).toBe(2);
-    checkUserDefinedListItem(userDefinedListItems[0], "my-list-1", [
-      "owner1/repo1",
-      "owner1/repo2",
-    ]);
-    checkUserDefinedListItem(userDefinedListItems[1], "my-list-2", [
-      "owner1/repo1",
-      "owner2/repo1",
-      "owner2/repo2",
-    ]);
+      expect(dbTreeItems).toHaveLength(0);
+    });
   });
 
-  it("should render owner list nodes", async () => {
-    const dbConfig: DbConfig = createDbConfig({
-      remoteOwners: ["owner1", "owner2"],
+  describe("when controller repo is set", () => {
+    beforeEach(() => {
+      mockConfiguration({
+        values: {
+          "codeQL.variantAnalysis": {
+            controllerRepo: "github/codeql",
+          },
+        },
+      });
     });
 
-    await saveDbConfig(dbConfig);
+    it("should render default remote nodes when the config is empty", async () => {
+      const dbConfig: DbConfig = createDbConfig();
 
-    const dbTreeItems = await dbTreeDataProvider.getChildren();
-    expect(dbTreeItems).toBeTruthy();
-    expect(dbTreeItems?.length).toBe(5);
+      await saveDbConfig(dbConfig);
 
-    const ownerListItems = dbTreeItems!.filter(
-      (item) => item.dbItem?.kind === DbItemKind.RemoteOwner,
-    );
-    expect(ownerListItems.length).toBe(2);
-    checkOwnerItem(ownerListItems[0], "owner1");
-    checkOwnerItem(ownerListItems[1], "owner2");
-  });
+      const dbTreeItems = await dbTreeDataProvider.getChildren();
 
-  it("should render repository nodes", async () => {
-    const dbConfig: DbConfig = createDbConfig({
-      remoteRepos: ["owner1/repo1", "owner1/repo2"],
+      expect(dbTreeItems).toBeTruthy();
+      const items = dbTreeItems!;
+      expect(items.length).toBe(3);
+
+      checkRemoteSystemDefinedListItem(items[0], 10);
+      checkRemoteSystemDefinedListItem(items[1], 100);
+      checkRemoteSystemDefinedListItem(items[2], 1000);
     });
 
-    await saveDbConfig(dbConfig);
+    it("should render remote repository list nodes", async () => {
+      const dbConfig: DbConfig = createDbConfig({
+        remoteLists: [
+          {
+            name: "my-list-1",
+            repositories: ["owner1/repo1", "owner1/repo2"],
+          },
+          {
+            name: "my-list-2",
+            repositories: ["owner1/repo1", "owner2/repo1", "owner2/repo2"],
+          },
+        ],
+      });
 
-    const dbTreeItems = await dbTreeDataProvider.getChildren();
-    expect(dbTreeItems).toBeTruthy();
-    expect(dbTreeItems!.length).toBe(5);
+      await saveDbConfig(dbConfig);
 
-    const repoItems = dbTreeItems!.filter(
-      (item) => item.dbItem?.kind === DbItemKind.RemoteRepo,
-    );
-    expect(repoItems.length).toBe(2);
-    checkRemoteRepoItem(repoItems[0], "owner1/repo1");
-    checkRemoteRepoItem(repoItems[1], "owner1/repo2");
-  });
+      const dbTreeItems = await dbTreeDataProvider.getChildren();
+      expect(dbTreeItems).toBeTruthy();
 
-  it.skip("should render local list nodes", async () => {
-    const dbConfig: DbConfig = createDbConfig({
-      localLists: [
+      const systemDefinedListItems = dbTreeItems!.filter(
+        (item) => item.dbItem?.kind === DbItemKind.RemoteSystemDefinedList,
+      );
+      expect(systemDefinedListItems.length).toBe(3);
+
+      const userDefinedListItems = dbTreeItems!.filter(
+        (item) => item.dbItem?.kind === DbItemKind.RemoteUserDefinedList,
+      );
+      expect(userDefinedListItems.length).toBe(2);
+      checkUserDefinedListItem(userDefinedListItems[0], "my-list-1", [
+        "owner1/repo1",
+        "owner1/repo2",
+      ]);
+      checkUserDefinedListItem(userDefinedListItems[1], "my-list-2", [
+        "owner1/repo1",
+        "owner2/repo1",
+        "owner2/repo2",
+      ]);
+    });
+
+    it("should render owner list nodes", async () => {
+      const dbConfig: DbConfig = createDbConfig({
+        remoteOwners: ["owner1", "owner2"],
+      });
+
+      await saveDbConfig(dbConfig);
+
+      const dbTreeItems = await dbTreeDataProvider.getChildren();
+      expect(dbTreeItems).toBeTruthy();
+      expect(dbTreeItems?.length).toBe(5);
+
+      const ownerListItems = dbTreeItems!.filter(
+        (item) => item.dbItem?.kind === DbItemKind.RemoteOwner,
+      );
+      expect(ownerListItems.length).toBe(2);
+      checkOwnerItem(ownerListItems[0], "owner1");
+      checkOwnerItem(ownerListItems[1], "owner2");
+    });
+
+    it("should render repository nodes", async () => {
+      const dbConfig: DbConfig = createDbConfig({
+        remoteRepos: ["owner1/repo1", "owner1/repo2"],
+      });
+
+      await saveDbConfig(dbConfig);
+
+      const dbTreeItems = await dbTreeDataProvider.getChildren();
+      expect(dbTreeItems).toBeTruthy();
+      expect(dbTreeItems!.length).toBe(5);
+
+      const repoItems = dbTreeItems!.filter(
+        (item) => item.dbItem?.kind === DbItemKind.RemoteRepo,
+      );
+      expect(repoItems.length).toBe(2);
+      checkRemoteRepoItem(repoItems[0], "owner1/repo1");
+      checkRemoteRepoItem(repoItems[1], "owner1/repo2");
+    });
+
+    it.skip("should render local list nodes", async () => {
+      const dbConfig: DbConfig = createDbConfig({
+        localLists: [
+          {
+            name: "my-list-1",
+            databases: [
+              {
+                name: "db1",
+                dateAdded: 1668428293677,
+                language: "cpp",
+                storagePath: "/path/to/db1/",
+              },
+              {
+                name: "db2",
+                dateAdded: 1668428472731,
+                language: "cpp",
+                storagePath: "/path/to/db2/",
+              },
+            ],
+          },
+          {
+            name: "my-list-2",
+            databases: [
+              {
+                name: "db3",
+                dateAdded: 1668428472731,
+                language: "ruby",
+                storagePath: "/path/to/db3/",
+              },
+            ],
+          },
+        ],
+      });
+
+      await saveDbConfig(dbConfig);
+
+      const dbTreeItems = await dbTreeDataProvider.getChildren();
+      expect(dbTreeItems).toBeTruthy();
+
+      const localRootNode = dbTreeItems?.find(
+        (i) => i.dbItem?.kind === DbItemKind.RootLocal,
+      );
+      expect(localRootNode).toBeTruthy();
+
+      expect(localRootNode!.dbItem).toBeTruthy();
+      expect(localRootNode!.collapsibleState).toBe(
+        TreeItemCollapsibleState.Collapsed,
+      );
+      expect(localRootNode!.children).toBeTruthy();
+      expect(localRootNode!.children.length).toBe(2);
+
+      const localListItems = localRootNode!.children.filter(
+        (item) => item.dbItem?.kind === DbItemKind.LocalList,
+      );
+      expect(localListItems.length).toBe(2);
+      checkLocalListItem(localListItems[0], "my-list-1", [
         {
-          name: "my-list-1",
-          databases: [
-            {
-              name: "db1",
-              dateAdded: 1668428293677,
-              language: "cpp",
-              storagePath: "/path/to/db1/",
-            },
-            {
-              name: "db2",
-              dateAdded: 1668428472731,
-              language: "cpp",
-              storagePath: "/path/to/db2/",
-            },
-          ],
+          kind: DbItemKind.LocalDatabase,
+          databaseName: "db1",
+          dateAdded: 1668428293677,
+          language: "cpp",
+          storagePath: "/path/to/db1/",
+          selected: false,
         },
         {
-          name: "my-list-2",
-          databases: [
-            {
-              name: "db3",
-              dateAdded: 1668428472731,
-              language: "ruby",
-              storagePath: "/path/to/db3/",
-            },
-          ],
+          kind: DbItemKind.LocalDatabase,
+          databaseName: "db2",
+          dateAdded: 1668428472731,
+          language: "cpp",
+          storagePath: "/path/to/db2/",
+          selected: false,
         },
-      ],
+      ]);
+      checkLocalListItem(localListItems[1], "my-list-2", [
+        {
+          kind: DbItemKind.LocalDatabase,
+          databaseName: "db3",
+          dateAdded: 1668428472731,
+          language: "ruby",
+          storagePath: "/path/to/db3/",
+          selected: false,
+        },
+      ]);
     });
 
-    await saveDbConfig(dbConfig);
+    it.skip("should render local database nodes", async () => {
+      const dbConfig: DbConfig = createDbConfig({
+        localDbs: [
+          {
+            name: "db1",
+            dateAdded: 1668428293677,
+            language: "csharp",
+            storagePath: "/path/to/db1/",
+          },
+          {
+            name: "db2",
+            dateAdded: 1668428472731,
+            language: "go",
+            storagePath: "/path/to/db2/",
+          },
+        ],
+      });
 
-    const dbTreeItems = await dbTreeDataProvider.getChildren();
-    expect(dbTreeItems).toBeTruthy();
+      await saveDbConfig(dbConfig);
 
-    const localRootNode = dbTreeItems?.find(
-      (i) => i.dbItem?.kind === DbItemKind.RootLocal,
-    );
-    expect(localRootNode).toBeTruthy();
+      const dbTreeItems = await dbTreeDataProvider.getChildren();
 
-    expect(localRootNode!.dbItem).toBeTruthy();
-    expect(localRootNode!.collapsibleState).toBe(
-      TreeItemCollapsibleState.Collapsed,
-    );
-    expect(localRootNode!.children).toBeTruthy();
-    expect(localRootNode!.children.length).toBe(2);
+      expect(dbTreeItems).toBeTruthy();
+      const localRootNode = dbTreeItems?.find(
+        (i) => i.dbItem?.kind === DbItemKind.RootLocal,
+      );
+      expect(localRootNode).toBeTruthy();
 
-    const localListItems = localRootNode!.children.filter(
-      (item) => item.dbItem?.kind === DbItemKind.LocalList,
-    );
-    expect(localListItems.length).toBe(2);
-    checkLocalListItem(localListItems[0], "my-list-1", [
-      {
+      expect(localRootNode!.dbItem).toBeTruthy();
+      expect(localRootNode!.collapsibleState).toBe(
+        TreeItemCollapsibleState.Collapsed,
+      );
+      expect(localRootNode!.children).toBeTruthy();
+      expect(localRootNode!.children.length).toBe(2);
+
+      const localDatabaseItems = localRootNode!.children.filter(
+        (item) => item.dbItem?.kind === DbItemKind.LocalDatabase,
+      );
+      expect(localDatabaseItems.length).toBe(2);
+      checkLocalDatabaseItem(localDatabaseItems[0], {
         kind: DbItemKind.LocalDatabase,
         databaseName: "db1",
         dateAdded: 1668428293677,
-        language: "cpp",
+        language: "csharp",
         storagePath: "/path/to/db1/",
         selected: false,
-      },
-      {
+      });
+      checkLocalDatabaseItem(localDatabaseItems[1], {
         kind: DbItemKind.LocalDatabase,
         databaseName: "db2",
         dateAdded: 1668428472731,
-        language: "cpp",
+        language: "go",
         storagePath: "/path/to/db2/",
         selected: false,
-      },
-    ]);
-    checkLocalListItem(localListItems[1], "my-list-2", [
-      {
-        kind: DbItemKind.LocalDatabase,
-        databaseName: "db3",
-        dateAdded: 1668428472731,
-        language: "ruby",
-        storagePath: "/path/to/db3/",
-        selected: false,
-      },
-    ]);
-  });
-
-  it.skip("should render local database nodes", async () => {
-    const dbConfig: DbConfig = createDbConfig({
-      localDbs: [
-        {
-          name: "db1",
-          dateAdded: 1668428293677,
-          language: "csharp",
-          storagePath: "/path/to/db1/",
-        },
-        {
-          name: "db2",
-          dateAdded: 1668428472731,
-          language: "go",
-          storagePath: "/path/to/db2/",
-        },
-      ],
-    });
-
-    await saveDbConfig(dbConfig);
-
-    const dbTreeItems = await dbTreeDataProvider.getChildren();
-
-    expect(dbTreeItems).toBeTruthy();
-    const localRootNode = dbTreeItems?.find(
-      (i) => i.dbItem?.kind === DbItemKind.RootLocal,
-    );
-    expect(localRootNode).toBeTruthy();
-
-    expect(localRootNode!.dbItem).toBeTruthy();
-    expect(localRootNode!.collapsibleState).toBe(
-      TreeItemCollapsibleState.Collapsed,
-    );
-    expect(localRootNode!.children).toBeTruthy();
-    expect(localRootNode!.children.length).toBe(2);
-
-    const localDatabaseItems = localRootNode!.children.filter(
-      (item) => item.dbItem?.kind === DbItemKind.LocalDatabase,
-    );
-    expect(localDatabaseItems.length).toBe(2);
-    checkLocalDatabaseItem(localDatabaseItems[0], {
-      kind: DbItemKind.LocalDatabase,
-      databaseName: "db1",
-      dateAdded: 1668428293677,
-      language: "csharp",
-      storagePath: "/path/to/db1/",
-      selected: false,
-    });
-    checkLocalDatabaseItem(localDatabaseItems[1], {
-      kind: DbItemKind.LocalDatabase,
-      databaseName: "db2",
-      dateAdded: 1668428472731,
-      language: "go",
-      storagePath: "/path/to/db2/",
-      selected: false,
+      });
     });
   });
 

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/databases/db-panel.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/databases/db-panel.test.ts
@@ -9,6 +9,7 @@ import { DbTreeViewItem } from "../../../../src/databases/ui/db-tree-view-item";
 import { ExtensionApp } from "../../../../src/common/vscode/vscode-app";
 import { createMockExtensionContext } from "../../../factories/extension-context";
 import { createDbConfig } from "../../../factories/db-config-factories";
+import { mockConfiguration } from "../../utils/configuration-helpers";
 
 describe("db panel", () => {
   const workspaceStoragePath = join(__dirname, "test-workspace-storage");
@@ -38,6 +39,14 @@ describe("db panel", () => {
 
   beforeEach(async () => {
     await ensureDir(workspaceStoragePath);
+
+    mockConfiguration({
+      values: {
+        "codeQL.variantAnalysis": {
+          controllerRepo: "github/codeql",
+        },
+      },
+    });
   });
 
   afterEach(async () => {

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/databases/db-panel-selection.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/databases/db-panel-selection.test.ts
@@ -45,156 +45,115 @@ describe("db panel selection", () => {
 
   beforeEach(async () => {
     await ensureDir(workspaceStoragePath);
+
+    mockConfiguration({
+      values: {
+        "codeQL.variantAnalysis": {
+          controllerRepo: "github/codeql",
+        },
+      },
+    });
   });
 
   afterEach(async () => {
     await remove(workspaceStoragePath);
   });
 
-  describe("when controller repo is not set", () => {
-    beforeEach(() => {
-      mockConfiguration({
-        values: {
-          "codeQL.variantAnalysis": {
-            controllerRepo: undefined,
-          },
+  it("should mark selected remote db list as selected", async () => {
+    const dbConfig: DbConfig = createDbConfig({
+      remoteLists: [
+        {
+          name: "my-list-1",
+          repositories: ["owner1/repo1", "owner1/repo2"],
         },
-      });
+        {
+          name: "my-list-2",
+          repositories: ["owner2/repo1", "owner2/repo2"],
+        },
+      ],
+      selected: {
+        kind: SelectedDbItemKind.VariantAnalysisUserDefinedList,
+        listName: "my-list-2",
+      },
     });
 
-    it("should not have any items", async () => {
-      const dbConfig: DbConfig = createDbConfig({
-        remoteLists: [
-          {
-            name: "my-list-1",
-            repositories: ["owner1/repo1", "owner1/repo2"],
-          },
-          {
-            name: "my-list-2",
-            repositories: ["owner2/repo1", "owner2/repo2"],
-          },
-        ],
-        selected: {
-          kind: SelectedDbItemKind.VariantAnalysisUserDefinedList,
-          listName: "my-list-2",
-        },
-      });
+    await saveDbConfig(dbConfig);
 
-      await saveDbConfig(dbConfig);
+    const dbTreeItems = await dbTreeDataProvider.getChildren();
 
-      const dbTreeItems = await dbTreeDataProvider.getChildren();
+    expect(dbTreeItems).toBeTruthy();
+    const items = dbTreeItems!;
 
-      expect(dbTreeItems).toHaveLength(0);
-    });
+    const list1 = items.find(
+      (c) =>
+        c.dbItem?.kind === DbItemKind.RemoteUserDefinedList &&
+        c.dbItem?.listName === "my-list-1",
+    );
+    const list2 = items.find(
+      (c) =>
+        c.dbItem?.kind === DbItemKind.RemoteUserDefinedList &&
+        c.dbItem?.listName === "my-list-2",
+    );
+
+    expect(list1).toBeTruthy();
+    expect(list2).toBeTruthy();
+    expect(isTreeViewItemSelectable(list1!)).toBeTruthy();
+    expect(isTreeViewItemSelected(list2!)).toBeTruthy();
   });
 
-  describe("when controller repo is set", () => {
-    beforeEach(() => {
-      mockConfiguration({
-        values: {
-          "codeQL.variantAnalysis": {
-            controllerRepo: "github/codeql",
-          },
+  it("should mark selected remote db inside list as selected", async () => {
+    const dbConfig: DbConfig = createDbConfig({
+      remoteLists: [
+        {
+          name: "my-list-1",
+          repositories: ["owner1/repo1", "owner1/repo2"],
         },
-      });
+        {
+          name: "my-list-2",
+          repositories: ["owner1/repo1", "owner2/repo2"],
+        },
+      ],
+      remoteRepos: ["owner1/repo1"],
+      selected: {
+        kind: SelectedDbItemKind.VariantAnalysisRepository,
+        repositoryName: "owner1/repo1",
+        listName: "my-list-2",
+      },
     });
 
-    it("should mark selected remote db list as selected", async () => {
-      const dbConfig: DbConfig = createDbConfig({
-        remoteLists: [
-          {
-            name: "my-list-1",
-            repositories: ["owner1/repo1", "owner1/repo2"],
-          },
-          {
-            name: "my-list-2",
-            repositories: ["owner2/repo1", "owner2/repo2"],
-          },
-        ],
-        selected: {
-          kind: SelectedDbItemKind.VariantAnalysisUserDefinedList,
-          listName: "my-list-2",
-        },
-      });
+    await saveDbConfig(dbConfig);
 
-      await saveDbConfig(dbConfig);
+    const dbTreeItems = await dbTreeDataProvider.getChildren();
 
-      const dbTreeItems = await dbTreeDataProvider.getChildren();
+    expect(dbTreeItems).toBeTruthy();
+    const items = dbTreeItems!;
 
-      expect(dbTreeItems).toBeTruthy();
-      const items = dbTreeItems!;
+    const list2 = items.find(
+      (c) =>
+        c.dbItem?.kind === DbItemKind.RemoteUserDefinedList &&
+        c.dbItem?.listName === "my-list-2",
+    );
+    expect(list2).toBeTruthy();
 
-      const list1 = items.find(
-        (c) =>
-          c.dbItem?.kind === DbItemKind.RemoteUserDefinedList &&
-          c.dbItem?.listName === "my-list-1",
-      );
-      const list2 = items.find(
-        (c) =>
-          c.dbItem?.kind === DbItemKind.RemoteUserDefinedList &&
-          c.dbItem?.listName === "my-list-2",
-      );
+    const repo1Node = list2?.children.find(
+      (c) =>
+        c.dbItem?.kind === DbItemKind.RemoteRepo &&
+        c.dbItem?.repoFullName === "owner1/repo1",
+    );
+    expect(repo1Node).toBeTruthy();
+    expect(isTreeViewItemSelected(repo1Node!)).toBeTruthy();
 
-      expect(list1).toBeTruthy();
-      expect(list2).toBeTruthy();
-      expect(isTreeViewItemSelectable(list1!)).toBeTruthy();
-      expect(isTreeViewItemSelected(list2!)).toBeTruthy();
-    });
+    const repo2Node = list2?.children.find(
+      (c) =>
+        c.dbItem?.kind === DbItemKind.RemoteRepo &&
+        c.dbItem?.repoFullName === "owner2/repo2",
+    );
+    expect(repo2Node).toBeTruthy();
+    expect(isTreeViewItemSelectable(repo2Node!)).toBeTruthy();
 
-    it("should mark selected remote db inside list as selected", async () => {
-      const dbConfig: DbConfig = createDbConfig({
-        remoteLists: [
-          {
-            name: "my-list-1",
-            repositories: ["owner1/repo1", "owner1/repo2"],
-          },
-          {
-            name: "my-list-2",
-            repositories: ["owner1/repo1", "owner2/repo2"],
-          },
-        ],
-        remoteRepos: ["owner1/repo1"],
-        selected: {
-          kind: SelectedDbItemKind.VariantAnalysisRepository,
-          repositoryName: "owner1/repo1",
-          listName: "my-list-2",
-        },
-      });
-
-      await saveDbConfig(dbConfig);
-
-      const dbTreeItems = await dbTreeDataProvider.getChildren();
-
-      expect(dbTreeItems).toBeTruthy();
-      const items = dbTreeItems!;
-
-      const list2 = items.find(
-        (c) =>
-          c.dbItem?.kind === DbItemKind.RemoteUserDefinedList &&
-          c.dbItem?.listName === "my-list-2",
-      );
-      expect(list2).toBeTruthy();
-
-      const repo1Node = list2?.children.find(
-        (c) =>
-          c.dbItem?.kind === DbItemKind.RemoteRepo &&
-          c.dbItem?.repoFullName === "owner1/repo1",
-      );
-      expect(repo1Node).toBeTruthy();
-      expect(isTreeViewItemSelected(repo1Node!)).toBeTruthy();
-
-      const repo2Node = list2?.children.find(
-        (c) =>
-          c.dbItem?.kind === DbItemKind.RemoteRepo &&
-          c.dbItem?.repoFullName === "owner2/repo2",
-      );
-      expect(repo2Node).toBeTruthy();
-      expect(isTreeViewItemSelectable(repo2Node!)).toBeTruthy();
-
-      for (const item of items) {
-        expect(isTreeViewItemSelectable(item)).toBeTruthy();
-      }
-    });
+    for (const item of items) {
+      expect(isTreeViewItemSelectable(item)).toBeTruthy();
+    }
   });
 
   async function saveDbConfig(dbConfig: DbConfig): Promise<void> {

--- a/extensions/ql-vscode/test/vscode-tests/utils/configuration-helpers.ts
+++ b/extensions/ql-vscode/test/vscode-tests/utils/configuration-helpers.ts
@@ -1,0 +1,53 @@
+import { workspace } from "vscode";
+
+type MockConfigurationConfig = {
+  values: {
+    [section: string]: {
+      [scope: string]: any | (() => any);
+    };
+  };
+};
+
+export function mockConfiguration(config: MockConfigurationConfig) {
+  const originalGetConfiguration = workspace.getConfiguration;
+
+  jest
+    .spyOn(workspace, "getConfiguration")
+    .mockImplementation((section, scope) => {
+      const configuration = originalGetConfiguration(section, scope);
+
+      return {
+        get(key: string, defaultValue?: unknown) {
+          if (
+            section &&
+            config.values[section] &&
+            config.values[section][key]
+          ) {
+            const value = config.values[section][key];
+            return typeof value === "function" ? value() : value;
+          }
+
+          return configuration.get(key, defaultValue);
+        },
+        has(key: string) {
+          return configuration.has(key);
+        },
+        inspect(key: string) {
+          return configuration.inspect(key);
+        },
+        update(
+          key: string,
+          value: unknown,
+          configurationTarget?: boolean,
+          overrideInLanguage?: boolean,
+        ) {
+          return configuration.update(
+            key,
+            value,
+            configurationTarget,
+            overrideInLanguage,
+          );
+        },
+      };
+    });
+}


### PR DESCRIPTION
This will add a welcome view to the database panel which is shown when the controller repository is not setup. This welcome view will show a button which can be used to set up the controller repository.

![Screenshot 2023-01-30 at 14 31 57](https://user-images.githubusercontent.com/1112623/215491262-685f477c-0c3a-45e0-89bc-ccea9ff2e50d.png)


## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
