### PR TITLE
Convert cleanDatabases to call typed commands

### DIFF
--- a/extensions/ql-vscode/test/vscode-tests/global.helper.ts
+++ b/extensions/ql-vscode/test/vscode-tests/global.helper.ts
@@ -1,11 +1,12 @@
 import { join } from "path";
 import { load, dump } from "js-yaml";
 import { realpathSync, readFileSync, writeFileSync } from "fs-extra";
-import { commands, extensions } from "vscode";
+import { extensions } from "vscode";
 import { DatabaseManager } from "../../src/local-databases";
 import { CodeQLCliServer } from "../../src/cli";
 import { removeWorkspaceRefs } from "../../src/variant-analysis/run-remote-query";
 import { CodeQLExtensionInterface } from "../../src/extension";
+import { createVSCodeCommandManager } from "../../src/common/vscode/commands";
 
 // This file contains helpers shared between tests that work with an activated extension.
 
@@ -37,8 +38,9 @@ export async function getActivatedExtension(): Promise<CodeQLExtensionInterface>
 }
 
 export async function cleanDatabases(databaseManager: DatabaseManager) {
+  const commandManager = createVSCodeCommandManager();
   for (const item of databaseManager.databaseItems) {
-    await commands.executeCommand("codeQLDatabases.removeDatabase", item);
+    await commandManager.execute("codeQLDatabases.removeDatabase", item);
   }
 }
 


### PR DESCRIPTION
The goal here is to remove a use of `commands.executeCommand` and instead use typed commands. The difference here from normal is that we actually need to call the command implementation, rather than providing a mocked implementation. This `cleanDatabases` method is used from a few tests (never from production code) so it's the effects of calling the command that we want.

I'm not 100% sure why we are using commands here at all. Another idea I explored was calling the underlying methods directly, and I pushed this up as [a branch](https://github.com/github/vscode-codeql/compare/robertbrignull/use_app_commands_4_alt). Unfortunately that ran into confusing errors saying `removeAllDatabases is not a function`, which I think means there's something screwy going on when constructing the `DatabaseManager` object but I was struggling to solve it. So I've opened this PR with a simpler but maybe less idealistic solution instead.

What do you think of this? Is this acceptable, or should I have another go at bugfixing that other branch (linked above)?

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
