### PR TITLE
Split up codeQL.restartQueryServer command

### DIFF
--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -69,6 +69,8 @@ export type BaseCommands = {
 
   "codeQL.copyVersion": () => Promise<void>;
   "codeQL.restartQueryServer": () => Promise<void>;
+  "codeQL.restartQueryServerOnConfigChange": () => Promise<void>;
+  "codeQL.restartLegacyQueryServerOnConfigChange": () => Promise<void>;
 };
 
 // Commands used when working with queries in the editor

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -169,27 +169,31 @@ function getCommands(
     }
   };
 
+  const restartQueryServer = async () =>
+    withProgress(
+      async (progress: ProgressCallback, token: CancellationToken) => {
+        // Restart all of the spawned servers: cli, query, and language.
+        cliServer.restartCliServer();
+        await Promise.all([
+          queryRunner.restartQueryServer(progress, token),
+          ideServer.restart(),
+        ]);
+        void showAndLogInformationMessage("CodeQL Query Server restarted.", {
+          outputLogger: queryServerLogger,
+        });
+      },
+      {
+        title: "Restarting Query Server",
+      },
+    );
+
   return {
     "codeQL.openDocumentation": async () => {
       await env.openExternal(Uri.parse("https://codeql.github.com/docs/"));
     },
-    "codeQL.restartQueryServer": async () =>
-      withProgress(
-        async (progress: ProgressCallback, token: CancellationToken) => {
-          // Restart all of the spawned servers: cli, query, and language.
-          cliServer.restartCliServer();
-          await Promise.all([
-            queryRunner.restartQueryServer(progress, token),
-            ideServer.restart(),
-          ]);
-          void showAndLogInformationMessage("CodeQL Query Server restarted.", {
-            outputLogger: queryServerLogger,
-          });
-        },
-        {
-          title: "Restarting Query Server",
-        },
-      ),
+    "codeQL.restartQueryServer": restartQueryServer,
+    "codeQL.restartQueryServerOnConfigChange": restartQueryServer,
+    "codeQL.restartLegacyQueryServerOnConfigChange": restartQueryServer,
     "codeQL.copyVersion": async () => {
       const text = `CodeQL extension version: ${
         extension?.packageJSON.version

--- a/extensions/ql-vscode/src/legacy-query-server/queryserver-client.ts
+++ b/extensions/ql-vscode/src/legacy-query-server/queryserver-client.ts
@@ -71,7 +71,7 @@ export class QueryServerClient extends DisposableObject {
     if (config.onDidChangeConfiguration !== undefined) {
       this.push(
         config.onDidChangeConfiguration(() =>
-          app.commands.execute("codeQL.restartQueryServer"),
+          app.commands.execute("codeQL.restartLegacyQueryServerOnConfigChange"),
         ),
       );
     }

--- a/extensions/ql-vscode/src/query-server/queryserver-client.ts
+++ b/extensions/ql-vscode/src/query-server/queryserver-client.ts
@@ -68,7 +68,7 @@ export class QueryServerClient extends DisposableObject {
     if (config.onDidChangeConfiguration !== undefined) {
       this.push(
         config.onDidChangeConfiguration(() =>
-          app.commands.execute("codeQL.restartQueryServer"),
+          app.commands.execute("codeQL.restartQueryServerOnConfigChange"),
         ),
       );
     }


### PR DESCRIPTION
Splits up the `codeQL.restartQueryServer` command into three commands, so we avoid calling each one from more than one code or user-triggered location. This will allow us to differentiate command usages in our telemetry.

The original `codeQL.restartQueryServer` command is defined in `package.json` and is available in the command palette. I believe we don't need to add either of the two new versions there, because we don't want them to be accessible to the user.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
