### PR TITLE
Extension Telemetry: Split `viewCfg`,`quickEval`, `openReferencedFile` command

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -323,6 +323,10 @@
         "title": "CodeQL: Run Variant Analysis"
       },
       {
+        "command": "codeQL.runVariantAnalysisContextEditor",
+        "title": "CodeQL: Run Variant Analysis"
+      },
+      {
         "command": "codeQL.exportSelectedVariantAnalysisResults",
         "title": "CodeQL: Export Variant Analysis Results"
       },
@@ -981,7 +985,8 @@
           "when": "editorLangId == ql && resourceExtname == .ql"
         },
         {
-          "command": "codeQL.exportSelectedVariantAnalysisResults"
+          "command": "codeQL.runVariantAnalysisContextEditor",
+          "when": "false"
         },
         {
           "command": "codeQL.runQueries",
@@ -1234,7 +1239,7 @@
           "when": "editorLangId == ql && resourceExtname == .ql"
         },
         {
-          "command": "codeQL.runVariantAnalysis",
+          "command": "codeQL.runVariantAnalysisContextEditor",
           "when": "editorLangId == ql && resourceExtname == .ql"
         },
         {

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -438,6 +438,14 @@
         "title": "CodeQL: View AST"
       },
       {
+        "command": "codeQL.viewAstContextExplorer",
+        "title": "CodeQL: View AST"
+      },
+      {
+        "command": "codeQL.viewAstContextEditor",
+        "title": "CodeQL: View AST"
+      },
+      {
         "command": "codeQL.viewCfg",
         "title": "CodeQL: View CFG"
       },
@@ -934,7 +942,7 @@
           "when": "resourceScheme == codeql-zip-archive || explorerResourceIsFolder || resourceExtname == .zip"
         },
         {
-          "command": "codeQL.viewAst",
+          "command": "codeQL.viewAstContextExplorer",
           "group": "9_qlCommands",
           "when": "resourceScheme == codeql-zip-archive && !explorerResourceIsFolder && !listMultiSelection"
         },
@@ -1011,6 +1019,14 @@
         {
           "command": "codeQL.viewAst",
           "when": "resourceScheme == codeql-zip-archive"
+        },
+        {
+          "command": "codeQL.viewAstContextEditor",
+          "when": "false"
+        },
+        {
+          "command": "codeQL.viewAstContextExplorer",
+          "when": "false"
         },
         {
           "command": "codeQL.viewCfg",
@@ -1243,7 +1259,7 @@
           "when": "editorLangId == ql && resourceExtname == .ql"
         },
         {
-          "command": "codeQL.viewAst",
+          "command": "codeQL.viewAstContextEditor",
           "when": "resourceScheme == codeql-zip-archive"
         },
         {

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -347,6 +347,14 @@
         "title": "CodeQL: Open Referenced File"
       },
       {
+        "command": "codeQL.openReferencedFileContextEditor",
+        "title": "CodeQL: Open Referenced File"
+      },
+      {
+        "command": "codeQL.openReferencedFileContextExplorer",
+        "title": "CodeQL: Open Referenced File"
+      },
+      {
         "command": "codeQL.previewQueryHelp",
         "title": "CodeQL: Preview Query Help"
       },
@@ -969,7 +977,7 @@
           "when": "resourceScheme != codeql-zip-archive"
         },
         {
-          "command": "codeQL.openReferencedFile",
+          "command": "codeQL.openReferencedFileContextExplorer",
           "group": "9_qlCommands",
           "when": "resourceExtname == .qlref"
         },
@@ -1023,6 +1031,14 @@
         {
           "command": "codeQL.openReferencedFile",
           "when": "resourceExtname == .qlref"
+        },
+        {
+          "command": "codeQL.openReferencedFileContextEditor",
+          "when": "false"
+        },
+        {
+          "command": "codeQL.openReferencedFileContextExplorer",
+          "when": "false"
         },
         {
           "command": "codeQL.previewQueryHelp",
@@ -1295,7 +1311,7 @@
           "when": "editorLangId == ql"
         },
         {
-          "command": "codeQL.openReferencedFile",
+          "command": "codeQL.openReferencedFileContextEditor",
           "when": "resourceExtname == .qlref"
         },
         {

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -339,6 +339,10 @@
         "title": "CodeQL: Quick Evaluation"
       },
       {
+        "command": "codeQL.quickEvalContextEditor",
+        "title": "CodeQL: Quick Evaluation"
+      },
+      {
         "command": "codeQL.openReferencedFile",
         "title": "CodeQL: Open Referenced File"
       },
