### PR TITLE
Correctly initialize App and DbManager in variant analysis tests

### DIFF
--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/remote-queries/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/remote-queries/variant-analysis-manager.test.ts
@@ -61,7 +61,8 @@ import {
 } from "../../../../src/pure/variant-analysis-filter-sort";
 import { DbManager } from "../../../../src/databases/db-manager";
 import { App } from "../../../../src/common/app";
-import { createMockApp } from "../../../__mocks__/appMock";
+import { ExtensionApp } from "../../../../src/common/vscode/vscode-app";
+import { DbConfigStore } from "../../../../src/databases/config/db-config-store";
 
 // up to 3 minutes per test
 jest.setTimeout(3 * 60 * 1000);
@@ -93,7 +94,8 @@ describe("Variant Analysis Manager", () => {
       )!
       .activate();
     cli = extension.cliServer;
-    app = createMockApp({});
+    app = new ExtensionApp(extension.ctx);
+    dbManager = new DbManager(app, new DbConfigStore(app));
     variantAnalysisResultsManager = new VariantAnalysisResultsManager(
       cli,
       extLogger,


### PR DESCRIPTION
The `DbManager` was never set.

We were also using a mock app when the real one is available and suitable.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
