### PR TITLE
Install dependencies for tutorial query in codespace

### DIFF
--- a/extensions/ql-vscode/src/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/local-databases-ui.ts
@@ -390,6 +390,7 @@ export class DatabaseUI extends DisposableObject {
           );
         }
         await this.databaseManager.setCurrentDatabaseItem(databaseItem);
+        await this.handleTourDependencies();
       }
     } catch (e) {
       // rethrow and let this be handled by default error handling.
@@ -398,6 +399,23 @@ export class DatabaseUI extends DisposableObject {
           e,
         )}`,
       );
+    }
+  };
+
+  private handleTourDependencies = async (): Promise<void> => {
+    // find workspace root folder
+    if (!workspace.workspaceFolders?.length) {
+      throw new Error("No workspace folder is open.");
+    } else {
+      // find tutorial queries folder
+      const tutorialQueriesPath = Uri.parse(
+        `${workspace.workspaceFolders?.[0].uri}/tutorial-queries`,
+      );
+      const cli = this.queryServer?.cliServer;
+      if (!cli) {
+        throw new Error("No CLI server found");
+      }
+      await cli.packInstall(tutorialQueriesPath.fsPath);
     }
   };
 

--- a/extensions/ql-vscode/src/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/local-databases-ui.ts
@@ -407,7 +407,8 @@ export class DatabaseUI extends DisposableObject {
       throw new Error("No workspace folder is open.");
     } else {
       const tutorialQueriesPath = join(
-        `${workspace.workspaceFolders[0].uri.fsPath}/tutorial-queries`,
+        workspace.workspaceFolders[0].uri.fsPath,
+        "tutorial-queries",
       );
       const cli = this.queryServer?.cliServer;
       if (!cli) {

--- a/extensions/ql-vscode/src/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/local-databases-ui.ts
@@ -403,19 +403,17 @@ export class DatabaseUI extends DisposableObject {
   };
 
   private handleTourDependencies = async (): Promise<void> => {
-    // find workspace root folder
     if (!workspace.workspaceFolders?.length) {
       throw new Error("No workspace folder is open.");
     } else {
-      // find tutorial queries folder
-      const tutorialQueriesPath = Uri.parse(
-        `${workspace.workspaceFolders?.[0].uri}/tutorial-queries`,
+      const tutorialQueriesPath = join(
+        `${workspace.workspaceFolders[0].uri.fsPath}/tutorial-queries`,
       );
       const cli = this.queryServer?.cliServer;
       if (!cli) {
         throw new Error("No CLI server found");
       }
-      await cli.packInstall(tutorialQueriesPath.fsPath);
+      await cli.packInstall(tutorialQueriesPath);
     }
   };
 


### PR DESCRIPTION
Required by this PR: https://github.com/github/codespaces-codeql/pull/6

When a user goes through the Code Tour, we select a dummy `csv` database
for them to get them up and running.

Once they complete the code tour and would like to continue writing
queries, they will need to add their own database.

After they do that, we check the language of their new database and
generate a skeleton QL pack for them so that they don't need to create
these files by hand. See [1] for details.

This skeleton pack folder will be called
`codeql-custom-queries-<language>` and it comes with its own example
query: `example.ql`.

When we try to run this example query, the query gets confused about
which `dbscheme` to pick, as it sees a `qlpack.yml` file in the new
skeleton pack folder, as well as one in the existing `tutorial-lib`
folder.

So we'll need to get rid of the `tutorial-lib` folder in order to make room
for new queries to be run once the tour is complete.

This PR introduces a `handleTourDependencies` step which will trigger a 
`codeql pack install` command in order to install real library dependencies 
for `tutorial-queries`, since we no longer have the dummy library in 
`tutorial-lib`.

[1]: https://github.com/github/vscode-codeql/pull/2055