### PR TITLE
Restart language server on command

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [UNRELEASED]
 
+- Restart the CodeQL language server whenever the _CodeQL: Restart Query Server_ command is invoked. This avoids bugs where the CLI version changes to support new language features, but the language server is not updated. [#2238](https://github.com/github/vscode-codeql/pull/2238)
+
 ## 1.8.1 - 23 March 2023
 
 - Show data flow paths of a variant analysis in a new tab. [#2172](https://github.com/github/vscode-codeql/pull/2172) & [#2182](https://github.com/github/vscode-codeql/pull/2182)

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -161,6 +161,7 @@ function getCommands(
   app: App,
   cliServer: CodeQLCliServer,
   queryRunner: QueryRunner,
+  ideServer: LanguageClient,
 ): BaseCommands {
   const getCliVersion = async () => {
     try {
@@ -177,9 +178,12 @@ function getCommands(
     "codeQL.restartQueryServer": async () =>
       withProgress(
         async (progress: ProgressCallback, token: CancellationToken) => {
-          // We restart the CLI server too, to ensure they are the same version
+          // Restart all of the spawned servers: cli, query, and language.
           cliServer.restartCliServer();
-          await queryRunner.restartQueryServer(progress, token);
+          await Promise.all([
+            queryRunner.restartQueryServer(progress, token),
+            ideServer.restart(),
+          ]);
           void showAndLogInformationMessage("CodeQL Query Server restarted.", {
             outputLogger: queryServerLogger,
           });
@@ -889,7 +893,7 @@ async function activateWithInstalledDistribution(
   void extLogger.log("Registering top-level command palette commands.");
 
   const allCommands: AllExtensionCommands = {
-    ...getCommands(app, cliServer, qs),
+    ...getCommands(app, cliServer, qs, client),
     ...getQueryEditorCommands({
       commandManager: app.commands,
       queryRunner: qs,


### PR DESCRIPTION
Ensure that the language server is restarted when the "Restart Query Server" command is invoked.

This PR fixes the first part of https://github.com/github/vscode-codeql/issues/2199 where there are spurious red squiggles when upgrading to a new CLI version.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Replace this with a description of the changes your pull request makes.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
