### PR TITLE
Rename query history read and write methods

### DIFF
--- a/extensions/ql-vscode/src/legacy-query-server/run-queries.ts
+++ b/extensions/ql-vscode/src/legacy-query-server/run-queries.ts
@@ -33,7 +33,7 @@ import { redactableError } from "../pure/errors";
 export class QueryInProgress {
   public queryEvalInfo: QueryEvaluationInfo;
   /**
-   * Note that in the {@link readFromQueryHistoryFile} method, we create a QueryEvaluationInfo instance
+   * Note that in the {@link readQueryHistoryFromFile} method, we create a QueryEvaluationInfo instance
    * by explicitly setting the prototype in order to avoid calling this constructor.
    */
   constructor(

--- a/extensions/ql-vscode/src/legacy-query-server/run-queries.ts
+++ b/extensions/ql-vscode/src/legacy-query-server/run-queries.ts
@@ -33,7 +33,7 @@ import { redactableError } from "../pure/errors";
 export class QueryInProgress {
   public queryEvalInfo: QueryEvaluationInfo;
   /**
-   * Note that in the {@link deserializeQueryHistory} method, we create a QueryEvaluationInfo instance
+   * Note that in the {@link readFromQueryHistoryFile} method, we create a QueryEvaluationInfo instance
    * by explicitly setting the prototype in order to avoid calling this constructor.
    */
   constructor(

--- a/extensions/ql-vscode/src/query-history/query-history-manager.ts
+++ b/extensions/ql-vscode/src/query-history/query-history-manager.ts
@@ -40,7 +40,7 @@ import {
   variantAnalysisStatusToQueryStatus,
 } from "../query-status";
 import {
-  readFromQueryHistoryFile,
+  readQueryHistoryFromFile,
   writeQueryHistoryToFile,
 } from "./store/query-history-store";
 import { pathExists } from "fs-extra";
@@ -379,7 +379,7 @@ export class QueryHistoryManager extends DisposableObject {
     void extLogger.log(
       `Reading cached query history from '${this.queryMetadataStorageLocation}'.`,
     );
-    const history = await readFromQueryHistoryFile(
+    const history = await readQueryHistoryFromFile(
       this.queryMetadataStorageLocation,
     );
     this.treeDataProvider.allHistory = history;

--- a/extensions/ql-vscode/src/query-history/query-history-manager.ts
+++ b/extensions/ql-vscode/src/query-history/query-history-manager.ts
@@ -40,8 +40,8 @@ import {
   variantAnalysisStatusToQueryStatus,
 } from "../query-status";
 import {
-  deserializeQueryHistory,
-  serializeQueryHistory,
+  readFromQueryHistoryFile,
+  writeQueryHistoryToFile,
 } from "./store/query-history-store";
 import { pathExists } from "fs-extra";
 import { CliVersionConstraint } from "../cli";
@@ -379,7 +379,7 @@ export class QueryHistoryManager extends DisposableObject {
     void extLogger.log(
       `Reading cached query history from '${this.queryMetadataStorageLocation}'.`,
     );
-    const history = await deserializeQueryHistory(
+    const history = await readFromQueryHistoryFile(
       this.queryMetadataStorageLocation,
     );
     this.treeDataProvider.allHistory = history;
@@ -395,7 +395,7 @@ export class QueryHistoryManager extends DisposableObject {
   }
 
   async writeQueryHistory(): Promise<void> {
-    await serializeQueryHistory(
+    await writeQueryHistoryToFile(
       this.treeDataProvider.allHistory,
       this.queryMetadataStorageLocation,
     );

--- a/extensions/ql-vscode/src/query-history/store/query-history-store.ts
+++ b/extensions/ql-vscode/src/query-history/store/query-history-store.ts
@@ -14,7 +14,7 @@ import { QueryEvaluationInfo } from "../../run-queries-shared";
 import { QueryResultType } from "../../pure/legacy-messages";
 import { redactableError } from "../../pure/errors";
 
-export async function readFromQueryHistoryFile(
+export async function readQueryHistoryFromFile(
   fsPath: string,
 ): Promise<QueryHistoryInfo[]> {
   try {

--- a/extensions/ql-vscode/src/query-history/store/query-history-store.ts
+++ b/extensions/ql-vscode/src/query-history/store/query-history-store.ts
@@ -14,7 +14,7 @@ import { QueryEvaluationInfo } from "../../run-queries-shared";
 import { QueryResultType } from "../../pure/legacy-messages";
 import { redactableError } from "../../pure/errors";
 
-export async function deserializeQueryHistory(
+export async function readFromQueryHistoryFile(
   fsPath: string,
 ): Promise<QueryHistoryInfo[]> {
   try {
@@ -109,7 +109,7 @@ export async function deserializeQueryHistory(
  * @param queries the list of queries to save.
  * @param fsPath the path to save the queries to.
  */
-export async function serializeQueryHistory(
+export async function writeQueryHistoryToFile(
   queries: QueryHistoryInfo[],
   fsPath: string,
 ): Promise<void> {

--- a/extensions/ql-vscode/src/query-results.ts
+++ b/extensions/ql-vscode/src/query-results.ts
@@ -70,7 +70,7 @@ export class CompletedQueryInfo implements QueryWithResults {
   interpretedResultsSortState: InterpretedResultsSortState | undefined;
 
   /**
-   * Note that in the {@link deserializeQueryHistory} method, we create a CompletedQueryInfo instance
+   * Note that in the {@link readFromQueryHistoryFile} method, we create a CompletedQueryInfo instance
    * by explicitly setting the prototype in order to avoid calling this constructor.
    */
   constructor(evaluation: QueryWithResults) {
@@ -224,7 +224,7 @@ export class LocalQueryInfo {
   public evalLogSummarySymbolsLocation: string | undefined;
 
   /**
-   * Note that in the {@link deserializeQueryHistory} method, we create a FullQueryInfo instance
+   * Note that in the {@link readFromQueryHistoryFile} method, we create a FullQueryInfo instance
    * by explicitly setting the prototype in order to avoid calling this constructor.
    */
   constructor(

--- a/extensions/ql-vscode/src/query-results.ts
+++ b/extensions/ql-vscode/src/query-results.ts
@@ -70,7 +70,7 @@ export class CompletedQueryInfo implements QueryWithResults {
   interpretedResultsSortState: InterpretedResultsSortState | undefined;
 
   /**
-   * Note that in the {@link readFromQueryHistoryFile} method, we create a CompletedQueryInfo instance
+   * Note that in the {@link readQueryHistoryFromFile} method, we create a CompletedQueryInfo instance
    * by explicitly setting the prototype in order to avoid calling this constructor.
    */
   constructor(evaluation: QueryWithResults) {
@@ -224,7 +224,7 @@ export class LocalQueryInfo {
   public evalLogSummarySymbolsLocation: string | undefined;
 
   /**
-   * Note that in the {@link readFromQueryHistoryFile} method, we create a FullQueryInfo instance
+   * Note that in the {@link readQueryHistoryFromFile} method, we create a FullQueryInfo instance
    * by explicitly setting the prototype in order to avoid calling this constructor.
    */
   constructor(

--- a/extensions/ql-vscode/src/run-queries-shared.ts
+++ b/extensions/ql-vscode/src/run-queries-shared.ts
@@ -68,7 +68,7 @@ function findQueryEvalLogEndSummaryFile(resultPath: string): string {
 
 export class QueryEvaluationInfo {
   /**
-   * Note that in the {@link readFromQueryHistoryFile} method, we create a QueryEvaluationInfo instance
+   * Note that in the {@link readQueryHistoryFromFile} method, we create a QueryEvaluationInfo instance
    * by explicitly setting the prototype in order to avoid calling this constructor.
    */
   constructor(

--- a/extensions/ql-vscode/src/run-queries-shared.ts
+++ b/extensions/ql-vscode/src/run-queries-shared.ts
@@ -68,7 +68,7 @@ function findQueryEvalLogEndSummaryFile(resultPath: string): string {
 
 export class QueryEvaluationInfo {
   /**
-   * Note that in the {@link deserializeQueryHistory} method, we create a QueryEvaluationInfo instance
+   * Note that in the {@link readFromQueryHistoryFile} method, we create a QueryEvaluationInfo instance
    * by explicitly setting the prototype in order to avoid calling this constructor.
    */
   constructor(

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/store/query-history-store.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/store/query-history-store.test.ts
@@ -1,6 +1,6 @@
 import {
-  deserializeQueryHistory,
-  serializeQueryHistory,
+  readFromQueryHistoryFile,
+  writeQueryHistoryToFile,
 } from "../../../../../src/query-history/store/query-history-store";
 import { join } from "path";
 import { writeFileSync, mkdirpSync, writeFile } from "fs-extra";
@@ -19,7 +19,7 @@ import { QueryHistoryInfo } from "../../../../../src/query-history/query-history
 import { createMockVariantAnalysisHistoryItem } from "../../../../factories/query-history/variant-analysis-history-item";
 import { nanoid } from "nanoid";
 
-describe("serialize and deserialize", () => {
+describe("write and read", () => {
   let infoSuccessRaw: LocalQueryInfo;
   let infoSuccessInterpreted: LocalQueryInfo;
   let infoEarlyFailure: LocalQueryInfo;
@@ -93,12 +93,12 @@ describe("serialize and deserialize", () => {
     ];
   });
 
-  it("should serialize and deserialize query history", async () => {
+  it("should write and read query history", async () => {
     const allHistoryPath = join(tmpDir.name, "workspace-query-history.json");
 
-    // serialize and deserialize
-    await serializeQueryHistory(allHistory, allHistoryPath);
-    const allHistoryActual = await deserializeQueryHistory(allHistoryPath);
+    // write and read
+    await writeQueryHistoryToFile(allHistory, allHistoryPath);
+    const allHistoryActual = await readFromQueryHistoryFile(allHistoryPath);
 
     // the dispose methods will be different. Ignore them.
     allHistoryActual.forEach((info) => {
@@ -106,7 +106,7 @@ describe("serialize and deserialize", () => {
         const completedQuery = info.completedQuery;
         (completedQuery as any).dispose = undefined;
 
-        // these fields should be missing on the deserialized value
+        // these fields should be missing on the read value
         // but they are undefined on the original value
         if (!("logFileLocation" in completedQuery)) {
           (completedQuery as any).logFileLocation = undefined;
@@ -181,7 +181,7 @@ describe("serialize and deserialize", () => {
       "utf8",
     );
 
-    const actual = await deserializeQueryHistory(path);
+    const actual = await readFromQueryHistoryFile(path);
     expect(actual.length).toEqual(expectedHistory.length);
   });
 
@@ -196,7 +196,7 @@ describe("serialize and deserialize", () => {
       "utf8",
     );
 
-    const allHistoryActual = await deserializeQueryHistory(badPath);
+    const allHistoryActual = await readFromQueryHistoryFile(badPath);
     // version number is invalid. Should return an empty array.
     expect(allHistoryActual).toEqual([]);
   });

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/store/query-history-store.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/store/query-history-store.test.ts
@@ -1,5 +1,5 @@
 import {
-  readFromQueryHistoryFile,
+  readQueryHistoryFromFile,
   writeQueryHistoryToFile,
 } from "../../../../../src/query-history/store/query-history-store";
 import { join } from "path";
@@ -98,7 +98,7 @@ describe("write and read", () => {
 
     // write and read
     await writeQueryHistoryToFile(allHistory, allHistoryPath);
-    const allHistoryActual = await readFromQueryHistoryFile(allHistoryPath);
+    const allHistoryActual = await readQueryHistoryFromFile(allHistoryPath);
 
     // the dispose methods will be different. Ignore them.
     allHistoryActual.forEach((info) => {
@@ -181,7 +181,7 @@ describe("write and read", () => {
       "utf8",
     );
 
-    const actual = await readFromQueryHistoryFile(path);
+    const actual = await readQueryHistoryFromFile(path);
     expect(actual.length).toEqual(expectedHistory.length);
   });
 
@@ -196,7 +196,7 @@ describe("write and read", () => {
       "utf8",
     );
 
-    const allHistoryActual = await readFromQueryHistoryFile(badPath);
+    const allHistoryActual = await readQueryHistoryFromFile(badPath);
     // version number is invalid. Should return an empty array.
     expect(allHistoryActual).toEqual([]);
   });


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

This PR is part of an endeavour to separate data and domain model for the query history. We are just renaming the methods responsible for reading and writing query history data to disk here.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
