### PR TITLE
Split up the codeQLQueryHistory.removeHistoryItem command

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -554,7 +554,17 @@
         "icon": "$(preview)"
       },
       {
-        "command": "codeQLQueryHistory.removeHistoryItem",
+        "command": "codeQLQueryHistory.removeHistoryItemTitleMenu",
+        "title": "Delete",
+        "icon": "$(trash)"
+      },
+      {
+        "command": "codeQLQueryHistory.removeHistoryItemContextMenu",
+        "title": "Delete",
+        "icon": "$(trash)"
+      },
+      {
+        "command": "codeQLQueryHistory.removeHistoryItemContextInline",
         "title": "Delete",
         "icon": "$(trash)"
       },
@@ -751,7 +761,7 @@
           "group": "navigation"
         },
         {
-          "command": "codeQLQueryHistory.removeHistoryItem",
+          "command": "codeQLQueryHistory.removeHistoryItemTitleMenu",
           "when": "view == codeQLQueryHistory",
           "group": "navigation"
         },
@@ -853,12 +863,12 @@
           "when": "view == codeQLQueryHistory"
         },
         {
-          "command": "codeQLQueryHistory.removeHistoryItem",
+          "command": "codeQLQueryHistory.removeHistoryItemContextMenu",
           "group": "7_queryHistory@0",
           "when": "viewItem == interpretedResultsItem || viewItem == rawResultsItem || viewItem == remoteResultsItem || viewItem == cancelledRemoteResultsItemWithoutLogs || viewItem == cancelledResultsItem || viewItem == cancelledRemoteResultsItem"
         },
         {
-          "command": "codeQLQueryHistory.removeHistoryItem",
+          "command": "codeQLQueryHistory.removeHistoryItemContextInline",
           "group": "inline",
           "when": "viewItem == interpretedResultsItem || viewItem == rawResultsItem || viewItem == remoteResultsItem || viewItem == cancelledRemoteResultsItemWithoutLogs || viewItem == cancelledResultsItem || viewItem == cancelledRemoteResultsItem"
         },
@@ -1159,7 +1169,15 @@
           "when": "false"
         },
         {
-          "command": "codeQLQueryHistory.removeHistoryItem",
+          "command": "codeQLQueryHistory.removeHistoryItemTitleMenu",
+          "when": "false"
+        },
+        {
+          "command": "codeQLQueryHistory.removeHistoryItemContextMenu",
+          "when": "false"
+        },
+        {
+          "command": "codeQLQueryHistory.removeHistoryItemContextInline",
           "when": "false"
         },
         {

--- a/extensions/ql-vscode/src/query-history/query-history-manager.ts
+++ b/extensions/ql-vscode/src/query-history/query-history-manager.ts
@@ -210,7 +210,19 @@ export class QueryHistoryManager extends DisposableObject {
     );
     this.push(
       commandRunner(
-        "codeQLQueryHistory.removeHistoryItem",
+        "codeQLQueryHistory.removeHistoryItemTitleMenu",
+        this.handleRemoveHistoryItem.bind(this),
+      ),
+    );
+    this.push(
+      commandRunner(
+        "codeQLQueryHistory.removeHistoryItemContextMenu",
+        this.handleRemoveHistoryItem.bind(this),
+      ),
+    );
+    this.push(
+      commandRunner(
+        "codeQLQueryHistory.removeHistoryItemContextInline",
         this.handleRemoveHistoryItem.bind(this),
       ),
     );


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Splits up the `codeQLQueryHistory.removeHistoryItem` command so we don't use the same command from more than one location. This makes our telemetry better because we can tell how users are interaction with features.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
