### PR TITLE
Remove additional `as unknown as` for database items

### DIFF
--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/astViewer.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/astViewer.test.ts
@@ -3,8 +3,8 @@ import { load } from "js-yaml";
 
 import { AstViewer, AstItem } from "../../../src/astViewer";
 import { commands, Range, Uri } from "vscode";
-import { DatabaseItem } from "../../../src/local-databases";
 import { testDisposeHandler } from "../test-dispose-handler";
+import { mockDatabaseItem } from "../utils/mocking.helpers";
 
 describe("AstViewer", () => {
   let astRoots: AstItem[];
@@ -31,7 +31,7 @@ describe("AstViewer", () => {
   });
 
   it("should update the viewer roots", () => {
-    const item = {} as DatabaseItem;
+    const item = mockDatabaseItem();
     viewer = new AstViewer();
     viewer.updateRoots(astRoots, item, Uri.file("def/abc"));
 
@@ -71,7 +71,7 @@ describe("AstViewer", () => {
     selectionRange: Range | undefined,
     fileUri = defaultUri,
   ) {
-    const item = {} as DatabaseItem;
+    const item = mockDatabaseItem();
     viewer = new AstViewer();
     viewer.updateRoots(astRoots, item, defaultUri);
 

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/contextual/astBuilder.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/contextual/astBuilder.test.ts
@@ -2,10 +2,9 @@ import { readFileSync } from "fs-extra";
 
 import AstBuilder from "../../../../src/contextual/astBuilder";
 import { CodeQLCliServer } from "../../../../src/cli";
-import { DatabaseItem } from "../../../../src/local-databases";
 import { Uri } from "vscode";
 import { QueryWithResults } from "../../../../src/run-queries-shared";
-import { mockedObject } from "../../utils/mocking.helpers";
+import { mockDatabaseItem, mockedObject } from "../../utils/mocking.helpers";
 
 /**
  *
@@ -146,7 +145,9 @@ describe("AstBuilder", () => {
         },
       } as QueryWithResults,
       mockCli,
-      {} as DatabaseItem,
+      mockDatabaseItem({
+        resolveSourceFile: undefined,
+      }),
       Uri.file(""),
     );
   }

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/contextual/fileRangeFromURI.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/contextual/fileRangeFromURI.test.ts
@@ -6,6 +6,7 @@ import {
   WholeFileLocation,
   LineColumnLocation,
 } from "../../../../src/pure/bqrs-cli-types";
+import { mockDatabaseItem } from "../../utils/mocking.helpers";
 
 describe("fileRangeFromURI", () => {
   it("should return undefined when value is not a file URI", () => {
@@ -92,8 +93,8 @@ describe("fileRangeFromURI", () => {
   });
 
   function createMockDatabaseItem(): DatabaseItem {
-    return {
+    return mockDatabaseItem({
       resolveSourceFile: (file: string) => Uri.parse(file),
-    } as DatabaseItem;
+    });
   }
 });

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/contextual/queryResolver.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/contextual/queryResolver.test.ts
@@ -10,8 +10,7 @@ import {
   resolveQueries,
 } from "../../../../src/contextual/queryResolver";
 import { CodeQLCliServer } from "../../../../src/cli";
-import { DatabaseItem } from "../../../../src/local-databases";
-import { mockedObject } from "../../utils/mocking.helpers";
+import { mockDatabaseItem, mockedObject } from "../../utils/mocking.helpers";
 
 describe("queryResolver", () => {
   let getQlPackForDbschemeSpy: jest.SpiedFunction<
@@ -96,13 +95,13 @@ describe("queryResolver", () => {
         dbschemePack: "my-qlpack",
         dbschemePackIsLibraryPack: false,
       });
-      const db = {
+      const db = mockDatabaseItem({
         contents: {
           datasetUri: {
             fsPath: "/path/to/database",
           },
         },
-      } as unknown as DatabaseItem;
+      });
       const result = await qlpackOfDatabase(mockCli, db);
       expect(result).toEqual({
         dbschemePack: "my-qlpack",

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/interface-utils.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/interface-utils.test.ts
@@ -14,7 +14,7 @@ import {
   tryResolveLocation,
 } from "../../../src/interface-utils";
 import { getDefaultResultSetName } from "../../../src/pure/interface-types";
-import { DatabaseItem } from "../../../src/local-databases";
+import { mockDatabaseItem } from "../utils/mocking.helpers";
 
 describe("interface-utils", () => {
   describe("webview uri conversion", () => {
@@ -84,27 +84,21 @@ describe("interface-utils", () => {
 
   describe("resolveWholeFileLocation", () => {
     it("should resolve a whole file location", () => {
-      const mockDatabaseItem: DatabaseItem = {
-        resolveSourceFile: jest.fn().mockReturnValue(Uri.file("abc")),
-      } as unknown as DatabaseItem;
+      const databaseItem = mockDatabaseItem();
       expect(
-        tryResolveLocation("file://hucairz:0:0:0:0", mockDatabaseItem),
+        tryResolveLocation("file://hucairz:0:0:0:0", databaseItem),
       ).toEqual(new Location(Uri.file("abc"), new Range(0, 0, 0, 0)));
     });
 
     it("should resolve a five-part location edge case", () => {
-      const mockDatabaseItem: DatabaseItem = {
-        resolveSourceFile: jest.fn().mockReturnValue(Uri.file("abc")),
-      } as unknown as DatabaseItem;
+      const databaseItem = mockDatabaseItem();
       expect(
-        tryResolveLocation("file://hucairz:1:1:1:1", mockDatabaseItem),
+        tryResolveLocation("file://hucairz:1:1:1:1", databaseItem),
       ).toEqual(new Location(Uri.file("abc"), new Range(0, 0, 0, 1)));
     });
 
     it("should resolve a five-part location", () => {
-      const mockDatabaseItem: DatabaseItem = {
-        resolveSourceFile: jest.fn().mockReturnValue(Uri.parse("abc")),
-      } as unknown as DatabaseItem;
+      const databaseItem = mockDatabaseItem();
 
       expect(
         tryResolveLocation(
@@ -115,7 +109,7 @@ describe("interface-utils", () => {
             endLine: 5,
             uri: "hucairz",
           },
-          mockDatabaseItem,
+          databaseItem,
         ),
       ).toEqual(
         new Location(
@@ -123,16 +117,12 @@ describe("interface-utils", () => {
           new Range(new Position(4, 3), new Position(3, 0)),
         ),
       );
-      expect(mockDatabaseItem.resolveSourceFile).toHaveBeenCalledTimes(1);
-      expect(mockDatabaseItem.resolveSourceFile).toHaveBeenCalledWith(
-        "hucairz",
-      );
+      expect(databaseItem.resolveSourceFile).toHaveBeenCalledTimes(1);
+      expect(databaseItem.resolveSourceFile).toHaveBeenCalledWith("hucairz");
     });
 
     it("should resolve a five-part location with an empty path", () => {
-      const mockDatabaseItem: DatabaseItem = {
-        resolveSourceFile: jest.fn().mockReturnValue(Uri.parse("abc")),
-      } as unknown as DatabaseItem;
+      const databaseItem = mockDatabaseItem();
 
       expect(
         tryResolveLocation(
@@ -143,51 +133,41 @@ describe("interface-utils", () => {
             endLine: 5,
             uri: "",
           },
-          mockDatabaseItem,
+          databaseItem,
         ),
       ).toBeUndefined();
     });
 
     it("should resolve a string location for whole file", () => {
-      const mockDatabaseItem: DatabaseItem = {
-        resolveSourceFile: jest.fn().mockReturnValue(Uri.parse("abc")),
-      } as unknown as DatabaseItem;
+      const databaseItem = mockDatabaseItem();
 
       expect(
-        tryResolveLocation("file://hucairz:0:0:0:0", mockDatabaseItem),
+        tryResolveLocation("file://hucairz:0:0:0:0", databaseItem),
       ).toEqual(new Location(Uri.parse("abc"), new Range(0, 0, 0, 0)));
-      expect(mockDatabaseItem.resolveSourceFile).toHaveBeenCalledTimes(1);
-      expect(mockDatabaseItem.resolveSourceFile).toHaveBeenCalledWith(
-        "hucairz",
-      );
+      expect(databaseItem.resolveSourceFile).toHaveBeenCalledTimes(1);
+      expect(databaseItem.resolveSourceFile).toHaveBeenCalledWith("hucairz");
     });
 
     it("should resolve a string location for five-part location", () => {
-      const mockDatabaseItem: DatabaseItem = {
-        resolveSourceFile: jest.fn().mockReturnValue(Uri.parse("abc")),
-      } as unknown as DatabaseItem;
+      const databaseItem = mockDatabaseItem();
 
       expect(
-        tryResolveLocation("file://hucairz:5:4:3:2", mockDatabaseItem),
+        tryResolveLocation("file://hucairz:5:4:3:2", databaseItem),
       ).toEqual(
         new Location(
           Uri.parse("abc"),
           new Range(new Position(4, 3), new Position(2, 2)),
         ),
       );
-      expect(mockDatabaseItem.resolveSourceFile).toHaveBeenCalledTimes(1);
-      expect(mockDatabaseItem.resolveSourceFile).toHaveBeenCalledWith(
-        "hucairz",
-      );
+      expect(databaseItem.resolveSourceFile).toHaveBeenCalledTimes(1);
+      expect(databaseItem.resolveSourceFile).toHaveBeenCalledWith("hucairz");
     });
 
     it("should resolve a string location for invalid string", () => {
-      const mockDatabaseItem: DatabaseItem = {
-        resolveSourceFile: jest.fn().mockReturnValue(Uri.parse("abc")),
-      } as unknown as DatabaseItem;
+      const databaseItem = mockDatabaseItem();
 
       expect(
-        tryResolveLocation("file://hucairz:x:y:z:a", mockDatabaseItem),
+        tryResolveLocation("file://hucairz:x:y:z:a", databaseItem),
       ).toBeUndefined();
     });
   });

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/test-adapter.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/test-adapter.test.ts
@@ -37,7 +37,7 @@ describe("test-adapter", () => {
   const preTestDatabaseItem = new DatabaseItemImpl(
     Uri.file("/path/to/test/dir/dir.testproj"),
     undefined,
-    { displayName: "custom display name" } as unknown as FullDatabaseOptions,
+    mockedObject<FullDatabaseOptions>({ displayName: "custom display name" }),
     (_) => {
       /* no change event listener */
     },
@@ -45,7 +45,7 @@ describe("test-adapter", () => {
   const postTestDatabaseItem = new DatabaseItemImpl(
     Uri.file("/path/to/test/dir/dir.testproj"),
     undefined,
-    { displayName: "default name" } as unknown as FullDatabaseOptions,
+    mockedObject<FullDatabaseOptions>({ displayName: "default name" }),
     (_) => {
       /* no change event listener */
     },

--- a/extensions/ql-vscode/test/vscode-tests/utils/mocking.helpers.ts
+++ b/extensions/ql-vscode/test/vscode-tests/utils/mocking.helpers.ts
@@ -1,3 +1,6 @@
+import { DatabaseItem } from "../../../src/local-databases";
+import { Uri } from "vscode";
+
 export type DeepPartial<T> = T extends object
   ? {
       [P in keyof T]?: DeepPartial<T[P]>;
@@ -39,5 +42,18 @@ export function mockedObject<T extends object>(
 
       throw new Error(`Method ${String(prop)} not mocked`);
     },
+  });
+}
+
+export function mockDatabaseItem(
+  props: DeepPartial<DatabaseItem> = {},
+): DatabaseItem {
+  return mockedObject<DatabaseItem>({
+    databaseUri: Uri.file("abc"),
+    name: "github/codeql",
+    language: "javascript",
+    sourceArchive: undefined,
+    resolveSourceFile: jest.fn().mockReturnValue(Uri.file("abc")),
+    ...props,
   });
 }


### PR DESCRIPTION
This removes `as unknown as DatabaseItem` and `as unknown as FullDatabaseOptions`.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
