### PR TITLE
Don't send `--format` option for `codeql pack add` command

### DIFF
--- a/extensions/ql-vscode/src/cli.ts
+++ b/extensions/ql-vscode/src/cli.ts
@@ -1227,10 +1227,12 @@ export class CodeQLCliServer implements Disposable {
   async packAdd(dir: string, queryLanguage: QueryLanguage) {
     const args = ["--dir", dir];
     args.push(`codeql/${queryLanguage}-all`);
+    const addFormat = false;
     return this.runJsonCodeQlCliCommandWithAuthentication(
       ["pack", "add"],
       args,
       `Adding and installing ${queryLanguage} pack dependency.`,
+      addFormat,
     );
   }
 


### PR DESCRIPTION
Follow-up to https://github.com/github/vscode-codeql/pull/2055.

Once we create a `qlpack.yml` file for you, we run the `codeql pack add` command to install all the dependencies for it.

For this [we added a wrapper](https://github.com/github/vscode-codeql/blob/95f46b3b3a69889532b504dbd8ccad3958da0f16/extensions/ql-vscode/src/cli.ts#L1227) around the `codeql pack add` command in the extension. 

By default, a `--format` option is added to the command when we call `runJsonCodeQlCliCommandWithAuthentication`.

However, `codeql pack add` doesn't support this option so we need to turn it off.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
