### PR TITLE
Convert summary language commands to typed commands

### DIFF
--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -185,6 +185,10 @@ export type EvalLogViewerCommands = {
   "codeQLEvalLogViewer.clear": () => Promise<void>;
 };
 
+export type SummaryLanguageSupportCommands = {
+  "codeQL.gotoQL": () => Promise<void>;
+};
+
 export type AllCommands = BaseCommands &
   QueryHistoryCommands &
   LocalDatabasesCommands &
@@ -192,7 +196,8 @@ export type AllCommands = BaseCommands &
   DatabasePanelCommands &
   AstCfgCommands &
   PackagingCommands &
-  EvalLogViewerCommands;
+  EvalLogViewerCommands &
+  SummaryLanguageSupportCommands;
 
 export type AppCommandManager = CommandManager<AllCommands>;
 

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -819,6 +819,9 @@ async function activateWithInstalledDistribution(
 
   ctx.subscriptions.push(astViewer);
 
+  const summaryLanguageSupport = new SummaryLanguageSupport();
+  ctx.subscriptions.push(summaryLanguageSupport);
+
   void extLogger.log("Registering top-level command palette commands.");
 
   const allCommands: AllCommands = {
@@ -841,6 +844,7 @@ async function activateWithInstalledDistribution(
       cliServer,
     }),
     ...evalLogViewer.getCommands(),
+    ...summaryLanguageSupport.getCommands(),
   };
 
   for (const [commandName, command] of Object.entries(allCommands)) {
@@ -936,8 +940,6 @@ async function activateWithInstalledDistribution(
       extLogger.show();
     }),
   );
-
-  ctx.subscriptions.push(new SummaryLanguageSupport());
 
   void extLogger.log("Starting language server.");
   await client.start();

--- a/extensions/ql-vscode/src/log-insights/summary-language-support.ts
+++ b/extensions/ql-vscode/src/log-insights/summary-language-support.ts
@@ -13,9 +13,9 @@ import {
   workspace,
 } from "vscode";
 import { DisposableObject } from "../pure/disposable-object";
-import { commandRunner } from "../commandRunner";
 import { extLogger } from "../common";
 import { getErrorMessage } from "../pure/helpers-pure";
+import { SummaryLanguageSupportCommands } from "../common/commands";
 
 /** A `Position` within a specified file on disk. */
 interface PositionInFile {
@@ -73,8 +73,12 @@ export class SummaryLanguageSupport extends DisposableObject {
         this.handleDidCloseTextDocument.bind(this),
       ),
     );
+  }
 
-    this.push(commandRunner("codeQL.gotoQL", this.handleGotoQL.bind(this)));
+  public getCommands(): SummaryLanguageSupportCommands {
+    return {
+      "codeQL.gotoQL": this.handleGotoQL.bind(this),
+    };
   }
 
   /**


### PR DESCRIPTION
This converts the summary language support commands to typed commands. There are no changes in behaviour.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
