### PR TITLE
Clean up variant analyses from query history

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -131,6 +131,7 @@ import { ExtensionApp } from "./common/vscode/vscode-app";
 import { RepositoriesFilterSortStateWithIds } from "./pure/variant-analysis-filter-sort";
 import { DbModule } from "./databases/db-module";
 import { redactableError } from "./pure/errors";
+import { QueryHistoryDirs } from "./query-history/query-history-dirs";
 
 /**
  * extension.ts
@@ -649,13 +650,18 @@ async function activateWithInstalledDistribution(
   );
 
   void extLogger.log("Initializing query history.");
+  const queryHistoryDirs: QueryHistoryDirs = {
+    localQueriesDirPath: queryStorageDir,
+    variantAnalysesDirPath: variantAnalysisStorageDir,
+  };
+
   const qhm = new QueryHistoryManager(
     qs,
     dbm,
     localQueryResultsView,
     variantAnalysisManager,
     evalLogViewer,
-    queryStorageDir,
+    queryHistoryDirs,
     ctx,
     queryHistoryConfigurationListener,
     labelProvider,

--- a/extensions/ql-vscode/src/pure/files.ts
+++ b/extensions/ql-vscode/src/pure/files.ts
@@ -67,3 +67,8 @@ export function pathsEqual(
   }
   return path1 === path2;
 }
+
+export async function readDirFullPaths(path: string): Promise<string[]> {
+  const baseNames = await readdir(path);
+  return baseNames.map((baseName) => join(path, baseName));
+}

--- a/extensions/ql-vscode/src/query-history/query-history-dirs.ts
+++ b/extensions/ql-vscode/src/query-history/query-history-dirs.ts
@@ -1,0 +1,4 @@
+export interface QueryHistoryDirs {
+  localQueriesDirPath: string;
+  variantAnalysesDirPath: string;
+}

--- a/extensions/ql-vscode/src/query-history/query-history-manager.ts
+++ b/extensions/ql-vscode/src/query-history/query-history-manager.ts
@@ -65,6 +65,7 @@ import { VariantAnalysisHistoryItem } from "./variant-analysis-history-item";
 import { getTotalResultCount } from "../variant-analysis/shared/variant-analysis";
 import { HistoryTreeDataProvider } from "./history-tree-data-provider";
 import { redactableError } from "../pure/errors";
+import { QueryHistoryDirs } from "./query-history-dirs";
 
 /**
  * query-history-manager.ts
@@ -139,7 +140,7 @@ export class QueryHistoryManager extends DisposableObject {
     private readonly localQueriesResultsView: ResultsView,
     private readonly variantAnalysisManager: VariantAnalysisManager,
     private readonly evalLogViewer: EvalLogViewer,
-    private readonly queryStorageDir: string,
+    private readonly queryHistoryDirs: QueryHistoryDirs,
     ctx: ExtensionContext,
     private readonly queryHistoryConfigListener: QueryHistoryConfig,
     private readonly labelProvider: HistoryItemLabelProvider,
@@ -389,7 +390,7 @@ export class QueryHistoryManager extends DisposableObject {
         ONE_HOUR_IN_MS,
         TWO_HOURS_IN_MS,
         queryHistoryConfigListener.ttlInMillis,
-        this.queryStorageDir,
+        this.queryHistoryDirs,
         qhm,
         ctx,
       ),

--- a/extensions/ql-vscode/test/factories/query-history/query-history-dirs.ts
+++ b/extensions/ql-vscode/test/factories/query-history/query-history-dirs.ts
@@ -1,0 +1,14 @@
+import { QueryHistoryDirs } from "../../../src/query-history/query-history-dirs";
+
+export function createMockQueryHistoryDirs({
+  localQueriesDirPath = "mock-local-queries-dir-path",
+  variantAnalysesDirPath = "mock-variant-analyses-dir-path",
+}: {
+  localQueriesDirPath?: string;
+  variantAnalysesDirPath?: string;
+} = {}): QueryHistoryDirs {
+  return {
+    localQueriesDirPath,
+    variantAnalysesDirPath,
+  };
+}

--- a/extensions/ql-vscode/test/unit-tests/pure/files.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/pure/files.test.ts
@@ -4,6 +4,7 @@ import {
   gatherQlFiles,
   getDirectoryNamesInsidePath,
   pathsEqual,
+  readDirFullPaths,
 } from "../../../src/pure/files";
 
 describe("files", () => {
@@ -98,6 +99,20 @@ describe("files", () => {
     it("should find sub-folders", async () => {
       const result = await getDirectoryNamesInsidePath(data2Dir);
       expect(result).toEqual(["sub-folder"]);
+    });
+  });
+
+  describe("readDirFullPaths", () => {
+    it("should return all files with full path", async () => {
+      const file1 = join(dataDir, "compute-default-strings.ql");
+      const file2 = join(dataDir, "multiple-result-sets.ql");
+      const file3 = join(dataDir, "query.ql");
+
+      const paths = await readDirFullPaths(dataDir);
+
+      expect(paths.some((path) => path === file1)).toBe(true);
+      expect(paths.some((path) => path === file2)).toBe(true);
+      expect(paths.some((path) => path === file3)).toBe(true);
     });
   });
 });

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/history-tree-data-provider.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/history-tree-data-provider.test.ts
@@ -26,6 +26,7 @@ import {
   SortOrder,
 } from "../../../../src/query-history/history-tree-data-provider";
 import { QueryHistoryManager } from "../../../../src/query-history/query-history-manager";
+import { createMockQueryHistoryDirs } from "../../../factories/query-history/query-history-dirs";
 
 describe("HistoryTreeDataProvider", () => {
   const mockExtensionLocation = join(tmpDir.name, "mock-extension-location");
@@ -425,7 +426,7 @@ describe("HistoryTreeDataProvider", () => {
       localQueriesResultsViewStub,
       variantAnalysisManagerStub,
       {} as EvalLogViewer,
-      "xxx",
+      createMockQueryHistoryDirs(),
       {
         globalStorageUri: vscode.Uri.file(mockExtensionLocation),
         extensionPath: vscode.Uri.file("/x/y/z").fsPath,

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-manager.test.ts
@@ -26,6 +26,7 @@ import { QuickPickItem, TextEditor } from "vscode";
 import { WebviewReveal } from "../../../../src/interface-utils";
 import * as helpers from "../../../../src/helpers";
 import { mockedObject } from "../../utils/mocking.helpers";
+import { createMockQueryHistoryDirs } from "../../../factories/query-history/query-history-dirs";
 
 describe("QueryHistoryManager", () => {
   const mockExtensionLocation = join(tmpDir.name, "mock-extension-location");
@@ -1150,7 +1151,7 @@ describe("QueryHistoryManager", () => {
       localQueriesResultsViewStub,
       variantAnalysisManagerStub,
       {} as EvalLogViewer,
-      "xxx",
+      createMockQueryHistoryDirs(),
       {
         globalStorageUri: vscode.Uri.file(mockExtensionLocation),
         extensionPath: vscode.Uri.file("/x/y/z").fsPath,

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-scrubber.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-scrubber.test.ts
@@ -181,7 +181,7 @@ describe("query history scrubber", () => {
       ONE_HOUR_IN_MS,
       TWO_HOURS_IN_MS,
       LESS_THAN_ONE_DAY,
-      dir,
+      { localQueriesDirPath: dir, variantAnalysesDirPath: dir },
       mockedObject<QueryHistoryManager>({
         removeDeletedQueries: () => {
           return Promise.resolve();

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/variant-analysis-history.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/variant-analysis-history.test.ts
@@ -20,6 +20,7 @@ import { QueryRunner } from "../../../../src/queryRunner";
 import { VariantAnalysisManager } from "../../../../src/variant-analysis/variant-analysis-manager";
 import { QueryHistoryManager } from "../../../../src/query-history/query-history-manager";
 import { mockedObject } from "../../utils/mocking.helpers";
+import { createMockQueryHistoryDirs } from "../../../factories/query-history/query-history-dirs";
 
 // set a higher timeout since recursive delete may take a while, expecially on Windows.
 jest.setTimeout(120000);
@@ -74,7 +75,7 @@ describe("Variant Analyses and QueryHistoryManager", () => {
       localQueriesResultsViewStub,
       variantAnalysisManagerStub,
       {} as EvalLogViewer,
-      STORAGE_DIR,
+      createMockQueryHistoryDirs({ localQueriesDirPath: STORAGE_DIR }),
       mockedObject<ExtensionContext>({
         globalStorageUri: Uri.file(STORAGE_DIR),
         storageUri: undefined,


### PR DESCRIPTION
Updated query history clean up logic to also clean up variant analyses.

This required some minor refactoring - see individual commits.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
