### PR TITLE
Convert call sites to use typed commands (part 6): createVSCodeCommandManager in tests

### DIFF
--- a/extensions/ql-vscode/test/vscode-tests/activated-extension/databases/db-panel.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/activated-extension/databases/db-panel.test.ts
@@ -16,12 +16,13 @@ import { createRemoteSystemDefinedListDbItem } from "../../../factories/db-item-
 import { DbConfigStore } from "../../../../src/databases/config/db-config-store";
 import { getActivatedExtension } from "../../global.helper";
 import { createVSCodeCommandManager } from "../../../../src/common/vscode/commands";
+import { AllCommands } from "../../../../src/common/commands";
 
 jest.setTimeout(60_000);
 
 describe("Db panel UI commands", () => {
   let storagePath: string;
-  const commandManager = createVSCodeCommandManager();
+  const commandManager = createVSCodeCommandManager<AllCommands>();
 
   beforeEach(async () => {
     const extension = await getActivatedExtension();

--- a/extensions/ql-vscode/test/vscode-tests/activated-extension/databases/db-panel.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/activated-extension/databases/db-panel.test.ts
@@ -1,4 +1,4 @@
-import { commands, window } from "vscode";
+import { window } from "vscode";
 
 import { readJson } from "fs-extra";
 import * as path from "path";
@@ -15,11 +15,13 @@ import { createDbTreeViewItemSystemDefinedList } from "../../../../src/databases
 import { createRemoteSystemDefinedListDbItem } from "../../../factories/db-item-factories";
 import { DbConfigStore } from "../../../../src/databases/config/db-config-store";
 import { getActivatedExtension } from "../../global.helper";
+import { createVSCodeCommandManager } from "../../../../src/common/vscode/commands";
 
 jest.setTimeout(60_000);
 
 describe("Db panel UI commands", () => {
   let storagePath: string;
+  const commandManager = createVSCodeCommandManager();
 
   beforeEach(async () => {
     const extension = await getActivatedExtension();
@@ -31,7 +33,7 @@ describe("Db panel UI commands", () => {
   it("should add new remote db list", async () => {
     // Add db list
     jest.spyOn(window, "showInputBox").mockResolvedValue("my-list-1");
-    await commands.executeCommand(
+    await commandManager.execute(
       "codeQLVariantAnalysisRepositories.addNewList",
     );
 
@@ -53,7 +55,7 @@ describe("Db panel UI commands", () => {
       kind: DbListKind.Local,
     } as AddListQuickPickItem);
     jest.spyOn(window, "showInputBox").mockResolvedValue("my-list-1");
-    await commands.executeCommand(
+    await commandManager.execute(
       "codeQLVariantAnalysisRepositories.addNewList",
     );
 
@@ -74,7 +76,7 @@ describe("Db panel UI commands", () => {
     } as RemoteDatabaseQuickPickItem);
 
     jest.spyOn(window, "showInputBox").mockResolvedValue("owner1/repo1");
-    await commands.executeCommand(
+    await commandManager.execute(
       "codeQLVariantAnalysisRepositories.addNewDatabase",
     );
 
@@ -97,7 +99,7 @@ describe("Db panel UI commands", () => {
     } as RemoteDatabaseQuickPickItem);
 
     jest.spyOn(window, "showInputBox").mockResolvedValue("owner1");
-    await commands.executeCommand(
+    await commandManager.execute(
       "codeQLVariantAnalysisRepositories.addNewDatabase",
     );
 
@@ -119,7 +121,7 @@ describe("Db panel UI commands", () => {
       "tooltip",
     );
 
-    await commands.executeCommand(
+    await commandManager.execute(
       "codeQLVariantAnalysisRepositories.setSelectedItemContextMenu",
       treeViewItem,
     );

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/queries.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/queries.test.ts
@@ -1,4 +1,4 @@
-import { CancellationToken, commands, ExtensionContext, Uri } from "vscode";
+import { CancellationToken, ExtensionContext, Uri } from "vscode";
 import { join, dirname } from "path";
 import {
   pathExistsSync,
@@ -25,6 +25,7 @@ import { QueryRunner } from "../../../src/queryRunner";
 import { CompletedQueryInfo } from "../../../src/query-results";
 import { SELECT_QUERY_NAME } from "../../../src/contextual/locationFinder";
 import { createMockCommandManager } from "../../__mocks__/commandsMock";
+import { createVSCodeCommandManager } from "../../../src/common/vscode/commands";
 
 jest.setTimeout(20_000);
 
@@ -39,6 +40,7 @@ describeWithCodeQL()("Queries", () => {
   const progress = jest.fn();
   let token: CancellationToken;
   let ctx: ExtensionContext;
+  const commandManager = createVSCodeCommandManager();
 
   let qlpackFile: string;
   let qlpackLockFile: string;
@@ -176,7 +178,7 @@ describeWithCodeQL()("Queries", () => {
 
   // Asserts a fix for bug https://github.com/github/vscode-codeql/issues/733
   it("should restart the database and run a query", async () => {
-    await commands.executeCommand("codeQL.restartQueryServer");
+    await commandManager.execute("codeQL.restartQueryServer");
     const queryPath = join(__dirname, "data", "simple-query.ql");
     const result = await qs.compileAndRunQueryAgainstDatabase(
       dbItem,
@@ -190,7 +192,7 @@ describeWithCodeQL()("Queries", () => {
   });
 
   it("should create a quick query", async () => {
-    await commands.executeCommand("codeQL.quickQuery");
+    await commandManager.execute("codeQL.quickQuery");
 
     // should have created the quick query file and query pack file
     expect(pathExistsSync(qlFile)).toBe(true);
@@ -223,7 +225,7 @@ describeWithCodeQL()("Queries", () => {
       }),
     );
     writeFileSync(qlFile, "xxx");
-    await commands.executeCommand("codeQL.quickQuery");
+    await commandManager.execute("codeQL.quickQuery");
 
     // should not have created the quick query file because database schema hasn't changed
     expect(readFileSync(qlFile, "utf8")).toBe("xxx");

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/queries.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/queries.test.ts
@@ -26,6 +26,7 @@ import { CompletedQueryInfo } from "../../../src/query-results";
 import { SELECT_QUERY_NAME } from "../../../src/contextual/locationFinder";
 import { createMockCommandManager } from "../../__mocks__/commandsMock";
 import { createVSCodeCommandManager } from "../../../src/common/vscode/commands";
+import { AllCommands, QueryServerCommands } from "../../../src/common/commands";
 
 jest.setTimeout(20_000);
 
@@ -40,7 +41,9 @@ describeWithCodeQL()("Queries", () => {
   const progress = jest.fn();
   let token: CancellationToken;
   let ctx: ExtensionContext;
-  const commandManager = createVSCodeCommandManager();
+  const appCommandManager = createVSCodeCommandManager<AllCommands>();
+  const queryServerCommandManager =
+    createVSCodeCommandManager<QueryServerCommands>();
 
   let qlpackFile: string;
   let qlpackLockFile: string;
@@ -178,7 +181,7 @@ describeWithCodeQL()("Queries", () => {
 
   // Asserts a fix for bug https://github.com/github/vscode-codeql/issues/733
   it("should restart the database and run a query", async () => {
-    await commandManager.execute("codeQL.restartQueryServer");
+    await appCommandManager.execute("codeQL.restartQueryServer");
     const queryPath = join(__dirname, "data", "simple-query.ql");
     const result = await qs.compileAndRunQueryAgainstDatabase(
       dbItem,
@@ -192,7 +195,7 @@ describeWithCodeQL()("Queries", () => {
   });
 
   it("should create a quick query", async () => {
-    await commandManager.execute("codeQL.quickQuery");
+    await queryServerCommandManager.execute("codeQL.quickQuery");
 
     // should have created the quick query file and query pack file
     expect(pathExistsSync(qlFile)).toBe(true);
@@ -225,7 +228,7 @@ describeWithCodeQL()("Queries", () => {
       }),
     );
     writeFileSync(qlFile, "xxx");
-    await commandManager.execute("codeQL.quickQuery");
+    await queryServerCommandManager.execute("codeQL.quickQuery");
 
     // should not have created the quick query file because database schema hasn't changed
     expect(readFileSync(qlFile, "utf8")).toBe("xxx");

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/sourcemap.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/sourcemap.test.ts
@@ -1,7 +1,8 @@
-import { commands, Selection, window, workspace } from "vscode";
+import { Selection, window, workspace } from "vscode";
 import { join, basename } from "path";
 import { tmpDir } from "../../../src/helpers";
 import { readFile, writeFile, ensureDir, copy } from "fs-extra";
+import { createVSCodeCommandManager } from "../../../src/common/vscode/commands";
 
 jest.setTimeout(20_000);
 
@@ -9,6 +10,8 @@ jest.setTimeout(20_000);
  * Integration tests for queries
  */
 describe("SourceMap", () => {
+  const commandManager = createVSCodeCommandManager();
+
   it("should jump to QL code", async () => {
     const root = workspace.workspaceFolders![0].uri.fsPath;
     const srcFiles = {
@@ -32,7 +35,7 @@ describe("SourceMap", () => {
     expect(summaryDocument.languageId).toBe("ql-summary");
     const summaryEditor = await window.showTextDocument(summaryDocument);
     summaryEditor.selection = new Selection(356, 10, 356, 10);
-    await commands.executeCommand("codeQL.gotoQL");
+    await commandManager.execute("codeQL.gotoQL");
 
     const newEditor = window.activeTextEditor;
     expect(newEditor).toBeDefined();

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/sourcemap.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/sourcemap.test.ts
@@ -3,6 +3,7 @@ import { join, basename } from "path";
 import { tmpDir } from "../../../src/helpers";
 import { readFile, writeFile, ensureDir, copy } from "fs-extra";
 import { createVSCodeCommandManager } from "../../../src/common/vscode/commands";
+import { AllCommands } from "../../../src/common/commands";
 
 jest.setTimeout(20_000);
 
@@ -10,7 +11,7 @@ jest.setTimeout(20_000);
  * Integration tests for queries
  */
 describe("SourceMap", () => {
-  const commandManager = createVSCodeCommandManager();
+  const commandManager = createVSCodeCommandManager<AllCommands>();
 
   it("should jump to QL code", async () => {
     const root = workspace.workspaceFolders![0].uri.fsPath;

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-submission-integration.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-submission-integration.test.ts
@@ -13,6 +13,7 @@ import { mockedQuickPickItem } from "../../utils/mocking.helpers";
 import { setRemoteControllerRepo } from "../../../../src/config";
 import { getActivatedExtension } from "../../global.helper";
 import { createVSCodeCommandManager } from "../../../../src/common/vscode/commands";
+import { AllCommands } from "../../../../src/common/commands";
 
 jest.setTimeout(30_000);
 
@@ -30,7 +31,7 @@ async function showQlDocument(name: string): Promise<TextDocument> {
 }
 
 describe("Variant Analysis Submission Integration", () => {
-  const commandManager = createVSCodeCommandManager();
+  const commandManager = createVSCodeCommandManager<AllCommands>();
   let quickPickSpy: jest.SpiedFunction<typeof window.showQuickPick>;
   let executeCommandSpy: jest.SpiedFunction<typeof commands.executeCommand>;
   let showErrorMessageSpy: jest.SpiedFunction<typeof window.showErrorMessage>;

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-submission-integration.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-submission-integration.test.ts
@@ -12,6 +12,7 @@ import { MockGitHubApiServer } from "../../../../src/mocks/mock-gh-api-server";
 import { mockedQuickPickItem } from "../../utils/mocking.helpers";
 import { setRemoteControllerRepo } from "../../../../src/config";
 import { getActivatedExtension } from "../../global.helper";
+import { createVSCodeCommandManager } from "../../../../src/common/vscode/commands";
 
 jest.setTimeout(30_000);
 
@@ -29,6 +30,7 @@ async function showQlDocument(name: string): Promise<TextDocument> {
 }
 
 describe("Variant Analysis Submission Integration", () => {
+  const commandManager = createVSCodeCommandManager();
   let quickPickSpy: jest.SpiedFunction<typeof window.showQuickPick>;
   let executeCommandSpy: jest.SpiedFunction<typeof commands.executeCommand>;
   let showErrorMessageSpy: jest.SpiedFunction<typeof window.showErrorMessage>;
@@ -68,7 +70,7 @@ describe("Variant Analysis Submission Integration", () => {
       // Select target language for your query
       quickPickSpy.mockResolvedValueOnce(mockedQuickPickItem("javascript"));
 
-      await commands.executeCommand("codeQL.runVariantAnalysis");
+      await commandManager.execute("codeQL.runVariantAnalysis");
 
       expect(executeCommandSpy).toHaveBeenCalledWith(
         "codeQL.openVariantAnalysisView",
@@ -85,7 +87,7 @@ describe("Variant Analysis Submission Integration", () => {
     it("shows the error message", async () => {
       await showQlDocument("query.ql");
 
-      await commands.executeCommand("codeQL.runVariantAnalysis");
+      await commandManager.execute("codeQL.runVariantAnalysis");
 
       expect(showErrorMessageSpy).toHaveBeenCalledWith(
         expect.stringContaining(
@@ -107,7 +109,7 @@ describe("Variant Analysis Submission Integration", () => {
       // Select target language for your query
       quickPickSpy.mockResolvedValueOnce(mockedQuickPickItem("javascript"));
 
-      await commands.executeCommand("codeQL.runVariantAnalysis");
+      await commandManager.execute("codeQL.runVariantAnalysis");
 
       expect(showErrorMessageSpy).toHaveBeenCalledWith(
         expect.stringContaining(


### PR DESCRIPTION
We have quite a few tests that trigger commands as part of them. They do this to call code that isn't accessible otherwise. The easiest way to convert these tests to use typed commands is to use `createVSCodeCommandManager` to get a real command manager than will trigger real commands. By doing this the the behaviour should be exactly the same except that the commands are type checked.

It would likely be better overall if these tests were able to call code without using commands. That would likely lead to better organised code. However, that is more of a long term goal.

Does this make sense? Or should we put in more effort to refactor the tests? Or something else entirely?

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
