### PR TITLE
Remove codeQL.openVariantAnalysisQueryFile command

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -1217,15 +1217,6 @@ async function activateWithInstalledDistribution(
   );
 
   ctx.subscriptions.push(
-    commandRunner(
-      "codeQL.openVariantAnalysisQueryFile",
-      async (variantAnalysisId: number) => {
-        await variantAnalysisManager.openQueryFile(variantAnalysisId);
-      },
-    ),
-  );
-
-  ctx.subscriptions.push(
     commandRunner("codeQL.openReferencedFile", async (selectedQuery: Uri) => {
       await openReferencedFile(qs, cliServer, selectedQuery);
     }),

--- a/extensions/ql-vscode/src/query-history/query-history-manager.ts
+++ b/extensions/ql-vscode/src/query-history/query-history-manager.ts
@@ -522,8 +522,7 @@ export class QueryHistoryManager extends DisposableObject {
     }
 
     if (finalSingleItem.t === "variant-analysis") {
-      await commands.executeCommand(
-        "codeQL.openVariantAnalysisQueryFile",
+      await this.variantAnalysisManager.openQueryFile(
         finalSingleItem.variantAnalysis.id,
       );
       return;

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-view-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-view-manager.ts
@@ -24,4 +24,5 @@ export interface VariantAnalysisViewManager<
   getRepoStates(
     variantAnalysisId: number,
   ): Promise<VariantAnalysisScannedRepositoryState[]>;
+  openQueryFile(variantAnalysisId: number): Promise<void>;
 }

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-view.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-view.ts
@@ -119,10 +119,7 @@ export class VariantAnalysisView
         );
         break;
       case "openQueryFile":
-        void commands.executeCommand(
-          "codeQL.openVariantAnalysisQueryFile",
-          this.variantAnalysisId,
-        );
+        await this.manager.openQueryFile(this.variantAnalysisId);
         break;
       case "openQueryText":
         void commands.executeCommand(

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
@@ -13,7 +13,7 @@ import { VariantAnalysisLoading } from "./VariantAnalysisLoading";
 import { ToVariantAnalysisMessage } from "../../pure/interface-types";
 import { vscode } from "../vscode-api";
 import { defaultFilterSortState } from "../../pure/variant-analysis-filter-sort";
-import { useTelemetryOnChange } from "../common/telemetry";
+import { sendTelemetry, useTelemetryOnChange } from "../common/telemetry";
 
 export type VariantAnalysisProps = {
   variantAnalysis?: VariantAnalysisDomainModel;
@@ -25,6 +25,7 @@ const openQueryFile = () => {
   vscode.postMessage({
     t: "openQueryFile",
   });
+  sendTelemetry("variant-analysis-open-query-file");
 };
 
 const openQueryText = () => {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

I'm not sure if this PR is the right way to go, but I want to open it to ask the question. What's wrong with doing this?

To make clear what's going on here, the `codeQL.openVariantAnalysisQueryFile` is only used internally from code and is not available to the user in the command palette. In the two places we use this command, we could instead just call the `openQueryFile`  method on the variant analysis manager directly. We have access to the variant analysis manager object already.

The reasons I can see for using a command are:
- It reduces coupling between the variant analysis manager and other parts of the codebase, but in this case the coupling is already there and unlikely to be removed.
- It adds more error handling/logging, but I don't think it adds much because we're always already either in a command or handling a webview message.

So does this PR actually make things any worse? It seems unclear to me. But it might still be working against our view of the perfect future.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
