### PR TITLE
Simpler `withProgress` calls

### DIFF
--- a/extensions/ql-vscode/src/contextual/templateProvider.ts
+++ b/extensions/ql-vscode/src/contextual/templateProvider.ts
@@ -73,11 +73,6 @@ export class TemplateQueryDefinitionProvider implements DefinitionProvider {
 
   private async getDefinitions(uriString: string): Promise<LocationLink[]> {
     return withProgress(
-      {
-        location: ProgressLocation.Notification,
-        cancellable: true,
-        title: "Finding definitions",
-      },
       async (progress, token) => {
         return getLocationsForUriString(
           this.cli,
@@ -90,6 +85,11 @@ export class TemplateQueryDefinitionProvider implements DefinitionProvider {
           token,
           (src, _dest) => src === uriString,
         );
+      },
+      {
+        location: ProgressLocation.Notification,
+        cancellable: true,
+        title: "Finding definitions",
       },
     );
   }
@@ -136,11 +136,6 @@ export class TemplateQueryReferenceProvider implements ReferenceProvider {
 
   private async getReferences(uriString: string): Promise<FullLocationLink[]> {
     return withProgress(
-      {
-        location: ProgressLocation.Notification,
-        cancellable: true,
-        title: "Finding references",
-      },
       async (progress, token) => {
         return getLocationsForUriString(
           this.cli,
@@ -153,6 +148,11 @@ export class TemplateQueryReferenceProvider implements ReferenceProvider {
           token,
           (src, _dest) => src === uriString,
         );
+      },
+      {
+        location: ProgressLocation.Notification,
+        cancellable: true,
+        title: "Finding references",
       },
     );
   }

--- a/extensions/ql-vscode/src/contextual/templateProvider.ts
+++ b/extensions/ql-vscode/src/contextual/templateProvider.ts
@@ -4,7 +4,6 @@ import {
   Location,
   LocationLink,
   Position,
-  ProgressLocation,
   ReferenceContext,
   ReferenceProvider,
   TextDocument,
@@ -87,7 +86,6 @@ export class TemplateQueryDefinitionProvider implements DefinitionProvider {
         );
       },
       {
-        location: ProgressLocation.Notification,
         cancellable: true,
         title: "Finding definitions",
       },
@@ -150,7 +148,6 @@ export class TemplateQueryReferenceProvider implements ReferenceProvider {
         );
       },
       {
-        location: ProgressLocation.Notification,
         cancellable: true,
         title: "Finding references",
       },

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -329,7 +329,6 @@ export async function activate(
               ),
             {
               title: progressTitle,
-              location: ProgressLocation.Notification,
             },
           );
 

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -9,7 +9,6 @@ import {
   extensions,
   languages,
   ProgressLocation,
-  ProgressOptions,
   QuickPickItem,
   Range,
   Uri,
@@ -322,16 +321,16 @@ export async function activate(
             await commands.executeCommand("workbench.action.reloadWindow");
           }
         } else {
-          const progressOptions: ProgressOptions = {
-            title: progressTitle,
-            location: ProgressLocation.Notification,
-          };
-
-          await withProgress(progressOptions, (progress) =>
-            distributionManager.installExtensionManagedDistributionRelease(
-              result.updatedRelease,
-              progress,
-            ),
+          await withProgress(
+            (progress) =>
+              distributionManager.installExtensionManagedDistributionRelease(
+                result.updatedRelease,
+                progress,
+              ),
+            {
+              title: progressTitle,
+              location: ProgressLocation.Notification,
+            },
           );
 
           await ctx.globalState.update(shouldUpdateOnNextActivationKey, false);

--- a/extensions/ql-vscode/src/local-databases.ts
+++ b/extensions/ql-vscode/src/local-databases.ts
@@ -794,74 +794,66 @@ export class DatabaseManager extends DisposableObject {
   }
 
   public async loadPersistedState(): Promise<void> {
-    return withProgress(
-      async (progress, token) => {
-        const currentDatabaseUri =
-          this.ctx.workspaceState.get<string>(CURRENT_DB);
-        const databases = this.ctx.workspaceState.get<PersistedDatabaseItem[]>(
-          DB_LIST,
-          [],
+    return withProgress(async (progress, token) => {
+      const currentDatabaseUri =
+        this.ctx.workspaceState.get<string>(CURRENT_DB);
+      const databases = this.ctx.workspaceState.get<PersistedDatabaseItem[]>(
+        DB_LIST,
+        [],
+      );
+      let step = 0;
+      progress({
+        maxStep: databases.length,
+        message: "Loading persisted databases",
+        step,
+      });
+      try {
+        void this.logger.log(
+          `Found ${databases.length} persisted databases: ${databases
+            .map((db) => db.uri)
+            .join(", ")}`,
         );
-        let step = 0;
-        progress({
-          maxStep: databases.length,
-          message: "Loading persisted databases",
-          step,
-        });
-        try {
-          void this.logger.log(
-            `Found ${databases.length} persisted databases: ${databases
-              .map((db) => db.uri)
-              .join(", ")}`,
-          );
-          for (const database of databases) {
-            progress({
-              maxStep: databases.length,
-              message: `Loading ${
-                database.options?.displayName || "databases"
-              }`,
-              step: ++step,
-            });
+        for (const database of databases) {
+          progress({
+            maxStep: databases.length,
+            message: `Loading ${database.options?.displayName || "databases"}`,
+            step: ++step,
+          });
 
-            const databaseItem =
-              await this.createDatabaseItemFromPersistedState(
-                progress,
-                token,
-                database,
-              );
-            try {
-              await databaseItem.refresh();
-              await this.registerDatabase(progress, token, databaseItem);
-              if (currentDatabaseUri === database.uri) {
-                await this.setCurrentDatabaseItem(databaseItem, true);
-              }
-              void this.logger.log(
-                `Loaded database ${databaseItem.name} at URI ${database.uri}.`,
-              );
-            } catch (e) {
-              // When loading from persisted state, leave invalid databases in the list. They will be
-              // marked as invalid, and cannot be set as the current database.
-              void this.logger.log(
-                `Error loading database ${database.uri}: ${e}.`,
-              );
+          const databaseItem = await this.createDatabaseItemFromPersistedState(
+            progress,
+            token,
+            database,
+          );
+          try {
+            await databaseItem.refresh();
+            await this.registerDatabase(progress, token, databaseItem);
+            if (currentDatabaseUri === database.uri) {
+              await this.setCurrentDatabaseItem(databaseItem, true);
             }
+            void this.logger.log(
+              `Loaded database ${databaseItem.name} at URI ${database.uri}.`,
+            );
+          } catch (e) {
+            // When loading from persisted state, leave invalid databases in the list. They will be
+            // marked as invalid, and cannot be set as the current database.
+            void this.logger.log(
+              `Error loading database ${database.uri}: ${e}.`,
+            );
           }
-          await this.updatePersistedDatabaseList();
-        } catch (e) {
-          // database list had an unexpected type - nothing to be done?
-          void showAndLogExceptionWithTelemetry(
-            redactableError(
-              asError(e),
-            )`Database list loading failed: ${getErrorMessage(e)}`,
-          );
         }
+        await this.updatePersistedDatabaseList();
+      } catch (e) {
+        // database list had an unexpected type - nothing to be done?
+        void showAndLogExceptionWithTelemetry(
+          redactableError(
+            asError(e),
+          )`Database list loading failed: ${getErrorMessage(e)}`,
+        );
+      }
 
-        void this.logger.log("Finished loading persisted databases.");
-      },
-      {
-        location: vscode.ProgressLocation.Notification,
-      },
-    );
+      void this.logger.log("Finished loading persisted databases.");
+    });
   }
 
   public get databaseItems(): readonly DatabaseItem[] {

--- a/extensions/ql-vscode/src/local-databases.ts
+++ b/extensions/ql-vscode/src/local-databases.ts
@@ -795,9 +795,6 @@ export class DatabaseManager extends DisposableObject {
 
   public async loadPersistedState(): Promise<void> {
     return withProgress(
-      {
-        location: vscode.ProgressLocation.Notification,
-      },
       async (progress, token) => {
         const currentDatabaseUri =
           this.ctx.workspaceState.get<string>(CURRENT_DB);
@@ -860,6 +857,9 @@ export class DatabaseManager extends DisposableObject {
         }
 
         void this.logger.log("Finished loading persisted databases.");
+      },
+      {
+        location: vscode.ProgressLocation.Notification,
       },
     );
   }


### PR DESCRIPTION
See the two separate commits. This will make `withProgress` easier to use by removing the required options argument and making it optional instead. This brings it in line with how `commandRunnerWithProgress` calls this function.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
