### PR TITLE
Don't lint on `git push`

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1483,7 +1483,7 @@
   "husky": {
     "hooks": {
       "pre-commit": "npm run format-staged",
-      "pre-push": "npm run lint && scripts/forbid-test-only"
+      "pre-push": "scripts/forbid-test-only"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
We run `npm run lint` every time we do a `git push`.

This takes quite a long time, and the lint command has already been run when we created the commit in the first place.

Could we instead skip this and rely on CI to tell us if we've failed to address a linting issue?

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
