### PR TITLE
(TEST PR) Convert cleanDatabases to not use commands

### DIFF
--- a/extensions/ql-vscode/src/local-databases.ts
+++ b/extensions/ql-vscode/src/local-databases.ts
@@ -1001,6 +1001,15 @@ export class DatabaseManager extends DisposableObject {
     });
   }
 
+  public async removeAllDatabases(
+    progress: ProgressCallback,
+    token: vscode.CancellationToken,
+  ) {
+    for (const item of this.databaseItems) {
+      await this.removeDatabaseItem(progress, token, item);
+    }
+  }
+
   private async deregisterDatabase(
     progress: ProgressCallback,
     token: vscode.CancellationToken,

--- a/extensions/ql-vscode/test/vscode-tests/global.helper.ts
+++ b/extensions/ql-vscode/test/vscode-tests/global.helper.ts
@@ -1,11 +1,12 @@
 import { join } from "path";
 import { load, dump } from "js-yaml";
 import { realpathSync, readFileSync, writeFileSync } from "fs-extra";
-import { commands, extensions } from "vscode";
+import { CancellationToken, extensions } from "vscode";
 import { DatabaseManager } from "../../src/local-databases";
 import { CodeQLCliServer } from "../../src/cli";
 import { removeWorkspaceRefs } from "../../src/variant-analysis/run-remote-query";
 import { CodeQLExtensionInterface } from "../../src/extension";
+import { ProgressCallback } from "../../src/progress";
 
 // This file contains helpers shared between tests that work with an activated extension.
 
@@ -37,9 +38,10 @@ export async function getActivatedExtension(): Promise<CodeQLExtensionInterface>
 }
 
 export async function cleanDatabases(databaseManager: DatabaseManager) {
-  for (const item of databaseManager.databaseItems) {
-    await commands.executeCommand("codeQLDatabases.removeDatabase", item);
-  }
+  await databaseManager.removeAllDatabases(
+    {} as ProgressCallback,
+    {} as CancellationToken,
+  );
 }
 
 /**


### PR DESCRIPTION
See https://github.com/github/vscode-codeql/pull/2233 for more context.

Just want to test this out running in CI on actions to see if it works.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
