### PR TITLE
Report unhandled errors, but only those that are from our extension

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [UNRELEASED]
 
+- Send telemetry about unhandled errors happening within the extension. [#2125](https://github.com/github/vscode-codeql/pull/2125)
+
 ## 1.7.11 - 1 March 2023
 
 - Enable collection of telemetry concerning interactions with UI elements, including buttons, links, and other inputs. [#2114](https://github.com/github/vscode-codeql/pull/2114)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

This is a second attempt at https://github.com/github/vscode-codeql/pull/2076. That PR worked a bit too well, in that it was picking up errors from other extensions and presenting them to the user. The fix for this that we discussed was to check the stack trace to see if it's from our extension or somewhere else.

I've implemented this by checking for `/extensions/ql-vscode/`. I couldn't think of a better string to check for. We might actually have trouble in the future if we move the extension to the top level of the repo. I'm not sure if that means we should look for a different approach now, or save that problem for if/when we do move the code in the repo.

I've tested this using https://github.com/robertbrignull/error-extension. I created a new extension (from a template) that provides commands that intentionally throw errors and reject promises. Using this I was able to reproduce the existing bad behaviour and then also show that we now don't report errors from other extensions.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
