### PR TITLE
Run tests after setup is complete

### DIFF
--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-manager.test.ts
@@ -409,14 +409,14 @@ describe("QueryHistoryManager", () => {
           ]);
         });
 
-        it("should remove the item", () => {
+        it("should remove the item", async () => {
           expect(toDelete.completedQuery!.dispose).toBeCalledTimes(1);
           expect(queryHistoryManager.treeDataProvider.allHistory).toEqual(
             expect.not.arrayContaining([toDelete]),
           );
         });
 
-        it("should not change the selection", () => {
+        it("should not change the selection", async () => {
           expect(queryHistoryManager.treeDataProvider.getCurrent()).toEqual(
             selected,
           );
@@ -452,14 +452,14 @@ describe("QueryHistoryManager", () => {
           ]);
         });
 
-        it("should remove the item", () => {
+        it("should remove the item", async () => {
           expect(toDelete.completedQuery!.dispose).toBeCalledTimes(1);
           expect(queryHistoryManager.treeDataProvider.allHistory).toEqual(
             expect.not.arrayContaining([toDelete]),
           );
         });
 
-        it("should change the selection", () => {
+        it("should change the selection", async () => {
           expect(queryHistoryManager.treeDataProvider.getCurrent()).toBe(
             newSelected,
           );
@@ -510,7 +510,7 @@ describe("QueryHistoryManager", () => {
           ]);
         });
 
-        it("should remove the item", () => {
+        it("should remove the item", async () => {
           expect(
             remoteQueriesManagerStub.removeRemoteQuery,
           ).toHaveBeenCalledWith(toDelete.queryId);
@@ -519,7 +519,7 @@ describe("QueryHistoryManager", () => {
           );
         });
 
-        it("should not change the selection", () => {
+        it("should not change the selection", async () => {
           expect(queryHistoryManager.treeDataProvider.getCurrent()).toEqual(
             selected,
           );
@@ -552,7 +552,7 @@ describe("QueryHistoryManager", () => {
           ]);
         });
 
-        it("should remove the item", () => {
+        it("should remove the item", async () => {
           expect(
             remoteQueriesManagerStub.removeRemoteQuery,
           ).toHaveBeenCalledWith(toDelete.queryId);
@@ -561,7 +561,7 @@ describe("QueryHistoryManager", () => {
           );
         });
 
-        it("should change the selection", () => {
+        it("should change the selection", async () => {
           expect(queryHistoryManager.treeDataProvider.getCurrent()).toEqual(
             newSelected,
           );
@@ -722,7 +722,7 @@ describe("QueryHistoryManager", () => {
             ]);
           });
 
-          it("should remove the item", () => {
+          it("should remove the item", async () => {
             expect(
               variantAnalysisManagerStub.removeVariantAnalysis,
             ).toHaveBeenCalledWith(toDelete.variantAnalysis);
@@ -731,7 +731,7 @@ describe("QueryHistoryManager", () => {
             ).not.toContain(toDelete);
           });
 
-          it.skip("should change the selection", () => {
+          it("should change the selection", async () => {
             expect(queryHistoryManager.treeDataProvider.getCurrent()).toEqual(
               newSelected,
             );
@@ -740,7 +740,7 @@ describe("QueryHistoryManager", () => {
             );
           });
 
-          it("should show a modal asking 'Are you sure?'", () => {
+          it("should show a modal asking 'Are you sure?'", async () => {
             expect(showBinaryChoiceDialogSpy).toHaveBeenCalledWith(
               "You are about to delete this query: query-name. Are you sure?",
             );
@@ -784,7 +784,7 @@ describe("QueryHistoryManager", () => {
             ]);
           });
 
-          it("should remove the item", () => {
+          it("should remove the item", async () => {
             expect(
               variantAnalysisManagerStub.removeVariantAnalysis,
             ).toHaveBeenCalledWith(toDelete.variantAnalysis);
@@ -793,7 +793,7 @@ describe("QueryHistoryManager", () => {
             ).not.toContain(toDelete);
           });
 
-          it("should not change the selection", () => {
+          it("should not change the selection", async () => {
             expect(queryHistoryManager.treeDataProvider.getCurrent()).toEqual(
               selected,
             );
@@ -802,7 +802,7 @@ describe("QueryHistoryManager", () => {
             );
           });
 
-          it("should not show a modal asking 'Are you sure?'", () => {
+          it("should not show a modal asking 'Are you sure?'", async () => {
             expect(showBinaryChoiceDialogSpy).not.toHaveBeenCalled();
           });
         });
@@ -829,7 +829,7 @@ describe("QueryHistoryManager", () => {
             ]);
           });
 
-          it("should remove the item", () => {
+          it("should remove the item", async () => {
             expect(
               variantAnalysisManagerStub.removeVariantAnalysis,
             ).toHaveBeenCalledWith(toDelete.variantAnalysis);
@@ -838,7 +838,7 @@ describe("QueryHistoryManager", () => {
             ).not.toContain(toDelete);
           });
 
-          it.skip("should change the selection", () => {
+          it.skip("should change the selection", async () => {
             expect(queryHistoryManager.treeDataProvider.getCurrent()).toEqual(
               newSelected,
             );
@@ -847,7 +847,7 @@ describe("QueryHistoryManager", () => {
             );
           });
 
-          it("should not show a modal asking 'Are you sure?'", () => {
+          it("should not show a modal asking 'Are you sure?'", async () => {
             expect(showBinaryChoiceDialogSpy).not.toHaveBeenCalled();
           });
         });

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-manager.test.ts
@@ -838,7 +838,7 @@ describe("QueryHistoryManager", () => {
             ).not.toContain(toDelete);
           });
 
-          it.skip("should change the selection", async () => {
+          it("should change the selection", async () => {
             expect(queryHistoryManager.treeDataProvider.getCurrent()).toEqual(
               newSelected,
             );


### PR DESCRIPTION
The before block for these tests runs `async`, but the tests don't.

Let's give the before block a chance to finish before running the tests.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
