### PR TITLE
Convert run variant analysis command to new commands package

### DIFF
--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -1,4 +1,5 @@
 import { CommandManager } from "../packages/commands";
+import type { Uri } from "vscode";
 
 /**
  * Contains type definitions for all commands used by the extension.
@@ -17,6 +18,8 @@ export type VariantAnalysisCommands = {
   "codeQL.openVariantAnalysisLogs": (
     variantAnalysisId: number,
   ) => Promise<void>;
+  "codeQL.runVariantAnalysis": (uri?: Uri) => Promise<void>;
+  "codeQL.runVariantAnalysisContextEditor": (uri?: Uri) => Promise<void>;
 };
 
 export type AllCommands = ExtensionCommands & VariantAnalysisCommands;

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -1151,55 +1151,6 @@ async function activateWithInstalledDistribution(
     ),
   );
 
-  async function runVariantAnalysis(
-    progress: ProgressCallback,
-    token: CancellationToken,
-    uri: Uri | undefined,
-  ): Promise<void> {
-    progress({
-      maxStep: 5,
-      step: 0,
-      message: "Getting credentials",
-    });
-
-    await variantAnalysisManager.runVariantAnalysis(
-      uri || window.activeTextEditor?.document.uri,
-      progress,
-      token,
-    );
-  }
-
-  ctx.subscriptions.push(
-    commandRunnerWithProgress(
-      "codeQL.runVariantAnalysis",
-      async (
-        progress: ProgressCallback,
-        token: CancellationToken,
-        uri: Uri | undefined,
-      ) => await runVariantAnalysis(progress, token, uri),
-      {
-        title: "Run Variant Analysis",
-        cancellable: true,
-      },
-    ),
-  );
-
-  // Since we are tracking extension usage through commands, this command mirrors the "codeQL.runVariantAnalysis" command
-  ctx.subscriptions.push(
-    commandRunnerWithProgress(
-      "codeQL.runVariantAnalysisContextEditor",
-      async (
-        progress: ProgressCallback,
-        token: CancellationToken,
-        uri: Uri | undefined,
-      ) => await runVariantAnalysis(progress, token, uri),
-      {
-        title: "Run Variant Analysis",
-        cancellable: true,
-      },
-    ),
-  );
-
   const allCommands: AllCommands = {
     ...getCommands(),
     ...variantAnalysisManager.getCommands(),

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -51,7 +51,11 @@ import {
 import { readFile, readJson, remove, pathExists, outputJson } from "fs-extra";
 import { EOL } from "os";
 import { cancelVariantAnalysis } from "./gh-api/gh-actions-api-client";
-import { ProgressCallback, UserCancellationException } from "../commandRunner";
+import {
+  ProgressCallback,
+  UserCancellationException,
+  withProgress,
+} from "../commandRunner";
 import { CodeQLCliServer } from "../cli";
 import {
   defaultFilterSortState,
@@ -132,6 +136,11 @@ export class VariantAnalysisManager
       "codeQL.openVariantAnalysisLogs": async (variantAnalysisId: number) => {
         await this.openVariantAnalysisLogs(variantAnalysisId);
       },
+      "codeQL.runVariantAnalysis": async (uri?: Uri) =>
+        this.runVariantAnalysisFromCommand(uri),
+      // Since we are tracking extension usage through commands, this command mirrors the "codeQL.runVariantAnalysis" command
+      "codeQL.runVariantAnalysisContextEditor": async (uri?: Uri) =>
+        this.runVariantAnalysisFromCommand(uri),
     };
   }
 
@@ -139,11 +148,32 @@ export class VariantAnalysisManager
     return this.app.commandManager;
   }
 
+  private async runVariantAnalysisFromCommand(uri?: Uri) {
+    return withProgress(
+      async (progress, token) =>
+        this.runVariantAnalysis(
+          uri || Window.activeTextEditor?.document.uri,
+          progress,
+          token,
+        ),
+      {
+        title: "Run Variant Analysis",
+        cancellable: true,
+      },
+    );
+  }
+
   public async runVariantAnalysis(
     uri: Uri | undefined,
     progress: ProgressCallback,
     token: CancellationToken,
   ): Promise<void> {
+    progress({
+      maxStep: 5,
+      step: 0,
+      message: "Getting credentials",
+    });
+
     const {
       actionBranch,
       base64Pack,


### PR DESCRIPTION
This replaces the run variant analysis commands by an implementation based on the new commands package. There should be no changes in behaviour.

Based on #2157

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
