### PR TITLE
Add feature flag for codespaces-codeql template workspace

### DIFF
--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -652,11 +652,11 @@ export function getMockGitHubApiServerScenariosPath(): string | undefined {
  * Enables features that are specific to the codespaces-codeql template workspace from
  * https://github.com/github/codespaces-codeql.
  */
-export const CODESPACES_CODE_TOUR = new Setting(
+export const CODESPACES_TEMPLATE = new Setting(
   "codespacesTemplate",
   ROOT_SETTING,
 );
 
 export function isCodespacesTemplate() {
-  return !!CODESPACES_CODE_TOUR.getValue<boolean>();
+  return !!CODESPACES_TEMPLATE.getValue<boolean>();
 }

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -647,3 +647,16 @@ export class MockGitHubApiConfigListener
 export function getMockGitHubApiServerScenariosPath(): string | undefined {
   return MOCK_GH_API_SERVER_SCENARIOS_PATH.getValue<string>();
 }
+
+/**
+ * Enables features that are specific to the codespaces-codeql template workspace from
+ * https://github.com/github/codespaces-codeql.
+ */
+export const CODESPACES_CODE_TOUR = new Setting(
+  "codespacesTemplate",
+  ROOT_SETTING,
+);
+
+export function isCodespacesTemplate() {
+  return !!CODESPACES_CODE_TOUR.getValue<boolean>();
+}


### PR DESCRIPTION
We'll use this flag for commands that are specific to the tutorial code tour and "quick setup" in https://github.com/github/codespaces-codeql. We can wrap those commands in some sort of `if(isCodespacesTemplate()) { ... }` check.


PR to enable the flag in the codespaces template: https://github.com/github/codespaces-codeql/pull/5


## Checklist

N/A - no user-visible impact

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
