### PR TITLE
Introduce command to set default Code Tour database

### DIFF
--- a/extensions/ql-vscode/src/databases-ui.ts
+++ b/extensions/ql-vscode/src/databases-ui.ts
@@ -363,7 +363,7 @@ export class DatabaseUI extends DisposableObject {
     token: CancellationToken,
   ): Promise<void> => {
     try {
-      if (workspace.workspaceFolders === undefined) {
+      if (!workspace.workspaceFolders?.length) {
         throw new Error("No workspace folder is open.");
       } else {
         // This specifically refers to the database folder in

--- a/extensions/ql-vscode/src/databases-ui.ts
+++ b/extensions/ql-vscode/src/databases-ui.ts
@@ -384,7 +384,11 @@ export class DatabaseUI extends DisposableObject {
       }
     } catch (e) {
       // rethrow and let this be handled by default error handling.
-      throw new Error(`Could not set database: ${getErrorMessage(e)}`);
+      throw new Error(
+        `Could not set the database for the Code Tour. Please make sure you are using the default workspace in your codespace: ${getErrorMessage(
+          e,
+        )}`,
+      );
     }
   };
 

--- a/extensions/ql-vscode/src/databases-ui.ts
+++ b/extensions/ql-vscode/src/databases-ui.ts
@@ -366,10 +366,10 @@ export class DatabaseUI extends DisposableObject {
       if (workspace.workspaceFolders === undefined) {
         throw new Error("No workspace folder is open.");
       } else {
-        const codespaceRootFolderUri = workspace.workspaceFolders[0].uri;
-
+        // This specifically refers to the database folder in
+        // https://github.com/github/codespaces-codeql
         const uri = Uri.parse(
-          `${codespaceRootFolderUri}/codeql-tutorial-database`,
+          `${workspace.workspaceFolders[0].uri}/codeql-tutorial-database`,
         );
 
         let databaseItem = this.databaseManager.findDatabaseItem(uri);


### PR DESCRIPTION
Makes this possible: https://github.com/github/codespaces-codeql/pull/4

We have a codespace template which houses our CodeQL tour: https://github.com/github/codespaces-codeql

This contains a repo with a default databases already loaded for the user so that they can start writing queries more quickly.

At the moment we're asking the user to manually right click on the database folder (`codeql-tutorial-database`) and set it as the current database.

We can take this one step further by defining a command that gets triggered when we arrive at the step for setting up the database.

The command (`codeQL.setDefaultTourDatabase`) will build the URI pointing to our preloaded database and set it as the current one.

We initially considered whether we can re-use the `setCurrentDatabase` command and pass the URI of the database from the codespace itself, but the URI would be hardcoded as:

```
file://0-62/workspaces/codespaces-codeql/codeql-tutorial-database
```

as we can only pass the codeTour extension a command and string parameters.

This would have been brittle as the filepath for a codespace might change in the future.

Instead we can define a custom tour command (`setDefaultTourDatabase`) to look at the current workspace folder and build the path to the database in the CodeQL extension.

We've made the command publicly visible so that we can execute it from our code tour. 

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
