### PR TITLE
Update `@types/vscode` and fix naming conflicts

### DIFF
--- a/extensions/ql-vscode/package-lock.json
+++ b/extensions/ql-vscode/package-lock.json
@@ -93,7 +93,7 @@
         "@types/through2": "^2.0.36",
         "@types/tmp": "^0.1.0",
         "@types/unzipper": "~0.10.1",
-        "@types/vscode": "^1.59.0",
+        "@types/vscode": "^1.67.0",
         "@types/webpack": "^5.28.0",
         "@types/webpack-env": "^1.18.0",
         "@types/xml2js": "~0.4.4",
@@ -19170,9 +19170,9 @@
       }
     },
     "node_modules/@types/vscode": {
-      "version": "1.63.1",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.63.1.tgz",
-      "integrity": "sha512-Z+ZqjRcnGfHP86dvx/BtSwWyZPKQ/LBdmAVImY82TphyjOw2KgTKcp7Nx92oNwCTsHzlshwexAG/WiY2JuUm3g==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.77.0.tgz",
+      "integrity": "sha512-MWFN5R7a33n8eJZJmdVlifjig3LWUNRrPeO1xemIcZ0ae0TEQuRc7G2xV0LUX78RZFECY1plYBn+dP/Acc3L0Q==",
       "dev": true
     },
     "node_modules/@types/webpack": {
@@ -61731,9 +61731,9 @@
       }
     },
     "@types/vscode": {
-      "version": "1.63.1",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.63.1.tgz",
-      "integrity": "sha512-Z+ZqjRcnGfHP86dvx/BtSwWyZPKQ/LBdmAVImY82TphyjOw2KgTKcp7Nx92oNwCTsHzlshwexAG/WiY2JuUm3g==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.77.0.tgz",
+      "integrity": "sha512-MWFN5R7a33n8eJZJmdVlifjig3LWUNRrPeO1xemIcZ0ae0TEQuRc7G2xV0LUX78RZFECY1plYBn+dP/Acc3L0Q==",
       "dev": true
     },
     "@types/webpack": {

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1531,7 +1531,7 @@
     "@types/through2": "^2.0.36",
     "@types/tmp": "^0.1.0",
     "@types/unzipper": "~0.10.1",
-    "@types/vscode": "^1.59.0",
+    "@types/vscode": "^1.67.0",
     "@types/webpack": "^5.28.0",
     "@types/webpack-env": "^1.18.0",
     "@types/xml2js": "~0.4.4",

--- a/extensions/ql-vscode/src/databases/ui/db-panel.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-panel.ts
@@ -34,11 +34,11 @@ import { DatabasePanelCommands } from "../../common/commands";
 import { App } from "../../common/app";
 
 export interface RemoteDatabaseQuickPickItem extends QuickPickItem {
-  kind: string;
+  remoteDatabaseKind: string;
 }
 
 export interface AddListQuickPickItem extends QuickPickItem {
-  kind: DbListKind;
+  databaseKind: DbListKind;
 }
 
 export class DbPanel extends DisposableObject {
@@ -113,19 +113,19 @@ export class DbPanel extends DisposableObject {
     ) {
       await this.addNewRemoteRepo(highlightedItem.parentListName);
     } else {
-      const quickPickItems = [
+      const quickPickItems: RemoteDatabaseQuickPickItem[] = [
         {
           label: "$(repo) From a GitHub repository",
           detail: "Add a variant analysis repository from GitHub",
           alwaysShow: true,
-          kind: "repo",
+          remoteDatabaseKind: "repo",
         },
         {
           label: "$(organization) All repositories of a GitHub org or owner",
           detail:
             "Add a variant analysis list of repositories from a GitHub organization/owner",
           alwaysShow: true,
-          kind: "owner",
+          remoteDatabaseKind: "owner",
         },
       ];
       const databaseKind =
@@ -142,9 +142,9 @@ export class DbPanel extends DisposableObject {
         // We set 'true' to make this a silent exception.
         throw new UserCancellationException("No repository selected", true);
       }
-      if (databaseKind.kind === "repo") {
+      if (databaseKind.remoteDatabaseKind === "repo") {
         await this.addNewRemoteRepo();
-      } else if (databaseKind.kind === "owner") {
+      } else if (databaseKind.remoteDatabaseKind === "owner") {
         await this.addNewRemoteOwner();
       }
     }

--- a/extensions/ql-vscode/test/vscode-tests/activated-extension/databases/db-panel.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/activated-extension/databases/db-panel.test.ts
@@ -53,7 +53,7 @@ describe("Db panel UI commands", () => {
   it.skip("should add new local db list", async () => {
     // Add db list
     jest.spyOn(window, "showQuickPick").mockResolvedValue({
-      kind: DbListKind.Local,
+      databaseKind: DbListKind.Local,
     } as AddListQuickPickItem);
     jest.spyOn(window, "showInputBox").mockResolvedValue("my-list-1");
     await commandManager.execute(
@@ -73,7 +73,7 @@ describe("Db panel UI commands", () => {
   it("should add new remote repository", async () => {
     // Add db
     jest.spyOn(window, "showQuickPick").mockResolvedValue({
-      kind: "repo",
+      remoteDatabaseKind: "repo",
     } as RemoteDatabaseQuickPickItem);
 
     jest.spyOn(window, "showInputBox").mockResolvedValue("owner1/repo1");
@@ -96,7 +96,7 @@ describe("Db panel UI commands", () => {
   it("should add new remote owner", async () => {
     // Add owner
     jest.spyOn(window, "showQuickPick").mockResolvedValue({
-      kind: "owner",
+      remoteDatabaseKind: "owner",
     } as RemoteDatabaseQuickPickItem);
 
     jest.spyOn(window, "showInputBox").mockResolvedValue("owner1");

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/helpers.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/helpers.test.ts
@@ -272,6 +272,13 @@ describe("helpers", () => {
   class MockEnvironmentVariableCollection
     implements EnvironmentVariableCollection
   {
+    [Symbol.iterator](): Iterator<
+      [variable: string, mutator: EnvironmentVariableMutator],
+      any,
+      undefined
+    > {
+      throw new Error("Method not implemented.");
+    }
     persistent = false;
     replace(_variable: string, _value: string): void {
       throw new Error("Method not implemented.");


### PR DESCRIPTION
This PR updates the extension to use a more recent version of the `@types/vscode` package, and fixes a couple naming conflicts that came up as part of that upgrade.
