### PR TITLE
Add `codeQL.checkForUpdatesToCLI` type for command

### DIFF
--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -39,6 +39,13 @@ export type BuiltInVsCodeCommands = {
   "workbench.action.reloadWindow": () => Promise<void>;
 };
 
+// Commands that are available before the extension is fully activated.
+// These commands are *not* registered using the command manager, but can
+// be invoked using the command manager.
+export type PreActivationCommands = {
+  "codeQL.checkForUpdatesToCLI": () => Promise<void>;
+};
+
 // Base commands not tied directly to a module like e.g. variant analysis.
 export type BaseCommands = {
   "codeQL.openDocumentation": () => Promise<void>;
@@ -237,7 +244,7 @@ export type MockGitHubApiServerCommands = {
   "codeQL.mockGitHubApiServer.unloadScenario": () => Promise<void>;
 };
 
-// All commands where the implementation is provided by this extension.
+// All commands where the implementation is provided by this activated extension.
 export type AllExtensionCommands = BaseCommands &
   QueryEditorCommands &
   ResultsViewCommands &
@@ -253,7 +260,9 @@ export type AllExtensionCommands = BaseCommands &
   Partial<TestUICommands> &
   MockGitHubApiServerCommands;
 
-export type AllCommands = AllExtensionCommands & BuiltInVsCodeCommands;
+export type AllCommands = AllExtensionCommands &
+  PreActivationCommands &
+  BuiltInVsCodeCommands;
 
 export type AppCommandManager = CommandManager<AllCommands>;
 

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -112,6 +112,7 @@ import { QueryHistoryDirs } from "./query-history/query-history-dirs";
 import {
   AllExtensionCommands,
   BaseCommands,
+  PreActivationCommands,
   QueryServerCommands,
   TestUICommands,
 } from "./common/commands";
@@ -204,6 +205,8 @@ function registerErrorStubs(
 
   stubbedCommands.forEach((command) => {
     if (excludedCommands.indexOf(command) === -1) {
+      // This is purposefully using `commandRunner` instead of the command manager because these
+      // commands are untyped and registered pre-activation.
       errorStubs.push(commandRunner(command, stubGenerator(command)));
     }
   });
@@ -305,6 +308,8 @@ export async function activate(
     ),
   );
   ctx.subscriptions.push(
+    // This is purposefully using `commandRunner` directly instead of the command manager
+    // because this command is registered pre-activation.
     commandRunner(checkForUpdatesCommand, () =>
       installOrUpdateThenTryActivate(
         ctx,
@@ -1096,7 +1101,8 @@ async function initializeLogging(ctx: ExtensionContext): Promise<void> {
   ctx.subscriptions.push(ideServerLogger);
 }
 
-const checkForUpdatesCommand = "codeQL.checkForUpdatesToCLI";
+const checkForUpdatesCommand: keyof PreActivationCommands =
+  "codeQL.checkForUpdatesToCLI" as const;
 
 const avoidVersionCheck = "avoid-version-check-at-startup";
 const lastVersionChecked = "last-version-checked";


### PR DESCRIPTION
The `codeQL.checkForUpdatesToCLI` command is registered pre-activation, and we don't really want to create the command manager before activation, so this will just add the correct type without registering it using the command manager.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
