### PR TITLE
Add simple regression unit test for the results view

### DIFF
--- a/extensions/ql-vscode/src/view/jest.config.ts
+++ b/extensions/ql-vscode/src/view/jest.config.ts
@@ -83,8 +83,8 @@ const config: Config = {
   // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
   moduleNameMapper: {
     "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":
-      "<rootDir>/test/__mocks__/fileMock.ts",
-    "\\.(css|less)$": "<rootDir>/test/__mocks__/styleMock.ts",
+      "<rootDir>/../../test/__mocks__/fileMock.ts",
+    "\\.(css|less)$": "<rootDir>/../../test/__mocks__/styleMock.ts",
   },
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
@@ -186,7 +186,7 @@ const config: Config = {
   // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
   transformIgnorePatterns: [
     // These use ES modules, so need to be transformed
-    "node_modules/(?!(?:@vscode/webview-ui-toolkit|@microsoft/.+|exenv-es6)/.*)",
+    "node_modules/(?!(?:@vscode/webview-ui-toolkit|@microsoft/.+|exenv-es6|d3|d3-(.*)|internmap|delaunator|robust-predicates)/.*)",
   ],
 
   // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them

--- a/extensions/ql-vscode/src/view/results/__tests__/results.spec.tsx
+++ b/extensions/ql-vscode/src/view/results/__tests__/results.spec.tsx
@@ -1,0 +1,120 @@
+import * as React from "react";
+import { render as reactRender, screen } from "@testing-library/react";
+import { ResultsApp } from "../results";
+import {
+  Interpretation,
+  IntoResultsViewMsg,
+  SortDirection,
+} from "../../../pure/interface-types";
+import * as fs from "fs-extra";
+import { resolve } from "path";
+import { ColumnKindCode } from "../../../pure/bqrs-cli-types";
+
+const exampleSarif = fs.readJSONSync(
+  resolve(
+    __dirname,
+    "../../../../test/vscode-tests/no-workspace/data/sarif/validSarif.sarif",
+  ),
+);
+
+describe(ResultsApp.name, () => {
+  const render = () => reactRender(<ResultsApp />);
+  const postMessage = async (msg: IntoResultsViewMsg) => {
+    // window.postMessage doesn't set the origin correctly, see
+    // https://github.com/jsdom/jsdom/issues/2745
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        source: window,
+        origin: window.location.origin,
+        data: msg,
+      }),
+    );
+
+    // The event is dispatched asynchronously, so we need to wait for it to be handled.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  };
+
+  it("renders results", async () => {
+    render();
+
+    const interpretation: Interpretation = {
+      sourceLocationPrefix: "/a/b/c",
+      numTruncatedResults: 0,
+      numTotalResults: 1,
+      data: {
+        t: "SarifInterpretationData",
+        sortState: undefined,
+        ...exampleSarif,
+      },
+    };
+    const message: IntoResultsViewMsg = {
+      t: "setState",
+      resultsPath: "/a/b/c/results",
+      origResultsPaths: {
+        resultsPath: "/a/b/c/results.bqrs",
+        interpretedResultsPath: "/a/b/c/interpreted-results.sarif",
+      },
+      sortedResultsMap: {
+        "1": {
+          resultsPath: "/a/b/c/results.bqrs",
+          sortState: {
+            columnIndex: 1,
+            sortDirection: SortDirection.asc,
+          },
+        },
+      },
+      interpretation,
+      database: {
+        name: "test-db",
+        databaseUri: "test-db-uri",
+      },
+      metadata: undefined, // TODO
+      queryName: "test-query",
+      queryPath: "/a/b/c/query.ql",
+      shouldKeepOldResultsWhileRendering: false,
+      parsedResultSets: {
+        pageNumber: 1,
+        pageSize: 1,
+        numPages: 1,
+        numInterpretedPages: 1,
+        resultSetNames: ["#select"],
+        resultSet: {
+          t: "InterpretedResultSet",
+          schema: {
+            name: "#select",
+            rows: 1,
+            columns: [
+              {
+                name: "Path",
+                kind: ColumnKindCode.STRING,
+              },
+            ],
+          },
+          name: "#select",
+          interpretation,
+        },
+      },
+    };
+    await postMessage(message);
+
+    expect(
+      screen.getByText("'x' is assigned a value but never used."),
+    ).toBeInTheDocument();
+
+    await postMessage({
+      ...message,
+      t: "showInterpretedPage",
+      pageNumber: 1,
+      numPages: 1,
+      pageSize: 1,
+      resultSetNames: ["#select"],
+      queryName: "test-query",
+      queryPath: "/a/b/c/query.ql",
+      interpretation,
+    });
+
+    expect(
+      screen.getByText("'x' is assigned a value but never used."),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
This adds a really simple regression unit test for the results view which checks that the results view can render a SARIF file. This is in preparation for the upgrade to React 18 to ensure that we don't break the basic functionality of the results view.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
