### PR TITLE
Set `DBUS_SESSION_BUS_ADDRESS` to `/dev/null`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -172,7 +172,7 @@ jobs:
         env:
           VSCODE_CODEQL_GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
-          unset DBUS_SESSION_BUS_ADDRESS
+          export DBUS_SESSION_BUS_ADDRESS="unix:abstract=/dev/null"
           /usr/bin/xvfb-run npm run integration
 
       - name: Run integration tests (Windows)
@@ -253,7 +253,7 @@ jobs:
         working-directory: extensions/ql-vscode
         if: matrix.os == 'ubuntu-latest'
         run: |
-          unset DBUS_SESSION_BUS_ADDRESS
+          export DBUS_SESSION_BUS_ADDRESS="unix:abstract=/dev/null"
           /usr/bin/xvfb-run npm run cli-integration
 
       - name: Run CLI tests (Windows)


### PR DESCRIPTION
This sets the `DBUS_SESSION_BUS_ADDRESS` to a valid address to remove warnings when running on CI.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
