### PR TITLE
Add creating extension packs when opening the editor

### DIFF
--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -16,6 +16,7 @@ import {
   window as Window,
   workspace,
   env,
+  WorkspaceFolder,
 } from "vscode";
 import { CodeQLCliServer, QlpacksInfo } from "./cli";
 import { UserCancellationException } from "./progress";
@@ -249,14 +250,19 @@ export async function showInformationMessageWithAction(
 }
 
 /** Gets all active workspace folders that are on the filesystem. */
-export function getOnDiskWorkspaceFolders() {
+export function getOnDiskWorkspaceFoldersObjects() {
   const workspaceFolders = workspace.workspaceFolders || [];
-  const diskWorkspaceFolders: string[] = [];
+  const diskWorkspaceFolders: WorkspaceFolder[] = [];
   for (const workspaceFolder of workspaceFolders) {
     if (workspaceFolder.uri.scheme === "file")
-      diskWorkspaceFolders.push(workspaceFolder.uri.fsPath);
+      diskWorkspaceFolders.push(workspaceFolder);
   }
   return diskWorkspaceFolders;
+}
+
+/** Gets all active workspace folders that are on the filesystem. */
+export function getOnDiskWorkspaceFolders() {
+  return getOnDiskWorkspaceFoldersObjects().map((folder) => folder.uri.fsPath);
 }
 
 /** Check if folder is already present in workspace */


### PR DESCRIPTION
This adds the ability to create a new extension pack when opening the data extension editor. It lets the user select a workspace folder and package name, but does not currently allow selecting the actual directory where it will be saved. For now, this is always in a subfolder of the workspace folder.

https://github.com/github/vscode-codeql/assets/1112623/534588bf-764c-4abb-a025-f3085feffd09

Based on #2296

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
