### PR TITLE
Split usage of runQuery and runQueryOnMultipleDatabases

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -69,8 +69,6 @@
     "onCommand:codeQLVariantAnalysisRepositories.removeItemContextMenu",
     "onCommand:codeQL.quickQuery",
     "onCommand:codeQL.restartQueryServer",
-    "onCommand:codeql.runQueryContextEditor",
-    "onCommand:codeql.runQueryOnMultipleDatabasesContextEditor",
     "onWebviewPanel:resultsView",
     "onWebviewPanel:codeQL.variantAnalysis",
     "onFileSystem:codeql-zip-archive"
@@ -309,12 +307,12 @@
         "title": "CodeQL: Run Query on Selected Database"
       },
       {
-        "command": "codeQL.runQueryOnMultipleDatabases",
-        "title": "CodeQL: Run Query on Multiple Databases"
-      },
-      {
         "command": "codeQL.runQueryContextEditor",
         "title": "CodeQL: Run Query on Selected Database"
+      },
+      {
+        "command": "codeQL.runQueryOnMultipleDatabases",
+        "title": "CodeQL: Run Query on Multiple Databases"
       },
       {
         "command": "codeQL.runQueryOnMultipleDatabasesContextEditor",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -69,6 +69,8 @@
     "onCommand:codeQLVariantAnalysisRepositories.removeItemContextMenu",
     "onCommand:codeQL.quickQuery",
     "onCommand:codeQL.restartQueryServer",
+    "onCommand:codeql.runQueryContextEditor",
+    "onCommand:codeql.runQueryOnMultipleDatabasesContextEditor",
     "onWebviewPanel:resultsView",
     "onWebviewPanel:codeQL.variantAnalysis",
     "onFileSystem:codeql-zip-archive"
@@ -308,6 +310,14 @@
       },
       {
         "command": "codeQL.runQueryOnMultipleDatabases",
+        "title": "CodeQL: Run Query on Multiple Databases"
+      },
+      {
+        "command": "codeQL.runQueryContextEditor",
+        "title": "CodeQL: Run Query on Selected Database"
+      },
+      {
+        "command": "codeQL.runQueryOnMultipleDatabasesContextEditor",
         "title": "CodeQL: Run Query on Multiple Databases"
       },
       {
@@ -1211,11 +1221,11 @@
       ],
       "editor/context": [
         {
-          "command": "codeQL.runQuery",
+          "command": "codeQL.runQueryContextEditor",
           "when": "editorLangId == ql && resourceExtname == .ql"
         },
         {
-          "command": "codeQL.runQueryOnMultipleDatabases",
+          "command": "codeQL.runQueryOnMultipleDatabasesContextEditor",
           "when": "editorLangId == ql && resourceExtname == .ql"
         },
         {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Since we're tracking user behaviour through command usage we need to split them by action.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
