### PR TITLE
Enable skeleton wizard in codespaces-codeql template

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1445,6 +1445,10 @@
           "when": "config.codeQL.mockGitHubApiServer.enabled && codeQL.mockGitHubApiServer.scenarioLoaded"
         },
         {
+          "command": "codeQL.createQuery",
+          "when": "config.codeQL.codespacesTemplate"
+        },
+        {
           "command": "codeQLTests.acceptOutputContextTestItem",
           "when": "false"
         }

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1445,10 +1445,6 @@
           "when": "config.codeQL.mockGitHubApiServer.enabled && codeQL.mockGitHubApiServer.scenarioLoaded"
         },
         {
-          "command": "codeQL.createQuery",
-          "when": "config.codeQL.canary"
-        },
-        {
           "command": "codeQLTests.acceptOutputContextTestItem",
           "when": "false"
         }

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/helpers.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/helpers.test.ts
@@ -635,7 +635,7 @@ describe("prepareCodeTour", () => {
 
     describe("if the workspace is already open", () => {
       it("should not open the tutorial workspace", async () => {
-        // Set isCodespaceTemplate to true to indicate the workspace has already been opened
+        // Set isCodespacesTemplate to true to indicate the workspace has already been opened
         jest.spyOn(Setting.prototype, "getValue").mockReturnValue(true);
 
         // set up directory to have a 'tutorial.code-workspace' file


### PR DESCRIPTION
Once we're satisfied with testing this flow (including with a [single rooted workspace](https://github.com/github/vscode-codeql/pull/2328)) we can enable it in the codespaces-template.



