### PR TITLE
Use undefined instead of Record<string, never> type when unable to activate extension

### DIFF
--- a/extensions/ql-vscode/test/vscode-tests/activated-extension/databases/db-panel.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/activated-extension/databases/db-panel.test.ts
@@ -1,6 +1,5 @@
-import { commands, extensions, window } from "vscode";
+import { commands, window } from "vscode";
 
-import { CodeQLExtensionInterface } from "../../../../src/extension";
 import { readJson } from "fs-extra";
 import * as path from "path";
 import {
@@ -15,19 +14,15 @@ import { DbListKind } from "../../../../src/databases/db-item";
 import { createDbTreeViewItemSystemDefinedList } from "../../../../src/databases/ui/db-tree-view-item";
 import { createRemoteSystemDefinedListDbItem } from "../../../factories/db-item-factories";
 import { DbConfigStore } from "../../../../src/databases/config/db-config-store";
+import { getActivatedExtension } from "../../global.helper";
 
 jest.setTimeout(60_000);
 
 describe("Db panel UI commands", () => {
-  let extension: CodeQLExtensionInterface | Record<string, never>;
   let storagePath: string;
 
   beforeEach(async () => {
-    extension = await extensions
-      .getExtension<CodeQLExtensionInterface | Record<string, never>>(
-        "GitHub.vscode-codeql",
-      )!
-      .activate();
+    const extension = await getActivatedExtension();
 
     storagePath =
       extension.ctx.storageUri?.fsPath || extension.ctx.globalStorageUri.fsPath;

--- a/extensions/ql-vscode/test/vscode-tests/activated-extension/variant-analysis/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/activated-extension/variant-analysis/variant-analysis-manager.test.ts
@@ -1,14 +1,12 @@
 import {
   commands,
   env,
-  extensions,
   TextDocument,
   TextEditor,
   Uri,
   window,
   workspace,
 } from "vscode";
-import { CodeQLExtensionInterface } from "../../../../src/extension";
 import { extLogger } from "../../../../src/common";
 import * as ghApiClient from "../../../../src/variant-analysis/gh-api/gh-api-client";
 import * as ghActionsApiClient from "../../../../src/variant-analysis/gh-api/gh-actions-api-client";
@@ -20,7 +18,7 @@ import { Response } from "node-fetch";
 
 import { VariantAnalysisManager } from "../../../../src/variant-analysis/variant-analysis-manager";
 import { CodeQLCliServer } from "../../../../src/cli";
-import { storagePath } from "../../global.helper";
+import { getActivatedExtension, storagePath } from "../../global.helper";
 import { VariantAnalysisResultsManager } from "../../../../src/variant-analysis/variant-analysis-results-manager";
 import { createMockVariantAnalysis } from "../../../factories/variant-analysis/shared/variant-analysis";
 import * as VariantAnalysisModule from "../../../../src/variant-analysis/shared/variant-analysis";
@@ -67,11 +65,7 @@ describe("Variant Analysis Manager", () => {
       scannedRepos,
     });
 
-    const extension = await extensions
-      .getExtension<CodeQLExtensionInterface | Record<string, never>>(
-        "GitHub.vscode-codeql",
-      )!
-      .activate();
+    const extension = await getActivatedExtension();
     const cli = mockedObject<CodeQLCliServer>({});
     app = new ExtensionApp(extension.ctx);
     const dbManager = new DbManager(app, new DbConfigStore(app));

--- a/extensions/ql-vscode/test/vscode-tests/activated-extension/variant-analysis/variant-analysis-monitor.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/activated-extension/variant-analysis/variant-analysis-monitor.test.ts
@@ -1,5 +1,4 @@
-import { commands, extensions } from "vscode";
-import { CodeQLExtensionInterface } from "../../../../src/extension";
+import { commands } from "vscode";
 
 import * as ghApiClient from "../../../../src/variant-analysis/gh-api/gh-api-client";
 import { VariantAnalysisMonitor } from "../../../../src/variant-analysis/variant-analysis-monitor";
@@ -25,11 +24,11 @@ import {
 import { createMockVariantAnalysis } from "../../../factories/variant-analysis/shared/variant-analysis";
 import { VariantAnalysisManager } from "../../../../src/variant-analysis/variant-analysis-manager";
 import { testCredentialsWithStub } from "../../../factories/authentication";
+import { getActivatedExtension } from "../../global.helper";
 
 jest.setTimeout(60_000);
 
 describe("Variant Analysis Monitor", () => {
-  let extension: CodeQLExtensionInterface | Record<string, never>;
   let mockGetVariantAnalysis: jest.SpiedFunction<
     typeof ghApiClient.getVariantAnalysis
   >;
@@ -48,11 +47,7 @@ describe("Variant Analysis Monitor", () => {
 
     shouldCancelMonitor = jest.fn();
 
-    extension = await extensions
-      .getExtension<CodeQLExtensionInterface | Record<string, never>>(
-        "GitHub.vscode-codeql",
-      )!
-      .activate();
+    const extension = await getActivatedExtension();
     variantAnalysisMonitor = new VariantAnalysisMonitor(shouldCancelMonitor);
     variantAnalysisMonitor.onVariantAnalysisChange(onVariantAnalysisChangeSpy);
 

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/databaseFetcher.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/databaseFetcher.test.ts
@@ -36,13 +36,7 @@ describe("DatabaseFetcher", () => {
     jest.spyOn(window, "showInformationMessage").mockResolvedValue(undefined);
 
     const extension = await getActivatedExtension();
-    if ("databaseManager" in extension) {
-      databaseManager = extension.databaseManager;
-    } else {
-      throw new Error(
-        "Extension not initialized. Make sure cli is downloaded and installed properly.",
-      );
-    }
+    databaseManager = extension.databaseManager;
 
     await cleanDatabases(databaseManager);
   });

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/databaseFetcher.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/databaseFetcher.test.ts
@@ -1,14 +1,19 @@
 import { join } from "path";
-import { extensions, CancellationToken, Uri, window } from "vscode";
+import { CancellationToken, Uri, window } from "vscode";
 
-import { CodeQLExtensionInterface } from "../../../src/extension";
 import { CodeQLCliServer } from "../../../src/cli";
 import { DatabaseManager } from "../../../src/local-databases";
 import {
   importArchiveDatabase,
   promptImportInternetDatabase,
 } from "../../../src/databaseFetcher";
-import { cleanDatabases, dbLoc, DB_URL, storagePath } from "../global.helper";
+import {
+  cleanDatabases,
+  dbLoc,
+  DB_URL,
+  getActivatedExtension,
+  storagePath,
+} from "../global.helper";
 import { createMockCommandManager } from "../../__mocks__/commandsMock";
 
 jest.setTimeout(60_000);
@@ -30,11 +35,7 @@ describe("DatabaseFetcher", () => {
     jest.spyOn(window, "showErrorMessage").mockResolvedValue(undefined);
     jest.spyOn(window, "showInformationMessage").mockResolvedValue(undefined);
 
-    const extension = await extensions
-      .getExtension<CodeQLExtensionInterface | Record<string, never>>(
-        "GitHub.vscode-codeql",
-      )!
-      .activate();
+    const extension = await getActivatedExtension();
     if ("databaseManager" in extension) {
       databaseManager = extension.databaseManager;
     } else {

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/helpers.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/helpers.test.ts
@@ -14,13 +14,7 @@ describe("helpers (with CLI)", () => {
 
   beforeEach(async () => {
     const extension = await getActivatedExtension();
-    if ("cliServer" in extension) {
-      cli = extension.cliServer;
-    } else {
-      throw new Error(
-        "Extension not initialized. Make sure cli is downloaded and installed properly.",
-      );
-    }
+    cli = extension.cliServer;
   });
 
   it("should get query metadata when available", async () => {

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/helpers.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/helpers.test.ts
@@ -1,9 +1,8 @@
 import { join } from "path";
-import { extensions } from "vscode";
 
 import { CodeQLCliServer } from "../../../src/cli";
-import { CodeQLExtensionInterface } from "../../../src/extension";
 import { tryGetQueryMetadata } from "../../../src/helpers";
+import { getActivatedExtension } from "../global.helper";
 
 // up to 3 minutes per test
 jest.setTimeout(3 * 60 * 1000);
@@ -14,11 +13,7 @@ describe("helpers (with CLI)", () => {
   let cli: CodeQLCliServer;
 
   beforeEach(async () => {
-    const extension = await extensions
-      .getExtension<CodeQLExtensionInterface | Record<string, never>>(
-        "GitHub.vscode-codeql",
-      )!
-      .activate();
+    const extension = await getActivatedExtension();
     if ("cliServer" in extension) {
       cli = extension.cliServer;
     } else {

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/legacy-query.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/legacy-query.test.ts
@@ -112,36 +112,29 @@ describeWithCodeQL()("using the legacy query server", () => {
 
   beforeAll(async () => {
     const extension = await getActivatedExtension();
-    if ("cliServer" in extension) {
-      cliServer = extension.cliServer;
-      cliServer.quiet = true;
+    cliServer = extension.cliServer;
+    cliServer.quiet = true;
 
-      qs = new QueryServerClient(
-        createMockApp({}),
-        {
-          codeQlPath:
-            (await extension.distributionManager.getCodeQlPathWithoutVersionCheck()) ||
-            "",
-          debug: false,
-          cacheSize: 0,
-          numThreads: 1,
-          saveCache: false,
-          timeoutSecs: 0,
-        },
-        cliServer,
-        {
-          contextStoragePath: tmpDir.name,
-          logger: extLogger,
-        },
-        (task) =>
-          task(nullProgressReporter, new CancellationTokenSource().token),
-      );
-      await qs.startQueryServer();
-    } else {
-      throw new Error(
-        "Extension not initialized. Make sure cli is downloaded and installed properly.",
-      );
-    }
+    qs = new QueryServerClient(
+      createMockApp({}),
+      {
+        codeQlPath:
+          (await extension.distributionManager.getCodeQlPathWithoutVersionCheck()) ||
+          "",
+        debug: false,
+        cacheSize: 0,
+        numThreads: 1,
+        saveCache: false,
+        timeoutSecs: 0,
+      },
+      cliServer,
+      {
+        contextStoragePath: tmpDir.name,
+        logger: extLogger,
+      },
+      (task) => task(nullProgressReporter, new CancellationTokenSource().token),
+    );
+    await qs.startQueryServer();
   });
 
   for (const queryTestCase of queryTestCases) {

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/legacy-query.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/legacy-query.test.ts
@@ -7,12 +7,11 @@ import * as messages from "../../../src/pure/legacy-messages";
 import * as qsClient from "../../../src/legacy-query-server/queryserver-client";
 import * as cli from "../../../src/cli";
 import { CellValue } from "../../../src/pure/bqrs-cli-types";
-import { extensions } from "vscode";
-import { CodeQLExtensionInterface } from "../../../src/extension";
 import { describeWithCodeQL } from "../cli";
 import { QueryServerClient } from "../../../src/legacy-query-server/queryserver-client";
 import { extLogger, ProgressReporter } from "../../../src/common";
 import { createMockApp } from "../../__mocks__/appMock";
+import { getActivatedExtension } from "../global.helper";
 
 const baseDir = join(__dirname, "../../../test/data");
 
@@ -112,11 +111,7 @@ describeWithCodeQL()("using the legacy query server", () => {
   let cliServer: cli.CodeQLCliServer;
 
   beforeAll(async () => {
-    const extension = await extensions
-      .getExtension<CodeQLExtensionInterface | Record<string, never>>(
-        "GitHub.vscode-codeql",
-      )!
-      .activate();
+    const extension = await getActivatedExtension();
     if ("cliServer" in extension) {
       cliServer = extension.cliServer;
       cliServer.quiet = true;

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/new-query.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/new-query.test.ts
@@ -5,13 +5,17 @@ import * as messages from "../../../src/pure/new-messages";
 import * as qsClient from "../../../src/query-server/queryserver-client";
 import * as cli from "../../../src/cli";
 import { CellValue } from "../../../src/pure/bqrs-cli-types";
-import { extensions, Uri } from "vscode";
-import { CodeQLExtensionInterface } from "../../../src/extension";
+import { Uri } from "vscode";
 import { describeWithCodeQL } from "../cli";
 import { QueryServerClient } from "../../../src/query-server/queryserver-client";
 import { extLogger, ProgressReporter } from "../../../src/common";
 import { QueryResultType } from "../../../src/pure/new-messages";
-import { cleanDatabases, dbLoc, storagePath } from "../global.helper";
+import {
+  cleanDatabases,
+  dbLoc,
+  getActivatedExtension,
+  storagePath,
+} from "../global.helper";
 import { importArchiveDatabase } from "../../../src/databaseFetcher";
 import { createMockCommandManager } from "../../__mocks__/commandsMock";
 
@@ -110,11 +114,7 @@ describeWithCodeQL()("using the new query server", () => {
   let supportNewQueryServer = true;
 
   beforeAll(async () => {
-    const extension = await extensions
-      .getExtension<CodeQLExtensionInterface | Record<string, never>>(
-        "GitHub.vscode-codeql",
-      )!
-      .activate();
+    const extension = await getActivatedExtension();
     if ("cliServer" in extension && "databaseManager" in extension) {
       cliServer = extension.cliServer;
 

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/new-query.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/new-query.test.ts
@@ -115,58 +115,51 @@ describeWithCodeQL()("using the new query server", () => {
 
   beforeAll(async () => {
     const extension = await getActivatedExtension();
-    if ("cliServer" in extension && "databaseManager" in extension) {
-      cliServer = extension.cliServer;
+    cliServer = extension.cliServer;
 
-      cliServer.quiet = true;
-      if (!(await cliServer.cliConstraints.supportsNewQueryServerForTests())) {
-        supportNewQueryServer = false;
-      }
-      qs = new QueryServerClient(
-        {
-          codeQlPath:
-            (await extension.distributionManager.getCodeQlPathWithoutVersionCheck()) ||
-            "",
-          debug: false,
-          cacheSize: 0,
-          numThreads: 1,
-          saveCache: false,
-          timeoutSecs: 0,
-        },
-        cliServer,
-        {
-          contextStoragePath: tmpDir.name,
-          logger: extLogger,
-        },
-        (task) =>
-          task(nullProgressReporter, new CancellationTokenSource().token),
-      );
-      await qs.startQueryServer();
-
-      // Unlike the old query sevre the new one wants a database and the empty direcrtory is not valid.
-      // Add a database, but make sure the database manager is empty first
-      await cleanDatabases(extension.databaseManager);
-      const uri = Uri.file(dbLoc);
-      const maybeDbItem = await importArchiveDatabase(
-        createMockCommandManager(),
-        uri.toString(true),
-        extension.databaseManager,
-        storagePath,
-        () => {
-          /**ignore progress */
-        },
-        token,
-      );
-
-      if (!maybeDbItem) {
-        throw new Error("Could not import database");
-      }
-      db = maybeDbItem.databaseUri.fsPath;
-    } else {
-      throw new Error(
-        "Extension not initialized. Make sure cli is downloaded and installed properly.",
-      );
+    cliServer.quiet = true;
+    if (!(await cliServer.cliConstraints.supportsNewQueryServerForTests())) {
+      supportNewQueryServer = false;
     }
+    qs = new QueryServerClient(
+      {
+        codeQlPath:
+          (await extension.distributionManager.getCodeQlPathWithoutVersionCheck()) ||
+          "",
+        debug: false,
+        cacheSize: 0,
+        numThreads: 1,
+        saveCache: false,
+        timeoutSecs: 0,
+      },
+      cliServer,
+      {
+        contextStoragePath: tmpDir.name,
+        logger: extLogger,
+      },
+      (task) => task(nullProgressReporter, new CancellationTokenSource().token),
+    );
+    await qs.startQueryServer();
+
+    // Unlike the old query sevre the new one wants a database and the empty direcrtory is not valid.
+    // Add a database, but make sure the database manager is empty first
+    await cleanDatabases(extension.databaseManager);
+    const uri = Uri.file(dbLoc);
+    const maybeDbItem = await importArchiveDatabase(
+      createMockCommandManager(),
+      uri.toString(true),
+      extension.databaseManager,
+      storagePath,
+      () => {
+        /**ignore progress */
+      },
+      token,
+    );
+
+    if (!maybeDbItem) {
+      throw new Error("Could not import database");
+    }
+    db = maybeDbItem.databaseUri.fsPath;
   });
 
   for (const queryTestCase of queryTestCases) {

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/packaging.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/packaging.test.ts
@@ -42,13 +42,7 @@ describe("Packaging commands", () => {
       .mockResolvedValue(undefined);
 
     const extension = await getActivatedExtension();
-    if ("cliServer" in extension) {
-      cli = extension.cliServer;
-    } else {
-      throw new Error(
-        "Extension not initialized. Make sure cli is downloaded and installed properly.",
-      );
-    }
+    cli = extension.cliServer;
   });
 
   it("should download all core query packs", async () => {

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/packaging.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/packaging.test.ts
@@ -1,8 +1,7 @@
-import { extensions, window } from "vscode";
+import { window } from "vscode";
 import { join } from "path";
 
 import { CodeQLCliServer } from "../../../src/cli";
-import { CodeQLExtensionInterface } from "../../../src/extension";
 import { getErrorMessage } from "../../../src/pure/helpers-pure";
 
 import * as helpers from "../../../src/helpers";
@@ -11,6 +10,7 @@ import {
   handleInstallPackDependencies,
 } from "../../../src/packaging";
 import { mockedQuickPickItem } from "../utils/mocking.helpers";
+import { getActivatedExtension } from "../global.helper";
 
 // up to 3 minutes per test
 jest.setTimeout(3 * 60 * 1000);
@@ -41,11 +41,7 @@ describe("Packaging commands", () => {
       .spyOn(helpers, "showAndLogInformationMessage")
       .mockResolvedValue(undefined);
 
-    const extension = await extensions
-      .getExtension<CodeQLExtensionInterface | Record<string, never>>(
-        "GitHub.vscode-codeql",
-      )!
-      .activate();
+    const extension = await getActivatedExtension();
     if ("cliServer" in extension) {
       cli = extension.cliServer;
     } else {

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/queries.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/queries.test.ts
@@ -1,10 +1,4 @@
-import {
-  CancellationToken,
-  commands,
-  ExtensionContext,
-  extensions,
-  Uri,
-} from "vscode";
+import { CancellationToken, commands, ExtensionContext, Uri } from "vscode";
 import { join, dirname } from "path";
 import {
   pathExistsSync,
@@ -16,8 +10,12 @@ import {
 import { load, dump } from "js-yaml";
 
 import { DatabaseItem, DatabaseManager } from "../../../src/local-databases";
-import { CodeQLExtensionInterface } from "../../../src/extension";
-import { cleanDatabases, dbLoc, storagePath } from "../global.helper";
+import {
+  cleanDatabases,
+  dbLoc,
+  getActivatedExtension,
+  storagePath,
+} from "../global.helper";
 import { importArchiveDatabase } from "../../../src/databaseFetcher";
 import { CliVersionConstraint, CodeQLCliServer } from "../../../src/cli";
 import { describeWithCodeQL } from "../cli";
@@ -48,11 +46,7 @@ describeWithCodeQL()("Queries", () => {
   let qlFile: string;
 
   beforeEach(async () => {
-    const extension = await extensions
-      .getExtension<CodeQLExtensionInterface | Record<string, never>>(
-        "GitHub.vscode-codeql",
-      )!
-      .activate();
+    const extension = await getActivatedExtension();
     if ("databaseManager" in extension) {
       databaseManager = extension.databaseManager;
       cli = extension.cliServer;

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/queries.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/queries.test.ts
@@ -47,21 +47,15 @@ describeWithCodeQL()("Queries", () => {
 
   beforeEach(async () => {
     const extension = await getActivatedExtension();
-    if ("databaseManager" in extension) {
-      databaseManager = extension.databaseManager;
-      cli = extension.cliServer;
-      qs = extension.qs;
-      cli.quiet = true;
-      ctx = extension.ctx;
-      qlpackFile = `${ctx.storageUri?.fsPath}/quick-queries/qlpack.yml`;
-      qlpackLockFile = `${ctx.storageUri?.fsPath}/quick-queries/codeql-pack.lock.yml`;
-      oldQlpackLockFile = `${ctx.storageUri?.fsPath}/quick-queries/qlpack.lock.yml`;
-      qlFile = `${ctx.storageUri?.fsPath}/quick-queries/quick-query.ql`;
-    } else {
-      throw new Error(
-        "Extension not initialized. Make sure cli is downloaded and installed properly.",
-      );
-    }
+    databaseManager = extension.databaseManager;
+    cli = extension.cliServer;
+    qs = extension.qs;
+    cli.quiet = true;
+    ctx = extension.ctx;
+    qlpackFile = `${ctx.storageUri?.fsPath}/quick-queries/qlpack.yml`;
+    qlpackLockFile = `${ctx.storageUri?.fsPath}/quick-queries/codeql-pack.lock.yml`;
+    oldQlpackLockFile = `${ctx.storageUri?.fsPath}/quick-queries/qlpack.lock.yml`;
+    qlFile = `${ctx.storageUri?.fsPath}/quick-queries/quick-query.ql`;
 
     // Ensure we are starting from a clean slate.
     safeDel(qlFile);

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/run-cli.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/run-cli.test.ts
@@ -1,9 +1,8 @@
-import { authentication, extensions, Uri } from "vscode";
+import { authentication, Uri } from "vscode";
 import { join } from "path";
 import { SemVer } from "semver";
 
 import { CodeQLCliServer, QueryInfoByLanguage } from "../../../src/cli";
-import { CodeQLExtensionInterface } from "../../../src/extension";
 import { itWithCodeQL } from "../cli";
 import {
   getOnDiskWorkspaceFolders,
@@ -13,6 +12,7 @@ import {
 import { resolveQueries } from "../../../src/contextual/queryResolver";
 import { KeyType } from "../../../src/contextual/keyType";
 import { faker } from "@faker-js/faker";
+import { getActivatedExtension } from "../global.helper";
 
 jest.setTimeout(60_000);
 
@@ -24,11 +24,7 @@ describe("Use cli", () => {
   let supportedLanguages: string[];
 
   beforeEach(async () => {
-    const extension = await extensions
-      .getExtension<CodeQLExtensionInterface | Record<string, never>>(
-        "GitHub.vscode-codeql",
-      )!
-      .activate();
+    const extension = await getActivatedExtension();
     if ("cliServer" in extension) {
       cli = extension.cliServer;
       supportedLanguages = await cli.getSupportedLanguages();

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/run-cli.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/run-cli.test.ts
@@ -25,14 +25,8 @@ describe("Use cli", () => {
 
   beforeEach(async () => {
     const extension = await getActivatedExtension();
-    if ("cliServer" in extension) {
-      cli = extension.cliServer;
-      supportedLanguages = await cli.getSupportedLanguages();
-    } else {
-      throw new Error(
-        "Extension not initialized. Make sure cli is downloaded and installed properly.",
-      );
-    }
+    cli = extension.cliServer;
+    supportedLanguages = await cli.getSupportedLanguages();
   });
 
   if (process.env.CLI_VERSION && process.env.CLI_VERSION !== "nightly") {

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
@@ -1,11 +1,4 @@
-import {
-  CancellationTokenSource,
-  commands,
-  extensions,
-  Uri,
-  window,
-} from "vscode";
-import { CodeQLExtensionInterface } from "../../../../src/extension";
+import { CancellationTokenSource, commands, Uri, window } from "vscode";
 import { extLogger } from "../../../../src/common";
 import { setRemoteControllerRepo } from "../../../../src/config";
 import * as ghApiClient from "../../../../src/variant-analysis/gh-api/gh-api-client";
@@ -15,6 +8,7 @@ import { VariantAnalysisManager } from "../../../../src/variant-analysis/variant
 import { CliVersionConstraint, CodeQLCliServer } from "../../../../src/cli";
 import {
   fixWorkspaceReferences,
+  getActivatedExtension,
   restoreWorkspaceReferences,
   storagePath,
 } from "../../global.helper";
@@ -48,11 +42,7 @@ describe("Variant Analysis Manager", () => {
 
     cancellationTokenSource = new CancellationTokenSource();
 
-    const extension = await extensions
-      .getExtension<CodeQLExtensionInterface | Record<string, never>>(
-        "GitHub.vscode-codeql",
-      )!
-      .activate();
+    const extension = await getActivatedExtension();
     cli = extension.cliServer;
     const app = new ExtensionApp(extension.ctx);
     const dbManager = new DbManager(app, new DbConfigStore(app));

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-submission-integration.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-submission-integration.test.ts
@@ -3,16 +3,15 @@ import { resolve } from "path";
 import {
   authentication,
   commands,
-  extensions,
   TextDocument,
   window,
   workspace,
 } from "vscode";
 
-import { CodeQLExtensionInterface } from "../../../../src/extension";
 import { MockGitHubApiServer } from "../../../../src/mocks/mock-gh-api-server";
 import { mockedQuickPickItem } from "../../utils/mocking.helpers";
 import { setRemoteControllerRepo } from "../../../../src/config";
+import { getActivatedExtension } from "../../global.helper";
 
 jest.setTimeout(30_000);
 
@@ -55,11 +54,7 @@ describe("Variant Analysis Submission Integration", () => {
       .spyOn(window, "showErrorMessage")
       .mockResolvedValue(undefined);
 
-    await extensions
-      .getExtension<CodeQLExtensionInterface | Record<string, never>>(
-        "GitHub.vscode-codeql",
-      )!
-      .activate();
+    await getActivatedExtension();
   });
 
   describe("Successful scenario", () => {

--- a/extensions/ql-vscode/test/vscode-tests/global.helper.ts
+++ b/extensions/ql-vscode/test/vscode-tests/global.helper.ts
@@ -29,7 +29,9 @@ export async function getActivatedExtension(): Promise<CodeQLExtensionInterface>
     .getExtension<CodeQLExtensionInterface | undefined>("GitHub.vscode-codeql")
     ?.activate();
   if (extension === undefined) {
-    throw new Error("Unable to active CodeQL extension");
+    throw new Error(
+      "Unable to active CodeQL extension. Make sure cli is downloaded and installed properly.",
+    );
   }
   return extension;
 }

--- a/extensions/ql-vscode/test/vscode-tests/global.helper.ts
+++ b/extensions/ql-vscode/test/vscode-tests/global.helper.ts
@@ -1,10 +1,11 @@
 import { join } from "path";
 import { load, dump } from "js-yaml";
 import { realpathSync, readFileSync, writeFileSync } from "fs-extra";
-import { commands } from "vscode";
+import { commands, extensions } from "vscode";
 import { DatabaseManager } from "../../src/local-databases";
 import { CodeQLCliServer } from "../../src/cli";
 import { removeWorkspaceRefs } from "../../src/variant-analysis/run-remote-query";
+import { CodeQLExtensionInterface } from "../../src/extension";
 
 // This file contains helpers shared between tests that work with an activated extension.
 
@@ -21,6 +22,16 @@ export let storagePath: string;
 
 export function setStoragePath(path: string) {
   storagePath = path;
+}
+
+export async function getActivatedExtension(): Promise<CodeQLExtensionInterface> {
+  const extension = await extensions
+    .getExtension<CodeQLExtensionInterface | undefined>("GitHub.vscode-codeql")
+    ?.activate();
+  if (extension === undefined) {
+    throw new Error("Unable to active CodeQL extension");
+  }
+  return extension;
 }
 
 export async function cleanDatabases(databaseManager: DatabaseManager) {

--- a/extensions/ql-vscode/test/vscode-tests/jest.activated-extension.setup.ts
+++ b/extensions/ql-vscode/test/vscode-tests/jest.activated-extension.setup.ts
@@ -1,9 +1,13 @@
 import { CUSTOM_CODEQL_PATH_SETTING } from "../../src/config";
-import { ConfigurationTarget, env, extensions } from "vscode";
+import { ConfigurationTarget, env } from "vscode";
 import { beforeEachAction as testConfigBeforeEachAction } from "./test-config";
 import * as tmp from "tmp";
 import { realpathSync } from "fs-extra";
-import { setStoragePath, storagePath } from "./global.helper";
+import {
+  getActivatedExtension,
+  setStoragePath,
+  storagePath,
+} from "./global.helper";
 
 if (process.env.CI) {
   jest.retryTimes(3, {
@@ -35,7 +39,7 @@ export async function beforeAllAction() {
   removeStorage = dir.removeCallback;
 
   // Activate the extension
-  await extensions.getExtension("GitHub.vscode-codeql")?.activate();
+  await getActivatedExtension();
 }
 
 export async function beforeEachAction() {


### PR DESCRIPTION
The main aim of this PR is to make activating the extension more type safe and less error prone.

A problem I've had a few times in tests is unexpectedly getting an `undefined` value because the `extension` variable was not a `CodeQLExtensionInterface` like I thought but actually a `Record<string, never>` which we are using as an error type. This means the type system will happily let you access any field on it, but it may be undefined and you can't tell.

The changes to `extension.ts` should be limited only to changing the error type from `Record<string, never>` to `undefined`. I'm hoping not to make any major behavioural changes here. There are some small changes such as around `variantAnalysisViewSerializer.onExtensionLoaded`, but previously we were just passing an `undefined` into the method.

In the tests I introduce `getActivatedExtension` which encapsulates a very common piece of code and adds extra error handling. This means we can make a lot of tests safer, and they should fail with an error message explaining that the extension couldn't be activated, rather than something being undefined somewhere down the line.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
