### PR TITLE
Don't send new telemetry data unless opted-in

### DIFF
--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -92,6 +92,15 @@ export const GLOBAL_ENABLE_TELEMETRY = new Setting(
   GLOBAL_TELEMETRY_SETTING,
 );
 
+const ENABLE_NEW_TELEMETRY = new Setting(
+  "enableNewTelemetry",
+  TELEMETRY_SETTING,
+);
+
+export function newTelemetryEnabled(): boolean {
+  return ENABLE_NEW_TELEMETRY.getValue<boolean>();
+}
+
 // Distribution configuration
 const DISTRIBUTION_SETTING = new Setting("cli", ROOT_SETTING);
 export const CUSTOM_CODEQL_PATH_SETTING = new Setting(

--- a/extensions/ql-vscode/src/telemetry.ts
+++ b/extensions/ql-vscode/src/telemetry.ts
@@ -13,6 +13,7 @@ import {
   LOG_TELEMETRY,
   isIntegrationTestMode,
   isCanary,
+  newTelemetryEnabled,
 } from "./config";
 import * as appInsights from "applicationinsights";
 import { extLogger } from "./common";
@@ -169,6 +170,10 @@ export class TelemetryListener extends ConfigListener {
 
   sendUIInteraction(name: string) {
     if (!this.reporter) {
+      return;
+    }
+
+    if (!newTelemetryEnabled()) {
       return;
     }
 

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/telemetry.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/telemetry.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../../../src/telemetry";
 import { UserCancellationException } from "../../../src/commandRunner";
 import { ENABLE_TELEMETRY } from "../../../src/config";
+import * as Config from "../../../src/config";
 import { createMockExtensionContext } from "./index";
 
 // setting preferences can trigger lots of background activity
@@ -386,6 +387,37 @@ describe("telemetry reporting", () => {
     // now, we should have to click through the telemetry requestor again
     expect(ctx.globalState.get("telemetry-request-viewed")).toBe(false);
     expect(showInformationMessageSpy).toBeCalledTimes(1);
+  });
+
+  describe("when new telementry is not enabled", () => {
+    it("should not send a telementry event", async () => {
+      await telemetryListener.initialize();
+
+      telemetryListener.sendUIInteraction("test");
+
+      expect(sendTelemetryEventSpy).not.toBeCalled();
+    });
+  });
+
+  describe("when new telementry is enabled", () => {
+    beforeEach(async () => {
+      jest.spyOn(Config, "newTelemetryEnabled").mockReturnValue(true);
+    });
+
+    it("should not send a telementry event", async () => {
+      await telemetryListener.initialize();
+
+      telemetryListener.sendUIInteraction("test");
+
+      expect(sendTelemetryEventSpy).toHaveBeenCalledWith(
+        "ui-interaction",
+        {
+          name: "test",
+          isCanary,
+        },
+        {},
+      );
+    });
   });
 
   async function enableTelemetry(section: string, value: boolean | undefined) {


### PR DESCRIPTION
I'm thinking we may have jumped the gun slightly by implementing the new telemetry before the privacy document has been updated. This hasn't been a huge problem in practice because we haven't actually released a new extension version. But we don't want this to be a blocked on releasing.

I'm proposing we make the new telemetry opt-in behind a new secret config option. We can then leave it this way as long as we like until the privacy document has been updated, and then we enable the new telemetry when we're ready. It'll also make the changelog easier, rather than a mess of a dozen PRs over a 2 month period.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
