### PR TITLE
Convert call sites to use typed commands (part 3)

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -876,7 +876,7 @@ async function activateWithInstalledDistribution(
 
   ctx.subscriptions.push(astViewer);
 
-  const summaryLanguageSupport = new SummaryLanguageSupport();
+  const summaryLanguageSupport = new SummaryLanguageSupport(app);
   ctx.subscriptions.push(summaryLanguageSupport);
 
   const mockServer = new VSCodeMockGitHubApiServer(ctx);

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -879,7 +879,7 @@ async function activateWithInstalledDistribution(
   const summaryLanguageSupport = new SummaryLanguageSupport(app);
   ctx.subscriptions.push(summaryLanguageSupport);
 
-  const mockServer = new VSCodeMockGitHubApiServer(ctx, app);
+  const mockServer = new VSCodeMockGitHubApiServer(app);
   ctx.subscriptions.push(mockServer);
 
   void extLogger.log("Registering top-level command palette commands.");

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -879,7 +879,7 @@ async function activateWithInstalledDistribution(
   const summaryLanguageSupport = new SummaryLanguageSupport(app);
   ctx.subscriptions.push(summaryLanguageSupport);
 
-  const mockServer = new VSCodeMockGitHubApiServer(ctx);
+  const mockServer = new VSCodeMockGitHubApiServer(ctx, app);
   ctx.subscriptions.push(mockServer);
 
   void extLogger.log("Registering top-level command palette commands.");

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -1074,6 +1074,7 @@ async function createQueryServer(
     );
   if (await cliServer.cliConstraints.supportsNewQueryServer()) {
     const qs = new QueryServerClient(
+      app,
       qlConfigurationListener,
       cliServer,
       qsOpts,

--- a/extensions/ql-vscode/src/log-insights/summary-language-support.ts
+++ b/extensions/ql-vscode/src/log-insights/summary-language-support.ts
@@ -1,7 +1,6 @@
 import { readFile } from "fs-extra";
 import { RawSourceMap, SourceMapConsumer } from "source-map";
 import {
-  commands,
   Position,
   Selection,
   TextDocument,
@@ -16,6 +15,7 @@ import { DisposableObject } from "../pure/disposable-object";
 import { extLogger } from "../common";
 import { getErrorMessage } from "../pure/helpers-pure";
 import { SummaryLanguageSupportCommands } from "../common/commands";
+import { App } from "../common/app";
 
 /** A `Position` within a specified file on disk. */
 interface PositionInFile {
@@ -55,7 +55,7 @@ export class SummaryLanguageSupport extends DisposableObject {
    */
   private sourceMap: SourceMapConsumer | undefined = undefined;
 
-  constructor() {
+  constructor(private readonly app: App) {
     super();
 
     this.push(
@@ -160,7 +160,7 @@ export class SummaryLanguageSupport extends DisposableObject {
   private async updateContext(): Promise<void> {
     const position = await this.getQLSourceLocation();
 
-    await commands.executeCommand(
+    await this.app.commands.execute(
       "setContext",
       "codeql.hasQLSource",
       position !== undefined,

--- a/extensions/ql-vscode/src/mocks/vscode-mock-gh-api-server.ts
+++ b/extensions/ql-vscode/src/mocks/vscode-mock-gh-api-server.ts
@@ -1,12 +1,5 @@
 import { pathExists } from "fs-extra";
-import {
-  env,
-  ExtensionContext,
-  ExtensionMode,
-  QuickPickItem,
-  Uri,
-  window,
-} from "vscode";
+import { env, QuickPickItem, Uri, window } from "vscode";
 
 import {
   getMockGitHubApiServerScenariosPath,
@@ -15,7 +8,8 @@ import {
 import { DisposableObject } from "../pure/disposable-object";
 import { MockGitHubApiServer } from "./mock-gh-api-server";
 import { MockGitHubApiServerCommands } from "../common/commands";
-import { App } from "../common/app";
+import { App, AppMode } from "../common/app";
+import path from "path";
 
 /**
  * "Interface" to the mock GitHub API server which implements VSCode interactions, such as
@@ -27,10 +21,7 @@ export class VSCodeMockGitHubApiServer extends DisposableObject {
   private readonly server: MockGitHubApiServer;
   private readonly config: MockGitHubApiConfigListener;
 
-  constructor(
-    private readonly ctx: ExtensionContext,
-    private readonly app: App,
-  ) {
+  constructor(private readonly app: App) {
     super();
     this.server = new MockGitHubApiServer();
     this.config = new MockGitHubApiConfigListener();
@@ -228,11 +219,11 @@ export class VSCodeMockGitHubApiServer extends DisposableObject {
       return scenariosPath;
     }
 
-    if (this.ctx.extensionMode === ExtensionMode.Development) {
-      const developmentScenariosPath = Uri.joinPath(
-        this.ctx.extensionUri,
+    if (this.app.mode === AppMode.Development) {
+      const developmentScenariosPath = path.join(
+        this.app.extensionPath,
         "src/mocks/scenarios",
-      ).fsPath.toString();
+      );
       if (await pathExists(developmentScenariosPath)) {
         return developmentScenariosPath;
       }

--- a/extensions/ql-vscode/src/mocks/vscode-mock-gh-api-server.ts
+++ b/extensions/ql-vscode/src/mocks/vscode-mock-gh-api-server.ts
@@ -1,6 +1,5 @@
 import { pathExists } from "fs-extra";
 import {
-  commands,
   env,
   ExtensionContext,
   ExtensionMode,
@@ -16,6 +15,7 @@ import {
 import { DisposableObject } from "../pure/disposable-object";
 import { MockGitHubApiServer } from "./mock-gh-api-server";
 import { MockGitHubApiServerCommands } from "../common/commands";
+import { App } from "../common/app";
 
 /**
  * "Interface" to the mock GitHub API server which implements VSCode interactions, such as
@@ -27,7 +27,10 @@ export class VSCodeMockGitHubApiServer extends DisposableObject {
   private readonly server: MockGitHubApiServer;
   private readonly config: MockGitHubApiConfigListener;
 
-  constructor(private readonly ctx: ExtensionContext) {
+  constructor(
+    private readonly ctx: ExtensionContext,
+    private readonly app: App,
+  ) {
     super();
     this.server = new MockGitHubApiServer();
     this.config = new MockGitHubApiConfigListener();
@@ -55,12 +58,12 @@ export class VSCodeMockGitHubApiServer extends DisposableObject {
   public async stopServer(): Promise<void> {
     this.server.stopServer();
 
-    await commands.executeCommand(
+    await this.app.commands.execute(
       "setContext",
       "codeQL.mockGitHubApiServer.scenarioLoaded",
       false,
     );
-    await commands.executeCommand(
+    await this.app.commands.execute(
       "setContext",
       "codeQL.mockGitHubApiServer.recording",
       false,
@@ -92,7 +95,7 @@ export class VSCodeMockGitHubApiServer extends DisposableObject {
 
     // Set a value in the context to track whether we have a scenario loaded.
     // This allows us to use this to show/hide commands (see package.json)
-    await commands.executeCommand(
+    await this.app.commands.execute(
       "setContext",
       "codeQL.mockGitHubApiServer.scenarioLoaded",
       true,
@@ -106,7 +109,7 @@ export class VSCodeMockGitHubApiServer extends DisposableObject {
       await window.showInformationMessage("No scenario currently loaded");
     } else {
       await this.server.unloadScenario();
-      await commands.executeCommand(
+      await this.app.commands.execute(
         "setContext",
         "codeQL.mockGitHubApiServer.scenarioLoaded",
         false,
@@ -125,7 +128,7 @@ export class VSCodeMockGitHubApiServer extends DisposableObject {
 
     if (this.server.isScenarioLoaded) {
       await this.server.unloadScenario();
-      await commands.executeCommand(
+      await this.app.commands.execute(
         "setContext",
         "codeQL.mockGitHubApiServer.scenarioLoaded",
         false,
@@ -137,7 +140,7 @@ export class VSCodeMockGitHubApiServer extends DisposableObject {
 
     await this.server.startRecording();
     // Set a value in the context to track whether we are recording. This allows us to use this to show/hide commands (see package.json)
-    await commands.executeCommand(
+    await this.app.commands.execute(
       "setContext",
       "codeQL.mockGitHubApiServer.recording",
       true,
@@ -155,7 +158,7 @@ export class VSCodeMockGitHubApiServer extends DisposableObject {
     }
 
     // Set a value in the context to track whether we are recording. This allows us to use this to show/hide commands (see package.json)
-    await commands.executeCommand(
+    await this.app.commands.execute(
       "setContext",
       "codeQL.mockGitHubApiServer.recording",
       false,
@@ -210,7 +213,7 @@ export class VSCodeMockGitHubApiServer extends DisposableObject {
 
   private async stopRecording(): Promise<void> {
     // Set a value in the context to track whether we are recording. This allows us to use this to show/hide commands (see package.json)
-    await commands.executeCommand(
+    await this.app.commands.execute(
       "setContext",
       "codeQL.mockGitHubApiServer.recording",
       false,

--- a/extensions/ql-vscode/src/query-server/queryserver-client.ts
+++ b/extensions/ql-vscode/src/query-server/queryserver-client.ts
@@ -1,7 +1,7 @@
 import { ensureFile } from "fs-extra";
 
 import { DisposableObject } from "../pure/disposable-object";
-import { CancellationToken, commands } from "vscode";
+import { CancellationToken } from "vscode";
 import { createMessageConnection, RequestType } from "vscode-jsonrpc/node";
 import * as cli from "../cli";
 import { QueryServerConfig } from "../config";
@@ -13,6 +13,7 @@ import {
 } from "../pure/new-messages";
 import { ProgressCallback, ProgressTask } from "../progress";
 import { ServerProcess } from "../json-rpc-server";
+import { App } from "../common/app";
 
 type ServerOpts = {
   logger: Logger;
@@ -53,6 +54,7 @@ export class QueryServerClient extends DisposableObject {
   public activeQueryLogger: Logger;
 
   constructor(
+    app: App,
     readonly config: QueryServerConfig,
     readonly cliServer: cli.CodeQLCliServer,
     readonly opts: ServerOpts,
@@ -66,7 +68,7 @@ export class QueryServerClient extends DisposableObject {
     if (config.onDidChangeConfiguration !== undefined) {
       this.push(
         config.onDidChangeConfiguration(() =>
-          commands.executeCommand("codeQL.restartQueryServer"),
+          app.commands.execute("codeQL.restartQueryServer"),
         ),
       );
     }

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -689,6 +689,7 @@ export class VariantAnalysisManager
       this,
       variantAnalysisId,
       filterSort,
+      this.app.commands,
       this.app.credentials,
     );
   }

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -6,7 +6,6 @@ import {
 } from "./gh-api/gh-api-client";
 import {
   CancellationToken,
-  commands,
   env,
   EventEmitter,
   ExtensionContext,
@@ -239,11 +238,11 @@ export class VariantAnalysisManager
       `Variant analysis ${processedVariantAnalysis.query.name} submitted for processing`,
     );
 
-    void commands.executeCommand(
+    void this.app.commands.execute(
       "codeQL.openVariantAnalysisView",
       processedVariantAnalysis.id,
     );
-    void commands.executeCommand(
+    void this.app.commands.execute(
       "codeQL.monitorVariantAnalysis",
       processedVariantAnalysis,
     );
@@ -273,7 +272,7 @@ export class VariantAnalysisManager
           this.makeResultDownloadChecker(variantAnalysis),
         ))
       ) {
-        void commands.executeCommand(
+        void this.app.commands.execute(
           "codeQL.monitorVariantAnalysis",
           variantAnalysis,
         );
@@ -641,7 +640,7 @@ export class VariantAnalysisManager
 
     const actionsWorkflowRunUrl = getActionsWorkflowRunUrl(variantAnalysis);
 
-    await commands.executeCommand(
+    await this.app.commands.execute(
       "vscode.open",
       Uri.parse(actionsWorkflowRunUrl),
     );

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -115,6 +115,7 @@ export class VariantAnalysisManager
     super();
     this.variantAnalysisMonitor = this.push(
       new VariantAnalysisMonitor(
+        app,
         this.shouldCancelMonitorVariantAnalysis.bind(this),
       ),
     );
@@ -501,10 +502,7 @@ export class VariantAnalysisManager
   public async monitorVariantAnalysis(
     variantAnalysis: VariantAnalysis,
   ): Promise<void> {
-    await this.variantAnalysisMonitor.monitorVariantAnalysis(
-      variantAnalysis,
-      this.app.credentials,
-    );
+    await this.variantAnalysisMonitor.monitorVariantAnalysis(variantAnalysis);
   }
 
   public async autoDownloadVariantAnalysisResult(

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-monitor.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-monitor.ts
@@ -1,4 +1,4 @@
-import { commands, EventEmitter } from "vscode";
+import { EventEmitter } from "vscode";
 import { getVariantAnalysis } from "./gh-api/gh-api-client";
 
 import {
@@ -13,7 +13,7 @@ import { DisposableObject } from "../pure/disposable-object";
 import { sleep } from "../pure/time";
 import { getErrorMessage } from "../pure/helpers-pure";
 import { showAndLogWarningMessage } from "../helpers";
-import { Credentials } from "../common/authentication";
+import { App } from "../common/app";
 
 export class VariantAnalysisMonitor extends DisposableObject {
   // With a sleep of 5 seconds, the maximum number of attempts takes
@@ -27,6 +27,7 @@ export class VariantAnalysisMonitor extends DisposableObject {
   readonly onVariantAnalysisChange = this._onVariantAnalysisChange.event;
 
   constructor(
+    private readonly app: App,
     private readonly shouldCancelMonitor: (
       variantAnalysisId: number,
     ) => Promise<boolean>,
@@ -36,7 +37,6 @@ export class VariantAnalysisMonitor extends DisposableObject {
 
   public async monitorVariantAnalysis(
     variantAnalysis: VariantAnalysis,
-    credentials: Credentials,
   ): Promise<void> {
     let attemptCount = 0;
     const scannedReposDownloaded: number[] = [];
@@ -51,7 +51,7 @@ export class VariantAnalysisMonitor extends DisposableObject {
       let variantAnalysisSummary: ApiVariantAnalysis;
       try {
         variantAnalysisSummary = await getVariantAnalysis(
-          credentials,
+          this.app.credentials,
           variantAnalysis.controllerRepo.id,
           variantAnalysis.id,
         );
@@ -87,7 +87,7 @@ export class VariantAnalysisMonitor extends DisposableObject {
     scannedRepo: VariantAnalysisScannedRepository,
     variantAnalysisSummary: VariantAnalysis,
   ) {
-    void commands.executeCommand(
+    void this.app.commands.execute(
       "codeQL.autoDownloadVariantAnalysisResult",
       scannedRepo,
       variantAnalysisSummary,

--- a/extensions/ql-vscode/test/vscode-tests/activated-extension/variant-analysis/variant-analysis-monitor.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/activated-extension/variant-analysis/variant-analysis-monitor.test.ts
@@ -1,6 +1,3 @@
-import { commands, extensions } from "vscode";
-import { CodeQLExtensionInterface } from "../../../../src/extension";
-
 import * as ghApiClient from "../../../../src/variant-analysis/gh-api/gh-api-client";
 import { VariantAnalysisMonitor } from "../../../../src/variant-analysis/variant-analysis-monitor";
 import {
@@ -23,43 +20,36 @@ import {
   processUpdatedVariantAnalysis,
 } from "../../../../src/variant-analysis/variant-analysis-processor";
 import { createMockVariantAnalysis } from "../../../factories/variant-analysis/shared/variant-analysis";
-import { VariantAnalysisManager } from "../../../../src/variant-analysis/variant-analysis-manager";
-import { testCredentialsWithStub } from "../../../factories/authentication";
+import { createMockApp } from "../../../__mocks__/appMock";
+import { createMockCommandManager } from "../../../__mocks__/commandsMock";
 
 jest.setTimeout(60_000);
 
 describe("Variant Analysis Monitor", () => {
-  let extension: CodeQLExtensionInterface | Record<string, never>;
   let mockGetVariantAnalysis: jest.SpiedFunction<
     typeof ghApiClient.getVariantAnalysis
   >;
   let variantAnalysisMonitor: VariantAnalysisMonitor;
   let shouldCancelMonitor: jest.Mock<Promise<boolean>, [number]>;
   let variantAnalysis: VariantAnalysis;
-  let variantAnalysisManager: VariantAnalysisManager;
-  let mockGetDownloadResult: jest.SpiedFunction<
-    typeof variantAnalysisManager.autoDownloadVariantAnalysisResult
-  >;
 
   const onVariantAnalysisChangeSpy = jest.fn();
+  const mockEecuteCommand = jest.fn();
 
   beforeEach(async () => {
     variantAnalysis = createMockVariantAnalysis({});
 
     shouldCancelMonitor = jest.fn();
 
-    extension = await extensions
-      .getExtension<CodeQLExtensionInterface | Record<string, never>>(
-        "GitHub.vscode-codeql",
-      )!
-      .activate();
-    variantAnalysisMonitor = new VariantAnalysisMonitor(shouldCancelMonitor);
+    variantAnalysisMonitor = new VariantAnalysisMonitor(
+      createMockApp({
+        commands: createMockCommandManager({
+          executeCommand: mockEecuteCommand,
+        }),
+      }),
+      shouldCancelMonitor,
+    );
     variantAnalysisMonitor.onVariantAnalysisChange(onVariantAnalysisChangeSpy);
-
-    variantAnalysisManager = extension.variantAnalysisManager;
-    mockGetDownloadResult = jest
-      .spyOn(variantAnalysisManager, "autoDownloadVariantAnalysisResult")
-      .mockResolvedValue(undefined);
 
     mockGetVariantAnalysis = jest
       .spyOn(ghApiClient, "getVariantAnalysis")
@@ -71,10 +61,7 @@ describe("Variant Analysis Monitor", () => {
   it("should return early if variant analysis should be cancelled", async () => {
     shouldCancelMonitor.mockResolvedValue(true);
 
-    await variantAnalysisMonitor.monitorVariantAnalysis(
-      variantAnalysis,
-      testCredentialsWithStub(),
-    );
+    await variantAnalysisMonitor.monitorVariantAnalysis(variantAnalysis);
 
     expect(onVariantAnalysisChangeSpy).not.toHaveBeenCalled();
   });
@@ -88,10 +75,7 @@ describe("Variant Analysis Monitor", () => {
     });
 
     it("should mark as failed and stop monitoring", async () => {
-      await variantAnalysisMonitor.monitorVariantAnalysis(
-        variantAnalysis,
-        testCredentialsWithStub(),
-      );
+      await variantAnalysisMonitor.monitorVariantAnalysis(variantAnalysis);
 
       expect(mockGetVariantAnalysis).toHaveBeenCalledTimes(1);
 
@@ -109,7 +93,6 @@ describe("Variant Analysis Monitor", () => {
   describe("when the variant analysis is in progress", () => {
     let mockApiResponse: VariantAnalysisApiResponse;
     let scannedRepos: ApiVariantAnalysisScannedRepository[];
-    let succeededRepos: ApiVariantAnalysisScannedRepository[];
 
     describe("when there are successfully scanned repos", () => {
       beforeEach(async () => {
@@ -124,47 +107,20 @@ describe("Variant Analysis Monitor", () => {
         ]);
         mockApiResponse = createMockApiResponse("succeeded", scannedRepos);
         mockGetVariantAnalysis.mockResolvedValue(mockApiResponse);
-        succeededRepos = scannedRepos.filter(
-          (r) => r.analysis_status === "succeeded",
-        );
       });
 
       it("should trigger a download extension command for each repo", async () => {
         const succeededRepos = scannedRepos.filter(
           (r) => r.analysis_status === "succeeded",
         );
-        const commandSpy = jest
-          .spyOn(commands, "executeCommand")
-          .mockResolvedValue(undefined);
+        await variantAnalysisMonitor.monitorVariantAnalysis(variantAnalysis);
 
-        await variantAnalysisMonitor.monitorVariantAnalysis(
-          variantAnalysis,
-          testCredentialsWithStub(),
-        );
-
-        expect(commandSpy).toBeCalledTimes(succeededRepos.length);
+        expect(mockEecuteCommand).toBeCalledTimes(succeededRepos.length);
 
         succeededRepos.forEach((succeededRepo, index) => {
-          expect(commandSpy).toHaveBeenNthCalledWith(
+          expect(mockEecuteCommand).toHaveBeenNthCalledWith(
             index + 1,
             "codeQL.autoDownloadVariantAnalysisResult",
-            processScannedRepository(succeededRepo),
-            processUpdatedVariantAnalysis(variantAnalysis, mockApiResponse),
-          );
-        });
-      });
-
-      it("should download all available results", async () => {
-        await variantAnalysisMonitor.monitorVariantAnalysis(
-          variantAnalysis,
-          testCredentialsWithStub(),
-        );
-
-        expect(mockGetDownloadResult).toBeCalledTimes(succeededRepos.length);
-
-        succeededRepos.forEach((succeededRepo, index) => {
-          expect(mockGetDownloadResult).toHaveBeenNthCalledWith(
-            index + 1,
             processScannedRepository(succeededRepo),
             processUpdatedVariantAnalysis(variantAnalysis, mockApiResponse),
           );
@@ -182,25 +138,9 @@ describe("Variant Analysis Monitor", () => {
       });
 
       it("should succeed and not download any repos via a command", async () => {
-        const commandSpy = jest
-          .spyOn(commands, "executeCommand")
-          .mockResolvedValue(undefined);
+        await variantAnalysisMonitor.monitorVariantAnalysis(variantAnalysis);
 
-        await variantAnalysisMonitor.monitorVariantAnalysis(
-          variantAnalysis,
-          testCredentialsWithStub(),
-        );
-
-        expect(commandSpy).not.toHaveBeenCalled();
-      });
-
-      it("should not try to download any repos", async () => {
-        await variantAnalysisMonitor.monitorVariantAnalysis(
-          variantAnalysis,
-          testCredentialsWithStub(),
-        );
-
-        expect(mockGetDownloadResult).not.toBeCalled();
+        expect(mockEecuteCommand).not.toHaveBeenCalled();
       });
     });
 
@@ -249,17 +189,10 @@ describe("Variant Analysis Monitor", () => {
       });
 
       it("should trigger a download extension command for each repo", async () => {
-        const commandSpy = jest
-          .spyOn(commands, "executeCommand")
-          .mockResolvedValue(undefined);
-
-        await variantAnalysisMonitor.monitorVariantAnalysis(
-          variantAnalysis,
-          testCredentialsWithStub(),
-        );
+        await variantAnalysisMonitor.monitorVariantAnalysis(variantAnalysis);
 
         expect(mockGetVariantAnalysis).toBeCalledTimes(4);
-        expect(commandSpy).toBeCalledTimes(5);
+        expect(mockEecuteCommand).toBeCalledTimes(5);
       });
     });
 
@@ -271,12 +204,9 @@ describe("Variant Analysis Monitor", () => {
       });
 
       it("should not try to download any repos", async () => {
-        await variantAnalysisMonitor.monitorVariantAnalysis(
-          variantAnalysis,
-          testCredentialsWithStub(),
-        );
+        await variantAnalysisMonitor.monitorVariantAnalysis(variantAnalysis);
 
-        expect(mockGetDownloadResult).not.toBeCalled();
+        expect(mockEecuteCommand).not.toBeCalled();
       });
     });
   });

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/new-query.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/new-query.test.ts
@@ -13,7 +13,7 @@ import { extLogger, ProgressReporter } from "../../../src/common";
 import { QueryResultType } from "../../../src/pure/new-messages";
 import { cleanDatabases, dbLoc, storagePath } from "../global.helper";
 import { importArchiveDatabase } from "../../../src/databaseFetcher";
-import { createMockCommandManager } from "../../__mocks__/commandsMock";
+import { createMockApp } from "../../__mocks__/appMock";
 
 const baseDir = join(__dirname, "../../../test/data");
 
@@ -110,6 +110,7 @@ describeWithCodeQL()("using the new query server", () => {
   let supportNewQueryServer = true;
 
   beforeAll(async () => {
+    const app = createMockApp({});
     const extension = await extensions
       .getExtension<CodeQLExtensionInterface | Record<string, never>>(
         "GitHub.vscode-codeql",
@@ -123,6 +124,7 @@ describeWithCodeQL()("using the new query server", () => {
         supportNewQueryServer = false;
       }
       qs = new QueryServerClient(
+        app,
         {
           codeQlPath:
             (await extension.distributionManager.getCodeQlPathWithoutVersionCheck()) ||
@@ -148,7 +150,7 @@ describeWithCodeQL()("using the new query server", () => {
       await cleanDatabases(extension.databaseManager);
       const uri = Uri.file(dbLoc);
       const maybeDbItem = await importArchiveDatabase(
-        createMockCommandManager(),
+        app.commands,
         uri.toString(true),
         extension.databaseManager,
         storagePath,


### PR DESCRIPTION
Follows on from earlier PRs and converts some more places to call typed commands.

The only non-trivial bit of this PR is around `VariantAnalysisMonitor`:
- This class already took credentials, but in this case I decided to instead provide a full app and moved it to the constructor instead of the `monitorVariantAnalysis` method.
- The tests were asserting that the `codeQL.autoDownloadVariantAnalysisResult` command was called, but then also asserting that the `VariantAnalysisManager. autoDownloadVariantAnalysisResult` method was called. This only works if it's actually executing commands rather than using a mock, and is also not very necessary. I decided to remove these and just check that the command was called, and this made the tests a lot simpler.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
