### PR TITLE
Convert some base commands to typed commands

### DIFF
--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -35,7 +35,10 @@ export type SingleSelectionCommandFunction<Item> = (
 // Base commands not tied directly to a module like e.g. variant analysis.
 export type BaseCommands = {
   "codeQL.openDocumentation": () => Promise<void>;
+  "codeQL.showLogs": () => Promise<void>;
+  "codeQL.authenticateToGitHub": () => Promise<void>;
 
+  "codeQL.copyVersion": () => Promise<void>;
   "codeQL.restartQueryServer": () => Promise<void>;
 };
 


### PR DESCRIPTION
This converts these commands to typed commands:
- `codeQL.showLogs`
- `codeQL.authenticateToGitHub`
- `codeQL.copyVersion`

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
