### PR TITLE
Repo task:  new data model and mapping

### DIFF
--- a/extensions/ql-vscode/src/variant-analysis/store/repo-states-store.ts
+++ b/extensions/ql-vscode/src/variant-analysis/store/repo-states-store.ts
@@ -17,7 +17,7 @@ export async function writeRepoStates(
     }),
   );
 
-  return await outputJson(storagePath, repoStatesData);
+  await outputJson(storagePath, repoStatesData);
 }
 
 export async function readRepoStates(

--- a/extensions/ql-vscode/src/variant-analysis/store/repo-task-data-types.ts
+++ b/extensions/ql-vscode/src/variant-analysis/store/repo-task-data-types.ts
@@ -1,0 +1,25 @@
+export interface VariantAnalysisRepositoryTaskData {
+  repository: RepositoryData;
+  analysisStatus: VariantAnalysisRepoStatusData;
+  resultCount?: number;
+  artifactSizeInBytes?: number;
+  failureMessage?: string;
+  databaseCommitSha?: string;
+  sourceLocationPrefix?: string;
+  artifactUrl?: string;
+}
+
+interface RepositoryData {
+  id: number;
+  fullName: string;
+  private: boolean;
+}
+
+export enum VariantAnalysisRepoStatusData {
+  Pending = "pending",
+  InProgress = "inProgress",
+  Succeeded = "succeeded",
+  Failed = "failed",
+  Canceled = "canceled",
+  TimedOut = "timedOut",
+}

--- a/extensions/ql-vscode/src/variant-analysis/store/repo-task-store.ts
+++ b/extensions/ql-vscode/src/variant-analysis/store/repo-task-store.ts
@@ -1,18 +1,27 @@
 import { outputJson, readJson } from "fs-extra";
 import { join } from "path";
 import { VariantAnalysisRepositoryTask } from "../shared/variant-analysis";
+import { mapRepoTaskToData } from "./repo-task-to-data-mapper";
+import { mapRepoTaskToDomain } from "./repo-task-to-domain-mapper";
 
 export const REPO_TASK_FILENAME = "repo_task.json";
 
-export function writeRepoTask(
+export async function writeRepoTask(
   storageDirectory: string,
   repoTask: VariantAnalysisRepositoryTask,
 ): Promise<void> {
-  return outputJson(join(storageDirectory, REPO_TASK_FILENAME), repoTask);
+  const repoTaskData = mapRepoTaskToData(repoTask);
+  return await outputJson(
+    join(storageDirectory, REPO_TASK_FILENAME),
+    repoTaskData,
+  );
 }
 
-export function readRepoTask(
+export async function readRepoTask(
   storageDirectory: string,
 ): Promise<VariantAnalysisRepositoryTask> {
-  return readJson(join(storageDirectory, REPO_TASK_FILENAME));
+  const repoTaskData = await readJson(
+    join(storageDirectory, REPO_TASK_FILENAME),
+  );
+  return mapRepoTaskToDomain(repoTaskData);
 }

--- a/extensions/ql-vscode/src/variant-analysis/store/repo-task-store.ts
+++ b/extensions/ql-vscode/src/variant-analysis/store/repo-task-store.ts
@@ -11,10 +11,7 @@ export async function writeRepoTask(
   repoTask: VariantAnalysisRepositoryTask,
 ): Promise<void> {
   const repoTaskData = mapRepoTaskToData(repoTask);
-  return await outputJson(
-    join(storageDirectory, REPO_TASK_FILENAME),
-    repoTaskData,
-  );
+  await outputJson(join(storageDirectory, REPO_TASK_FILENAME), repoTaskData);
 }
 
 export async function readRepoTask(

--- a/extensions/ql-vscode/src/variant-analysis/store/repo-task-store.ts
+++ b/extensions/ql-vscode/src/variant-analysis/store/repo-task-store.ts
@@ -1,0 +1,18 @@
+import { outputJson, readJson } from "fs-extra";
+import { join } from "path";
+import { VariantAnalysisRepositoryTask } from "../shared/variant-analysis";
+
+export const REPO_TASK_FILENAME = "repo_task.json";
+
+export function writeRepoTask(
+  storageDirectory: string,
+  repoTask: VariantAnalysisRepositoryTask,
+): Promise<void> {
+  return outputJson(join(storageDirectory, REPO_TASK_FILENAME), repoTask);
+}
+
+export function readRepoTask(
+  storageDirectory: string,
+): Promise<VariantAnalysisRepositoryTask> {
+  return readJson(join(storageDirectory, REPO_TASK_FILENAME));
+}

--- a/extensions/ql-vscode/src/variant-analysis/store/repo-task-to-data-mapper.ts
+++ b/extensions/ql-vscode/src/variant-analysis/store/repo-task-to-data-mapper.ts
@@ -1,0 +1,49 @@
+import { assertNever } from "../../pure/helpers-pure";
+import {
+  VariantAnalysisRepositoryTask,
+  VariantAnalysisRepoStatus,
+} from "../shared/variant-analysis";
+import {
+  VariantAnalysisRepositoryTaskData,
+  VariantAnalysisRepoStatusData,
+} from "./repo-task-data-types";
+
+export function mapRepoTaskToData(
+  repoTask: VariantAnalysisRepositoryTask,
+): VariantAnalysisRepositoryTaskData {
+  return {
+    repository: {
+      id: repoTask.repository.id,
+      fullName: repoTask.repository.fullName,
+      private: repoTask.repository.private,
+    },
+    analysisStatus: mapRepoTaskAnalysisStatusToData(repoTask.analysisStatus),
+    resultCount: repoTask.resultCount,
+    artifactSizeInBytes: repoTask.artifactSizeInBytes,
+    failureMessage: repoTask.failureMessage,
+    databaseCommitSha: repoTask.databaseCommitSha,
+    sourceLocationPrefix: repoTask.sourceLocationPrefix,
+    artifactUrl: repoTask.artifactUrl,
+  };
+}
+
+function mapRepoTaskAnalysisStatusToData(
+  analysisStatus: VariantAnalysisRepoStatus,
+): VariantAnalysisRepoStatusData {
+  switch (analysisStatus) {
+    case VariantAnalysisRepoStatus.Pending:
+      return VariantAnalysisRepoStatusData.Pending;
+    case VariantAnalysisRepoStatus.InProgress:
+      return VariantAnalysisRepoStatusData.InProgress;
+    case VariantAnalysisRepoStatus.Succeeded:
+      return VariantAnalysisRepoStatusData.Succeeded;
+    case VariantAnalysisRepoStatus.Failed:
+      return VariantAnalysisRepoStatusData.Failed;
+    case VariantAnalysisRepoStatus.Canceled:
+      return VariantAnalysisRepoStatusData.Canceled;
+    case VariantAnalysisRepoStatus.TimedOut:
+      return VariantAnalysisRepoStatusData.TimedOut;
+    default:
+      assertNever(analysisStatus);
+  }
+}

--- a/extensions/ql-vscode/src/variant-analysis/store/repo-task-to-domain-mapper.ts
+++ b/extensions/ql-vscode/src/variant-analysis/store/repo-task-to-domain-mapper.ts
@@ -1,0 +1,49 @@
+import { assertNever } from "../../pure/helpers-pure";
+import {
+  VariantAnalysisRepositoryTask,
+  VariantAnalysisRepoStatus,
+} from "../shared/variant-analysis";
+import {
+  VariantAnalysisRepositoryTaskData,
+  VariantAnalysisRepoStatusData,
+} from "./repo-task-data-types";
+
+export function mapRepoTaskToDomain(
+  repoTask: VariantAnalysisRepositoryTaskData,
+): VariantAnalysisRepositoryTask {
+  return {
+    repository: {
+      id: repoTask.repository.id,
+      fullName: repoTask.repository.fullName,
+      private: repoTask.repository.private,
+    },
+    analysisStatus: mapRepoTaskAnalysisStatusToDomain(repoTask.analysisStatus),
+    resultCount: repoTask.resultCount,
+    artifactSizeInBytes: repoTask.artifactSizeInBytes,
+    failureMessage: repoTask.failureMessage,
+    databaseCommitSha: repoTask.databaseCommitSha,
+    sourceLocationPrefix: repoTask.sourceLocationPrefix,
+    artifactUrl: repoTask.artifactUrl,
+  };
+}
+
+function mapRepoTaskAnalysisStatusToDomain(
+  analysisStatus: VariantAnalysisRepoStatusData,
+): VariantAnalysisRepoStatus {
+  switch (analysisStatus) {
+    case VariantAnalysisRepoStatusData.Pending:
+      return VariantAnalysisRepoStatus.Pending;
+    case VariantAnalysisRepoStatusData.InProgress:
+      return VariantAnalysisRepoStatus.InProgress;
+    case VariantAnalysisRepoStatusData.Succeeded:
+      return VariantAnalysisRepoStatus.Succeeded;
+    case VariantAnalysisRepoStatusData.Failed:
+      return VariantAnalysisRepoStatus.Failed;
+    case VariantAnalysisRepoStatusData.Canceled:
+      return VariantAnalysisRepoStatus.Canceled;
+    case VariantAnalysisRepoStatusData.TimedOut:
+      return VariantAnalysisRepoStatus.TimedOut;
+    default:
+      assertNever(analysisStatus);
+  }
+}

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-results-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-results-manager.ts
@@ -1,4 +1,4 @@
-import { appendFile, pathExists, mkdir } from "fs-extra";
+import { appendFile, pathExists } from "fs-extra";
 import fetch from "node-fetch";
 import { EOL } from "os";
 import { join } from "path";
@@ -77,10 +77,6 @@ export class VariantAnalysisResultsManager extends DisposableObject {
       variantAnalysisStoragePath,
       repoTask.repository.fullName,
     );
-
-    if (!(await pathExists(resultDirectory))) {
-      await mkdir(resultDirectory, { recursive: true });
-    }
 
     await writeRepoTask(resultDirectory, repoTask);
 

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-results-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-results-manager.ts
@@ -1,4 +1,4 @@
-import { appendFile, pathExists, mkdir, outputJson, readJson } from "fs-extra";
+import { appendFile, pathExists, mkdir } from "fs-extra";
 import fetch from "node-fetch";
 import { EOL } from "os";
 import { join } from "path";
@@ -17,6 +17,7 @@ import {
 import { DisposableObject, DisposeHandler } from "../pure/disposable-object";
 import { EventEmitter } from "vscode";
 import { unzipFile } from "../pure/zip";
+import { readRepoTask, writeRepoTask } from "./store/repo-task-store";
 
 type CacheKey = `${number}/${string}`;
 
@@ -37,7 +38,6 @@ export type LoadResultsOptions = {
 };
 
 export class VariantAnalysisResultsManager extends DisposableObject {
-  private static readonly REPO_TASK_FILENAME = "repo_task.json";
   private static readonly RESULTS_DIRECTORY = "results";
 
   private readonly cachedResults: Map<
@@ -82,10 +82,7 @@ export class VariantAnalysisResultsManager extends DisposableObject {
       await mkdir(resultDirectory, { recursive: true });
     }
 
-    await outputJson(
-      join(resultDirectory, VariantAnalysisResultsManager.REPO_TASK_FILENAME),
-      repoTask,
-    );
+    await writeRepoTask(resultDirectory, repoTask);
 
     const zipFilePath = join(resultDirectory, "results.zip");
 
@@ -184,8 +181,8 @@ export class VariantAnalysisResultsManager extends DisposableObject {
       repositoryFullName,
     );
 
-    const repoTask: VariantAnalysisRepositoryTask = await readJson(
-      join(storageDirectory, VariantAnalysisResultsManager.REPO_TASK_FILENAME),
+    const repoTask: VariantAnalysisRepositoryTask = await readRepoTask(
+      storageDirectory,
     );
 
     if (!repoTask.databaseCommitSha || !repoTask.sourceLocationPrefix) {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

This PR introduces new data types for storing the repo task and uses them to map between data and domain model.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
