### PR TITLE
Add an extra line for testing the codespace-codeql tour

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,6 +11,7 @@
         "--extensionDevelopmentPath=${workspaceRoot}/extensions/ql-vscode",
         // Add a reference to a workspace to open. Eg-
         // "${workspaceRoot}/../vscode-codeql-starter/vscode-codeql-starter.code-workspace"
+        // "${workspaceRoot}/../codespaces-codeql/tutorial.code-workspace"
       ],
       "sourceMaps": true,
       "outFiles": [


### PR DESCRIPTION
If you uncomment this, you'll be able to test the [codespaces-codeql](https://github.com/github/codespaces-codeql) tour locally. It's quite handy so adding it here for convenience.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
