### PR TITLE
Update path to codespace tutorial database

### DIFF
--- a/extensions/ql-vscode/src/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/local-databases-ui.ts
@@ -375,7 +375,7 @@ export class DatabaseUI extends DisposableObject {
         // This specifically refers to the database folder in
         // https://github.com/github/codespaces-codeql
         const uri = Uri.parse(
-          `${workspace.workspaceFolders[0].uri}/codeql-tutorial-database`,
+          `${workspace.workspaceFolders[0].uri}/.tours/codeql-tutorial-database`,
         );
 
         let databaseItem = this.databaseManager.findDatabaseItem(uri);


### PR DESCRIPTION
In https://github.com/github/codespaces-codeql/pull/12 we moved the source for our tutorial database into `.tours` in order to avoid confusing the user when we load the database into the workspace, since they'd see two databases.

Since this is just the source, we'd like to hide it.



