### PR TITLE
Convert results view commands to typed commands

### DIFF
--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -53,6 +53,15 @@ export type LocalQueryCommands = {
   "codeQL.quickQuery": () => Promise<void>;
 };
 
+export type ResultsViewCommands = {
+  "codeQLQueryResults.up": () => Promise<void>;
+  "codeQLQueryResults.down": () => Promise<void>;
+  "codeQLQueryResults.left": () => Promise<void>;
+  "codeQLQueryResults.right": () => Promise<void>;
+  "codeQLQueryResults.nextPathStep": () => Promise<void>;
+  "codeQLQueryResults.previousPathStep": () => Promise<void>;
+};
+
 // Commands used for the query history panel
 export type QueryHistoryCommands = {
   // Commands in the "navigation" group
@@ -196,6 +205,7 @@ export type SummaryLanguageSupportCommands = {
 };
 
 export type AllCommands = BaseCommands &
+  ResultsViewCommands &
   QueryHistoryCommands &
   LocalDatabasesCommands &
   VariantAnalysisCommands &

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -826,6 +826,7 @@ async function activateWithInstalledDistribution(
 
   const allCommands: AllCommands = {
     ...getCommands(cliServer, qs),
+    ...localQueryResultsView.getCommands(),
     ...qhm.getCommands(),
     ...variantAnalysisManager.getCommands(),
     ...databaseUI.getCommands(),

--- a/extensions/ql-vscode/src/interface.ts
+++ b/extensions/ql-vscode/src/interface.ts
@@ -42,7 +42,6 @@ import {
   ParsedResultSets,
 } from "./pure/interface-types";
 import { Logger } from "./common";
-import { commandRunner } from "./commandRunner";
 import {
   CompletedQueryInfo,
   interpretResultsSarif,
@@ -72,6 +71,7 @@ import { isCanary, PAGE_SIZE } from "./config";
 import { HistoryItemLabelProvider } from "./query-history/history-item-label-provider";
 import { telemetryListener } from "./telemetry";
 import { redactableError } from "./pure/errors";
+import { ResultsViewCommands } from "./common/commands";
 
 /**
  * interface.ts
@@ -179,21 +179,6 @@ export class ResultsView extends AbstractWebview<
         this.handleSelectionChange.bind(this),
       ),
     );
-    const navigationCommands = {
-      "codeQLQueryResults.up": NavigationDirection.up,
-      "codeQLQueryResults.down": NavigationDirection.down,
-      "codeQLQueryResults.left": NavigationDirection.left,
-      "codeQLQueryResults.right": NavigationDirection.right,
-      // For backwards compatibility with keybindings set using an earlier version of the extension.
-      "codeQLQueryResults.nextPathStep": NavigationDirection.down,
-      "codeQLQueryResults.previousPathStep": NavigationDirection.up,
-    };
-    void logger.log("Registering result view navigation commands.");
-    for (const [commandId, direction] of Object.entries(navigationCommands)) {
-      this.push(
-        commandRunner(commandId, this.navigateResultView.bind(this, direction)),
-      );
-    }
 
     this.push(
       this.databaseManager.onDidChangeDatabaseItem(({ kind }) => {
@@ -207,6 +192,36 @@ export class ResultsView extends AbstractWebview<
         }
       }),
     );
+  }
+
+  public getCommands(): ResultsViewCommands {
+    return {
+      "codeQLQueryResults.up": this.navigateResultView.bind(
+        this,
+        NavigationDirection.up,
+      ),
+      "codeQLQueryResults.down": this.navigateResultView.bind(
+        this,
+        NavigationDirection.down,
+      ),
+      "codeQLQueryResults.left": this.navigateResultView.bind(
+        this,
+        NavigationDirection.left,
+      ),
+      "codeQLQueryResults.right": this.navigateResultView.bind(
+        this,
+        NavigationDirection.right,
+      ),
+      // For backwards compatibility with keybindings set using an earlier version of the extension.
+      "codeQLQueryResults.nextPathStep": this.navigateResultView.bind(
+        this,
+        NavigationDirection.down,
+      ),
+      "codeQLQueryResults.previousPathStep": this.navigateResultView.bind(
+        this,
+        NavigationDirection.up,
+      ),
+    };
   }
 
   async navigateResultView(direction: NavigationDirection): Promise<void> {


### PR DESCRIPTION
This converts the results view commands to typed command registration.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
