### PR TITLE
Use gh release create instead of deprecated actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,49 +67,19 @@ jobs:
 
         # TODO Run tests, or check that a test run on the same branch succeeded.
 
-      - name: Create release
-        id: create-release
-        uses: actions/create-release@v1.0.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          # This gives us a chance to manually review the created release before publishing it,
-          # as well as to test the release workflow by pushing temporary tags.
-          # Once we have set all required release metadata in this step, we can set this to `false`.
-          draft: true
-          prerelease: false
-
-      - name: Upload release asset
-        uses: actions/upload-release-asset@v1.0.1
-        if: success()
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          # Get the `upload_url` from the `create-release` step above.
-          upload_url: ${{ steps.create-release.outputs.upload_url }}
-          # Get the `vsix_path` and `ref_name` from the `prepare-artifacts` step above.
-          asset_path: ${{ steps.prepare-artifacts.outputs.vsix_path }}
-          asset_name: ${{ format('vscode-codeql-{0}.vsix', steps.prepare-artifacts.outputs.ref_name) }}
-          asset_content_type: application/zip
-
       - name: Create sourcemap ZIP file
         run: |
           cd dist/vscode-codeql/out
           zip -r ../../vscode-codeql-sourcemaps.zip *.map
 
-      - name: Upload sourcemap ZIP file
-        uses: actions/upload-release-asset@v1.0.1
-        if: success()
+      - name: Create release
+        id: create-release
+        run: |
+          gh release create ${{ github.ref_name }} --draft --title "Release ${{ github.ref_name }}" \
+            '${{ steps.prepare-artifacts.outputs.vsix_path }}#${{ format('vscode-codeql-{0}.vsix', steps.prepare-artifacts.outputs.ref_name) }}' \
+            'dist/vscode-codeql-sourcemaps.zip#${{ format('vscode-codeql-sourcemaps-{0}.zip', steps.prepare-artifacts.outputs.ref_name) }}'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          # Get the `upload_url` from the `create-release` step above.
-          upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: dist/vscode-codeql-sourcemaps.zip
-          asset_name: ${{ format('vscode-codeql-sourcemaps-{0}.zip', steps.prepare-artifacts.outputs.ref_name) }}
-          asset_content_type: application/zip
 
       ###
       # Do Post release work: version bump and changelog PR


### PR DESCRIPTION
This switches the release workflow to use [`gh release create` ](https://cli.github.com/manual/gh_release_create) instead of the deprecated `actions/create-release` and `actions/upload-release-asset`. The `gh release create` supports uploading assets to the release using the same command invocation, so this also simplifies the creation of the release.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
