### PR TITLE
Check controller repo before we set it

### DIFF
--- a/extensions/ql-vscode/src/variant-analysis/run-remote-query.ts
+++ b/extensions/ql-vscode/src/variant-analysis/run-remote-query.ts
@@ -364,6 +364,8 @@ export function getQueryName(
 export async function getControllerRepo(
   credentials: Credentials,
 ): Promise<Repository> {
+  let shouldSetControllerRepo = false;
+
   // Get the controller repo from the config, if it exists.
   // If it doesn't exist, prompt the user to enter it, and save that value to the config.
   let controllerRepoNwo: string | undefined;
@@ -390,15 +392,31 @@ export async function getControllerRepo(
         "Invalid repository format. Must be a valid GitHub repository in the format <owner>/<repo>.",
       );
     }
+
+    shouldSetControllerRepo = true;
+  }
+
+  void extLogger.log(`Using controller repository: ${controllerRepoNwo}`);
+  const controllerRepo = await getControllerRepoFromApi(
+    credentials,
+    controllerRepoNwo,
+  );
+
+  if (shouldSetControllerRepo) {
     void extLogger.log(
       `Setting the controller repository as: ${controllerRepoNwo}`,
     );
     await setRemoteControllerRepo(controllerRepoNwo);
   }
 
-  void extLogger.log(`Using controller repository: ${controllerRepoNwo}`);
-  const [owner, repo] = controllerRepoNwo.split("/");
+  return controllerRepo;
+}
 
+async function getControllerRepoFromApi(
+  credentials: Credentials,
+  nwo: string,
+): Promise<Repository> {
+  const [owner, repo] = nwo.split("/");
   try {
     const controllerRepo = await getRepositoryFromNwo(credentials, owner, repo);
     void extLogger.log(`Controller repository ID: ${controllerRepo.id}`);
@@ -419,6 +437,7 @@ export async function getControllerRepo(
     }
   }
 }
+
 export function removeWorkspaceRefs(qlpack: QlPack) {
   for (const [key, value] of Object.entries(qlpack.dependencies || {})) {
     if (value === "${workspace}") {


### PR DESCRIPTION
Changed the order of things so that we validate the controller repo before setting it.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
