### PR TITLE
Inject extension pack dependencies into MRVA packs

### DIFF
--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -1284,10 +1284,24 @@ export class CodeQLCliServer implements Disposable {
     );
   }
 
-  async packInstall(dir: string, forceUpdate = false) {
+  async packInstall(
+    dir: string,
+    { forceUpdate = false, workspaceFolders = [] as string[] } = {},
+  ) {
     const args = [dir];
     if (forceUpdate) {
       args.push("--mode", "update");
+    }
+    if (workspaceFolders?.length > 0) {
+      if (await this.cliConstraints.supportsAdditionalPacksInstall()) {
+        args.push(
+          // Allow prerelease packs from the ql submodule.
+          "--allow-prerelease",
+          // Allow the use of --additional-packs argument without issueing a warning
+          "--no-strict-mode",
+          ...this.getAdditionalPacksArg(workspaceFolders),
+        );
+      }
     }
     return this.runJsonCodeQlCliCommandWithAuthentication(
       ["pack", "install"],
@@ -1692,6 +1706,13 @@ export class CliVersionConstraint {
    */
   public static CLI_VERSION_WITH_QLPACKS_KIND = new SemVer("2.12.3");
 
+  /**
+   * CLI version that supports the `--additional-packs` option for the `pack install` command.
+   */
+  public static CLI_VERSION_WITH_ADDITIONAL_PACKS_INSTALL = new SemVer(
+    "2.12.4",
+  );
+
   constructor(private readonly cli: CodeQLCliServer) {
     /**/
   }
@@ -1753,6 +1774,12 @@ export class CliVersionConstraint {
   async supportsQlpacksKind() {
     return this.isVersionAtLeast(
       CliVersionConstraint.CLI_VERSION_WITH_QLPACKS_KIND,
+    );
+  }
+
+  async supportsAdditionalPacksInstall() {
+    return this.isVersionAtLeast(
+      CliVersionConstraint.CLI_VERSION_WITH_ADDITIONAL_PACKS_INSTALL,
     );
   }
 }

--- a/extensions/ql-vscode/src/pure/ql.ts
+++ b/extensions/ql-vscode/src/pure/ql.ts
@@ -2,6 +2,10 @@ import { join } from "path";
 import { pathExists } from "fs-extra";
 
 export const QLPACK_FILENAMES = ["qlpack.yml", "codeql-pack.yml"];
+export const QLPACK_LOCK_FILENAMES = [
+  "qlpack.lock.yml",
+  "codeql-pack.lock.yml",
+];
 export const FALLBACK_QLPACK_FILENAME = QLPACK_FILENAMES[0];
 
 export async function getQlPackPath(

--- a/extensions/ql-vscode/src/quick-query.ts
+++ b/extensions/ql-vscode/src/quick-query.ts
@@ -143,7 +143,7 @@ export async function displayQuickQuery(
 
     if (shouldRewrite) {
       await cliServer.clearCache();
-      await cliServer.packInstall(queriesDir, true);
+      await cliServer.packInstall(queriesDir, { forceUpdate: true });
     }
 
     await Window.showTextDocument(await workspace.openTextDocument(qlFile));

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/data-extension-pack/extension-file.yml
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/data-extension-pack/extension-file.yml
@@ -1,0 +1,12 @@
+extensions:
+  - addsTo:
+      pack: codeql/javascript-all
+      extensible: sourceModel
+    data:
+      - [ "@example/read-write-user-data", "Member[readUserData].ReturnValue.Awaited", "remote" ]
+
+  - addsTo:
+      pack: codeql/javascript-all
+      extensible: sinkModel
+    data:
+      - [ "@example/read-write-user-data", "Member[writeUserData].Argument[0]", "command-line-injection" ]

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/data-extension-pack/qlpack.yml
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/data-extension-pack/qlpack.yml
@@ -1,0 +1,8 @@
+name: github/extension-pack-for-testing
+version: 0.0.0
+library: true
+extensionTargets:
+  github/remote-query-pack: "*"
+
+dataExtensions:
+  - extension-file.yml

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
@@ -12,7 +12,7 @@ import * as ghApiClient from "../../../../src/variant-analysis/gh-api/gh-api-cli
 import { join } from "path";
 
 import { VariantAnalysisManager } from "../../../../src/variant-analysis/variant-analysis-manager";
-import { CodeQLCliServer } from "../../../../src/cli";
+import { CliVersionConstraint, CodeQLCliServer } from "../../../../src/cli";
 import {
   fixWorkspaceReferences,
   restoreWorkspaceReferences,
@@ -255,6 +255,30 @@ describe("Variant Analysis Manager", () => {
           qlxFilesThatExist: ["subfolder/in-pack.qlx"],
         });
       });
+
+      it("should run a remote query with extension packs inside a qlpack", async () => {
+        if (!(await cli.cliConstraints.supportsQlpacksKind())) {
+          console.log(
+            `Skipping test because qlpacks kind is only suppported in CLI version ${CliVersionConstraint.CLI_VERSION_WITH_QLPACKS_KIND} or later.`,
+          );
+          return;
+        }
+        await cli.setUseExtensionPacks(true);
+        await doVariantAnalysisTest({
+          queryPath: "data-remote-qlpack-nested/subfolder/in-pack.ql",
+          filesThatExist: [
+            "subfolder/in-pack.ql",
+            "otherfolder/lib.qll",
+            ".codeql/libraries/semmle/targets-extension/0.0.0/ext/extension.yml",
+          ],
+          filesThatDoNotExist: ["subfolder/not-in-pack.ql"],
+          qlxFilesThatExist: ["subfolder/in-pack.qlx"],
+          dependenciesToCheck: [
+            "codeql/javascript-all",
+            "semmle/targets-extension",
+          ],
+        });
+      });
     });
 
     async function doVariantAnalysisTest({
@@ -262,11 +286,13 @@ describe("Variant Analysis Manager", () => {
       filesThatExist,
       qlxFilesThatExist,
       filesThatDoNotExist,
+      dependenciesToCheck = ["codeql/javascript-all"],
     }: {
       queryPath: string;
       filesThatExist: string[];
       qlxFilesThatExist: string[];
       filesThatDoNotExist: string[];
+      dependenciesToCheck?: string[];
     }) {
       const fileUri = getFile(queryPath);
       await variantAnalysisManager.runVariantAnalysis(
@@ -328,8 +354,10 @@ describe("Variant Analysis Manager", () => {
 
       const actualLockKeys = Object.keys(qlpackLockContents.dependencies);
 
-      // The lock file should contain at least codeql/javascript-all.
-      expect(actualLockKeys).toContain("codeql/javascript-all");
+      // The lock file should contain at least the specified dependencies.
+      dependenciesToCheck.forEach((dep) =>
+        expect(actualLockKeys).toContain(dep),
+      );
     }
 
     function getFile(file: string): Uri {


### PR DESCRIPTION
If the user requests that extension packs be included in their MRVA run,
then do the following:

1. Search the workspace for all extension packs
2. Add each extension pack as an explicit and direct dependency on
   the generated pack.

It is ok to use `*` as a dependency since we are guaranteed that
exactly one version of each injected extension pack dependency is
available when the pack is being compiled.

If we find multiple paths to an extension pack of the same name, this
is an error since it is ambiguous which path to use.

Commit-by-commit review is recommended.

The first commit introduces a refactoring with no behavioural changes. Second commit introduces the actual change for this PR.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
