### PR TITLE
Fix error while deleting query history item

### DIFF
--- a/extensions/ql-vscode/src/interface.ts
+++ b/extensions/ql-vscode/src/interface.ts
@@ -399,7 +399,7 @@ export class ResultsView extends AbstractWebview<
     forceReveal: WebviewReveal,
     shouldKeepOldResultsWhileRendering = false,
   ): Promise<void> {
-    if (!fullQuery.completedQuery.successful) {
+    if (!fullQuery.completedQuery?.successful) {
       return;
     }
 


### PR DESCRIPTION
When deleting a query history item and the "next" query is still running, the `completedQuery` is `undefined`. This commit fixes it by using optional chaining to ensure that the `completedQuery` is defined before accessing its `successful` property.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
