### PR TITLE
Convert codeQLEvalLogViewer.clear to a typed command

### DIFF
--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -108,10 +108,15 @@ export type DatabasePanelCommands = {
   "codeQLVariantAnalysisRepositories.removeItemContextMenu": SingleSelectionCommandFunction<DbTreeViewItem>;
 };
 
+export type EvalLogViewerCommands = {
+  "codeQLEvalLogViewer.clear": () => Promise<void>;
+};
+
 export type AllCommands = BaseCommands &
   QueryHistoryCommands &
   LocalDatabasesCommands &
   VariantAnalysisCommands &
-  DatabasePanelCommands;
+  DatabasePanelCommands &
+  EvalLogViewerCommands;
 
 export type AppCommandManager = CommandManager<AllCommands>;

--- a/extensions/ql-vscode/src/eval-log-viewer.ts
+++ b/extensions/ql-vscode/src/eval-log-viewer.ts
@@ -8,11 +8,11 @@ import {
   EventEmitter,
   TreeItemCollapsibleState,
 } from "vscode";
-import { commandRunner } from "./commandRunner";
 import { DisposableObject } from "./pure/disposable-object";
 import { showAndLogExceptionWithTelemetry } from "./helpers";
 import { asError, getErrorMessage } from "./pure/helpers-pure";
 import { redactableError } from "./pure/errors";
+import { EvalLogViewerCommands } from "./common/commands";
 
 export interface EvalLogTreeItem {
   label?: string;
@@ -80,11 +80,12 @@ export class EvalLogViewer extends DisposableObject {
 
     this.push(this.treeView);
     this.push(this.treeDataProvider);
-    this.push(
-      commandRunner("codeQLEvalLogViewer.clear", async () => {
-        this.clear();
-      }),
-    );
+  }
+
+  public getCommands(): EvalLogViewerCommands {
+    return {
+      "codeQLEvalLogViewer.clear": async () => this.clear(),
+    };
   }
 
   private clear(): void {

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -1102,6 +1102,7 @@ async function activateWithInstalledDistribution(
     ...variantAnalysisManager.getCommands(),
     ...databaseUI.getCommands(),
     ...dbModule.getCommands(),
+    ...evalLogViewer.getCommands(),
   };
 
   for (const [commandName, command] of Object.entries(allCommands)) {


### PR DESCRIPTION
This converts the `codeQLEvalLogViewer.clear` command to a typed command.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
