### PR TITLE
Hack to avoid CodeQL CLI v2.12.3

### DIFF
--- a/extensions/ql-vscode/src/distribution.ts
+++ b/extensions/ql-vscode/src/distribution.ts
@@ -315,6 +315,15 @@ class ExtensionSpecificDistributionManager {
     const extensionSpecificRelease = this.getInstalledRelease();
     const latestRelease = await this.getLatestRelease();
 
+    // v2.12.3 was released with a bug that causes the extension to fail
+    // so we force the extension to ignore it.
+    if (
+      extensionSpecificRelease &&
+      extensionSpecificRelease.name === "v2.12.3"
+    ) {
+      return createUpdateAvailableResult(latestRelease);
+    }
+
     if (
       extensionSpecificRelease !== undefined &&
       codeQlPath !== undefined &&
@@ -430,6 +439,12 @@ class ExtensionSpecificDistributionManager {
       this.versionRange,
       this.config.includePrerelease,
       (release) => {
+        // v2.12.3 was released with a bug that causes the extension to fail
+        // so we force the extension to ignore it.
+        if (release.name === "v2.12.3") {
+          return false;
+        }
+
         const matchingAssets = release.assets.filter(
           (asset) => asset.name === requiredAssetName,
         );


### PR DESCRIPTION
(Paired with @robertbrignull)

CodeQL CLI v2.12.3 was released with a bug that causes the extension to fail so we force the extension to ignore it.

Raising the PR against main for now, but we might need to target a different branch.

The CHANGELOG will need to be updated.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
