### PR TITLE
Convert local query commands to typed commands

### DIFF
--- a/extensions/ql-vscode/src/commandRunner.ts
+++ b/extensions/ql-vscode/src/commandRunner.ts
@@ -89,7 +89,7 @@ export type ProgressTaskWithArgs<R> = (
  * @param args arguments passed to this task passed on from
  * `commands.registerCommand`.
  */
-type NoProgressTask = (...args: any[]) => Promise<any>;
+export type NoProgressTask = (...args: any[]) => Promise<any>;
 
 /**
  * This mediates between the kind of progress callbacks we want to

--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -1,5 +1,5 @@
 import type { CommandManager } from "../packages/commands";
-import type { Uri } from "vscode";
+import type { Uri, Range } from "vscode";
 import type { DbTreeViewItem } from "../databases/ui/db-tree-view-item";
 import type { DatabaseItem } from "../local-databases";
 import type { QueryHistoryInfo } from "../query-history/query-history-info";
@@ -27,6 +27,21 @@ export type SingleSelectionCommandFunction<Item> = (
 // Base commands not tied directly to a module like e.g. variant analysis.
 export type BaseCommands = {
   "codeQL.openDocumentation": () => Promise<void>;
+};
+
+// Commands used for running local queries
+export type LocalQueryCommands = {
+  "codeQL.runQuery": (uri?: Uri) => Promise<void>;
+  "codeQL.runQueryContextEditor": (uri?: Uri) => Promise<void>;
+  "codeQL.runQueryOnMultipleDatabases": (uri?: Uri) => Promise<void>;
+  "codeQL.runQueryOnMultipleDatabasesContextEditor": (
+    uri?: Uri,
+  ) => Promise<void>;
+  "codeQL.runQueries": SelectionCommandFunction<Uri>;
+  "codeQL.quickEval": (uri: Uri) => Promise<void>;
+  "codeQL.quickEvalContextEditor": (uri: Uri) => Promise<void>;
+  "codeQL.codeLensQuickEval": (uri: Uri, range: Range) => Promise<void>;
+  "codeQL.quickQuery": () => Promise<void>;
 };
 
 // Commands used for the query history panel
@@ -115,3 +130,7 @@ export type AllCommands = BaseCommands &
   DatabasePanelCommands;
 
 export type AppCommandManager = CommandManager<AllCommands>;
+
+// Separate command manager because it uses a different logger
+export type QueryServerCommands = LocalQueryCommands;
+export type QueryServerCommandManager = CommandManager<QueryServerCommands>;

--- a/extensions/ql-vscode/src/common/vscode/commands.ts
+++ b/extensions/ql-vscode/src/common/vscode/commands.ts
@@ -1,6 +1,7 @@
 import { commands } from "vscode";
-import { commandRunner } from "../../commandRunner";
+import { commandRunner, NoProgressTask } from "../../commandRunner";
 import { CommandFunction, CommandManager } from "../../packages/commands";
+import { OutputChannelLogger } from "../logging";
 
 /**
  * Create a command manager for VSCode, wrapping the commandRunner
@@ -8,8 +9,10 @@ import { CommandFunction, CommandManager } from "../../packages/commands";
  */
 export function createVSCodeCommandManager<
   Commands extends Record<string, CommandFunction>,
->(): CommandManager<Commands> {
-  return new CommandManager(commandRunner, wrapExecuteCommand);
+>(outputLogger?: OutputChannelLogger): CommandManager<Commands> {
+  return new CommandManager((commandId, task: NoProgressTask) => {
+    return commandRunner(commandId, task, outputLogger);
+  }, wrapExecuteCommand);
 }
 
 /**

--- a/extensions/ql-vscode/src/common/vscode/vscode-app.ts
+++ b/extensions/ql-vscode/src/common/vscode/vscode-app.ts
@@ -3,21 +3,23 @@ import { VSCodeCredentials } from "../../authentication";
 import { Disposable } from "../../pure/disposable-object";
 import { App, AppMode } from "../app";
 import { AppEventEmitter } from "../events";
-import { extLogger, Logger } from "../logging";
+import { extLogger, Logger, queryServerLogger } from "../logging";
 import { Memento } from "../memento";
 import { VSCodeAppEventEmitter } from "./events";
-import { AppCommandManager } from "../commands";
+import { AppCommandManager, QueryServerCommandManager } from "../commands";
 import { createVSCodeCommandManager } from "./commands";
 
 export class ExtensionApp implements App {
   public readonly credentials: VSCodeCredentials;
   public readonly commands: AppCommandManager;
+  public readonly queryServerCommands: QueryServerCommandManager;
 
   public constructor(
     public readonly extensionContext: vscode.ExtensionContext,
   ) {
     this.credentials = new VSCodeCredentials();
     this.commands = createVSCodeCommandManager();
+    this.queryServerCommands = createVSCodeCommandManager(queryServerLogger);
     extensionContext.subscriptions.push(this.commands);
   }
 

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -1,7 +1,6 @@
 import "source-map-support/register";
 import {
   CancellationToken,
-  CancellationTokenSource,
   commands,
   Disposable,
   env,
@@ -9,8 +8,6 @@ import {
   extensions,
   languages,
   ProgressLocation,
-  QuickPickItem,
-  Range,
   Uri,
   version as vscodeVersion,
   window as Window,
@@ -36,12 +33,11 @@ import {
   CliConfigListener,
   DistributionConfigListener,
   joinOrderWarningThreshold,
-  MAX_QUERIES,
   QueryHistoryConfigListener,
   QueryServerConfigListener,
 } from "./config";
 import { install } from "./languageSupport";
-import { DatabaseItem, DatabaseManager } from "./local-databases";
+import { DatabaseManager } from "./local-databases";
 import { DatabaseUI } from "./local-databases-ui";
 import {
   TemplatePrintAstProvider,
@@ -60,7 +56,6 @@ import {
   GithubRateLimitedError,
 } from "./distribution";
 import {
-  findLanguage,
   showAndLogErrorMessage,
   showAndLogExceptionWithTelemetry,
   showAndLogInformationMessage,
@@ -86,20 +81,17 @@ import {
   queryServerLogger,
 } from "./common";
 import { QueryHistoryManager } from "./query-history/query-history-manager";
-import { CompletedLocalQueryInfo, LocalQueryInfo } from "./query-results";
+import { CompletedLocalQueryInfo } from "./query-results";
 import { QueryServerClient as LegacyQueryServerClient } from "./legacy-query-server/queryserver-client";
 import { QueryServerClient } from "./query-server/queryserver-client";
-import { displayQuickQuery } from "./quick-query";
 import { QLTestAdapterFactory } from "./test-adapter";
 import { TestUIService } from "./test-ui";
 import { CompareView } from "./compare/compare-view";
-import { gatherQlFiles } from "./pure/files";
 import { initializeTelemetry } from "./telemetry";
 import {
   commandRunner,
   commandRunnerWithProgress,
   ProgressCallback,
-  ProgressUpdate,
   withProgress,
 } from "./commandRunner";
 import { CodeQlStatusBarHandler } from "./status-bar";
@@ -113,7 +105,6 @@ import { EvalLogViewer } from "./eval-log-viewer";
 import { SummaryLanguageSupport } from "./log-insights/summary-language-support";
 import { JoinOrderScannerProvider } from "./log-insights/join-order";
 import { LogScannerService } from "./log-insights/log-scanner-service";
-import { createInitialQueryInfo } from "./run-queries-shared";
 import { LegacyQueryRunner } from "./legacy-query-server/legacyRunner";
 import { NewQueryRunner } from "./query-server/query-runner";
 import { QueryRunner } from "./queryRunner";
@@ -134,6 +125,11 @@ import { redactableError } from "./pure/errors";
 import { QueryHistoryDirs } from "./query-history/query-history-dirs";
 import { DirResult } from "tmp";
 import { AllCommands, BaseCommands } from "./common/commands";
+import {
+  compileAndRunQuery,
+  registerLocalQueryCommands,
+  showResultsForCompletedQuery,
+} from "./local-queries";
 
 /**
  * extension.ts
@@ -224,10 +220,6 @@ interface DistributionUpdateConfig {
   isUserInitiated: boolean;
   shouldDisplayMessageWhenNoUpdates: boolean;
   allowAutoUpdating: boolean;
-}
-
-interface DatabaseQuickPickItem extends QuickPickItem {
-  databaseItem: DatabaseItem;
 }
 
 const shouldUpdateOnNextActivationKey = "shouldUpdateOnNextActivation";
@@ -792,300 +784,16 @@ async function activateWithInstalledDistribution(
   }
 
   void extLogger.log("Registering top-level command palette commands.");
-  ctx.subscriptions.push(
-    commandRunnerWithProgress(
-      "codeQL.runQuery",
-      async (
-        progress: ProgressCallback,
-        token: CancellationToken,
-        uri: Uri | undefined,
-      ) =>
-        await compileAndRunQuery(
-          qs,
-          qhm,
-          databaseUI,
-          localQueryResultsView,
-          queryStorageDir,
-          false,
-          uri,
-          progress,
-          token,
-          undefined,
-        ),
-      {
-        title: "Running query",
-        cancellable: true,
-      },
 
-      // Open the query server logger on error since that's usually where the interesting errors appear.
-      queryServerLogger,
-    ),
-  );
-
-  // Since we are tracking extension usage through commands, this command mirrors the runQuery command
-  ctx.subscriptions.push(
-    commandRunnerWithProgress(
-      "codeQL.runQueryContextEditor",
-      async (
-        progress: ProgressCallback,
-        token: CancellationToken,
-        uri: Uri | undefined,
-      ) =>
-        await compileAndRunQuery(
-          qs,
-          qhm,
-          databaseUI,
-          localQueryResultsView,
-          queryStorageDir,
-          false,
-          uri,
-          progress,
-          token,
-          undefined,
-        ),
-      {
-        title: "Running query",
-        cancellable: true,
-      },
-
-      // Open the query server logger on error since that's usually where the interesting errors appear.
-      queryServerLogger,
-    ),
-  );
-  ctx.subscriptions.push(
-    commandRunnerWithProgress(
-      "codeQL.runQueryOnMultipleDatabases",
-      async (
-        progress: ProgressCallback,
-        token: CancellationToken,
-        uri: Uri | undefined,
-      ) =>
-        await compileAndRunQueryOnMultipleDatabases(
-          cliServer,
-          qs,
-          qhm,
-          dbm,
-          databaseUI,
-          localQueryResultsView,
-          queryStorageDir,
-          progress,
-          token,
-          uri,
-        ),
-      {
-        title: "Running query on selected databases",
-        cancellable: true,
-      },
-    ),
-  );
-  // Since we are tracking extension usage through commands, this command mirrors the runQueryOnMultipleDatabases command
-  ctx.subscriptions.push(
-    commandRunnerWithProgress(
-      "codeQL.runQueryOnMultipleDatabasesContextEditor",
-      async (
-        progress: ProgressCallback,
-        token: CancellationToken,
-        uri: Uri | undefined,
-      ) =>
-        await compileAndRunQueryOnMultipleDatabases(
-          cliServer,
-          qs,
-          qhm,
-          dbm,
-          databaseUI,
-          localQueryResultsView,
-          queryStorageDir,
-          progress,
-          token,
-          uri,
-        ),
-      {
-        title: "Running query on selected databases",
-        cancellable: true,
-      },
-    ),
-  );
-  ctx.subscriptions.push(
-    commandRunnerWithProgress(
-      "codeQL.runQueries",
-      async (
-        progress: ProgressCallback,
-        token: CancellationToken,
-        _: Uri | undefined,
-        multi: Uri[],
-      ) => {
-        const maxQueryCount = MAX_QUERIES.getValue() as number;
-        const [files, dirFound] = await gatherQlFiles(
-          multi.map((uri) => uri.fsPath),
-        );
-        if (files.length > maxQueryCount) {
-          throw new Error(
-            `You tried to run ${files.length} queries, but the maximum is ${maxQueryCount}. Try selecting fewer queries or changing the 'codeQL.runningQueries.maxQueries' setting.`,
-          );
-        }
-        // warn user and display selected files when a directory is selected because some ql
-        // files may be hidden from the user.
-        if (dirFound) {
-          const fileString = files.map((file) => basename(file)).join(", ");
-          const res = await showBinaryChoiceDialog(
-            `You are about to run ${files.length} queries: ${fileString} Do you want to continue?`,
-          );
-          if (!res) {
-            return;
-          }
-        }
-        const queryUris = files.map((path) => Uri.parse(`file:${path}`, true));
-
-        // Use a wrapped progress so that messages appear with the queries remaining in it.
-        let queriesRemaining = queryUris.length;
-        function wrappedProgress(update: ProgressUpdate) {
-          const message =
-            queriesRemaining > 1
-              ? `${queriesRemaining} remaining. ${update.message}`
-              : update.message;
-          progress({
-            ...update,
-            message,
-          });
-        }
-
-        wrappedProgress({
-          maxStep: queryUris.length,
-          step: queryUris.length - queriesRemaining,
-          message: "",
-        });
-
-        await Promise.all(
-          queryUris.map(async (uri) =>
-            compileAndRunQuery(
-              qs,
-              qhm,
-              databaseUI,
-              localQueryResultsView,
-              queryStorageDir,
-              false,
-              uri,
-              wrappedProgress,
-              token,
-              undefined,
-            ).then(() => queriesRemaining--),
-          ),
-        );
-      },
-      {
-        title: "Running queries",
-        cancellable: true,
-      },
-
-      // Open the query server logger on error since that's usually where the interesting errors appear.
-      queryServerLogger,
-    ),
-  );
-
-  ctx.subscriptions.push(
-    commandRunnerWithProgress(
-      "codeQL.quickEval",
-      async (
-        progress: ProgressCallback,
-        token: CancellationToken,
-        uri: Uri | undefined,
-      ) =>
-        await compileAndRunQuery(
-          qs,
-          qhm,
-          databaseUI,
-          localQueryResultsView,
-          queryStorageDir,
-          true,
-          uri,
-          progress,
-          token,
-          undefined,
-        ),
-      {
-        title: "Running query",
-        cancellable: true,
-      },
-      // Open the query server logger on error since that's usually where the interesting errors appear.
-      queryServerLogger,
-    ),
-  );
-
-  // Since we are tracking extension usage through commands, this command mirrors the "codeQL.quickEval" command
-  ctx.subscriptions.push(
-    commandRunnerWithProgress(
-      "codeQL.quickEvalContextEditor",
-      async (
-        progress: ProgressCallback,
-        token: CancellationToken,
-        uri: Uri | undefined,
-      ) =>
-        await compileAndRunQuery(
-          qs,
-          qhm,
-          databaseUI,
-          localQueryResultsView,
-          queryStorageDir,
-          true,
-          uri,
-          progress,
-          token,
-          undefined,
-        ),
-      {
-        title: "Running query",
-        cancellable: true,
-      },
-      // Open the query server logger on error since that's usually where the interesting errors appear.
-      queryServerLogger,
-    ),
-  );
-
-  ctx.subscriptions.push(
-    commandRunnerWithProgress(
-      "codeQL.codeLensQuickEval",
-      async (
-        progress: ProgressCallback,
-        token: CancellationToken,
-        uri: Uri,
-        range: Range,
-      ) =>
-        await compileAndRunQuery(
-          qs,
-          qhm,
-          databaseUI,
-          localQueryResultsView,
-          queryStorageDir,
-          true,
-          uri,
-          progress,
-          token,
-          undefined,
-          range,
-        ),
-      {
-        title: "Running query",
-        cancellable: true,
-      },
-
-      // Open the query server logger on error since that's usually where the interesting errors appear.
-      queryServerLogger,
-    ),
-  );
-
-  ctx.subscriptions.push(
-    commandRunnerWithProgress(
-      "codeQL.quickQuery",
-      async (progress: ProgressCallback, token: CancellationToken) =>
-        displayQuickQuery(ctx, cliServer, databaseUI, progress, token),
-      {
-        title: "Run Quick Query",
-      },
-
-      // Open the query server logger on error since that's usually where the interesting errors appear.
-      queryServerLogger,
-    ),
-  );
+  registerLocalQueryCommands(ctx, {
+    queryRunner: qs,
+    queryHistoryManager: qhm,
+    databaseManager: dbm,
+    cliServer,
+    databaseUI,
+    localQueryResultsView,
+    queryStorageDir,
+  });
 
   const allCommands: AllCommands = {
     ...getCommands(),
@@ -1597,160 +1305,6 @@ async function showResultsForComparison(
         e,
       )}`,
     );
-  }
-}
-
-async function showResultsForCompletedQuery(
-  localQueryResultsView: ResultsView,
-  query: CompletedLocalQueryInfo,
-  forceReveal: WebviewReveal,
-): Promise<void> {
-  await localQueryResultsView.showResults(query, forceReveal, false);
-}
-async function compileAndRunQuery(
-  qs: QueryRunner,
-  qhm: QueryHistoryManager,
-  databaseUI: DatabaseUI,
-  localQueryResultsView: ResultsView,
-  queryStorageDir: string,
-  quickEval: boolean,
-  selectedQuery: Uri | undefined,
-  progress: ProgressCallback,
-  token: CancellationToken,
-  databaseItem: DatabaseItem | undefined,
-  range?: Range,
-): Promise<void> {
-  if (qs !== undefined) {
-    // If no databaseItem is specified, use the database currently selected in the Databases UI
-    databaseItem =
-      databaseItem || (await databaseUI.getDatabaseItem(progress, token));
-    if (databaseItem === undefined) {
-      throw new Error("Can't run query without a selected database");
-    }
-    const databaseInfo = {
-      name: databaseItem.name,
-      databaseUri: databaseItem.databaseUri.toString(),
-    };
-
-    // handle cancellation from the history view.
-    const source = new CancellationTokenSource();
-    token.onCancellationRequested(() => source.cancel());
-
-    const initialInfo = await createInitialQueryInfo(
-      selectedQuery,
-      databaseInfo,
-      quickEval,
-      range,
-    );
-    const item = new LocalQueryInfo(initialInfo, source);
-    qhm.addQuery(item);
-    try {
-      const completedQueryInfo = await qs.compileAndRunQueryAgainstDatabase(
-        databaseItem,
-        initialInfo,
-        queryStorageDir,
-        progress,
-        source.token,
-        undefined,
-        item,
-      );
-      qhm.completeQuery(item, completedQueryInfo);
-      await showResultsForCompletedQuery(
-        localQueryResultsView,
-        item as CompletedLocalQueryInfo,
-        WebviewReveal.Forced,
-      );
-      // Note we must update the query history view after showing results as the
-      // display and sorting might depend on the number of results
-    } catch (e) {
-      const err = asError(e);
-      err.message = `Error running query: ${err.message}`;
-      item.failureReason = err.message;
-      throw e;
-    } finally {
-      await qhm.refreshTreeView();
-      source.dispose();
-    }
-  }
-}
-
-async function compileAndRunQueryOnMultipleDatabases(
-  cliServer: CodeQLCliServer,
-  qs: QueryRunner,
-  qhm: QueryHistoryManager,
-  dbm: DatabaseManager,
-  databaseUI: DatabaseUI,
-  localQueryResultsView: ResultsView,
-  queryStorageDir: string,
-  progress: ProgressCallback,
-  token: CancellationToken,
-  uri: Uri | undefined,
-): Promise<void> {
-  let filteredDBs = dbm.databaseItems;
-  if (filteredDBs.length === 0) {
-    void showAndLogErrorMessage(
-      "No databases found. Please add a suitable database to your workspace.",
-    );
-    return;
-  }
-  // If possible, only show databases with the right language (otherwise show all databases).
-  const queryLanguage = await findLanguage(cliServer, uri);
-  if (queryLanguage) {
-    filteredDBs = dbm.databaseItems.filter(
-      (db) => db.language === queryLanguage,
-    );
-    if (filteredDBs.length === 0) {
-      void showAndLogErrorMessage(
-        `No databases found for language ${queryLanguage}. Please add a suitable database to your workspace.`,
-      );
-      return;
-    }
-  }
-  const quickPickItems = filteredDBs.map<DatabaseQuickPickItem>((dbItem) => ({
-    databaseItem: dbItem,
-    label: dbItem.name,
-    description: dbItem.language,
-  }));
-  /**
-   * Databases that were selected in the quick pick menu.
-   */
-  const quickpick = await window.showQuickPick<DatabaseQuickPickItem>(
-    quickPickItems,
-    { canPickMany: true, ignoreFocusOut: true },
-  );
-  if (quickpick !== undefined) {
-    // Collect all skipped databases and display them at the end (instead of popping up individual errors)
-    const skippedDatabases = [];
-    const errors = [];
-    for (const item of quickpick) {
-      try {
-        await compileAndRunQuery(
-          qs,
-          qhm,
-          databaseUI,
-          localQueryResultsView,
-          queryStorageDir,
-          false,
-          uri,
-          progress,
-          token,
-          item.databaseItem,
-        );
-      } catch (e) {
-        skippedDatabases.push(item.label);
-        errors.push(getErrorMessage(e));
-      }
-    }
-    if (skippedDatabases.length > 0) {
-      void extLogger.log(`Errors:\n${errors.join("\n")}`);
-      void showAndLogWarningMessage(
-        `The following databases were skipped:\n${skippedDatabases.join(
-          "\n",
-        )}.\nFor details about the errors, see the logs.`,
-      );
-    }
-  } else {
-    void showAndLogErrorMessage("No databases selected.");
   }
 }
 

--- a/extensions/ql-vscode/src/local-queries.ts
+++ b/extensions/ql-vscode/src/local-queries.ts
@@ -47,9 +47,9 @@ type LocalQueryOptions = {
 export function registerLocalQueryCommands(
   ctx: ExtensionContext,
   {
-    queryRunner: qs,
-    queryHistoryManager: qhm,
-    databaseManager: dbm,
+    queryRunner,
+    queryHistoryManager,
+    databaseManager,
     cliServer,
     databaseUI,
     localQueryResultsView,
@@ -65,8 +65,8 @@ export function registerLocalQueryCommands(
         uri: Uri | undefined,
       ) =>
         await compileAndRunQuery(
-          qs,
-          qhm,
+          queryRunner,
+          queryHistoryManager,
           databaseUI,
           localQueryResultsView,
           queryStorageDir,
@@ -96,8 +96,8 @@ export function registerLocalQueryCommands(
         uri: Uri | undefined,
       ) =>
         await compileAndRunQuery(
-          qs,
-          qhm,
+          queryRunner,
+          queryHistoryManager,
           databaseUI,
           localQueryResultsView,
           queryStorageDir,
@@ -126,9 +126,9 @@ export function registerLocalQueryCommands(
       ) =>
         await compileAndRunQueryOnMultipleDatabases(
           cliServer,
-          qs,
-          qhm,
-          dbm,
+          queryRunner,
+          queryHistoryManager,
+          databaseManager,
           databaseUI,
           localQueryResultsView,
           queryStorageDir,
@@ -153,9 +153,9 @@ export function registerLocalQueryCommands(
       ) =>
         await compileAndRunQueryOnMultipleDatabases(
           cliServer,
-          qs,
-          qhm,
-          dbm,
+          queryRunner,
+          queryHistoryManager,
+          databaseManager,
           databaseUI,
           localQueryResultsView,
           queryStorageDir,
@@ -222,8 +222,8 @@ export function registerLocalQueryCommands(
         await Promise.all(
           queryUris.map(async (uri) =>
             compileAndRunQuery(
-              qs,
-              qhm,
+              queryRunner,
+              queryHistoryManager,
               databaseUI,
               localQueryResultsView,
               queryStorageDir,
@@ -255,8 +255,8 @@ export function registerLocalQueryCommands(
         uri: Uri | undefined,
       ) =>
         await compileAndRunQuery(
-          qs,
-          qhm,
+          queryRunner,
+          queryHistoryManager,
           databaseUI,
           localQueryResultsView,
           queryStorageDir,
@@ -285,8 +285,8 @@ export function registerLocalQueryCommands(
         uri: Uri | undefined,
       ) =>
         await compileAndRunQuery(
-          qs,
-          qhm,
+          queryRunner,
+          queryHistoryManager,
           databaseUI,
           localQueryResultsView,
           queryStorageDir,
@@ -315,8 +315,8 @@ export function registerLocalQueryCommands(
         range: Range,
       ) =>
         await compileAndRunQuery(
-          qs,
-          qhm,
+          queryRunner,
+          queryHistoryManager,
           databaseUI,
           localQueryResultsView,
           queryStorageDir,

--- a/extensions/ql-vscode/src/local-queries.ts
+++ b/extensions/ql-vscode/src/local-queries.ts
@@ -1,0 +1,512 @@
+import {
+  commandRunnerWithProgress,
+  ProgressCallback,
+  ProgressUpdate,
+} from "./commandRunner";
+import {
+  CancellationToken,
+  CancellationTokenSource,
+  ExtensionContext,
+  QuickPickItem,
+  Range,
+  Uri,
+  window,
+} from "vscode";
+import { extLogger, queryServerLogger } from "./common";
+import { MAX_QUERIES } from "./config";
+import { gatherQlFiles } from "./pure/files";
+import { basename } from "path";
+import {
+  findLanguage,
+  showAndLogErrorMessage,
+  showAndLogWarningMessage,
+  showBinaryChoiceDialog,
+} from "./helpers";
+import { displayQuickQuery } from "./quick-query";
+import { QueryRunner } from "./queryRunner";
+import { QueryHistoryManager } from "./query-history/query-history-manager";
+import { DatabaseUI } from "./local-databases-ui";
+import { ResultsView } from "./interface";
+import { DatabaseItem, DatabaseManager } from "./local-databases";
+import { createInitialQueryInfo } from "./run-queries-shared";
+import { CompletedLocalQueryInfo, LocalQueryInfo } from "./query-results";
+import { WebviewReveal } from "./interface-utils";
+import { asError, getErrorMessage } from "./pure/helpers-pure";
+import { CodeQLCliServer } from "./cli";
+
+type LocalQueryOptions = {
+  queryRunner: QueryRunner;
+  queryHistoryManager: QueryHistoryManager;
+  databaseManager: DatabaseManager;
+  cliServer: CodeQLCliServer;
+  databaseUI: DatabaseUI;
+  localQueryResultsView: ResultsView;
+  queryStorageDir: string;
+};
+
+export function registerLocalQueryCommands(
+  ctx: ExtensionContext,
+  {
+    queryRunner: qs,
+    queryHistoryManager: qhm,
+    databaseManager: dbm,
+    cliServer,
+    databaseUI,
+    localQueryResultsView,
+    queryStorageDir,
+  }: LocalQueryOptions,
+) {
+  ctx.subscriptions.push(
+    commandRunnerWithProgress(
+      "codeQL.runQuery",
+      async (
+        progress: ProgressCallback,
+        token: CancellationToken,
+        uri: Uri | undefined,
+      ) =>
+        await compileAndRunQuery(
+          qs,
+          qhm,
+          databaseUI,
+          localQueryResultsView,
+          queryStorageDir,
+          false,
+          uri,
+          progress,
+          token,
+          undefined,
+        ),
+      {
+        title: "Running query",
+        cancellable: true,
+      },
+
+      // Open the query server logger on error since that's usually where the interesting errors appear.
+      queryServerLogger,
+    ),
+  );
+
+  // Since we are tracking extension usage through commands, this command mirrors the runQuery command
+  ctx.subscriptions.push(
+    commandRunnerWithProgress(
+      "codeQL.runQueryContextEditor",
+      async (
+        progress: ProgressCallback,
+        token: CancellationToken,
+        uri: Uri | undefined,
+      ) =>
+        await compileAndRunQuery(
+          qs,
+          qhm,
+          databaseUI,
+          localQueryResultsView,
+          queryStorageDir,
+          false,
+          uri,
+          progress,
+          token,
+          undefined,
+        ),
+      {
+        title: "Running query",
+        cancellable: true,
+      },
+
+      // Open the query server logger on error since that's usually where the interesting errors appear.
+      queryServerLogger,
+    ),
+  );
+  ctx.subscriptions.push(
+    commandRunnerWithProgress(
+      "codeQL.runQueryOnMultipleDatabases",
+      async (
+        progress: ProgressCallback,
+        token: CancellationToken,
+        uri: Uri | undefined,
+      ) =>
+        await compileAndRunQueryOnMultipleDatabases(
+          cliServer,
+          qs,
+          qhm,
+          dbm,
+          databaseUI,
+          localQueryResultsView,
+          queryStorageDir,
+          progress,
+          token,
+          uri,
+        ),
+      {
+        title: "Running query on selected databases",
+        cancellable: true,
+      },
+    ),
+  );
+  // Since we are tracking extension usage through commands, this command mirrors the runQueryOnMultipleDatabases command
+  ctx.subscriptions.push(
+    commandRunnerWithProgress(
+      "codeQL.runQueryOnMultipleDatabasesContextEditor",
+      async (
+        progress: ProgressCallback,
+        token: CancellationToken,
+        uri: Uri | undefined,
+      ) =>
+        await compileAndRunQueryOnMultipleDatabases(
+          cliServer,
+          qs,
+          qhm,
+          dbm,
+          databaseUI,
+          localQueryResultsView,
+          queryStorageDir,
+          progress,
+          token,
+          uri,
+        ),
+      {
+        title: "Running query on selected databases",
+        cancellable: true,
+      },
+    ),
+  );
+  ctx.subscriptions.push(
+    commandRunnerWithProgress(
+      "codeQL.runQueries",
+      async (
+        progress: ProgressCallback,
+        token: CancellationToken,
+        _: Uri | undefined,
+        multi: Uri[],
+      ) => {
+        const maxQueryCount = MAX_QUERIES.getValue() as number;
+        const [files, dirFound] = await gatherQlFiles(
+          multi.map((uri) => uri.fsPath),
+        );
+        if (files.length > maxQueryCount) {
+          throw new Error(
+            `You tried to run ${files.length} queries, but the maximum is ${maxQueryCount}. Try selecting fewer queries or changing the 'codeQL.runningQueries.maxQueries' setting.`,
+          );
+        }
+        // warn user and display selected files when a directory is selected because some ql
+        // files may be hidden from the user.
+        if (dirFound) {
+          const fileString = files.map((file) => basename(file)).join(", ");
+          const res = await showBinaryChoiceDialog(
+            `You are about to run ${files.length} queries: ${fileString} Do you want to continue?`,
+          );
+          if (!res) {
+            return;
+          }
+        }
+        const queryUris = files.map((path) => Uri.parse(`file:${path}`, true));
+
+        // Use a wrapped progress so that messages appear with the queries remaining in it.
+        let queriesRemaining = queryUris.length;
+        function wrappedProgress(update: ProgressUpdate) {
+          const message =
+            queriesRemaining > 1
+              ? `${queriesRemaining} remaining. ${update.message}`
+              : update.message;
+          progress({
+            ...update,
+            message,
+          });
+        }
+
+        wrappedProgress({
+          maxStep: queryUris.length,
+          step: queryUris.length - queriesRemaining,
+          message: "",
+        });
+
+        await Promise.all(
+          queryUris.map(async (uri) =>
+            compileAndRunQuery(
+              qs,
+              qhm,
+              databaseUI,
+              localQueryResultsView,
+              queryStorageDir,
+              false,
+              uri,
+              wrappedProgress,
+              token,
+              undefined,
+            ).then(() => queriesRemaining--),
+          ),
+        );
+      },
+      {
+        title: "Running queries",
+        cancellable: true,
+      },
+
+      // Open the query server logger on error since that's usually where the interesting errors appear.
+      queryServerLogger,
+    ),
+  );
+
+  ctx.subscriptions.push(
+    commandRunnerWithProgress(
+      "codeQL.quickEval",
+      async (
+        progress: ProgressCallback,
+        token: CancellationToken,
+        uri: Uri | undefined,
+      ) =>
+        await compileAndRunQuery(
+          qs,
+          qhm,
+          databaseUI,
+          localQueryResultsView,
+          queryStorageDir,
+          true,
+          uri,
+          progress,
+          token,
+          undefined,
+        ),
+      {
+        title: "Running query",
+        cancellable: true,
+      },
+      // Open the query server logger on error since that's usually where the interesting errors appear.
+      queryServerLogger,
+    ),
+  );
+
+  // Since we are tracking extension usage through commands, this command mirrors the "codeQL.quickEval" command
+  ctx.subscriptions.push(
+    commandRunnerWithProgress(
+      "codeQL.quickEvalContextEditor",
+      async (
+        progress: ProgressCallback,
+        token: CancellationToken,
+        uri: Uri | undefined,
+      ) =>
+        await compileAndRunQuery(
+          qs,
+          qhm,
+          databaseUI,
+          localQueryResultsView,
+          queryStorageDir,
+          true,
+          uri,
+          progress,
+          token,
+          undefined,
+        ),
+      {
+        title: "Running query",
+        cancellable: true,
+      },
+      // Open the query server logger on error since that's usually where the interesting errors appear.
+      queryServerLogger,
+    ),
+  );
+
+  ctx.subscriptions.push(
+    commandRunnerWithProgress(
+      "codeQL.codeLensQuickEval",
+      async (
+        progress: ProgressCallback,
+        token: CancellationToken,
+        uri: Uri,
+        range: Range,
+      ) =>
+        await compileAndRunQuery(
+          qs,
+          qhm,
+          databaseUI,
+          localQueryResultsView,
+          queryStorageDir,
+          true,
+          uri,
+          progress,
+          token,
+          undefined,
+          range,
+        ),
+      {
+        title: "Running query",
+        cancellable: true,
+      },
+
+      // Open the query server logger on error since that's usually where the interesting errors appear.
+      queryServerLogger,
+    ),
+  );
+
+  ctx.subscriptions.push(
+    commandRunnerWithProgress(
+      "codeQL.quickQuery",
+      async (progress: ProgressCallback, token: CancellationToken) =>
+        displayQuickQuery(ctx, cliServer, databaseUI, progress, token),
+      {
+        title: "Run Quick Query",
+      },
+
+      // Open the query server logger on error since that's usually where the interesting errors appear.
+      queryServerLogger,
+    ),
+  );
+}
+
+export async function compileAndRunQuery(
+  qs: QueryRunner,
+  qhm: QueryHistoryManager,
+  databaseUI: DatabaseUI,
+  localQueryResultsView: ResultsView,
+  queryStorageDir: string,
+  quickEval: boolean,
+  selectedQuery: Uri | undefined,
+  progress: ProgressCallback,
+  token: CancellationToken,
+  databaseItem: DatabaseItem | undefined,
+  range?: Range,
+): Promise<void> {
+  if (qs !== undefined) {
+    // If no databaseItem is specified, use the database currently selected in the Databases UI
+    databaseItem =
+      databaseItem || (await databaseUI.getDatabaseItem(progress, token));
+    if (databaseItem === undefined) {
+      throw new Error("Can't run query without a selected database");
+    }
+    const databaseInfo = {
+      name: databaseItem.name,
+      databaseUri: databaseItem.databaseUri.toString(),
+    };
+
+    // handle cancellation from the history view.
+    const source = new CancellationTokenSource();
+    token.onCancellationRequested(() => source.cancel());
+
+    const initialInfo = await createInitialQueryInfo(
+      selectedQuery,
+      databaseInfo,
+      quickEval,
+      range,
+    );
+    const item = new LocalQueryInfo(initialInfo, source);
+    qhm.addQuery(item);
+    try {
+      const completedQueryInfo = await qs.compileAndRunQueryAgainstDatabase(
+        databaseItem,
+        initialInfo,
+        queryStorageDir,
+        progress,
+        source.token,
+        undefined,
+        item,
+      );
+      qhm.completeQuery(item, completedQueryInfo);
+      await showResultsForCompletedQuery(
+        localQueryResultsView,
+        item as CompletedLocalQueryInfo,
+        WebviewReveal.Forced,
+      );
+      // Note we must update the query history view after showing results as the
+      // display and sorting might depend on the number of results
+    } catch (e) {
+      const err = asError(e);
+      err.message = `Error running query: ${err.message}`;
+      item.failureReason = err.message;
+      throw e;
+    } finally {
+      await qhm.refreshTreeView();
+      source.dispose();
+    }
+  }
+}
+
+interface DatabaseQuickPickItem extends QuickPickItem {
+  databaseItem: DatabaseItem;
+}
+
+async function compileAndRunQueryOnMultipleDatabases(
+  cliServer: CodeQLCliServer,
+  qs: QueryRunner,
+  qhm: QueryHistoryManager,
+  dbm: DatabaseManager,
+  databaseUI: DatabaseUI,
+  localQueryResultsView: ResultsView,
+  queryStorageDir: string,
+  progress: ProgressCallback,
+  token: CancellationToken,
+  uri: Uri | undefined,
+): Promise<void> {
+  let filteredDBs = dbm.databaseItems;
+  if (filteredDBs.length === 0) {
+    void showAndLogErrorMessage(
+      "No databases found. Please add a suitable database to your workspace.",
+    );
+    return;
+  }
+  // If possible, only show databases with the right language (otherwise show all databases).
+  const queryLanguage = await findLanguage(cliServer, uri);
+  if (queryLanguage) {
+    filteredDBs = dbm.databaseItems.filter(
+      (db) => db.language === queryLanguage,
+    );
+    if (filteredDBs.length === 0) {
+      void showAndLogErrorMessage(
+        `No databases found for language ${queryLanguage}. Please add a suitable database to your workspace.`,
+      );
+      return;
+    }
+  }
+  const quickPickItems = filteredDBs.map<DatabaseQuickPickItem>((dbItem) => ({
+    databaseItem: dbItem,
+    label: dbItem.name,
+    description: dbItem.language,
+  }));
+  /**
+   * Databases that were selected in the quick pick menu.
+   */
+  const quickpick = await window.showQuickPick<DatabaseQuickPickItem>(
+    quickPickItems,
+    { canPickMany: true, ignoreFocusOut: true },
+  );
+  if (quickpick !== undefined) {
+    // Collect all skipped databases and display them at the end (instead of popping up individual errors)
+    const skippedDatabases = [];
+    const errors = [];
+    for (const item of quickpick) {
+      try {
+        await compileAndRunQuery(
+          qs,
+          qhm,
+          databaseUI,
+          localQueryResultsView,
+          queryStorageDir,
+          false,
+          uri,
+          progress,
+          token,
+          item.databaseItem,
+        );
+      } catch (e) {
+        skippedDatabases.push(item.label);
+        errors.push(getErrorMessage(e));
+      }
+    }
+    if (skippedDatabases.length > 0) {
+      void extLogger.log(`Errors:\n${errors.join("\n")}`);
+      void showAndLogWarningMessage(
+        `The following databases were skipped:\n${skippedDatabases.join(
+          "\n",
+        )}.\nFor details about the errors, see the logs.`,
+      );
+    }
+  } else {
+    void showAndLogErrorMessage("No databases selected.");
+  }
+}
+
+export async function showResultsForCompletedQuery(
+  localQueryResultsView: ResultsView,
+  query: CompletedLocalQueryInfo,
+  forceReveal: WebviewReveal,
+): Promise<void> {
+  await localQueryResultsView.showResults(query, forceReveal, false);
+}

--- a/extensions/ql-vscode/src/quick-query.ts
+++ b/extensions/ql-vscode/src/quick-query.ts
@@ -1,13 +1,7 @@
 import { ensureDir, writeFile, pathExists, readFile } from "fs-extra";
 import { dump, load } from "js-yaml";
 import { basename, join } from "path";
-import {
-  CancellationToken,
-  ExtensionContext,
-  window as Window,
-  workspace,
-  Uri,
-} from "vscode";
+import { CancellationToken, window as Window, workspace, Uri } from "vscode";
 import { LSPErrorCodes, ResponseError } from "vscode-languageclient";
 import { CodeQLCliServer } from "./cli";
 import { DatabaseUI } from "./local-databases-ui";
@@ -20,6 +14,7 @@ import {
 import { ProgressCallback, UserCancellationException } from "./commandRunner";
 import { getErrorMessage } from "./pure/helpers-pure";
 import { FALLBACK_QLPACK_FILENAME, getQlPackPath } from "./pure/ql";
+import { App } from "./common/app";
 
 const QUICK_QUERIES_DIR_NAME = "quick-queries";
 const QUICK_QUERY_QUERY_NAME = "quick-query.ql";
@@ -30,8 +25,8 @@ export function isQuickQueryPath(queryPath: string): boolean {
   return basename(queryPath) === QUICK_QUERY_QUERY_NAME;
 }
 
-async function getQuickQueriesDir(ctx: ExtensionContext): Promise<string> {
-  const storagePath = ctx.storagePath;
+async function getQuickQueriesDir(app: App): Promise<string> {
+  const storagePath = app.workspaceStoragePath;
   if (storagePath === undefined) {
     throw new Error("Workspace storage path is undefined");
   }
@@ -57,7 +52,7 @@ function findExistingQuickQueryEditor() {
  * Show a buffer the user can enter a simple query into.
  */
 export async function displayQuickQuery(
-  ctx: ExtensionContext,
+  app: App,
   cliServer: CodeQLCliServer,
   databaseUI: DatabaseUI,
   progress: ProgressCallback,
@@ -73,7 +68,7 @@ export async function displayQuickQuery(
     }
 
     const workspaceFolders = workspace.workspaceFolders || [];
-    const queriesDir = await getQuickQueriesDir(ctx);
+    const queriesDir = await getQuickQueriesDir(app);
 
     // We need to have a multi-root workspace to make quick query work
     // at all. Changing the workspace from single-root to multi-root


### PR DESCRIPTION
Please review this commit-by-commit. Each commit makes the move to typed commands a bit easier.

One difference from all other typed commands is that the local query commands are using a separate logger, and this is not supported by the command manager because it is quite specific to this extension. Therefore, we create a separate command manager which uses a different logger to separate the commands. I have purposefully not added this to the `App` interface since we're not using it anywhere yet. Instead of adding it to the `ExtensionApp`, we could also create it in the `extension.ts` file and not store it on the `ExtensionApp`. I'm not sure which approach is better.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
