### PR TITLE
Convert packaging to typed commands

### DIFF
--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -108,10 +108,16 @@ export type DatabasePanelCommands = {
   "codeQLVariantAnalysisRepositories.removeItemContextMenu": SingleSelectionCommandFunction<DbTreeViewItem>;
 };
 
+export type PackagingCommands = {
+  "codeQL.installPackDependencies": () => Promise<void>;
+  "codeQL.downloadPacks": () => Promise<void>;
+};
+
 export type AllCommands = BaseCommands &
   QueryHistoryCommands &
   LocalDatabasesCommands &
   VariantAnalysisCommands &
-  DatabasePanelCommands;
+  DatabasePanelCommands &
+  PackagingCommands;
 
 export type AppCommandManager = CommandManager<AllCommands>;

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -103,10 +103,7 @@ import {
   withProgress,
 } from "./commandRunner";
 import { CodeQlStatusBarHandler } from "./status-bar";
-import {
-  handleDownloadPacks,
-  handleInstallPackDependencies,
-} from "./packaging";
+import { registerPackagingCommands } from "./packaging";
 import { HistoryItemLabelProvider } from "./query-history/history-item-label-provider";
 import { exportSelectedVariantAnalysisResults } from "./variant-analysis/export-results";
 import { EvalLogViewer } from "./eval-log-viewer";
@@ -1295,27 +1292,9 @@ async function activateWithInstalledDistribution(
     }),
   );
 
