### PR TITLE
Update skeleton query

### DIFF
--- a/extensions/ql-vscode/src/qlpack-generator.ts
+++ b/extensions/ql-vscode/src/qlpack-generator.ts
@@ -72,15 +72,16 @@ export class QlPackGenerator {
     const exampleQl = `
 /**
  * This is an automatically generated file
- * @name Empty block
+ * @name Hello world
  * @kind problem
  * @problem.severity warning
- * @id ${this.queryLanguage}/example/empty-block
+ * @id ${this.queryLanguage}/example/hello-world
  */
 
 import ${this.queryLanguage}
 
-select "Hello, world!"
+from File f
+select f, "Hello, world!"
 `.trim();
 
     await writeFile(exampleQlFilePath, exampleQl, "utf8");


### PR DESCRIPTION
We mark this generated query as `@kind problem`.

We'll need to change the query a bit to make it fit this type of ...
erm... kind.

This means the results view will be formatted to display the file name
next to each of the results.

We're also getting rid of any mentions of an empty block query since
that's no longer what it checks.

