### PR TITLE
Use data extensions for finding external API calls

### DIFF
--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-module.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-module.ts
@@ -1,13 +1,13 @@
 import { ExtensionContext } from "vscode";
 import { DataExtensionsEditorView } from "./data-extensions-editor-view";
 import { DataExtensionsEditorCommands } from "../common/commands";
-import { CodeQLCliServer } from "../cli";
+import { CliVersionConstraint, CodeQLCliServer } from "../cli";
 import { QueryRunner } from "../queryRunner";
 import { DatabaseManager } from "../local-databases";
-import { extLogger } from "../common";
 import { ensureDir } from "fs-extra";
 import { join } from "path";
 import { App } from "../common/app";
+import { showAndLogErrorMessage } from "../helpers";
 
 export class DataExtensionsEditorModule {
   private readonly queryStorageDir: string;
@@ -52,7 +52,14 @@ export class DataExtensionsEditorModule {
       "codeQL.openDataExtensionsEditor": async () => {
         const db = this.databaseManager.currentDatabaseItem;
         if (!db) {
-          void extLogger.log("No database selected");
+          void showAndLogErrorMessage("No database selected");
+          return;
+        }
+
+        if (!(await this.cliServer.cliConstraints.supportsQlpacksKind())) {
+          void showAndLogErrorMessage(
+            `This feature requires CodeQL CLI version ${CliVersionConstraint.CLI_VERSION_WITH_QLPACKS_KIND.format()} or later.`,
+          );
           return;
         }
 

--- a/extensions/ql-vscode/src/data-extensions-editor/external-api-usage-query.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/external-api-usage-query.ts
@@ -54,6 +54,11 @@ export async function runQuery({
   }
   await writeFile(suiteFile, dumpYaml(suiteYaml), "utf8");
 
+  const additionalPacks = getOnDiskWorkspaceFolders();
+  const extensionPacks = Object.keys(
+    await cliServer.resolveQlpacks(additionalPacks, true),
+  );
+
   const queries = await cliServer.resolveQueriesInSuite(
     suiteFile,
     getOnDiskWorkspaceFolders(),
@@ -71,7 +76,7 @@ export async function runQuery({
     { queryPath: query, quickEvalPosition: undefined },
     false,
     getOnDiskWorkspaceFolders(),
-    undefined,
+    extensionPacks,
     queryStorageDir,
     undefined,
     undefined,

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/data-extensions-editor/external-api-usage-query.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/data-extensions-editor/external-api-usage-query.test.ts
@@ -36,11 +36,9 @@ describe("runQuery", () => {
 
     const options = {
       cliServer: {
-        resolveQlpacks: jest
-          .fn()
-          .mockRejectedValue(
-            new Error("Did not expect mocked method to be called"),
-          ),
+        resolveQlpacks: jest.fn().mockResolvedValue({
+          "my/java-extensions": "/a/b/c/",
+        }),
         resolveQueriesInSuite: jest
           .fn()
           .mockResolvedValue([
@@ -103,6 +101,8 @@ describe("runQuery", () => {
       },
     ]);
 
+    expect(options.cliServer.resolveQlpacks).toHaveBeenCalledTimes(1);
+    expect(options.cliServer.resolveQlpacks).toHaveBeenCalledWith([], true);
     expect(options.queryRunner.createQueryRun).toHaveBeenCalledWith(
       "/a/b/c/src.zip",
       {
@@ -112,7 +112,7 @@ describe("runQuery", () => {
       },
       false,
       [],
-      undefined,
+      ["my/java-extensions"],
       "/tmp/queries",
       undefined,
       undefined,
@@ -120,7 +120,7 @@ describe("runQuery", () => {
   });
 });
 
-describe("getResults", () => {
+describe("readQueryResults", () => {
   const options = {
     cliServer: {
       bqrsInfo: jest.fn(),


### PR DESCRIPTION
The data extension editor was only using the default data extensions found in the `ql` submodule to find external API calls. This will add support for using data extensions found in the workspace.

Rather than using the `codeQL.runningQueries.useExtensionPacks` setting, this will always include data extensions since the editor doesn't make sense to use without data extensions. We will also forbid the user from opening this view unless they are using a CLI which supports data extension packs.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
