### PR TITLE
Optimistically update the UI when user selects db/list

### DIFF
--- a/extensions/ql-vscode/src/databases/ui/db-panel.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-panel.ts
@@ -256,8 +256,8 @@ export class DbPanel extends DisposableObject {
     }
 
     // Optimistically update the UI to select the item that the user
-    // to avoid delay in the UI.
-    await this.dataProvider.updateSelectedItem(treeViewItem);
+    // selected to avoid delay in the UI.
+    this.dataProvider.updateSelectedItem(treeViewItem);
 
     await this.dbManager.setSelectedDbItem(treeViewItem.dbItem);
   }

--- a/extensions/ql-vscode/src/databases/ui/db-panel.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-panel.ts
@@ -254,6 +254,11 @@ export class DbPanel extends DisposableObject {
         "Not a selectable database item. Please select a valid item.",
       );
     }
+
+    // Optimistically update the UI to select the item that the user
+    // to avoid delay in the UI.
+    await this.dataProvider.updateSelectedItem(treeViewItem);
+
     await this.dbManager.setSelectedDbItem(treeViewItem.dbItem);
   }
 

--- a/extensions/ql-vscode/src/databases/ui/db-tree-data-provider.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-tree-data-provider.ts
@@ -52,14 +52,9 @@ export class DbTreeDataProvider
    * Updates the selected item and re-renders the tree.
    * @param selectedItem The item to select.
    */
-  public async updateSelectedItem(selectedItem: DbTreeViewItem): Promise<void> {
-    const items = await this.getChildren();
-    if (items === undefined || items === null) {
-      return;
-    }
-
+  public updateSelectedItem(selectedItem: DbTreeViewItem): void {
     // Unselect all items
-    for (const item of items) {
+    for (const item of this.dbTreeItems) {
       item.setAsUnselected();
     }
 

--- a/extensions/ql-vscode/src/databases/ui/db-tree-data-provider.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-tree-data-provider.ts
@@ -49,6 +49,28 @@ export class DbTreeDataProvider
   }
 
   /**
+   * Updates the selected item and re-renders the tree.
+   * @param selectedItem The item to select.
+   */
+  public async updateSelectedItem(selectedItem: DbTreeViewItem): Promise<void> {
+    const items = await this.getChildren();
+    if (items === undefined || items === null) {
+      return;
+    }
+
+    // Unselect all items
+    for (const item of items) {
+      item.setAsUnselected();
+    }
+
+    // Select the new item
+    selectedItem.setAsSelected();
+
+    // Re-render the tree
+    this._onDidChangeTreeData.fire(undefined);
+  }
+
+  /**
    * Called when expanding a node (including the root node).
    * @param node The node to expand.
    * @returns The children of the node.

--- a/extensions/ql-vscode/src/databases/ui/db-tree-view-item.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-tree-view-item.ts
@@ -36,10 +36,18 @@ export class DbTreeViewItem extends vscode.TreeItem {
     if (dbItem) {
       this.contextValue = getContextValue(dbItem);
       if (isSelectableDbItem(dbItem) && dbItem.selected) {
-        // Define the resource id to drive the UI to render this item as selected.
-        this.resourceUri = vscode.Uri.parse(SELECTED_DB_ITEM_RESOURCE_URI);
+        this.setAsSelected();
       }
     }
+  }
+
+  public setAsSelected(): void {
+    // Define the resource id to drive the UI to render this item as selected.
+    this.resourceUri = vscode.Uri.parse(SELECTED_DB_ITEM_RESOURCE_URI);
+  }
+
+  public setAsUnselected(): void {
+    this.resourceUri = undefined;
   }
 }
 


### PR DESCRIPTION
This removes the delay between the user selecting a new db/list and the UI updating.

See internal linked issue with more details.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
