### PR TITLE
Add unique-command-use.ql

### DIFF
--- a/.github/codeql/queries/unique-command-use.ql
+++ b/.github/codeql/queries/unique-command-use.ql
@@ -1,0 +1,93 @@
+/**
+ * @name A VS Code command should not be used in multiple locations
+ * @kind problem
+ * @problem.severity warning
+ * @id vscode-codeql/unique-command-use
+ * @description Using each VS Code command from only one location makes
+ * our telemtry more useful because we can differentiate more user
+ * interactions and know which features of the UI users are using.
+ */
+
+ import javascript
+
+ abstract class CommandUsage extends Locatable {
+   abstract string getCommandName();
+ 
+   predicate isUsedFromOtherPlace() {
+     exists(CommandUsage e | e != this and e.getCommandName() = this.getCommandName())
+   }
+ 
+   predicate isFirstUsage() {
+     forall(CommandUsage e | e.getCommandName() = this.getCommandName() |
+       e.getLocationOrdinal() >= this.getLocationOrdinal()
+     )
+   }
+ 
+   string getLocationOrdinal() {
+     result =
+       this.getFile().getRelativePath() + ":" + this.getLocation().getStartLine() + ":" +
+         this.getLocation().getStartColumn()
+   }
+ }
+ 
+ class CommandUsageCallExpr extends CommandUsage, CallExpr {
+   CommandUsageCallExpr() {
+     this.getCalleeName() = "executeCommand" and
+     this.getArgument(0).(StringLiteral).getValue().matches("%codeQL%") and
+     not this.getFile().getRelativePath().matches("extensions/ql-vscode/test/%")
+   }
+ 
+   override string getCommandName() { result = this.getArgument(0).(StringLiteral).getValue() }
+ }
+ 
+ class CommandUsagePackageJsonMenuItem extends CommandUsage, JsonObject {
+   CommandUsagePackageJsonMenuItem() {
+     this.getFile().getBaseName() = "package.json" and
+     exists(this.getPropValue("command")) and
+     exists(JsonObject topObject, string menuName |
+       not exists(topObject.getParent()) and
+       topObject
+           .getPropValue("contributes")
+           .getPropValue("menus")
+           .getPropValue(menuName)
+           .getElementValue(_) = this and
+       menuName != "commandPalette"
+     )
+   }
+ 
+   override string getCommandName() { result = this.getPropValue("command").getStringValue() }
+ }
+ 
+ predicate isDisabledInCommandPalette(string commandName) {
+   exists(JsonObject topObject, JsonObject commandPaletteObject |
+     not exists(topObject.getParent()) and
+     topObject
+         .getPropValue("contributes")
+         .getPropValue("menus")
+         .getPropValue("commandPalette")
+         .getElementValue(_) = commandPaletteObject and
+     commandPaletteObject.getPropValue("command").getStringValue() = commandName and
+     commandPaletteObject.getPropValue("when").getStringValue() = "false"
+   )
+ }
+ 
+ class CommandUsagePackageJsonCommandPalette extends CommandUsage, JsonObject {
+   CommandUsagePackageJsonCommandPalette() {
+     this.getFile().getBaseName() = "package.json" and
+     exists(this.getPropValue("command")) and
+     exists(JsonObject topObject |
+       not exists(topObject.getParent()) and
+       topObject.getPropValue("contributes").getPropValue("commands").getElementValue(_) = this
+     ) and
+     not isDisabledInCommandPalette(this.getPropValue("command").getStringValue())
+   }
+ 
+   override string getCommandName() { result = this.getPropValue("command").getStringValue() }
+ }
+ 
+ from CommandUsage e
+ where
+   e.isUsedFromOtherPlace() and
+   not e.isFirstUsage()
+ select e, "The " + e.getCommandName() + " command is used from another location"
+ 

--- a/.github/codeql/queries/unique-command-use.ql
+++ b/.github/codeql/queries/unique-command-use.ql
@@ -26,7 +26,12 @@
    /**
     * In how many ways is this command used. Will always be at least 1.
     */
-   int getNumberOfUsages() { result = count(CommandUsage e | e.getCommandName() = this | e) }
+   int getNumberOfUsages() { result = count(this.getAUse()) }
+
+   /**
+    * Get a usage of this command.
+    */
+   CommandUsage getAUse() { result.getCommandName() = this }
  
    /**
     * Get the canonical first usage of this command, to use for the location
@@ -35,10 +40,7 @@
     * the alert.
     */
    CommandUsage getFirstUsage() {
-     result.getCommandName() = this and
-     forall(CommandUsage e | e.getCommandName() = this |
-       e.getLocationOrdinal() >= result.getLocationOrdinal()
-     )
+     result = max(CommandUsage use | use = this.getAUse() | use order by use.getLocationOrdinal())
    }
  }
  

--- a/.github/codeql/queries/unique-command-use.ql
+++ b/.github/codeql/queries/unique-command-use.ql
@@ -40,7 +40,15 @@
     * the alert.
     */
    CommandUsage getFirstUsage() {
-     result = max(CommandUsage use | use = this.getAUse() | use order by use.getLocationOrdinal())
+     result =
+       max(CommandUsage use |
+         use = this.getAUse()
+       |
+         use
+         order by
+           use.getFile().getRelativePath(), use.getLocation().getStartLine(),
+           use.getLocation().getStartColumn()
+       )
    }
  }
  
