### PR TITLE
Add stories for data extension editor

### DIFF
--- a/extensions/ql-vscode/.babelrc.json
+++ b/extensions/ql-vscode/.babelrc.json
@@ -1,0 +1,16 @@
+{
+  "sourceType": "unambiguous",
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "targets": {
+          "chrome": 100
+        }
+      }
+    ],
+    "@babel/preset-typescript",
+    "@babel/preset-react"
+  ],
+  "plugins": []
+}

--- a/extensions/ql-vscode/.storybook/main.ts
+++ b/extensions/ql-vscode/.storybook/main.ts
@@ -12,6 +12,9 @@ const config: StorybookConfig = {
   core: {
     builder: "@storybook/builder-webpack5",
   },
+  features: {
+    babelModeV7: true,
+  },
 };
 
 module.exports = config;

--- a/extensions/ql-vscode/src/stories/data-extensions-editor/DataExtensionsEditor.stories.tsx
+++ b/extensions/ql-vscode/src/stories/data-extensions-editor/DataExtensionsEditor.stories.tsx
@@ -1,0 +1,223 @@
+import * as React from "react";
+
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+
+import { DataExtensionsEditor as DataExtensionsEditorComponent } from "../../view/data-extensions-editor/DataExtensionsEditor";
+
+export default {
+  title: "Data Extensions Editor/Data Extensions Editor",
+  component: DataExtensionsEditorComponent,
+} as ComponentMeta<typeof DataExtensionsEditorComponent>;
+
+const Template: ComponentStory<typeof DataExtensionsEditorComponent> = (
+  args,
+) => <DataExtensionsEditorComponent {...args} />;
+
+export const DataExtensionsEditor = Template.bind({});
+DataExtensionsEditor.args = {
+  initialExternalApiUsages: [
+    {
+      signature: "org.sql2o.Connection#createQuery(String)",
+      packageName: "org.sql2o",
+      typeName: "Connection",
+      methodName: "createQuery",
+      methodParameters: "(String)",
+      supported: true,
+      usages: [
+        {
+          label: "createQuery(...)",
+          url: {
+            uri: "file:/home/runner/work/sql2o-example/sql2o-example/src/main/java/org/example/HelloController.java",
+            startLine: 15,
+            startColumn: 13,
+            endLine: 15,
+            endColumn: 56,
+          },
+        },
+        {
+          label: "createQuery(...)",
+          url: {
+            uri: "file:/home/runner/work/sql2o-example/sql2o-example/src/main/java/org/example/HelloController.java",
+            startLine: 26,
+            startColumn: 13,
+            endLine: 26,
+            endColumn: 39,
+          },
+        },
+      ],
+    },
+    {
+      signature: "org.sql2o.Query#executeScalar(Class)",
+      packageName: "org.sql2o",
+      typeName: "Query",
+      methodName: "executeScalar",
+      methodParameters: "(Class)",
+      supported: true,
+      usages: [
+        {
+          label: "executeScalar(...)",
+          url: {
+            uri: "file:/home/runner/work/sql2o-example/sql2o-example/src/main/java/org/example/HelloController.java",
+            startLine: 15,
+            startColumn: 13,
+            endLine: 15,
+            endColumn: 85,
+          },
+        },
+        {
+          label: "executeScalar(...)",
+          url: {
+            uri: "file:/home/runner/work/sql2o-example/sql2o-example/src/main/java/org/example/HelloController.java",
+            startLine: 26,
+            startColumn: 13,
+            endLine: 26,
+            endColumn: 68,
+          },
+        },
+      ],
+    },
+    {
+      signature: "org.sql2o.Sql2o#open()",
+      packageName: "org.sql2o",
+      typeName: "Sql2o",
+      methodName: "open",
+      methodParameters: "()",
+      supported: false,
+      usages: [
+        {
+          label: "open(...)",
+          url: {
+            uri: "file:/home/runner/work/sql2o-example/sql2o-example/src/main/java/org/example/HelloController.java",
+            startLine: 14,
+            startColumn: 24,
+            endLine: 14,
+            endColumn: 35,
+          },
+        },
+        {
+          label: "open(...)",
+          url: {
+            uri: "file:/home/runner/work/sql2o-example/sql2o-example/src/main/java/org/example/HelloController.java",
+            startLine: 25,
+            startColumn: 24,
+            endLine: 25,
+            endColumn: 35,
+          },
+        },
+      ],
+    },
+    {
+      signature: "java.io.PrintStream#println(String)",
+      packageName: "java.io",
+      typeName: "PrintStream",
+      methodName: "println",
+      methodParameters: "(String)",
+      supported: true,
+      usages: [
+        {
+          label: "println(...)",
+          url: {
+            uri: "file:/home/runner/work/sql2o-example/sql2o-example/src/main/java/org/example/HelloController.java",
+            startLine: 29,
+            startColumn: 9,
+            endLine: 29,
+            endColumn: 49,
+          },
+        },
+      ],
+    },
+    {
+      signature:
+        "org.springframework.boot.SpringApplication#run(Class,String[])",
+      packageName: "org.springframework.boot",
+      typeName: "SpringApplication",
+      methodName: "run",
+      methodParameters: "(Class,String[])",
+      supported: false,
+      usages: [
+        {
+          label: "run(...)",
+          url: {
+            uri: "file:/home/runner/work/sql2o-example/sql2o-example/src/main/java/org/example/Sql2oExampleApplication.java",
+            startLine: 9,
+            startColumn: 9,
+            endLine: 9,
+            endColumn: 66,
+          },
+        },
+      ],
+    },
+    {
+      signature: "org.sql2o.Sql2o#Sql2o(String,String,String)",
+      packageName: "org.sql2o",
+      typeName: "Sql2o",
+      methodName: "Sql2o",
+      methodParameters: "(String,String,String)",
+      supported: false,
+      usages: [
+        {
+          label: "new Sql2o(...)",
+          url: {
+            uri: "file:/home/runner/work/sql2o-example/sql2o-example/src/main/java/org/example/HelloController.java",
+            startLine: 10,
+            startColumn: 33,
+            endLine: 10,
+            endColumn: 88,
+          },
+        },
+      ],
+    },
+    {
+      signature: "org.sql2o.Sql2o#Sql2o(String)",
+      packageName: "org.sql2o",
+      typeName: "Sql2o",
+      methodName: "Sql2o",
+      methodParameters: "(String)",
+      supported: false,
+      usages: [
+        {
+          label: "new Sql2o(...)",
+          url: {
+            uri: "file:/home/runner/work/sql2o-example/sql2o-example/src/main/java/org/example/HelloController.java",
+            startLine: 23,
+            startColumn: 23,
+            endLine: 23,
+            endColumn: 36,
+          },
+        },
+      ],
+    },
+  ],
+  initialModeledMethods: {
+    "org.sql2o.Sql2o#Sql2o(String)": {
+      type: "sink",
+      input: "Argument[0]",
+      output: "",
+      kind: "jndi-injection",
+    },
+    "org.sql2o.Connection#createQuery(String)": {
+      type: "summary",
+      input: "Argument[-1]",
+      output: "ReturnValue",
+      kind: "taint",
+    },
+    "org.sql2o.Sql2o#open()": {
+      type: "summary",
+      input: "Argument[-1]",
+      output: "ReturnValue",
+      kind: "taint",
+    },
+    "org.sql2o.Query#executeScalar(Class)": {
+      type: "neutral",
+      input: "",
+      output: "",
+      kind: "",
+    },
+    "org.sql2o.Sql2o#Sql2o(String,String,String)": {
+      type: "neutral",
+      input: "",
+      output: "",
+      kind: "",
+    },
+  },
+};

