### PR TITLE
Convert local database commands to typed commands

### DIFF
--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -1,5 +1,6 @@
 import type { CommandManager } from "../packages/commands";
 import type { Uri } from "vscode";
+import type { DatabaseItem } from "../local-databases";
 import type { QueryHistoryInfo } from "../query-history/query-history-info";
 
 // A command function matching the signature that VS Code calls when
@@ -53,6 +54,31 @@ export type QueryHistoryCommands = {
   "codeQLQueryHistory.copyRepoList": SelectionCommandFunction<QueryHistoryInfo>;
 };
 
+// Commands used for the local databases panel
+export type LocalDatabasesCommands = {
+  "codeQL.setCurrentDatabase": (uri: Uri) => Promise<void>;
+  "codeQL.setDefaultTourDatabase": () => Promise<void>;
+  "codeQL.upgradeCurrentDatabase": () => Promise<void>;
+  "codeQL.clearCache": () => Promise<void>;
+
+  "codeQLDatabases.chooseDatabaseFolder": () => Promise<void>;
+  "codeQLDatabases.chooseDatabaseArchive": () => Promise<void>;
+  "codeQLDatabases.chooseDatabaseInternet": () => Promise<void>;
+  "codeQLDatabases.chooseDatabaseGithub": () => Promise<void>;
+  "codeQLDatabases.setCurrentDatabase": (
+    databaseItem: DatabaseItem,
+  ) => Promise<void>;
+  "codeQLDatabases.sortByName": () => Promise<void>;
+  "codeQLDatabases.sortByDateAdded": () => Promise<void>;
+  "codeQLDatabases.removeOrphanedDatabases": () => Promise<void>;
+
+  "codeQLDatabases.removeDatabase": SelectionCommandFunction<DatabaseItem>;
+  "codeQLDatabases.upgradeDatabase": SelectionCommandFunction<DatabaseItem>;
+  "codeQLDatabases.renameDatabase": SelectionCommandFunction<DatabaseItem>;
+  "codeQLDatabases.openDatabaseFolder": SelectionCommandFunction<DatabaseItem>;
+  "codeQLDatabases.addDatabaseSource": SelectionCommandFunction<DatabaseItem>;
+};
+
 // Commands tied to variant analysis
 export type VariantAnalysisCommands = {
   "codeQL.openVariantAnalysisLogs": (
@@ -64,6 +90,7 @@ export type VariantAnalysisCommands = {
 
 export type AllCommands = BaseCommands &
   QueryHistoryCommands &
+  LocalDatabasesCommands &
   VariantAnalysisCommands;
 
 export type AppCommandManager = CommandManager<AllCommands>;

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -35,7 +35,6 @@ import { CodeQLCliServer } from "./cli";
 import {
   CliConfigListener,
   DistributionConfigListener,
-  isCanary,
   joinOrderWarningThreshold,
   MAX_QUERIES,
   QueryHistoryConfigListener,
@@ -642,7 +641,6 @@ async function activateWithInstalledDistribution(
     getContextStoragePath(ctx),
     ctx.extensionPath,
   );
-  databaseUI.init();
   ctx.subscriptions.push(databaseUI);
 
   void extLogger.log("Initializing evaluator log viewer.");
@@ -1096,6 +1094,7 @@ async function activateWithInstalledDistribution(
     ...getCommands(),
     ...qhm.getCommands(),
     ...variantAnalysisManager.getCommands(),
+    ...databaseUI.getCommands(),
   };
 
   for (const [commandName, command] of Object.entries(allCommands)) {
@@ -1290,8 +1289,7 @@ async function activateWithInstalledDistribution(
     commandRunnerWithProgress(
       "codeQL.chooseDatabaseGithub",
       async (progress: ProgressCallback, token: CancellationToken) => {
-        const credentials = isCanary() ? app.credentials : undefined;
-        await databaseUI.chooseDatabaseGithub(credentials, progress, token);
+        await databaseUI.chooseDatabaseGithub(progress, token);
       },
       {
         title: "Adding database from GitHub",

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -1270,7 +1270,7 @@ async function activateWithInstalledDistribution(
     commandRunnerWithProgress(
       "codeQL.chooseDatabaseFolder",
       (progress: ProgressCallback, token: CancellationToken) =>
-        databaseUI.handleChooseDatabaseFolder(progress, token),
+        databaseUI.chooseDatabaseFolder(progress, token),
       {
         title: "Choose a Database from a Folder",
       },
@@ -1280,7 +1280,7 @@ async function activateWithInstalledDistribution(
     commandRunnerWithProgress(
       "codeQL.chooseDatabaseArchive",
       (progress: ProgressCallback, token: CancellationToken) =>
-        databaseUI.handleChooseDatabaseArchive(progress, token),
+        databaseUI.chooseDatabaseArchive(progress, token),
       {
         title: "Choose a Database from an Archive",
       },
@@ -1291,11 +1291,7 @@ async function activateWithInstalledDistribution(
       "codeQL.chooseDatabaseGithub",
       async (progress: ProgressCallback, token: CancellationToken) => {
         const credentials = isCanary() ? app.credentials : undefined;
-        await databaseUI.handleChooseDatabaseGithub(
-          credentials,
-          progress,
-          token,
-        );
+        await databaseUI.chooseDatabaseGithub(credentials, progress, token);
       },
       {
         title: "Adding database from GitHub",
@@ -1306,7 +1302,7 @@ async function activateWithInstalledDistribution(
     commandRunnerWithProgress(
       "codeQL.chooseDatabaseInternet",
       (progress: ProgressCallback, token: CancellationToken) =>
-        databaseUI.handleChooseDatabaseInternet(progress, token),
+        databaseUI.chooseDatabaseInternet(progress, token),
 
       {
         title: "Adding database from URL",

--- a/extensions/ql-vscode/src/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/local-databases-ui.ts
@@ -69,12 +69,12 @@ class DatabaseTreeDataProvider
 
     this.push(
       this.databaseManager.onDidChangeDatabaseItem(
-        this.handleDidChangeDatabaseItem,
+        this.handleDidChangeDatabaseItem.bind(this),
       ),
     );
     this.push(
       this.databaseManager.onDidChangeCurrentDatabaseItem(
-        this.handleDidChangeCurrentDatabaseItem,
+        this.handleDidChangeCurrentDatabaseItem.bind(this),
       ),
     );
   }
@@ -83,18 +83,18 @@ class DatabaseTreeDataProvider
     return this._onDidChangeTreeData.event;
   }
 
-  private handleDidChangeDatabaseItem = (event: DatabaseChangedEvent): void => {
+  private handleDidChangeDatabaseItem(event: DatabaseChangedEvent): void {
     // Note that events from the database manager are instances of DatabaseChangedEvent
     // and events fired by the UI are instances of DatabaseItem
 
     // When event.item is undefined, then the entire tree is refreshed.
     // When event.item is a db item, then only that item is refreshed.
     this._onDidChangeTreeData.fire(event.item);
-  };
+  }
 
-  private handleDidChangeCurrentDatabaseItem = (
+  private handleDidChangeCurrentDatabaseItem(
     event: DatabaseChangedEvent,
-  ): void => {
+  ): void {
     if (this.currentDatabaseItem) {
       this._onDidChangeTreeData.fire(this.currentDatabaseItem);
     }
@@ -102,7 +102,7 @@ class DatabaseTreeDataProvider
     if (this.currentDatabaseItem) {
       this._onDidChangeTreeData.fire(this.currentDatabaseItem);
     }
-  };
+  }
 
   public getTreeItem(element: DatabaseItem): TreeItem {
     const item = new TreeItem(element.name);
@@ -209,38 +209,43 @@ export class DatabaseUI extends DisposableObject {
   init() {
     void extLogger.log("Registering database panel commands.");
     this.push(
-      commandRunner("codeQL.setCurrentDatabase", this.handleSetCurrentDatabase),
+      commandRunner(
+        "codeQL.setCurrentDatabase",
+        this.handleSetCurrentDatabase.bind(this),
+      ),
     );
     this.push(
       commandRunner(
         "codeQL.setDefaultTourDatabase",
-        this.handleSetDefaultTourDatabase,
+        this.handleSetDefaultTourDatabase.bind(this),
       ),
     );
     this.push(
       commandRunner(
         "codeQL.upgradeCurrentDatabase",
-        this.handleUpgradeCurrentDatabase,
+        this.handleUpgradeCurrentDatabase.bind(this),
       ),
     );
-    this.push(commandRunner("codeQL.clearCache", this.handleClearCache));
+    this.push(
+      commandRunner("codeQL.clearCache", this.handleClearCache.bind(this)),
+    );
 
     this.push(
       commandRunner(
         "codeQLDatabases.chooseDatabaseFolder",
-        this.handleChooseDatabaseFolder,
+        this.handleChooseDatabaseFolder.bind(this),
       ),
     );
     this.push(
       commandRunner(
         "codeQLDatabases.chooseDatabaseArchive",
-        this.handleChooseDatabaseArchive,
+        this.handleChooseDatabaseArchive.bind(this),
       ),
     );
     this.push(
       commandRunner(
         "codeQLDatabases.chooseDatabaseInternet",
-        this.handleChooseDatabaseInternet,
+        this.handleChooseDatabaseInternet.bind(this),
       ),
     );
     this.push(
@@ -252,63 +257,69 @@ export class DatabaseUI extends DisposableObject {
     this.push(
       commandRunner(
         "codeQLDatabases.setCurrentDatabase",
-        this.handleMakeCurrentDatabase,
+        this.handleMakeCurrentDatabase.bind(this),
       ),
     );
     this.push(
-      commandRunner("codeQLDatabases.sortByName", this.handleSortByName),
+      commandRunner(
+        "codeQLDatabases.sortByName",
+        this.handleSortByName.bind(this),
+      ),
     );
     this.push(
       commandRunner(
         "codeQLDatabases.sortByDateAdded",
-        this.handleSortByDateAdded,
+        this.handleSortByDateAdded.bind(this),
       ),
     );
     this.push(
       commandRunner(
         "codeQLDatabases.removeDatabase",
-        this.handleRemoveDatabase,
+        this.handleRemoveDatabase.bind(this),
       ),
     );
     this.push(
       commandRunner(
         "codeQLDatabases.upgradeDatabase",
-        this.handleUpgradeDatabase,
+        this.handleUpgradeDatabase.bind(this),
       ),
     );
     this.push(
       commandRunner(
         "codeQLDatabases.renameDatabase",
-        this.handleRenameDatabase,
+        this.handleRenameDatabase.bind(this),
       ),
     );
     this.push(
       commandRunner(
         "codeQLDatabases.openDatabaseFolder",
-        this.handleOpenFolder,
+        this.handleOpenFolder.bind(this),
       ),
     );
     this.push(
-      commandRunner("codeQLDatabases.addDatabaseSource", this.handleAddSource),
+      commandRunner(
+        "codeQLDatabases.addDatabaseSource",
+        this.handleAddSource.bind(this),
+      ),
     );
     this.push(
       commandRunner(
         "codeQLDatabases.removeOrphanedDatabases",
-        this.handleRemoveOrphanedDatabases,
+        this.handleRemoveOrphanedDatabases.bind(this),
       ),
     );
   }
 
-  private handleMakeCurrentDatabase = async (
+  private async handleMakeCurrentDatabase(
     databaseItem: DatabaseItem,
-  ): Promise<void> => {
+  ): Promise<void> {
     await this.databaseManager.setCurrentDatabaseItem(databaseItem);
-  };
+  }
 
-  chooseDatabaseFolder = async (
+  public async chooseDatabaseFolder(
     progress: ProgressCallback,
     token: CancellationToken,
-  ): Promise<void> => {
+  ): Promise<void> {
     try {
       await this.chooseAndSetDatabase(true, progress, token);
     } catch (e) {
@@ -318,9 +329,9 @@ export class DatabaseUI extends DisposableObject {
         )`Failed to choose and set database: ${getErrorMessage(e)}`,
       );
     }
-  };
+  }
 
-  private handleChooseDatabaseFolder = async (): Promise<void> => {
+  private async handleChooseDatabaseFolder(): Promise<void> {
     return withProgress(
       async (progress, token) => {
         await this.chooseDatabaseFolder(progress, token);
@@ -329,9 +340,9 @@ export class DatabaseUI extends DisposableObject {
         title: "Adding database from folder",
       },
     );
-  };
+  }
 
-  private handleSetDefaultTourDatabase = async (): Promise<void> => {
+  private async handleSetDefaultTourDatabase(): Promise<void> {
     return withProgress(
       async (progress, token) => {
         try {
@@ -371,9 +382,9 @@ export class DatabaseUI extends DisposableObject {
         title: "Set Default Database for Codespace CodeQL Tour",
       },
     );
-  };
+  }
 
-  private handleTourDependencies = async (): Promise<void> => {
+  private async handleTourDependencies(): Promise<void> {
     if (!workspace.workspaceFolders?.length) {
       throw new Error("No workspace folder is open.");
     } else {
@@ -387,9 +398,10 @@ export class DatabaseUI extends DisposableObject {
       }
       await cli.packInstall(tutorialQueriesPath);
     }
-  };
+  }
 
-  handleRemoveOrphanedDatabases = async (): Promise<void> => {
+  // Public because it's used in tests
+  public async handleRemoveOrphanedDatabases(): Promise<void> {
     void extLogger.log("Removing orphaned databases from workspace storage.");
     let dbDirs = undefined;
 
@@ -452,12 +464,12 @@ export class DatabaseUI extends DisposableObject {
         )}).\nTo delete unused databases, please remove them manually from the storage folder ${dirname}.`,
       );
     }
-  };
+  }
 
-  chooseDatabaseArchive = async (
+  public async chooseDatabaseArchive(
     progress: ProgressCallback,
     token: CancellationToken,
-  ): Promise<void> => {
+  ): Promise<void> {
     try {
       await this.chooseAndSetDatabase(false, progress, token);
     } catch (e: unknown) {
@@ -467,9 +479,9 @@ export class DatabaseUI extends DisposableObject {
         )`Failed to choose and set database: ${getErrorMessage(e)}`,
       );
     }
-  };
+  }
 
-  private handleChooseDatabaseArchive = async (): Promise<void> => {
+  private async handleChooseDatabaseArchive(): Promise<void> {
     return withProgress(
       async (progress, token) => {
         await this.chooseDatabaseArchive(progress, token);
@@ -478,12 +490,12 @@ export class DatabaseUI extends DisposableObject {
         title: "Adding database from archive",
       },
     );
-  };
+  }
 
-  chooseDatabaseInternet = async (
+  public async chooseDatabaseInternet(
     progress: ProgressCallback,
     token: CancellationToken,
-  ): Promise<DatabaseItem | undefined> => {
+  ): Promise<DatabaseItem | undefined> {
     return await promptImportInternetDatabase(
       this.databaseManager,
       this.storagePath,
@@ -491,11 +503,11 @@ export class DatabaseUI extends DisposableObject {
       token,
       this.queryServer?.cliServer,
     );
-  };
+  }
 
-  private handleChooseDatabaseInternet = async (): Promise<
+  private async handleChooseDatabaseInternet(): Promise<
     DatabaseItem | undefined
-  > => {
+  > {
     return withProgress(
       async (progress, token) => {
         return await this.chooseDatabaseInternet(progress, token);
@@ -504,13 +516,13 @@ export class DatabaseUI extends DisposableObject {
         title: "Adding database from URL",
       },
     );
-  };
+  }
 
-  chooseDatabaseGithub = async (
+  public async chooseDatabaseGithub(
     credentials: Credentials | undefined,
     progress: ProgressCallback,
     token: CancellationToken,
-  ): Promise<DatabaseItem | undefined> => {
+  ): Promise<DatabaseItem | undefined> {
     return await promptImportGithubDatabase(
       this.databaseManager,
       this.storagePath,
@@ -519,11 +531,11 @@ export class DatabaseUI extends DisposableObject {
       token,
       this.queryServer?.cliServer,
     );
-  };
+  }
 
-  private handleChooseDatabaseGithub = async (
+  private async handleChooseDatabaseGithub(
     credentials: Credentials | undefined,
-  ): Promise<DatabaseItem | undefined> => {
+  ): Promise<DatabaseItem | undefined> {
     return withProgress(
       async (progress, token) => {
         return await this.chooseDatabaseGithub(credentials, progress, token);
@@ -532,25 +544,25 @@ export class DatabaseUI extends DisposableObject {
         title: "Adding database from GitHub",
       },
     );
-  };
+  }
 
-  private handleSortByName = async () => {
+  private async handleSortByName() {
     if (this.treeDataProvider.sortOrder === SortOrder.NameAsc) {
       this.treeDataProvider.sortOrder = SortOrder.NameDesc;
     } else {
       this.treeDataProvider.sortOrder = SortOrder.NameAsc;
     }
-  };
+  }
 
-  private handleSortByDateAdded = async () => {
+  private async handleSortByDateAdded() {
     if (this.treeDataProvider.sortOrder === SortOrder.DateAddedAsc) {
       this.treeDataProvider.sortOrder = SortOrder.DateAddedDesc;
     } else {
       this.treeDataProvider.sortOrder = SortOrder.DateAddedAsc;
     }
-  };
+  }
 
-  private handleUpgradeCurrentDatabase = async (): Promise<void> => {
+  private async handleUpgradeCurrentDatabase(): Promise<void> {
     return withProgress(
       async (progress, token) => {
         await this.handleUpgradeDatabaseInternal(
@@ -565,12 +577,12 @@ export class DatabaseUI extends DisposableObject {
         cancellable: true,
       },
     );
-  };
+  }
 
-  private handleUpgradeDatabase = async (
+  private async handleUpgradeDatabase(
     databaseItem: DatabaseItem | undefined,
     multiSelect: DatabaseItem[] | undefined,
-  ): Promise<void> => {
+  ): Promise<void> {
     return withProgress(
       async (progress, token) => {
         return await this.handleUpgradeDatabaseInternal(
@@ -585,14 +597,14 @@ export class DatabaseUI extends DisposableObject {
         cancellable: true,
       },
     );
-  };
+  }
 
-  private handleUpgradeDatabaseInternal = async (
+  private async handleUpgradeDatabaseInternal(
     progress: ProgressCallback,
     token: CancellationToken,
     databaseItem: DatabaseItem | undefined,
     multiSelect: DatabaseItem[] | undefined,
-  ): Promise<void> => {
+  ): Promise<void> {
     if (multiSelect?.length) {
       await Promise.all(
         multiSelect.map((dbItem) =>
@@ -628,9 +640,9 @@ export class DatabaseUI extends DisposableObject {
       progress,
       token,
     );
-  };
+  }
 
-  private handleClearCache = async (): Promise<void> => {
+  private async handleClearCache(): Promise<void> {
     return withProgress(
       async (progress, token) => {
         if (
@@ -648,9 +660,9 @@ export class DatabaseUI extends DisposableObject {
         title: "Clearing cache",
       },
     );
-  };
+  }
 
-  private handleSetCurrentDatabase = async (uri: Uri): Promise<void> => {
+  private async handleSetCurrentDatabase(uri: Uri): Promise<void> {
     return withProgress(
       async (progress, token) => {
         try {
@@ -680,12 +692,12 @@ export class DatabaseUI extends DisposableObject {
         title: "Importing database from archive",
       },
     );
-  };
+  }
 
-  private handleRemoveDatabase = async (
+  private async handleRemoveDatabase(
     databaseItem: DatabaseItem,
     multiSelect: DatabaseItem[] | undefined,
-  ): Promise<void> => {
+  ): Promise<void> {
     return withProgress(
       async (progress, token) => {
         if (multiSelect?.length) {
@@ -707,12 +719,12 @@ export class DatabaseUI extends DisposableObject {
         cancellable: false,
       },
     );
-  };
+  }
 
-  private handleRenameDatabase = async (
+  private async handleRenameDatabase(
     databaseItem: DatabaseItem,
     multiSelect: DatabaseItem[] | undefined,
-  ): Promise<void> => {
+  ): Promise<void> {
     this.assertSingleDatabase(multiSelect);
 
     const newName = await window.showInputBox({
@@ -723,12 +735,12 @@ export class DatabaseUI extends DisposableObject {
     if (newName) {
       await this.databaseManager.renameDatabaseItem(databaseItem, newName);
     }
-  };
+  }
 
-  private handleOpenFolder = async (
+  private async handleOpenFolder(
     databaseItem: DatabaseItem,
     multiSelect: DatabaseItem[] | undefined,
-  ): Promise<void> => {
+  ): Promise<void> {
     if (multiSelect?.length) {
       await Promise.all(
         multiSelect.map((dbItem) => env.openExternal(dbItem.databaseUri)),
@@ -736,17 +748,17 @@ export class DatabaseUI extends DisposableObject {
     } else {
       await env.openExternal(databaseItem.databaseUri);
     }
-  };
+  }
 
   /**
    * Adds the source folder of a CodeQL database to the workspace.
    * When a database is first added in the "Databases" view, its source folder is added to the workspace.
    * If the source folder is removed from the workspace for some reason, we want to be able to re-add it if need be.
    */
-  private handleAddSource = async (
+  private async handleAddSource(
     databaseItem: DatabaseItem,
     multiSelect: DatabaseItem[] | undefined,
-  ): Promise<void> => {
+  ): Promise<void> {
     if (multiSelect?.length) {
       for (const dbItem of multiSelect) {
         await this.databaseManager.addDatabaseSourceArchiveFolder(dbItem);
@@ -754,7 +766,7 @@ export class DatabaseUI extends DisposableObject {
     } else {
       await this.databaseManager.addDatabaseSourceArchiveFolder(databaseItem);
     }
-  };
+  }
 
   /**
    * Return the current database directory. If we don't already have a


### PR DESCRIPTION
This converts the local databases UI to use typed commands. Please review this commit-by-commit since this also does some clean-up of the commands itself.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
