### PR TITLE
Starcke/qlpack gen rename

### DIFF
--- a/extensions/ql-vscode/src/legacy-query-server/run-queries.ts
+++ b/extensions/ql-vscode/src/legacy-query-server/run-queries.ts
@@ -313,7 +313,7 @@ export async function compileAndRunQueryAgainstDatabase(
 
   if (!packConfig.dbscheme) {
     throw new Error(
-      "Could not find a database scheme for this query. Please check that you have a valid qlpack.yml file for this query, which refers to a database scheme either in the `dbscheme` field or through one of its dependencies.",
+      "Could not find a database scheme for this query. Please check that you have a valid qlpack.yml or codeql-pack.yml file for this query, which refers to a database scheme either in the `dbscheme` field or through one of its dependencies.",
     );
   }
 

--- a/extensions/ql-vscode/src/qlpack-generator.ts
+++ b/extensions/ql-vscode/src/qlpack-generator.ts
@@ -34,7 +34,7 @@ export class QlPackGenerator {
     this.qlpackVersion = "1.0.0";
     this.header = "# This is an automatically generated file.\n\n";
 
-    this.qlpackFileName = "qlpack.yml";
+    this.qlpackFileName = "codeql-pack.yml";
     this.folderUri = Uri.file(join(this.storagePath, this.folderName));
   }
 
@@ -42,7 +42,7 @@ export class QlPackGenerator {
     // create QL pack folder and add to workspace
     await this.createWorkspaceFolder();
 
-    // create qlpack.yml
+    // create codeql-pack.yml
     await this.createQlPackYaml();
 
     // create example.ql

--- a/extensions/ql-vscode/src/variant-analysis/run-remote-query.ts
+++ b/extensions/ql-vscode/src/variant-analysis/run-remote-query.ts
@@ -57,8 +57,8 @@ export interface GeneratedQueryPack {
 
 /**
  * Two possibilities:
- * 1. There is no qlpack.yml in this directory. Assume this is a lone query and generate a synthetic qlpack for it.
- * 2. There is a qlpack.yml in this directory. Assume this is a query pack and use the yml to pack the query before uploading it.
+ * 1. There is no qlpack.yml (or codeql-pack.yml) in this directory. Assume this is a lone query and generate a synthetic qlpack for it.
+ * 2. There is a qlpack.yml (or codeql-pack.yml) in this directory. Assume this is a query pack and use the yml to pack the query before uploading it.
  *
  * @returns the entire qlpack as a base64 string.
  */
@@ -169,12 +169,12 @@ async function generateQueryPack(
 }
 
 async function findPackRoot(queryFile: string): Promise<string> {
-  // recursively find the directory containing qlpack.yml
+  // recursively find the directory containing qlpack.yml or codeql-pack.yml
   let dir = dirname(queryFile);
   while (!(await getQlPackPath(dir))) {
     dir = dirname(dir);
     if (isFileSystemRoot(dir)) {
-      // there is no qlpack.yml in this directory or any parent directory.
+      // there is no qlpack.yml or codeql-pack.yml in this directory or any parent directory.
       // just use the query file's directory as the pack root.
       return dirname(queryFile);
     }
@@ -300,14 +300,14 @@ export async function prepareRemoteQueryRun(
 }
 
 /**
- * Fixes the qlpack.yml file to be correct in the context of the MRVA request.
+ * Fixes the qlpack.yml or codeql-pack.yml file to be correct in the context of the MRVA request.
  *
  * Performs the following fixes:
  *
  * - Updates the default suite of the query pack. This is used to ensure
  *   only the specified query is run.
  * - Ensures the query pack name is set to the name expected by the server.
- * - Removes any `${workspace}` version references from the qlpack.yml file. Converts them
+ * - Removes any `${workspace}` version references from the qlpack.yml or codeql-pack.yml file. Converts them
  *   to `*` versions.
  *
  * @param queryPackDir The directory containing the query pack

--- a/extensions/ql-vscode/test/vscode-tests/global.helper.ts
+++ b/extensions/ql-vscode/test/vscode-tests/global.helper.ts
@@ -30,12 +30,12 @@ export async function cleanDatabases(databaseManager: DatabaseManager) {
 }
 
 /**
- * Conditionally removes `${workspace}` references from a qlpack.yml file.
+ * Conditionally removes `${workspace}` references from a qlpack.yml or codeql-pack.yml file.
  * CLI versions earlier than 2.11.3 do not support `${workspace}` references in the dependencies block.
- * If workspace references are removed, the qlpack.yml file is re-written to disk
+ * If workspace references are removed, the qlpack.yml or codeql-pack.yml file is re-written to disk
  * without the `${workspace}` references and the original dependencies are returned.
  *
- * @param qlpackFileWithWorkspaceRefs The qlpack.yml file with workspace refs
+ * @param qlpackFileWithWorkspaceRefs The qlpack.yml or codeql-pack.yml file with workspace refs
  * @param cli The cli to use to check version constraints
  * @returns The original dependencies with workspace refs, or undefined if the CLI version supports workspace refs and no changes were made
  */
@@ -55,10 +55,10 @@ export async function fixWorkspaceReferences(
 }
 
 /**
- * Restores the original dependencies with `${workspace}` refs to a qlpack.yml file.
+ * Restores the original dependencies with `${workspace}` refs to a qlpack.yml or codeql-pack.yml file.
  * See `fixWorkspaceReferences` for more details.
  *
- * @param qlpackFileWithWorkspaceRefs The qlpack.yml file to restore workspace refs
+ * @param qlpackFileWithWorkspaceRefs The qlpack.yml or codeql-pack.yml file to restore workspace refs
  * @param originalDeps the original dependencies with workspace refs or undefined if
  *  no changes were made.
  */

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/qlpack-generator.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/qlpack-generator.test.ts
@@ -23,7 +23,7 @@ describe("QlPackGenerator", () => {
     packFolderName = `test-ql-pack-${language}`;
     packFolderPath = Uri.file(join(dir.name, packFolderName)).fsPath;
 
-    qlPackYamlFilePath = join(packFolderPath, "qlpack.yml");
+    qlPackYamlFilePath = join(packFolderPath, "codeql-pack.yml");
     exampleQlFilePath = join(packFolderPath, "example.ql");
 
     packAddSpy = jest.fn();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

The first commit changes the name of the generated pack from `qlpack.yml` to `codeql-pack.yml`.

The second commit is a single error message change and some comment changes. I noticed them when doing the change, but I can just revert that commit if we do not want to change it.

## Checklist

N/A.

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
