### PR TITLE
Be able to send params to `installPackDependencies` command

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -1399,8 +1399,16 @@ async function activateWithInstalledDistribution(
   ctx.subscriptions.push(
     commandRunnerWithProgress(
       "codeQL.installPackDependencies",
-      async (progress: ProgressCallback) =>
-        await handleInstallPackDependencies(cliServer, progress),
+      async (
+        progress: ProgressCallback,
+        _token: CancellationToken,
+        relativeDirectoryPath: string | undefined,
+      ) =>
+        await handleInstallPackDependencies(
+          cliServer,
+          progress,
+          relativeDirectoryPath,
+        ),
       {
         title: "Installing pack dependencies",
       },

--- a/extensions/ql-vscode/src/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/local-databases-ui.ts
@@ -390,7 +390,6 @@ export class DatabaseUI extends DisposableObject {
           );
         }
         await this.databaseManager.setCurrentDatabaseItem(databaseItem);
-        await this.handleTourDependencies();
       }
     } catch (e) {
       // rethrow and let this be handled by default error handling.
@@ -399,22 +398,6 @@ export class DatabaseUI extends DisposableObject {
           e,
         )}`,
       );
-    }
-  };
-
-  private handleTourDependencies = async (): Promise<void> => {
-    if (!workspace.workspaceFolders?.length) {
-      throw new Error("No workspace folder is open.");
-    } else {
-      const tutorialQueriesPath = join(
-        workspace.workspaceFolders[0].uri.fsPath,
-        "tutorial-queries",
-      );
-      const cli = this.queryServer?.cliServer;
-      if (!cli) {
-        throw new Error("No CLI server found");
-      }
-      await cli.packInstall(tutorialQueriesPath);
     }
   };
 

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/packaging.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/packaging.test.ts
@@ -1,5 +1,5 @@
 import { extensions, QuickPickItem, window } from "vscode";
-import { join } from "path";
+import { join, resolve } from "path";
 
 import { CodeQLCliServer } from "../../../src/cli";
 import { CodeQLExtensionInterface } from "../../../src/extension";
@@ -25,6 +25,7 @@ describe("Packaging commands", () => {
   let showAndLogInformationMessageSpy: jest.SpiedFunction<
     typeof helpers.showAndLogInformationMessage
   >;
+  let packInstallSpy: jest.SpiedFunction<typeof cli.packInstall>;
 
   beforeEach(async () => {
     quickPickSpy = jest
@@ -52,6 +53,10 @@ describe("Packaging commands", () => {
         "Extension not initialized. Make sure cli is downloaded and installed properly.",
       );
     }
+
+    packInstallSpy = jest
+      .spyOn(cli, "packInstall")
+      .mockResolvedValue(undefined);
   });
 
   it("should download all core query packs", async () => {
@@ -125,5 +130,15 @@ describe("Packaging commands", () => {
         "Unable to install pack dependencies",
       );
     }
+  });
+
+  describe("when provided with a custom directory", () => {
+    it("should install dependencies in the provided directory", async () => {
+      await handleInstallPackDependencies(cli, progress, "custom-dir");
+      expect(packInstallSpy).toHaveBeenCalledWith(resolve("custom-dir"));
+      expect(showAndLogInformationMessageSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Finished installing pack dependencies."),
+      );
+    });
   });
 });


### PR DESCRIPTION
We'd like to install QL pack dependencies from within a code tour step.

This involves triggering a `codeQL.installPackDependencies` command with a custom directory parameter. 

However, this command doesn't currently support receiving a directory as a param. We need to change this in order to unblock ourselves. 

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