-  ctx.subscriptions.push(
-    commandRunnerWithProgress(
-      "codeQL.installPackDependencies",
-      async (progress: ProgressCallback) =>
-        await handleInstallPackDependencies(cliServer, progress),
-      {
-        title: "Installing pack dependencies",
-      },
-    ),
-  );
-
-  ctx.subscriptions.push(
-    commandRunnerWithProgress(
-      "codeQL.downloadPacks",
-      async (progress: ProgressCallback) =>
-        await handleDownloadPacks(cliServer, progress),
-      {
-        title: "Downloading packs",
-      },
-    ),
-  );
+  registerPackagingCommands(ctx, {
+    cliServer,
+  });
 
   ctx.subscriptions.push(
     commandRunner("codeQL.showLogs", async () => {

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -103,7 +103,7 @@ import {
   withProgress,
 } from "./commandRunner";
 import { CodeQlStatusBarHandler } from "./status-bar";
-import { registerPackagingCommands } from "./packaging";
+import { getPackagingCommands } from "./packaging";
 import { HistoryItemLabelProvider } from "./query-history/history-item-label-provider";
 import { exportSelectedVariantAnalysisResults } from "./variant-analysis/export-results";
 import { EvalLogViewer } from "./eval-log-viewer";
@@ -1090,6 +1090,9 @@ async function activateWithInstalledDistribution(
     ...variantAnalysisManager.getCommands(),
     ...databaseUI.getCommands(),
     ...dbModule.getCommands(),
+    ...getPackagingCommands({
+      cliServer,
+    }),
   };
 
   for (const [commandName, command] of Object.entries(allCommands)) {
@@ -1291,10 +1294,6 @@ async function activateWithInstalledDistribution(
       );
     }),
   );
-
-  registerPackagingCommands(ctx, {
-    cliServer,
-  });
 
   ctx.subscriptions.push(
     commandRunner("codeQL.showLogs", async () => {

--- a/extensions/ql-vscode/src/packaging.ts
+++ b/extensions/ql-vscode/src/packaging.ts
@@ -4,9 +4,8 @@ import {
   showAndLogExceptionWithTelemetry,
   showAndLogInformationMessage,
 } from "./helpers";
-import { ExtensionContext, QuickPickItem, window } from "vscode";
+import { QuickPickItem, window } from "vscode";
 import {
-  commandRunner,
   ProgressCallback,
   UserCancellationException,
   withProgress,
@@ -15,17 +14,17 @@ import { extLogger } from "./common";
 import { asError, getErrorStack } from "./pure/helpers-pure";
 import { redactableError } from "./pure/errors";
 import { PACKS_BY_QUERY_LANGUAGE } from "./common/query-language";
+import { PackagingCommands } from "./common/commands";
 
 type PackagingOptions = {
   cliServer: CodeQLCliServer;
 };
 
-export function registerPackagingCommands(
-  ctx: ExtensionContext,
-  { cliServer }: PackagingOptions,
-) {
-  ctx.subscriptions.push(
-    commandRunner("codeQL.installPackDependencies", async () =>
+export function getPackagingCommands({
+  cliServer,
+}: PackagingOptions): PackagingCommands {
+  return {
+    "codeQL.installPackDependencies": async () =>
       withProgress(
         async (progress: ProgressCallback) =>
           await handleInstallPackDependencies(cliServer, progress),
@@ -33,11 +32,7 @@ export function registerPackagingCommands(
           title: "Installing pack dependencies",
         },
       ),
-    ),
-  );
-
-  ctx.subscriptions.push(
-    commandRunner("codeQL.downloadPacks", async () =>
+    "codeQL.downloadPacks": async () =>
       withProgress(
         async (progress: ProgressCallback) =>
           await handleDownloadPacks(cliServer, progress),
@@ -45,8 +40,7 @@ export function registerPackagingCommands(
           title: "Downloading packs",
         },
       ),
-    ),
-  );
+  };
 }
 
 /**

--- a/extensions/ql-vscode/src/packaging.ts
+++ b/extensions/ql-vscode/src/packaging.ts
@@ -4,12 +4,47 @@ import {
   showAndLogExceptionWithTelemetry,
   showAndLogInformationMessage,
 } from "./helpers";
-import { QuickPickItem, window } from "vscode";
-import { ProgressCallback, UserCancellationException } from "./commandRunner";
+import { ExtensionContext, QuickPickItem, window } from "vscode";
+import {
+  commandRunnerWithProgress,
+  ProgressCallback,
+  UserCancellationException,
+} from "./commandRunner";
 import { extLogger } from "./common";
 import { asError, getErrorStack } from "./pure/helpers-pure";
 import { redactableError } from "./pure/errors";
 import { PACKS_BY_QUERY_LANGUAGE } from "./common/query-language";
+
+type PackagingOptions = {
+  cliServer: CodeQLCliServer;
+};
+
+export function registerPackagingCommands(
+  ctx: ExtensionContext,
+  { cliServer }: PackagingOptions,
+) {
+  ctx.subscriptions.push(
+    commandRunnerWithProgress(
+      "codeQL.installPackDependencies",
+      async (progress: ProgressCallback) =>
+        await handleInstallPackDependencies(cliServer, progress),
+      {
+        title: "Installing pack dependencies",
+      },
+    ),
+  );
+
+  ctx.subscriptions.push(
+    commandRunnerWithProgress(
+      "codeQL.downloadPacks",
+      async (progress: ProgressCallback) =>
+        await handleDownloadPacks(cliServer, progress),
+      {
+        title: "Downloading packs",
+      },
+    ),
+  );
+}
 
 /**
  * Prompts user to choose packs to download, and downloads them.

--- a/extensions/ql-vscode/src/packaging.ts
+++ b/extensions/ql-vscode/src/packaging.ts
@@ -6,9 +6,10 @@ import {
 } from "./helpers";
 import { ExtensionContext, QuickPickItem, window } from "vscode";
 import {
-  commandRunnerWithProgress,
+  commandRunner,
   ProgressCallback,
   UserCancellationException,
+  withProgress,
 } from "./commandRunner";
 import { extLogger } from "./common";
 import { asError, getErrorStack } from "./pure/helpers-pure";
@@ -24,24 +25,26 @@ export function registerPackagingCommands(
   { cliServer }: PackagingOptions,
 ) {
   ctx.subscriptions.push(
-    commandRunnerWithProgress(
-      "codeQL.installPackDependencies",
-      async (progress: ProgressCallback) =>
-        await handleInstallPackDependencies(cliServer, progress),
-      {
-        title: "Installing pack dependencies",
-      },
+    commandRunner("codeQL.installPackDependencies", async () =>
+      withProgress(
+        async (progress: ProgressCallback) =>
+          await handleInstallPackDependencies(cliServer, progress),
+        {
+          title: "Installing pack dependencies",
+        },
+      ),
     ),
   );
 
   ctx.subscriptions.push(
-    commandRunnerWithProgress(
-      "codeQL.downloadPacks",
-      async (progress: ProgressCallback) =>
-        await handleDownloadPacks(cliServer, progress),
-      {
-        title: "Downloading packs",
-      },
+    commandRunner("codeQL.downloadPacks", async () =>
+      withProgress(
+        async (progress: ProgressCallback) =>
+          await handleDownloadPacks(cliServer, progress),
+        {
+          title: "Downloading packs",
+        },
+      ),
     ),
   );
 }


### PR DESCRIPTION
Please review this commit-by-commit. This converts the packaging commands to typed commands.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
