### PR TITLE
Don't rate limit if no CLI is installed

### DIFF
--- a/extensions/ql-vscode/src/distribution.ts
+++ b/extensions/ql-vscode/src/distribution.ts
@@ -215,6 +215,9 @@ export class DistributionManager implements DistributionProvider {
     minSecondsSinceLastUpdateCheck: number,
   ): Promise<DistributionUpdateCheckResult> {
     const distribution = await this.getDistributionWithoutVersionCheck();
+    if (distribution === undefined) {
+      minSecondsSinceLastUpdateCheck = 0;
+    }
     const extensionManagedCodeQlPath =
       await this.extensionSpecificDistributionManager.getCodeQlPathWithoutVersionCheck();
     if (distribution?.codeQlPath !== extensionManagedCodeQlPath) {


### PR DESCRIPTION
This PR helps to avoid a specific case where your managed CodeQL CLI gets uninstalled (not sure how, but it can happen during extension upgrades) and then the extension refuses to install a new one because it tried that within the last 24 hours. This PR makes it so that if no CLI is installed then it'll always try installing one.

I'm able to reproduce the bug easily by adding a simple "removeDatabase" command. I didn't include it in this screenshot but the extension fails to load and you're totally stuck.
<img width="1213" alt="Screenshot 2023-04-11 at 12 41 19" src="https://github.com/github/code-scanning/assets/3749000/11ffe050-eed3-4ef4-9397-10d656e0d8f6">

With this PR it always installs the CLI if it couldn't find one.
<img width="972" alt="Screenshot 2023-04-11 at 12 44 15" src="https://github.com/github/code-scanning/assets/3749000/c1bddcca-d93b-401b-b66d-cd4d86dabf68">

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