@@ -1013,6 +1017,10 @@
           "when": "editorLangId == ql"
         },
         {
+          "command": "codeQL.quickEvalContextEditor",
+          "when": "false"
+        },
+        {
           "command": "codeQL.openReferencedFile",
           "when": "resourceExtname == .qlref"
         },
@@ -1283,7 +1291,7 @@
           "when": "resourceScheme == codeql-zip-archive && config.codeQL.canary"
         },
         {
-          "command": "codeQL.quickEval",
+          "command": "codeQL.quickEvalContextEditor",
           "when": "editorLangId == ql"
         },
         {

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -450,6 +450,14 @@
         "title": "CodeQL: View CFG"
       },
       {
+        "command": "codeQL.viewCfgContextExplorer",
+        "title": "CodeQL: View CFG"
+      },
+      {
+        "command": "codeQL.viewCfgContextEditor",
+        "title": "CodeQL: View CFG"
+      },
+      {
         "command": "codeQL.upgradeCurrentDatabase",
         "title": "CodeQL: Upgrade Current Database"
       },
@@ -947,7 +955,7 @@
           "when": "resourceScheme == codeql-zip-archive && !explorerResourceIsFolder && !listMultiSelection"
         },
         {
-          "command": "codeQL.viewCfg",
+          "command": "codeQL.viewCfgContextExplorer",
           "group": "9_qlCommands",
           "when": "resourceScheme == codeql-zip-archive && config.codeQL.canary"
         },
@@ -1032,6 +1040,14 @@
           "command": "codeQL.viewCfg",
           "when": "resourceScheme == codeql-zip-archive && config.codeQL.canary"
         },
+        {
+          "command": "codeQL.viewCfgContextExplorer",
+          "when": "false"
+        },
+        {
+          "command": "codeQL.viewCfgContextEditor",
+          "when": "false"
+        }, 
         {
           "command": "codeQLVariantAnalysisRepositories.openConfigFile",
           "when": "false"
@@ -1263,7 +1279,7 @@
           "when": "resourceScheme == codeql-zip-archive"
         },
         {
-          "command": "codeQL.viewCfg",
+          "command": "codeQL.viewCfgContextEditor",
           "when": "resourceScheme == codeql-zip-archive && config.codeQL.canary"
         },
         {

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -1125,7 +1125,24 @@ async function activateWithInstalledDistribution(
     ),
   );
 