@@ -50,16 +58,6 @@
   */
  abstract class CommandUsage extends Locatable {
    abstract string getCommandName();
- 
-   /**
-    * Used as a way of ordering locations. The implementation is basically
-    * arbitrary, so long as the ordering is consistent across analyses.
-    */
-   string getLocationOrdinal() {
-     result =
-       this.getFile().getRelativePath() + ":" + this.getLocation().getStartLine() + ":" +
-         this.getLocation().getStartColumn()
-   }
  }
  
  /**

--- a/.github/codeql/queries/unique-command-use.ql
+++ b/.github/codeql/queries/unique-command-use.ql
@@ -42,11 +42,9 @@
  
  class CommandUsagePackageJsonMenuItem extends CommandUsage, JsonObject {
    CommandUsagePackageJsonMenuItem() {
-     this.getFile().getBaseName() = "package.json" and
      exists(this.getPropValue("command")) and
-     exists(JsonObject topObject, string menuName |
-       not exists(topObject.getParent()) and
-       topObject
+     exists(PackageJson packageJson, string menuName |
+       packageJson
            .getPropValue("contributes")
            .getPropValue("menus")
            .getPropValue(menuName)
@@ -59,9 +57,8 @@
  }
  
  predicate isDisabledInCommandPalette(string commandName) {
-   exists(JsonObject topObject, JsonObject commandPaletteObject |
-     not exists(topObject.getParent()) and
-     topObject
+   exists(PackageJson packageJson, JsonObject commandPaletteObject |
+     packageJson
          .getPropValue("contributes")
          .getPropValue("menus")
          .getPropValue("commandPalette")
@@ -75,9 +72,8 @@
    CommandUsagePackageJsonCommandPalette() {
      this.getFile().getBaseName() = "package.json" and
      exists(this.getPropValue("command")) and
-     exists(JsonObject topObject |
-       not exists(topObject.getParent()) and
-       topObject.getPropValue("contributes").getPropValue("commands").getElementValue(_) = this
+     exists(PackageJson packageJson |
+       packageJson.getPropValue("contributes").getPropValue("commands").getElementValue(_) = this
      ) and
      not isDisabledInCommandPalette(this.getPropValue("command").getStringValue())
    }

--- a/.github/codeql/queries/unique-command-use.ql
+++ b/.github/codeql/queries/unique-command-use.ql
@@ -4,13 +4,13 @@
  * @problem.severity warning
  * @id vscode-codeql/unique-command-use
  * @description Using each VS Code command from only one location makes
- * our telemtry more useful because we can differentiate more user
- * interactions and know which features of the UI users are using.
+ * our telemetry more useful, because we can differentiate more user
+ * interactions and know which features of the UI our users are using.
  * To fix this alert, new commands will need to be made so that each one
  * is only used from one location. The commands should share the same
  * implementation so we do not introduce duplicate code.
  * When fixing this alert, search the codebase for all other references
- * to the commnad name. The location of the alert is an arbitrarily
+ * to the command name. The location of the alert is an arbitrarily
  * chosen usage of the command, and may not necessarily be the location
  * that should be changed to fix the alert.
  */
@@ -75,7 +75,7 @@
  
  /**
   * A usage of a command from any menu that isn't the command palette.
-  * This means a user could invoke the command by clicking on a button in a
+  * This means a user could invoke the command by clicking on a button in
   * something like a menu or a dropdown.
   */
  class CommandUsagePackageJsonMenuItem extends CommandUsage, JsonObject {

--- a/.github/codeql/queries/unique-command-use.ql
+++ b/.github/codeql/queries/unique-command-use.ql
@@ -10,18 +10,21 @@
 
  import javascript
 
- abstract class CommandUsage extends Locatable {
-   abstract string getCommandName();
+ class CommandName extends string {
+   CommandName() { exists(CommandUsage e | e.getCommandName() = this) }
  
-   predicate isUsedFromOtherPlace() {
-     exists(CommandUsage e | e != this and e.getCommandName() = this.getCommandName())
-   }
+   int getNumberOfUsages() { result = count(CommandUsage e | e.getCommandName() = this | e) }
  
-   predicate isFirstUsage() {
-     forall(CommandUsage e | e.getCommandName() = this.getCommandName() |
-       e.getLocationOrdinal() >= this.getLocationOrdinal()
+   CommandUsage getFirstUsage() {
+     result.getCommandName() = this and
+     forall(CommandUsage e | e.getCommandName() = this |
+       e.getLocationOrdinal() >= result.getLocationOrdinal()
      )
    }
+ }
+ 
+ abstract class CommandUsage extends Locatable {
+   abstract string getCommandName();
  
    string getLocationOrdinal() {
      result =
@@ -81,9 +84,8 @@
    override string getCommandName() { result = this.getPropValue("command").getStringValue() }
  }
  
- from CommandUsage e
- where
-   e.isUsedFromOtherPlace() and
-   not e.isFirstUsage()
- select e, "The " + e.getCommandName() + " command is used from another location"
+ from CommandName c
+ where c.getNumberOfUsages() > 1
+ select c.getFirstUsage(),
+   "The " + c + " command is used from " + c.getNumberOfUsages() + " locations"
  


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Introduces a new CodeQL query for detecting when a VS Code command is used in more than one location. By "location" we mean a UI element or being called from the code or being available in the command palette. The intention is to make our telemetry more useful, because in the telemetry we can't tell which place the command was called from. To remedy an alert, the command should effectively be duplicated with a new name but referencing the same implementation.

This is still a draft, to share the query and get thoughts. I'll come and add more comments, and I'm sure the CodeQL team will have some helpful advice.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
