### PR TITLE
Save scroll position before opening code paths

### DIFF
--- a/extensions/ql-vscode/src/view/common/CodePaths/CodePaths.tsx
+++ b/extensions/ql-vscode/src/view/common/CodePaths/CodePaths.tsx
@@ -37,13 +37,24 @@ export const CodePaths = ({
     filterTelemetryOnValue: filterIsOpenTelemetry,
   });
 
+  const [scrollPosition, setScrollPosition] = useState({ x: 0, y: 0 });
+  React.useEffect(() => {
+    window.scrollTo(scrollPosition.x, scrollPosition.y);
+  }, [scrollPosition]);
+
   const linkRef = useRef<HTMLAnchorElement>(null);
 
   const closeOverlay = () => setIsOpen(false);
 
   return (
     <>
-      <ShowPathsLink onClick={() => setIsOpen(true)} ref={linkRef}>
+      <ShowPathsLink
+        onClick={() => {
+          setScrollPosition({ x: window.scrollX, y: window.scrollY });
+          setIsOpen(true);
+        }}
+        ref={linkRef}
+      >
         Show paths
       </ShowPathsLink>
       {isOpen && (

--- a/extensions/ql-vscode/src/view/common/CodePaths/CodePaths.tsx
+++ b/extensions/ql-vscode/src/view/common/CodePaths/CodePaths.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import styled from "styled-components";
 import { VSCodeLink } from "@vscode/webview-ui-toolkit/react";
 
@@ -24,6 +24,11 @@ export type CodePathsProps = {
   severity: ResultSeverity;
 };
 
+type ScrollPosition = {
+  x: number;
+  y: number;
+};
+
 const filterIsOpenTelemetry = (v: boolean) => v;
 
 export const CodePaths = ({
@@ -37,9 +42,13 @@ export const CodePaths = ({
     filterTelemetryOnValue: filterIsOpenTelemetry,
   });
 
-  const [scrollPosition, setScrollPosition] = useState({ x: 0, y: 0 });
-  React.useEffect(() => {
-    window.scrollTo(scrollPosition.x, scrollPosition.y);
+  const [scrollPosition, setScrollPosition] = useState<
+    ScrollPosition | undefined
+  >(undefined);
+  useEffect(() => {
+    if (scrollPosition) {
+      window.scrollTo(scrollPosition.x, scrollPosition.y);
+    }
   }, [scrollPosition]);
 
   const linkRef = useRef<HTMLAnchorElement>(null);


### PR DESCRIPTION
This is so that the user doesn't lose their place in the results view.

https://user-images.githubusercontent.com/311693/212700041-573ea61d-582b-4a76-b07d-3237e957f74c.mov

We do this by storing the scroll position in state when the show paths link gets clicked.

A [previous PR](https://github.com/github/vscode-codeql/pull/1970) attempted the same approach, but was setting the initial scroll position to (0,0) instead of undefined, so was causing a different bug.

Note that this is meant to be a quick workaround for the issue that has been reported by users. There are a few other issues around the area, but those won't be addressed by this PR. We're looking to change the UI/flow a bit anyway, so I don't want to spend too much time on this.  

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
