### PR TITLE
Display EntityValue labels in CSV export

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [UNRELEASED]
 
 - Show data flow paths of a variant analysis in a new tab
-- Show labels of entities in CSV export [#2170](https://github.com/github/vscode-codeql/pull/2170)
+- Show labels of entities in exported CSV results [#2170](https://github.com/github/vscode-codeql/pull/2170)
 
 ## 1.8.0 - 9 March 2023
 

--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [UNRELEASED]
 
 - Show data flow paths of a variant analysis in a new tab
+- Show labels of entities in CSV export [#2170](https://github.com/github/vscode-codeql/pull/2170)
 
 ## 1.8.0 - 9 March 2023
 

--- a/extensions/ql-vscode/src/run-queries-shared.ts
+++ b/extensions/ql-vscode/src/run-queries-shared.ts
@@ -30,7 +30,7 @@ import { nanoid } from "nanoid";
 import { CodeQLCliServer } from "./cli";
 import { SELECT_QUERY_NAME } from "./contextual/locationFinder";
 import { DatabaseManager } from "./local-databases";
-import { DecodedBqrsChunk } from "./pure/bqrs-cli-types";
+import { DecodedBqrsChunk, EntityValue } from "./pure/bqrs-cli-types";
 import { extLogger, Logger } from "./common";
 import { generateSummarySymbolsFile } from "./log-insights/summary-parser";
 import { getErrorMessage } from "./pure/helpers-pure";
@@ -351,11 +351,17 @@ export class QueryEvaluationInfo {
       chunk.tuples.forEach((tuple) => {
         out.write(
           `${tuple
-            .map((v, i) =>
-              chunk.columns[i].kind === "String"
-                ? `"${typeof v === "string" ? v.replaceAll('"', '""') : v}"`
-                : v,
-            )
+            .map((v, i) => {
+              if (chunk.columns[i].kind === "String") {
+                return `"${
+                  typeof v === "string" ? v.replaceAll('"', '""') : v
+                }"`;
+              } else if (chunk.columns[i].kind === "Entity") {
+                return (v as EntityValue).label;
+              } else {
+                return v;
+              }
+            })
             .join(",")}\n`,
         );
       });


### PR DESCRIPTION
EntityValues are currently exported in the CSV as `[Object object]`, this PR returns the label for the EntityValue instead, which is more useful.

Fixes https://github.com/github/vscode-codeql/issues/981

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
