### PR TITLE
Split up codeQLQueryHistory.openQuery command

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -544,7 +544,12 @@
         "title": "CodeQL: Check for CLI Updates"
       },
       {
-        "command": "codeQLQueryHistory.openQuery",
+        "command": "codeQLQueryHistory.openQueryTitleMenu",
+        "title": "View Query",
+        "icon": "$(edit)"
+      },
+      {
+        "command": "codeQLQueryHistory.openQueryContextMenu",
         "title": "View Query",
         "icon": "$(edit)"
       },
@@ -751,7 +756,7 @@
           "group": "navigation"
         },
         {
-          "command": "codeQLQueryHistory.openQuery",
+          "command": "codeQLQueryHistory.openQueryTitleMenu",
           "when": "view == codeQLQueryHistory",
           "group": "navigation"
         },
@@ -858,7 +863,7 @@
           "group": "inline"
         },
         {
-          "command": "codeQLQueryHistory.openQuery",
+          "command": "codeQLQueryHistory.openQueryContextMenu",
           "group": "2_queryHistory@0",
           "when": "view == codeQLQueryHistory"
         },
@@ -1165,7 +1170,11 @@
           "when": "false"
         },
         {
-          "command": "codeQLQueryHistory.openQuery",
+          "command": "codeQLQueryHistory.openQueryTitleMenu",
+          "when": "false"
+        },
+        {
+          "command": "codeQLQueryHistory.openQueryContextMenu",
           "when": "false"
         },
         {

--- a/extensions/ql-vscode/src/query-history/query-history-manager.ts
+++ b/extensions/ql-vscode/src/query-history/query-history-manager.ts
@@ -204,7 +204,13 @@ export class QueryHistoryManager extends DisposableObject {
     void extLogger.log("Registering query history panel commands.");
     this.push(
       commandRunner(
-        "codeQLQueryHistory.openQuery",
+        "codeQLQueryHistory.openQueryTitleMenu",
+        this.handleOpenQuery.bind(this),
+      ),
+    );
+    this.push(
+      commandRunner(
+        "codeQLQueryHistory.openQueryContextMenu",
         this.handleOpenQuery.bind(this),
       ),
     );


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Splits up the `codeQLQueryHistory.openQuery` command so we don't use the same command from more than one location. This makes our telemetry better because we can tell how users are interaction with features. It's ok to rename these commands because they are not visible to users in the command palette.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
