### PR TITLE
Improvements to skeleton query flow

### DIFF
--- a/extensions/ql-vscode/src/databaseFetcher.ts
+++ b/extensions/ql-vscode/src/databaseFetcher.ts
@@ -122,12 +122,11 @@ export async function askForGitHubRepo(
   progress?: ProgressCallback,
   suggestedValue?: string,
 ): Promise<string | undefined> {
-  progress &&
-    progress({
-      message: "Choose repository",
-      step: 1,
-      maxStep: 2,
-    });
+  progress?.({
+    message: "Choose repository",
+    step: 1,
+    maxStep: 2,
+  });
 
   const options: InputBoxOptions = {
     title:

--- a/extensions/ql-vscode/src/databaseFetcher.ts
+++ b/extensions/ql-vscode/src/databaseFetcher.ts
@@ -119,14 +119,15 @@ export async function promptImportGithubDatabase(
 }
 
 export async function askForGitHubRepo(
-  progress: ProgressCallback,
+  progress?: ProgressCallback,
   suggestedValue?: string,
 ): Promise<string | undefined> {
-  progress({
-    message: "Choose repository",
-    step: 1,
-    maxStep: 2,
-  });
+  progress &&
+    progress({
+      message: "Choose repository",
+      step: 1,
+      maxStep: 2,
+    });
 
   const options: InputBoxOptions = {
     title:

--- a/extensions/ql-vscode/src/databaseFetcher.ts
+++ b/extensions/ql-vscode/src/databaseFetcher.ts
@@ -1,7 +1,7 @@
 import fetch, { Response } from "node-fetch";
 import { zip } from "zip-a-folder";
 import { Open } from "unzipper";
-import { Uri, CancellationToken, window } from "vscode";
+import { Uri, CancellationToken, window, InputBoxOptions } from "vscode";
 import { CodeQLCliServer } from "./cli";
 import {
   ensureDir,
@@ -92,17 +92,7 @@ export async function promptImportGithubDatabase(
   token: CancellationToken,
   cli?: CodeQLCliServer,
 ): Promise<DatabaseItem | undefined> {
-  progress({
-    message: "Choose repository",
-    step: 1,
-    maxStep: 2,
-  });
-  const githubRepo = await window.showInputBox({
-    title:
-      'Enter a GitHub repository URL or "name with owner" (e.g. https://github.com/github/codeql or github/codeql)',
-    placeHolder: "https://github.com/<owner>/<repo> or <owner>/<repo>",
-    ignoreFocusOut: true,
-  });
+  const githubRepo = await askForGitHubRepo(progress);
   if (!githubRepo) {
     return;
   }
@@ -126,6 +116,30 @@ export async function promptImportGithubDatabase(
   }
 
   return;
+}
+
+export async function askForGitHubRepo(
+  progress: ProgressCallback,
+  suggestedValue?: string,
+): Promise<string | undefined> {
+  progress({
+    message: "Choose repository",
+    step: 1,
+    maxStep: 2,
+  });
+
+  const options: InputBoxOptions = {
+    title:
+      'Enter a GitHub repository URL or "name with owner" (e.g. https://github.com/github/codeql or github/codeql)',
+    placeHolder: "https://github.com/<owner>/<repo> or <owner>/<repo>",
+    ignoreFocusOut: true,
+  };
+
+  if (suggestedValue) {
+    options.value = suggestedValue;
+  }
+
+  return await window.showInputBox(options);
 }
 
 /**

--- a/extensions/ql-vscode/src/local-databases.ts
+++ b/extensions/ql-vscode/src/local-databases.ts
@@ -911,6 +911,17 @@ export class DatabaseManager extends DisposableObject {
     return dbs[0];
   }
 
+  public async digForDatabaseWithSameLanguage(
+    language: string,
+  ): Promise<DatabaseItem | undefined> {
+    const dbItems = this.databaseItems || [];
+    const dbs = dbItems.filter((db) => db.language === language);
+    if (dbs.length === 0) {
+      return undefined;
+    }
+    return dbs[0];
+  }
+
   /**
    * Returns the index of the workspace folder that corresponds to the source archive of `item`
    * if there is one, and -1 otherwise.

--- a/extensions/ql-vscode/src/skeleton-query-wizard.ts
+++ b/extensions/ql-vscode/src/skeleton-query-wizard.ts
@@ -208,7 +208,7 @@ export class SkeletonQueryWizard {
 
     const githubRepoNwo = QUERY_LANGUAGE_TO_DATABASE_REPO[this.language];
     const chosenRepo = await databaseFetcher.askForGitHubRepo(
-      this.progress,
+      undefined,
       githubRepoNwo,
     );
 

--- a/extensions/ql-vscode/src/skeleton-query-wizard.ts
+++ b/extensions/ql-vscode/src/skeleton-query-wizard.ts
@@ -207,9 +207,17 @@ export class SkeletonQueryWizard {
     });
 
     const githubRepoNwo = QUERY_LANGUAGE_TO_DATABASE_REPO[this.language];
+    const chosenRepo = await databaseFetcher.askForGitHubRepo(
+      this.progress,
+      githubRepoNwo,
+    );
+
+    if (!chosenRepo) {
+      throw new Error("No GitHub repository provided");
+    }
 
     await databaseFetcher.downloadGitHubDatabase(
-      githubRepoNwo,
+      chosenRepo,
       this.databaseManager,
       this.storagePath,
       this.credentials,

--- a/extensions/ql-vscode/src/skeleton-query-wizard.ts
+++ b/extensions/ql-vscode/src/skeleton-query-wizard.ts
@@ -231,17 +231,30 @@ export class SkeletonQueryWizard {
 
     const databaseNwo = QUERY_LANGUAGE_TO_DATABASE_REPO[this.language];
 
-    const databaseItem = await this.databaseManager.digForDatabaseItem(
+    // Check that we haven't already downloaded a database for this language
+    const existingDatabaseItem = await this.databaseManager.digForDatabaseItem(
       this.language,
       databaseNwo,
     );
 
-    if (databaseItem) {
+    if (existingDatabaseItem) {
       // select the found database
-      await this.databaseManager.setCurrentDatabaseItem(databaseItem);
+      await this.databaseManager.setCurrentDatabaseItem(existingDatabaseItem);
     } else {
-      // download new database and select it
-      await this.downloadDatabase();
+      const sameLanguageDatabaseItem =
+        await this.databaseManager.digForDatabaseWithSameLanguage(
+          this.language,
+        );
+
+      if (sameLanguageDatabaseItem) {
+        // select the found database
+        await this.databaseManager.setCurrentDatabaseItem(
+          sameLanguageDatabaseItem,
+        );
+      } else {
+        // download new database and select it
+        await this.downloadDatabase();
+      }
     }
   }
 }

--- a/extensions/ql-vscode/src/skeleton-query-wizard.ts
+++ b/extensions/ql-vscode/src/skeleton-query-wizard.ts
@@ -9,7 +9,7 @@ import { getErrorMessage } from "./pure/helpers-pure";
 import { QlPackGenerator } from "./qlpack-generator";
 import { DatabaseManager } from "./local-databases";
 import * as databaseFetcher from "./databaseFetcher";
-import { ProgressCallback } from "./progress";
+import { ProgressCallback, UserCancellationException } from "./progress";
 
 type QueryLanguagesToDatabaseMap = Record<string, string>;
 
@@ -213,7 +213,7 @@ export class SkeletonQueryWizard {
     );
 
     if (!chosenRepo) {
-      throw new Error("No GitHub repository provided");
+      throw new UserCancellationException("No GitHub repository provided");
     }
 
     await databaseFetcher.downloadGitHubDatabase(

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/skeleton-query-wizard.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/skeleton-query-wizard.test.ts
@@ -42,6 +42,7 @@ describe("SkeletonQueryWizard", () => {
   const mockDatabaseManager = mockedObject<DatabaseManager>({
     setCurrentDatabaseItem: jest.fn(),
     digForDatabaseItem: jest.fn(),
+    digForDatabaseWithSameLanguage: jest.fn(),
   });
   const mockCli = mockedObject<CodeQLCliServer>({
     resolveLanguages: jest


### PR DESCRIPTION
Please review this PR commit-by-commit. 

Follow up to https://github.com/github/vscode-codeql/pull/2250 where we added a wizard which will guide you through generating an example query based on the language of your choice. 

The wizard would then create a skeleton QL pack and download an appropriate database for you, so that you could focus on just writing your query. 

We've received some feedback on improvements for this flow:
1. If a database using the same language is already downloaded, re-use that database instead of downloading a new one.
2. Show the user a selection box before downloading our suggested database. The selection box will have our suggested database pre-filled but will require the user to press "Ok" to download it. The user can choose to type in a different database instead. 

https://user-images.githubusercontent.com/1354439/229190596-a75f18dd-6ad1-406b-97b5-98f1abdfbb41.mov

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
