### PR TITLE
Move MRVA out of canary 

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ To see what has changed in the last few versions of the extension, see the [Chan
 * Shows the flow of data through the results of path queries, which is essential for triaging security results.
 * Provides an easy way to run queries from the large, open source repository of [CodeQL security queries](https://github.com/github/codeql).
 * Adds IntelliSense to support you writing and editing your own CodeQL query and library files.
+* Supports you running CodeQL queries against thousands of repositories on GitHub using multi-repository variant analysis.
 
 ## Project goals and scope
 

--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [UNRELEASED]
 
+- Enable multi-repository variant analysis. [#2121](https://github.com/github/vscode-codeql/pull/2121)
 - Enable collection of telemetry concerning interactions with UI elements, including buttons, links, and other inputs. [#2114](https://github.com/github/vscode-codeql/pull/2114)
 
 # 1.7.10 - 23 February 2023

--- a/extensions/ql-vscode/docs/test-plan.md
+++ b/extensions/ql-vscode/docs/test-plan.md
@@ -16,10 +16,6 @@ choose to go through some of the Optional Test Cases.
 
 ## Required Test Cases
 
-### Pre-requisites
-
-- Flip the `codeQL.canary` flag. This will enable MRVA in the extension.
-
 ### Test Case 1: MRVA - Running a problem path query and viewing results
 
 1. Open the [UnsafeJQueryPlugin query](https://github.com/github/codeql/blob/main/javascript/ql/src/Security/CWE-079/UnsafeJQueryPlugin.ql).

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1281,8 +1281,7 @@
         },
         {
           "id": "codeQLVariantAnalysisRepositories",
-          "name": "Variant Analysis Repositories",
-          "when": "config.codeQL.canary"
+          "name": "Variant Analysis Repositories"
         },
         {
           "id": "codeQLQueryHistory",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -978,11 +978,10 @@
         },
         {
           "command": "codeQL.runVariantAnalysis",
-          "when": "config.codeQL.canary && editorLangId == ql && resourceExtname == .ql"
+          "when": "editorLangId == ql && resourceExtname == .ql"
         },
         {
-          "command": "codeQL.exportSelectedVariantAnalysisResults",
-          "when": "config.codeQL.canary"
+          "command": "codeQL.exportSelectedVariantAnalysisResults"
         },
         {
           "command": "codeQL.runQueries",
@@ -1236,7 +1235,7 @@
         },
         {
           "command": "codeQL.runVariantAnalysis",
-          "when": "config.codeQL.canary && editorLangId == ql && resourceExtname == .ql"
+          "when": "editorLangId == ql && resourceExtname == .ql"
         },
         {
           "command": "codeQL.viewAst",

--- a/extensions/ql-vscode/src/databases/db-module.ts
+++ b/extensions/ql-vscode/src/databases/db-module.ts
@@ -1,12 +1,11 @@
 import { window } from "vscode";
-import { App, AppMode } from "../common/app";
+import { App } from "../common/app";
 import { extLogger } from "../common";
 import { DisposableObject } from "../pure/disposable-object";
 import { DbConfigStore } from "./config/db-config-store";
 import { DbManager } from "./db-manager";
 import { DbPanel } from "./ui/db-panel";
 import { DbSelectionDecorationProvider } from "./ui/db-selection-decoration-provider";
-import { isCanary } from "../config";
 
 export class DbModule extends DisposableObject {
   public readonly dbManager: DbManager;
@@ -19,24 +18,12 @@ export class DbModule extends DisposableObject {
     this.dbManager = new DbManager(app, this.dbConfigStore);
   }
 
-  public static async initialize(app: App): Promise<DbModule | undefined> {
-    if (DbModule.shouldEnableModule(app.mode)) {
-      const dbModule = new DbModule(app);
-      app.subscriptions.push(dbModule);
+  public static async initialize(app: App): Promise<DbModule> {
+    const dbModule = new DbModule(app);
+    app.subscriptions.push(dbModule);
 
-      await dbModule.initialize(app);
-      return dbModule;
-    }
-
-    return undefined;
-  }
-
-  private static shouldEnableModule(app: AppMode): boolean {
-    if (app === AppMode.Development || app === AppMode.Test) {
-      return true;
-    }
-
-    return isCanary();
+    await dbModule.initialize(app);
+    return dbModule;
   }
 
   private async initialize(app: App): Promise<void> {

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -637,7 +637,7 @@ async function activateWithInstalledDistribution(
     cliServer,
     variantAnalysisStorageDir,
     variantAnalysisResultsManager,
-    dbModule?.dbManager,
+    dbModule.dbManager,
   );
   ctx.subscriptions.push(variantAnalysisManager);
   ctx.subscriptions.push(variantAnalysisResultsManager);

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -1121,23 +1121,17 @@ async function activateWithInstalledDistribution(
         token: CancellationToken,
         uri: Uri | undefined,
       ) => {
-        if (isCanary()) {
-          progress({
-            maxStep: 5,
-            step: 0,
-            message: "Getting credentials",
-          });
+        progress({
+          maxStep: 5,
+          step: 0,
+          message: "Getting credentials",
+        });
 
-          await variantAnalysisManager.runVariantAnalysis(
-            uri || window.activeTextEditor?.document.uri,
-            progress,
-            token,
-          );
-        } else {
-          throw new Error(
-            "Variant analysis requires the CodeQL Canary version to run.",
-          );
-        }
+        await variantAnalysisManager.runVariantAnalysis(
+          uri || window.activeTextEditor?.document.uri,
+          progress,
+          token,
+        );
       },
       {
         title: "Run Variant Analysis",

--- a/extensions/ql-vscode/src/variant-analysis/repository-selection.ts
+++ b/extensions/ql-vscode/src/variant-analysis/repository-selection.ts
@@ -13,9 +13,9 @@ export interface RepositorySelection {
  * @returns The user selection.
  */
 export async function getRepositorySelection(
-  dbManager?: DbManager,
+  dbManager: DbManager,
 ): Promise<RepositorySelection> {
-  const selectedDbItem = dbManager?.getSelectedDbItem();
+  const selectedDbItem = dbManager.getSelectedDbItem();
   if (selectedDbItem) {
     switch (selectedDbItem.kind) {
       case DbItemKind.LocalDatabase || DbItemKind.LocalList:

--- a/extensions/ql-vscode/src/variant-analysis/run-remote-query.ts
+++ b/extensions/ql-vscode/src/variant-analysis/run-remote-query.ts
@@ -223,7 +223,7 @@ export async function prepareRemoteQueryRun(
   uri: Uri | undefined,
   progress: ProgressCallback,
   token: CancellationToken,
-  dbManager?: DbManager,
+  dbManager: DbManager,
 ): Promise<PreparedRemoteQuery> {
   if (!uri?.fsPath.endsWith(".ql")) {
     throw new UserCancellationException("Not a CodeQL query file.");

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -105,7 +105,7 @@ export class VariantAnalysisManager
     private readonly cliServer: CodeQLCliServer,
     private readonly storagePath: string,
     private readonly variantAnalysisResultsManager: VariantAnalysisResultsManager,
-    private readonly dbManager?: DbManager,
+    private readonly dbManager: DbManager,
   ) {
     super();
     this.variantAnalysisMonitor = this.push(

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-submission-integration.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-submission-integration.test.ts
@@ -3,7 +3,6 @@ import { resolve } from "path";
 import {
   authentication,
   commands,
-  ConfigurationTarget,
   extensions,
   QuickPickItem,
   TextDocument,
@@ -13,10 +12,7 @@ import {
 
 import { CodeQLExtensionInterface } from "../../../../src/extension";
 import { MockGitHubApiServer } from "../../../../src/mocks/mock-gh-api-server";
-import {
-  CANARY_FEATURES,
-  setRemoteControllerRepo,
-} from "../../../../src/config";
+import { setRemoteControllerRepo } from "../../../../src/config";
 
 jest.setTimeout(30_000);
 
@@ -39,7 +35,6 @@ describe("Variant Analysis Submission Integration", () => {
   let showErrorMessageSpy: jest.SpiedFunction<typeof window.showErrorMessage>;
 
   beforeEach(async () => {
-    await CANARY_FEATURES.updateValue(true, ConfigurationTarget.Global);
     await setRemoteControllerRepo("github/vscode-codeql");
 
     jest.spyOn(authentication, "getSession").mockResolvedValue({


### PR DESCRIPTION
Changes the extension so that it no longer requires users to be in the canary channel to use multi-repository variant analysis.

It might be easier if this is reviewed commit by commit.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