--- a/extensions/ql-vscode/src/stories/data-extensions-editor/MethodRow.stories.tsx
+++ b/extensions/ql-vscode/src/stories/data-extensions-editor/MethodRow.stories.tsx
@@ -1,0 +1,54 @@
+import * as React from "react";
+
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+
+import { MethodRow as MethodRowComponent } from "../../view/data-extensions-editor/MethodRow";
+
+export default {
+  title: "Data Extensions Editor/Method Row",
+  component: MethodRowComponent,
+} as ComponentMeta<typeof MethodRowComponent>;
+
+const Template: ComponentStory<typeof MethodRowComponent> = (args) => (
+  <MethodRowComponent {...args} />
+);
+
+export const MethodRow = Template.bind({});
+MethodRow.args = {
+  externalApiUsage: {
+    signature: "org.sql2o.Sql2o#open()",
+    packageName: "org.sql2o",
+    typeName: "Sql2o",
+    methodName: "open",
+    methodParameters: "()",
+    supported: true,
+    usages: [
+      {
+        label: "open(...)",
+        url: {
+          uri: "file:/home/runner/work/sql2o-example/sql2o-example/src/main/java/org/example/HelloController.java",
+          startLine: 14,
+          startColumn: 24,
+          endLine: 14,
+          endColumn: 35,
+        },
+      },
+      {
+        label: "open(...)",
+        url: {
+          uri: "file:/home/runner/work/sql2o-example/sql2o-example/src/main/java/org/example/HelloController.java",
+          startLine: 25,
+          startColumn: 24,
+          endLine: 25,
+          endColumn: 35,
+        },
+      },
+    ],
+  },
+  modeledMethod: {
+    type: "summary",
+    input: "Argument[-1]",
+    output: "ReturnValue",
+    kind: "taint",
+  },
+};

--- a/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
@@ -33,13 +33,21 @@ const ProgressBar = styled.div<ProgressBarProps>`
   background-color: var(--vscode-progressBar-background);
 `;
 
-export function DataExtensionsEditor(): JSX.Element {
+type Props = {
+  initialExternalApiUsages?: ExternalApiUsage[];
+  initialModeledMethods?: Record<string, ModeledMethod>;
+};
+
+export function DataExtensionsEditor({
+  initialExternalApiUsages = [],
+  initialModeledMethods = {},
+}: Props): JSX.Element {
   const [externalApiUsages, setExternalApiUsages] = useState<
     ExternalApiUsage[]
-  >([]);
+  >(initialExternalApiUsages);
   const [modeledMethods, setModeledMethods] = useState<
     Record<string, ModeledMethod>
-  >({});
+  >(initialModeledMethods);
   const [progress, setProgress] = useState<Omit<ShowProgressMessage, "t">>({
     step: 0,
     maxStep: 0,


### PR DESCRIPTION
This adds stories for the two components included in the data extensions editor. This is dependent on #2257 and on #2258.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
