### PR TITLE
Remove two more internal-only commands

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -1146,15 +1146,6 @@ async function activateWithInstalledDistribution(
   );
 
   ctx.subscriptions.push(
-    commandRunner(
-      "codeQL.cancelVariantAnalysis",
-      async (variantAnalysisId: number) => {
-        await variantAnalysisManager.cancelVariantAnalysis(variantAnalysisId);
-      },
-    ),
-  );
-
-  ctx.subscriptions.push(
     commandRunner("codeQL.exportSelectedVariantAnalysisResults", async () => {
       await exportSelectedVariantAnalysisResults(qhm);
     }),

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -1199,15 +1199,6 @@ async function activateWithInstalledDistribution(
   );
 
   ctx.subscriptions.push(
-    commandRunner(
-      "codeQL.openVariantAnalysisQueryText",
-      async (variantAnalysisId: number) => {
-        await variantAnalysisManager.openQueryText(variantAnalysisId);
-      },
-    ),
-  );
-
-  ctx.subscriptions.push(
     commandRunner("codeQL.openReferencedFile", async (selectedQuery: Uri) => {
       await openReferencedFile(qs, cliServer, selectedQuery);
     }),

--- a/extensions/ql-vscode/src/query-history/query-history-manager.ts
+++ b/extensions/ql-vscode/src/query-history/query-history-manager.ts
@@ -1008,8 +1008,7 @@ export class QueryHistoryManager extends DisposableObject {
         if (item.t === "local") {
           item.cancel();
         } else if (item.t === "variant-analysis") {
-          await commands.executeCommand(
-            "codeQL.cancelVariantAnalysis",
+          await this.variantAnalysisManager.cancelVariantAnalysis(
             item.variantAnalysis.id,
           );
         } else {

--- a/extensions/ql-vscode/src/query-history/query-history-manager.ts
+++ b/extensions/ql-vscode/src/query-history/query-history-manager.ts
@@ -1034,8 +1034,7 @@ export class QueryHistoryManager extends DisposableObject {
     }
 
     if (finalSingleItem.t === "variant-analysis") {
-      await commands.executeCommand(
-        "codeQL.openVariantAnalysisQueryText",
+      await this.variantAnalysisManager.openQueryText(
         finalSingleItem.variantAnalysis.id,
       );
       return;

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-view-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-view-manager.ts
@@ -25,5 +25,6 @@ export interface VariantAnalysisViewManager<
     variantAnalysisId: number,
   ): Promise<VariantAnalysisScannedRepositoryState[]>;
   openQueryFile(variantAnalysisId: number): Promise<void>;
+  openQueryText(variantAnalysisId: number): Promise<void>;
   cancelVariantAnalysis(variantAnalysisId: number): Promise<void>;
 }

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-view-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-view-manager.ts
@@ -25,4 +25,5 @@ export interface VariantAnalysisViewManager<
     variantAnalysisId: number,
   ): Promise<VariantAnalysisScannedRepositoryState[]>;
   openQueryFile(variantAnalysisId: number): Promise<void>;
+  cancelVariantAnalysis(variantAnalysisId: number): Promise<void>;
 }

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-view.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-view.ts
@@ -110,10 +110,7 @@ export class VariantAnalysisView
 
         break;
       case "cancelVariantAnalysis":
-        void commands.executeCommand(
-          "codeQL.cancelVariantAnalysis",
-          this.variantAnalysisId,
-        );
+        await this.manager.cancelVariantAnalysis(this.variantAnalysisId);
         break;
       case "requestRepositoryResults":
         void commands.executeCommand(

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-view.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-view.ts
@@ -123,10 +123,7 @@ export class VariantAnalysisView
         await this.manager.openQueryFile(this.variantAnalysisId);
         break;
       case "openQueryText":
-        void commands.executeCommand(
-          "codeQL.openVariantAnalysisQueryText",
-          this.variantAnalysisId,
-        );
+        await this.manager.openQueryText(this.variantAnalysisId);
         break;
       case "copyRepositoryList":
         void commands.executeCommand(

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
@@ -32,6 +32,7 @@ const openQueryText = () => {
   vscode.postMessage({
     t: "openQueryText",
   });
+  sendTelemetry("variant-analysis-open-query-text");
 };
 
 const stopQuery = () => {

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
@@ -38,6 +38,7 @@ const stopQuery = () => {
   vscode.postMessage({
     t: "cancelVariantAnalysis",
   });
+  sendTelemetry("variant-analysis-cancel");
 };
 
 const openLogs = () => {

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-manager.test.ts
@@ -41,6 +41,9 @@ describe("QueryHistoryManager", () => {
   let executeCommandSpy: jest.SpiedFunction<
     typeof vscode.commands.executeCommand
   >;
+  let cancelVariantAnalysisSpy: jest.SpiedFunction<
+    typeof variantAnalysisManagerStub.cancelVariantAnalysis
+  >;
   const doCompareCallback = jest.fn();
 
   let queryHistoryManager: QueryHistoryManager;
@@ -82,8 +85,13 @@ describe("QueryHistoryManager", () => {
       onVariantAnalysisStatusUpdated: jest.fn(),
       onVariantAnalysisRemoved: jest.fn(),
       removeVariantAnalysis: jest.fn(),
+      cancelVariantAnalysis: jest.fn(),
       showView: jest.fn(),
     } as any as VariantAnalysisManager;
+
+    cancelVariantAnalysisSpy = jest
+      .spyOn(variantAnalysisManagerStub, "cancelVariantAnalysis")
+      .mockResolvedValue(undefined);
 
     localQueryHistory = [
       // completed
@@ -729,8 +737,7 @@ describe("QueryHistoryManager", () => {
         const inProgress1 = variantAnalysisHistory[1];
 
         await queryHistoryManager.handleCancel(inProgress1, [inProgress1]);
-        expect(executeCommandSpy).toBeCalledWith(
-          "codeQL.cancelVariantAnalysis",
+        expect(cancelVariantAnalysisSpy).toBeCalledWith(
           inProgress1.variantAnalysis.id,
         );
       });
@@ -746,12 +753,10 @@ describe("QueryHistoryManager", () => {
           inProgress1,
           inProgress2,
         ]);
-        expect(executeCommandSpy).toBeCalledWith(
-          "codeQL.cancelVariantAnalysis",
+        expect(cancelVariantAnalysisSpy).toBeCalledWith(
           inProgress1.variantAnalysis.id,
         );
-        expect(executeCommandSpy).toBeCalledWith(
-          "codeQL.cancelVariantAnalysis",
+        expect(cancelVariantAnalysisSpy).toBeCalledWith(
           inProgress2.variantAnalysis.id,
         );
       });
@@ -793,8 +798,7 @@ describe("QueryHistoryManager", () => {
         await queryHistoryManager.handleCancel(completedVariantAnalysis, [
           completedVariantAnalysis,
         ]);
-        expect(executeCommandSpy).not.toBeCalledWith(
-          "codeQL.cancelVariantAnalysis",
+        expect(cancelVariantAnalysisSpy).not.toBeCalledWith(
           completedVariantAnalysis.variantAnalysis,
         );
       });
@@ -810,12 +814,10 @@ describe("QueryHistoryManager", () => {
           completedVariantAnalysis,
           failedVariantAnalysis,
         ]);
-        expect(executeCommandSpy).not.toBeCalledWith(
-          "codeQL.cancelVariantAnalysis",
+        expect(cancelVariantAnalysisSpy).not.toBeCalledWith(
           completedVariantAnalysis.variantAnalysis.id,
         );
-        expect(executeCommandSpy).not.toBeCalledWith(
-          "codeQL.cancelVariantAnalysis",
+        expect(cancelVariantAnalysisSpy).not.toBeCalledWith(
           failedVariantAnalysis.variantAnalysis.id,
         );
       });

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/variant-analysis-history.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/variant-analysis-history.test.ts
@@ -8,7 +8,7 @@ import {
 } from "fs-extra";
 import { join } from "path";
 
-import { commands, ExtensionContext, Uri } from "vscode";
+import { ExtensionContext, Uri } from "vscode";
 import { DatabaseManager } from "../../../../src/local-databases";
 import { tmpDir, walkDirectory } from "../../../../src/helpers";
 import { DisposableBucket } from "../../disposable-bucket";
@@ -54,9 +54,12 @@ describe("Variant Analyses and QueryHistoryManager", () => {
     rehydrateVariantAnalysis: rehydrateVariantAnalysisStub,
     onVariantAnalysisStatusUpdated: jest.fn(),
     showView: showViewStub,
+    openQueryText: jest.fn(),
   } as any as VariantAnalysisManager;
 
-  let executeCommandSpy: jest.SpiedFunction<typeof commands.executeCommand>;
+  let openQueryTextSpy: jest.SpiedFunction<
+    typeof variantAnalysisManagerStub.openQueryText
+  >;
 
   beforeEach(async () => {
     // Since these tests change the state of the query history manager, we need to copy the original
@@ -95,8 +98,8 @@ describe("Variant Analyses and QueryHistoryManager", () => {
     );
     disposables.push(qhm);
 
-    executeCommandSpy = jest
-      .spyOn(commands, "executeCommand")
+    openQueryTextSpy = jest
+      .spyOn(variantAnalysisManagerStub, "openQueryText")
       .mockResolvedValue(undefined);
   });
 
@@ -180,8 +183,7 @@ describe("Variant Analyses and QueryHistoryManager", () => {
     await qhm.readQueryHistory();
     await qhm.handleShowQueryText(qhm.treeDataProvider.allHistory[0], []);
 
-    expect(executeCommandSpy).toHaveBeenCalledWith(
-      "codeQL.openVariantAnalysisQueryText",
+    expect(openQueryTextSpy).toHaveBeenCalledWith(
       rawQueryHistory[0].variantAnalysis.id,
     );
   });


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Removes the `codeQL.cancelVariantAnalysis` and `codeQL.openVariantAnalysisQueryText` commands. I've done these two together in one PR since they both also use the approach from https://github.com/github/vscode-codeql/pull/2179.

Check the individual commits for changes relevant to each command. For each one we essentially inline the implementation so we call the method on the variant analysis manager directly instead of going through a command. The only case where we're not already inside a command is when triggered from the variant analysis view, so we add dedicated telemetry to cover that.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
