### PR TITLE
Convert mock API server commands to typed commands

### DIFF
--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -204,6 +204,14 @@ export type SummaryLanguageSupportCommands = {
   "codeQL.gotoQL": () => Promise<void>;
 };
 
+export type MockGitHubApiServerCommands = {
+  "codeQL.mockGitHubApiServer.startRecording": () => Promise<void>;
+  "codeQL.mockGitHubApiServer.saveScenario": () => Promise<void>;
+  "codeQL.mockGitHubApiServer.cancelRecording": () => Promise<void>;
+  "codeQL.mockGitHubApiServer.loadScenario": () => Promise<void>;
+  "codeQL.mockGitHubApiServer.unloadScenario": () => Promise<void>;
+};
+
 export type AllCommands = BaseCommands &
   ResultsViewCommands &
   QueryHistoryCommands &
@@ -214,7 +222,8 @@ export type AllCommands = BaseCommands &
   AstViewerCommands &
   PackagingCommands &
   EvalLogViewerCommands &
-  SummaryLanguageSupportCommands;
+  SummaryLanguageSupportCommands &
+  MockGitHubApiServerCommands;
 
 export type AppCommandManager = CommandManager<AllCommands>;
 

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -822,6 +822,9 @@ async function activateWithInstalledDistribution(
   const summaryLanguageSupport = new SummaryLanguageSupport();
   ctx.subscriptions.push(summaryLanguageSupport);
 
+  const mockServer = new VSCodeMockGitHubApiServer(ctx);
+  ctx.subscriptions.push(mockServer);
+
   void extLogger.log("Registering top-level command palette commands.");
 
   const allCommands: AllCommands = {
@@ -847,6 +850,7 @@ async function activateWithInstalledDistribution(
     }),
     ...evalLogViewer.getCommands(),
     ...summaryLanguageSupport.getCommands(),
+    ...mockServer.getCommands(),
   };
 
   for (const [commandName, command] of Object.entries(allCommands)) {
@@ -970,39 +974,6 @@ async function activateWithInstalledDistribution(
       qs,
       dbm,
       contextualQueryStorageDir,
-    ),
-  );
-
-  const mockServer = new VSCodeMockGitHubApiServer(ctx);
-  ctx.subscriptions.push(mockServer);
-  ctx.subscriptions.push(
-    commandRunner(
-      "codeQL.mockGitHubApiServer.startRecording",
-      async () => await mockServer.startRecording(),
-    ),
-  );
-  ctx.subscriptions.push(
-    commandRunner(
-      "codeQL.mockGitHubApiServer.saveScenario",
-      async () => await mockServer.saveScenario(),
-    ),
-  );
-  ctx.subscriptions.push(
-    commandRunner(
-      "codeQL.mockGitHubApiServer.cancelRecording",
-      async () => await mockServer.cancelRecording(),
-    ),
-  );
-  ctx.subscriptions.push(
-    commandRunner(
-      "codeQL.mockGitHubApiServer.loadScenario",
-      async () => await mockServer.loadScenario(),
-    ),
-  );
-  ctx.subscriptions.push(
-    commandRunner(
-      "codeQL.mockGitHubApiServer.unloadScenario",
-      async () => await mockServer.unloadScenario(),
     ),
   );
 

--- a/extensions/ql-vscode/src/mocks/vscode-mock-gh-api-server.ts
+++ b/extensions/ql-vscode/src/mocks/vscode-mock-gh-api-server.ts
@@ -15,6 +15,7 @@ import {
 } from "../config";
 import { DisposableObject } from "../pure/disposable-object";
 import { MockGitHubApiServer } from "./mock-gh-api-server";
+import { MockGitHubApiServerCommands } from "../common/commands";
 
 /**
  * "Interface" to the mock GitHub API server which implements VSCode interactions, such as
@@ -32,6 +33,19 @@ export class VSCodeMockGitHubApiServer extends DisposableObject {
     this.config = new MockGitHubApiConfigListener();
 
     this.setupConfigListener();
+  }
+
+  public getCommands(): MockGitHubApiServerCommands {
+    return {
+      "codeQL.mockGitHubApiServer.startRecording":
+        this.startRecording.bind(this),
+      "codeQL.mockGitHubApiServer.saveScenario": this.saveScenario.bind(this),
+      "codeQL.mockGitHubApiServer.cancelRecording":
+        this.cancelRecording.bind(this),
+      "codeQL.mockGitHubApiServer.loadScenario": this.loadScenario.bind(this),
+      "codeQL.mockGitHubApiServer.unloadScenario":
+        this.unloadScenario.bind(this),
+    };
   }
 
   public async startServer(): Promise<void> {


### PR DESCRIPTION
This converts the mock GitHub API server commands to typed command registration. There should be no changes in behaviour.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
