### PR TITLE
Convert new database panel to typed commands

### DIFF
--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -1,5 +1,6 @@
 import type { CommandManager } from "../packages/commands";
 import type { Uri } from "vscode";
+import type { DbTreeViewItem } from "../databases/ui/db-tree-view-item";
 import type { QueryHistoryInfo } from "../query-history/query-history-info";
 
 // A command function matching the signature that VS Code calls when
@@ -7,6 +8,12 @@ import type { QueryHistoryInfo } from "../query-history/query-history-info";
 export type SelectionCommandFunction<Item> = (
   singleItem: Item,
   multiSelect: Item[],
+) => Promise<void>;
+
+// A command function matching the signature that VS Code calls when
+// a command on a selection is invoked when canSelectMany is false.
+export type SingleSelectionCommandFunction<Item> = (
+  singleItem: Item,
 ) => Promise<void>;
 
 /**
@@ -62,8 +69,22 @@ export type VariantAnalysisCommands = {
   "codeQL.runVariantAnalysisContextEditor": (uri?: Uri) => Promise<void>;
 };
 
+export type DatabasePanelCommands = {
+  "codeQLVariantAnalysisRepositories.openConfigFile": () => Promise<void>;
+  "codeQLVariantAnalysisRepositories.addNewDatabase": () => Promise<void>;
+  "codeQLVariantAnalysisRepositories.addNewList": () => Promise<void>;
+  "codeQLVariantAnalysisRepositories.setupControllerRepository": () => Promise<void>;
+
+  "codeQLVariantAnalysisRepositories.setSelectedItem": SingleSelectionCommandFunction<DbTreeViewItem>;
+  "codeQLVariantAnalysisRepositories.setSelectedItemContextMenu": SingleSelectionCommandFunction<DbTreeViewItem>;
+  "codeQLVariantAnalysisRepositories.openOnGitHubContextMenu": SingleSelectionCommandFunction<DbTreeViewItem>;
+  "codeQLVariantAnalysisRepositories.renameItemContextMenu": SingleSelectionCommandFunction<DbTreeViewItem>;
+  "codeQLVariantAnalysisRepositories.removeItemContextMenu": SingleSelectionCommandFunction<DbTreeViewItem>;
+};
+
 export type AllCommands = BaseCommands &
   QueryHistoryCommands &
-  VariantAnalysisCommands;
+  VariantAnalysisCommands &
+  DatabasePanelCommands;
 
 export type AppCommandManager = CommandManager<AllCommands>;

--- a/extensions/ql-vscode/src/databases/db-module.ts
+++ b/extensions/ql-vscode/src/databases/db-module.ts
@@ -6,10 +6,12 @@ import { DbConfigStore } from "./config/db-config-store";
 import { DbManager } from "./db-manager";
 import { DbPanel } from "./ui/db-panel";
 import { DbSelectionDecorationProvider } from "./ui/db-selection-decoration-provider";
+import { DatabasePanelCommands } from "../common/commands";
 
 export class DbModule extends DisposableObject {
   public readonly dbManager: DbManager;
   private readonly dbConfigStore: DbConfigStore;
+  private dbPanel: DbPanel | undefined;
 
   private constructor(app: App) {
     super();
@@ -26,15 +28,24 @@ export class DbModule extends DisposableObject {
     return dbModule;
   }
 
+  public getCommands(): DatabasePanelCommands {
+    if (!this.dbPanel) {
+      throw new Error("Database panel not initialized");
+    }
+
+    return {
+      ...this.dbPanel.getCommands(),
+    };
+  }
+
   private async initialize(app: App): Promise<void> {
     void extLogger.log("Initializing database module");
 
     await this.dbConfigStore.initialize();
 
-    const dbPanel = new DbPanel(this.dbManager, app.credentials);
-    await dbPanel.initialize();
+    this.dbPanel = new DbPanel(this.dbManager, app.credentials);
 
-    this.push(dbPanel);
+    this.push(this.dbPanel);
     this.push(this.dbConfigStore);
 
     const dbSelectionDecorationProvider = new DbSelectionDecorationProvider();

--- a/extensions/ql-vscode/src/databases/ui/db-panel.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-panel.ts
@@ -7,7 +7,7 @@ import {
   window,
   workspace,
 } from "vscode";
-import { commandRunner, UserCancellationException } from "../../commandRunner";
+import { UserCancellationException } from "../../commandRunner";
 import {
   getNwoFromGitHubUrl,
   isValidGitHubNwo,
@@ -32,6 +32,7 @@ import { getGitHubUrl } from "./db-tree-view-item-action";
 import { getControllerRepo } from "../../variant-analysis/run-remote-query";
 import { getErrorMessage } from "../../pure/helpers-pure";
 import { Credentials } from "../../common/authentication";
+import { DatabasePanelCommands } from "../../common/commands";
 
 export interface RemoteDatabaseQuickPickItem extends QuickPickItem {
   kind: string;
@@ -72,58 +73,28 @@ export class DbPanel extends DisposableObject {
     this.push(this.treeView);
   }
 
-  public async initialize(): Promise<void> {
-    this.push(
-      commandRunner("codeQLVariantAnalysisRepositories.openConfigFile", () =>
-        this.openConfigFile(),
-      ),
-    );
-    this.push(
-      commandRunner("codeQLVariantAnalysisRepositories.addNewDatabase", () =>
-        this.addNewRemoteDatabase(),
-      ),
-    );
-    this.push(
-      commandRunner("codeQLVariantAnalysisRepositories.addNewList", () =>
-        this.addNewList(),
-      ),
-    );
-    this.push(
-      commandRunner(
-        "codeQLVariantAnalysisRepositories.setSelectedItem",
-        (treeViewItem: DbTreeViewItem) => this.setSelectedItem(treeViewItem),
-      ),
-    );
-    this.push(
-      commandRunner(
-        "codeQLVariantAnalysisRepositories.setSelectedItemContextMenu",
-        (treeViewItem: DbTreeViewItem) => this.setSelectedItem(treeViewItem),
-      ),
-    );
-    this.push(
-      commandRunner(
-        "codeQLVariantAnalysisRepositories.openOnGitHubContextMenu",
-        (treeViewItem: DbTreeViewItem) => this.openOnGitHub(treeViewItem),
-      ),
-    );
-    this.push(
-      commandRunner(
-        "codeQLVariantAnalysisRepositories.renameItemContextMenu",
-        (treeViewItem: DbTreeViewItem) => this.renameItem(treeViewItem),
-      ),
-    );
-    this.push(
-      commandRunner(
-        "codeQLVariantAnalysisRepositories.removeItemContextMenu",
-        (treeViewItem: DbTreeViewItem) => this.removeItem(treeViewItem),
-      ),
-    );
-    this.push(
-      commandRunner(
-        "codeQLVariantAnalysisRepositories.setupControllerRepository",
-        () => this.setupControllerRepository(),
-      ),
-    );
+  public getCommands(): DatabasePanelCommands {
+    return {
+      "codeQLVariantAnalysisRepositories.openConfigFile":
+        this.openConfigFile.bind(this),
+      "codeQLVariantAnalysisRepositories.addNewDatabase":
+        this.addNewRemoteDatabase.bind(this),
+      "codeQLVariantAnalysisRepositories.addNewList":
+        this.addNewList.bind(this),
+      "codeQLVariantAnalysisRepositories.setupControllerRepository":
+        this.setupControllerRepository.bind(this),
+
+      "codeQLVariantAnalysisRepositories.setSelectedItem":
+        this.setSelectedItem.bind(this),
+      "codeQLVariantAnalysisRepositories.setSelectedItemContextMenu":
+        this.setSelectedItem.bind(this),
+      "codeQLVariantAnalysisRepositories.openOnGitHubContextMenu":
+        this.openOnGitHub.bind(this),
+      "codeQLVariantAnalysisRepositories.renameItemContextMenu":
+        this.renameItem.bind(this),
+      "codeQLVariantAnalysisRepositories.removeItemContextMenu":
+        this.removeItem.bind(this),
+    };
   }
 
   private async openConfigFile(): Promise<void> {

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -1096,6 +1096,7 @@ async function activateWithInstalledDistribution(
     ...getCommands(),
     ...qhm.getCommands(),
     ...variantAnalysisManager.getCommands(),
+    ...dbModule.getCommands(),
   };
 
   for (const [commandName, command] of Object.entries(allCommands)) {


### PR DESCRIPTION
This converts the new database panel to use typed commands. There should be no changes in behaviour.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
