### PR TITLE
Convert call sites to use typed commands (part 5): VariantAnalysisView

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -358,7 +358,10 @@ export async function activate(
     ),
   );
 
-  const variantAnalysisViewSerializer = new VariantAnalysisViewSerializer(ctx);
+  const variantAnalysisViewSerializer = new VariantAnalysisViewSerializer(
+    ctx,
+    app,
+  );
   Window.registerWebviewPanelSerializer(
     VariantAnalysisView.viewType,
     variantAnalysisViewSerializer,

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -317,7 +317,9 @@ export class VariantAnalysisManager
     }
     if (!this.views.has(variantAnalysisId)) {
       // The view will register itself with the manager, so we don't need to do anything here.
-      this.track(new VariantAnalysisView(this.ctx, variantAnalysisId, this));
+      this.track(
+        new VariantAnalysisView(this.ctx, this.app, variantAnalysisId, this),
+      );
     }
 
     const variantAnalysisView = this.views.get(variantAnalysisId)!;

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-view-serializer.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-view-serializer.ts
@@ -2,6 +2,7 @@ import { ExtensionContext, WebviewPanel, WebviewPanelSerializer } from "vscode";
 import { VariantAnalysisView } from "./variant-analysis-view";
 import { VariantAnalysisState } from "../pure/interface-types";
 import { VariantAnalysisViewManager } from "./variant-analysis-view-manager";
+import { App } from "../common/app";
 
 export class VariantAnalysisViewSerializer implements WebviewPanelSerializer {
   private resolvePromises: Array<
@@ -10,7 +11,10 @@ export class VariantAnalysisViewSerializer implements WebviewPanelSerializer {
 
   private manager?: VariantAnalysisViewManager<VariantAnalysisView>;
 
-  public constructor(private readonly ctx: ExtensionContext) {}
+  public constructor(
+    private readonly ctx: ExtensionContext,
+    private readonly app: App,
+  ) {}
 
   onExtensionLoaded(
     manager: VariantAnalysisViewManager<VariantAnalysisView>,
@@ -49,6 +53,7 @@ export class VariantAnalysisViewSerializer implements WebviewPanelSerializer {
 
     const view = new VariantAnalysisView(
       this.ctx,
+      this.app,
       variantAnalysisState.variantAnalysisId,
       manager,
     );

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-view.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-view.ts
@@ -1,4 +1,4 @@
-import { commands, ExtensionContext, ViewColumn } from "vscode";
+import { ExtensionContext, ViewColumn } from "vscode";
 import { AbstractWebview, WebviewPanelConfig } from "../abstract-webview";
 import { extLogger } from "../common";
 import {
@@ -23,6 +23,7 @@ import { telemetryListener } from "../telemetry";
 import { redactableError } from "../pure/errors";
 import { DataFlowPathsView } from "./data-flow-paths-view";
 import { DataFlowPaths } from "./shared/data-flow-paths";
+import { App } from "../common/app";
 
 export class VariantAnalysisView
   extends AbstractWebview<ToVariantAnalysisMessage, FromVariantAnalysisMessage>
@@ -33,6 +34,7 @@ export class VariantAnalysisView
 
   public constructor(
     ctx: ExtensionContext,
+    private readonly app: App,
     public readonly variantAnalysisId: number,
     private readonly manager: VariantAnalysisViewManager<VariantAnalysisView>,
   ) {
@@ -118,7 +120,7 @@ export class VariantAnalysisView
         await this.manager.cancelVariantAnalysis(this.variantAnalysisId);
         break;
       case "requestRepositoryResults":
-        void commands.executeCommand(
+        void this.app.commands.execute(
           "codeQL.loadVariantAnalysisRepoResults",
           this.variantAnalysisId,
           msg.repositoryFullName,
@@ -131,7 +133,7 @@ export class VariantAnalysisView
         await this.manager.openQueryText(this.variantAnalysisId);
         break;
       case "copyRepositoryList":
-        void commands.executeCommand(
+        void this.app.commands.execute(
           "codeQL.copyVariantAnalysisRepoList",
           this.variantAnalysisId,
           msg.filterSort,


### PR DESCRIPTION
Converts `VariantAnalysisView` to call typed commands.

This PR is simpler than I originally expected. I pulled this out to a separate PR because I thought it was going to be hard, but in the meantime someone has fixed the main issue which is that the app wasn't available when we constructed `VariantAnalysisViewSerializer`. But now we create the app much earlier in activation, so this PR is very simple.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
