### PR TITLE
Add empty data extension editor view

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,4 @@
 **/* @github/codeql-vscode-reviewers
 **/variant-analysis/ @github/code-scanning-secexp-reviewers
 **/databases/ @github/code-scanning-secexp-reviewers
+**/data-extensions-editor/ @github/code-scanning-secexp-reviewers

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -704,6 +704,10 @@
         "enablement": "codeql.hasQLSource"
       },
       {
+        "command": "codeQL.openDataExtensionsEditor",
+        "title": "CodeQL: Open Data Extensions Editor"
+      },
+      {
         "command": "codeQL.mockGitHubApiServer.startRecording",
         "title": "CodeQL: Mock GitHub API Server: Start Scenario Recording"
       },
@@ -1085,6 +1089,10 @@
         {
           "command": "codeQL.viewCfgContextEditor",
           "when": "false"
+        },
+        {
+          "command": "codeQL.openDataExtensionsEditor",
+          "when": "config.codeQL.canary && config.codeQL.dataExtensions.editor"
         },
         {
           "command": "codeQLVariantAnalysisRepositories.openConfigFile",

--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -241,6 +241,10 @@ export type PackagingCommands = {
   "codeQL.downloadPacks": () => Promise<void>;
 };
 
+export type DataExtensionsEditorCommands = {
+  "codeQL.openDataExtensionsEditor": () => Promise<void>;
+};
+
 export type EvalLogViewerCommands = {
   "codeQLEvalLogViewer.clear": () => Promise<void>;
 };
@@ -273,6 +277,7 @@ export type AllExtensionCommands = BaseCommands &
   AstCfgCommands &
   AstViewerCommands &
   PackagingCommands &
+  DataExtensionsEditorCommands &
   EvalLogViewerCommands &
   SummaryLanguageSupportCommands &
   Partial<TestUICommands> &

--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-module.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-module.ts
@@ -1,0 +1,16 @@
+import { ExtensionContext } from "vscode";
+import { DataExtensionsEditorView } from "./data-extensions-editor-view";
+import { DataExtensionsEditorCommands } from "../common/commands";
+
+export class DataExtensionsEditorModule {
+  public constructor(private readonly ctx: ExtensionContext) {}
+
+  public getCommands(): DataExtensionsEditorCommands {
+    return {
+      "codeQL.openDataExtensionsEditor": async () => {
+        const view = new DataExtensionsEditorView(this.ctx);
+        await view.openView();
+      },
+    };
+  }
+}

--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
@@ -1,0 +1,53 @@
+import { ExtensionContext, ViewColumn } from "vscode";
+import { AbstractWebview, WebviewPanelConfig } from "../abstract-webview";
+import {
+  FromDataExtensionsEditorMessage,
+  ToDataExtensionsEditorMessage,
+} from "../pure/interface-types";
+
+export class DataExtensionsEditorView extends AbstractWebview<
+  ToDataExtensionsEditorMessage,
+  FromDataExtensionsEditorMessage
+> {
+  public constructor(ctx: ExtensionContext) {
+    super(ctx);
+  }
+
+  public async openView() {
+    const panel = await this.getPanel();
+    panel.reveal(undefined, true);
+
+    await this.waitForPanelLoaded();
+  }
+
+  protected async getPanelConfig(): Promise<WebviewPanelConfig> {
+    return {
+      viewId: "data-extensions-editor",
+      title: "Data Extensions Editor",
+      viewColumn: ViewColumn.Active,
+      preserveFocus: true,
+      view: "data-extensions-editor",
+    };
+  }
+
+  protected onPanelDispose(): void {
+    // Nothing to do here
+  }
+
+  protected async onMessage(
+    msg: FromDataExtensionsEditorMessage,
+  ): Promise<void> {
+    switch (msg.t) {
+      case "viewLoaded":
+        await this.onWebViewLoaded();
+
+        break;
+      default:
+        throw new Error("Unexpected message type");
+    }
+  }
+
+  protected async onWebViewLoaded() {
+    super.onWebViewLoaded();
+  }
+}

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -120,6 +120,7 @@ import { getAstCfgCommands } from "./ast-cfg-commands";
 import { getQueryEditorCommands } from "./query-editor";
 import { App } from "./common/app";
 import { registerCommandWithErrorHandling } from "./common/vscode/commands";
+import { DataExtensionsEditorModule } from "./data-extensions-editor/data-extensions-editor-module";
 
 /**
  * extension.ts
@@ -860,6 +861,8 @@ async function activateWithInstalledDistribution(
   );
   ctx.subscriptions.push(localQueries);
 
+  const dataExtensionsEditorModule = new DataExtensionsEditorModule(ctx);
+
   void extLogger.log("Initializing QLTest interface.");
   const testExplorerExtension = extensions.getExtension<TestHub>(
     testExplorerExtensionId,
@@ -922,6 +925,7 @@ async function activateWithInstalledDistribution(
     ...getPackagingCommands({
       cliServer,
     }),
+    ...dataExtensionsEditorModule.getCommands(),
     ...evalLogViewer.getCommands(),
     ...summaryLanguageSupport.getCommands(),
     ...testUiCommands,

--- a/extensions/ql-vscode/src/interface-utils.ts
+++ b/extensions/ql-vscode/src/interface-utils.ts
@@ -113,7 +113,8 @@ export type WebviewView =
   | "results"
   | "compare"
   | "variant-analysis"
-  | "data-flow-paths";
+  | "data-flow-paths"
+  | "data-extensions-editor";
 
 export interface WebviewMessage {
   t: string;

--- a/extensions/ql-vscode/src/pure/interface-types.ts
+++ b/extensions/ql-vscode/src/pure/interface-types.ts
@@ -478,3 +478,7 @@ export interface SetDataFlowPathsMessage {
 export type ToDataFlowPathsMessage = SetDataFlowPathsMessage;
 
 export type FromDataFlowPathsMessage = CommonFromViewMessages;
+
+export type ToDataExtensionsEditorMessage = never;
+
+export type FromDataExtensionsEditorMessage = ViewLoadedMsg;

--- a/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
@@ -1,0 +1,5 @@
+import * as React from "react";
+
+export function DataExtensionsEditor(): JSX.Element {
+  return <div>Data extensions editor</div>;
+}

--- a/extensions/ql-vscode/src/view/data-extensions-editor/index.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/index.tsx
@@ -1,0 +1,9 @@
+import * as React from "react";
+import { WebviewDefinition } from "../webview-definition";
+import { DataExtensionsEditor } from "./DataExtensionsEditor";
+
+const definition: WebviewDefinition = {
+  component: <DataExtensionsEditor />,
+};
+
+export default definition;

--- a/extensions/ql-vscode/src/view/vscode-api.ts
+++ b/extensions/ql-vscode/src/view/vscode-api.ts
@@ -1,5 +1,6 @@
 import {
   FromCompareViewMessage,
+  FromDataExtensionsEditorMessage,
   FromResultsViewMsg,
   FromVariantAnalysisMessage,
   VariantAnalysisState,
@@ -13,7 +14,8 @@ export interface VsCodeApi {
     msg:
       | FromResultsViewMsg
       | FromCompareViewMessage
-      | FromVariantAnalysisMessage,
+      | FromVariantAnalysisMessage
+      | FromDataExtensionsEditorMessage,
   ): void;
 
   /**


### PR DESCRIPTION
This adds an empty data extension editor view which is only available behind the `codeQL.dataExtensions.editor` and `codeQL.canary` settings.

This is a split-up from #2257.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
