### PR TITLE
Remove directory dependency on babel-loader

### DIFF
--- a/extensions/ql-vscode/package-lock.json
+++ b/extensions/ql-vscode/package-lock.json
@@ -105,7 +105,6 @@
         "@vscode/vsce": "^2.15.0",
         "ansi-colors": "^4.1.1",
         "applicationinsights": "^2.3.5",
-        "babel-loader": "^8.2.5",
         "cross-env": "^7.0.3",
         "css-loader": "~3.1.0",
         "del": "^6.0.0",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1069,7 +1069,7 @@
         {
           "command": "codeQL.viewCfgContextEditor",
           "when": "false"
-        }, 
+        },
         {
           "command": "codeQLVariantAnalysisRepositories.openConfigFile",
           "when": "false"
@@ -1498,7 +1498,6 @@
     "@vscode/vsce": "^2.15.0",
     "ansi-colors": "^4.1.1",
     "applicationinsights": "^2.3.5",
-    "babel-loader": "^8.2.5",
     "cross-env": "^7.0.3",
     "css-loader": "~3.1.0",
     "del": "^6.0.0",


### PR DESCRIPTION
The extension Webpack config does not use `babel-loader`, so we can remove it as a direct dependency. `babel-loader` is still included in our `node_modules` because Storybook depends on it, but the version is now completely managed by Storybook rather than us.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
