### PR TITLE
Convert query history commands to typed commands

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -644,7 +644,7 @@
       },
       {
         "command": "codeQLQueryHistory.openOnGithub",
-        "title": "Open on GitHub"
+        "title": "View Logs"
       },
       {
         "command": "codeQLQueryHistory.copyRepoList",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -644,7 +644,7 @@
       },
       {
         "command": "codeQLQueryHistory.openOnGithub",
-        "title": "View Logs"
+        "title": "Open on GitHub"
       },
       {
         "command": "codeQLQueryHistory.copyRepoList",

--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -1,5 +1,13 @@
-import { CommandManager } from "../packages/commands";
+import type { CommandManager } from "../packages/commands";
 import type { Uri } from "vscode";
+import type { QueryHistoryInfo } from "../query-history/query-history-info";
+
+// A command function matching the signature that VS Code calls when
+// a command on a selection is invoked.
+export type SelectionCommandFunction<Item> = (
+  singleItem: Item,
+  multiSelect: Item[],
+) => Promise<void>;
 
 /**
  * Contains type definitions for all commands used by the extension.
@@ -13,6 +21,38 @@ export type BaseCommands = {
   "codeQL.openDocumentation": () => Promise<void>;
 };
 
+// Commands used for the query history panel
+export type QueryHistoryCommands = {
+  // Commands in the "navigation" group
+  "codeQLQueryHistory.sortByName": () => Promise<void>;
+  "codeQLQueryHistory.sortByDate": () => Promise<void>;
+  "codeQLQueryHistory.sortByCount": () => Promise<void>;
+
+  // Commands in the context menu or in the hover menu
+  "codeQLQueryHistory.openQueryTitleMenu": SelectionCommandFunction<QueryHistoryInfo>;
+  "codeQLQueryHistory.openQueryContextMenu": SelectionCommandFunction<QueryHistoryInfo>;
+  "codeQLQueryHistory.removeHistoryItemTitleMenu": SelectionCommandFunction<QueryHistoryInfo>;
+  "codeQLQueryHistory.removeHistoryItemContextMenu": SelectionCommandFunction<QueryHistoryInfo>;
+  "codeQLQueryHistory.removeHistoryItemContextInline": SelectionCommandFunction<QueryHistoryInfo>;
+  "codeQLQueryHistory.renameItem": SelectionCommandFunction<QueryHistoryInfo>;
+  "codeQLQueryHistory.compareWith": SelectionCommandFunction<QueryHistoryInfo>;
+  "codeQLQueryHistory.showEvalLog": SelectionCommandFunction<QueryHistoryInfo>;
+  "codeQLQueryHistory.showEvalLogSummary": SelectionCommandFunction<QueryHistoryInfo>;
+  "codeQLQueryHistory.showEvalLogViewer": SelectionCommandFunction<QueryHistoryInfo>;
+  "codeQLQueryHistory.showQueryLog": SelectionCommandFunction<QueryHistoryInfo>;
+  "codeQLQueryHistory.showQueryText": SelectionCommandFunction<QueryHistoryInfo>;
+  "codeQLQueryHistory.openQueryDirectory": SelectionCommandFunction<QueryHistoryInfo>;
+  "codeQLQueryHistory.cancel": SelectionCommandFunction<QueryHistoryInfo>;
+  "codeQLQueryHistory.exportResults": SelectionCommandFunction<QueryHistoryInfo>;
+  "codeQLQueryHistory.viewCsvResults": SelectionCommandFunction<QueryHistoryInfo>;
+  "codeQLQueryHistory.viewCsvAlerts": SelectionCommandFunction<QueryHistoryInfo>;
+  "codeQLQueryHistory.viewSarifAlerts": SelectionCommandFunction<QueryHistoryInfo>;
+  "codeQLQueryHistory.viewDil": SelectionCommandFunction<QueryHistoryInfo>;
+  "codeQLQueryHistory.itemClicked": SelectionCommandFunction<QueryHistoryInfo>;
+  "codeQLQueryHistory.openOnGithub": SelectionCommandFunction<QueryHistoryInfo>;
+  "codeQLQueryHistory.copyRepoList": SelectionCommandFunction<QueryHistoryInfo>;
+};
+
 // Commands tied to variant analysis
 export type VariantAnalysisCommands = {
   "codeQL.openVariantAnalysisLogs": (
@@ -22,6 +62,8 @@ export type VariantAnalysisCommands = {
   "codeQL.runVariantAnalysisContextEditor": (uri?: Uri) => Promise<void>;
 };
 
-export type AllCommands = BaseCommands & VariantAnalysisCommands;
+export type AllCommands = BaseCommands &
+  QueryHistoryCommands &
+  VariantAnalysisCommands;
 
 export type AppCommandManager = CommandManager<AllCommands>;

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -1094,6 +1094,7 @@ async function activateWithInstalledDistribution(
 
   const allCommands: AllCommands = {
     ...getCommands(),
+    ...qhm.getCommands(),
     ...variantAnalysisManager.getCommands(),
   };
 

--- a/extensions/ql-vscode/src/query-history/query-history-manager.ts
+++ b/extensions/ql-vscode/src/query-history/query-history-manager.ts
@@ -25,7 +25,6 @@ import {
 import { extLogger } from "../common";
 import { URLSearchParams } from "url";
 import { DisposableObject } from "../pure/disposable-object";
-import { commandRunner } from "../commandRunner";
 import { ONE_HOUR_IN_MS, TWO_HOURS_IN_MS } from "../pure/time";
 import {
   asError,
@@ -66,6 +65,7 @@ import { getTotalResultCount } from "../variant-analysis/shared/variant-analysis
 import { HistoryTreeDataProvider } from "./history-tree-data-provider";
 import { redactableError } from "../pure/errors";
 import { QueryHistoryDirs } from "./query-history-dirs";
+import { QueryHistoryCommands } from "../common/commands";
 
 /**
  * query-history-manager.ts
@@ -201,159 +201,6 @@ export class QueryHistoryManager extends DisposableObject {
       }),
     );
 
-    void extLogger.log("Registering query history panel commands.");
-    this.push(
-      commandRunner(
-        "codeQLQueryHistory.openQueryTitleMenu",
-        this.handleOpenQuery.bind(this),
-      ),
-    );
-    this.push(
-      commandRunner(
-        "codeQLQueryHistory.openQueryContextMenu",
-        this.handleOpenQuery.bind(this),
-      ),
-    );
-    this.push(
-      commandRunner(
-        "codeQLQueryHistory.removeHistoryItemTitleMenu",
-        this.handleRemoveHistoryItem.bind(this),
-      ),
-    );
-    this.push(
-      commandRunner(
-        "codeQLQueryHistory.removeHistoryItemContextMenu",
-        this.handleRemoveHistoryItem.bind(this),
-      ),
-    );
-    this.push(
-      commandRunner(
-        "codeQLQueryHistory.removeHistoryItemContextInline",
-        this.handleRemoveHistoryItem.bind(this),
-      ),
-    );
-    this.push(
-      commandRunner(
-        "codeQLQueryHistory.sortByName",
-        this.handleSortByName.bind(this),
-      ),
-    );
-    this.push(
-      commandRunner(
-        "codeQLQueryHistory.sortByDate",
-        this.handleSortByDate.bind(this),
-      ),
-    );
-    this.push(
-      commandRunner(
-        "codeQLQueryHistory.sortByCount",
-        this.handleSortByCount.bind(this),
-      ),
-    );
-    this.push(
-      commandRunner(
-        "codeQLQueryHistory.renameItem",
-        this.handleRenameItem.bind(this),
-      ),
-    );
-    this.push(
-      commandRunner(
-        "codeQLQueryHistory.compareWith",
-        this.handleCompareWith.bind(this),
-      ),
-    );
-    this.push(
-      commandRunner(
-        "codeQLQueryHistory.showQueryLog",
-        this.handleShowQueryLog.bind(this),
-      ),
-    );
-    this.push(
-      commandRunner(
-        "codeQLQueryHistory.openQueryDirectory",
-        this.handleOpenQueryDirectory.bind(this),
-      ),
-    );
-    this.push(
-      commandRunner(
-        "codeQLQueryHistory.showEvalLog",
-        this.handleShowEvalLog.bind(this),
-      ),
-    );
-    this.push(
-      commandRunner(
-        "codeQLQueryHistory.showEvalLogSummary",
-        this.handleShowEvalLogSummary.bind(this),
-      ),
-    );
-    this.push(
-      commandRunner(
-        "codeQLQueryHistory.showEvalLogViewer",
-        this.handleShowEvalLogViewer.bind(this),
-      ),
-    );
-    this.push(
-      commandRunner("codeQLQueryHistory.cancel", this.handleCancel.bind(this)),
-    );
-    this.push(
-      commandRunner(
-        "codeQLQueryHistory.showQueryText",
-        this.handleShowQueryText.bind(this),
-      ),
-    );
-    this.push(
-      commandRunner(
-        "codeQLQueryHistory.exportResults",
-        this.handleExportResults.bind(this),
-      ),
-    );
-    this.push(
-      commandRunner(
-        "codeQLQueryHistory.viewCsvResults",
-        this.handleViewCsvResults.bind(this),
-      ),
-    );
-    this.push(
-      commandRunner(
-        "codeQLQueryHistory.viewCsvAlerts",
-        this.handleViewCsvAlerts.bind(this),
-      ),
-    );
-    this.push(
-      commandRunner(
-        "codeQLQueryHistory.viewSarifAlerts",
-        this.handleViewSarifAlerts.bind(this),
-      ),
-    );
-    this.push(
-      commandRunner(
-        "codeQLQueryHistory.viewDil",
-        this.handleViewDil.bind(this),
-      ),
-    );
-    this.push(
-      commandRunner(
-        "codeQLQueryHistory.itemClicked",
-        async (item: LocalQueryInfo) => {
-          return this.handleItemClicked(item, [item]);
-        },
-      ),
-    );
-    this.push(
-      commandRunner(
-        "codeQLQueryHistory.openOnGithub",
-        async (item: LocalQueryInfo) => {
-          return this.handleOpenOnGithub(item, [item]);
-        },
-      ),
-    );
-    this.push(
-      commandRunner(
-        "codeQLQueryHistory.copyRepoList",
-        this.handleCopyRepoList.bind(this),
-      ),
-    );
-
     // There are two configuration items that affect the query history:
     // 1. The ttl for query history items.
     // 2. The default label for query history items.
@@ -386,6 +233,45 @@ export class QueryHistoryManager extends DisposableObject {
 
     this.registerQueryHistoryScrubber(queryHistoryConfigListener, this, ctx);
     this.registerToVariantAnalysisEvents();
+  }
+
+  public getCommands(): QueryHistoryCommands {
+    return {
+      "codeQLQueryHistory.sortByName": this.handleSortByName.bind(this),
+      "codeQLQueryHistory.sortByDate": this.handleSortByDate.bind(this),
+      "codeQLQueryHistory.sortByCount": this.handleSortByCount.bind(this),
+
+      "codeQLQueryHistory.openQueryTitleMenu": this.handleOpenQuery.bind(this),
+      "codeQLQueryHistory.openQueryContextMenu":
+        this.handleOpenQuery.bind(this),
+      "codeQLQueryHistory.removeHistoryItemTitleMenu":
+        this.handleRemoveHistoryItem.bind(this),
+      "codeQLQueryHistory.removeHistoryItemContextMenu":
+        this.handleRemoveHistoryItem.bind(this),
+      "codeQLQueryHistory.removeHistoryItemContextInline":
+        this.handleRemoveHistoryItem.bind(this),
+      "codeQLQueryHistory.renameItem": this.handleRenameItem.bind(this),
+      "codeQLQueryHistory.compareWith": this.handleCompareWith.bind(this),
+      "codeQLQueryHistory.showEvalLog": this.handleShowEvalLog.bind(this),
+      "codeQLQueryHistory.showEvalLogSummary":
+        this.handleShowEvalLogSummary.bind(this),
+      "codeQLQueryHistory.showEvalLogViewer":
+        this.handleShowEvalLogViewer.bind(this),
+      "codeQLQueryHistory.showQueryLog": this.handleShowQueryLog.bind(this),
+      "codeQLQueryHistory.showQueryText": this.handleShowQueryText.bind(this),
+      "codeQLQueryHistory.openQueryDirectory":
+        this.handleOpenQueryDirectory.bind(this),
+      "codeQLQueryHistory.cancel": this.handleCancel.bind(this),
+      "codeQLQueryHistory.exportResults": this.handleExportResults.bind(this),
+      "codeQLQueryHistory.viewCsvResults": this.handleViewCsvResults.bind(this),
+      "codeQLQueryHistory.viewCsvAlerts": this.handleViewCsvAlerts.bind(this),
+      "codeQLQueryHistory.viewSarifAlerts":
+        this.handleViewSarifAlerts.bind(this),
+      "codeQLQueryHistory.viewDil": this.handleViewDil.bind(this),
+      "codeQLQueryHistory.itemClicked": this.handleItemClicked.bind(this),
+      "codeQLQueryHistory.openOnGithub": this.handleOpenOnGithub.bind(this),
+      "codeQLQueryHistory.copyRepoList": this.handleCopyRepoList.bind(this),
+    };
   }
 
   public completeQuery(info: LocalQueryInfo, results: QueryWithResults): void {


### PR DESCRIPTION
This converts the query history commands to the new typed commands package. There should be no behaviour changes.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
