### PR TITLE
Add support for typed commands to CodeQL query

### DIFF
--- a/.github/codeql/queries/unique-command-use.ql
+++ b/.github/codeql/queries/unique-command-use.ql
@@ -72,6 +72,20 @@
  
    override string getCommandName() { result = this.getArgument(0).(StringLiteral).getValue() }
  }
+
+ /**
+  * A usage of a command from the typescript code, by calling `CommandManager.execute`.
+  */
+ class CommandUsageCommandManagerMethodCallExpr extends CommandUsage, MethodCallExpr {
+   CommandUsageCommandManagerMethodCallExpr() {
+     this.getCalleeName() = "execute" and
+     this.getReceiver().getType().unfold().(TypeReference).getTypeName().getName() = "CommandManager" and
+     this.getArgument(0).(StringLiteral).getValue().matches("%codeQL%") and
+     not this.getFile().getRelativePath().matches("extensions/ql-vscode/test/%")
+   }
+
+   override string getCommandName() { result = this.getArgument(0).(StringLiteral).getValue() }
+ }
  
  /**
   * A usage of a command from any menu that isn't the command palette.


### PR DESCRIPTION
This adds support for detecting the `CommandManager.execute` method in the unique command use query.

This may not be the best way to implement this. There's a method `hasUnderlyingType` on `this.getReceiver().getType()`, but I couldn't really figure out how to get it recognize `CommandManager`. It might be possible if we can construct the type of `CommandManager`, but this will probably include the filepath to the `CommandManager` class, which might not neccessarily be something we want: moving the `CommandManager` class should not require updating the query. I'm very happy to hear other suggestions.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
