### PR TITLE
Don't offer to create skeleton pack for default database in CodeTour

### DIFF
--- a/extensions/ql-vscode/src/databases-ui.ts
+++ b/extensions/ql-vscode/src/databases-ui.ts
@@ -379,11 +379,14 @@ export class DatabaseUI extends DisposableObject {
         );
 
         let databaseItem = this.databaseManager.findDatabaseItem(uri);
+        const isTutorialDatabase = true;
         if (databaseItem === undefined) {
           databaseItem = await this.databaseManager.openDatabase(
             progress,
             token,
             uri,
+            "CodeQL Tutorial Database",
+            isTutorialDatabase,
           );
         }
         await this.databaseManager.setCurrentDatabaseItem(databaseItem);

--- a/extensions/ql-vscode/src/databases.ts
+++ b/extensions/ql-vscode/src/databases.ts
@@ -606,6 +606,7 @@ export class DatabaseManager extends DisposableObject {
     token: vscode.CancellationToken,
     uri: vscode.Uri,
     displayName?: string,
+    isTutorialDatabase?: boolean,
   ): Promise<DatabaseItem> {
     const contents = await DatabaseResolver.resolveDatabaseContents(uri);
     // Ignore the source archive for QLTest databases by default.
@@ -629,7 +630,7 @@ export class DatabaseManager extends DisposableObject {
     await this.addDatabaseItem(progress, token, databaseItem);
     await this.addDatabaseSourceArchiveFolder(databaseItem);
 
-    if (isCodespacesTemplate()) {
+    if (isCodespacesTemplate() && !isTutorialDatabase) {
       await this.createSkeletonPacks(databaseItem);
     }
 

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/databases.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/databases.test.ts
@@ -711,16 +711,36 @@ describe("databases", () => {
     });
 
     describe("when codeQL.codespacesTemplate is set to true", () => {
-      it("should create a skeleton QL pack", async () => {
-        jest.spyOn(Setting.prototype, "getValue").mockReturnValue(true);
+      describe("when we add the tutorial database to the codespace", () => {
+        it("should not offer to create a skeleton QL pack", async () => {
+          jest.spyOn(Setting.prototype, "getValue").mockReturnValue(true);
 
-        await databaseManager.openDatabase(
-          {} as ProgressCallback,
-          {} as CancellationToken,
-          mockDbItem.databaseUri,
-        );
+          const isTutorialDatabase = true;
 
-        expect(createSkeletonPacksSpy).toBeCalledTimes(1);
+          await databaseManager.openDatabase(
+            {} as ProgressCallback,
+            {} as CancellationToken,
+            mockDbItem.databaseUri,
+            "CodeQL Tutorial Database",
+            isTutorialDatabase,
+          );
+
+          expect(createSkeletonPacksSpy).toBeCalledTimes(0);
+        });
+      });
+
+      describe("when we add a new database that isn't the tutorial one", () => {
+        it("should create a skeleton QL pack", async () => {
+          jest.spyOn(Setting.prototype, "getValue").mockReturnValue(true);
+
+          await databaseManager.openDatabase(
+            {} as ProgressCallback,
+            {} as CancellationToken,
+            mockDbItem.databaseUri,
+          );
+
+          expect(createSkeletonPacksSpy).toBeCalledTimes(1);
+        });
       });
     });
 


### PR DESCRIPTION
Once the user completes the CodeQL tour, they'll be able to add additional databases so they can continue to write queries on their own. For these databases, we want to offer to create the skeleton pack (implemented [here](https://github.com/github/vscode-codeql/pull/2055)). 

However, in Step 3 in the code tour, we also add a default database for you. At this point we don't need to create the skeleton pack, so we're disabling this functionality for the default database.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
