### PR TITLE
Convert AST viewer commands to typed commands

### DIFF
--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -1,5 +1,6 @@
 import type { CommandManager } from "../packages/commands";
 import type { Uri, Range } from "vscode";
+import type { AstItem } from "../astViewer";
 import type { DbTreeViewItem } from "../databases/ui/db-tree-view-item";
 import type { DatabaseItem } from "../local-databases";
 import type { QueryHistoryInfo } from "../query-history/query-history-info";
@@ -176,6 +177,11 @@ export type AstCfgCommands = {
   "codeQL.viewCfgContextEditor": () => Promise<void>;
 };
 
+export type AstViewerCommands = {
+  "codeQLAstViewer.clear": () => Promise<void>;
+  "codeQLAstViewer.gotoCode": (item: AstItem) => Promise<void>;
+};
+
 export type PackagingCommands = {
   "codeQL.installPackDependencies": () => Promise<void>;
   "codeQL.downloadPacks": () => Promise<void>;
@@ -191,6 +197,7 @@ export type AllCommands = BaseCommands &
   VariantAnalysisCommands &
   DatabasePanelCommands &
   AstCfgCommands &
+  AstViewerCommands &
   PackagingCommands &
   EvalLogViewerCommands;
 

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -837,6 +837,7 @@ async function activateWithInstalledDistribution(
       astTemplateProvider,
       cfgTemplateProvider,
     }),
+    ...astViewer.getCommands(),
     ...getPackagingCommands({
       cliServer,
     }),


### PR DESCRIPTION
This converts the commands in the `astViewer` file to use typed command registration. There are no changes in behaviour.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
