### PR TITLE
Remove more instances of `as unknown as`

### DIFF
--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
@@ -59,6 +59,7 @@ import { DbManager } from "../../../../src/databases/db-manager";
 import { App } from "../../../../src/common/app";
 import { ExtensionApp } from "../../../../src/common/vscode/vscode-app";
 import { DbConfigStore } from "../../../../src/databases/config/db-config-store";
+import { mockedObject } from "../../utils/mocking.helpers";
 
 // up to 3 minutes per test
 jest.setTimeout(3 * 60 * 1000);
@@ -992,10 +993,10 @@ describe("Variant Analysis Manager", () => {
 
       showTextDocumentSpy = jest
         .spyOn(window, "showTextDocument")
-        .mockResolvedValue(undefined as unknown as TextEditor);
+        .mockResolvedValue(mockedObject<TextEditor>({}));
       openTextDocumentSpy = jest
         .spyOn(workspace, "openTextDocument")
-        .mockResolvedValue(undefined as unknown as TextDocument);
+        .mockResolvedValue(mockedObject<TextDocument>({}));
     });
 
     afterEach(() => {
@@ -1005,8 +1006,8 @@ describe("Variant Analysis Manager", () => {
     it("opens the query text", async () => {
       await variantAnalysisManager.openQueryText(variantAnalysis.id);
 
-      expect(showTextDocumentSpy).toHaveBeenCalledTimes(1);
       expect(openTextDocumentSpy).toHaveBeenCalledTimes(1);
+      expect(showTextDocumentSpy).toHaveBeenCalledTimes(1);
 
       const uri: Uri = openTextDocumentSpy.mock.calls[0][0] as Uri;
       expect(uri.scheme).toEqual("codeql-variant-analysis");
@@ -1040,10 +1041,10 @@ describe("Variant Analysis Manager", () => {
 
       showTextDocumentSpy = jest
         .spyOn(window, "showTextDocument")
-        .mockResolvedValue(undefined as unknown as TextEditor);
+        .mockResolvedValue(mockedObject<TextEditor>({}));
       openTextDocumentSpy = jest
         .spyOn(workspace, "openTextDocument")
-        .mockResolvedValue(undefined as unknown as TextDocument);
+        .mockResolvedValue(mockedObject<TextDocument>({}));
     });
 
     afterEach(() => {

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/qltest-discovery.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/qltest-discovery.test.ts
@@ -7,6 +7,7 @@ import { DirectoryResult } from "tmp-promise";
 import * as tmp from "tmp-promise";
 
 import "../../matchers/toEqualPath";
+import { mockedObject } from "../utils/mocking.helpers";
 
 describe("qltest-discovery", () => {
   describe("discoverTests", () => {
@@ -34,10 +35,10 @@ describe("qltest-discovery", () => {
       iFile = join(hDir, "i.ql");
 
       qlTestDiscover = new QLTestDiscovery(
-        {
+        mockedObject<WorkspaceFolder>({
           uri: baseUri,
           name: "My tests",
-        } as unknown as WorkspaceFolder,
+        }),
         {
           resolveTests() {
             return [dFile, eFile, iFile];

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/history-item-label-provider.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/history-item-label-provider.test.ts
@@ -22,7 +22,9 @@ describe("HistoryItemLabelProvider", () => {
   beforeEach(() => {
     config = {
       format: "xxx %q xxx",
-    } as unknown as QueryHistoryConfig;
+      ttlInMillis: 0,
+      onDidChangeConfiguration: jest.fn(),
+    };
     labelProvider = new HistoryItemLabelProvider(config);
   });
 

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/history-tree-data-provider.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/history-tree-data-provider.test.ts
@@ -2,10 +2,7 @@ import { join } from "path";
 import * as vscode from "vscode";
 
 import { extLogger } from "../../../../src/common";
-import {
-  QueryHistoryConfig,
-  QueryHistoryConfigListener,
-} from "../../../../src/config";
+import { QueryHistoryConfigListener } from "../../../../src/config";
 import { LocalQueryInfo } from "../../../../src/query-results";
 import { DatabaseManager } from "../../../../src/local-databases";
 import { tmpDir } from "../../../../src/helpers";
@@ -121,8 +118,10 @@ describe("HistoryTreeDataProvider", () => {
     ]);
 
     labelProvider = new HistoryItemLabelProvider({
-      /**/
-    } as QueryHistoryConfig);
+      format: "",
+      ttlInMillis: 0,
+      onDidChangeConfiguration: jest.fn(),
+    });
     historyTreeDataProvider = new HistoryTreeDataProvider(labelProvider);
   });
 
@@ -432,7 +431,11 @@ describe("HistoryTreeDataProvider", () => {
         extensionPath: vscode.Uri.file("/x/y/z").fsPath,
       } as vscode.ExtensionContext,
       configListener,
-      new HistoryItemLabelProvider({} as QueryHistoryConfig),
+      new HistoryItemLabelProvider({
+        format: "",
+        ttlInMillis: 0,
+        onDidChangeConfiguration: jest.fn(),
+      }),
       doCompareCallback,
     );
     (qhm.treeDataProvider as any).history = [...allHistory];

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-manager.test.ts
@@ -3,10 +3,7 @@ import * as vscode from "vscode";
 
 import { extLogger } from "../../../../src/common";
 import { QueryHistoryManager } from "../../../../src/query-history/query-history-manager";
-import {
-  QueryHistoryConfig,
-  QueryHistoryConfigListener,
-} from "../../../../src/config";
+import { QueryHistoryConfigListener } from "../../../../src/config";
 import { LocalQueryInfo } from "../../../../src/query-results";
 import { DatabaseManager } from "../../../../src/local-databases";
 import { tmpDir } from "../../../../src/helpers";
@@ -1159,7 +1156,11 @@ describe("QueryHistoryManager", () => {
         extensionPath: vscode.Uri.file("/x/y/z").fsPath,
       } as vscode.ExtensionContext,
       configListener,
-      new HistoryItemLabelProvider({} as QueryHistoryConfig),
+      new HistoryItemLabelProvider({
+        format: "",
+        ttlInMillis: 0,
+        onDidChangeConfiguration: jest.fn(),
+      }),
       doCompareCallback,
     );
     (qhm.treeDataProvider as any).history = [...allHistory];

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-manager.test.ts
@@ -28,6 +28,7 @@ import { VariantAnalysisStatus } from "../../../../src/variant-analysis/shared/v
 import { QuickPickItem, TextEditor } from "vscode";
 import { WebviewReveal } from "../../../../src/interface-utils";
 import * as helpers from "../../../../src/helpers";
+import { mockedObject } from "../../utils/mocking.helpers";
 
 describe("QueryHistoryManager", () => {
   const mockExtensionLocation = join(tmpDir.name, "mock-extension-location");
@@ -58,7 +59,7 @@ describe("QueryHistoryManager", () => {
   beforeEach(() => {
     showTextDocumentSpy = jest
       .spyOn(vscode.window, "showTextDocument")
-      .mockResolvedValue(undefined as unknown as TextEditor);
+      .mockResolvedValue(mockedObject<TextEditor>({}));
     showInformationMessageSpy = jest
       .spyOn(vscode.window, "showInformationMessage")
       .mockResolvedValue(undefined);

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-scrubber.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-scrubber.test.ts
@@ -12,6 +12,7 @@ import {
   THREE_HOURS_IN_MS,
   TWO_HOURS_IN_MS,
 } from "../../../../src/pure/time";
+import { mockedObject } from "../../utils/mocking.helpers";
 
 describe("query history scrubber", () => {
   const now = Date.now();
@@ -181,11 +182,11 @@ describe("query history scrubber", () => {
       TWO_HOURS_IN_MS,
       LESS_THAN_ONE_DAY,
       dir,
-      {
+      mockedObject<QueryHistoryManager>({
         removeDeletedQueries: () => {
           return Promise.resolve();
         },
-      } as QueryHistoryManager,
+      }),
       mockCtx,
       {
         increment: () => runCount++,

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/variant-analysis-history.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/variant-analysis-history.test.ts
@@ -20,6 +20,7 @@ import { EvalLogViewer } from "../../../../src/eval-log-viewer";
 import { QueryRunner } from "../../../../src/queryRunner";
 import { VariantAnalysisManager } from "../../../../src/variant-analysis/variant-analysis-manager";
 import { QueryHistoryManager } from "../../../../src/query-history/query-history-manager";
+import { mockedObject } from "../../utils/mocking.helpers";
 
 // set a higher timeout since recursive delete may take a while, expecially on Windows.
 jest.setTimeout(120000);
@@ -75,10 +76,11 @@ describe("Variant Analyses and QueryHistoryManager", () => {
       variantAnalysisManagerStub,
       {} as EvalLogViewer,
       STORAGE_DIR,
-      {
+      mockedObject<ExtensionContext>({
         globalStorageUri: Uri.file(STORAGE_DIR),
+        storageUri: undefined,
         extensionPath: EXTENSION_PATH,
-      } as ExtensionContext,
+      }),
       {
         onDidChangeConfiguration: () => new DisposableBucket(),
       } as unknown as QueryHistoryConfig,

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/variant-analysis-history.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/variant-analysis-history.test.ts
@@ -9,7 +9,6 @@ import {
 import { join } from "path";
 
 import { commands, ExtensionContext, Uri } from "vscode";
-import { QueryHistoryConfig } from "../../../../src/config";
 import { DatabaseManager } from "../../../../src/local-databases";
 import { tmpDir, walkDirectory } from "../../../../src/helpers";
 import { DisposableBucket } from "../../disposable-bucket";
@@ -82,9 +81,15 @@ describe("Variant Analyses and QueryHistoryManager", () => {
         extensionPath: EXTENSION_PATH,
       }),
       {
+        format: "",
+        ttlInMillis: 0,
         onDidChangeConfiguration: () => new DisposableBucket(),
-      } as unknown as QueryHistoryConfig,
-      new HistoryItemLabelProvider({} as QueryHistoryConfig),
+      },
+      new HistoryItemLabelProvider({
+        format: "",
+        ttlInMillis: 0,
+        onDidChangeConfiguration: jest.fn(),
+      }),
       asyncNoop,
     );
     disposables.push(qhm);

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/test-adapter.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/test-adapter.test.ts
@@ -59,18 +59,20 @@ describe("test-adapter", () => {
     setCurrentDatabaseItemSpy.mockResolvedValue(undefined);
     resolveQlpacksSpy.mockResolvedValue({});
     resolveTestsSpy.mockResolvedValue([]);
-    fakeDatabaseManager = {
-      openDatabase: openDatabaseSpy,
-      removeDatabaseItem: removeDatabaseItemSpy,
-      renameDatabaseItem: renameDatabaseItemSpy,
-      setCurrentDatabaseItem: setCurrentDatabaseItemSpy,
-    } as unknown as DatabaseManager;
-    Object.defineProperty(fakeDatabaseManager, "currentDatabaseItem", {
-      get: () => currentDatabaseItem,
-    });
-    Object.defineProperty(fakeDatabaseManager, "databaseItems", {
-      get: () => databaseItems,
-    });
+    fakeDatabaseManager = mockedObject<DatabaseManager>(
+      {
+        openDatabase: openDatabaseSpy,
+        removeDatabaseItem: removeDatabaseItemSpy,
+        renameDatabaseItem: renameDatabaseItemSpy,
+        setCurrentDatabaseItem: setCurrentDatabaseItemSpy,
+      },
+      {
+        dynamicProperties: {
+          currentDatabaseItem: () => currentDatabaseItem,
+          databaseItems: () => databaseItems,
+        },
+      },
+    );
 
     jest.spyOn(preTestDatabaseItem, "isAffectedByTest").mockResolvedValue(true);
 

--- a/extensions/ql-vscode/test/vscode-tests/utils/mocking.helpers.ts
+++ b/extensions/ql-vscode/test/vscode-tests/utils/mocking.helpers.ts
@@ -30,6 +30,13 @@ export function mockedObject<T extends object>(
       if (dynamicProperties && prop in dynamicProperties) {
         return (dynamicProperties as any)[prop]();
       }
+
+      // The `then` method is accessed by `Promise.resolve` to check if the object is a thenable.
+      // We don't want to throw an error when this happens.
+      if (prop === "then") {
+        return undefined;
+      }
+
       throw new Error(`Method ${String(prop)} not mocked`);
     },
   });

--- a/extensions/ql-vscode/test/vscode-tests/utils/mocking.helpers.ts
+++ b/extensions/ql-vscode/test/vscode-tests/utils/mocking.helpers.ts
@@ -4,11 +4,31 @@ export type DeepPartial<T> = T extends object
     }
   : T;
 
-export function mockedObject<T extends object>(props: DeepPartial<T>): T {
+export type DynamicProperties<T extends object> = {
+  [P in keyof T]?: () => T[P];
+};
+
+type MockedObjectOptions<T extends object> = {
+  /**
+   * Properties for which the given method should be called when accessed.
+   * The method should return the value to be returned when the property is accessed.
+   * Methods which are explicitly defined in `methods` will take precedence over
+   * dynamic properties.
+   */
+  dynamicProperties?: DynamicProperties<T>;
+};
+
+export function mockedObject<T extends object>(
+  props: DeepPartial<T>,
+  { dynamicProperties }: MockedObjectOptions<T> = {},
+): T {
   return new Proxy<T>({} as unknown as T, {
     get: (_target, prop) => {
       if (prop in props) {
         return (props as any)[prop];
+      }
+      if (dynamicProperties && prop in dynamicProperties) {
+        return (dynamicProperties as any)[prop]();
       }
       throw new Error(`Method ${String(prop)} not mocked`);
     },


### PR DESCRIPTION
See the individual commits for the full changes. This removes `as unknown as` for some more types.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
