### PR TITLE
Add back variant analysis tests

### DIFF
--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
@@ -269,7 +269,6 @@ describe("Variant Analysis Manager", () => {
       filesThatDoNotExist: string[];
     }) {
       const fileUri = getFile(queryPath);
-
       await variantAnalysisManager.runVariantAnalysis(
         fileUri,
         progress,
@@ -291,6 +290,7 @@ describe("Variant Analysis Manager", () => {
       filesThatExist.forEach((file) => {
         expect(packFS.fileExists(file)).toBe(true);
       });
+
       if (await cli.cliConstraints.supportsQlxRemote()) {
         qlxFilesThatExist.forEach((file) => {
           expect(packFS.fileExists(file)).toBe(true);
@@ -313,7 +313,7 @@ describe("Variant Analysis Manager", () => {
       const packFileName = packFS.fileExists("qlpack.yml")
         ? "qlpack.yml"
         : "codeql-pack.yml";
-      const qlpackContents: any = load(
+      const qlpackContents = load(
         packFS.fileContents(packFileName).toString("utf-8"),
       );
       expect(qlpackContents.name).toEqual("codeql-remote/query");
@@ -322,7 +322,7 @@ describe("Variant Analysis Manager", () => {
         "*",
       );
 
-      const qlpackLockContents: any = load(
+      const qlpackLockContents = load(
         packFS.fileContents("codeql-pack.lock.yml").toString("utf-8"),
       );
 


### PR DESCRIPTION
This commit adds back the variant analysis tests that were inadvertently deleted after this commit

https://github.com/github/vscode-codeql/blob/82ada54103f591228d9c61ac6b3c93c85d6ffd1c/extensions/ql-vscode/src/vscode-tests/cli-integration/remote-queries/run-remote-query.test.ts#L67

They are not identical to the removed tests. I refactored them so that there is a single test function invoked three times with different parameters.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Replace this with a description of the changes your pull request makes.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
