### PR TITLE
Open correct tutorial workspace on Windows

### DIFF
--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -304,7 +304,7 @@ export async function prepareCodeTour(
         return;
       }
 
-      const tutorialWorkspaceUri = Uri.parse(tutorialWorkspacePath);
+      const tutorialWorkspaceUri = Uri.file(tutorialWorkspacePath);
 
       void extLogger.log(
         `In prepareCodeTour() method, going to open the tutorial workspace file: ${tutorialWorkspacePath}`,

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/helpers.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/helpers.test.ts
@@ -619,7 +619,7 @@ describe("prepareCodeTour", () => {
         expect(executeCommand).toHaveBeenCalledWith(
           "vscode.openFolder",
           expect.objectContaining({
-            path: Uri.file(tutorialWorkspacePath).path,
+            path: expect.stringMatching(/tutorial.code-workspace$/),
           }),
         );
       });

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/helpers.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/helpers.test.ts
@@ -619,7 +619,7 @@ describe("prepareCodeTour", () => {
         expect(executeCommand).toHaveBeenCalledWith(
           "vscode.openFolder",
           expect.objectContaining({
-            path: Uri.parse(tutorialWorkspacePath).fsPath,
+            path: Uri.file(tutorialWorkspacePath).path,
           }),
         );
       });


### PR DESCRIPTION
Follow-up to https://github.com/github/vscode-codeql/pull/2188#pullrequestreview-1350910732, which didn't quite work on Windows due to URI parsing issues.

Using `Uri.file` instead of `Uri.parse` works on Windows and I'll test in a codespace to make sure it also works there! (update: it works)

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->


## Checklist

N/A

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
