### PR TITLE
Give the LanguageClient an easier id to use.

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -887,6 +887,7 @@ async function activateWithInstalledDistribution(
 
   void extLogger.log("Initializing CodeQL language server.");
   const client = new LanguageClient(
+    "codeQL.lsp",
     "CodeQL Language Server",
     () => spawnIdeServer(qlConfigurationListener),
     {


### PR DESCRIPTION
The default id is the lowerase of the name. This is particually wordy and looks wierd.

This is only used for the lsp internal settings root which will now be things like `codeQL.lsp.trace.server`,  rather than `codeql langauge server.trace.server`. 

All these intenral settings are undocumented and for debugging on our side so changing them shouldn't matter.