### PR TITLE
Add linting of jsdoc comments

### DIFF
--- a/extensions/ql-vscode/.eslintrc.js
+++ b/extensions/ql-vscode/.eslintrc.js
@@ -14,7 +14,7 @@ const baseConfig = {
       resolve(__dirname, ".storybook/tsconfig.json"),
     ],
   },
-  plugins: ["github", "@typescript-eslint", "etc"],
+  plugins: ["github", "@typescript-eslint", "etc", "jsdoc"],
   env: {
     node: true,
     es6: true,
@@ -27,6 +27,7 @@ const baseConfig = {
     "plugin:jest-dom/recommended",
     "plugin:prettier/recommended",
     "plugin:@typescript-eslint/recommended",
+    "plugin:jsdoc/recommended",
   ],
   rules: {
     "@typescript-eslint/await-thenable": "error",
@@ -65,6 +66,8 @@ const baseConfig = {
     "import/no-namespace": "off",
     "import/no-unresolved": "off",
     "import/no-webpack-loader-syntax": "off",
+    "jsdoc/require-jsdoc": "off",
+    "jsdoc/require-param-type": "off",
     "jsx-a11y/anchor-is-valid": "off",
     "jsx-a11y/no-noninteractive-element-interactions": "off",
     "jsx-a11y/no-static-element-interactions": "off",
@@ -75,6 +78,11 @@ const baseConfig = {
     "no-shadow": "off",
     "github/array-foreach": "off",
     "github/no-then": "off",
+  },
+  settings: {
+    jsdoc: {
+      mode: "typescript",
+    },
   },
 };
 
@@ -97,6 +105,7 @@ module.exports = {
         ...baseConfig.rules,
       },
       settings: {
+        ...baseConfig.settings,
         react: {
           version: "detect",
         },
@@ -116,6 +125,7 @@ module.exports = {
         ...baseConfig.rules,
       },
       settings: {
+        ...baseConfig.settings,
         react: {
           version: "detect",
         },

--- a/extensions/ql-vscode/package-lock.json
+++ b/extensions/ql-vscode/package-lock.json
@@ -114,6 +114,7 @@
         "eslint-plugin-etc": "^2.0.2",
         "eslint-plugin-github": "^4.4.1",
         "eslint-plugin-jest-dom": "^4.0.2",
+        "eslint-plugin-jsdoc": "^40.0.2",
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-react": "^7.31.8",
         "eslint-plugin-react-hooks": "^4.6.0",
@@ -2546,6 +2547,20 @@
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+    },
+    "node_modules/@es-joy/jsdoccomment": {
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.36.1.tgz",
+      "integrity": "sha512-922xqFsTpHs6D0BUiG4toiyPOMc8/jafnWKxz1KWgS4XzKPy2qXf1Pe6UFuNSCQqt6tOuhAWXBNuuyUhJmw9Vg==",
+      "dev": true,
+      "dependencies": {
+        "comment-parser": "1.3.1",
+        "esquery": "^1.4.0",
+        "jsdoc-type-pratt-parser": "~3.1.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || ^17 || ^18 || ^19"
+      }
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.15.15",
@@ -18452,6 +18467,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/comment-parser": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
+      "integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/common-path-prefix": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
@@ -21657,6 +21681,62 @@
       "peerDependencies": {
         "eslint": "^6.8.0 || ^7.0.0 || ^8.0.0"
       }
+    },
+    "node_modules/eslint-plugin-jsdoc": {
+      "version": "40.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-40.0.2.tgz",
+      "integrity": "sha512-EjcpQX64+d02kKMlBZbTc7xIkCOa0A9TF2AlB/3NlM7Xl8bywwvJ5Wo7ickEn/EzfauMbZcCCKSZItAH+6Xakg==",
+      "dev": true,
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.36.1",
+        "comment-parser": "1.3.1",
+        "debug": "^4.3.4",
+        "escape-string-regexp": "^4.0.0",
+        "esquery": "^1.4.0",
+        "semver": "^7.3.8",
+        "spdx-expression-parse": "^3.0.1"
+      },
+      "engines": {
+        "node": "^14 || ^16 || ^17 || ^18 || ^19"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "node_modules/eslint-plugin-jsx-a11y": {
       "version": "6.6.1",
@@ -30792,6 +30872,15 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdoc-type-pratt-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.1.0.tgz",
+      "integrity": "sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/jsdom": {
       "version": "20.0.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.0.tgz",
@@ -36518,9 +36607,9 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -43031,6 +43120,17 @@
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+    },
+    "@es-joy/jsdoccomment": {
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.36.1.tgz",
+      "integrity": "sha512-922xqFsTpHs6D0BUiG4toiyPOMc8/jafnWKxz1KWgS4XzKPy2qXf1Pe6UFuNSCQqt6tOuhAWXBNuuyUhJmw9Vg==",
+      "dev": true,
+      "requires": {
+        "comment-parser": "1.3.1",
+        "esquery": "^1.4.0",
+        "jsdoc-type-pratt-parser": "~3.1.0"
+      }
     },
     "@esbuild/android-arm": {
       "version": "0.15.15",
@@ -55343,6 +55443,12 @@
       "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
       "dev": true
     },
+    "comment-parser": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
+      "integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
+      "dev": true
+    },
     "common-path-prefix": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
@@ -58015,6 +58121,44 @@
         "@babel/runtime": "^7.16.3",
         "@testing-library/dom": "^8.11.1",
         "requireindex": "^1.2.0"
+      }
+    },
+    "eslint-plugin-jsdoc": {
+      "version": "40.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-40.0.2.tgz",
+      "integrity": "sha512-EjcpQX64+d02kKMlBZbTc7xIkCOa0A9TF2AlB/3NlM7Xl8bywwvJ5Wo7ickEn/EzfauMbZcCCKSZItAH+6Xakg==",
+      "dev": true,
+      "requires": {
+        "@es-joy/jsdoccomment": "~0.36.1",
+        "comment-parser": "1.3.1",
+        "debug": "^4.3.4",
+        "escape-string-regexp": "^4.0.0",
+        "esquery": "^1.4.0",
+        "semver": "^7.3.8",
+        "spdx-expression-parse": "^3.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
       }
     },
     "eslint-plugin-jsx-a11y": {
@@ -64731,6 +64875,12 @@
         "argparse": "^2.0.1"
       }
     },
+    "jsdoc-type-pratt-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.1.0.tgz",
+      "integrity": "sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==",
+      "dev": true
+    },
     "jsdom": {
       "version": "20.0.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.0.tgz",
@@ -69221,9 +69371,9 @@
       }
     },
     "semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "requires": {
         "lru-cache": "^6.0.0"
       },

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1507,6 +1507,7 @@
     "eslint-plugin-etc": "^2.0.2",
     "eslint-plugin-github": "^4.4.1",
     "eslint-plugin-jest-dom": "^4.0.2",
+    "eslint-plugin-jsdoc": "^40.0.2",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.31.8",
     "eslint-plugin-react-hooks": "^4.6.0",


### PR DESCRIPTION
Installs the [jsdoc eslint plugin](https://github.com/gajus/eslint-plugin-jsdoc). This plugin is recommended from https://eslint.org/blog/2018/11/jsdoc-end-of-life/ as the suggested replacement for eslint's builtin rules which were deprecated.

We have quite a bit of jsdoc in the repo and a lot of it is outdated and incorrect. I'm not arguing that every function needs to have a jsdoc comment, but if there is a jsdoc comment it should be correct. So I'm suggesting we disable the `jsdoc/require-jsdoc` rule, but keep basically everything else from the "recommended" set. I've also disabled the `jsdoc/require-param-type` rule because it seems unnecessary to duplicate the type information.

As of opening this PR, this generates 590 warnings. Fixing these will take time and effort so I don't want to make these errors, though that could be an eventual goal. Right now it'll just put a whole load of yellow squigglies in the IDE and hopefully we'll address them as we touch those areas of code.

Do people agree that getting rid of incorrect jsdoc is important enough to do this? And is this many warnings ok, or is it too annoying?

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
