### PR TITLE
Convert call sites to use typed commands (part 2): QueryHistoryManager

### DIFF
--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -38,6 +38,7 @@ export type BuiltInVsCodeCommands = {
   // The codeQLDatabases.focus command is provided by VS Code because we've registered the custom view
   "codeQLDatabases.focus": () => Promise<void>;
   "markdown.showPreviewToSide": (uri: Uri) => Promise<void>;
+  revealFileInOS: (uri: Uri) => Promise<void>;
   setContext: (
     key: `${"codeql" | "codeQL"}${string}`,
     value: unknown,

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -777,6 +777,7 @@ async function activateWithInstalledDistribution(
   };
 
   const qhm = new QueryHistoryManager(
+    app,
     qs,
     dbm,
     localQueryResultsView,

--- a/extensions/ql-vscode/src/query-history/query-history-manager.ts
+++ b/extensions/ql-vscode/src/query-history/query-history-manager.ts
@@ -680,7 +680,10 @@ export class QueryHistoryManager extends DisposableObject {
     }
 
     if (singleItem.completedQuery.logFileLocation) {
-      await tryOpenExternalFile(singleItem.completedQuery.logFileLocation);
+      await tryOpenExternalFile(
+        this.app.commands,
+        singleItem.completedQuery.logFileLocation,
+      );
     } else {
       void showAndLogWarningMessage("No log file available");
     }
@@ -797,7 +800,10 @@ export class QueryHistoryManager extends DisposableObject {
     }
 
     if (finalSingleItem.evalLogLocation) {
-      await tryOpenExternalFile(finalSingleItem.evalLogLocation);
+      await tryOpenExternalFile(
+        this.app.commands,
+        finalSingleItem.evalLogLocation,
+      );
     } else {
       this.warnNoEvalLogs();
     }
@@ -822,7 +828,10 @@ export class QueryHistoryManager extends DisposableObject {
     }
 
     if (finalSingleItem.evalLogSummaryLocation) {
-      await tryOpenExternalFile(finalSingleItem.evalLogSummaryLocation);
+      await tryOpenExternalFile(
+        this.app.commands,
+        finalSingleItem.evalLogSummaryLocation,
+      );
       return;
     }
 
@@ -965,7 +974,10 @@ export class QueryHistoryManager extends DisposableObject {
     const query = finalSingleItem.completedQuery.query;
     const hasInterpretedResults = query.canHaveInterpretedResults();
     if (hasInterpretedResults) {
-      await tryOpenExternalFile(query.resultsPaths.interpretedResultsPath);
+      await tryOpenExternalFile(
+        this.app.commands,
+        query.resultsPaths.interpretedResultsPath,
+      );
     } else {
       const label = this.labelProvider.getLabel(finalSingleItem);
       void showAndLogInformationMessage(
@@ -994,11 +1006,11 @@ export class QueryHistoryManager extends DisposableObject {
     }
     const query = finalSingleItem.completedQuery.query;
     if (await query.hasCsv()) {
-      void tryOpenExternalFile(query.csvPath);
+      void tryOpenExternalFile(this.app.commands, query.csvPath);
       return;
     }
     if (await query.exportCsvResults(this.qs.cliServer, query.csvPath)) {
-      void tryOpenExternalFile(query.csvPath);
+      void tryOpenExternalFile(this.app.commands, query.csvPath);
     }
   }
 
@@ -1022,6 +1034,7 @@ export class QueryHistoryManager extends DisposableObject {
     }
 
     await tryOpenExternalFile(
+      this.app.commands,
       await finalSingleItem.completedQuery.query.ensureCsvAlerts(
         this.qs.cliServer,
         this.dbm,
@@ -1049,6 +1062,7 @@ export class QueryHistoryManager extends DisposableObject {
     }
 
     await tryOpenExternalFile(
+      this.app.commands,
       await finalSingleItem.completedQuery.query.ensureDilPath(
         this.qs.cliServer,
       ),

--- a/extensions/ql-vscode/src/query-history/query-history-manager.ts
+++ b/extensions/ql-vscode/src/query-history/query-history-manager.ts
@@ -1,6 +1,5 @@
 import { join, dirname } from "path";
 import {
-  commands,
   Disposable,
   env,
   EventEmitter,
@@ -61,6 +60,7 @@ import { HistoryTreeDataProvider } from "./history-tree-data-provider";
 import { redactableError } from "../pure/errors";
 import { QueryHistoryDirs } from "./query-history-dirs";
 import { QueryHistoryCommands } from "../common/commands";
+import { App } from "../common/app";
 import { tryOpenExternalFile } from "../vscode-utils/external-files";
 
 /**
@@ -131,6 +131,7 @@ export class QueryHistoryManager extends DisposableObject {
   readonly onDidCompleteQuery = this._onDidCompleteQuery.event;
 
   constructor(
+    private readonly app: App,
     private readonly qs: QueryRunner,
     private readonly dbm: DatabaseManager,
     private readonly localQueriesResultsView: ResultsView,
@@ -747,7 +748,7 @@ export class QueryHistoryManager extends DisposableObject {
         }
       }
       try {
-        await commands.executeCommand(
+        await this.app.commands.execute(
           "revealFileInOS",
           Uri.file(externalFilePath),
         );
@@ -1073,7 +1074,7 @@ export class QueryHistoryManager extends DisposableObject {
 
     const actionsWorkflowRunUrl = getActionsWorkflowRunUrl(finalSingleItem);
 
-    await commands.executeCommand(
+    await this.app.commands.execute(
       "vscode.open",
       Uri.parse(actionsWorkflowRunUrl),
     );
@@ -1097,7 +1098,7 @@ export class QueryHistoryManager extends DisposableObject {
       return;
     }
 
-    await commands.executeCommand(
+    await this.app.commands.execute(
       "codeQL.copyVariantAnalysisRepoList",
       finalSingleItem.variantAnalysis.id,
     );

--- a/extensions/ql-vscode/src/vscode-utils/external-files.ts
+++ b/extensions/ql-vscode/src/vscode-utils/external-files.ts
@@ -1,4 +1,5 @@
-import { commands, Uri, window } from "vscode";
+import { Uri, window } from "vscode";
+import { AppCommandManager } from "../common/commands";
 import {
   showAndLogExceptionWithTelemetry,
   showBinaryChoiceDialog,
@@ -6,7 +7,10 @@ import {
 import { redactableError } from "../pure/errors";
 import { asError, getErrorMessage, getErrorStack } from "../pure/helpers-pure";
 
-export async function tryOpenExternalFile(fileLocation: string) {
+export async function tryOpenExternalFile(
+  CommandManager: AppCommandManager,
+  fileLocation: string,
+) {
   const uri = Uri.file(fileLocation);
   try {
     await window.showTextDocument(uri, { preview: false });
@@ -25,7 +29,7 @@ the file in the file explorer and dragging it into the workspace.`,
       );
       if (res) {
         try {
-          await commands.executeCommand("revealFileInOS", uri);
+          await CommandManager.execute("revealFileInOS", uri);
         } catch (e) {
           void showAndLogExceptionWithTelemetry(
             redactableError(

--- a/extensions/ql-vscode/src/vscode-utils/external-files.ts
+++ b/extensions/ql-vscode/src/vscode-utils/external-files.ts
@@ -8,7 +8,7 @@ import { redactableError } from "../pure/errors";
 import { asError, getErrorMessage, getErrorStack } from "../pure/helpers-pure";
 
 export async function tryOpenExternalFile(
-  CommandManager: AppCommandManager,
+  commandManager: AppCommandManager,
   fileLocation: string,
 ) {
   const uri = Uri.file(fileLocation);
@@ -29,7 +29,7 @@ the file in the file explorer and dragging it into the workspace.`,
       );
       if (res) {
         try {
-          await CommandManager.execute("revealFileInOS", uri);
+          await commandManager.execute("revealFileInOS", uri);
         } catch (e) {
           void showAndLogExceptionWithTelemetry(
             redactableError(

--- a/extensions/ql-vscode/src/vscode-utils/external-files.ts
+++ b/extensions/ql-vscode/src/vscode-utils/external-files.ts
@@ -1,0 +1,46 @@
+import { commands, Uri, window } from "vscode";
+import {
+  showAndLogExceptionWithTelemetry,
+  showBinaryChoiceDialog,
+} from "../helpers";
+import { redactableError } from "../pure/errors";
+import { asError, getErrorMessage, getErrorStack } from "../pure/helpers-pure";
+
+export async function tryOpenExternalFile(fileLocation: string) {
+  const uri = Uri.file(fileLocation);
+  try {
+    await window.showTextDocument(uri, { preview: false });
+  } catch (e) {
+    const msg = getErrorMessage(e);
+    if (
+      msg.includes("Files above 50MB cannot be synchronized with extensions") ||
+      msg.includes("too large to open")
+    ) {
+      const res = await showBinaryChoiceDialog(
+        `VS Code does not allow extensions to open files >50MB. This file
+exceeds that limit. Do you want to open it outside of VS Code?
+
+You can also try manually opening it inside VS Code by selecting
+the file in the file explorer and dragging it into the workspace.`,
+      );
+      if (res) {
+        try {
+          await commands.executeCommand("revealFileInOS", uri);
+        } catch (e) {
+          void showAndLogExceptionWithTelemetry(
+            redactableError(
+              asError(e),
+            )`Failed to reveal file in OS: ${getErrorMessage(e)}`,
+          );
+        }
+      }
+    } else {
+      void showAndLogExceptionWithTelemetry(
+        redactableError(asError(e))`Could not open file ${fileLocation}`,
+        {
+          fullMessage: `${getErrorMessage(e)}\n${getErrorStack(e)}`,
+        },
+      );
+    }
+  }
+}

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/history-tree-data-provider.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/history-tree-data-provider.test.ts
@@ -27,6 +27,7 @@ import {
 } from "../../../../src/query-history/history-tree-data-provider";
 import { QueryHistoryManager } from "../../../../src/query-history/query-history-manager";
 import { createMockQueryHistoryDirs } from "../../../factories/query-history/query-history-dirs";
+import { createMockApp } from "../../../__mocks__/appMock";
 
 describe("HistoryTreeDataProvider", () => {
   const mockExtensionLocation = join(tmpDir.name, "mock-extension-location");
@@ -421,6 +422,7 @@ describe("HistoryTreeDataProvider", () => {
 
   async function createMockQueryHistory(allHistory: QueryHistoryInfo[]) {
     const qhm = new QueryHistoryManager(
+      createMockApp({}),
       {} as QueryRunner,
       {} as DatabaseManager,
       localQueriesResultsViewStub,

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-manager.test.ts
@@ -777,7 +777,7 @@ describe("QueryHistoryManager", () => {
       const item = localQueryHistory[4];
       await queryHistoryManager.handleCopyRepoList(item, [item]);
 
-      expect(executeCommandSpy).not.toBeCalled();
+      expect(executeCommand).not.toBeCalled();
     });
 
     it("should copy repo list for a single variant analysis", async () => {
@@ -785,7 +785,7 @@ describe("QueryHistoryManager", () => {
 
       const item = variantAnalysisHistory[1];
       await queryHistoryManager.handleCopyRepoList(item, [item]);
-      expect(executeCommandSpy).toBeCalledWith(
+      expect(executeCommand).toBeCalledWith(
         "codeQL.copyVariantAnalysisRepoList",
         item.variantAnalysis.id,
       );
@@ -797,7 +797,7 @@ describe("QueryHistoryManager", () => {
       const item1 = variantAnalysisHistory[1];
       const item2 = variantAnalysisHistory[3];
       await queryHistoryManager.handleCopyRepoList(item1, [item1, item2]);
-      expect(executeCommandSpy).not.toBeCalled();
+      expect(executeCommand).not.toBeCalled();
     });
   });
 
@@ -1094,6 +1094,7 @@ describe("QueryHistoryManager", () => {
 
   async function createMockQueryHistory(allHistory: QueryHistoryInfo[]) {
     const qhm = new QueryHistoryManager(
+      mockApp,
       {} as QueryRunner,
       {} as DatabaseManager,
       localQueriesResultsViewStub,

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/variant-analysis-history.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/variant-analysis-history.test.ts
@@ -21,6 +21,7 @@ import { VariantAnalysisManager } from "../../../../src/variant-analysis/variant
 import { QueryHistoryManager } from "../../../../src/query-history/query-history-manager";
 import { mockedObject } from "../../utils/mocking.helpers";
 import { createMockQueryHistoryDirs } from "../../../factories/query-history/query-history-dirs";
+import { createMockApp } from "../../../__mocks__/appMock";
 
 // set a higher timeout since recursive delete may take a while, expecially on Windows.
 jest.setTimeout(120000);
@@ -73,6 +74,7 @@ describe("Variant Analyses and QueryHistoryManager", () => {
     ).queries;
 
     qhm = new QueryHistoryManager(
+      createMockApp({}),
       {} as QueryRunner,
       {} as DatabaseManager,
       localQueriesResultsViewStub,

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/vscode-utils/external-files.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/vscode-utils/external-files.test.ts
@@ -1,0 +1,65 @@
+import * as vscode from "vscode";
+import { tryOpenExternalFile } from "../../../../../src/vscode-utils/external-files";
+import { mockedObject } from "../../../utils/mocking.helpers";
+
+describe("tryOpenExternalFile", () => {
+  let showTextDocumentSpy: jest.SpiedFunction<
+    typeof vscode.window.showTextDocument
+  >;
+  let showInformationMessageSpy: jest.SpiedFunction<
+    typeof vscode.window.showInformationMessage
+  >;
+  let executeCommandSpy: jest.SpiedFunction<
+    typeof vscode.commands.executeCommand
+  >;
+
+  beforeEach(() => {
+    showTextDocumentSpy = jest
+      .spyOn(vscode.window, "showTextDocument")
+      .mockResolvedValue(mockedObject<vscode.TextEditor>({}));
+    showInformationMessageSpy = jest
+      .spyOn(vscode.window, "showInformationMessage")
+      .mockResolvedValue(undefined);
+    executeCommandSpy = jest
+      .spyOn(vscode.commands, "executeCommand")
+      .mockResolvedValue(undefined);
+  });
+
+  it("should open an external file", async () => {
+    await tryOpenExternalFile("xxx");
+    expect(showTextDocumentSpy).toHaveBeenCalledTimes(1);
+    expect(showTextDocumentSpy).toHaveBeenCalledWith(
+      vscode.Uri.file("xxx"),
+      expect.anything(),
+    );
+    expect(executeCommandSpy).not.toBeCalled();
+  });
+
+  [
+    "too large to open",
+    "Files above 50MB cannot be synchronized with extensions",
+  ].forEach((msg) => {
+    it(`should fail to open a file because "${msg}" and open externally`, async () => {
+      showTextDocumentSpy.mockRejectedValue(new Error(msg));
+      showInformationMessageSpy.mockResolvedValue({ title: "Yes" });
+
+      await tryOpenExternalFile("xxx");
+      const uri = vscode.Uri.file("xxx");
+      expect(showTextDocumentSpy).toHaveBeenCalledTimes(1);
+      expect(showTextDocumentSpy).toHaveBeenCalledWith(uri, expect.anything());
+      expect(executeCommandSpy).toHaveBeenCalledWith("revealFileInOS", uri);
+    });
+
+    it(`should fail to open a file because "${msg}" and NOT open externally`, async () => {
+      showTextDocumentSpy.mockRejectedValue(new Error(msg));
+      showInformationMessageSpy.mockResolvedValue({ title: "No" });
+
+      await tryOpenExternalFile("xxx");
+      const uri = vscode.Uri.file("xxx");
+      expect(showTextDocumentSpy).toHaveBeenCalledTimes(1);
+      expect(showTextDocumentSpy).toHaveBeenCalledWith(uri, expect.anything());
+      expect(showInformationMessageSpy).toBeCalled();
+      expect(executeCommandSpy).not.toBeCalled();
+    });
+  });
+});


### PR DESCRIPTION
Following on from https://github.com/github/vscode-codeql/pull/2217, this PR converts some more places to call typed commands, focussing on the `QueryHistoryManager` class because that turned out to need some non-trivial refactoring to make it work.

The problem was because the tests used `tryOpenExternalFile = (QueryHistoryManager.prototype as any).tryOpenExternalFile;` to access and call the `tryOpenExternalFile` method but without actually constructing a `QueryHistoryManager` instance. Somehow this worked for calling the actual method, but it was a problem when we needed to check that it called `this.app.commands.execute` because we couldn't pass in the correct `app`.

To get around this I pulled the `tryOpenExternalFile` method out to a separate file so it's no longer defined on the `QueryHistoryManager` class. This then means we can test it separately and makes it possible to test when using typed commands.

I wasn't quite sure where to put the new file, so if anyone has suggestions I'm very open. I went with the `src/vscode-utils/` directory because it was nearby and it already existed. I think the tests still need to be in `no-workspace` because it calls `window.showTextDocument`, so that made me think that `common/vscode` wouldn't work out.

Each commit can be reviewed independently if desired.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
