### PR TITLE
Convert codeQL.restartQueryServer to a typed command

### DIFF
--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -27,6 +27,8 @@ export type SingleSelectionCommandFunction<Item> = (
 // Base commands not tied directly to a module like e.g. variant analysis.
 export type BaseCommands = {
   "codeQL.openDocumentation": () => Promise<void>;
+
+  "codeQL.restartQueryServer": () => Promise<void>;
 };
 
 // Commands used for the query history panel

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -1213,19 +1213,20 @@ async function activateWithInstalledDistribution(
   );
 
   ctx.subscriptions.push(
-    commandRunnerWithProgress(
-      "codeQL.restartQueryServer",
-      async (progress: ProgressCallback, token: CancellationToken) => {
-        // We restart the CLI server too, to ensure they are the same version
-        cliServer.restartCliServer();
-        await qs.restartQueryServer(progress, token);
-        void showAndLogInformationMessage("CodeQL Query Server restarted.", {
-          outputLogger: queryServerLogger,
-        });
-      },
-      {
-        title: "Restarting Query Server",
-      },
+    commandRunner("codeQL.restartQueryServer", async () =>
+      withProgress(
+        async (progress: ProgressCallback, token: CancellationToken) => {
+          // We restart the CLI server too, to ensure they are the same version
+          cliServer.restartCliServer();
+          await qs.restartQueryServer(progress, token);
+          void showAndLogInformationMessage("CodeQL Query Server restarted.", {
+            outputLogger: queryServerLogger,
+          });
+        },
+        {
+          title: "Restarting Query Server",
+        },
+      ),
     ),
   );
 

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -169,11 +169,28 @@ const extension = extensions.getExtension(extensionId);
 /**
  * Return all commands that are not tied to the more specific managers.
  */
-function getCommands(): BaseCommands {
+function getCommands(
+  cliServer: CodeQLCliServer,
+  queryRunner: QueryRunner,
+): BaseCommands {
   return {
     "codeQL.openDocumentation": async () => {
       await env.openExternal(Uri.parse("https://codeql.github.com/docs/"));
     },
+    "codeQL.restartQueryServer": async () =>
+      withProgress(
+        async (progress: ProgressCallback, token: CancellationToken) => {
+          // We restart the CLI server too, to ensure they are the same version
+          cliServer.restartCliServer();
+          await queryRunner.restartQueryServer(progress, token);
+          void showAndLogInformationMessage("CodeQL Query Server restarted.", {
+            outputLogger: queryServerLogger,
+          });
+        },
+        {
+          title: "Restarting Query Server",
+        },
+      ),
   };
 }
 
@@ -1097,7 +1114,7 @@ async function activateWithInstalledDistribution(
   );
 
   const allCommands: AllCommands = {
-    ...getCommands(),
+    ...getCommands(cliServer, qs),
     ...qhm.getCommands(),
     ...variantAnalysisManager.getCommands(),
     ...databaseUI.getCommands(),
@@ -1210,24 +1227,6 @@ async function activateWithInstalledDistribution(
     commandRunner("codeQL.previewQueryHelp", async (selectedQuery: Uri) => {
       await previewQueryHelp(cliServer, qhelpTmpDir, selectedQuery);
     }),
-  );
-
-  ctx.subscriptions.push(
-    commandRunner("codeQL.restartQueryServer", async () =>
-      withProgress(
-        async (progress: ProgressCallback, token: CancellationToken) => {
-          // We restart the CLI server too, to ensure they are the same version
-          cliServer.restartCliServer();
-          await qs.restartQueryServer(progress, token);
-          void showAndLogInformationMessage("CodeQL Query Server restarted.", {
-            outputLogger: queryServerLogger,
-          });
-        },
-        {
-          title: "Restarting Query Server",
-        },
-      ),
-    ),
   );
 
   ctx.subscriptions.push(


### PR DESCRIPTION
Please review this commit-by-commit. This converts the `codeQL.restartQueryServer` command to a typed command. I couldn't really find a good place for it, so for now it's just in `extension.ts`.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
