### PR TITLE
Repo States: Extract read/write methods to repo states store

### DIFF
--- a/extensions/ql-vscode/src/variant-analysis/store/repo-states-store.ts
+++ b/extensions/ql-vscode/src/variant-analysis/store/repo-states-store.ts
@@ -1,0 +1,17 @@
+import { outputJson, readJson } from "fs-extra";
+import { VariantAnalysisScannedRepositoryState } from "../shared/variant-analysis";
+
+export const REPO_STATES_FILENAME = "repo_states.json";
+
+export async function writeRepoStates(
+  storagePath: string,
+  repoStates: Record<number, VariantAnalysisScannedRepositoryState> | undefined,
+): Promise<void> {
+  return await outputJson(storagePath, repoStates);
+}
+
+export async function readRepoStates(
+  storagePath: string,
+): Promise<Record<number, VariantAnalysisScannedRepositoryState>> {
+  return await readJson(storagePath);
+}

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -47,7 +47,7 @@ import {
   showAndLogInformationMessage,
   showAndLogWarningMessage,
 } from "../helpers";
-import { readFile, readJson, remove, pathExists, outputJson } from "fs-extra";
+import { readFile, remove, pathExists } from "fs-extra";
 import { EOL } from "os";
 import { cancelVariantAnalysis } from "./gh-api/gh-actions-api-client";
 import {
@@ -67,12 +67,16 @@ import { App } from "../common/app";
 import { redactableError } from "../pure/errors";
 import { AppCommandManager, VariantAnalysisCommands } from "../common/commands";
 import { exportVariantAnalysisResults } from "./export-results";
+import {
+  readRepoStates,
+  REPO_STATES_FILENAME,
+  writeRepoStates,
+} from "./store/repo-states-store";
 
 export class VariantAnalysisManager
   extends DisposableObject
   implements VariantAnalysisViewManager<VariantAnalysisView>
 {
-  private static readonly REPO_STATES_FILENAME = "repo_states.json";
   private static readonly DOWNLOAD_PERCENTAGE_UPDATE_DELAY_MS = 500;
 
   private readonly _onVariantAnalysisAdded = this.push(
@@ -258,7 +262,7 @@ export class VariantAnalysisManager
       await this.setVariantAnalysis(variantAnalysis);
 
       try {
-        const repoStates = await readJson(
+        const repoStates = await readRepoStates(
           this.getRepoStatesStoragePath(variantAnalysis.id),
         );
         this.repoStates.set(variantAnalysis.id, repoStates);
@@ -591,7 +595,7 @@ export class VariantAnalysisManager
       VariantAnalysisScannedRepositoryDownloadStatus.Succeeded;
     await this.onRepoStateUpdated(variantAnalysis.id, repoState);
 
-    await outputJson(
+    await writeRepoStates(
       this.getRepoStatesStoragePath(variantAnalysis.id),
       this.repoStates.get(variantAnalysis.id),
     );
@@ -696,7 +700,7 @@ export class VariantAnalysisManager
   private getRepoStatesStoragePath(variantAnalysisId: number): string {
     return join(
       this.getVariantAnalysisStorageLocation(variantAnalysisId),
-      VariantAnalysisManager.REPO_STATES_FILENAME,
+      REPO_STATES_FILENAME,
     );
   }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

This is a first step to separate the repo-states domain and data model. This PR creates a new repo-states store that hosts the read- and write methods.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
