### PR TITLE
Refactor local query evaluation to prepare for debug adapter

### DIFF
--- a/extensions/ql-vscode/src/ast-cfg-commands.ts
+++ b/extensions/ql-vscode/src/ast-cfg-commands.ts
@@ -5,31 +5,18 @@ import {
   TemplatePrintAstProvider,
   TemplatePrintCfgProvider,
 } from "./contextual/templateProvider";
-import { compileAndRunQuery } from "./local-queries";
-import { QueryRunner } from "./queryRunner";
-import { QueryHistoryManager } from "./query-history/query-history-manager";
-import { DatabaseUI } from "./local-databases-ui";
-import { ResultsView } from "./interface";
 import { AstCfgCommands } from "./common/commands";
+import { LocalQueries } from "./local-queries";
 
 type AstCfgOptions = {
-  queryRunner: QueryRunner;
-  queryHistoryManager: QueryHistoryManager;
-  databaseUI: DatabaseUI;
-  localQueryResultsView: ResultsView;
-  queryStorageDir: string;
-
+  localQueries: LocalQueries;
   astViewer: AstViewer;
   astTemplateProvider: TemplatePrintAstProvider;
   cfgTemplateProvider: TemplatePrintCfgProvider;
 };
 
 export function getAstCfgCommands({
-  queryRunner,
-  queryHistoryManager,
-  databaseUI,
-  localQueryResultsView,
-  queryStorageDir,
+  localQueries,
   astViewer,
   astTemplateProvider,
   cfgTemplateProvider,
@@ -59,12 +46,7 @@ export function getAstCfgCommands({
           window.activeTextEditor?.document,
         );
         if (res) {
-          await compileAndRunQuery(
-            queryRunner,
-            queryHistoryManager,
-            databaseUI,
-            localQueryResultsView,
-            queryStorageDir,
+          await localQueries.compileAndRunQuery(
             false,
             res[0],
             progress,

--- a/extensions/ql-vscode/src/common/logging/logger.ts
+++ b/extensions/ql-vscode/src/common/logging/logger.ts
@@ -3,7 +3,8 @@ export interface LogOptions {
   trailingNewline?: boolean;
 }
 
-export interface Logger {
+/** Minimal logger interface. */
+export interface BaseLogger {
   /**
    * Writes the given log message, optionally followed by a newline.
    * This function is asynchronous and will only resolve once the message is written
@@ -15,7 +16,10 @@ export interface Logger {
    * @param options Optional settings.
    */
   log(message: string, options?: LogOptions): Promise<void>;
+}
 
+/** Full logger interface, including a function to show the log in the UI. */
+export interface Logger extends BaseLogger {
   /**
    * Reveal the logger channel in the UI.
    *

--- a/extensions/ql-vscode/src/contextual/astBuilder.ts
+++ b/extensions/ql-vscode/src/contextual/astBuilder.ts
@@ -4,7 +4,7 @@ import { DatabaseItem } from "../local-databases";
 import { ChildAstItem, AstItem } from "../astViewer";
 import fileRangeFromURI from "./fileRangeFromURI";
 import { Uri } from "vscode";
-import { QueryWithResults } from "../run-queries-shared";
+import { QueryOutputDir } from "../run-queries-shared";
 
 /**
  * A class that wraps a tree of QL results from a query that
@@ -14,12 +14,12 @@ export default class AstBuilder {
   private roots: AstItem[] | undefined;
   private bqrsPath: string;
   constructor(
-    queryResults: QueryWithResults,
+    outputDir: QueryOutputDir,
     private cli: CodeQLCliServer,
     public db: DatabaseItem,
     public fileName: Uri,
   ) {
-    this.bqrsPath = queryResults.query.resultsPaths.resultsPath;
+    this.bqrsPath = outputDir.bqrsPath;
   }
 
   async getRoots(): Promise<AstItem[]> {

--- a/extensions/ql-vscode/src/contextual/queryResolver.ts
+++ b/extensions/ql-vscode/src/contextual/queryResolver.ts
@@ -13,11 +13,10 @@ import {
 import { KeyType, kindOfKeyType, nameOfKeyType, tagOfKeyType } from "./keyType";
 import { CodeQLCliServer } from "../cli";
 import { DatabaseItem } from "../local-databases";
-import { extLogger } from "../common";
-import { createInitialQueryInfo } from "../run-queries-shared";
-import { CancellationToken, Uri } from "vscode";
+import { extLogger, TeeLogger } from "../common";
+import { CancellationToken } from "vscode";
 import { ProgressCallback } from "../progress";
-import { QueryRunner } from "../queryRunner";
+import { CoreCompletedQuery, QueryRunner } from "../queryRunner";
 import { redactableError } from "../pure/errors";
 import { QLPACK_FILENAMES } from "../pure/ql";
 
@@ -169,32 +168,30 @@ export async function runContextualQuery(
   progress: ProgressCallback,
   token: CancellationToken,
   templates: Record<string, string>,
-) {
+): Promise<CoreCompletedQuery> {
   const { packPath, createdTempLockFile } = await resolveContextualQuery(
     cli,
     query,
   );
-  const initialInfo = await createInitialQueryInfo(
-    Uri.file(query),
-    {
-      name: db.name,
-      databaseUri: db.databaseUri.toString(),
-    },
+  const queryRun = qs.createQueryRun(
+    db.databaseUri.fsPath,
+    { queryPath: query, quickEvalPosition: undefined },
     false,
+    getOnDiskWorkspaceFolders(),
+    queryStorageDir,
+    undefined,
+    templates,
   );
   void extLogger.log(
-    `Running contextual query ${query}; results will be stored in ${queryStorageDir}`,
+    `Running contextual query ${query}; results will be stored in ${queryRun.outputDir}`,
   );
-  const queryResult = await qs.compileAndRunQueryAgainstDatabase(
-    db,
-    initialInfo,
-    queryStorageDir,
+  const results = await queryRun.evaluate(
     progress,
     token,
-    templates,
+    new TeeLogger(qs.logger, queryRun.outputDir.logPath),
   );
   if (createdTempLockFile) {
     await removeTemporaryLockFile(packPath);
   }
-  return queryResult;
+  return results;
 }

--- a/extensions/ql-vscode/src/contextual/queryResolver.ts
+++ b/extensions/ql-vscode/src/contextual/queryResolver.ts
@@ -183,7 +183,7 @@ export async function runContextualQuery(
     templates,
   );
   void extLogger.log(
-    `Running contextual query ${query}; results will be stored in ${queryRun.outputDir}`,
+    `Running contextual query ${query}; results will be stored in ${queryRun.outputDir.querySaveDir}`,
   );
   const results = await queryRun.evaluate(
     progress,

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -253,6 +253,7 @@ export interface CodeQLExtensionInterface {
   readonly distributionManager: DistributionManager;
   readonly databaseManager: DatabaseManager;
   readonly databaseUI: DatabaseUI;
+  readonly localQueries: LocalQueries;
   readonly variantAnalysisManager: VariantAnalysisManager;
   readonly dispose: () => void;
 }
@@ -978,6 +979,7 @@ async function activateWithInstalledDistribution(
   return {
     ctx,
     cliServer,
+    localQueries,
     qs,
     distributionManager,
     databaseManager: dbm,

--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -754,7 +754,7 @@ export async function tryGetQueryMetadata(
  * Creates a file in the query directory that indicates when this query was created.
  * This is important for keeping track of when queries should be removed.
  *
- * @param queryPath The directory that will containt all files relevant to a query result.
+ * @param queryPath The directory that will contain all files relevant to a query result.
  * It does not need to exist.
  */
 export async function createTimestampFile(storagePath: string) {

--- a/extensions/ql-vscode/src/legacy-query-server/legacyRunner.ts
+++ b/extensions/ql-vscode/src/legacy-query-server/legacyRunner.ts
@@ -57,7 +57,7 @@ export class LegacyQueryRunner extends QueryRunner {
     await clearCacheInDatabase(this.qs, dbItem, progress, token);
   }
 
-  protected async compileAndRunQueryAgainstDatabaseCore(
+  public async compileAndRunQueryAgainstDatabaseCore(
     dbPath: string,
     query: CoreQueryTarget,
     additionalPacks: string[],

--- a/extensions/ql-vscode/src/legacy-query-server/legacyRunner.ts
+++ b/extensions/ql-vscode/src/legacy-query-server/legacyRunner.ts
@@ -1,18 +1,19 @@
 import { CancellationToken } from "vscode";
+import { CodeQLCliServer } from "../cli";
 import { ProgressCallback } from "../progress";
+import { Logger } from "../common";
 import { DatabaseItem } from "../local-databases";
 import {
   Dataset,
   deregisterDatabases,
   registerDatabases,
 } from "../pure/legacy-messages";
-import { InitialQueryInfo, LocalQueryInfo } from "../query-results";
-import { QueryRunner } from "../queryRunner";
-import { QueryWithResults } from "../run-queries-shared";
+import { CoreQueryResults, CoreQueryTarget, QueryRunner } from "../queryRunner";
+import { QueryOutputDir } from "../run-queries-shared";
 import { QueryServerClient } from "./queryserver-client";
 import {
   clearCacheInDatabase,
-  compileAndRunQueryAgainstDatabase,
+  compileAndRunQueryAgainstDatabaseCore,
 } from "./run-queries";
 import { upgradeDatabaseExplicit } from "./upgrades";
 
@@ -21,8 +22,16 @@ export class LegacyQueryRunner extends QueryRunner {
     super();
   }
 
-  get cliServer() {
+  get cliServer(): CodeQLCliServer {
     return this.qs.cliServer;
+  }
+
+  get customLogDirectory(): string | undefined {
+    return undefined;
+  }
+
+  get logger(): Logger {
+    return this.qs.logger;
   }
 
   async restartQueryServer(
@@ -47,25 +56,29 @@ export class LegacyQueryRunner extends QueryRunner {
   ): Promise<void> {
     await clearCacheInDatabase(this.qs, dbItem, progress, token);
   }
-  async compileAndRunQueryAgainstDatabase(
-    dbItem: DatabaseItem,
-    initialInfo: InitialQueryInfo,
-    queryStorageDir: string,
+
+  protected async compileAndRunQueryAgainstDatabaseCore(
+    dbPath: string,
+    query: CoreQueryTarget,
+    additionalPacks: string[],
+    generateEvalLog: boolean,
+    outputDir: QueryOutputDir,
     progress: ProgressCallback,
     token: CancellationToken,
-    templates?: Record<string, string>,
-    queryInfo?: LocalQueryInfo,
-  ): Promise<QueryWithResults> {
-    return await compileAndRunQueryAgainstDatabase(
-      this.qs.cliServer,
+    templates: Record<string, string> | undefined,
+    logger: Logger,
+  ): Promise<CoreQueryResults> {
+    return await compileAndRunQueryAgainstDatabaseCore(
       this.qs,
-      dbItem,
-      initialInfo,
-      queryStorageDir,
+      dbPath,
+      query,
+      generateEvalLog,
+      additionalPacks,
+      outputDir,
       progress,
       token,
       templates,
-      queryInfo,
+      logger,
     );
   }
 

--- a/extensions/ql-vscode/src/legacy-query-server/run-queries.ts
+++ b/extensions/ql-vscode/src/legacy-query-server/run-queries.ts
@@ -27,7 +27,7 @@ import { redactableError } from "../pure/errors";
 import { CoreQueryResults, CoreQueryTarget } from "../queryRunner";
 import { Position } from "../pure/messages-shared";
 
-async function compileQuery(
+export async function compileQuery(
   qs: qsClient.QueryServerClient,
   program: messages.QlProgram,
   quickEvalPosition: Position | undefined,
@@ -185,7 +185,7 @@ export class QueryInProgress {
     readonly querySaveDir: string,
     readonly dbItemPath: string,
     databaseHasMetadataFile: boolean,
-    readonly queryDbscheme: string, // the dbscheme file the query expects, based on library path resolution
+    readonly queryDbscheme: string, // the dbscheme file the query expects, ba`sed on library path resolution
     readonly quickEvalPosition?: messages.Position,
     readonly metadata?: QueryMetadata,
     readonly templates?: Record<string, string>,

--- a/extensions/ql-vscode/src/legacy-query-server/run-queries.ts
+++ b/extensions/ql-vscode/src/legacy-query-server/run-queries.ts
@@ -292,7 +292,7 @@ function translateLegacyResult(
       break;
     case messages.QueryResultType.TIMEOUT:
       // This is the only legacy result type that doesn't exist for the new query server. Format the
-      // messasge here, and let the later code treat is as `OTHER_ERROR`.
+      // messasge here, and let the later code treat it as `OTHER_ERROR`.
       newResultType = newMessages.QueryResultType.OTHER_ERROR;
       newMessage = `timed out after ${Math.round(
         legacyResult.evaluationTime / 1000,

--- a/extensions/ql-vscode/src/legacy-query-server/run-queries.ts
+++ b/extensions/ql-vscode/src/legacy-query-server/run-queries.ts
@@ -9,11 +9,7 @@ import {
   DatabaseItem,
   DatabaseResolver,
 } from "../local-databases";
-import {
-  showAndLogExceptionWithTelemetry,
-  showAndLogWarningMessage,
-  upgradesTmpDir,
-} from "../helpers";
+import { showAndLogExceptionWithTelemetry, upgradesTmpDir } from "../helpers";
 import { ProgressCallback } from "../progress";
 import { QueryMetadata } from "../pure/interface-types";
 import { extLogger, Logger } from "../common";
@@ -141,11 +137,6 @@ async function runQuery(
   };
   try {
     await qs.sendRequest(messages.runQueries, params, token, progress);
-    if (qs.config.customLogDirectory) {
-      void showAndLogWarningMessage(
-        `Custom log directories are no longer supported. The "codeQL.runningQueries.customLogDirectory" setting is deprecated. Unset the setting to stop seeing this message. Query logs saved to ${logPath}.`,
-      );
-    }
   } finally {
     qs.unRegisterCallback(callbackId);
     if (

--- a/extensions/ql-vscode/src/legacy-query-server/run-queries.ts
+++ b/extensions/ql-vscode/src/legacy-query-server/run-queries.ts
@@ -292,7 +292,7 @@ function translateLegacyResult(
       break;
     case messages.QueryResultType.TIMEOUT:
       // This is the only legacy result type that doesn't exist for the new query server. Format the
-      // messasge here, and let the later code treat it as `OTHER_ERROR`.
+      // message here, and let the later code treat it as `OTHER_ERROR`.
       newResultType = newMessages.QueryResultType.OTHER_ERROR;
       newMessage = `timed out after ${Math.round(
         legacyResult.evaluationTime / 1000,

--- a/extensions/ql-vscode/src/legacy-query-server/run-queries.ts
+++ b/extensions/ql-vscode/src/legacy-query-server/run-queries.ts
@@ -445,9 +445,7 @@ export async function compileAndRunQueryAgainstDatabaseCore(
         void showAndLogExceptionWithTelemetry(error);
       }
 
-      return {
-        ...translateLegacyResult(result),
-      };
+      return translateLegacyResult(result);
     } else {
       // Error dialogs are limited in size and scrollability,
       // so we include a general description of the problem,

--- a/extensions/ql-vscode/src/legacy-query-server/run-queries.ts
+++ b/extensions/ql-vscode/src/legacy-query-server/run-queries.ts
@@ -1,28 +1,173 @@
 import * as tmp from "tmp-promise";
-import { basename, join } from "path";
+import { basename } from "path";
 import { CancellationToken, Uri } from "vscode";
 import { LSPErrorCodes, ResponseError } from "vscode-languageclient";
 
 import * as cli from "../cli";
-import { DatabaseItem } from "../local-databases";
 import {
-  getOnDiskWorkspaceFolders,
-  showAndLogErrorMessage,
+  DatabaseContentsWithDbScheme,
+  DatabaseItem,
+  DatabaseResolver,
+} from "../local-databases";
+import {
   showAndLogExceptionWithTelemetry,
   showAndLogWarningMessage,
-  tryGetQueryMetadata,
   upgradesTmpDir,
 } from "../helpers";
 import { ProgressCallback } from "../progress";
 import { QueryMetadata } from "../pure/interface-types";
-import { extLogger, Logger, TeeLogger } from "../common";
+import { extLogger, Logger } from "../common";
 import * as messages from "../pure/legacy-messages";
-import { InitialQueryInfo, LocalQueryInfo } from "../query-results";
+import * as newMessages from "../pure/new-messages";
 import * as qsClient from "./queryserver-client";
 import { asError, getErrorMessage } from "../pure/helpers-pure";
 import { compileDatabaseUpgradeSequence } from "./upgrades";
-import { QueryEvaluationInfo, QueryWithResults } from "../run-queries-shared";
+import { QueryEvaluationInfo, QueryOutputDir } from "../run-queries-shared";
 import { redactableError } from "../pure/errors";
+import { CoreQueryResults, CoreQueryTarget } from "../queryRunner";
+import { Position } from "../pure/messages-shared";
+
+async function compileQuery(
+  qs: qsClient.QueryServerClient,
+  program: messages.QlProgram,
+  quickEvalPosition: Position | undefined,
+  outputDir: QueryOutputDir,
+  progress: ProgressCallback,
+  token: CancellationToken,
+  logger: Logger,
+): Promise<messages.CompilationMessage[]> {
+  let compiled: messages.CheckQueryResult | undefined;
+  try {
+    const target: messages.CompilationTarget = quickEvalPosition
+      ? {
+          quickEval: { quickEvalPos: quickEvalPosition },
+        }
+      : { query: {} };
+    const params: messages.CompileQueryParams = {
+      compilationOptions: {
+        computeNoLocationUrls: true,
+        failOnWarnings: false,
+        fastCompilation: false,
+        includeDilInQlo: true,
+        localChecking: false,
+        noComputeGetUrl: false,
+        noComputeToString: false,
+        computeDefaultStrings: true,
+        emitDebugInfo: true,
+      },
+      extraOptions: {
+        timeoutSecs: qs.config.timeoutSecs,
+      },
+      queryToCheck: program,
+      resultPath: outputDir.compileQueryPath,
+      target,
+    };
+
+    // Update the active query logger every time there is a new request to compile.
+    // This isn't ideal because in situations where there are queries running
+    // in parallel, each query's log messages are interleaved. Fixing this
+    // properly will require a change in the query server.
+    qs.activeQueryLogger = logger;
+    compiled = await qs.sendRequest(
+      messages.compileQuery,
+      params,
+      token,
+      progress,
+    );
+  } finally {
+    void logger.log(" - - - COMPILATION DONE - - - ");
+  }
+  return (compiled?.messages || []).filter(
+    (msg) => msg.severity === messages.Severity.ERROR,
+  );
+}
+
+async function runQuery(
+  qs: qsClient.QueryServerClient,
+  upgradeQlo: string | undefined,
+  availableMlModels: cli.MlModelInfo[],
+  dbContents: DatabaseContentsWithDbScheme,
+  templates: Record<string, string> | undefined,
+  generateEvalLog: boolean,
+  outputDir: QueryOutputDir,
+  progress: ProgressCallback,
+  token: CancellationToken,
+): Promise<messages.EvaluationResult> {
+  let result: messages.EvaluationResult | null = null;
+
+  const logPath = outputDir.logPath;
+
+  const callbackId = qs.registerCallback((res) => {
+    result = {
+      ...res,
+      logFileLocation: logPath,
+    };
+  });
+
+  const availableMlModelUris: messages.MlModel[] = availableMlModels.map(
+    (model) => ({ uri: Uri.file(model.path).toString(true) }),
+  );
+
+  const queryToRun: messages.QueryToRun = {
+    resultsPath: outputDir.bqrsPath,
+    qlo: Uri.file(outputDir.compileQueryPath).toString(),
+    compiledUpgrade: upgradeQlo && Uri.file(upgradeQlo).toString(),
+    allowUnknownTemplates: true,
+    templateValues: createSimpleTemplates(templates),
+    availableMlModels: availableMlModelUris,
+    id: callbackId,
+    timeoutSecs: qs.config.timeoutSecs,
+  };
+
+  const dataset: messages.Dataset = {
+    dbDir: dbContents.datasetUri.fsPath,
+    workingSet: "default",
+  };
+  if (
+    generateEvalLog &&
+    (await qs.cliServer.cliConstraints.supportsPerQueryEvalLog())
+  ) {
+    await qs.sendRequest(messages.startLog, {
+      db: dataset,
+      logPath: outputDir.evalLogPath,
+    });
+  }
+  const params: messages.EvaluateQueriesParams = {
+    db: dataset,
+    evaluateId: callbackId,
+    queries: [queryToRun],
+    stopOnError: false,
+    useSequenceHint: false,
+  };
+  try {
+    await qs.sendRequest(messages.runQueries, params, token, progress);
+    if (qs.config.customLogDirectory) {
+      void showAndLogWarningMessage(
+        `Custom log directories are no longer supported. The "codeQL.runningQueries.customLogDirectory" setting is deprecated. Unset the setting to stop seeing this message. Query logs saved to ${logPath}.`,
+      );
+    }
+  } finally {
+    qs.unRegisterCallback(callbackId);
+    if (
+      generateEvalLog &&
+      (await qs.cliServer.cliConstraints.supportsPerQueryEvalLog())
+    ) {
+      await qs.sendRequest(messages.endLog, {
+        db: dataset,
+        logPath: outputDir.evalLogPath,
+      });
+    }
+  }
+  return (
+    result || {
+      evaluationTime: 0,
+      message: "No result from server",
+      queryId: -1,
+      runId: callbackId,
+      resultType: messages.QueryResultType.OTHER_ERROR,
+    }
+  );
+}
 
 /**
  * A collection of evaluation-time information about a query,
@@ -54,162 +199,6 @@ export class QueryInProgress {
     );
     /**/
   }
-
-  get compiledQueryPath() {
-    return this.queryEvalInfo.compileQueryPath;
-  }
-
-  async run(
-    qs: qsClient.QueryServerClient,
-    upgradeQlo: string | undefined,
-    availableMlModels: cli.MlModelInfo[],
-    dbItem: DatabaseItem,
-    progress: ProgressCallback,
-    token: CancellationToken,
-    logger: Logger,
-    queryInfo: LocalQueryInfo | undefined,
-  ): Promise<messages.EvaluationResult> {
-    if (!dbItem.contents || dbItem.error) {
-      throw new Error("Can't run query on invalid database.");
-    }
-
-    let result: messages.EvaluationResult | null = null;
-
-    const callbackId = qs.registerCallback((res) => {
-      result = {
-        ...res,
-        logFileLocation: this.queryEvalInfo.logPath,
-      };
-    });
-
-    const availableMlModelUris: messages.MlModel[] = availableMlModels.map(
-      (model) => ({ uri: Uri.file(model.path).toString(true) }),
-    );
-
-    const queryToRun: messages.QueryToRun = {
-      resultsPath: this.queryEvalInfo.resultsPaths.resultsPath,
-      qlo: Uri.file(this.compiledQueryPath).toString(),
-      compiledUpgrade: upgradeQlo && Uri.file(upgradeQlo).toString(),
-      allowUnknownTemplates: true,
-      templateValues: createSimpleTemplates(this.templates),
-      availableMlModels: availableMlModelUris,
-      id: callbackId,
-      timeoutSecs: qs.config.timeoutSecs,
-    };
-
-    const dataset: messages.Dataset = {
-      dbDir: dbItem.contents.datasetUri.fsPath,
-      workingSet: "default",
-    };
-    if (
-      queryInfo &&
-      (await qs.cliServer.cliConstraints.supportsPerQueryEvalLog())
-    ) {
-      await qs.sendRequest(messages.startLog, {
-        db: dataset,
-        logPath: this.queryEvalInfo.evalLogPath,
-      });
-    }
-    const params: messages.EvaluateQueriesParams = {
-      db: dataset,
-      evaluateId: callbackId,
-      queries: [queryToRun],
-      stopOnError: false,
-      useSequenceHint: false,
-    };
-    try {
-      await qs.sendRequest(messages.runQueries, params, token, progress);
-      if (qs.config.customLogDirectory) {
-        void showAndLogWarningMessage(
-          `Custom log directories are no longer supported. The "codeQL.runningQueries.customLogDirectory" setting is deprecated. Unset the setting to stop seeing this message. Query logs saved to ${this.queryEvalInfo.logPath}.`,
-        );
-      }
-    } finally {
-      qs.unRegisterCallback(callbackId);
-      if (
-        queryInfo &&
-        (await qs.cliServer.cliConstraints.supportsPerQueryEvalLog())
-      ) {
-        await qs.sendRequest(messages.endLog, {
-          db: dataset,
-          logPath: this.queryEvalInfo.evalLogPath,
-        });
-        if (await this.queryEvalInfo.hasEvalLog()) {
-          await this.queryEvalInfo.addQueryLogs(
-            queryInfo,
-            qs.cliServer,
-            logger,
-          );
-        } else {
-          void showAndLogWarningMessage(
-            `Failed to write structured evaluator log to ${this.queryEvalInfo.evalLogPath}.`,
-          );
-        }
-      }
-    }
-    return (
-      result || {
-        evaluationTime: 0,
-        message: "No result from server",
-        queryId: -1,
-        runId: callbackId,
-        resultType: messages.QueryResultType.OTHER_ERROR,
-      }
-    );
-  }
-
-  async compile(
-    qs: qsClient.QueryServerClient,
-    program: messages.QlProgram,
-    progress: ProgressCallback,
-    token: CancellationToken,
-    logger: Logger,
-  ): Promise<messages.CompilationMessage[]> {
-    let compiled: messages.CheckQueryResult | undefined;
-    try {
-      const target = this.quickEvalPosition
-        ? {
-            quickEval: { quickEvalPos: this.quickEvalPosition },
-          }
-        : { query: {} };
-      const params: messages.CompileQueryParams = {
-        compilationOptions: {
-          computeNoLocationUrls: true,
-          failOnWarnings: false,
-          fastCompilation: false,
-          includeDilInQlo: true,
-          localChecking: false,
-          noComputeGetUrl: false,
-          noComputeToString: false,
-          computeDefaultStrings: true,
-          emitDebugInfo: true,
-        },
-        extraOptions: {
-          timeoutSecs: qs.config.timeoutSecs,
-        },
-        queryToCheck: program,
-        resultPath: this.compiledQueryPath,
-        target,
-      };
-
-      // Update the active query logger every time there is a new request to compile.
-      // This isn't ideal because in situations where there are queries running
-      // in parallel, each query's log messages are interleaved. Fixing this
-      // properly will require a change in the query server.
-      qs.activeQueryLogger = logger;
-      compiled = await qs.sendRequest(
-        messages.compileQuery,
-        params,
-        token,
-        progress,
-      );
-    } finally {
-      void logger.log(" - - - COMPILATION DONE - - - ");
-    }
-    return (compiled?.messages || []).filter(
-      (msg) => msg.severity === messages.Severity.ERROR,
-    );
-  }
 }
 
 export async function clearCacheInDatabase(
@@ -237,10 +226,10 @@ export async function clearCacheInDatabase(
 
 function reportNoUpgradePath(
   qlProgram: messages.QlProgram,
-  query: QueryInProgress,
+  queryDbscheme: string,
 ): void {
   throw new Error(
-    `Query ${qlProgram.queryPath} expects database scheme ${query.queryDbscheme}, but the current database has a different scheme, and no database upgrades are available. The current database scheme may be newer than the CodeQL query libraries in your workspace.\n\nPlease try using a newer version of the query libraries.`,
+    `Query ${qlProgram.queryPath} expects database scheme ${queryDbscheme}, but the current database has a different scheme, and no database upgrades are available. The current database scheme may be newer than the CodeQL query libraries in your workspace.\n\nPlease try using a newer version of the query libraries.`,
   );
 }
 
@@ -250,32 +239,27 @@ function reportNoUpgradePath(
 async function compileNonDestructiveUpgrade(
   qs: qsClient.QueryServerClient,
   upgradeTemp: tmp.DirectoryResult,
-  query: QueryInProgress,
+  queryDbscheme: string,
   qlProgram: messages.QlProgram,
-  dbItem: DatabaseItem,
+  dbContents: DatabaseContentsWithDbScheme,
   progress: ProgressCallback,
   token: CancellationToken,
 ): Promise<string> {
-  if (!dbItem?.contents?.dbSchemeUri) {
-    throw new Error("Database is invalid, and cannot be upgraded.");
-  }
-
   // Dependencies may exist outside of the workspace and they are always on the resolved search path.
   const upgradesPath = qlProgram.libraryPath;
 
   const { scripts, matchesTarget } = await qs.cliServer.resolveUpgrades(
-    dbItem.contents.dbSchemeUri.fsPath,
+    dbContents.dbSchemeUri.fsPath,
     upgradesPath,
     true,
-    query.queryDbscheme,
+    queryDbscheme,
   );
 
   if (!matchesTarget) {
-    reportNoUpgradePath(qlProgram, query);
+    reportNoUpgradePath(qlProgram, queryDbscheme);
   }
   const result = await compileDatabaseUpgradeSequence(
     qs,
-    dbItem,
     scripts,
     upgradeTemp,
     progress,
@@ -286,34 +270,67 @@ async function compileNonDestructiveUpgrade(
     throw new Error(error);
   }
   // We can upgrade to the actual target
-  qlProgram.dbschemePath = query.queryDbscheme;
+  qlProgram.dbschemePath = queryDbscheme;
   // We are new enough that we will always support single file upgrades.
   return result.compiledUpgrade;
 }
 
-export async function compileAndRunQueryAgainstDatabase(
-  cliServer: cli.CodeQLCliServer,
-  qs: qsClient.QueryServerClient,
-  dbItem: DatabaseItem,
-  initialInfo: InitialQueryInfo,
-  queryStorageDir: string,
-  progress: ProgressCallback,
-  token: CancellationToken,
-  templates?: Record<string, string>,
-  queryInfo?: LocalQueryInfo, // May be omitted for queries not initiated by the user. If omitted we won't create a structured log for the query.
-): Promise<QueryWithResults> {
-  if (!dbItem.contents || !dbItem.contents.dbSchemeUri) {
-    throw new Error(
-      `Database ${dbItem.databaseUri} does not have a CodeQL database scheme.`,
-    );
+function translateLegacyResult(
+  legacyResult: messages.EvaluationResult,
+): Omit<CoreQueryResults, "dispose"> {
+  let newResultType: newMessages.QueryResultType;
+  let newMessage = legacyResult.message;
+  switch (legacyResult.resultType) {
+    case messages.QueryResultType.SUCCESS:
+      newResultType = newMessages.QueryResultType.SUCCESS;
+      break;
+    case messages.QueryResultType.CANCELLATION:
+      newResultType = newMessages.QueryResultType.CANCELLATION;
+      break;
+    case messages.QueryResultType.OOM:
+      newResultType = newMessages.QueryResultType.OOM;
+      break;
+    case messages.QueryResultType.TIMEOUT:
+      // This is the only legacy result type that doesn't exist for the new query server. Format the
+      // messasge here, and let the later code treat is as `OTHER_ERROR`.
+      newResultType = newMessages.QueryResultType.OTHER_ERROR;
+      newMessage = `timed out after ${Math.round(
+        legacyResult.evaluationTime / 1000,
+      )} seconds`;
+      break;
+    case messages.QueryResultType.OTHER_ERROR:
+    default:
+      newResultType = newMessages.QueryResultType.OTHER_ERROR;
+      break;
   }
 
-  // Get the workspace folder paths.
-  const diskWorkspaceFolders = getOnDiskWorkspaceFolders();
+  return {
+    resultType: newResultType,
+    message: newMessage,
+    evaluationTime: legacyResult.evaluationTime,
+  };
+}
+
+export async function compileAndRunQueryAgainstDatabaseCore(
+  qs: qsClient.QueryServerClient,
+  dbPath: string,
+  query: CoreQueryTarget,
+  generateEvalLog: boolean,
+  additionalPacks: string[],
+  outputDir: QueryOutputDir,
+  progress: ProgressCallback,
+  token: CancellationToken,
+  templates: Record<string, string> | undefined,
+  logger: Logger,
+): Promise<CoreQueryResults> {
+  const dbContents = await DatabaseResolver.resolveDatabaseContents(
+    Uri.file(dbPath),
+  );
+
   // Figure out the library path for the query.
-  const packConfig = await cliServer.resolveLibraryPath(
-    diskWorkspaceFolders,
-    initialInfo.queryPath,
+  const packConfig = await qs.cliServer.resolveLibraryPath(
+    additionalPacks,
+    query.queryPath,
   );
 
   if (!packConfig.dbscheme) {
@@ -327,17 +344,15 @@ export async function compileAndRunQueryAgainstDatabase(
   // won't trigger this check)
   // This test will produce confusing results if we ever change the name of the database schema files.
   const querySchemaName = basename(packConfig.dbscheme);
-  const dbSchemaName = basename(dbItem.contents.dbSchemeUri.fsPath);
+  const dbSchemaName = basename(dbContents.dbSchemeUri?.fsPath);
   if (querySchemaName !== dbSchemaName) {
     void extLogger.log(
       `Query schema was ${querySchemaName}, but database schema was ${dbSchemaName}.`,
     );
     throw new Error(
       `The query ${basename(
-        initialInfo.queryPath,
-      )} cannot be run against the selected database (${
-        dbItem.name
-      }): their target languages are different. Please select a different database and try again.`,
+        query.queryPath,
+      )} cannot be run against the selected database: their target languages are different. Please select a different database and try again.`,
     );
   }
 
@@ -349,20 +364,14 @@ export async function compileAndRunQueryAgainstDatabase(
     // Since we are compiling and running a query against a database,
     // we use the database's DB scheme here instead of the DB scheme
     // from the current document's project.
-    dbschemePath: dbItem.contents.dbSchemeUri.fsPath,
-    queryPath: initialInfo.queryPath,
+    dbschemePath: dbContents.dbSchemeUri.fsPath,
+    queryPath: query.queryPath,
   };
-
-  // Read the query metadata if possible, to use in the UI.
-  const metadata = await tryGetQueryMetadata(cliServer, qlProgram.queryPath);
 
   let availableMlModels: cli.MlModelInfo[] = [];
   try {
     availableMlModels = (
-      await cliServer.resolveMlModels(
-        diskWorkspaceFolders,
-        initialInfo.queryPath,
-      )
+      await qs.cliServer.resolveMlModels(additionalPacks, query.queryPath)
     ).models;
     if (availableMlModels.length) {
       void extLogger.log(
@@ -381,57 +390,53 @@ export async function compileAndRunQueryAgainstDatabase(
     );
   }
 
-  const hasMetadataFile = await dbItem.hasMetadataFile();
-  const query = new QueryInProgress(
-    join(queryStorageDir, initialInfo.id),
-    dbItem.databaseUri.fsPath,
-    hasMetadataFile,
-    packConfig.dbscheme,
-    initialInfo.quickEvalPosition,
-    metadata,
-    templates,
-  );
-  const logger = new TeeLogger(qs.logger, query.queryEvalInfo.logPath);
-
-  await query.queryEvalInfo.createTimestampFile();
-
   let upgradeDir: tmp.DirectoryResult | undefined;
   try {
     upgradeDir = await tmp.dir({ dir: upgradesTmpDir, unsafeCleanup: true });
     const upgradeQlo = await compileNonDestructiveUpgrade(
       qs,
       upgradeDir,
-      query,
+      packConfig.dbscheme,
       qlProgram,
-      dbItem,
+      dbContents,
       progress,
       token,
     );
     let errors;
     try {
-      errors = await query.compile(qs, qlProgram, progress, token, logger);
+      errors = await compileQuery(
+        qs,
+        qlProgram,
+        query.quickEvalPosition,
+        outputDir,
+        progress,
+        token,
+        logger,
+      );
     } catch (e) {
       if (
         e instanceof ResponseError &&
         e.code === LSPErrorCodes.RequestCancelled
       ) {
-        return createSyntheticResult(query, "Query cancelled");
+        return createSyntheticResult("Query cancelled");
       } else {
         throw e;
       }
     }
 
     if (errors.length === 0) {
-      const result = await query.run(
+      const result = await runQuery(
         qs,
         upgradeQlo,
         availableMlModels,
-        dbItem,
+        dbContents,
+        templates,
+        generateEvalLog,
+        outputDir,
         progress,
         token,
-        logger,
-        queryInfo,
       );
+
       if (result.resultType !== messages.QueryResultType.SUCCESS) {
         const error = result.message
           ? redactableError`${result.message}`
@@ -439,14 +444,9 @@ export async function compileAndRunQueryAgainstDatabase(
         void extLogger.log(error.fullMessage);
         void showAndLogExceptionWithTelemetry(error);
       }
-      const message = formatLegacyMessage(result);
 
       return {
-        query: query.queryEvalInfo,
-        message,
-        result,
-        successful: result.resultType === messages.QueryResultType.SUCCESS,
-        logFileLocation: result.logFileLocation,
+        ...translateLegacyResult(result),
       };
     } else {
       // Error dialogs are limited in size and scrollability,
@@ -454,7 +454,7 @@ export async function compileAndRunQueryAgainstDatabase(
       // and direct the user to the output window for the detailed compilation messages.
       // However we don't show quick eval errors there so we need to display them anyway.
       void logger.log(
-        `Failed to compile query ${initialInfo.queryPath} against database scheme ${qlProgram.dbschemePath}:`,
+        `Failed to compile query ${query.queryPath} against database scheme ${qlProgram.dbschemePath}:`,
       );
 
       const formattedMessages: string[] = [];
@@ -465,22 +465,12 @@ export async function compileAndRunQueryAgainstDatabase(
         formattedMessages.push(formatted);
         void logger.log(formatted);
       }
-      if (initialInfo.isQuickEval && formattedMessages.length <= 2) {
-        // If there are more than 2 error messages, they will not be displayed well in a popup
-        // and will be trimmed by the function displaying the error popup. Accordingly, we only
-        // try to show the errors if there are 2 or less, otherwise we direct the user to the log.
-        void showAndLogErrorMessage(
-          `Quick evaluation compilation failed: ${formattedMessages.join(
-            "\n",
-          )}`,
-        );
-      } else {
-        void showAndLogErrorMessage(
-          (initialInfo.isQuickEval ? "Quick evaluation" : "Query") +
-            compilationFailedErrorTail,
-        );
-      }
-      return createSyntheticResult(query, "Query had compilation errors");
+
+      return {
+        evaluationTime: 0,
+        resultType: newMessages.QueryResultType.COMPILATION_ERROR,
+        message: formattedMessages[0],
+      };
     }
   } finally {
     try {
@@ -492,11 +482,6 @@ export async function compileAndRunQueryAgainstDatabase(
     }
   }
 }
-
-const compilationFailedErrorTail =
-  " compilation failed. Please make sure there are no errors in the query, the database is up to date," +
-  " and the query and database use the same target language. For more details on the error, go to View > Output," +
-  " and choose CodeQL Query Server from the dropdown.";
 
 export function formatLegacyMessage(result: messages.EvaluationResult) {
   switch (result.resultType) {
@@ -521,21 +506,11 @@ export function formatLegacyMessage(result: messages.EvaluationResult) {
 /**
  * Create a synthetic result for a query that failed to compile.
  */
-function createSyntheticResult(
-  query: QueryInProgress,
-  message: string,
-): QueryWithResults {
+function createSyntheticResult(message: string): CoreQueryResults {
   return {
-    query: query.queryEvalInfo,
+    evaluationTime: 0,
+    resultType: newMessages.QueryResultType.OTHER_ERROR,
     message,
-    result: {
-      evaluationTime: 0,
-      queryId: 0,
-      resultType: messages.QueryResultType.OTHER_ERROR,
-      message,
-      runId: 0,
-    },
-    successful: false,
   };
 }
 

--- a/extensions/ql-vscode/src/legacy-query-server/upgrades.ts
+++ b/extensions/ql-vscode/src/legacy-query-server/upgrades.ts
@@ -27,18 +27,11 @@ const MAX_UPGRADE_MESSAGE_LINES = 10;
  */
 export async function compileDatabaseUpgradeSequence(
   qs: qsClient.QueryServerClient,
-  dbItem: DatabaseItem,
   resolvedSequence: string[],
   currentUpgradeTmp: tmp.DirectoryResult,
   progress: ProgressCallback,
   token: vscode.CancellationToken,
 ): Promise<messages.CompileUpgradeSequenceResult> {
-  if (
-    dbItem.contents === undefined ||
-    dbItem.contents.dbSchemeUri === undefined
-  ) {
-    throw new Error("Database is invalid, and cannot be upgraded.");
-  }
   // If possible just compile the upgrade sequence
   return await qs.sendRequest(
     messages.compileUpgradeSequence,

--- a/extensions/ql-vscode/src/local-databases.ts
+++ b/extensions/ql-vscode/src/local-databases.ts
@@ -95,6 +95,10 @@ export interface DatabaseContents {
   dbSchemeUri?: vscode.Uri;
 }
 
+export interface DatabaseContentsWithDbScheme extends DatabaseContents {
+  dbSchemeUri: vscode.Uri; // Always present
+}
+
 /**
  * An error thrown when we cannot find a valid database in a putative
  * database directory.
@@ -165,7 +169,7 @@ async function getDbSchemeFiles(dbDirectory: string): Promise<string[]> {
 export class DatabaseResolver {
   public static async resolveDatabaseContents(
     uri: vscode.Uri,
-  ): Promise<DatabaseContents> {
+  ): Promise<DatabaseContentsWithDbScheme> {
     if (uri.scheme !== "file") {
       throw new Error(
         `Database URI scheme '${uri.scheme}' not supported; only 'file' URIs are supported.`,
@@ -199,9 +203,12 @@ export class DatabaseResolver {
         `Database '${databasePath}' contains multiple CodeQL dbschemes under '${dbPath}'.`,
       );
     } else {
-      contents.dbSchemeUri = vscode.Uri.file(resolve(dbPath, dbSchemeFiles[0]));
+      const dbSchemeUri = vscode.Uri.file(resolve(dbPath, dbSchemeFiles[0]));
+      return {
+        ...contents,
+        dbSchemeUri,
+      };
     }
-    return contents;
   }
 
   public static async resolveDatabase(

--- a/extensions/ql-vscode/src/local-queries.ts
+++ b/extensions/ql-vscode/src/local-queries.ts
@@ -371,7 +371,7 @@ export class LocalQueries extends DisposableObject {
     await this.localQueryResultsView.showResults(query, forceReveal, false);
   }
 
-  private async compileAndRunQueryAgainstDatabase(
+  async compileAndRunQueryAgainstDatabase(
     db: DatabaseItem,
     initialInfo: InitialQueryInfo,
     queryStorageDir: string,

--- a/extensions/ql-vscode/src/local-queries.ts
+++ b/extensions/ql-vscode/src/local-queries.ts
@@ -7,384 +7,508 @@ import {
   Uri,
   window,
 } from "vscode";
-import { extLogger } from "./common";
+import { BaseLogger, extLogger, TeeLogger } from "./common";
 import { MAX_QUERIES } from "./config";
 import { gatherQlFiles } from "./pure/files";
 import { basename } from "path";
 import {
+  createTimestampFile,
   findLanguage,
+  getOnDiskWorkspaceFolders,
   showAndLogErrorMessage,
+  showAndLogExceptionWithTelemetry,
   showAndLogWarningMessage,
   showBinaryChoiceDialog,
+  tryGetQueryMetadata,
 } from "./helpers";
 import { displayQuickQuery } from "./quick-query";
-import { QueryRunner } from "./queryRunner";
+import { CoreQueryResults, CoreQueryTarget, QueryRunner } from "./queryRunner";
 import { QueryHistoryManager } from "./query-history/query-history-manager";
 import { DatabaseUI } from "./local-databases-ui";
 import { ResultsView } from "./interface";
 import { DatabaseItem, DatabaseManager } from "./local-databases";
-import { createInitialQueryInfo } from "./run-queries-shared";
-import { CompletedLocalQueryInfo, LocalQueryInfo } from "./query-results";
+import {
+  createInitialQueryInfo,
+  EvaluatorLogPaths,
+  generateEvalLogSummaries,
+  logEndSummary,
+  QueryEvaluationInfo,
+  QueryOutputDir,
+  QueryWithResults,
+} from "./run-queries-shared";
+import {
+  CompletedLocalQueryInfo,
+  InitialQueryInfo,
+  LocalQueryInfo,
+} from "./query-results";
 import { WebviewReveal } from "./interface-utils";
 import { asError, getErrorMessage } from "./pure/helpers-pure";
 import { CodeQLCliServer } from "./cli";
 import { LocalQueryCommands } from "./common/commands";
 import { App } from "./common/app";
-
-type LocalQueryOptions = {
-  app: App;
-  queryRunner: QueryRunner;
-  queryHistoryManager: QueryHistoryManager;
-  databaseManager: DatabaseManager;
-  cliServer: CodeQLCliServer;
-  databaseUI: DatabaseUI;
-  localQueryResultsView: ResultsView;
-  queryStorageDir: string;
-};
-
-export function getLocalQueryCommands({
-  app,
-  queryRunner,
-  queryHistoryManager,
-  databaseManager,
-  cliServer,
-  databaseUI,
-  localQueryResultsView,
-  queryStorageDir,
-}: LocalQueryOptions): LocalQueryCommands {
-  const runQuery = async (uri: Uri | undefined) =>
-    withProgress(
-      async (progress, token) => {
-        await compileAndRunQuery(
-          queryRunner,
-          queryHistoryManager,
-          databaseUI,
-          localQueryResultsView,
-          queryStorageDir,
-          false,
-          uri,
-          progress,
-          token,
-          undefined,
-        );
-      },
-      {
-        title: "Running query",
-        cancellable: true,
-      },
-    );
-
-  const runQueryOnMultipleDatabases = async (uri: Uri | undefined) =>
-    withProgress(
-      async (progress, token) =>
-        await compileAndRunQueryOnMultipleDatabases(
-          cliServer,
-          queryRunner,
-          queryHistoryManager,
-          databaseManager,
-          databaseUI,
-          localQueryResultsView,
-          queryStorageDir,
-          progress,
-          token,
-          uri,
-        ),
-      {
-        title: "Running query on selected databases",
-        cancellable: true,
-      },
-    );
-
-  const runQueries = async (_: Uri | undefined, multi: Uri[]) =>
-    withProgress(
-      async (progress, token) => {
-        const maxQueryCount = MAX_QUERIES.getValue() as number;
-        const [files, dirFound] = await gatherQlFiles(
-          multi.map((uri) => uri.fsPath),
-        );
-        if (files.length > maxQueryCount) {
-          throw new Error(
-            `You tried to run ${files.length} queries, but the maximum is ${maxQueryCount}. Try selecting fewer queries or changing the 'codeQL.runningQueries.maxQueries' setting.`,
-          );
-        }
-        // warn user and display selected files when a directory is selected because some ql
-        // files may be hidden from the user.
-        if (dirFound) {
-          const fileString = files.map((file) => basename(file)).join(", ");
-          const res = await showBinaryChoiceDialog(
-            `You are about to run ${files.length} queries: ${fileString} Do you want to continue?`,
-          );
-          if (!res) {
-            return;
-          }
-        }
-        const queryUris = files.map((path) => Uri.parse(`file:${path}`, true));
-
-        // Use a wrapped progress so that messages appear with the queries remaining in it.
-        let queriesRemaining = queryUris.length;
-
-        function wrappedProgress(update: ProgressUpdate) {
-          const message =
-            queriesRemaining > 1
-              ? `${queriesRemaining} remaining. ${update.message}`
-              : update.message;
-          progress({
-            ...update,
-            message,
-          });
-        }
-
-        wrappedProgress({
-          maxStep: queryUris.length,
-          step: queryUris.length - queriesRemaining,
-          message: "",
-        });
-
-        await Promise.all(
-          queryUris.map(async (uri) =>
-            compileAndRunQuery(
-              queryRunner,
-              queryHistoryManager,
-              databaseUI,
-              localQueryResultsView,
-              queryStorageDir,
-              false,
-              uri,
-              wrappedProgress,
-              token,
-              undefined,
-            ).then(() => queriesRemaining--),
-          ),
-        );
-      },
-      {
-        title: "Running queries",
-        cancellable: true,
-      },
-    );
-
-  const quickEval = async (uri: Uri) =>
-    withProgress(
-      async (progress, token) => {
-        await compileAndRunQuery(
-          queryRunner,
-          queryHistoryManager,
-          databaseUI,
-          localQueryResultsView,
-          queryStorageDir,
-          true,
-          uri,
-          progress,
-          token,
-          undefined,
-        );
-      },
-      {
-        title: "Running query",
-        cancellable: true,
-      },
-    );
-
-  const codeLensQuickEval = async (uri: Uri, range: Range) =>
-    withProgress(
-      async (progress, token) =>
-        await compileAndRunQuery(
-          queryRunner,
-          queryHistoryManager,
-          databaseUI,
-          localQueryResultsView,
-          queryStorageDir,
-          true,
-          uri,
-          progress,
-          token,
-          undefined,
-          range,
-        ),
-      {
-        title: "Running query",
-        cancellable: true,
-      },
-    );
-
-  const quickQuery = async () =>
-    withProgress(
-      async (progress, token) =>
-        displayQuickQuery(app, cliServer, databaseUI, progress, token),
-      {
-        title: "Run Quick Query",
-      },
-    );
-
-  return {
-    "codeQL.runQuery": runQuery,
-    "codeQL.runQueryContextEditor": runQuery,
-    "codeQL.runQueryOnMultipleDatabases": runQueryOnMultipleDatabases,
-    "codeQL.runQueryOnMultipleDatabasesContextEditor":
-      runQueryOnMultipleDatabases,
-    "codeQL.runQueries": runQueries,
-    "codeQL.quickEval": quickEval,
-    "codeQL.quickEvalContextEditor": quickEval,
-    "codeQL.codeLensQuickEval": codeLensQuickEval,
-    "codeQL.quickQuery": quickQuery,
-  };
-}
-
-export async function compileAndRunQuery(
-  qs: QueryRunner,
-  qhm: QueryHistoryManager,
-  databaseUI: DatabaseUI,
-  localQueryResultsView: ResultsView,
-  queryStorageDir: string,
-  quickEval: boolean,
-  selectedQuery: Uri | undefined,
-  progress: ProgressCallback,
-  token: CancellationToken,
-  databaseItem: DatabaseItem | undefined,
-  range?: Range,
-): Promise<void> {
-  if (qs !== undefined) {
-    // If no databaseItem is specified, use the database currently selected in the Databases UI
-    databaseItem =
-      databaseItem || (await databaseUI.getDatabaseItem(progress, token));
-    if (databaseItem === undefined) {
-      throw new Error("Can't run query without a selected database");
-    }
-    const databaseInfo = {
-      name: databaseItem.name,
-      databaseUri: databaseItem.databaseUri.toString(),
-    };
-
-    // handle cancellation from the history view.
-    const source = new CancellationTokenSource();
-    token.onCancellationRequested(() => source.cancel());
-
-    const initialInfo = await createInitialQueryInfo(
-      selectedQuery,
-      databaseInfo,
-      quickEval,
-      range,
-    );
-    const item = new LocalQueryInfo(initialInfo, source);
-    qhm.addQuery(item);
-    try {
-      const completedQueryInfo = await qs.compileAndRunQueryAgainstDatabase(
-        databaseItem,
-        initialInfo,
-        queryStorageDir,
-        progress,
-        source.token,
-        undefined,
-        item,
-      );
-      qhm.completeQuery(item, completedQueryInfo);
-      await showResultsForCompletedQuery(
-        localQueryResultsView,
-        item as CompletedLocalQueryInfo,
-        WebviewReveal.Forced,
-      );
-      // Note we must update the query history view after showing results as the
-      // display and sorting might depend on the number of results
-    } catch (e) {
-      const err = asError(e);
-      err.message = `Error running query: ${err.message}`;
-      item.failureReason = err.message;
-      throw e;
-    } finally {
-      await qhm.refreshTreeView();
-      source.dispose();
-    }
-  }
-}
+import { DisposableObject } from "./pure/disposable-object";
+import { QueryResultType } from "./pure/new-messages";
+import { redactableError } from "./pure/errors";
 
 interface DatabaseQuickPickItem extends QuickPickItem {
   databaseItem: DatabaseItem;
 }
 
-async function compileAndRunQueryOnMultipleDatabases(
-  cliServer: CodeQLCliServer,
-  qs: QueryRunner,
-  qhm: QueryHistoryManager,
-  dbm: DatabaseManager,
-  databaseUI: DatabaseUI,
-  localQueryResultsView: ResultsView,
-  queryStorageDir: string,
-  progress: ProgressCallback,
-  token: CancellationToken,
-  uri: Uri | undefined,
-): Promise<void> {
-  let filteredDBs = dbm.databaseItems;
-  if (filteredDBs.length === 0) {
-    void showAndLogErrorMessage(
-      "No databases found. Please add a suitable database to your workspace.",
-    );
-    return;
-  }
-  // If possible, only show databases with the right language (otherwise show all databases).
-  const queryLanguage = await findLanguage(cliServer, uri);
-  if (queryLanguage) {
-    filteredDBs = dbm.databaseItems.filter(
-      (db) => db.language === queryLanguage,
-    );
-    if (filteredDBs.length === 0) {
-      void showAndLogErrorMessage(
-        `No databases found for language ${queryLanguage}. Please add a suitable database to your workspace.`,
-      );
-      return;
-    }
-  }
-  const quickPickItems = filteredDBs.map<DatabaseQuickPickItem>((dbItem) => ({
-    databaseItem: dbItem,
-    label: dbItem.name,
-    description: dbItem.language,
-  }));
-  /**
-   * Databases that were selected in the quick pick menu.
-   */
-  const quickpick = await window.showQuickPick<DatabaseQuickPickItem>(
-    quickPickItems,
-    { canPickMany: true, ignoreFocusOut: true },
-  );
-  if (quickpick !== undefined) {
-    // Collect all skipped databases and display them at the end (instead of popping up individual errors)
-    const skippedDatabases = [];
-    const errors = [];
-    for (const item of quickpick) {
-      try {
-        await compileAndRunQuery(
-          qs,
-          qhm,
-          databaseUI,
-          localQueryResultsView,
-          queryStorageDir,
-          false,
-          uri,
-          progress,
-          token,
-          item.databaseItem,
-        );
-      } catch (e) {
-        skippedDatabases.push(item.label);
-        errors.push(getErrorMessage(e));
-      }
-    }
-    if (skippedDatabases.length > 0) {
-      void extLogger.log(`Errors:\n${errors.join("\n")}`);
-      void showAndLogWarningMessage(
-        `The following databases were skipped:\n${skippedDatabases.join(
-          "\n",
-        )}.\nFor details about the errors, see the logs.`,
-      );
-    }
-  } else {
-    void showAndLogErrorMessage("No databases selected.");
+function formatResultMessage(result: CoreQueryResults): string {
+  switch (result.resultType) {
+    case QueryResultType.CANCELLATION:
+      return `cancelled after ${Math.round(
+        result.evaluationTime / 1000,
+      )} seconds`;
+    case QueryResultType.OOM:
+      return "out of memory";
+    case QueryResultType.SUCCESS:
+      return `finished in ${Math.round(result.evaluationTime / 1000)} seconds`;
+    case QueryResultType.COMPILATION_ERROR:
+      return `compilation failed: ${result.message}`;
+    case QueryResultType.OTHER_ERROR:
+    default:
+      return result.message ? `failed: ${result.message}` : "failed";
   }
 }
 
-export async function showResultsForCompletedQuery(
-  localQueryResultsView: ResultsView,
-  query: CompletedLocalQueryInfo,
-  forceReveal: WebviewReveal,
-): Promise<void> {
-  await localQueryResultsView.showResults(query, forceReveal, false);
+export class LocalQueries extends DisposableObject {
+  public constructor(
+    private readonly app: App,
+    private readonly queryRunner: QueryRunner,
+    private readonly queryHistoryManager: QueryHistoryManager,
+    private readonly databaseManager: DatabaseManager,
+    private readonly cliServer: CodeQLCliServer,
+    private readonly databaseUI: DatabaseUI,
+    private readonly localQueryResultsView: ResultsView,
+    private readonly queryStorageDir: string,
+  ) {
+    super();
+  }
+
+  public getCommands(): LocalQueryCommands {
+    const runQuery = async (uri: Uri | undefined) =>
+      withProgress(
+        async (progress, token) => {
+          await this.compileAndRunQuery(false, uri, progress, token, undefined);
+        },
+        {
+          title: "Running query",
+          cancellable: true,
+        },
+      );
+
+    const runQueryOnMultipleDatabases = async (uri: Uri | undefined) =>
+      withProgress(
+        async (progress, token) =>
+          await this.compileAndRunQueryOnMultipleDatabases(
+            progress,
+            token,
+            uri,
+          ),
+        {
+          title: "Running query on selected databases",
+          cancellable: true,
+        },
+      );
+
+    const runQueries = async (_: Uri | undefined, multi: Uri[]) =>
+      withProgress(
+        async (progress, token) => {
+          const maxQueryCount = MAX_QUERIES.getValue() as number;
+          const [files, dirFound] = await gatherQlFiles(
+            multi.map((uri) => uri.fsPath),
+          );
+          if (files.length > maxQueryCount) {
+            throw new Error(
+              `You tried to run ${files.length} queries, but the maximum is ${maxQueryCount}. Try selecting fewer queries or changing the 'codeQL.runningQueries.maxQueries' setting.`,
+            );
+          }
+          // warn user and display selected files when a directory is selected because some ql
+          // files may be hidden from the user.
+          if (dirFound) {
+            const fileString = files.map((file) => basename(file)).join(", ");
+            const res = await showBinaryChoiceDialog(
+              `You are about to run ${files.length} queries: ${fileString} Do you want to continue?`,
+            );
+            if (!res) {
+              return;
+            }
+          }
+          const queryUris = files.map((path) =>
+            Uri.parse(`file:${path}`, true),
+          );
+
+          // Use a wrapped progress so that messages appear with the queries remaining in it.
+          let queriesRemaining = queryUris.length;
+
+          function wrappedProgress(update: ProgressUpdate) {
+            const message =
+              queriesRemaining > 1
+                ? `${queriesRemaining} remaining. ${update.message}`
+                : update.message;
+            progress({
+              ...update,
+              message,
+            });
+          }
+
+          wrappedProgress({
+            maxStep: queryUris.length,
+            step: queryUris.length - queriesRemaining,
+            message: "",
+          });
+
+          await Promise.all(
+            queryUris.map(async (uri) =>
+              this.compileAndRunQuery(
+                false,
+                uri,
+                wrappedProgress,
+                token,
+                undefined,
+              ).then(() => queriesRemaining--),
+            ),
+          );
+        },
+        {
+          title: "Running queries",
+          cancellable: true,
+        },
+      );
+
+    const quickEval = async (uri: Uri) =>
+      withProgress(
+        async (progress, token) => {
+          await this.compileAndRunQuery(true, uri, progress, token, undefined);
+        },
+        {
+          title: "Running query",
+          cancellable: true,
+        },
+      );
+
+    const codeLensQuickEval = async (uri: Uri, range: Range) =>
+      withProgress(
+        async (progress, token) =>
+          await this.compileAndRunQuery(
+            true,
+            uri,
+            progress,
+            token,
+            undefined,
+            range,
+          ),
+        {
+          title: "Running query",
+          cancellable: true,
+        },
+      );
+
+    const quickQuery = async () =>
+      withProgress(
+        async (progress, token) =>
+          displayQuickQuery(
+            this.app,
+            this.cliServer,
+            this.databaseUI,
+            progress,
+            token,
+          ),
+        {
+          title: "Run Quick Query",
+        },
+      );
+
+    return {
+      "codeQL.runQuery": runQuery,
+      "codeQL.runQueryContextEditor": runQuery,
+      "codeQL.runQueryOnMultipleDatabases": runQueryOnMultipleDatabases,
+      "codeQL.runQueryOnMultipleDatabasesContextEditor":
+        runQueryOnMultipleDatabases,
+      "codeQL.runQueries": runQueries,
+      "codeQL.quickEval": quickEval,
+      "codeQL.quickEvalContextEditor": quickEval,
+      "codeQL.codeLensQuickEval": codeLensQuickEval,
+      "codeQL.quickQuery": quickQuery,
+    };
+  }
+
+  async compileAndRunQuery(
+    quickEval: boolean,
+    selectedQuery: Uri | undefined,
+    progress: ProgressCallback,
+    token: CancellationToken,
+    databaseItem: DatabaseItem | undefined,
+    range?: Range,
+  ): Promise<void> {
+    if (this.queryRunner !== undefined) {
+      // If no databaseItem is specified, use the database currently selected in the Databases UI
+      databaseItem =
+        databaseItem ||
+        (await this.databaseUI.getDatabaseItem(progress, token));
+      if (databaseItem === undefined) {
+        throw new Error("Can't run query without a selected database");
+      }
+      const databaseInfo = {
+        name: databaseItem.name,
+        databaseUri: databaseItem.databaseUri.toString(),
+      };
+
+      // handle cancellation from the history view.
+      const source = new CancellationTokenSource();
+      token.onCancellationRequested(() => source.cancel());
+
+      const initialInfo = await createInitialQueryInfo(
+        selectedQuery,
+        databaseInfo,
+        quickEval,
+        range,
+      );
+      const item = new LocalQueryInfo(initialInfo, source);
+      this.queryHistoryManager.addQuery(item);
+      try {
+        const completedQueryInfo = await this.compileAndRunQueryAgainstDatabase(
+          databaseItem,
+          initialInfo,
+          this.queryStorageDir,
+          progress,
+          source.token,
+          undefined,
+          item,
+        );
+        this.queryHistoryManager.completeQuery(item, completedQueryInfo);
+        await this.showResultsForCompletedQuery(
+          item as CompletedLocalQueryInfo,
+          WebviewReveal.Forced,
+        );
+        // Note we must update the query history view after showing results as the
+        // display and sorting might depend on the number of results
+      } catch (e) {
+        const err = asError(e);
+        err.message = `Error running query: ${err.message}`;
+        item.failureReason = err.message;
+        throw e;
+      } finally {
+        await this.queryHistoryManager.refreshTreeView();
+        source.dispose();
+      }
+    }
+  }
+
+  async compileAndRunQueryOnMultipleDatabases(
+    progress: ProgressCallback,
+    token: CancellationToken,
+    uri: Uri | undefined,
+  ): Promise<void> {
+    let filteredDBs = this.databaseManager.databaseItems;
+    if (filteredDBs.length === 0) {
+      void showAndLogErrorMessage(
+        "No databases found. Please add a suitable database to your workspace.",
+      );
+      return;
+    }
+    // If possible, only show databases with the right language (otherwise show all databases).
+    const queryLanguage = await findLanguage(this.cliServer, uri);
+    if (queryLanguage) {
+      filteredDBs = this.databaseManager.databaseItems.filter(
+        (db) => db.language === queryLanguage,
+      );
+      if (filteredDBs.length === 0) {
+        void showAndLogErrorMessage(
+          `No databases found for language ${queryLanguage}. Please add a suitable database to your workspace.`,
+        );
+        return;
+      }
+    }
+    const quickPickItems = filteredDBs.map<DatabaseQuickPickItem>((dbItem) => ({
+      databaseItem: dbItem,
+      label: dbItem.name,
+      description: dbItem.language,
+    }));
+    /**
+     * Databases that were selected in the quick pick menu.
+     */
+    const quickpick = await window.showQuickPick<DatabaseQuickPickItem>(
+      quickPickItems,
+      { canPickMany: true, ignoreFocusOut: true },
+    );
+    if (quickpick !== undefined) {
+      // Collect all skipped databases and display them at the end (instead of popping up individual errors)
+      const skippedDatabases = [];
+      const errors = [];
+      for (const item of quickpick) {
+        try {
+          await this.compileAndRunQuery(
+            false,
+            uri,
+            progress,
+            token,
+            item.databaseItem,
+          );
+        } catch (e) {
+          skippedDatabases.push(item.label);
+          errors.push(getErrorMessage(e));
+        }
+      }
+      if (skippedDatabases.length > 0) {
+        void extLogger.log(`Errors:\n${errors.join("\n")}`);
+        void showAndLogWarningMessage(
+          `The following databases were skipped:\n${skippedDatabases.join(
+            "\n",
+          )}.\nFor details about the errors, see the logs.`,
+        );
+      }
+    } else {
+      void showAndLogErrorMessage("No databases selected.");
+    }
+  }
+
+  async showResultsForCompletedQuery(
+    query: CompletedLocalQueryInfo,
+    forceReveal: WebviewReveal,
+  ): Promise<void> {
+    await this.localQueryResultsView.showResults(query, forceReveal, false);
+  }
+
+  private async compileAndRunQueryAgainstDatabase(
+    db: DatabaseItem,
+    initialInfo: InitialQueryInfo,
+    queryStorageDir: string,
+    progress: ProgressCallback,
+    token: CancellationToken,
+    templates?: Record<string, string>,
+    queryInfo?: LocalQueryInfo, // May be omitted for queries not initiated by the user. If omitted we won't create a structured log for the query.
+  ): Promise<QueryWithResults> {
+    const queryTarget: CoreQueryTarget = {
+      queryPath: initialInfo.queryPath,
+      quickEvalPosition: initialInfo.quickEvalPosition,
+    };
+
+    const diskWorkspaceFolders = getOnDiskWorkspaceFolders();
+    const queryRun = this.queryRunner.createQueryRun(
+      db.databaseUri.fsPath,
+      queryTarget,
+      queryInfo !== undefined,
+      diskWorkspaceFolders,
+      queryStorageDir,
+      initialInfo.id,
+      templates,
+    );
+
+    await createTimestampFile(queryRun.outputDir.querySaveDir);
+
+    const logPath = queryRun.outputDir.logPath;
+    if (this.queryRunner.customLogDirectory) {
+      void showAndLogWarningMessage(
+        `Custom log directories are no longer supported. The "codeQL.runningQueries.customLogDirectory" setting is deprecated. Unset the setting to stop seeing this message. Query logs saved to ${logPath}`,
+      );
+    }
+
+    const logger = new TeeLogger(this.queryRunner.logger, logPath);
+    const coreResults = await queryRun.evaluate(progress, token, logger);
+    if (queryInfo !== undefined) {
+      const evalLogPaths = await this.summarizeEvalLog(
+        coreResults.resultType,
+        queryRun.outputDir,
+        logger,
+      );
+      if (evalLogPaths !== undefined) {
+        queryInfo.setEvaluatorLogPaths(evalLogPaths);
+      }
+    }
+
+    return await this.getCompletedQueryInfo(
+      db,
+      queryTarget,
+      queryRun.outputDir,
+      coreResults,
+    );
+  }
+
+  /**
+   * Generate summaries of the structured evaluator log.
+   */
+  public async summarizeEvalLog(
+    resultType: QueryResultType,
+    outputDir: QueryOutputDir,
+    logger: BaseLogger,
+  ): Promise<EvaluatorLogPaths | undefined> {
+    const evalLogPaths = await generateEvalLogSummaries(
+      this.cliServer,
+      outputDir,
+    );
+    if (evalLogPaths !== undefined) {
+      if (evalLogPaths.endSummary !== undefined) {
+        void logEndSummary(evalLogPaths.endSummary, logger); // Logged asynchrnously
+      }
+    } else {
+      // Raw evaluator log was not found. Notify the user, unless we know why it wasn't found.
+      switch (resultType) {
+        case QueryResultType.COMPILATION_ERROR:
+        case QueryResultType.DBSCHEME_MISMATCH_NAME:
+        case QueryResultType.DBSCHEME_NO_UPGRADE:
+          // In these cases, the evaluator was never invoked anyway, so don't bother warning.
+          break;
+
+        default:
+          void showAndLogWarningMessage(
+            `Failed to write structured evaluator log to ${outputDir.evalLogPath}.`,
+          );
+          break;
+      }
+    }
+
+    return evalLogPaths;
+  }
+
+  /**
+   * Gets a `QueryWithResults` containing information about the evaluation of the query and its
+   * result, in the form expected by the query history UI.
+   */
+  public async getCompletedQueryInfo(
+    dbItem: DatabaseItem,
+    queryTarget: CoreQueryTarget,
+    outputDir: QueryOutputDir,
+    results: CoreQueryResults,
+  ): Promise<QueryWithResults> {
+    // Read the query metadata if possible, to use in the UI.
+    const metadata = await tryGetQueryMetadata(
+      this.cliServer,
+      queryTarget.queryPath,
+    );
+    const query = new QueryEvaluationInfo(
+      outputDir.querySaveDir,
+      dbItem.databaseUri.fsPath,
+      await dbItem.hasMetadataFile(),
+      queryTarget.quickEvalPosition,
+      metadata,
+    );
+
+    if (results.resultType !== QueryResultType.SUCCESS) {
+      const message = results.message
+        ? redactableError`${results.message}`
+        : redactableError`Failed to run query`;
+      void extLogger.log(message.fullMessage);
+      void showAndLogExceptionWithTelemetry(
+        redactableError`Failed to run query: ${message}`,
+      );
+    }
+    const message = formatResultMessage(results);
+    const successful = results.resultType === QueryResultType.SUCCESS;
+    return {
+      query,
+      result: {
+        evaluationTime: results.evaluationTime,
+        queryId: 0,
+        resultType: successful
+          ? QueryResultType.SUCCESS
+          : QueryResultType.OTHER_ERROR,
+        runId: 0,
+        message,
+      },
+      message,
+      successful,
+    };
+  }
 }

--- a/extensions/ql-vscode/src/query-results.ts
+++ b/extensions/ql-vscode/src/query-results.ts
@@ -16,7 +16,11 @@ import {
   DatabaseInfo,
 } from "./pure/interface-types";
 import { QueryStatus } from "./query-status";
-import { QueryEvaluationInfo, QueryWithResults } from "./run-queries-shared";
+import {
+  EvaluatorLogPaths,
+  QueryEvaluationInfo,
+  QueryWithResults,
+} from "./run-queries-shared";
 import { formatLegacyMessage } from "./legacy-query-server/run-queries";
 import { sarifParser } from "./sarif-parser";
 
@@ -251,6 +255,14 @@ export class LocalQueryInfo {
 
   set userSpecifiedLabel(label: string | undefined) {
     this.initialInfo.userSpecifiedLabel = label;
+  }
+
+  /** Sets the paths to the various structured evaluator logs. */
+  public setEvaluatorLogPaths(logPaths: EvaluatorLogPaths): void {
+    this.evalLogLocation = logPaths.log;
+    this.evalLogSummaryLocation = logPaths.humanReadableSummary;
+    this.jsonEvalLogSummaryLocation = logPaths.jsonSummary;
+    this.evalLogSummarySymbolsLocation = logPaths.summarySymbols;
   }
 
   /**

--- a/extensions/ql-vscode/src/query-server/query-runner.ts
+++ b/extensions/ql-vscode/src/query-server/query-runner.ts
@@ -9,20 +9,30 @@ import {
   registerDatabases,
   upgradeDatabase,
 } from "../pure/new-messages";
-import { InitialQueryInfo, LocalQueryInfo } from "../query-results";
-import { QueryRunner } from "../queryRunner";
-import { QueryWithResults } from "../run-queries-shared";
+import { CoreQueryResults, CoreQueryTarget, QueryRunner } from "../queryRunner";
 import { QueryServerClient } from "./queryserver-client";
-import { compileAndRunQueryAgainstDatabase } from "./run-queries";
+import { compileAndRunQueryAgainstDatabaseCore } from "./run-queries";
 import * as vscode from "vscode";
 import { getOnDiskWorkspaceFolders } from "../helpers";
+import { CodeQLCliServer } from "../cli";
+import { Logger } from "../common";
+import { QueryOutputDir } from "../run-queries-shared";
+
 export class NewQueryRunner extends QueryRunner {
   constructor(public readonly qs: QueryServerClient) {
     super();
   }
 
-  get cliServer() {
+  get cliServer(): CodeQLCliServer {
     return this.qs.cliServer;
+  }
+
+  get customLogDirectory(): string | undefined {
+    return this.qs.config.customLogDirectory;
+  }
+
+  get logger(): Logger {
+    return this.qs.logger;
   }
 
   async restartQueryServer(
@@ -57,25 +67,29 @@ export class NewQueryRunner extends QueryRunner {
     };
     await this.qs.sendRequest(clearCache, params, token, progress);
   }
-  async compileAndRunQueryAgainstDatabase(
-    dbItem: DatabaseItem,
-    initialInfo: InitialQueryInfo,
-    queryStorageDir: string,
+
+  protected async compileAndRunQueryAgainstDatabaseCore(
+    dbPath: string,
+    query: CoreQueryTarget,
+    additionalPacks: string[],
+    generateEvalLog: boolean,
+    outputDir: QueryOutputDir,
     progress: ProgressCallback,
     token: CancellationToken,
-    templates?: Record<string, string>,
-    queryInfo?: LocalQueryInfo,
-  ): Promise<QueryWithResults> {
-    return await compileAndRunQueryAgainstDatabase(
-      this.qs.cliServer,
+    templates: Record<string, string> | undefined,
+    logger: Logger,
+  ): Promise<CoreQueryResults> {
+    return await compileAndRunQueryAgainstDatabaseCore(
       this.qs,
-      dbItem,
-      initialInfo,
-      queryStorageDir,
+      dbPath,
+      query,
+      generateEvalLog,
+      additionalPacks,
+      outputDir,
       progress,
       token,
       templates,
-      queryInfo,
+      logger,
     );
   }
 

--- a/extensions/ql-vscode/src/query-server/query-runner.ts
+++ b/extensions/ql-vscode/src/query-server/query-runner.ts
@@ -68,7 +68,7 @@ export class NewQueryRunner extends QueryRunner {
     await this.qs.sendRequest(clearCache, params, token, progress);
   }
 
-  protected async compileAndRunQueryAgainstDatabaseCore(
+  public async compileAndRunQueryAgainstDatabaseCore(
     dbPath: string,
     query: CoreQueryTarget,
     additionalPacks: string[],

--- a/extensions/ql-vscode/src/query-server/run-queries.ts
+++ b/extensions/ql-vscode/src/query-server/run-queries.ts
@@ -1,21 +1,10 @@
-import { join } from "path";
 import { CancellationToken } from "vscode";
-import * as cli from "../cli";
 import { ProgressCallback } from "../progress";
-import { DatabaseItem } from "../local-databases";
-import {
-  getOnDiskWorkspaceFolders,
-  showAndLogExceptionWithTelemetry,
-  showAndLogWarningMessage,
-  tryGetQueryMetadata,
-} from "../helpers";
-import { extLogger, TeeLogger } from "../common";
 import * as messages from "../pure/new-messages";
-import { QueryResultType } from "../pure/legacy-messages";
-import { InitialQueryInfo, LocalQueryInfo } from "../query-results";
-import { QueryEvaluationInfo, QueryWithResults } from "../run-queries-shared";
+import { QueryOutputDir } from "../run-queries-shared";
 import * as qsClient from "./queryserver-client";
-import { redactableError } from "../pure/errors";
+import { CoreQueryResults, CoreQueryTarget } from "../queryRunner";
+import { Logger } from "../common";
 
 /**
  * run-queries.ts
@@ -31,140 +20,58 @@ import { redactableError } from "../pure/errors";
  * output and results.
  */
 
-export async function compileAndRunQueryAgainstDatabase(
-  cliServer: cli.CodeQLCliServer,
+export async function compileAndRunQueryAgainstDatabaseCore(
   qs: qsClient.QueryServerClient,
-  dbItem: DatabaseItem,
-  initialInfo: InitialQueryInfo,
-  queryStorageDir: string,
+  dbPath: string,
+  query: CoreQueryTarget,
+  generateEvalLog: boolean,
+  additionalPacks: string[],
+  outputDir: QueryOutputDir,
   progress: ProgressCallback,
   token: CancellationToken,
-  templates?: Record<string, string>,
-  queryInfo?: LocalQueryInfo, // May be omitted for queries not initiated by the user. If omitted we won't create a structured log for the query.
-): Promise<QueryWithResults> {
-  if (!dbItem.contents || !dbItem.contents.dbSchemeUri) {
-    throw new Error(
-      `Database ${dbItem.databaseUri} does not have a CodeQL database scheme.`,
-    );
-  }
+  templates: Record<string, string> | undefined,
+  logger: Logger,
+): Promise<CoreQueryResults> {
+  const target =
+    query.quickEvalPosition !== undefined
+      ? {
+          quickEval: { quickEvalPos: query.quickEvalPosition },
+        }
+      : { query: {} };
 
-  // Read the query metadata if possible, to use in the UI.
-  const metadata = await tryGetQueryMetadata(cliServer, initialInfo.queryPath);
-
-  const hasMetadataFile = await dbItem.hasMetadataFile();
-  const query = new QueryEvaluationInfo(
-    join(queryStorageDir, initialInfo.id),
-    dbItem.databaseUri.fsPath,
-    hasMetadataFile,
-    initialInfo.quickEvalPosition,
-    metadata,
-  );
-
-  if (!dbItem.contents || dbItem.error) {
-    throw new Error("Can't run query on invalid database.");
-  }
-  const target = query.quickEvalPosition
-    ? {
-        quickEval: { quickEvalPos: query.quickEvalPosition },
-      }
-    : { query: {} };
-
-  const diskWorkspaceFolders = getOnDiskWorkspaceFolders();
   const extensionPacks = (await qs.cliServer.useExtensionPacks())
-    ? Object.keys(await qs.cliServer.resolveQlpacks(diskWorkspaceFolders, true))
+    ? Object.keys(await qs.cliServer.resolveQlpacks(additionalPacks, true))
     : undefined;
 
-  const db = dbItem.databaseUri.fsPath;
-  const logPath = queryInfo ? query.evalLogPath : undefined;
+  const evalLogPath = generateEvalLog ? outputDir.evalLogPath : undefined;
   const queryToRun: messages.RunQueryParams = {
-    db,
-    additionalPacks: diskWorkspaceFolders,
+    db: dbPath,
+    additionalPacks,
     externalInputs: {},
     singletonExternalInputs: templates || {},
-    outputPath: query.resultsPaths.resultsPath,
-    queryPath: initialInfo.queryPath,
-    dilPath: query.dilPath,
-    logPath,
+    outputPath: outputDir.bqrsPath,
+    queryPath: query.queryPath,
+    dilPath: outputDir.dilPath,
+    logPath: evalLogPath,
     target,
     extensionPacks,
   };
-  const logger = new TeeLogger(qs.logger, query.logPath);
-  await query.createTimestampFile();
-  let result: messages.RunQueryResult | undefined;
-  try {
-    // Update the active query logger every time there is a new request to compile.
-    // This isn't ideal because in situations where there are queries running
-    // in parallel, each query's log messages are interleaved. Fixing this
-    // properly will require a change in the query server.
-    qs.activeQueryLogger = logger;
-    result = await qs.sendRequest(
-      messages.runQuery,
-      queryToRun,
-      token,
-      progress,
-    );
-    if (qs.config.customLogDirectory) {
-      void showAndLogWarningMessage(
-        `Custom log directories are no longer supported. The "codeQL.runningQueries.customLogDirectory" setting is deprecated. Unset the setting to stop seeing this message. Query logs saved to ${query.logPath}.`,
-      );
-    }
-  } finally {
-    if (queryInfo) {
-      if (await query.hasEvalLog()) {
-        await query.addQueryLogs(queryInfo, qs.cliServer, logger);
-      } else {
-        void showAndLogWarningMessage(
-          `Failed to write structured evaluator log to ${query.evalLogPath}.`,
-        );
-      }
-    }
-  }
 
-  if (result.resultType !== messages.QueryResultType.SUCCESS) {
-    const message = result?.message
-      ? redactableError`${result.message}`
-      : redactableError`Failed to run query`;
-    void extLogger.log(message.fullMessage);
-    void showAndLogExceptionWithTelemetry(
-      redactableError`Failed to run query: ${message}`,
-    );
-  }
-  let message;
-  switch (result.resultType) {
-    case messages.QueryResultType.CANCELLATION:
-      message = `cancelled after ${Math.round(
-        result.evaluationTime / 1000,
-      )} seconds`;
-      break;
-    case messages.QueryResultType.OOM:
-      message = "out of memory";
-      break;
-    case messages.QueryResultType.SUCCESS:
-      message = `finished in ${Math.round(
-        result.evaluationTime / 1000,
-      )} seconds`;
-      break;
-    case messages.QueryResultType.COMPILATION_ERROR:
-      message = `compilation failed: ${result.message}`;
-      break;
-    case messages.QueryResultType.OTHER_ERROR:
-    default:
-      message = result.message ? `failed: ${result.message}` : "failed";
-      break;
-  }
-  const successful = result.resultType === messages.QueryResultType.SUCCESS;
+  // Update the active query logger every time there is a new request to compile.
+  // This isn't ideal because in situations where there are queries running
+  // in parallel, each query's log messages are interleaved. Fixing this
+  // properly will require a change in the query server.
+  qs.activeQueryLogger = logger;
+  const result = await qs.sendRequest(
+    messages.runQuery,
+    queryToRun,
+    token,
+    progress,
+  );
+
   return {
-    query,
-    result: {
-      evaluationTime: result.evaluationTime,
-      queryId: 0,
-      resultType: successful
-        ? QueryResultType.SUCCESS
-        : QueryResultType.OTHER_ERROR,
-      runId: 0,
-      message,
-    },
-    message,
-    successful,
+    resultType: result.resultType,
+    message: result.message,
+    evaluationTime: result.evaluationTime,
   };
 }

--- a/extensions/ql-vscode/src/queryRunner.ts
+++ b/extensions/ql-vscode/src/queryRunner.ts
@@ -110,16 +110,15 @@ export abstract class QueryRunner {
     generateEvalLog: boolean,
     additionalPacks: string[],
     queryStorageDir: string,
-    id: string | undefined,
+    id = `${basename(query.queryPath)}-${nanoid()}`,
     templates: Record<string, string> | undefined,
   ): CoreQueryRun {
-    const actualId = id ?? `${basename(query.queryPath)}-${nanoid()}`;
-    const outputDir = new QueryOutputDir(join(queryStorageDir, actualId));
+    const outputDir = new QueryOutputDir(join(queryStorageDir, id));
 
     return {
       queryTarget: query,
       dbPath,
-      id: actualId,
+      id,
       outputDir,
       evaluate: async (
         progress: ProgressCallback,
@@ -127,7 +126,7 @@ export abstract class QueryRunner {
         logger: BaseLogger,
       ): Promise<CoreCompletedQuery> => {
         return {
-          id: actualId,
+          id,
           outputDir,
           dbPath,
           queryTarget: query,

--- a/extensions/ql-vscode/src/queryRunner.ts
+++ b/extensions/ql-vscode/src/queryRunner.ts
@@ -3,7 +3,77 @@ import { CodeQLCliServer } from "./cli";
 import { ProgressCallback } from "./progress";
 import { DatabaseItem } from "./local-databases";
 import { InitialQueryInfo, LocalQueryInfo } from "./query-results";
-import { QueryWithResults } from "./run-queries-shared";
+import {
+  EvaluatorLogPaths,
+  generateEvalLogSummaries,
+  logEndSummary,
+  QueryEvaluationInfo,
+  QueryOutputDir,
+  QueryWithResults,
+} from "./run-queries-shared";
+import { Position, QueryResultType } from "./pure/new-messages";
+import {
+  createTimestampFile,
+  getOnDiskWorkspaceFolders,
+  showAndLogExceptionWithTelemetry,
+  showAndLogWarningMessage,
+  tryGetQueryMetadata,
+} from "./helpers";
+import { basename, join } from "path";
+import { BaseLogger, extLogger, Logger, TeeLogger } from "./common";
+import { redactableError } from "./pure/errors";
+import { nanoid } from "nanoid";
+
+export interface CoreQueryTarget {
+  /** The full path to the query. */
+  queryPath: string;
+  /**
+   * Optional position of text to be used as QuickEval target. This need not be in the same file as
+   * `query`.
+   */
+  quickEvalPosition?: Position;
+}
+
+export interface CoreQueryResults {
+  readonly resultType: QueryResultType;
+  readonly message: string | undefined;
+  readonly evaluationTime: number;
+}
+
+export interface CoreQueryRun {
+  readonly queryTarget: CoreQueryTarget;
+  readonly dbPath: string;
+  readonly id: string;
+  readonly outputDir: QueryOutputDir;
+
+  evaluate(
+    progress: ProgressCallback,
+    token: CancellationToken,
+    logger: BaseLogger,
+  ): Promise<CoreCompletedQuery>;
+}
+
+/** Includes both the results of the query and the initial information from `CoreQueryRun`. */
+export type CoreCompletedQuery = CoreQueryResults &
+  Omit<CoreQueryRun, "evaluate">;
+
+function formatResultMessage(result: CoreQueryResults): string {
+  switch (result.resultType) {
+    case QueryResultType.CANCELLATION:
+      return `cancelled after ${Math.round(
+        result.evaluationTime / 1000,
+      )} seconds`;
+    case QueryResultType.OOM:
+      return "out of memory";
+    case QueryResultType.SUCCESS:
+      return `finished in ${Math.round(result.evaluationTime / 1000)} seconds`;
+    case QueryResultType.COMPILATION_ERROR:
+      return `compilation failed: ${result.message}`;
+    case QueryResultType.OTHER_ERROR:
+    default:
+      return result.message ? `failed: ${result.message}` : "failed";
+  }
+}
 
 export abstract class QueryRunner {
   abstract restartQueryServer(
@@ -12,6 +82,8 @@ export abstract class QueryRunner {
   ): Promise<void>;
 
   abstract cliServer: CodeQLCliServer;
+  abstract customLogDirectory: string | undefined;
+  abstract logger: Logger;
 
   abstract onStart(
     arg0: (
@@ -25,15 +97,210 @@ export abstract class QueryRunner {
     token: CancellationToken,
   ): Promise<void>;
 
-  abstract compileAndRunQueryAgainstDatabase(
-    dbItem: DatabaseItem,
+  public async compileAndRunQueryAgainstDatabase(
+    db: DatabaseItem,
     initialInfo: InitialQueryInfo,
     queryStorageDir: string,
     progress: ProgressCallback,
     token: CancellationToken,
     templates?: Record<string, string>,
     queryInfo?: LocalQueryInfo, // May be omitted for queries not initiated by the user. If omitted we won't create a structured log for the query.
-  ): Promise<QueryWithResults>;
+  ): Promise<QueryWithResults> {
+    const queryTarget: CoreQueryTarget = {
+      queryPath: initialInfo.queryPath,
+      quickEvalPosition: initialInfo.quickEvalPosition,
+    };
+
+    const diskWorkspaceFolders = getOnDiskWorkspaceFolders();
+    const queryRun = this.createQueryRun(
+      db.databaseUri.fsPath,
+      queryTarget,
+      queryInfo !== undefined,
+      diskWorkspaceFolders,
+      queryStorageDir,
+      initialInfo.id,
+      templates,
+    );
+
+    await createTimestampFile(queryRun.outputDir.querySaveDir);
+
+    const logPath = queryRun.outputDir.logPath;
+    if (this.customLogDirectory) {
+      void showAndLogWarningMessage(
+        `Custom log directories are no longer supported. The "codeQL.runningQueries.customLogDirectory" setting is deprecated. Unset the setting to stop seeing this message. Query logs saved to ${logPath}`,
+      );
+    }
+
+    const logger = new TeeLogger(this.logger, logPath);
+    const coreResults = await queryRun.evaluate(progress, token, logger);
+    if (queryInfo !== undefined) {
+      const evalLogPaths = await this.summarizeEvalLog(
+        coreResults.resultType,
+        queryRun.outputDir,
+        logger,
+      );
+      if (evalLogPaths !== undefined) {
+        queryInfo.setEvaluatorLogPaths(evalLogPaths);
+      }
+    }
+
+    return await this.getCompletedQueryInfo(
+      db,
+      queryTarget,
+      queryRun.outputDir,
+      coreResults,
+    );
+  }
+
+  /**
+   * Generate summaries of the structured evaluator log.
+   */
+  public async summarizeEvalLog(
+    resultType: QueryResultType,
+    outputDir: QueryOutputDir,
+    logger: BaseLogger,
+  ): Promise<EvaluatorLogPaths | undefined> {
+    const evalLogPaths = await generateEvalLogSummaries(
+      this.cliServer,
+      outputDir,
+    );
+    if (evalLogPaths !== undefined) {
+      if (evalLogPaths.endSummary !== undefined) {
+        void logEndSummary(evalLogPaths.endSummary, logger); // Logged asynchrnously
+      }
+    } else {
+      // Raw evaluator log was not found. Notify the user, unless we know why it wasn't found.
+      switch (resultType) {
+        case QueryResultType.COMPILATION_ERROR:
+        case QueryResultType.DBSCHEME_MISMATCH_NAME:
+        case QueryResultType.DBSCHEME_NO_UPGRADE:
+          // In these cases, the evaluator was never invoked anyway, so don't bother warning.
+          break;
+
+        default:
+          void showAndLogWarningMessage(
+            `Failed to write structured evaluator log to ${outputDir.evalLogPath}.`,
+          );
+          break;
+      }
+    }
+
+    return evalLogPaths;
+  }
+
+  /**
+   * Gets a `QueryWithResults` containing information about the evaluation of the query and its
+   * result, in the form expected by the query history UI.
+   */
+  public async getCompletedQueryInfo(
+    dbItem: DatabaseItem,
+    queryTarget: CoreQueryTarget,
+    outputDir: QueryOutputDir,
+    results: CoreQueryResults,
+  ): Promise<QueryWithResults> {
+    // Read the query metadata if possible, to use in the UI.
+    const metadata = await tryGetQueryMetadata(
+      this.cliServer,
+      queryTarget.queryPath,
+    );
+    const query = new QueryEvaluationInfo(
+      outputDir.querySaveDir,
+      dbItem.databaseUri.fsPath,
+      await dbItem.hasMetadataFile(),
+      queryTarget.quickEvalPosition,
+      metadata,
+    );
+
+    if (results.resultType !== QueryResultType.SUCCESS) {
+      const message = results.message
+        ? redactableError`${results.message}`
+        : redactableError`Failed to run query`;
+      void extLogger.log(message.fullMessage);
+      void showAndLogExceptionWithTelemetry(
+        redactableError`Failed to run query: ${message}`,
+      );
+    }
+    const message = formatResultMessage(results);
+    const successful = results.resultType === QueryResultType.SUCCESS;
+    return {
+      query,
+      result: {
+        evaluationTime: results.evaluationTime,
+        queryId: 0,
+        resultType: successful
+          ? QueryResultType.SUCCESS
+          : QueryResultType.OTHER_ERROR,
+        runId: 0,
+        message,
+      },
+      message,
+      successful,
+    };
+  }
+
+  /**
+   * Create a `CoreQueryRun` object. This creates an object whose `evaluate()` function can be
+   * called to actually evaluate the query. The returned object also contains information about the
+   * query evaluation that is known even before evaluation starts, including the unique ID of the
+   * evaluation and the path to its output directory.
+   */
+  public createQueryRun(
+    dbPath: string,
+    query: CoreQueryTarget,
+    generateEvalLog: boolean,
+    additionalPacks: string[],
+    queryStorageDir: string,
+    id: string | undefined,
+    templates: Record<string, string> | undefined,
+  ): CoreQueryRun {
+    const actualId = id ?? `${basename(query.queryPath)}-${nanoid()}`;
+    const outputDir = new QueryOutputDir(join(queryStorageDir, actualId));
+
+    return {
+      queryTarget: query,
+      dbPath,
+      id: actualId,
+      outputDir,
+      evaluate: async (
+        progress: ProgressCallback,
+        token: CancellationToken,
+        logger: BaseLogger,
+      ): Promise<CoreCompletedQuery> => {
+        return {
+          id: actualId,
+          outputDir,
+          dbPath,
+          queryTarget: query,
+          ...(await this.compileAndRunQueryAgainstDatabaseCore(
+            dbPath,
+            query,
+            additionalPacks,
+            generateEvalLog,
+            outputDir,
+            progress,
+            token,
+            templates,
+            logger,
+          )),
+        };
+      },
+    };
+  }
+
+  /**
+   * Overridden in subclasses to evaluate the query via the query server and return the results.
+   */
+  protected abstract compileAndRunQueryAgainstDatabaseCore(
+    dbPath: string,
+    query: CoreQueryTarget,
+    additionalPacks: string[],
+    generateEvalLog: boolean,
+    outputDir: QueryOutputDir,
+    progress: ProgressCallback,
+    token: CancellationToken,
+    templates: Record<string, string> | undefined,
+    logger: BaseLogger,
+  ): Promise<CoreQueryResults>;
 
   abstract deregisterDatabase(
     progress: ProgressCallback,

--- a/extensions/ql-vscode/src/queryRunner.ts
+++ b/extensions/ql-vscode/src/queryRunner.ts
@@ -2,26 +2,10 @@ import { CancellationToken } from "vscode";
 import { CodeQLCliServer } from "./cli";
 import { ProgressCallback } from "./progress";
 import { DatabaseItem } from "./local-databases";
-import { InitialQueryInfo, LocalQueryInfo } from "./query-results";
-import {
-  EvaluatorLogPaths,
-  generateEvalLogSummaries,
-  logEndSummary,
-  QueryEvaluationInfo,
-  QueryOutputDir,
-  QueryWithResults,
-} from "./run-queries-shared";
+import { QueryOutputDir } from "./run-queries-shared";
 import { Position, QueryResultType } from "./pure/new-messages";
-import {
-  createTimestampFile,
-  getOnDiskWorkspaceFolders,
-  showAndLogExceptionWithTelemetry,
-  showAndLogWarningMessage,
-  tryGetQueryMetadata,
-} from "./helpers";
+import { BaseLogger, Logger } from "./common";
 import { basename, join } from "path";
-import { BaseLogger, extLogger, Logger, TeeLogger } from "./common";
-import { redactableError } from "./pure/errors";
 import { nanoid } from "nanoid";
 
 export interface CoreQueryTarget {
@@ -57,24 +41,6 @@ export interface CoreQueryRun {
 export type CoreCompletedQuery = CoreQueryResults &
   Omit<CoreQueryRun, "evaluate">;
 
-function formatResultMessage(result: CoreQueryResults): string {
-  switch (result.resultType) {
-    case QueryResultType.CANCELLATION:
-      return `cancelled after ${Math.round(
-        result.evaluationTime / 1000,
-      )} seconds`;
-    case QueryResultType.OOM:
-      return "out of memory";
-    case QueryResultType.SUCCESS:
-      return `finished in ${Math.round(result.evaluationTime / 1000)} seconds`;
-    case QueryResultType.COMPILATION_ERROR:
-      return `compilation failed: ${result.message}`;
-    case QueryResultType.OTHER_ERROR:
-    default:
-      return result.message ? `failed: ${result.message}` : "failed";
-  }
-}
-
 export abstract class QueryRunner {
   abstract restartQueryServer(
     progress: ProgressCallback,
@@ -97,146 +63,40 @@ export abstract class QueryRunner {
     token: CancellationToken,
   ): Promise<void>;
 
-  public async compileAndRunQueryAgainstDatabase(
-    db: DatabaseItem,
-    initialInfo: InitialQueryInfo,
-    queryStorageDir: string,
+  /**
+   * Overridden in subclasses to evaluate the query via the query server and return the results.
+   */
+  public abstract compileAndRunQueryAgainstDatabaseCore(
+    dbPath: string,
+    query: CoreQueryTarget,
+    additionalPacks: string[],
+    generateEvalLog: boolean,
+    outputDir: QueryOutputDir,
     progress: ProgressCallback,
     token: CancellationToken,
-    templates?: Record<string, string>,
-    queryInfo?: LocalQueryInfo, // May be omitted for queries not initiated by the user. If omitted we won't create a structured log for the query.
-  ): Promise<QueryWithResults> {
-    const queryTarget: CoreQueryTarget = {
-      queryPath: initialInfo.queryPath,
-      quickEvalPosition: initialInfo.quickEvalPosition,
-    };
-
-    const diskWorkspaceFolders = getOnDiskWorkspaceFolders();
-    const queryRun = this.createQueryRun(
-      db.databaseUri.fsPath,
-      queryTarget,
-      queryInfo !== undefined,
-      diskWorkspaceFolders,
-      queryStorageDir,
-      initialInfo.id,
-      templates,
-    );
-
-    await createTimestampFile(queryRun.outputDir.querySaveDir);
-
-    const logPath = queryRun.outputDir.logPath;
-    if (this.customLogDirectory) {
-      void showAndLogWarningMessage(
-        `Custom log directories are no longer supported. The "codeQL.runningQueries.customLogDirectory" setting is deprecated. Unset the setting to stop seeing this message. Query logs saved to ${logPath}`,
-      );
-    }
-
-    const logger = new TeeLogger(this.logger, logPath);
-    const coreResults = await queryRun.evaluate(progress, token, logger);
-    if (queryInfo !== undefined) {
-      const evalLogPaths = await this.summarizeEvalLog(
-        coreResults.resultType,
-        queryRun.outputDir,
-        logger,
-      );
-      if (evalLogPaths !== undefined) {
-        queryInfo.setEvaluatorLogPaths(evalLogPaths);
-      }
-    }
-
-    return await this.getCompletedQueryInfo(
-      db,
-      queryTarget,
-      queryRun.outputDir,
-      coreResults,
-    );
-  }
-
-  /**
-   * Generate summaries of the structured evaluator log.
-   */
-  public async summarizeEvalLog(
-    resultType: QueryResultType,
-    outputDir: QueryOutputDir,
+    templates: Record<string, string> | undefined,
     logger: BaseLogger,
-  ): Promise<EvaluatorLogPaths | undefined> {
-    const evalLogPaths = await generateEvalLogSummaries(
-      this.cliServer,
-      outputDir,
-    );
-    if (evalLogPaths !== undefined) {
-      if (evalLogPaths.endSummary !== undefined) {
-        void logEndSummary(evalLogPaths.endSummary, logger); // Logged asynchrnously
-      }
-    } else {
-      // Raw evaluator log was not found. Notify the user, unless we know why it wasn't found.
-      switch (resultType) {
-        case QueryResultType.COMPILATION_ERROR:
-        case QueryResultType.DBSCHEME_MISMATCH_NAME:
-        case QueryResultType.DBSCHEME_NO_UPGRADE:
-          // In these cases, the evaluator was never invoked anyway, so don't bother warning.
-          break;
+  ): Promise<CoreQueryResults>;
 
-        default:
-          void showAndLogWarningMessage(
-            `Failed to write structured evaluator log to ${outputDir.evalLogPath}.`,
-          );
-          break;
-      }
-    }
-
-    return evalLogPaths;
-  }
-
-  /**
-   * Gets a `QueryWithResults` containing information about the evaluation of the query and its
-   * result, in the form expected by the query history UI.
-   */
-  public async getCompletedQueryInfo(
+  abstract deregisterDatabase(
+    progress: ProgressCallback,
+    token: CancellationToken,
     dbItem: DatabaseItem,
-    queryTarget: CoreQueryTarget,
-    outputDir: QueryOutputDir,
-    results: CoreQueryResults,
-  ): Promise<QueryWithResults> {
-    // Read the query metadata if possible, to use in the UI.
-    const metadata = await tryGetQueryMetadata(
-      this.cliServer,
-      queryTarget.queryPath,
-    );
-    const query = new QueryEvaluationInfo(
-      outputDir.querySaveDir,
-      dbItem.databaseUri.fsPath,
-      await dbItem.hasMetadataFile(),
-      queryTarget.quickEvalPosition,
-      metadata,
-    );
+  ): Promise<void>;
 
-    if (results.resultType !== QueryResultType.SUCCESS) {
-      const message = results.message
-        ? redactableError`${results.message}`
-        : redactableError`Failed to run query`;
-      void extLogger.log(message.fullMessage);
-      void showAndLogExceptionWithTelemetry(
-        redactableError`Failed to run query: ${message}`,
-      );
-    }
-    const message = formatResultMessage(results);
-    const successful = results.resultType === QueryResultType.SUCCESS;
-    return {
-      query,
-      result: {
-        evaluationTime: results.evaluationTime,
-        queryId: 0,
-        resultType: successful
-          ? QueryResultType.SUCCESS
-          : QueryResultType.OTHER_ERROR,
-        runId: 0,
-        message,
-      },
-      message,
-      successful,
-    };
-  }
+  abstract registerDatabase(
+    progress: ProgressCallback,
+    token: CancellationToken,
+    dbItem: DatabaseItem,
+  ): Promise<void>;
+
+  abstract upgradeDatabaseExplicit(
+    dbItem: DatabaseItem,
+    progress: ProgressCallback,
+    token: CancellationToken,
+  ): Promise<void>;
+
+  abstract clearPackCache(): Promise<void>;
 
   /**
    * Create a `CoreQueryRun` object. This creates an object whose `evaluate()` function can be
@@ -286,39 +146,4 @@ export abstract class QueryRunner {
       },
     };
   }
-
-  /**
-   * Overridden in subclasses to evaluate the query via the query server and return the results.
-   */
-  protected abstract compileAndRunQueryAgainstDatabaseCore(
-    dbPath: string,
-    query: CoreQueryTarget,
-    additionalPacks: string[],
-    generateEvalLog: boolean,
-    outputDir: QueryOutputDir,
-    progress: ProgressCallback,
-    token: CancellationToken,
-    templates: Record<string, string> | undefined,
-    logger: BaseLogger,
-  ): Promise<CoreQueryResults>;
-
-  abstract deregisterDatabase(
-    progress: ProgressCallback,
-    token: CancellationToken,
-    dbItem: DatabaseItem,
-  ): Promise<void>;
-
-  abstract registerDatabase(
-    progress: ProgressCallback,
-    token: CancellationToken,
-    dbItem: DatabaseItem,
-  ): Promise<void>;
-
-  abstract upgradeDatabaseExplicit(
-    dbItem: DatabaseItem,
-    progress: ProgressCallback,
-    token: CancellationToken,
-  ): Promise<void>;
-
-  abstract clearPackCache(): Promise<void>;
 }

--- a/extensions/ql-vscode/src/run-queries-shared.ts
+++ b/extensions/ql-vscode/src/run-queries-shared.ts
@@ -653,7 +653,8 @@ export async function generateEvalLogSummaries(
 
 /**
  * Calls the appropriate CLI command to generate a human-readable log summary.
- * @param cliServer The cli server client. * @param outputDir The query's output directory, where all of the logs are located.
+ * @param cliServer The cli server client.
+ * @param outputDir The query's output directory, where all of the logs are located.
  * @returns True if the summary and end summary were generated, or false if not.
  */
 async function generateHumanReadableLogSummary(

--- a/extensions/ql-vscode/src/run-queries-shared.ts
+++ b/extensions/ql-vscode/src/run-queries-shared.ts
@@ -653,8 +653,7 @@ export async function generateEvalLogSummaries(
 
 /**
  * Calls the appropriate CLI command to generate a human-readable log summary.
- * @param qs The query server client.
- * @param outputDir The query's output directory, where all of the logs are located.
+ * @param cliServer The cli server client. * @param outputDir The query's output directory, where all of the logs are located.
  * @returns True if the summary and end summary were generated, or false if not.
  */
 async function generateHumanReadableLogSummary(

--- a/extensions/ql-vscode/src/run-queries-shared.ts
+++ b/extensions/ql-vscode/src/run-queries-shared.ts
@@ -124,6 +124,12 @@ export class QueryOutputDir {
 }
 
 export class QueryEvaluationInfo extends QueryOutputDir {
+  // We extend `QueryOutputDir`, rather than having it as a property, because we need
+  // `QueryOutputDir`'s `querySaveDir` property to be a property of `QueryEvaluationInfo`. This is
+  // because `QueryEvaluationInfo` is serialized directly as JSON, and before we hoisted
+  // `QueryOutputDir` out into a base class, `querySaveDir` was a property on `QueryEvaluationInfo`
+  // itself.
+
   /**
    * Note that in the {@link readQueryHistoryFromFile} method, we create a QueryEvaluationInfo instance
    * by explicitly setting the prototype in order to avoid calling this constructor.

--- a/extensions/ql-vscode/test/common/logging/output-channel-logger.test.ts
+++ b/extensions/ql-vscode/test/common/logging/output-channel-logger.test.ts
@@ -1,7 +1,12 @@
 import { readdirSync, readFileSync } from "fs-extra";
 import { join } from "path";
 import * as tmp from "tmp";
-import { Logger, OutputChannelLogger, TeeLogger } from "../../../src/common";
+import {
+  BaseLogger,
+  Logger,
+  OutputChannelLogger,
+  TeeLogger,
+} from "../../../src/common";
 
 jest.setTimeout(999999);
 
@@ -88,7 +93,7 @@ describe("OutputChannelLogger tests", function () {
   function createSideLogger(
     logger: Logger,
     additionalLogLocation: string,
-  ): Logger {
+  ): BaseLogger {
     return new TeeLogger(
       logger,
       join(tempFolders.storagePath.name, additionalLogLocation),

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/queries.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/queries.test.ts
@@ -62,7 +62,11 @@ describeWithCodeQL()("Queries", () => {
     safeDel(qlFile);
     safeDel(qlpackFile);
 
-    token = {} as CancellationToken;
+    token = {
+      onCancellationRequested: (_) => {
+        void _;
+      },
+    } as CancellationToken;
 
     // Add a database, but make sure the database manager is empty first
     await cleanDatabases(databaseManager);

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/queries.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/queries.test.ts
@@ -25,6 +25,7 @@ import { QueryRunner } from "../../../src/queryRunner";
 import { CompletedQueryInfo } from "../../../src/query-results";
 import { SELECT_QUERY_NAME } from "../../../src/contextual/locationFinder";
 import { createMockCommandManager } from "../../__mocks__/commandsMock";
+import { LocalQueries } from "../../../src/local-queries";
 
 jest.setTimeout(20_000);
 
@@ -36,6 +37,7 @@ describeWithCodeQL()("Queries", () => {
   let databaseManager: DatabaseManager;
   let cli: CodeQLCliServer;
   let qs: QueryRunner;
+  let localQueries: LocalQueries;
   const progress = jest.fn();
   let token: CancellationToken;
   let ctx: ExtensionContext;
@@ -50,6 +52,7 @@ describeWithCodeQL()("Queries", () => {
     databaseManager = extension.databaseManager;
     cli = extension.cliServer;
     qs = extension.qs;
+    localQueries = extension.localQueries;
     cli.quiet = true;
     ctx = extension.ctx;
     qlpackFile = `${ctx.storageUri?.fsPath}/quick-queries/qlpack.yml`;
@@ -132,7 +135,7 @@ describeWithCodeQL()("Queries", () => {
 
     async function runQueryWithExtensions() {
       const result = new CompletedQueryInfo(
-        await qs.compileAndRunQueryAgainstDatabase(
+        await localQueries.compileAndRunQueryAgainstDatabase(
           dbItem,
           await mockInitialQueryInfo(queryUsingExtensionPath),
           join(tmpDir.name, "mock-storage-path"),
@@ -162,7 +165,7 @@ describeWithCodeQL()("Queries", () => {
 
   it("should run a query", async () => {
     const queryPath = join(__dirname, "data", "simple-query.ql");
-    const result = qs.compileAndRunQueryAgainstDatabase(
+    const result = localQueries.compileAndRunQueryAgainstDatabase(
       dbItem,
       await mockInitialQueryInfo(queryPath),
       join(tmpDir.name, "mock-storage-path"),
@@ -178,7 +181,7 @@ describeWithCodeQL()("Queries", () => {
   it("should restart the database and run a query", async () => {
     await commands.executeCommand("codeQL.restartQueryServer");
     const queryPath = join(__dirname, "data", "simple-query.ql");
-    const result = await qs.compileAndRunQueryAgainstDatabase(
+    const result = await localQueries.compileAndRunQueryAgainstDatabase(
       dbItem,
       await mockInitialQueryInfo(queryPath),
       join(tmpDir.name, "mock-storage-path"),

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-databases.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-databases.test.ts
@@ -5,6 +5,7 @@ import { CancellationToken, ExtensionContext, Uri, workspace } from "vscode";
 
 import {
   DatabaseContents,
+  DatabaseContentsWithDbScheme,
   DatabaseEventKind,
   DatabaseItemImpl,
   DatabaseManager,
@@ -687,7 +688,7 @@ describe("local databases", () => {
 
       resolveDatabaseContentsSpy = jest
         .spyOn(DatabaseResolver, "resolveDatabaseContents")
-        .mockResolvedValue({} as DatabaseContents);
+        .mockResolvedValue({} as DatabaseContentsWithDbScheme);
 
       addDatabaseSourceArchiveFolderSpy = jest.spyOn(
         databaseManager,

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/contextual/astBuilder.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/contextual/astBuilder.test.ts
@@ -5,6 +5,7 @@ import { CodeQLCliServer } from "../../../../src/cli";
 import { Uri } from "vscode";
 import { QueryOutputDir } from "../../../../src/run-queries-shared";
 import { mockDatabaseItem, mockedObject } from "../../utils/mocking.helpers";
+import path from "path";
 
 /**
  *
@@ -52,19 +53,12 @@ describe("AstBuilder", () => {
     const astBuilder = createAstBuilder();
     const roots = await astBuilder.getRoots();
 
+    const bqrsPath = path.normalize("/a/b/c/results.bqrs");
     const options = { entities: ["id", "url", "string"] };
+    expect(mockCli.bqrsDecode).toBeCalledWith(bqrsPath, "nodes", options);
+    expect(mockCli.bqrsDecode).toBeCalledWith(bqrsPath, "edges", options);
     expect(mockCli.bqrsDecode).toBeCalledWith(
-      "/a/b/c/results.bqrs",
-      "nodes",
-      options,
-    );
-    expect(mockCli.bqrsDecode).toBeCalledWith(
-      "/a/b/c/results.bqrs",
-      "edges",
-      options,
-    );
-    expect(mockCli.bqrsDecode).toBeCalledWith(
-      "/a/b/c/results.bqrs",
+      bqrsPath,
       "graphProperties",
       options,
     );

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/contextual/astBuilder.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/contextual/astBuilder.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "fs-extra";
 import AstBuilder from "../../../../src/contextual/astBuilder";
 import { CodeQLCliServer } from "../../../../src/cli";
 import { Uri } from "vscode";
-import { QueryWithResults } from "../../../../src/run-queries-shared";
+import { QueryOutputDir } from "../../../../src/run-queries-shared";
 import { mockDatabaseItem, mockedObject } from "../../utils/mocking.helpers";
 
 /**
@@ -137,13 +137,7 @@ describe("AstBuilder", () => {
 
   function createAstBuilder() {
     return new AstBuilder(
-      {
-        query: {
-          resultsPaths: {
-            resultsPath: "/a/b/c",
-          },
-        },
-      } as QueryWithResults,
+      new QueryOutputDir("/a/b/c"),
       mockCli,
       mockDatabaseItem({
         resolveSourceFile: undefined,

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/contextual/astBuilder.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/contextual/astBuilder.test.ts
@@ -53,10 +53,18 @@ describe("AstBuilder", () => {
     const roots = await astBuilder.getRoots();
 
     const options = { entities: ["id", "url", "string"] };
-    expect(mockCli.bqrsDecode).toBeCalledWith("/a/b/c", "nodes", options);
-    expect(mockCli.bqrsDecode).toBeCalledWith("/a/b/c", "edges", options);
     expect(mockCli.bqrsDecode).toBeCalledWith(
-      "/a/b/c",
+      "/a/b/c/results.bqrs",
+      "nodes",
+      options,
+    );
+    expect(mockCli.bqrsDecode).toBeCalledWith(
+      "/a/b/c/results.bqrs",
+      "edges",
+      options,
+    );
+    expect(mockCli.bqrsDecode).toBeCalledWith(
+      "/a/b/c/results.bqrs",
       "graphProperties",
       options,
     );


### PR DESCRIPTION
_Review tip: This PR will probably make more sense if you step through the code. I suggest that you do so after you've read the PR description, but before you try to make sense of the diffs. Set a breakpoint at `compileAndRunQuery()`, select the `Run query against a single database...` command, and follow along._

This PR refactors our existing code path for local query evaluation so that it can be used by the CodeQL Debug Adapter, which will be added in an upcoming PR.

Our existing code path for local query evaluation goes through several layers of code, but there is no clear separation of concerns between those layers. As one extreme example, the `LocalQueryInfo` object, which handles the UI presentation of the query evaluation in the query history view, is passed all the way down the same function that directly invokes the query server. The same goes for the `InitialQueryInfo` object, which has a couple properties that only apply to the UI. The `QueryEvaluationInfo` object, also passed all the way down, mixed some very handy functions for determining the paths to various files in the query's output directory with a bunch of properties and functions used in the UI, and even serialized to disk for query history persistence. The same goes for `DatabaseItem`.

The separate code paths to handle the new query server vs. the legacy query server has quite a bit of duplicated and almost-duplicated code, which, due to the abovementioned comingling of concerns, was difficult to factor out.

The comingling of UI and non-UI responsibilities also makes it more difficult for the code paths that invoke the query server but do not populate the query history (example: AST generation) to evaluate a query, because they have to create extra UI-related state that will never be used.

The changes in this PR thoroughly refactor the whole code path to separate concerns. Specifically, the `QueryRunner` abstract class and everything below it are now focused on the mechanics of the actual evaluation via the query server, with no connection to the UI other than a progress callback and a `Logger` inteface. Everything else, including query history UI, timestamp file generation, and evaluator log summarization, has been hoisted out of `QueryRunner` and its implementations.

## Details

The two implementations of `QueryRunner` now focus solely on evaluating the query. In particular, the implementation of `compileAndRunQueryAgainstDatabaseCore()` for the new query server does nothing but set up the message to send to the query server, send the message, and then return the results. The implementation for the legacy query server does much more work, but only because the legacy query server interface requires it to. The evaluation is initialized by calling `createQueryRun()` on `QueryRunner`. This holds information that will be needed even before the evaluation completes, like the path to the evaluation's output directory. The actual evaluation is invoked by calling `evaluate()` on the `CoreQueryRun` object, which will evantually return the evaluation results.

The interface to `QueryRunner` now defines its own minimal interfaces to specify the arguments to the evaluation (query, database, additional search paths) and the results of the evaluation, rather than reusing the UI-related types from the higher layers.

I left the layout and functionality of most of the UI-related types (`LocalQueryInfo`, etc.) alone, because those are serialized directly to disk and deserialized from JSON by slapping a new prototype on the raw JSON object. We could do better than this, but improving this wasn't necessary for this PR.

I factored all the properties of `QueryEvaluationInfo` that just computed output file paths out into a new base class `QueryOutputDir`. This new class is now used throughout the lower-level code to find paths, without depending on other state that is only necessary for results interpretation.

The top-level command handling for the various `Run query...` commands had recently been factored out into a separate `local-queries.ts` file, instead of being a bunch of ugly nested functions within the extension initialization code (thanks, @koesie10!). I've converted that file to a full on `LocalQueries` service, in the pattern used by most of our other components. All of the UI-related code that used to be scattered throughout the query evaluation code path is now here. All of the UI setup that's done before query evaluation starts (picking an output directory, creating a cancellation token source, etc.) is done via `createLocalQueryRun()`, and all of the post-evaluation updates are done by calling `complete()` on the `LocalQueryRun` object. As the comment in the code indicates, this looks a little clunky as-is, but it will be necessary when we try to hook it up to the debug adapter.

The diffs in `local-queries.ts` look scarier than they are. I didn't actually change any of the commands except to put them into the new `LocalQueries` class. They all just go through `compileAndRunQuery()`, which is where the real changes are.

The AST and Go To Reference code now talks directly to the `QueryRunner` without having to manufacture the various UI-related state that it doesn't need.

I separated the existing `Logger` interface into `BaseLogger`, with just the `log()` function, and `Logger`, which adds the `show()` function. Code that only generates log messages needs only `BaseLogger`. The distinction isn't critical in this PR, but becomes more important when I add the debug adapter, which will need a `BaseLogger` that routes the messages over the Debug Adapter Protocol, but has no way to implement the `show()` function.

