### PR TITLE
Enable new telemetry by default

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [UNRELEASED]
 
-- Enable collection of telemetry for UI interactions in webviews. [#2114](https://github.com/github/vscode-codeql/pull/2114)
+- Enable collection of telemetry concerning interactions with UI elements, including buttons, links, and other inputs. [#2114](https://github.com/github/vscode-codeql/pull/2114)
 
 # 1.7.10 - 23 February 2023
 

--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [UNRELEASED]
 
-## [UNRELEASED]
+- Enable collection of telemetry for UI interactions in webviews. [#2114](https://github.com/github/vscode-codeql/pull/2114)
 
 # 1.7.10 - 23 February 2023
 

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -83,13 +83,8 @@ export const GLOBAL_ENABLE_TELEMETRY = new Setting(
   GLOBAL_TELEMETRY_SETTING,
 );
 
-const ENABLE_NEW_TELEMETRY = new Setting(
-  "enableNewTelemetry",
-  TELEMETRY_SETTING,
-);
-
 export function newTelemetryEnabled(): boolean {
-  return ENABLE_NEW_TELEMETRY.getValue<boolean>();
+  return true;
 }
 
 // Distribution configuration

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/telemetry.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/telemetry.test.ts
@@ -394,6 +394,10 @@ describe("telemetry reporting", () => {
   });
 
   describe("when new telementry is not enabled", () => {
+    beforeEach(async () => {
+      jest.spyOn(Config, "newTelemetryEnabled").mockReturnValue(false);
+    });
+
     it("should not send a ui-interaction telementry event", async () => {
       await telemetryListener.initialize();
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Enables the new telemetry events. Previous this was opt-in on top of the existing telemetry, but now it'll be included for anyone that is opted in to existing telemetry.

This new telemetry currently only includes clicking on UI elements in web views, such as buttons and links. See https://codeql.github.com/docs/codeql-for-visual-studio-code/about-telemetry-in-codeql-for-visual-studio-code/ for the full information on what telemetry we collect.

Also see https://github.com/github/vscode-codeql/pull/2115 for cleaning up afterwards, but I'll avoid merging that PR until after the next release to reduce code churn and make reverting easier.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
