### PR TITLE
Restart query server when external config changes

### DIFF
--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -71,6 +71,7 @@ export type BaseCommands = {
   "codeQL.restartQueryServer": () => Promise<void>;
   "codeQL.restartQueryServerOnConfigChange": () => Promise<void>;
   "codeQL.restartLegacyQueryServerOnConfigChange": () => Promise<void>;
+  "codeQL.restartQueryServerOnExternalConfigChange": () => Promise<void>;
 };
 
 // Commands used when working with queries in the editor

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -19,6 +19,7 @@ import { join } from "path";
 import { dirSync } from "tmp-promise";
 import { testExplorerExtensionId, TestHub } from "vscode-test-adapter-api";
 import { lt, parse } from "semver";
+import { watch } from "chokidar";
 
 import { AstViewer } from "./astViewer";
 import {
@@ -194,6 +195,7 @@ function getCommands(
     "codeQL.restartQueryServer": restartQueryServer,
     "codeQL.restartQueryServerOnConfigChange": restartQueryServer,
     "codeQL.restartLegacyQueryServerOnConfigChange": restartQueryServer,
+    "codeQL.restartQueryServerOnExternalConfigChange": restartQueryServer,
     "codeQL.copyVersion": async () => {
       const text = `CodeQL extension version: ${
         extension?.packageJSON.version
@@ -672,6 +674,7 @@ async function activateWithInstalledDistribution(
     extLogger,
   );
   ctx.subscriptions.push(cliServer);
+  watchExternalConfigFile(app, ctx);
 
   const statusBar = new CodeQlStatusBarHandler(
     cliServer,
@@ -1008,6 +1011,33 @@ async function activateWithInstalledDistribution(
       ctx.subscriptions.forEach((d) => d.dispose());
     },
   };
+}
+
+/**
+ * Handle changes to the external config file. This is used to restart the query server
+ * when the user changes options.
+ * See https://docs.github.com/en/code-security/codeql-cli/using-the-codeql-cli/specifying-command-options-in-a-codeql-configuration-file#using-a-codeql-configuration-file
+ */
+function watchExternalConfigFile(app: ExtensionApp, ctx: ExtensionContext) {
+  if (process.env.HOME) {
+    const configPath = join(process.env.HOME, ".config/codeql", "config");
+    const configWatcher = watch(configPath, {
+      // These options avoid firing the event twice.
+      persistent: true,
+      ignoreInitial: true,
+      awaitWriteFinish: true,
+    });
+    configWatcher.on("all", async () => {
+      await app.commands.execute(
+        "codeQL.restartQueryServerOnExternalConfigChange",
+      );
+    });
+    ctx.subscriptions.push({
+      dispose: () => {
+        void configWatcher.close();
+      },
+    });
+  }
 }
 
 async function showResultsForComparison(


### PR DESCRIPTION
This avoids manually restarting the query server when this file changes.

Fixes https://github.com/github/vscode-codeql/issues/1141

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Replace this with a description of the changes your pull request makes.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
