### PR TITLE
Handle `codeql-pack.yml` files everywhere

### DIFF
--- a/extensions/ql-vscode/src/contextual/queryResolver.ts
+++ b/extensions/ql-vscode/src/contextual/queryResolver.ts
@@ -9,7 +9,6 @@ import {
   getOnDiskWorkspaceFolders,
   QlPacksForLanguage,
   showAndLogExceptionWithTelemetry,
-  QLPACK_FILENAMES,
 } from "../helpers";
 import { KeyType, kindOfKeyType, nameOfKeyType, tagOfKeyType } from "./keyType";
 import { CodeQLCliServer } from "../cli";
@@ -20,6 +19,7 @@ import { CancellationToken, Uri } from "vscode";
 import { ProgressCallback } from "../commandRunner";
 import { QueryRunner } from "../queryRunner";
 import { redactableError } from "../pure/errors";
+import { QLPACK_FILENAMES } from "../pure/ql";
 
 export async function qlpackOfDatabase(
   cli: CodeQLCliServer,

--- a/extensions/ql-vscode/src/contextual/queryResolver.ts
+++ b/extensions/ql-vscode/src/contextual/queryResolver.ts
@@ -9,6 +9,7 @@ import {
   getOnDiskWorkspaceFolders,
   QlPacksForLanguage,
   showAndLogExceptionWithTelemetry,
+  QLPACK_FILENAMES,
 } from "../helpers";
 import { KeyType, kindOfKeyType, nameOfKeyType, tagOfKeyType } from "./keyType";
 import { CodeQLCliServer } from "../cli";
@@ -113,7 +114,7 @@ async function resolveContextualQuery(
   // Work out the enclosing pack.
   const packContents = await cli.packPacklist(query, false);
   const packFilePath = packContents.find((p) =>
-    ["codeql-pack.yml", "qlpack.yml"].includes(basename(p)),
+    QLPACK_FILENAMES.includes(basename(p)),
   );
   if (packFilePath === undefined) {
     // Should not happen; we already resolved this query.

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -845,6 +845,7 @@ async function activateWithInstalledDistribution(
       documentSelector: [
         { language: "ql", scheme: "file" },
         { language: "yaml", scheme: "file", pattern: "**/qlpack.yml" },
+        { language: "yaml", scheme: "file", pattern: "**/codeql-pack.yml" },
       ],
       synchronize: {
         configurationSection: "codeQL",

--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -23,6 +23,7 @@ import { extLogger, OutputChannelLogger } from "./common";
 import { QueryMetadata } from "./pure/interface-types";
 import { telemetryListener } from "./telemetry";
 import { RedactableError } from "./pure/errors";
+import { getQlPackPath } from "./pure/ql";
 
 // Shared temporary folder for the extension.
 export const tmpDir = dirSync({
@@ -741,21 +742,4 @@ export async function* walkDirectory(
       yield entry;
     }
   }
-}
-
-export const QLPACK_FILENAMES = ["qlpack.yml", "codeql-pack.yml"];
-export const FALLBACK_QLPACK_FILENAME = QLPACK_FILENAMES[0];
-
-export async function getQlPackPath(
-  packRoot: string,
-): Promise<string | undefined> {
-  for (const filename of QLPACK_FILENAMES) {
-    const path = join(packRoot, filename);
-
-    if (await pathExists(path)) {
-      return path;
-    }
-  }
-
-  return undefined;
 }

--- a/extensions/ql-vscode/src/pure/ql.ts
+++ b/extensions/ql-vscode/src/pure/ql.ts
@@ -1,0 +1,19 @@
+import { join } from "path";
+import { pathExists } from "fs-extra";
+
+export const QLPACK_FILENAMES = ["qlpack.yml", "codeql-pack.yml"];
+export const FALLBACK_QLPACK_FILENAME = QLPACK_FILENAMES[0];
+
+export async function getQlPackPath(
+  packRoot: string,
+): Promise<string | undefined> {
+  for (const filename of QLPACK_FILENAMES) {
+    const path = join(packRoot, filename);
+
+    if (await pathExists(path)) {
+      return path;
+    }
+  }
+
+  return undefined;
+}

--- a/extensions/ql-vscode/src/quick-query.ts
+++ b/extensions/ql-vscode/src/quick-query.ts
@@ -12,15 +12,14 @@ import { LSPErrorCodes, ResponseError } from "vscode-languageclient";
 import { CodeQLCliServer } from "./cli";
 import { DatabaseUI } from "./databases-ui";
 import {
-  FALLBACK_QLPACK_FILENAME,
   getInitialQueryContents,
   getPrimaryDbscheme,
   getQlPackForDbscheme,
-  getQlPackPath,
   showBinaryChoiceDialog,
 } from "./helpers";
 import { ProgressCallback, UserCancellationException } from "./commandRunner";
 import { getErrorMessage } from "./pure/helpers-pure";
+import { FALLBACK_QLPACK_FILENAME, getQlPackPath } from "./pure/ql";
 
 const QUICK_QUERIES_DIR_NAME = "quick-queries";
 const QUICK_QUERY_QUERY_NAME = "quick-query.ql";

--- a/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
+++ b/extensions/ql-vscode/src/remote-queries/run-remote-query.ts
@@ -9,9 +9,6 @@ import {
   getOnDiskWorkspaceFolders,
   tryGetQueryMetadata,
   tmpDir,
-  FALLBACK_QLPACK_FILENAME,
-  getQlPackPath,
-  QLPACK_FILENAMES,
 } from "../helpers";
 import { Credentials } from "../common/authentication";
 import * as cli from "../cli";
@@ -33,6 +30,11 @@ import {
 } from "./repository-selection";
 import { Repository } from "./shared/repository";
 import { DbManager } from "../databases/db-manager";
+import {
+  getQlPackPath,
+  FALLBACK_QLPACK_FILENAME,
+  QLPACK_FILENAMES,
+} from "../pure/ql";
 
 export interface QlPack {
   name: string;

--- a/extensions/ql-vscode/test/unit-tests/pure/ql.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/pure/ql.test.ts
@@ -1,0 +1,48 @@
+import { join } from "path";
+import { dirSync } from "tmp-promise";
+import { DirResult } from "tmp";
+import { writeFile } from "fs-extra";
+import { getQlPackPath } from "../../../src/pure/ql";
+
+describe("getQlPackPath", () => {
+  let tmpDir: DirResult;
+
+  beforeEach(() => {
+    tmpDir = dirSync({
+      prefix: "queries_",
+      keep: false,
+      unsafeCleanup: true,
+    });
+  });
+
+  afterEach(() => {
+    tmpDir.removeCallback();
+  });
+
+  it("should find a qlpack.yml when it exists", async () => {
+    await writeFile(join(tmpDir.name, "qlpack.yml"), "name: test");
+
+    const result = await getQlPackPath(tmpDir.name);
+    expect(result).toEqual(join(tmpDir.name, "qlpack.yml"));
+  });
+
+  it("should find a codeql-pack.yml when it exists", async () => {
+    await writeFile(join(tmpDir.name, "codeql-pack.yml"), "name: test");
+
+    const result = await getQlPackPath(tmpDir.name);
+    expect(result).toEqual(join(tmpDir.name, "codeql-pack.yml"));
+  });
+
+  it("should find a qlpack.yml when both exist", async () => {
+    await writeFile(join(tmpDir.name, "qlpack.yml"), "name: test");
+    await writeFile(join(tmpDir.name, "codeql-pack.yml"), "name: test");
+
+    const result = await getQlPackPath(tmpDir.name);
+    expect(result).toEqual(join(tmpDir.name, "qlpack.yml"));
+  });
+
+  it("should find nothing when it doesn't exist", async () => {
+    const result = await getQlPackPath(tmpDir.name);
+    expect(result).toEqual(undefined);
+  });
+});


### PR DESCRIPTION
This will add support for the `codeql-pack.yml` filename in all places where we currently support `qlpack.yml`. It centralizes the list of the supported filenames in a single place and a method that can figure out the correct filename to use.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
