### PR TITLE
Extension Telemetry: Split `runVariantAnalysis` and `viewAst` command

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -323,6 +323,10 @@
         "title": "CodeQL: Run Variant Analysis"
       },
       {
+        "command": "codeQL.runVariantAnalysisContextEditor",
+        "title": "CodeQL: Run Variant Analysis"
+      },
+      {
         "command": "codeQL.exportSelectedVariantAnalysisResults",
         "title": "CodeQL: Export Variant Analysis Results"
       },
@@ -981,7 +985,8 @@
           "when": "editorLangId == ql && resourceExtname == .ql"
         },
         {
-          "command": "codeQL.exportSelectedVariantAnalysisResults"
+          "command": "codeQL.runVariantAnalysisContextEditor",
+          "when": "false"
         },
         {
           "command": "codeQL.runQueries",
@@ -1234,7 +1239,7 @@
           "when": "editorLangId == ql && resourceExtname == .ql"
         },
         {
-          "command": "codeQL.runVariantAnalysis",
+          "command": "codeQL.runVariantAnalysisContextEditor",
           "when": "editorLangId == ql && resourceExtname == .ql"
         },
         {

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -438,6 +438,14 @@
         "title": "CodeQL: View AST"
       },
       {
+        "command": "codeQL.viewAstContextExplorer",
+        "title": "CodeQL: View AST"
+      },
+      {
+        "command": "codeQL.viewAstContextEditor",
+        "title": "CodeQL: View AST"
+      },
+      {
         "command": "codeQL.viewCfg",
         "title": "CodeQL: View CFG"
       },
@@ -934,7 +942,7 @@
           "when": "resourceScheme == codeql-zip-archive || explorerResourceIsFolder || resourceExtname == .zip"
         },
         {
-          "command": "codeQL.viewAst",
+          "command": "codeQL.viewAstContextExplorer",
           "group": "9_qlCommands",
           "when": "resourceScheme == codeql-zip-archive && !explorerResourceIsFolder && !listMultiSelection"
         },
@@ -1011,6 +1019,14 @@
         {
           "command": "codeQL.viewAst",
           "when": "resourceScheme == codeql-zip-archive"
+        },
+        {
+          "command": "codeQL.viewAstContextEditor",
+          "when": "false"
+        },
+        {
+          "command": "codeQL.viewAstContextExplorer",
+          "when": "false"
         },
         {
           "command": "codeQL.viewCfg",
@@ -1243,7 +1259,7 @@
           "when": "editorLangId == ql && resourceExtname == .ql"
         },
         {
-          "command": "codeQL.viewAst",
+          "command": "codeQL.viewAstContextEditor",
           "when": "resourceScheme == codeql-zip-archive"
         },
         {

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -1125,7 +1125,24 @@ async function activateWithInstalledDistribution(
     ),
   );
 
-  // The "runVariantAnalysis" command is internal-only.
+  async function runVariantAnalysis(
+    progress: ProgressCallback,
+    token: CancellationToken,
+    uri: Uri | undefined,
+  ): Promise<void> {
+    progress({
+      maxStep: 5,
+      step: 0,
+      message: "Getting credentials",
+    });
+
+    await variantAnalysisManager.runVariantAnalysis(
+      uri || window.activeTextEditor?.document.uri,
+      progress,
+      token,
+    );
+  }
+
   ctx.subscriptions.push(
     commandRunnerWithProgress(
       "codeQL.runVariantAnalysis",
@@ -1133,19 +1150,23 @@ async function activateWithInstalledDistribution(
         progress: ProgressCallback,
         token: CancellationToken,
         uri: Uri | undefined,
-      ) => {
-        progress({
-          maxStep: 5,
-          step: 0,
-          message: "Getting credentials",
-        });
-
-        await variantAnalysisManager.runVariantAnalysis(
-          uri || window.activeTextEditor?.document.uri,
-          progress,
-          token,
-        );
+      ) => await runVariantAnalysis(progress, token, uri),
+      {
+        title: "Run Variant Analysis",
+        cancellable: true,
       },
+    ),
+  );
+
+  // Since we are tracking extension usage through commands, this command mirrors the "codeQL.runVariantAnalysis" command
+  ctx.subscriptions.push(
+    commandRunnerWithProgress(
+      "codeQL.runVariantAnalysisContextEditor",
+      async (
+        progress: ProgressCallback,
+        token: CancellationToken,
+        uri: Uri | undefined,
+      ) => await runVariantAnalysis(progress, token, uri),
       {
         title: "Run Variant Analysis",
         cancellable: true,


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->


Since we track usage behaviour by command usage at the moment, we have to use different commands for different user interactions. Each command has to be unique. Even if the underlying behaviour in the extension is identical.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
