### PR TITLE
Small fixes to skeleton query wizard

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -362,7 +362,7 @@
         "title": "CodeQL: Quick Query"
       },
       {
-        "command": "codeQL.createSkeletonQuery",
+        "command": "codeQL.createQuery",
         "title": "CodeQL: Create Query"
       },
       {

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1321,6 +1321,10 @@
         {
           "command": "codeQL.mockGitHubApiServer.unloadScenario",
           "when": "config.codeQL.mockGitHubApiServer.enabled && codeQL.mockGitHubApiServer.scenarioLoaded"
+        },
+        {
+          "command": "codeQL.createQuery",
+          "when": "config.codeQL.canary"
         }
       ],
       "editor/context": [

--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -98,7 +98,7 @@ export type LocalQueryCommands = {
   "codeQL.quickEvalContextEditor": (uri: Uri) => Promise<void>;
   "codeQL.codeLensQuickEval": (uri: Uri, range: Range) => Promise<void>;
   "codeQL.quickQuery": () => Promise<void>;
-  "codeQL.createSkeletonQuery": () => Promise<void>;
+  "codeQL.createQuery": () => Promise<void>;
 };
 
 export type ResultsViewCommands = {

--- a/extensions/ql-vscode/src/local-queries.ts
+++ b/extensions/ql-vscode/src/local-queries.ts
@@ -238,7 +238,7 @@ export class LocalQueries extends DisposableObject {
       "codeQL.quickEvalContextEditor": this.quickEval.bind(this),
       "codeQL.codeLensQuickEval": this.codeLensQuickEval.bind(this),
       "codeQL.quickQuery": this.quickQuery.bind(this),
-      "codeQL.createSkeletonQuery": this.createSkeletonQuery.bind(this),
+      "codeQL.createQuery": this.createSkeletonQuery.bind(this),
     };
   }
 

--- a/extensions/ql-vscode/src/skeleton-query-wizard.ts
+++ b/extensions/ql-vscode/src/skeleton-query-wizard.ts
@@ -187,7 +187,7 @@ export class SkeletonQueryWizard {
     const folderUri = Uri.file(join(this.qlPackStoragePath, folderName));
     const files = await workspace.fs.readDirectory(folderUri);
     const qlFiles = files.filter(([filename, _fileType]) =>
-      filename.match(/example[0-9]*.ql/),
+      filename.match(/^example[0-9]*\.ql$/),
     );
 
     return `example${qlFiles.length + 1}.ql`;

--- a/extensions/ql-vscode/src/skeleton-query-wizard.ts
+++ b/extensions/ql-vscode/src/skeleton-query-wizard.ts
@@ -182,7 +182,7 @@ export class SkeletonQueryWizard {
 
   private async determineNextFileName(folderName: string): Promise<string> {
     if (this.qlPackStoragePath === undefined) {
-      throw new Error("Workspace storage path is undefined");
+      throw new Error("QL Pack storage path is undefined");
     }
 
     const folderUri = Uri.file(join(this.qlPackStoragePath, folderName));
@@ -196,7 +196,7 @@ export class SkeletonQueryWizard {
 
   private async downloadDatabase() {
     if (this.qlPackStoragePath === undefined) {
-      throw new Error("Workspace storage path is undefined");
+      throw new Error("QL Pack storage path is undefined");
     }
 
     if (this.databaseStoragePath === undefined) {
@@ -238,7 +238,7 @@ export class SkeletonQueryWizard {
     }
 
     if (this.qlPackStoragePath === undefined) {
-      throw new Error("Workspace storage path is undefined");
+      throw new Error("QL Pack storage path is undefined");
     }
 
     const databaseNwo = QUERY_LANGUAGE_TO_DATABASE_REPO[this.language];

--- a/extensions/ql-vscode/src/skeleton-query-wizard.ts
+++ b/extensions/ql-vscode/src/skeleton-query-wizard.ts
@@ -117,7 +117,7 @@ export class SkeletonQueryWizard {
     this.progress({
       message: "Choose language",
       step: 1,
-      maxStep: 1,
+      maxStep: 3,
     });
 
     return await askForLanguage(this.cliServer, false);
@@ -131,7 +131,7 @@ export class SkeletonQueryWizard {
     this.progress({
       message: "Creating skeleton QL pack around query",
       step: 2,
-      maxStep: 2,
+      maxStep: 3,
     });
 
     try {
@@ -159,7 +159,7 @@ export class SkeletonQueryWizard {
       message:
         "Skeleton query pack already exists. Creating additional query example file.",
       step: 2,
-      maxStep: 2,
+      maxStep: 3,
     });
 
     try {

--- a/extensions/ql-vscode/src/skeleton-query-wizard.ts
+++ b/extensions/ql-vscode/src/skeleton-query-wizard.ts
@@ -8,8 +8,8 @@ import { askForLanguage, isFolderAlreadyInWorkspace } from "./helpers";
 import { getErrorMessage } from "./pure/helpers-pure";
 import { QlPackGenerator } from "./qlpack-generator";
 import { DatabaseItem, DatabaseManager } from "./local-databases";
-import * as databaseFetcher from "./databaseFetcher";
 import { ProgressCallback, UserCancellationException } from "./progress";
+import { askForGitHubRepo, downloadGitHubDatabase } from "./databaseFetcher";
 
 type QueryLanguagesToDatabaseMap = Record<string, string>;
 
@@ -214,16 +214,13 @@ export class SkeletonQueryWizard {
     });
 
     const githubRepoNwo = QUERY_LANGUAGE_TO_DATABASE_REPO[this.language];
-    const chosenRepo = await databaseFetcher.askForGitHubRepo(
-      undefined,
-      githubRepoNwo,
-    );
+    const chosenRepo = await askForGitHubRepo(undefined, githubRepoNwo);
 
     if (!chosenRepo) {
       throw new UserCancellationException("No GitHub repository provided");
     }
 
-    await databaseFetcher.downloadGitHubDatabase(
+    await downloadGitHubDatabase(
       chosenRepo,
       this.databaseManager,
       this.databaseStoragePath,

--- a/extensions/ql-vscode/src/skeleton-query-wizard.ts
+++ b/extensions/ql-vscode/src/skeleton-query-wizard.ts
@@ -69,7 +69,14 @@ export class SkeletonQueryWizard {
     }
 
     // open a query file
-    await this.openExampleFile();
+
+    try {
+      await this.openExampleFile();
+    } catch (e: unknown) {
+      void this.extLogger.log(
+        `Could not open example query file: ${getErrorMessage(e)}`,
+      );
+    }
   }
 
   private async openExampleFile() {
@@ -81,15 +88,9 @@ export class SkeletonQueryWizard {
       join(this.qlPackStoragePath, this.folderName, this.fileName),
     );
 
-    try {
-      void workspace.openTextDocument(queryFileUri).then((doc) => {
-        void Window.showTextDocument(doc);
-      });
-    } catch (e: unknown) {
-      void this.extLogger.log(
-        `Could not open example query file: ${getErrorMessage(e)}`,
-      );
-    }
+    void workspace.openTextDocument(queryFileUri).then((doc) => {
+      void Window.showTextDocument(doc);
+    });
   }
 
   public getFirstStoragePath() {


### PR DESCRIPTION
Came out of final set of reviews for https://github.com/github/vscode-codeql/pull/2250#discussion_r1164275045

- Fixes progress indicator to provide the correct max steps
- Fixes regex expression
- Moves up place where we catch errors if we fail to open an example file
- Renames `codeQL.createSkeletonQuery` to `codeQL.createQuery`
- Import individual methods instead of whole databaseFetcher object
- Corrects some error messages
- Temporarily adds `codeQL.createQuery` command behind a canary flag