-  // The "runVariantAnalysis" command is internal-only.
+  async function runVariantAnalysis(
+    progress: ProgressCallback,
+    token: CancellationToken,
+    uri: Uri | undefined,
+  ): Promise<void> {
+    progress({
+      maxStep: 5,
+      step: 0,
+      message: "Getting credentials",
+    });
+
+    await variantAnalysisManager.runVariantAnalysis(
+      uri || window.activeTextEditor?.document.uri,
+      progress,
+      token,
+    );
+  }
+
   ctx.subscriptions.push(
     commandRunnerWithProgress(
       "codeQL.runVariantAnalysis",
@@ -1133,19 +1150,23 @@ async function activateWithInstalledDistribution(
         progress: ProgressCallback,
         token: CancellationToken,
         uri: Uri | undefined,
-      ) => {
-        progress({
-          maxStep: 5,
-          step: 0,
-          message: "Getting credentials",
-        });
-
-        await variantAnalysisManager.runVariantAnalysis(
-          uri || window.activeTextEditor?.document.uri,
-          progress,
-          token,
-        );
+      ) => await runVariantAnalysis(progress, token, uri),
+      {
+        title: "Run Variant Analysis",
+        cancellable: true,
       },
+    ),
+  );
+
+  // Since we are tracking extension usage through commands, this command mirrors the "codeQL.runVariantAnalysis" command
+  ctx.subscriptions.push(
+    commandRunnerWithProgress(
+      "codeQL.runVariantAnalysisContextEditor",
+      async (
+        progress: ProgressCallback,
+        token: CancellationToken,
+        uri: Uri | undefined,
+      ) => await runVariantAnalysis(progress, token, uri),
       {
         title: "Run Variant Analysis",
         cancellable: true,

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -1074,9 +1074,28 @@ async function activateWithInstalledDistribution(
       queryServerLogger,
     ),
   );
+
   ctx.subscriptions.push(
     commandRunnerWithProgress(
       "codeQL.quickEval",
+      async (
+        progress: ProgressCallback,
+        token: CancellationToken,
+        uri: Uri | undefined,
+      ) => await compileAndRunQuery(true, uri, progress, token, undefined),
+      {
+        title: "Running query",
+        cancellable: true,
+      },
+      // Open the query server logger on error since that's usually where the interesting errors appear.
+      queryServerLogger,
+    ),
+  );
+
+  // Since we are tracking extension usage through commands, this command mirrors the "codeQL.quickEval" command
+  ctx.subscriptions.push(
+    commandRunnerWithProgress(
+      "codeQL.quickEvalContextEditor",
       async (
         progress: ProgressCallback,
         token: CancellationToken,

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -1330,6 +1330,19 @@ async function activateWithInstalledDistribution(
     commandRunner("codeQL.openReferencedFile", openReferencedFile),
   );
 
+  // Since we are tracking extension usage through commands, this command mirrors the "codeQL.openReferencedFile" command
+  ctx.subscriptions.push(
+    commandRunner("codeQL.openReferencedFileContextEditor", openReferencedFile),
+  );
+
+  // Since we are tracking extension usage through commands, this command mirrors the "codeQL.openReferencedFile" command
+  ctx.subscriptions.push(
+    commandRunner(
+      "codeQL.openReferencedFileContextExplorer",
+      openReferencedFile,
+    ),
+  );
+
   ctx.subscriptions.push(
     commandRunner("codeQL.previewQueryHelp", previewQueryHelp),
   );

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -1576,6 +1576,44 @@ async function activateWithInstalledDistribution(
     ),
   );
 
+  // Since we are tracking extension usage through commands, this command mirrors the "codeQL.viewCfg" command
+  ctx.subscriptions.push(
+    commandRunnerWithProgress(
+      "codeQL.viewCfgContextExplorer",
+      async (progress: ProgressCallback, token: CancellationToken) => {
+        const res = await cfgTemplateProvider.provideCfgUri(
+          window.activeTextEditor?.document,
+        );
+        if (res) {
+          await compileAndRunQuery(false, res[0], progress, token, undefined);
+        }
+      },
+      {
+        title: "Calculating Control Flow Graph",
+        cancellable: true,
+      },
+    ),
+  );
+
+  // Since we are tracking extension usage through commands, this command mirrors the "codeQL.viewCfg" command
+  ctx.subscriptions.push(
+    commandRunnerWithProgress(
+      "codeQL.viewCfgContextEditor",
+      async (progress: ProgressCallback, token: CancellationToken) => {
+        const res = await cfgTemplateProvider.provideCfgUri(
+          window.activeTextEditor?.document,
+        );
+        if (res) {
+          await compileAndRunQuery(false, res[0], progress, token, undefined);
+        }
+      },
+      {
+        title: "Calculating Control Flow Graph",
+        cancellable: true,
+      },
+    ),
+  );
+
   const mockServer = new VSCodeMockGitHubApiServer(ctx);
   ctx.subscriptions.push(mockServer);
   ctx.subscriptions.push(


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->
Since we track usage behaviour by command usage at the moment, we have to use different commands for different user interactions. Each command has to be unique. Even if the underlying behaviour in the extension is identical.

To prevent merge conflicts the branch is based on https://github.com/github/vscode-codeql/pull/2142

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
