### PR TITLE
Remove remaining references to `commandRunner`

### DIFF
--- a/extensions/ql-vscode/src/common/vscode/commands.ts
+++ b/extensions/ql-vscode/src/common/vscode/commands.ts
@@ -15,7 +15,7 @@ import {
 import { telemetryListener } from "../../telemetry";
 
 /**
- * Create a command manager for VSCode, wrapping the commandRunner
+ * Create a command manager for VSCode, wrapping registerCommandWithErrorHandling
  * and vscode.executeCommand.
  */
 export function createVSCodeCommandManager<

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -236,7 +236,7 @@ function registerErrorStubs(
 
   stubbedCommands.forEach((command) => {
     if (excludedCommands.indexOf(command) === -1) {
-      // This is purposefully using `commandRunner` instead of the command manager because these
+      // This is purposefully using `registerCommandWithErrorHandling` instead of the command manager because these
       // commands are untyped and registered pre-activation.
       errorStubs.push(
         registerCommandWithErrorHandling(command, stubGenerator(command)),
@@ -341,7 +341,7 @@ export async function activate(
     ),
   );
   ctx.subscriptions.push(
-    // This is purposefully using `commandRunner` directly instead of the command manager
+    // This is purposefully using `registerCommandWithErrorHandling` directly instead of the command manager
     // because this command is registered pre-activation.
     registerCommandWithErrorHandling(checkForUpdatesCommand, () =>
       installOrUpdateThenTryActivate(
@@ -1035,7 +1035,8 @@ function addUnhandledRejectionListener() {
   // "uncaughtException" will trigger whenever an exception reaches the top level.
   // This covers extension initialization and any code within a `setTimeout`.
   // Notably this does not include exceptions thrown when executing commands,
-  // because `commandRunner` wraps the command body and handles errors.
+  // because `registerCommandWithErrorHandling` wraps the command body and
+  // handles errors.
   process.addListener("uncaughtException", handler);
 
   // "unhandledRejection" will trigger whenever any promise is rejected and it is


### PR DESCRIPTION
There were still some unintentional references to `commandRunner`. This PR removes them.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
