### PR TITLE
Query History: create and map data model to domain model

### DIFF
--- a/extensions/ql-vscode/src/legacy-query-server/run-queries.ts
+++ b/extensions/ql-vscode/src/legacy-query-server/run-queries.ts
@@ -172,10 +172,6 @@ async function runQuery(
  */
 export class QueryInProgress {
   public queryEvalInfo: QueryEvaluationInfo;
-  /**
-   * Note that in the {@link readQueryHistoryFromFile} method, we create a QueryEvaluationInfo instance
-   * by explicitly setting the prototype in order to avoid calling this constructor.
-   */
   constructor(
     readonly querySaveDir: string,
     readonly dbItemPath: string,

--- a/extensions/ql-vscode/src/query-history/store/data-mapper.ts
+++ b/extensions/ql-vscode/src/query-history/store/data-mapper.ts
@@ -1,0 +1,105 @@
+import {
+  LocalQueryInfo,
+  CompletedQueryInfo,
+  InitialQueryInfo,
+} from "../../query-results";
+import { QueryEvaluationInfo } from "../../run-queries-shared";
+import { QueryHistoryInfo } from "../query-history-info";
+import { VariantAnalysisHistoryItem } from "../variant-analysis-history-item";
+import {
+  CompletedQueryInfoData,
+  QueryEvaluationInfoData,
+  InitialQueryInfoData,
+  LocalQueryDataItem,
+} from "./local-query-data-item";
+import { QueryHistoryDataItem } from "./query-history-data";
+
+// Maps Query History Data Models to Domain Models
+
+export function mapQueryHistoryToDomainModels(
+  queries: QueryHistoryDataItem[],
+): QueryHistoryInfo[] {
+  return queries.map((d) => {
+    if (d.t === "variant-analysis") {
+      const query: VariantAnalysisHistoryItem = d;
+      return query;
+    } else if (d.t === "local") {
+      return mapLocalQueryDataItemToDomainModel(d);
+    }
+
+    throw Error(
+      `Unexpected or corrupted query history file. Unknown query history item: ${JSON.stringify(
+        d,
+      )}`,
+    );
+  });
+}
+
+function mapLocalQueryDataItemToDomainModel(
+  localQuery: LocalQueryDataItem,
+): LocalQueryInfo {
+  return new LocalQueryInfo(
+    mapInitialQueryInfoDataToDomainModel(localQuery.initialInfo),
+    undefined,
+    localQuery.failureReason,
+    localQuery.completedQuery &&
+      mapCompletedQueryInfoDataToDomainModel(localQuery.completedQuery),
+    localQuery.evalLogLocation,
+    localQuery.evalLogSummaryLocation,
+    localQuery.jsonEvalLogSummaryLocation,
+    localQuery.evalLogSummarySymbolsLocation,
+  );
+}
+
+function mapCompletedQueryInfoDataToDomainModel(
+  completedQuery: CompletedQueryInfoData,
+): CompletedQueryInfo {
+  return new CompletedQueryInfo(
+    mapQueryEvaluationInfoDataToDomainModel(completedQuery.query),
+    {
+      runId: completedQuery.result.runId,
+      queryId: completedQuery.result.queryId,
+      resultType: completedQuery.result.resultType,
+      evaluationTime: completedQuery.result.evaluationTime,
+      message: completedQuery.result.message,
+      logFileLocation: completedQuery.result.logFileLocation,
+    },
+    completedQuery.logFileLocation,
+    completedQuery.successful ?? completedQuery.sucessful,
+    completedQuery.message,
+    completedQuery.interpretedResultsSortState,
+    completedQuery.resultCount,
+    completedQuery.sortedResultsInfo,
+  );
+}
+
+function mapInitialQueryInfoDataToDomainModel(
+  initialInfo: InitialQueryInfoData,
+): InitialQueryInfo {
+  return {
+    userSpecifiedLabel: initialInfo.userSpecifiedLabel,
+    queryText: initialInfo.queryText,
+    isQuickQuery: initialInfo.isQuickQuery,
+    isQuickEval: initialInfo.isQuickEval,
+    quickEvalPosition: initialInfo.quickEvalPosition,
+    queryPath: initialInfo.queryPath,
+    databaseInfo: {
+      databaseUri: initialInfo.databaseInfo.databaseUri,
+      name: initialInfo.databaseInfo.name,
+    },
+    start: new Date(initialInfo.start),
+    id: initialInfo.id,
+  };
+}
+
+function mapQueryEvaluationInfoDataToDomainModel(
+  evaluationInfo: QueryEvaluationInfoData,
+): QueryEvaluationInfo {
+  return new QueryEvaluationInfo(
+    evaluationInfo.querySaveDir,
+    evaluationInfo.dbItemPath,
+    evaluationInfo.databaseHasMetadataFile,
+    evaluationInfo.quickEvalPosition,
+    evaluationInfo.metadata,
+  );
+}

--- a/extensions/ql-vscode/src/query-history/store/domain-mapper.ts
+++ b/extensions/ql-vscode/src/query-history/store/domain-mapper.ts
@@ -1,0 +1,90 @@
+import { assertNever } from "../../pure/helpers-pure";
+import { LocalQueryInfo, InitialQueryInfo } from "../../query-results";
+import { QueryEvaluationInfo } from "../../run-queries-shared";
+import { QueryHistoryInfo } from "../query-history-info";
+import {
+  LocalQueryDataItem,
+  InitialQueryInfoData,
+  QueryEvaluationInfoData,
+} from "./local-query-data-item";
+import { QueryHistoryDataItem } from "./query-history-data";
+import { VariantAnalysisDataItem } from "./variant-analysis-data-item";
+
+// Maps Query History Domain Models to Data Models
+
+export function mapQueryHistoryToDataModels(
+  queries: QueryHistoryInfo[],
+): QueryHistoryDataItem[] {
+  return queries.map((q) => {
+    if (q.t === "variant-analysis") {
+      const query: VariantAnalysisDataItem = q;
+      return query;
+    } else if (q.t === "local") {
+      return mapLocalQueryInfoToDataModel(q);
+    } else {
+      assertNever(q);
+    }
+  });
+}
+
+function mapLocalQueryInfoToDataModel(
+  query: LocalQueryInfo,
+): LocalQueryDataItem {
+  return {
+    initialInfo: mapInitialQueryInfoToDataModel(query.initialInfo),
+    t: "local",
+    evalLogLocation: query.evalLogLocation,
+    evalLogSummaryLocation: query.evalLogSummaryLocation,
+    jsonEvalLogSummaryLocation: query.jsonEvalLogSummaryLocation,
+    evalLogSummarySymbolsLocation: query.evalLogSummarySymbolsLocation,
+    failureReason: query.failureReason,
+    completedQuery: query.completedQuery && {
+      query: mapQueryEvaluationInfoToDataModel(query.completedQuery.query),
+      result: {
+        runId: query.completedQuery.result.runId,
+        queryId: query.completedQuery.result.queryId,
+        resultType: query.completedQuery.result.resultType,
+        evaluationTime: query.completedQuery.result.evaluationTime,
+        message: query.completedQuery.result.message,
+        logFileLocation: query.completedQuery.result.logFileLocation,
+      },
+      logFileLocation: query.completedQuery.logFileLocation,
+      successful: query.completedQuery.successful,
+      message: query.completedQuery.message,
+      resultCount: query.completedQuery.resultCount,
+      sortedResultsInfo: query.completedQuery.sortedResultsInfo,
+    },
+  };
+}
+
+function mapInitialQueryInfoToDataModel(
+  localQueryInitialInfo: InitialQueryInfo,
+): InitialQueryInfoData {
+  return {
+    userSpecifiedLabel: localQueryInitialInfo.userSpecifiedLabel,
+    queryText: localQueryInitialInfo.queryText,
+    isQuickQuery: localQueryInitialInfo.isQuickQuery,
+    isQuickEval: localQueryInitialInfo.isQuickEval,
+    quickEvalPosition: localQueryInitialInfo.quickEvalPosition,
+    queryPath: localQueryInitialInfo.queryPath,
+    databaseInfo: {
+      databaseUri: localQueryInitialInfo.databaseInfo.databaseUri,
+      name: localQueryInitialInfo.databaseInfo.name,
+    },
+    start: localQueryInitialInfo.start,
+    id: localQueryInitialInfo.id,
+  };
+}
+
+function mapQueryEvaluationInfoToDataModel(
+  queryEvaluationInfo: QueryEvaluationInfo,
+): QueryEvaluationInfoData {
+  return {
+    querySaveDir: queryEvaluationInfo.querySaveDir,
+    dbItemPath: queryEvaluationInfo.dbItemPath,
+    databaseHasMetadataFile: queryEvaluationInfo.databaseHasMetadataFile,
+    quickEvalPosition: queryEvaluationInfo.quickEvalPosition,
+    metadata: queryEvaluationInfo.metadata,
+    resultsPaths: queryEvaluationInfo.resultsPaths,
+  };
+}

--- a/extensions/ql-vscode/src/query-history/store/local-query-data-item.ts
+++ b/extensions/ql-vscode/src/query-history/store/local-query-data-item.ts
@@ -1,0 +1,100 @@
+export interface LocalQueryDataItem {
+  initialInfo: InitialQueryInfoData;
+  t: "local";
+  evalLogLocation?: string;
+  evalLogSummaryLocation?: string;
+  jsonEvalLogSummaryLocation?: string;
+  evalLogSummarySymbolsLocation?: string;
+  completedQuery?: CompletedQueryInfoData;
+  failureReason?: string;
+}
+
+export interface InitialQueryInfoData {
+  userSpecifiedLabel?: string;
+  queryText: string;
+  isQuickQuery: boolean;
+  isQuickEval: boolean;
+  quickEvalPosition?: PositionData;
+  queryPath: string;
+  databaseInfo: DatabaseInfoData;
+  start: Date;
+  id: string;
+}
+
+interface DatabaseInfoData {
+  name: string;
+  databaseUri: string;
+}
+
+interface PositionData {
+  line: number;
+  column: number;
+  endLine: number;
+  endColumn: number;
+  fileName: string;
+}
+
+export interface CompletedQueryInfoData {
+  query: QueryEvaluationInfoData;
+  message?: string;
+  successful?: boolean;
+
+  // There once was a typo in the data model, which is why we need to support both
+  sucessful?: boolean;
+  result: EvaluationResultData;
+  logFileLocation?: string;
+  resultCount: number;
+  sortedResultsInfo: Record<string, SortedResultSetInfo>;
+  interpretedResultsSortState?: InterpretedResultsSortState;
+}
+
+interface InterpretedResultsSortState {
+  sortBy: InterpretedResultsSortColumn;
+  sortDirection: SortDirection;
+}
+
+type InterpretedResultsSortColumn = "alert-message";
+
+interface SortedResultSetInfo {
+  resultsPath: string;
+  sortState: RawResultsSortState;
+}
+
+interface RawResultsSortState {
+  columnIndex: number;
+  sortDirection: SortDirection;
+}
+
+enum SortDirection {
+  asc,
+  desc,
+}
+
+interface EvaluationResultData {
+  runId: number;
+  queryId: number;
+  resultType: number;
+  evaluationTime: number;
+  message?: string;
+  logFileLocation?: string;
+}
+
+export interface QueryEvaluationInfoData {
+  querySaveDir: string;
+  dbItemPath: string;
+  databaseHasMetadataFile: boolean;
+  quickEvalPosition?: PositionData;
+  metadata?: QueryMetadataData;
+  resultsPaths: {
+    resultsPath: string;
+    interpretedResultsPath: string;
+  };
+}
+
+interface QueryMetadataData {
+  name?: string;
+  description?: string;
+  id?: string;
+  kind?: string;
+  scored?: string;
+}

--- a/extensions/ql-vscode/src/query-history/store/query-history-data.ts
+++ b/extensions/ql-vscode/src/query-history/store/query-history-data.ts
@@ -1,0 +1,14 @@
+// Contains models and consts for the data we want to store in the query history store.
+// Changes to these models should be done carefully and account for backwards compatibility of data.
+
+import { LocalQueryDataItem } from "./local-query-data-item";
+import { VariantAnalysisDataItem } from "./variant-analysis-data-item";
+
+export const ALLOWED_QUERY_HISTORY_VERSIONS = [1, 2];
+
+export interface QueryHistoryData {
+  version: number;
+  queries: QueryHistoryDataItem[];
+}
+
+export type QueryHistoryDataItem = LocalQueryDataItem | VariantAnalysisDataItem;

--- a/extensions/ql-vscode/src/query-history/store/variant-analysis-data-item.ts
+++ b/extensions/ql-vscode/src/query-history/store/variant-analysis-data-item.ts
@@ -1,0 +1,83 @@
+import { QueryLanguage } from "../../common/query-language";
+import { QueryStatus } from "../../query-status";
+import {
+  VariantAnalysisFailureReason,
+  VariantAnalysisRepoStatus,
+  VariantAnalysisStatus,
+} from "../../variant-analysis/shared/variant-analysis";
+
+// Data Model for Variant Analysis Query History Items
+// All data points are modelled, except enums.
+
+export interface VariantAnalysisDataItem {
+  readonly t: "variant-analysis";
+  failureReason?: string;
+  resultCount?: number;
+  status: QueryStatus;
+  completed: boolean;
+  variantAnalysis: VariantAnalysisQueryHistoryData;
+  userSpecifiedLabel?: string;
+}
+
+export interface VariantAnalysisQueryHistoryData {
+  id: number;
+  controllerRepo: {
+    id: number;
+    fullName: string;
+    private: boolean;
+  };
+  query: {
+    name: string;
+    filePath: string;
+    language: QueryLanguage;
+    text: string;
+  };
+  databases: {
+    repositories?: string[];
+    repositoryLists?: string[];
+    repositoryOwners?: string[];
+  };
+  createdAt: string;
+  updatedAt: string;
+  executionStartTime: number;
+  status: VariantAnalysisStatus;
+  completedAt?: string;
+  actionsWorkflowRunId?: number;
+  failureReason?: VariantAnalysisFailureReason;
+  scannedRepos?: VariantAnalysisScannedRepositoryData[];
+  skippedRepos?: VariantAnalysisSkippedRepositoriesData;
+}
+
+export interface VariantAnalysisScannedRepositoryData {
+  repository: {
+    id: number;
+    fullName: string;
+    private: boolean;
+    stargazersCount: number;
+    updatedAt: string | null;
+  };
+  analysisStatus: VariantAnalysisRepoStatus;
+  resultCount?: number;
+  artifactSizeInBytes?: number;
+  failureMessage?: string;
+}
+
+export interface VariantAnalysisSkippedRepositoriesData {
+  accessMismatchRepos?: VariantAnalysisSkippedRepositoryGroupData;
+  notFoundRepos?: VariantAnalysisSkippedRepositoryGroupData;
+  noCodeqlDbRepos?: VariantAnalysisSkippedRepositoryGroupData;
+  overLimitRepos?: VariantAnalysisSkippedRepositoryGroupData;
+}
+
+export interface VariantAnalysisSkippedRepositoryGroupData {
+  repositoryCount: number;
+  repositories: VariantAnalysisSkippedRepositoryData[];
+}
+
+export interface VariantAnalysisSkippedRepositoryData {
+  id?: number;
+  fullName: string;
+  private?: boolean;
+  stargazersCount?: number;
+  updatedAt?: string | null;
+}

--- a/extensions/ql-vscode/src/run-queries-shared.ts
+++ b/extensions/ql-vscode/src/run-queries-shared.ts
@@ -137,7 +137,7 @@ export class QueryEvaluationInfo extends QueryOutputDir {
   constructor(
     querySaveDir: string,
     public readonly dbItemPath: string,
-    private readonly databaseHasMetadataFile: boolean,
+    public readonly databaseHasMetadataFile: boolean,
     public readonly quickEvalPosition?: messages.Position,
     public readonly metadata?: QueryMetadata,
   ) {
@@ -382,10 +382,10 @@ export class QueryEvaluationInfo extends QueryOutputDir {
 
 export interface QueryWithResults {
   readonly query: QueryEvaluationInfo;
+  readonly result: legacyMessages.EvaluationResult;
   readonly logFileLocation?: string;
   readonly successful?: boolean;
   readonly message?: string;
-  readonly result: legacyMessages.EvaluationResult;
 }
 
 /**


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

To prevent changes in our domain to impact what and how we store the query history directly, we separated both worlds by creating specific data models.

This PR: 
- Creates new interfaces (data models) for local queries and variant analysis query history storage
- Rewrites constructors for the following classes: 
     - LocalQueryInfo
     - CompletedQueryInfo
- Maps new data models to domain model and vice versa

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
