### PR TITLE
Fail VSCE workflow on failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,10 +164,7 @@ jobs:
 
       - name: Publish to Registry
         run: |
-          npx vsce publish -p $VSCE_TOKEN --packagePath *.vsix || \
-            echo "Failed to publish to VS Code Marketplace. \
-                  If this was an authentication problem, please make sure the \
-                  auth token hasn't expired."
+          npx vsce publish -p $VSCE_TOKEN --packagePath *.vsix
 
   open-vsx-publish:
     name: Publish to Open VSX Registry


### PR DESCRIPTION
We were ignoring errors coming from `vsce publish` and this was causing the workflow to succeed even when the publish failed. This will remove the `||` and let the workflow fail if the publish fails.

@aeisenberg I've requested your review because you originally added this step in https://github.com/github/vscode-codeql/pull/716, so you might have additional context on why this was necessary.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
