### PR TITLE
Improve error handling in data extension editor

### DIFF
--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
@@ -14,8 +14,8 @@ import {
 import { ProgressUpdate } from "../progress";
 import { QueryRunner } from "../queryRunner";
 import {
+  showAndLogErrorMessage,
   showAndLogExceptionWithTelemetry,
-  showAndLogWarningMessage,
 } from "../helpers";
 import { extLogger } from "../common";
 import { readFile, writeFile } from "fs-extra";
@@ -166,7 +166,9 @@ export class DataExtensionsEditorView extends AbstractWebview<
       const existingModeledMethods = loadDataExtensionYaml(data);
 
       if (!existingModeledMethods) {
-        void showAndLogWarningMessage("Failed to parse data extension YAML.");
+        void showAndLogErrorMessage(
+          `Failed to parse data extension YAML ${this.modelFilename}.`,
+        );
         return;
       }
 
@@ -175,7 +177,11 @@ export class DataExtensionsEditorView extends AbstractWebview<
         modeledMethods: existingModeledMethods,
       });
     } catch (e: unknown) {
-      void extLogger.log(`Unable to read data extension YAML: ${e}`);
+      void showAndLogErrorMessage(
+        `Unable to read data extension YAML ${
+          this.modelFilename
+        }: ${getErrorMessage(e)}`,
+      );
     }
   }
 
@@ -208,7 +214,6 @@ export class DataExtensionsEditorView extends AbstractWebview<
       const bqrsChunk = await readQueryResults({
         cliServer: this.cliServer,
         bqrsPath: queryResult.outputDir.bqrsPath,
-        logger: extLogger,
       });
       if (!bqrsChunk) {
         await this.clearProgress();
@@ -233,7 +238,7 @@ export class DataExtensionsEditorView extends AbstractWebview<
       void showAndLogExceptionWithTelemetry(
         redactableError(
           asError(err),
-        )`Failed to load external APi usages: ${getErrorMessage(err)}`,
+        )`Failed to load external API usages: ${getErrorMessage(err)}`,
       );
     }
   }

--- a/extensions/ql-vscode/src/data-extensions-editor/data-schema.json
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-schema.json
@@ -1,0 +1,45 @@
+{
+  "type": "object",
+  "properties": {
+    "extensions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["addsTo", "data"],
+        "properties": {
+          "addsTo": {
+            "type": "object",
+            "required": ["pack", "extensible"],
+            "properties": {
+              "pack": {
+                "type": "string"
+              },
+              "extensible": {
+                "type": "string"
+              }
+            }
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/extensions/ql-vscode/src/data-extensions-editor/generate-flow-model.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/generate-flow-model.ts
@@ -6,11 +6,16 @@ import { CodeQLCliServer } from "../cli";
 import { TeeLogger } from "../common";
 import { extensiblePredicateDefinitions } from "./yaml";
 import { ProgressCallback } from "../progress";
-import { getOnDiskWorkspaceFolders } from "../helpers";
+import {
+  getOnDiskWorkspaceFolders,
+  showAndLogExceptionWithTelemetry,
+} from "../helpers";
 import {
   ModeledMethodType,
   ModeledMethodWithSignature,
 } from "./modeled-method";
+import { redactableError } from "../pure/errors";
+import { QueryResultType } from "../pure/new-messages";
 
 type FlowModelOptions = {
   cliServer: CodeQLCliServer;
@@ -67,13 +72,21 @@ async function getModeledMethodsFromFlow(
     token,
     new TeeLogger(queryRunner.logger, queryRun.outputDir.logPath),
   );
+  if (queryResult.resultType !== QueryResultType.SUCCESS) {
+    void showAndLogExceptionWithTelemetry(
+      redactableError`Failed to run ${queryName} query: ${
+        queryResult.message ?? "No message"
+      }`,
+    );
+    return [];
+  }
 
   const bqrsPath = queryResult.outputDir.bqrsPath;
 
   const bqrsInfo = await cliServer.bqrsInfo(bqrsPath);
   if (bqrsInfo["result-sets"].length !== 1) {
-    throw new Error(
-      `Expected exactly one result set, got ${bqrsInfo["result-sets"].length}`,
+    void showAndLogExceptionWithTelemetry(
+      redactableError`Expected exactly one result set, got ${bqrsInfo["result-sets"].length} for ${queryName}`,
     );
   }
 

--- a/extensions/ql-vscode/test/unit-tests/data-extensions-editor/yaml.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/data-extensions-editor/yaml.test.ts
@@ -149,14 +149,14 @@ describe("loadDataExtensionYaml", () => {
   });
 
   it("returns undefined if given a string", () => {
-    const data = loadDataExtensionYaml(`extensions:
+    expect(() =>
+      loadDataExtensionYaml(`extensions:
   - addsTo:
       pack: codeql/java-all
       extensible: sinkModel
     data:
       - ["org.sql2o","Connection",true,"createQuery","(String)","","Argument[0]","sql","manual"]
-`);
-
-    expect(data).toBeUndefined();
+`),
+    ).toThrow("Invalid data extension YAML:  must be object");
   });
 });

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/data-extensions-editor/external-api-usage-query.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/data-extensions-editor/external-api-usage-query.test.ts
@@ -10,6 +10,8 @@ import { file } from "tmp-promise";
 import { QueryResultType } from "../../../../src/pure/new-messages";
 import { readFile } from "fs-extra";
 import { load } from "js-yaml";
+import * as helpers from "../../../../src/helpers";
+import { RedactableError } from "../../../../src/pure/errors";
 
 function createMockUri(path = "/a/b/c/foo"): Uri {
   return {
@@ -127,8 +129,18 @@ describe("readQueryResults", () => {
       bqrsDecode: jest.fn(),
     },
     bqrsPath: "/tmp/results.bqrs",
-    logger: createMockLogger(),
   };
+
+  let showAndLogExceptionWithTelemetrySpy: jest.SpiedFunction<
+    typeof helpers.showAndLogExceptionWithTelemetry
+  >;
+
+  beforeEach(() => {
+    showAndLogExceptionWithTelemetrySpy = jest.spyOn(
+      helpers,
+      "showAndLogExceptionWithTelemetry",
+    );
+  });
 
   it("returns undefined when there are no results", async () => {
     options.cliServer.bqrsInfo.mockResolvedValue({
@@ -136,8 +148,8 @@ describe("readQueryResults", () => {
     });
 
     expect(await readQueryResults(options)).toBeUndefined();
-    expect(options.logger.log).toHaveBeenCalledWith(
-      expect.stringMatching(/Expected exactly one result set/),
+    expect(showAndLogExceptionWithTelemetrySpy).toHaveBeenCalledWith(
+      expect.any(RedactableError),
     );
   });
 
@@ -166,8 +178,8 @@ describe("readQueryResults", () => {
     });
 
     expect(await readQueryResults(options)).toBeUndefined();
-    expect(options.logger.log).toHaveBeenCalledWith(
-      expect.stringMatching(/Expected exactly one result set/),
+    expect(showAndLogExceptionWithTelemetrySpy).toHaveBeenCalledWith(
+      expect.any(RedactableError),
     );
   });
 


### PR DESCRIPTION
This improves the error handling in the data extension editor by showing more errors to the user and adding validation to data extension model files.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
