### PR TITLE
Fix `Unhandled error: Invalid arguments` bug

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -37,6 +37,7 @@ import {
   CliConfigListener,
   DistributionConfigListener,
   isCanary,
+  isCodespacesTemplate,
   joinOrderWarningThreshold,
   MAX_QUERIES,
   QueryHistoryConfigListener,
@@ -234,7 +235,10 @@ export async function activate(
   const distributionConfigListener = new DistributionConfigListener();
   await initializeLogging(ctx);
   await initializeTelemetry(extension, ctx);
-  addUnhandledRejectionListener();
+  if (!isCodespacesTemplate()) {
+    addUnhandledRejectionListener();
+  }
+
   install();
 
   const codelensProvider = new QuickEvalCodeLensProvider();

--- a/extensions/ql-vscode/src/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/local-databases-ui.ts
@@ -380,12 +380,7 @@ export class DatabaseUI extends DisposableObject {
 
         let databaseItem = this.databaseManager.findDatabaseItem(uri);
         if (databaseItem === undefined) {
-          databaseItem = await this.databaseManager.openDatabase(
-            progress,
-            token,
-            uri,
-            "CodeQL Tutorial Database",
-          );
+          databaseItem = await this.openTutorialDatabase(progress, token, uri);
         }
         await this.databaseManager.setCurrentDatabaseItem(databaseItem);
       }
@@ -397,6 +392,22 @@ export class DatabaseUI extends DisposableObject {
         )}`,
       );
     }
+  };
+
+  // Opens the tutorial database for the CodeQL Tour.
+  // We set the database name as "CodeQL Tutorial Database" in purpose. This means
+  // we won't attempt to create a skeleton QL pack for this database.
+  openTutorialDatabase = async (
+    progress: ProgressCallback,
+    token: CancellationToken,
+    uri: Uri,
+  ): Promise<DatabaseItem> => {
+    return await this.databaseManager.openDatabase(
+      progress,
+      token,
+      uri,
+      "CodeQL Tutorial Database",
+    );
   };
 
   handleRemoveOrphanedDatabases = async (): Promise<void> => {

--- a/extensions/ql-vscode/src/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/local-databases-ui.ts
@@ -379,14 +379,12 @@ export class DatabaseUI extends DisposableObject {
         );
 
         let databaseItem = this.databaseManager.findDatabaseItem(uri);
-        const isTutorialDatabase = true;
         if (databaseItem === undefined) {
           databaseItem = await this.databaseManager.openDatabase(
             progress,
             token,
             uri,
             "CodeQL Tutorial Database",
-            isTutorialDatabase,
           );
         }
         await this.databaseManager.setCurrentDatabaseItem(databaseItem);

--- a/extensions/ql-vscode/src/local-databases.ts
+++ b/extensions/ql-vscode/src/local-databases.ts
@@ -607,7 +607,6 @@ export class DatabaseManager extends DisposableObject {
     token: vscode.CancellationToken,
     uri: vscode.Uri,
     displayName?: string,
-    isTutorialDatabase?: boolean,
   ): Promise<DatabaseItem> {
     const contents = await DatabaseResolver.resolveDatabaseContents(uri);
     // Ignore the source archive for QLTest databases by default.
@@ -631,7 +630,7 @@ export class DatabaseManager extends DisposableObject {
     await this.addDatabaseItem(progress, token, databaseItem);
     await this.addDatabaseSourceArchiveFolder(databaseItem);
 
-    if (isCodespacesTemplate() && !isTutorialDatabase) {
+    if (isCodespacesTemplate() && displayName !== "CodeQL Tutorial Database") {
       await this.createSkeletonPacks(databaseItem);
     }
 

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-databases.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-databases.test.ts
@@ -715,14 +715,11 @@ describe("local databases", () => {
         it("should not offer to create a skeleton QL pack", async () => {
           jest.spyOn(Setting.prototype, "getValue").mockReturnValue(true);
 
-          const isTutorialDatabase = true;
-
           await databaseManager.openDatabase(
             {} as ProgressCallback,
             {} as CancellationToken,
             mockDbItem.databaseUri,
             "CodeQL Tutorial Database",
-            isTutorialDatabase,
           );
 
           expect(createSkeletonPacksSpy).toBeCalledTimes(0);

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/local-databases-ui.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/local-databases-ui.test.ts
@@ -7,12 +7,14 @@ import {
   createFileSync,
   pathExistsSync,
 } from "fs-extra";
-import { Uri } from "vscode";
+import { CancellationToken, Uri } from "vscode";
 
 import { DatabaseUI } from "../../../src/local-databases-ui";
 import { testDisposeHandler } from "../test-dispose-handler";
 import { createMockApp } from "../../__mocks__/appMock";
 import { QueryLanguage } from "../../../src/common/query-language";
+import { App } from "../../../src/common/app";
+import { ProgressCallback } from "../../../src/commandRunner";
 
 describe("local-databases-ui", () => {
   describe("fixDbUri", () => {
@@ -114,6 +116,51 @@ describe("local-databases-ui", () => {
     expect(pathExistsSync(db5)).toBe(false);
 
     databaseUI.dispose(testDisposeHandler);
+  });
+
+  describe("openTutorialDatabase", () => {
+    let app: App;
+    let databaseUI: DatabaseUI;
+    let openDatabaseSpy: jest.SpyInstance;
+    let databaseManager: any;
+
+    beforeEach(async () => {
+      app = createMockApp({});
+      openDatabaseSpy = jest.fn();
+
+      databaseManager = {
+        databaseItems: [],
+        openDatabase: openDatabaseSpy,
+        onDidChangeDatabaseItem: () => {
+          /**/
+        },
+        onDidChangeCurrentDatabaseItem: () => {
+          /**/
+        },
+      };
+      databaseUI = new DatabaseUI(
+        app,
+        databaseManager as any,
+        {} as any,
+        "",
+        "",
+      );
+    });
+
+    it("should call openDatase with 'CodeQL Tutorial Database' as displayName", async () => {
+      await databaseUI.openTutorialDatabase(
+        {} as ProgressCallback,
+        {} as CancellationToken,
+        Uri.parse(""),
+      );
+
+      expect(openDatabaseSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        "CodeQL Tutorial Database",
+      );
+    });
   });
 
   function createDatabase(


### PR DESCRIPTION
When we added an extra optional param `isTutorialDatabase` to `openDatabase` [1] , the tests all passed but there is at least one call [2] where this triggers an `Unhandled arguments` error.

![image](https://user-images.githubusercontent.com/29482385/220328213-c8388f2c-6cd6-4337-b446-7218d1e47089.png)

This is because the method call doesn't know which optional param we're passing (`displayName` or `isTutorialDatabase`).

Let's revert back to the original method signature where we had just one optional parameter (the database's `displayName`) and set it to a special "CodeQL Tutorial Database" value (which we want to do anyway).

We can then use this to skip creating a skeleton pack for the tutorial database since it comes with a checked-in QL pack.

[1]: https://github.com/github/vscode-codeql/blob/5e51bb57f5f76b57768fb6a3543f153f5752c23c/extensions/ql-vscode/src/local-databases.ts#L610
[2]: https://github.com/github/vscode-codeql/blob/5e51bb57f5f76b57768fb6a3543f153f5752c23c/extensions/ql-vscode/src/databaseFetcher.ts#L257-L262

NB: Unfortunately the error message doesn't link to any further information or a stack trace but after testing with this change, the error is resolved.