### PR TITLE
Fix problem with detecting storage folder on windows 

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -862,7 +862,6 @@ async function activateWithInstalledDistribution(
     databaseUI,
     localQueryResultsView,
     queryStorageDir,
-    ctx,
   );
   ctx.subscriptions.push(localQueries);
 

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -862,6 +862,7 @@ async function activateWithInstalledDistribution(
     databaseUI,
     localQueryResultsView,
     queryStorageDir,
+    ctx,
   );
   ctx.subscriptions.push(localQueries);
 

--- a/extensions/ql-vscode/src/local-queries.ts
+++ b/extensions/ql-vscode/src/local-queries.ts
@@ -2,6 +2,7 @@ import { ProgressCallback, ProgressUpdate, withProgress } from "./progress";
 import {
   CancellationToken,
   CancellationTokenSource,
+  ExtensionContext,
   QuickPickItem,
   Range,
   Uri,
@@ -221,6 +222,7 @@ export class LocalQueries extends DisposableObject {
     private readonly databaseUI: DatabaseUI,
     private readonly localQueryResultsView: ResultsView,
     private readonly queryStorageDir: string,
+    private readonly ctx: ExtensionContext,
   ) {
     super();
   }
@@ -381,6 +383,8 @@ export class LocalQueries extends DisposableObject {
     await withProgress(
       async (progress: ProgressCallback, token: CancellationToken) => {
         const credentials = isCanary() ? this.app.credentials : undefined;
+        const contextStoragePath =
+          this.ctx.storageUri?.fsPath || this.ctx.globalStorageUri.fsPath;
         const skeletonQueryWizard = new SkeletonQueryWizard(
           this.cliServer,
           progress,
@@ -388,6 +392,7 @@ export class LocalQueries extends DisposableObject {
           extLogger,
           this.databaseManager,
           token,
+          contextStoragePath,
         );
         await skeletonQueryWizard.execute();
       },

--- a/extensions/ql-vscode/src/local-queries.ts
+++ b/extensions/ql-vscode/src/local-queries.ts
@@ -2,7 +2,6 @@ import { ProgressCallback, ProgressUpdate, withProgress } from "./progress";
 import {
   CancellationToken,
   CancellationTokenSource,
-  ExtensionContext,
   QuickPickItem,
   Range,
   Uri,
@@ -222,7 +221,6 @@ export class LocalQueries extends DisposableObject {
     private readonly databaseUI: DatabaseUI,
     private readonly localQueryResultsView: ResultsView,
     private readonly queryStorageDir: string,
-    private readonly ctx: ExtensionContext,
   ) {
     super();
   }
@@ -384,7 +382,7 @@ export class LocalQueries extends DisposableObject {
       async (progress: ProgressCallback, token: CancellationToken) => {
         const credentials = isCanary() ? this.app.credentials : undefined;
         const contextStoragePath =
-          this.ctx.storageUri?.fsPath || this.ctx.globalStorageUri.fsPath;
+          this.app.workspaceStoragePath || this.app.globalStoragePath;
         const skeletonQueryWizard = new SkeletonQueryWizard(
           this.cliServer,
           progress,

--- a/extensions/ql-vscode/src/skeleton-query-wizard.ts
+++ b/extensions/ql-vscode/src/skeleton-query-wizard.ts
@@ -1,4 +1,4 @@
-import { join } from "path";
+import { join, dirname } from "path";
 import { CancellationToken, Uri, workspace, window as Window } from "vscode";
 import { CodeQLCliServer } from "./cli";
 import { OutputChannelLogger } from "./common";
@@ -103,15 +103,11 @@ export class SkeletonQueryWizard {
     // For the vscode-codeql-starter repo, the first folder will be a ql pack
     // so we need to get the parent folder
     if (firstFolder.uri.path.includes("codeql-custom-queries")) {
-      // slice off the last part of the path and return the parent folder
-      if (process.platform === "win32") {
-        return firstFolder.uri.path.split("\\").slice(0, -1).join("\\");
-      } else {
-        return firstFolder.uri.path.split("/").slice(0, -1).join("/");
-      }
+      // return the parent folder
+      return dirname(firstFolder.uri.fsPath);
     } else {
       // if the first folder is not a ql pack, then we are in a normal workspace
-      return firstFolder.uri.path;
+      return firstFolder.uri.fsPath;
     }
   }
 

--- a/extensions/ql-vscode/src/skeleton-query-wizard.ts
+++ b/extensions/ql-vscode/src/skeleton-query-wizard.ts
@@ -99,15 +99,16 @@ export class SkeletonQueryWizard {
     }
 
     const firstFolder = workspaceFolders[0];
+    const firstFolderFsPath = firstFolder.uri.fsPath;
 
     // For the vscode-codeql-starter repo, the first folder will be a ql pack
     // so we need to get the parent folder
-    if (firstFolder.uri.path.includes("codeql-custom-queries")) {
+    if (firstFolderFsPath.includes("codeql-custom-queries")) {
       // return the parent folder
-      return dirname(firstFolder.uri.fsPath);
+      return dirname(firstFolderFsPath);
     } else {
       // if the first folder is not a ql pack, then we are in a normal workspace
-      return firstFolder.uri.fsPath;
+      return firstFolderFsPath;
     }
   }
 

--- a/extensions/ql-vscode/src/skeleton-query-wizard.ts
+++ b/extensions/ql-vscode/src/skeleton-query-wizard.ts
@@ -104,7 +104,11 @@ export class SkeletonQueryWizard {
     // so we need to get the parent folder
     if (firstFolder.uri.path.includes("codeql-custom-queries")) {
       // slice off the last part of the path and return the parent folder
-      return firstFolder.uri.path.split("/").slice(0, -1).join("/");
+      if (process.platform === "win32") {
+        return firstFolder.uri.path.split("\\").slice(0, -1).join("\\");
+      } else {
+        return firstFolder.uri.path.split("/").slice(0, -1).join("/");
+      }
     } else {
       // if the first folder is not a ql pack, then we are in a normal workspace
       return firstFolder.uri.path;

--- a/extensions/ql-vscode/src/skeleton-query-wizard.ts
+++ b/extensions/ql-vscode/src/skeleton-query-wizard.ts
@@ -36,6 +36,7 @@ export class SkeletonQueryWizard {
     private readonly extLogger: OutputChannelLogger,
     private readonly databaseManager: DatabaseManager,
     private readonly token: CancellationToken,
+    private readonly databaseStoragePath: string | undefined,
   ) {}
 
   private get folderName() {
@@ -197,6 +198,10 @@ export class SkeletonQueryWizard {
       throw new Error("Workspace storage path is undefined");
     }
 
+    if (this.databaseStoragePath === undefined) {
+      throw new Error("Database storage path is undefined");
+    }
+
     if (this.language === undefined) {
       throw new Error("Language is undefined");
     }
@@ -220,7 +225,7 @@ export class SkeletonQueryWizard {
     await databaseFetcher.downloadGitHubDatabase(
       chosenRepo,
       this.databaseManager,
-      this.qlPackStoragePath,
+      this.databaseStoragePath,
       this.credentials,
       this.progress,
       this.token,

--- a/extensions/ql-vscode/src/skeleton-query-wizard.ts
+++ b/extensions/ql-vscode/src/skeleton-query-wizard.ts
@@ -27,7 +27,7 @@ export const QUERY_LANGUAGE_TO_DATABASE_REPO: QueryLanguagesToDatabaseMap = {
 export class SkeletonQueryWizard {
   private language: string | undefined;
   private fileName = "example.ql";
-  private storagePath: string | undefined;
+  private qlPackStoragePath: string | undefined;
 
   constructor(
     private readonly cliServer: CodeQLCliServer,
@@ -49,7 +49,7 @@ export class SkeletonQueryWizard {
       return;
     }
 
-    this.storagePath = this.getFirstStoragePath();
+    this.qlPackStoragePath = this.getFirstStoragePath();
 
     const skeletonPackAlreadyExists = isFolderAlreadyInWorkspace(
       this.folderName,
@@ -72,12 +72,12 @@ export class SkeletonQueryWizard {
   }
 
   private async openExampleFile() {
-    if (this.folderName === undefined || this.storagePath === undefined) {
+    if (this.folderName === undefined || this.qlPackStoragePath === undefined) {
       throw new Error("Path to folder is undefined");
     }
 
     const queryFileUri = Uri.file(
-      join(this.storagePath, this.folderName, this.fileName),
+      join(this.qlPackStoragePath, this.folderName, this.fileName),
     );
 
     try {
@@ -138,7 +138,7 @@ export class SkeletonQueryWizard {
         this.folderName,
         this.language as QueryLanguage,
         this.cliServer,
-        this.storagePath,
+        this.qlPackStoragePath,
       );
 
       await qlPackGenerator.generate();
@@ -166,7 +166,7 @@ export class SkeletonQueryWizard {
         this.folderName,
         this.language as QueryLanguage,
         this.cliServer,
-        this.storagePath,
+        this.qlPackStoragePath,
       );
 
       this.fileName = await this.determineNextFileName(this.folderName);
@@ -179,11 +179,11 @@ export class SkeletonQueryWizard {
   }
 
   private async determineNextFileName(folderName: string): Promise<string> {
-    if (this.storagePath === undefined) {
+    if (this.qlPackStoragePath === undefined) {
       throw new Error("Workspace storage path is undefined");
     }
 
-    const folderUri = Uri.file(join(this.storagePath, folderName));
+    const folderUri = Uri.file(join(this.qlPackStoragePath, folderName));
     const files = await workspace.fs.readDirectory(folderUri);
     const qlFiles = files.filter(([filename, _fileType]) =>
       filename.match(/example[0-9]*.ql/),
@@ -193,7 +193,7 @@ export class SkeletonQueryWizard {
   }
 
   private async downloadDatabase() {
-    if (this.storagePath === undefined) {
+    if (this.qlPackStoragePath === undefined) {
       throw new Error("Workspace storage path is undefined");
     }
 
@@ -220,7 +220,7 @@ export class SkeletonQueryWizard {
     await databaseFetcher.downloadGitHubDatabase(
       chosenRepo,
       this.databaseManager,
-      this.storagePath,
+      this.qlPackStoragePath,
       this.credentials,
       this.progress,
       this.token,
@@ -234,7 +234,7 @@ export class SkeletonQueryWizard {
       throw new Error("Language is undefined");
     }
 
-    if (this.storagePath === undefined) {
+    if (this.qlPackStoragePath === undefined) {
       throw new Error("Workspace storage path is undefined");
     }
 

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/skeleton-query-wizard.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/skeleton-query-wizard.test.ts
@@ -349,48 +349,6 @@ describe("SkeletonQueryWizard", () => {
         expect(wizard.getFirstStoragePath()).toEqual("vscode-codeql-starter");
       });
     });
-
-    describe("if user is on windows", () => {
-      let originalPlatform: string;
-
-      beforeEach(() => {
-        originalPlatform = process.platform;
-        Object.defineProperty(process, "platform", {
-          value: "win32",
-        });
-      });
-
-      afterEach(() => {
-        originalPlatform = process.platform;
-        Object.defineProperty(process, "platform", {
-          value: originalPlatform,
-        });
-      });
-
-      it("should return the first workspace folder", async () => {
-        jest.spyOn(workspace, "workspaceFolders", "get").mockReturnValue([
-          {
-            name: "codespaces-codeql",
-            uri: { fsPath: "codespaces-codeql\\codeql-custom-queries-cpp" },
-          },
-        ] as WorkspaceFolder[]);
-
-        Object.defineProperty(process, "platform", {
-          value: "win32",
-        });
-
-        wizard = new SkeletonQueryWizard(
-          mockCli,
-          jest.fn(),
-          credentials,
-          extLogger,
-          mockDatabaseManager,
-          token,
-        );
-
-        expect(wizard.getFirstStoragePath()).toEqual("codespaces-codeql");
-      });
-    });
   });
 
   describe("findDatabaseItemByNwo", () => {

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/skeleton-query-wizard.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/skeleton-query-wizard.test.ts
@@ -83,11 +83,11 @@ describe("SkeletonQueryWizard", () => {
     jest.spyOn(workspace, "workspaceFolders", "get").mockReturnValue([
       {
         name: `codespaces-codeql`,
-        uri: { path: storagePath },
+        uri: { fsPath: storagePath },
       },
       {
         name: "/second/folder/path",
-        uri: { path: storagePath },
+        uri: { fsPath: storagePath },
       },
     ] as WorkspaceFolder[]);
 
@@ -306,7 +306,7 @@ describe("SkeletonQueryWizard", () => {
       jest.spyOn(workspace, "workspaceFolders", "get").mockReturnValue([
         {
           name: "codespaces-codeql",
-          uri: { path: "codespaces-codeql" },
+          uri: { fsPath: "codespaces-codeql" },
         },
       ] as WorkspaceFolder[]);
 
@@ -327,11 +327,13 @@ describe("SkeletonQueryWizard", () => {
         jest.spyOn(workspace, "workspaceFolders", "get").mockReturnValue([
           {
             name: "codeql-custom-queries-cpp",
-            uri: { path: "vscode-codeql-starter/codeql-custom-queries-cpp" },
+            uri: { fsPath: "vscode-codeql-starter/codeql-custom-queries-cpp" },
           },
           {
             name: "codeql-custom-queries-csharp",
-            uri: { path: "vscode-codeql-starter/codeql-custom-queries-csharp" },
+            uri: {
+              fsPath: "vscode-codeql-starter/codeql-custom-queries-csharp",
+            },
           },
         ] as WorkspaceFolder[]);
 
@@ -369,7 +371,7 @@ describe("SkeletonQueryWizard", () => {
         jest.spyOn(workspace, "workspaceFolders", "get").mockReturnValue([
           {
             name: "codespaces-codeql",
-            uri: { path: "codespaces-codeql\\codeql-custom-queries-cpp" },
+            uri: { fsPath: "codespaces-codeql\\codeql-custom-queries-cpp" },
           },
         ] as WorkspaceFolder[]);
 

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/skeleton-query-wizard.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/skeleton-query-wizard.test.ts
@@ -114,6 +114,7 @@ describe("SkeletonQueryWizard", () => {
       extLogger,
       mockDatabaseManager,
       token,
+      storagePath,
     );
 
     askForGitHubRepoSpy = jest
@@ -244,6 +245,7 @@ describe("SkeletonQueryWizard", () => {
           extLogger,
           mockDatabaseManagerWithItems,
           token,
+          storagePath,
         );
       });
 
@@ -317,6 +319,7 @@ describe("SkeletonQueryWizard", () => {
         extLogger,
         mockDatabaseManager,
         token,
+        storagePath,
       );
 
       expect(wizard.getFirstStoragePath()).toEqual("codespaces-codeql");
@@ -352,6 +355,7 @@ describe("SkeletonQueryWizard", () => {
           extLogger,
           mockDatabaseManager,
           token,
+          storagePath,
         );
 
         expect(wizard.getFirstStoragePath()).toEqual("vscode-codeql-starter");

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/skeleton-query-wizard.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/skeleton-query-wizard.test.ts
@@ -305,7 +305,7 @@ describe("SkeletonQueryWizard", () => {
     it("should return the first workspace folder", async () => {
       jest.spyOn(workspace, "workspaceFolders", "get").mockReturnValue([
         {
-          name: "codeql-custom-queries-cpp",
+          name: "codespaces-codeql",
           uri: { path: "codespaces-codeql" },
         },
       ] as WorkspaceFolder[]);
@@ -345,6 +345,48 @@ describe("SkeletonQueryWizard", () => {
         );
 
         expect(wizard.getFirstStoragePath()).toEqual("vscode-codeql-starter");
+      });
+    });
+
+    describe("if user is on windows", () => {
+      let originalPlatform: string;
+
+      beforeEach(() => {
+        originalPlatform = process.platform;
+        Object.defineProperty(process, "platform", {
+          value: "win32",
+        });
+      });
+
+      afterEach(() => {
+        originalPlatform = process.platform;
+        Object.defineProperty(process, "platform", {
+          value: originalPlatform,
+        });
+      });
+
+      it("should return the first workspace folder", async () => {
+        jest.spyOn(workspace, "workspaceFolders", "get").mockReturnValue([
+          {
+            name: "codespaces-codeql",
+            uri: { path: "codespaces-codeql\\codeql-custom-queries-cpp" },
+          },
+        ] as WorkspaceFolder[]);
+
+        Object.defineProperty(process, "platform", {
+          value: "win32",
+        });
+
+        wizard = new SkeletonQueryWizard(
+          mockCli,
+          jest.fn(),
+          credentials,
+          extLogger,
+          mockDatabaseManager,
+          token,
+        );
+
+        expect(wizard.getFirstStoragePath()).toEqual("codespaces-codeql");
       });
     });
   });

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/skeleton-query-wizard.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/skeleton-query-wizard.test.ts
@@ -327,12 +327,20 @@ describe("SkeletonQueryWizard", () => {
         jest.spyOn(workspace, "workspaceFolders", "get").mockReturnValue([
           {
             name: "codeql-custom-queries-cpp",
-            uri: { fsPath: "vscode-codeql-starter/codeql-custom-queries-cpp" },
+            uri: {
+              fsPath: join(
+                "vscode-codeql-starter",
+                "codeql-custom-queries-cpp",
+              ),
+            },
           },
           {
             name: "codeql-custom-queries-csharp",
             uri: {
-              fsPath: "vscode-codeql-starter/codeql-custom-queries-csharp",
+              fsPath: join(
+                "vscode-codeql-starter",
+                "codeql-custom-queries-csharp",
+              ),
             },
           },
         ] as WorkspaceFolder[]);


### PR DESCRIPTION
Discovered by @shati-patel [here](https://github.com/github/vscode-codeql/pull/2250#discussion_r1158611185). 

The `getFirstStoragePath()` method would break on windows:

```
Path contains invalid characters: /c:/git-repo/codespaces-codeql (codeQL.createSkeletonQuery)
```

This makes sense, since we're looking to get the parent folder by splitting for `/`. In Windows, paths use `\` instead of `/`. So let's detect the platform and add a test for this case.
