### PR TITLE
Filter out databases with errors

### DIFF
--- a/extensions/ql-vscode/src/skeleton-query-wizard.ts
+++ b/extensions/ql-vscode/src/skeleton-query-wizard.ts
@@ -277,8 +277,12 @@ export class SkeletonQueryWizard {
   ): Promise<DatabaseItem | undefined> {
     const dbItems = databaseItems || [];
     const dbs = dbItems.filter(
-      (db) => db.language === language && db.name === databaseNwo,
+      (db) =>
+        db.language === language &&
+        db.name === databaseNwo &&
+        db.error === undefined,
     );
+
     if (dbs.length === 0) {
       return undefined;
     }
@@ -290,7 +294,9 @@ export class SkeletonQueryWizard {
     databaseItems: readonly DatabaseItem[],
   ): Promise<DatabaseItem | undefined> {
     const dbItems = databaseItems || [];
-    const dbs = dbItems.filter((db) => db.language === language);
+    const dbs = dbItems.filter(
+      (db) => db.language === language && db.error === undefined,
+    );
     if (dbs.length === 0) {
       return undefined;
     }

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/skeleton-query-wizard.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/skeleton-query-wizard.test.ts
@@ -20,6 +20,7 @@ import {
 } from "../../../src/local-databases";
 import * as databaseFetcher from "../../../src/databaseFetcher";
 import { createMockDB } from "../../factories/databases/databases";
+import { asError } from "../../../src/pure/helpers-pure";
 
 jest.setTimeout(40_000);
 
@@ -366,8 +367,15 @@ describe("SkeletonQueryWizard", () => {
   describe("findDatabaseItemByNwo", () => {
     describe("when the item exists", () => {
       it("should return the database item", async () => {
-        const mockDbItem = createMockDB(dir);
-        const mockDbItem2 = createMockDB(dir);
+        const mockDbItem = createMockDB(dir, {
+          language: "ruby",
+          dateAdded: 123,
+        } as FullDatabaseOptions);
+        const mockDbItem2 = createMockDB(dir, {
+          language: "javascript",
+        } as FullDatabaseOptions);
+
+        jest.spyOn(mockDbItem, "name", "get").mockReturnValue("mock-name");
 
         const databaseItem = await wizard.findDatabaseItemByNwo(
           mockDbItem.language,
@@ -375,8 +383,40 @@ describe("SkeletonQueryWizard", () => {
           [mockDbItem, mockDbItem2],
         );
 
-        expect(databaseItem!.language).toEqual(mockDbItem.language);
-        expect(databaseItem!.name).toEqual(mockDbItem.name);
+        expect(JSON.stringify(databaseItem)).toEqual(
+          JSON.stringify(mockDbItem),
+        );
+      });
+
+      it("should ignore databases with errors", async () => {
+        const mockDbItem = createMockDB(dir, {
+          language: "ruby",
+          dateAdded: 123,
+        } as FullDatabaseOptions);
+        const mockDbItem2 = createMockDB(dir, {
+          language: "javascript",
+        } as FullDatabaseOptions);
+        const mockDbItem3 = createMockDB(dir, {
+          language: "ruby",
+          dateAdded: 345,
+        } as FullDatabaseOptions);
+
+        jest.spyOn(mockDbItem, "name", "get").mockReturnValue("mock-name");
+        jest.spyOn(mockDbItem3, "name", "get").mockReturnValue(mockDbItem.name);
+
+        jest
+          .spyOn(mockDbItem, "error", "get")
+          .mockReturnValue(asError("database go boom!"));
+
+        const databaseItem = await wizard.findDatabaseItemByNwo(
+          mockDbItem.language,
+          mockDbItem.name,
+          [mockDbItem, mockDbItem2, mockDbItem3],
+        );
+
+        expect(JSON.stringify(databaseItem)).toEqual(
+          JSON.stringify(mockDbItem3),
+        );
       });
     });
 
@@ -412,6 +452,32 @@ describe("SkeletonQueryWizard", () => {
         ]);
 
         expect(databaseItem).toEqual(mockDbItem);
+      });
+
+      it("should ignore databases with errors", async () => {
+        const mockDbItem = createMockDB(dir, {
+          language: "ruby",
+        } as FullDatabaseOptions);
+        const mockDbItem2 = createMockDB(dir, {
+          language: "javascript",
+        } as FullDatabaseOptions);
+        const mockDbItem3 = createMockDB(dir, {
+          language: "ruby",
+        } as FullDatabaseOptions);
+
+        jest
+          .spyOn(mockDbItem, "error", "get")
+          .mockReturnValue(asError("database go boom!"));
+
+        const databaseItem = await wizard.findDatabaseItemByLanguage("ruby", [
+          mockDbItem,
+          mockDbItem2,
+          mockDbItem3,
+        ]);
+
+        expect(JSON.stringify(databaseItem)).toEqual(
+          JSON.stringify(mockDbItem3),
+        );
       });
     });
 

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/skeleton-query-wizard.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/skeleton-query-wizard.test.ts
@@ -22,7 +22,7 @@ import * as databaseFetcher from "../../../src/databaseFetcher";
 import { createMockDB } from "../../factories/databases/databases";
 import { asError } from "../../../src/pure/helpers-pure";
 
-jest.setTimeout(40_000);
+jest.setTimeout(80_000);
 
 describe("SkeletonQueryWizard", () => {
   let mockCli: CodeQLCliServer;


### PR DESCRIPTION
Came out of https://github.com/github/vscode-codeql/pull/2250#discussion_r1164267824

When we create a skeleton query, we check whether you already have an
existing database with the same name (e.g. `github/codeql`). If we can't
find one, we also check for an existing database with the same language.

If we find a matching database, we select it instead of downloading a new 
database.

Here we're filtering out databases with errors so that we don't accidentally
select an invalid database for you.