### PR TITLE
Convert query editing commands to typed commands

### DIFF
--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -38,6 +38,18 @@ export type BaseCommands = {
   "codeQL.restartQueryServer": () => Promise<void>;
 };
 
+// Commands used when working with queries in the editor
+export type QueryEditorCommands = {
+  "codeQL.openReferencedFile": (selectedQuery: Uri) => Promise<void>;
+  "codeQL.openReferencedFileContextEditor": (
+    selectedQuery: Uri,
+  ) => Promise<void>;
+  "codeQL.openReferencedFileContextExplorer": (
+    selectedQuery: Uri,
+  ) => Promise<void>;
+  "codeQL.previewQueryHelp": (selectedQuery: Uri) => Promise<void>;
+};
+
 // Commands used for running local queries
 export type LocalQueryCommands = {
   "codeQL.runQuery": (uri?: Uri) => Promise<void>;
@@ -213,6 +225,7 @@ export type MockGitHubApiServerCommands = {
 };
 
 export type AllCommands = BaseCommands &
+  QueryEditorCommands &
   ResultsViewCommands &
   QueryHistoryCommands &
   LocalDatabasesCommands &

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -120,7 +120,7 @@ import {
   showResultsForCompletedQuery,
 } from "./local-queries";
 import { getAstCfgCommands } from "./ast-cfg-commands";
-import { registerQueryEditorCommands } from "./query-editor";
+import { getQueryEditorCommands } from "./query-editor";
 
 /**
  * extension.ts
@@ -829,6 +829,11 @@ async function activateWithInstalledDistribution(
 
   const allCommands: AllCommands = {
     ...getCommands(cliServer, qs),
+    ...getQueryEditorCommands({
+      queryRunner: qs,
+      cliServer,
+      qhelpTmpDir: qhelpTmpDir.name,
+    }),
     ...localQueryResultsView.getCommands(),
     ...qhm.getCommands(),
     ...variantAnalysisManager.getCommands(),
@@ -876,12 +881,6 @@ async function activateWithInstalledDistribution(
       command,
     );
   }
-
-  registerQueryEditorCommands(ctx, {
-    queryRunner: qs,
-    cliServer,
-    qhelpTmpDir: qhelpTmpDir.name,
-  });
 
   ctx.subscriptions.push(
     commandRunner("codeQL.copyVersion", async () => {

--- a/extensions/ql-vscode/src/query-editor.ts
+++ b/extensions/ql-vscode/src/query-editor.ts
@@ -1,0 +1,97 @@
+import { commands, ExtensionContext, Uri, window } from "vscode";
+import { CodeQLCliServer } from "./cli";
+import { QueryRunner } from "./queryRunner";
+import { commandRunner } from "./commandRunner";
+import { basename, join } from "path";
+import { getErrorMessage } from "./pure/helpers-pure";
+import { redactableError } from "./pure/errors";
+import { showAndLogExceptionWithTelemetry } from "./helpers";
+
+type QueryEditorOptions = {
+  queryRunner: QueryRunner;
+  cliServer: CodeQLCliServer;
+
+  qhelpTmpDir: string;
+};
+
+export function registerQueryEditorCommands(
+  ctx: ExtensionContext,
+  { queryRunner, cliServer, qhelpTmpDir }: QueryEditorOptions,
+) {
+  ctx.subscriptions.push(
+    commandRunner("codeQL.openReferencedFile", async (selectedQuery: Uri) => {
+      await openReferencedFile(queryRunner, cliServer, selectedQuery);
+    }),
+  );
+
+  // Since we are tracking extension usage through commands, this command mirrors the "codeQL.openReferencedFile" command
+  ctx.subscriptions.push(
+    commandRunner(
+      "codeQL.openReferencedFileContextEditor",
+      async (selectedQuery: Uri) => {
+        await openReferencedFile(queryRunner, cliServer, selectedQuery);
+      },
+    ),
+  );
+
+  // Since we are tracking extension usage through commands, this command mirrors the "codeQL.openReferencedFile" command
+  ctx.subscriptions.push(
+    commandRunner(
+      "codeQL.openReferencedFileContextExplorer",
+      async (selectedQuery: Uri) => {
+        await openReferencedFile(queryRunner, cliServer, selectedQuery);
+      },
+    ),
+  );
+
+  ctx.subscriptions.push(
+    commandRunner("codeQL.previewQueryHelp", async (selectedQuery: Uri) => {
+      await previewQueryHelp(cliServer, qhelpTmpDir, selectedQuery);
+    }),
+  );
+}
+
+async function previewQueryHelp(
+  cliServer: CodeQLCliServer,
+  qhelpTmpDir: string,
+  selectedQuery: Uri,
+): Promise<void> {
+  // selectedQuery is unpopulated when executing through the command palette
+  const pathToQhelp = selectedQuery
+    ? selectedQuery.fsPath
+    : window.activeTextEditor?.document.uri.fsPath;
+  if (pathToQhelp) {
+    // Create temporary directory
+    const relativePathToMd = `${basename(pathToQhelp, ".qhelp")}.md`;
+    const absolutePathToMd = join(qhelpTmpDir, relativePathToMd);
+    const uri = Uri.file(absolutePathToMd);
+    try {
+      await cliServer.generateQueryHelp(pathToQhelp, absolutePathToMd);
+      await commands.executeCommand("markdown.showPreviewToSide", uri);
+    } catch (e) {
+      const errorMessage = getErrorMessage(e).includes(
+        "Generating qhelp in markdown",
+      )
+        ? redactableError`Could not generate markdown from ${pathToQhelp}: Bad formatting in .qhelp file.`
+        : redactableError`Could not open a preview of the generated file (${absolutePathToMd}).`;
+      void showAndLogExceptionWithTelemetry(errorMessage, {
+        fullMessage: `${errorMessage}\n${getErrorMessage(e)}`,
+      });
+    }
+  }
+}
+
+async function openReferencedFile(
+  qs: QueryRunner,
+  cliServer: CodeQLCliServer,
+  selectedQuery: Uri,
+): Promise<void> {
+  // If no file is selected, the path of the file in the editor is selected
+  const path =
+    selectedQuery?.fsPath || window.activeTextEditor?.document.uri.fsPath;
+  if (qs !== undefined && path) {
+    const resolved = await cliServer.resolveQlref(path);
+    const uri = Uri.file(resolved.resolvedPath);
+    await window.showTextDocument(uri, { preview: false });
+  }
+}


### PR DESCRIPTION
Please review this commit-by-commit. This splits up the query editing commands into a separate file and converts their registration to using typed commands. If this split doesn't make sense, I'm open to finding another split to avoid all remaining commands ending up in the `BaseCommands`.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
