### PR TITLE
Move codeQL.exportSelectedVariantAnalysisResults to query history manager

### DIFF
--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -58,6 +58,9 @@ export type QueryHistoryCommands = {
   "codeQLQueryHistory.itemClicked": SelectionCommandFunction<QueryHistoryInfo>;
   "codeQLQueryHistory.openOnGithub": SelectionCommandFunction<QueryHistoryInfo>;
   "codeQLQueryHistory.copyRepoList": SelectionCommandFunction<QueryHistoryInfo>;
+
+  // Commands in the command pallete
+  "codeQL.exportSelectedVariantAnalysisResults": () => Promise<void>;
 };
 
 // Commands tied to variant analysis

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -109,7 +109,6 @@ import {
   handleInstallPackDependencies,
 } from "./packaging";
 import { HistoryItemLabelProvider } from "./query-history/history-item-label-provider";
-import { exportSelectedVariantAnalysisResults } from "./variant-analysis/export-results";
 import { EvalLogViewer } from "./eval-log-viewer";
 import { SummaryLanguageSupport } from "./log-insights/summary-language-support";
 import { JoinOrderScannerProvider } from "./log-insights/join-order";
@@ -1142,12 +1141,6 @@ async function activateWithInstalledDistribution(
         );
       },
     ),
-  );
-
-  ctx.subscriptions.push(
-    commandRunner("codeQL.exportSelectedVariantAnalysisResults", async () => {
-      await exportSelectedVariantAnalysisResults(variantAnalysisManager, qhm);
-    }),
   );
 
   ctx.subscriptions.push(

--- a/extensions/ql-vscode/src/query-history/query-history-manager.ts
+++ b/extensions/ql-vscode/src/query-history/query-history-manager.ts
@@ -271,6 +271,9 @@ export class QueryHistoryManager extends DisposableObject {
       "codeQLQueryHistory.itemClicked": this.handleItemClicked.bind(this),
       "codeQLQueryHistory.openOnGithub": this.handleOpenOnGithub.bind(this),
       "codeQLQueryHistory.copyRepoList": this.handleCopyRepoList.bind(this),
+
+      "codeQL.exportSelectedVariantAnalysisResults":
+        this.exportSelectedVariantAnalysisResults.bind(this),
     };
   }
 
@@ -1124,6 +1127,22 @@ export class QueryHistoryManager extends DisposableObject {
 
     await this.variantAnalysisManager.exportResults(
       finalSingleItem.variantAnalysis.id,
+    );
+  }
+
+  /**
+   * Exports the results of the currently-selected variant analysis.
+   */
+  async exportSelectedVariantAnalysisResults(): Promise<void> {
+    const queryHistoryItem = this.getCurrentQueryHistoryItem();
+    if (!queryHistoryItem || queryHistoryItem.t !== "variant-analysis") {
+      throw new Error(
+        "No variant analysis results currently open. To open results, click an item in the query history view.",
+      );
+    }
+
+    await this.variantAnalysisManager.exportResults(
+      queryHistoryItem.variantAnalysis.id,
     );
   }
 

--- a/extensions/ql-vscode/src/variant-analysis/export-results.ts
+++ b/extensions/ql-vscode/src/variant-analysis/export-results.ts
@@ -16,7 +16,6 @@ import {
 } from "../commandRunner";
 import { showInformationMessageWithAction } from "../helpers";
 import { extLogger } from "../common";
-import { QueryHistoryManager } from "../query-history/query-history-manager";
 import { createGist } from "./gh-api/gh-api-client";
 import {
   generateVariantAnalysisMarkdown,
@@ -36,25 +35,6 @@ import {
   RepositoriesFilterSortStateWithIds,
 } from "../pure/variant-analysis-filter-sort";
 import { Credentials } from "../common/authentication";
-
-/**
- * Exports the results of the currently-selected variant analysis.
- */
-export async function exportSelectedVariantAnalysisResults(
-  variantAnalysisManager: VariantAnalysisManager,
-  queryHistoryManager: QueryHistoryManager,
-): Promise<void> {
-  const queryHistoryItem = queryHistoryManager.getCurrentQueryHistoryItem();
-  if (!queryHistoryItem || queryHistoryItem.t !== "variant-analysis") {
-    throw new Error(
-      "No variant analysis results currently open. To open results, click an item in the query history view.",
-    );
-  }
-
-  await variantAnalysisManager.exportResults(
-    queryHistoryItem.variantAnalysis.id,
-  );
-}
 
 const MAX_VARIANT_ANALYSIS_EXPORT_PROGRESS_STEPS = 2;
 


### PR DESCRIPTION
This follows on from https://github.com/github/vscode-codeql/pull/2186 and is also tangentially related to converting the variant analysis commands (https://github.com/github/vscode-codeql/pull/2191).

I think this command probably fits best on the query history manager, because it is acting on the variant analysis currently selected in the query history panel. I've checked and having a view open does not affect it. It's purely operating on the query history selection state.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
