### PR TITLE
Generate QL pack for CodeTour

### DIFF
--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -28,6 +28,7 @@ import { CompilationMessage } from "./pure/legacy-messages";
 import { sarifParser } from "./sarif-parser";
 import { dbSchemeToLanguage, walkDirectory } from "./helpers";
 import { App } from "./common/app";
+import { QueryLanguage } from "./qlpack-generator";
 
 /**
  * The version of the SARIF format that we are using.
@@ -1213,6 +1214,23 @@ export class CodeQLCliServer implements Disposable {
       ["resolve", "queries"],
       args,
       "Resolving queries",
+    );
+  }
+
+  /**
+   * Adds a list of QL library packs with optional version ranges as dependencies of
+   * the current package, and then installs them. This command modifies the qlpack.yml
+   * file of the current package. Formatting and comments will be removed.
+   * @param dir The directory where QL pack exists.
+   * @param language The language of the QL pack.
+   */
+  async packAdd(dir: string, queryLanguage: QueryLanguage) {
+    const args = ["--dir", dir];
+    args.push(`codeql/${queryLanguage}-all`);
+    return this.runJsonCodeQlCliCommandWithAuthentication(
+      ["pack", "add"],
+      args,
+      "Adding pack dependencies and installing them",
     );
   }
 

--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -1218,8 +1218,8 @@ export class CodeQLCliServer implements Disposable {
   }
 
   /**
-   * Adds a list of QL library packs with optional version ranges as dependencies of
-   * the current package, and then installs them. This command modifies the qlpack.yml
+   * Adds a core language QL library pack for the given query language as a dependency
+   * of the current package, and then installs them. This command modifies the qlpack.yml
    * file of the current package. Formatting and comments will be removed.
    * @param dir The directory where QL pack exists.
    * @param language The language of the QL pack.
@@ -1230,7 +1230,7 @@ export class CodeQLCliServer implements Disposable {
     return this.runJsonCodeQlCliCommandWithAuthentication(
       ["pack", "add"],
       args,
-      "Adding and installing pack dependencies.",
+      `Adding and installing ${queryLanguage} pack dependency.`,
     );
   }
 

--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -1230,7 +1230,7 @@ export class CodeQLCliServer implements Disposable {
     return this.runJsonCodeQlCliCommandWithAuthentication(
       ["pack", "add"],
       args,
-      "Adding pack dependencies and installing them",
+      "Adding and installing pack dependencies.",
     );
   }
 

--- a/extensions/ql-vscode/src/databases.ts
+++ b/extensions/ql-vscode/src/databases.ts
@@ -669,6 +669,7 @@ export class DatabaseManager extends DisposableObject {
         folderName,
         databaseItem.language as QueryLanguage,
         this.cli,
+        this.ctx.storageUri?.fsPath,
       );
       await qlPackGenerator.generate();
     } catch (e: unknown) {

--- a/extensions/ql-vscode/src/databases.ts
+++ b/extensions/ql-vscode/src/databases.ts
@@ -657,7 +657,7 @@ export class DatabaseManager extends DisposableObject {
     }
 
     const answer = await showBinaryChoiceDialog(
-      `We've noticed you don't have a QL pack downloaded to analyze this database. Can we set up a query pack for you?`,
+      `We've noticed you don't have a CodeQL pack available to analyze this database. Can we set up a query pack for you?`,
     );
 
     if (!answer) {

--- a/extensions/ql-vscode/src/qlpack-generator.ts
+++ b/extensions/ql-vscode/src/qlpack-generator.ts
@@ -1,0 +1,85 @@
+import { mkdir, writeFile } from "fs-extra";
+import { dump } from "js-yaml";
+import { join } from "path";
+import { CodeQLCliServer } from "./cli";
+
+export type QueryLanguage =
+  | "csharp"
+  | "cpp"
+  | "go"
+  | "java"
+  | "javascript"
+  | "python"
+  | "ruby"
+  | "swift";
+
+export class QlPackGenerator {
+  private readonly qlpackName: string;
+  private readonly qlpackVersion: string;
+  private readonly header: string;
+  private readonly qlpackFileName: string;
+
+  constructor(
+    private readonly folderName: string,
+    private readonly queryLanguage: QueryLanguage,
+    private readonly cliServer: CodeQLCliServer,
+  ) {
+    this.qlpackName = `getting-started/codeql-extra-queries-${this.queryLanguage}`;
+    this.qlpackVersion = "1.0.0";
+    this.header = "# This is an automatically generated file.\n\n";
+
+    this.qlpackFileName = "qlpack.yml";
+  }
+
+  public async generate() {
+    await mkdir(this.folderName);
+
+    // create qlpack.yml
+    await this.createQlPackYaml();
+
+    // create example.ql
+    await this.createExampleQlFile();
+
+    // create codeql-pack.lock.yml
+    await this.createCodeqlPackLockYaml();
+  }
+
+  private async createQlPackYaml() {
+    const qlPackFile = join(this.folderName, this.qlpackFileName);
+
+    const qlPackYml = {
+      name: this.qlpackName,
+      version: this.qlpackVersion,
+      dependencies: {
+        [`codeql/${this.queryLanguage}-all`]: "*",
+      },
+    };
+
+    await writeFile(qlPackFile, this.header + dump(qlPackYml), "utf8");
+  }
+
+  private async createExampleQlFile() {
+    const exampleQlFile = join(this.folderName, "example.ql");
+
+    const exampleQl = `
+/**
+ * @name Empty block
+ * @kind problem
+ * @problem.severity warning
+ * @id ${this.queryLanguage}/example/empty-block
+ */
+
+import ${this.queryLanguage}
+
+from BlockStmt b
+where b.getNumStmt() = 0
+select b, "This is an empty block."
+`.trim();
+
+    await writeFile(exampleQlFile, exampleQl, "utf8");
+  }
+
+  private async createCodeqlPackLockYaml() {
+    await this.cliServer.packAdd(this.folderName, this.queryLanguage);
+  }
+}

--- a/extensions/ql-vscode/src/qlpack-generator.ts
+++ b/extensions/ql-vscode/src/qlpack-generator.ts
@@ -63,6 +63,7 @@ export class QlPackGenerator {
 
     const exampleQl = `
 /**
+ * This is an automatically generated file
  * @name Empty block
  * @kind problem
  * @problem.severity warning

--- a/extensions/ql-vscode/src/qlpack-generator.ts
+++ b/extensions/ql-vscode/src/qlpack-generator.ts
@@ -71,9 +71,7 @@ export class QlPackGenerator {
 
 import ${this.queryLanguage}
 
-from BlockStmt b
-where b.getNumStmt() = 0
-select b, "This is an empty block."
+select "Hello, world!"
 `.trim();
 
     await writeFile(exampleQlFile, exampleQl, "utf8");

--- a/extensions/ql-vscode/src/qlpack-generator.ts
+++ b/extensions/ql-vscode/src/qlpack-generator.ts
@@ -69,9 +69,7 @@ export class QlPackGenerator {
     const qlPackYml = {
       name: this.qlpackName,
       version: this.qlpackVersion,
-      dependencies: {
-        [`codeql/${this.queryLanguage}-all`]: "*",
-      },
+      dependencies: {},
     };
 
     await writeFile(qlPackFilePath, this.header + dump(qlPackYml), "utf8");

--- a/extensions/ql-vscode/src/qlpack-generator.ts
+++ b/extensions/ql-vscode/src/qlpack-generator.ts
@@ -35,7 +35,7 @@ export class QlPackGenerator {
     this.header = "# This is an automatically generated file.\n\n";
 
     this.qlpackFileName = "qlpack.yml";
-    this.folderUri = Uri.parse(join(this.storagePath, this.folderName));
+    this.folderUri = Uri.file(join(this.storagePath, this.folderName));
   }
 
   public async generate() {

--- a/extensions/ql-vscode/src/qlpack-generator.ts
+++ b/extensions/ql-vscode/src/qlpack-generator.ts
@@ -64,7 +64,7 @@ export class QlPackGenerator {
   }
 
   private async createQlPackYaml() {
-    const qlPackFilePath = join(this.folderUri.path, this.qlpackFileName);
+    const qlPackFilePath = join(this.folderUri.fsPath, this.qlpackFileName);
 
     const qlPackYml = {
       name: this.qlpackName,
@@ -78,7 +78,7 @@ export class QlPackGenerator {
   }
 
   private async createExampleQlFile() {
-    const exampleQlFilePath = join(this.folderUri.path, "example.ql");
+    const exampleQlFilePath = join(this.folderUri.fsPath, "example.ql");
 
     const exampleQl = `
 /**
@@ -98,6 +98,6 @@ select "Hello, world!"
   }
 
   private async createCodeqlPackLockYaml() {
-    await this.cliServer.packAdd(this.folderUri.path, this.queryLanguage);
+    await this.cliServer.packAdd(this.folderUri.fsPath, this.queryLanguage);
   }
 }

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/databases.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/databases.test.ts
@@ -33,6 +33,7 @@ describe("databases", () => {
   };
 
   let databaseManager: DatabaseManager;
+  let extensionContext: ExtensionContext;
 
   let updateSpy: jest.Mock<Promise<void>, []>;
   let registerSpy: jest.Mock<Promise<void>, []>;
@@ -63,16 +64,19 @@ describe("databases", () => {
       .spyOn(helpers, "showBinaryChoiceDialog")
       .mockResolvedValue(true);
 
+    extensionContext = {
+      workspaceState: {
+        update: updateSpy,
+        get: () => [],
+      },
+      // pretend like databases added in the temp dir are controlled by the extension
+      // so that they are deleted upon removal
+      storagePath: dir.name,
+      storageUri: Uri.parse(dir.name),
+    } as unknown as ExtensionContext;
+
     databaseManager = new DatabaseManager(
-      {
-        workspaceState: {
-          update: updateSpy,
-          get: () => [],
-        },
-        // pretend like databases added in the temp dir are controlled by the extension
-        // so that they are deleted upon removal
-        storagePath: dir.name,
-      } as unknown as ExtensionContext,
+      extensionContext,
       {
         registerDatabase: registerSpy,
         deregisterDatabase: deregisterSpy,

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/qlpack-generator.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/qlpack-generator.test.ts
@@ -1,0 +1,53 @@
+import { join } from "path";
+import { existsSync, rmdirSync } from "fs";
+import { QlPackGenerator, QueryLanguage } from "../../../src/qlpack-generator";
+import { CodeQLCliServer } from "../../../src/cli";
+
+describe("QlPackGenerator", () => {
+  let packfolderName: string;
+  let qlPackYamlFilePath: string;
+  let exampleQlFilePath: string;
+  let language: string;
+  let generator: QlPackGenerator;
+  let packAddSpy: jest.SpyInstance;
+
+  beforeEach(async () => {
+    language = "ruby";
+    packfolderName = `test-ql-pack-${language}`;
+    qlPackYamlFilePath = join(packfolderName, "qlpack.yml");
+    exampleQlFilePath = join(packfolderName, "example.ql");
+
+    packAddSpy = jest.fn();
+    const mockCli = {
+      packAdd: packAddSpy,
+    } as unknown as CodeQLCliServer;
+
+    generator = new QlPackGenerator(
+      packfolderName,
+      language as QueryLanguage,
+      mockCli,
+    );
+  });
+
+  afterEach(async () => {
+    try {
+      rmdirSync(packfolderName, { recursive: true });
+    } catch (e) {
+      // ignore
+    }
+  });
+
+  it("should generate a QL pack", async () => {
+    expect(existsSync(packfolderName)).toBe(false);
+    expect(existsSync(qlPackYamlFilePath)).toBe(false);
+    expect(existsSync(exampleQlFilePath)).toBe(false);
+
+    await generator.generate();
+
+    expect(existsSync(packfolderName)).toBe(true);
+    expect(existsSync(qlPackYamlFilePath)).toBe(true);
+    expect(existsSync(exampleQlFilePath)).toBe(true);
+
+    expect(packAddSpy).toHaveBeenCalledWith(packfolderName, language);
+  });
+});

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/qlpack-generator.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/qlpack-generator.test.ts
@@ -2,8 +2,7 @@ import { join } from "path";
 import { existsSync } from "fs";
 import { QlPackGenerator, QueryLanguage } from "../../../src/qlpack-generator";
 import { CodeQLCliServer } from "../../../src/cli";
-import { isFolderAlreadyInWorkspace } from "../../../src/helpers";
-import { workspace } from "vscode";
+import { Uri, workspace } from "vscode";
 import { getErrorMessage } from "../../../src/pure/helpers-pure";
 import * as tmp from "tmp";
 
@@ -22,7 +21,7 @@ describe("QlPackGenerator", () => {
 
     language = "ruby";
     packFolderName = `test-ql-pack-${language}`;
-    packFolderPath = join(dir.name, packFolderName);
+    packFolderPath = Uri.file(join(dir.name, packFolderName)).fsPath;
 
     qlPackYamlFilePath = join(packFolderPath, "qlpack.yml");
     exampleQlFilePath = join(packFolderPath, "example.ql");
@@ -60,15 +59,16 @@ describe("QlPackGenerator", () => {
   });
 
   it("should generate a QL pack", async () => {
-    expect(isFolderAlreadyInWorkspace(packFolderName)).toBe(false);
+    expect(existsSync(packFolderPath)).toBe(false);
     expect(existsSync(qlPackYamlFilePath)).toBe(false);
     expect(existsSync(exampleQlFilePath)).toBe(false);
 
     await generator.generate();
 
-    expect(isFolderAlreadyInWorkspace(packFolderName)).toBe(true);
+    expect(existsSync(packFolderPath)).toBe(true);
     expect(existsSync(qlPackYamlFilePath)).toBe(true);
     expect(existsSync(exampleQlFilePath)).toBe(true);
+
     expect(packAddSpy).toHaveBeenCalledWith(packFolderPath, language);
   });
 });

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/qlpack-generator.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/qlpack-generator.test.ts
@@ -1,10 +1,11 @@
 import { join } from "path";
-import { existsSync, rmSync } from "fs";
+import { existsSync } from "fs";
 import { QlPackGenerator, QueryLanguage } from "../../../src/qlpack-generator";
 import { CodeQLCliServer } from "../../../src/cli";
 import { isFolderAlreadyInWorkspace } from "../../../src/helpers";
 import { workspace } from "vscode";
 import { getErrorMessage } from "../../../src/pure/helpers-pure";
+import * as tmp from "tmp";
 
 describe("QlPackGenerator", () => {
   let packFolderName: string;
@@ -14,11 +15,14 @@ describe("QlPackGenerator", () => {
   let language: string;
   let generator: QlPackGenerator;
   let packAddSpy: jest.SpyInstance;
+  let dir: tmp.DirResult;
 
   beforeEach(async () => {
+    dir = tmp.dirSync();
+
     language = "ruby";
     packFolderName = `test-ql-pack-${language}`;
-    packFolderPath = join(__dirname, packFolderName);
+    packFolderPath = join(dir.name, packFolderName);
 
     qlPackYamlFilePath = join(packFolderPath, "qlpack.yml");
     exampleQlFilePath = join(packFolderPath, "example.ql");
@@ -32,13 +36,13 @@ describe("QlPackGenerator", () => {
       packFolderName,
       language as QueryLanguage,
       mockCli,
-      __dirname,
+      dir.name,
     );
   });
 
   afterEach(async () => {
     try {
-      rmSync(packFolderPath, { recursive: true });
+      dir.removeCallback();
 
       const end = (workspace.workspaceFolders || []).length;
       workspace.updateWorkspaceFolders(end - 1, 1);

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/qlpack-generator.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/qlpack-generator.test.ts
@@ -44,8 +44,14 @@ describe("QlPackGenerator", () => {
     try {
       dir.removeCallback();
 
-      const end = (workspace.workspaceFolders || []).length;
-      workspace.updateWorkspaceFolders(end - 1, 1);
+      const workspaceFolders = workspace.workspaceFolders || [];
+      const folderIndex = workspaceFolders.findIndex(
+        (workspaceFolder) => workspaceFolder.name === dir.name,
+      );
+
+      if (folderIndex !== undefined) {
+        workspace.updateWorkspaceFolders(folderIndex, 1);
+      }
     } catch (e) {
       console.log(
         `Could not remove folder from workspace: ${getErrorMessage(e)}`,
@@ -63,7 +69,6 @@ describe("QlPackGenerator", () => {
     expect(isFolderAlreadyInWorkspace(packFolderName)).toBe(true);
     expect(existsSync(qlPackYamlFilePath)).toBe(true);
     expect(existsSync(exampleQlFilePath)).toBe(true);
-
     expect(packAddSpy).toHaveBeenCalledWith(packFolderPath, language);
   });
 });


### PR DESCRIPTION
Follow-up to https://github.com/github/vscode-codeql/pull/2036 where we set up the check for existing QL packs and offer to help the user download the packs.

This PR contains the "doing the thing" part --> downloading the QL packs. 

When you run the [codespace template](https://github.com/github/codespaces-codeql) for the first time, you will automatically have QL packs downloaded for you.

It creates:
- an `example.ql` file
- a `qlpack.yml` file
- a `codeql-pack.lock.yml` file

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
