### PR TITLE
Introduce command for creating skeleton QL packs

### DIFF
--- a/extensions/ql-vscode/src/databases.ts
+++ b/extensions/ql-vscode/src/databases.ts
@@ -634,7 +634,7 @@ export class DatabaseManager extends DisposableObject {
   public async createSkeletonPacks(databaseItem: DatabaseItem) {
     if (databaseItem === undefined) {
       void this.logger.log(
-        "Could not create QL pack as no database is selected. Please select a database.",
+        "Could not create QL pack because no database is selected. Please add a database.",
       );
       return;
     }

--- a/extensions/ql-vscode/src/databases.ts
+++ b/extensions/ql-vscode/src/databases.ts
@@ -652,7 +652,7 @@ export class DatabaseManager extends DisposableObject {
     }
 
     await showBinaryChoiceDialog(
-      "We've noticed you don't have QL packs downloaded to analyze this database. Can we set it up for you?",
+      `We've noticed you don't have a QL pack downloaded to analyze this database. Can we set up a ${databaseItem.language} query pack for you`,
     );
   }
 

--- a/extensions/ql-vscode/src/databases.ts
+++ b/extensions/ql-vscode/src/databases.ts
@@ -639,7 +639,7 @@ export class DatabaseManager extends DisposableObject {
       return;
     }
 
-    if (databaseItem.language == "") {
+    if (databaseItem.language === "") {
       void this.logger.log(
         "Could not create skeleton QL pack because the selected database's language is not set.",
       );

--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -260,7 +260,7 @@ export function isFolderAlreadyInWorkspace(folderName: string) {
   const workspaceFolders = workspace.workspaceFolders || [];
 
   return !!workspaceFolders.find(
-    (workspaceFolder) => workspaceFolder.name == folderName,
+    (workspaceFolder) => workspaceFolder.name === folderName,
   );
 }
 

--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -255,6 +255,15 @@ export function getOnDiskWorkspaceFolders() {
   return diskWorkspaceFolders;
 }
 
+/** Check if folder is already present in workspace */
+export function isFolderAlreadyInWorkspace(folderName: string) {
+  const workspaceFolders = workspace.workspaceFolders || [];
+
+  return !!workspaceFolders.find(
+    (workspaceFolder) => workspaceFolder.name == folderName,
+  );
+}
+
 /**
  * Provides a utility method to invoke a function only if a minimum time interval has elapsed since
  * the last invocation of that function.

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/config.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/config.test.ts
@@ -108,7 +108,7 @@ describe("config listeners", () => {
           await wait();
           const newValue = listener[setting.property as keyof typeof listener];
           expect(newValue).toEqual(setting.values[1]);
-          expect(onDidChangeConfiguration).toHaveBeenCalledTimes(1);
+          expect(onDidChangeConfiguration).toHaveBeenCalled();
         });
       });
     });

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/databases.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/databases.test.ts
@@ -122,29 +122,31 @@ describe("databases", () => {
     });
   });
 
-  it("should rename a db item and emit an event", async () => {
-    const mockDbItem = createMockDB();
-    const onDidChangeDatabaseItem = jest.fn();
-    databaseManager.onDidChangeDatabaseItem(onDidChangeDatabaseItem);
-    await (databaseManager as any).addDatabaseItem(
-      {} as ProgressCallback,
-      {} as CancellationToken,
-      mockDbItem,
-    );
+  describe("renameDatabaseItem", () => {
+    it("should rename a db item and emit an event", async () => {
+      const mockDbItem = createMockDB();
+      const onDidChangeDatabaseItem = jest.fn();
+      databaseManager.onDidChangeDatabaseItem(onDidChangeDatabaseItem);
+      await (databaseManager as any).addDatabaseItem(
+        {} as ProgressCallback,
+        {} as CancellationToken,
+        mockDbItem,
+      );
 
-    await databaseManager.renameDatabaseItem(mockDbItem, "new name");
+      await databaseManager.renameDatabaseItem(mockDbItem, "new name");
 
-    expect(mockDbItem.name).toBe("new name");
-    expect(updateSpy).toBeCalledWith("databaseList", [
-      {
-        options: { ...MOCK_DB_OPTIONS, displayName: "new name" },
-        uri: dbLocationUri().toString(true),
-      },
-    ]);
+      expect(mockDbItem.name).toBe("new name");
+      expect(updateSpy).toBeCalledWith("databaseList", [
+        {
+          options: { ...MOCK_DB_OPTIONS, displayName: "new name" },
+          uri: dbLocationUri().toString(true),
+        },
+      ]);
 
-    expect(onDidChangeDatabaseItem).toBeCalledWith({
-      item: undefined,
-      kind: DatabaseEventKind.Rename,
+      expect(onDidChangeDatabaseItem).toBeCalledWith({
+        item: undefined,
+        kind: DatabaseEventKind.Rename,
+      });
     });
   });
 
@@ -378,20 +380,26 @@ describe("databases", () => {
     });
   });
 
-  it("should get the primary language", async () => {
-    resolveDatabaseSpy.mockResolvedValue({
-      languages: ["python"],
-    } as unknown as DbInfo);
-    const result = await (databaseManager as any).getPrimaryLanguage("hucairz");
-    expect(result).toBe("python");
-  });
+  describe("getPrimaryLanguage", () => {
+    it("should get the primary language", async () => {
+      resolveDatabaseSpy.mockResolvedValue({
+        languages: ["python"],
+      } as unknown as DbInfo);
+      const result = await (databaseManager as any).getPrimaryLanguage(
+        "hucairz",
+      );
+      expect(result).toBe("python");
+    });
 
-  it("should handle missing the primary language", async () => {
-    resolveDatabaseSpy.mockResolvedValue({
-      languages: [],
-    } as unknown as DbInfo);
-    const result = await (databaseManager as any).getPrimaryLanguage("hucairz");
-    expect(result).toBe("");
+    it("should handle missing the primary language", async () => {
+      resolveDatabaseSpy.mockResolvedValue({
+        languages: [],
+      } as unknown as DbInfo);
+      const result = await (databaseManager as any).getPrimaryLanguage(
+        "hucairz",
+      );
+      expect(result).toBe("");
+    });
   });
 
   describe("isAffectedByTest", () => {

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/databases.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/databases.test.ts
@@ -617,7 +617,7 @@ describe("databases", () => {
       it("should fail gracefully", async () => {
         await (databaseManager as any).createSkeletonPacks(undefined);
         expect(logSpy).toHaveBeenCalledWith(
-          "Could not create QL pack as no database is selected. Please select a database.",
+          "Could not create QL pack because no database is selected. Please add a database.",
         );
       });
     });

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/databases.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/databases.test.ts
@@ -289,7 +289,10 @@ describe("databases", () => {
 
   describe("resolveSourceFile", () => {
     it("should fail to resolve when not a uri", () => {
-      const db = createMockDB(Uri.parse("file:/sourceArchive-uri/"));
+      const db = createMockDB(
+        MOCK_DB_OPTIONS,
+        Uri.parse("file:/sourceArchive-uri/"),
+      );
       (db as any)._contents.sourceArchiveUri = undefined;
       expect(() => db.resolveSourceFile("abc")).toThrowError(
         "Scheme is missing",
@@ -297,7 +300,10 @@ describe("databases", () => {
     });
 
     it("should fail to resolve when not a file uri", () => {
-      const db = createMockDB(Uri.parse("file:/sourceArchive-uri/"));
+      const db = createMockDB(
+        MOCK_DB_OPTIONS,
+        Uri.parse("file:/sourceArchive-uri/"),
+      );
       (db as any)._contents.sourceArchiveUri = undefined;
       expect(() => db.resolveSourceFile("http://abc")).toThrowError(
         "Invalid uri scheme",
@@ -306,14 +312,20 @@ describe("databases", () => {
 
     describe("no source archive", () => {
       it("should resolve undefined", () => {
-        const db = createMockDB(Uri.parse("file:/sourceArchive-uri/"));
+        const db = createMockDB(
+          MOCK_DB_OPTIONS,
+          Uri.parse("file:/sourceArchive-uri/"),
+        );
         (db as any)._contents.sourceArchiveUri = undefined;
         const resolved = db.resolveSourceFile(undefined);
         expect(resolved.toString(true)).toBe(dbLocationUri().toString(true));
       });
 
       it("should resolve an empty file", () => {
-        const db = createMockDB(Uri.parse("file:/sourceArchive-uri/"));
+        const db = createMockDB(
+          MOCK_DB_OPTIONS,
+          Uri.parse("file:/sourceArchive-uri/"),
+        );
         (db as any)._contents.sourceArchiveUri = undefined;
         const resolved = db.resolveSourceFile("file:");
         expect(resolved.toString()).toBe("file:///");
@@ -323,6 +335,7 @@ describe("databases", () => {
     describe("zipped source archive", () => {
       it("should encode a source archive url", () => {
         const db = createMockDB(
+          MOCK_DB_OPTIONS,
           encodeSourceArchiveUri({
             sourceArchiveZipPath: "sourceArchive-uri",
             pathWithinSourceArchive: "def",
@@ -342,6 +355,7 @@ describe("databases", () => {
 
       it("should encode a source archive url with trailing slash", () => {
         const db = createMockDB(
+          MOCK_DB_OPTIONS,
           encodeSourceArchiveUri({
             sourceArchiveZipPath: "sourceArchive-uri",
             pathWithinSourceArchive: "def/",
@@ -361,6 +375,7 @@ describe("databases", () => {
 
       it("should encode an empty source archive url", () => {
         const db = createMockDB(
+          MOCK_DB_OPTIONS,
           encodeSourceArchiveUri({
             sourceArchiveZipPath: "sourceArchive-uri",
             pathWithinSourceArchive: "def",
@@ -374,7 +389,10 @@ describe("databases", () => {
     });
 
     it("should handle an empty file", () => {
-      const db = createMockDB(Uri.parse("file:/sourceArchive-uri/"));
+      const db = createMockDB(
+        MOCK_DB_OPTIONS,
+        Uri.parse("file:/sourceArchive-uri/"),
+      );
       const resolved = db.resolveSourceFile("");
       expect(resolved.toString()).toBe("file:///sourceArchive-uri/");
     });
@@ -417,12 +435,17 @@ describe("databases", () => {
     });
 
     it("should return true for testproj database in test directory", async () => {
-      const db = createMockDB(sourceLocationUri(), Uri.file(projectPath));
+      const db = createMockDB(
+        MOCK_DB_OPTIONS,
+        sourceLocationUri(),
+        Uri.file(projectPath),
+      );
       expect(await db.isAffectedByTest(directoryPath)).toBe(true);
     });
 
     it("should return false for non-existent test directory", async () => {
       const db = createMockDB(
+        MOCK_DB_OPTIONS,
         sourceLocationUri(),
         Uri.file(join(dir.name, "non-existent/non-existent.testproj")),
       );
@@ -436,6 +459,7 @@ describe("databases", () => {
       await fs.writeFile(anotherProjectPath, "");
 
       const db = createMockDB(
+        MOCK_DB_OPTIONS,
         sourceLocationUri(),
         Uri.file(anotherProjectPath),
       );
@@ -449,6 +473,7 @@ describe("databases", () => {
       await fs.writeFile(anotherProjectPath, "");
 
       const db = createMockDB(
+        MOCK_DB_OPTIONS,
         sourceLocationUri(),
         Uri.file(anotherProjectPath),
       );
@@ -456,20 +481,32 @@ describe("databases", () => {
     });
 
     it("should return false for testproj database for prefix directory", async () => {
-      const db = createMockDB(sourceLocationUri(), Uri.file(projectPath));
+      const db = createMockDB(
+        MOCK_DB_OPTIONS,
+        sourceLocationUri(),
+        Uri.file(projectPath),
+      );
       // /d is a prefix of /dir/dir.testproj, but
       // /dir/dir.testproj is not under /d
       expect(await db.isAffectedByTest(join(directoryPath, "d"))).toBe(false);
     });
 
     it("should return true for testproj database for test file", async () => {
-      const db = createMockDB(sourceLocationUri(), Uri.file(projectPath));
+      const db = createMockDB(
+        MOCK_DB_OPTIONS,
+        sourceLocationUri(),
+        Uri.file(projectPath),
+      );
       expect(await db.isAffectedByTest(qlFilePath)).toBe(true);
     });
 
     it("should return false for non-existent test file", async () => {
       const otherTestFile = join(directoryPath, "other-test.ql");
-      const db = createMockDB(sourceLocationUri(), Uri.file(projectPath));
+      const db = createMockDB(
+        MOCK_DB_OPTIONS,
+        sourceLocationUri(),
+        Uri.file(projectPath),
+      );
       expect(await db.isAffectedByTest(otherTestFile)).toBe(false);
     });
 
@@ -478,6 +515,7 @@ describe("databases", () => {
       await fs.writeFile(anotherProjectPath, "");
 
       const db = createMockDB(
+        MOCK_DB_OPTIONS,
         sourceLocationUri(),
         Uri.file(anotherProjectPath),
       );
@@ -488,7 +526,11 @@ describe("databases", () => {
       const otherTestFile = join(dir.name, "test.ql");
       await fs.writeFile(otherTestFile, "");
 
-      const db = createMockDB(sourceLocationUri(), Uri.file(projectPath));
+      const db = createMockDB(
+        MOCK_DB_OPTIONS,
+        sourceLocationUri(),
+        Uri.file(projectPath),
+      );
       expect(await db.isAffectedByTest(otherTestFile)).toBe(false);
     });
   });
@@ -533,6 +575,7 @@ describe("databases", () => {
   });
 
   function createMockDB(
+    mockDbOptions = MOCK_DB_OPTIONS,
     // source archive location must be a real(-ish) location since
     // tests will add this to the workspace location
     sourceArchiveUri = sourceLocationUri(),
@@ -544,7 +587,7 @@ describe("databases", () => {
         sourceArchiveUri,
         datasetUri: databaseUri,
       } as DatabaseContents,
-      MOCK_DB_OPTIONS,
+      mockDbOptions,
       () => void 0,
     );
   }

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/helpers.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/helpers.test.ts
@@ -9,6 +9,8 @@ import {
   SecretStorageChangeEvent,
   Uri,
   window,
+  workspace,
+  WorkspaceFolder,
 } from "vscode";
 import { dump } from "js-yaml";
 import * as tmp from "tmp";
@@ -19,6 +21,7 @@ import { DirResult } from "tmp";
 import {
   getInitialQueryContents,
   InvocationRateLimiter,
+  isFolderAlreadyInWorkspace,
   isLikelyDatabaseRoot,
   isLikelyDbLanguageFolder,
   showBinaryChoiceDialog,
@@ -531,5 +534,23 @@ describe("walkDirectory", () => {
 
     // Only real files should be returned.
     expect(files.sort()).toEqual([file1, file2, file3, file4, file5, file6]);
+  });
+});
+
+describe("isFolderAlreadyInWorkspace", () => {
+  beforeEach(() => {
+    const folders = [
+      { name: "/first/path" },
+      { name: "/second/path" },
+    ] as WorkspaceFolder[];
+
+    jest.spyOn(workspace, "workspaceFolders", "get").mockReturnValue(folders);
+  });
+  it("should return true if the folder is already in the workspace", () => {
+    expect(isFolderAlreadyInWorkspace("/first/path")).toBe(true);
+  });
+
+  it("should return false if the folder is not in the workspace", () => {
+    expect(isFolderAlreadyInWorkspace("/third/path")).toBe(false);
   });
 });


### PR DESCRIPTION
We'd like to make it easier for a user going through the CodeQL Tour to write their queries.

To help them along, we can generate skeleton QL packs once we know which database they're using, instead of expecting them to know how to create this themselves.

We're then able to download the necessary dependencies for their CodeQL queries.



## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
