### PR TITLE
Rename "Last commit" to "Last updated"

### DIFF
--- a/extensions/ql-vscode/docs/test-plan.md
+++ b/extensions/ql-vscode/docs/test-plan.md
@@ -244,7 +244,7 @@ This requires running a MRVA query and seeing the results view.
    1. By name 
    2. By results 
    3. By stars 
-   4. By last commit
+   4. By last updated
 9. Can filter repos
 10. Shows correct statistics 
     1. Total number of results 

--- a/extensions/ql-vscode/src/view/variant-analysis/RepositoriesSort.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/RepositoriesSort.tsx
@@ -32,7 +32,7 @@ export const RepositoriesSort = ({ value, onChange, className }: Props) => {
       <VSCodeOption value={SortKey.Name}>Name</VSCodeOption>
       <VSCodeOption value={SortKey.ResultsCount}>Results</VSCodeOption>
       <VSCodeOption value={SortKey.Stars}>Stars</VSCodeOption>
-      <VSCodeOption value={SortKey.LastUpdated}>Last commit</VSCodeOption>
+      <VSCodeOption value={SortKey.LastUpdated}>Last updated</VSCodeOption>
     </Dropdown>
   );
 };


### PR DESCRIPTION
Last commit is confusing because it's actually the `updated_at` of the repository. By renaming it, this will be clearer to users.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
