### PR TITLE
Improve monitor error message

### DIFF
--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-monitor.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-monitor.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from "vscode";
+import { env, EventEmitter } from "vscode";
 import { getVariantAnalysis } from "./gh-api/gh-api-client";
 
 import {
@@ -57,7 +57,11 @@ export class VariantAnalysisMonitor extends DisposableObject {
         );
       } catch (e) {
         void showAndLogWarningMessage(
-          `Error while monitoring variant analysis: ${getErrorMessage(e)}`,
+          `Error while monitoring variant analysis ${
+            variantAnalysis.query.name
+          } (${variantAnalysis.query.language}) [${new Date(
+            variantAnalysis.executionStartTime,
+          ).toLocaleString(env.language)}]: ${getErrorMessage(e)}`,
         );
         continue;
       }


### PR DESCRIPTION
This will improve the error message shown when monitoring fails. Instead of showing "Error while monitoring variant analysis: Not Found", this will now show "Error while monitoring variant analysis "Empty block (javascript) [29/3/2023 10:45:10]: Not Found". This should make it easier for the user to figure out which query history item is problematic.

We're not using the full query history item label here because that would require access to the query history item, which we don't yet have here. Adding it here would add a dependency on the query history, which seems undesirable.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
