### PR TITLE
Set default higher timeout on CLI integration tests

### DIFF
--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/databaseFetcher.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/databaseFetcher.test.ts
@@ -16,8 +16,6 @@ import {
 } from "../global.helper";
 import { createMockCommandManager } from "../../__mocks__/commandsMock";
 
-jest.setTimeout(60_000);
-
 /**
  * Run various integration tests for databases
  */

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/helpers.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/helpers.test.ts
@@ -4,9 +4,6 @@ import { CodeQLCliServer } from "../../../src/cli";
 import { tryGetQueryMetadata } from "../../../src/helpers";
 import { getActivatedExtension } from "../global.helper";
 
-// up to 3 minutes per test
-jest.setTimeout(3 * 60 * 1000);
-
 describe("helpers (with CLI)", () => {
   const baseDir = __dirname;
 

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/jest.config.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/jest.config.ts
@@ -6,6 +6,9 @@ const config: Config = {
   ...baseConfig,
   runner: "<rootDir>/../jest-runner-installed-extensions.ts",
   setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
+  // CLI integration tests call into the CLI and execute queries, so these are expected to take a lot longer
+  // than the default 5 seconds.
+  testTimeout: 180_000, // 3 minutes
 };
 
 export default config;

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/legacy-query.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/legacy-query.test.ts
@@ -98,8 +98,6 @@ const db: messages.Dataset = {
   workingSet: "default",
 };
 
-jest.setTimeout(60_000);
-
 describeWithCodeQL()("using the legacy query server", () => {
   const nullProgressReporter: ProgressReporter = {
     report: () => {

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/new-query.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/new-query.test.ts
@@ -104,8 +104,6 @@ const nullProgressReporter: ProgressReporter = {
   },
 };
 
-jest.setTimeout(20_000);
-
 describeWithCodeQL()("using the new query server", () => {
   let qs: qsClient.QueryServerClient;
   let cliServer: cli.CodeQLCliServer;

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/packaging.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/packaging.test.ts
@@ -12,9 +12,6 @@ import {
 import { mockedQuickPickItem } from "../utils/mocking.helpers";
 import { getActivatedExtension } from "../global.helper";
 
-// up to 3 minutes per test
-jest.setTimeout(3 * 60 * 1000);
-
 describe("Packaging commands", () => {
   let cli: CodeQLCliServer;
   const progress = jest.fn();

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/queries.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/queries.test.ts
@@ -27,8 +27,6 @@ import { QueryResultType } from "../../../src/pure/new-messages";
 import { createVSCodeCommandManager } from "../../../src/common/vscode/commands";
 import { AllCommands, QueryServerCommands } from "../../../src/common/commands";
 
-jest.setTimeout(60_000);
-
 /**
  * Integration tests for queries
  */

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/run-cli.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/run-cli.test.ts
@@ -14,8 +14,6 @@ import { KeyType } from "../../../src/contextual/keyType";
 import { faker } from "@faker-js/faker";
 import { getActivatedExtension } from "../global.helper";
 
-jest.setTimeout(60_000);
-
 /**
  * Perform proper integration tests by running the CLI
  */

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/skeleton-query-wizard.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/skeleton-query-wizard.test.ts
@@ -22,8 +22,6 @@ import * as databaseFetcher from "../../../src/databaseFetcher";
 import { createMockDB } from "../../factories/databases/databases";
 import { asError } from "../../../src/pure/helpers-pure";
 
-jest.setTimeout(80_000);
-
 describe("SkeletonQueryWizard", () => {
   let mockCli: CodeQLCliServer;
   let wizard: SkeletonQueryWizard;

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/sourcemap.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/sourcemap.test.ts
@@ -5,8 +5,6 @@ import { readFile, writeFile, ensureDir, copy } from "fs-extra";
 import { createVSCodeCommandManager } from "../../../src/common/vscode/commands";
 import { AllCommands } from "../../../src/common/commands";
 
-jest.setTimeout(20_000);
-
 /**
  * Integration tests for queries
  */

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
@@ -29,9 +29,6 @@ import { QueryLanguage } from "../../../../src/common/query-language";
 import { readBundledPack } from "../../utils/bundled-pack-helpers";
 import { load } from "js-yaml";
 
-// up to 3 minutes per test
-jest.setTimeout(3 * 60 * 1000);
-
 describe("Variant Analysis Manager", () => {
   let cli: CodeQLCliServer;
   let cancellationTokenSource: CancellationTokenSource;

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-submission-integration.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-submission-integration.test.ts
@@ -15,8 +15,6 @@ import { getActivatedExtension } from "../../global.helper";
 import { createVSCodeCommandManager } from "../../../../src/common/vscode/commands";
 import { AllCommands } from "../../../../src/common/commands";
 
-jest.setTimeout(30_000);
-
 const mockServer = new MockGitHubApiServer();
 beforeAll(() => mockServer.startServer());
 afterEach(() => mockServer.unloadScenario());


### PR DESCRIPTION
This sets a default timeout of 3 minutes on CLI integration tests. This is because these tests call into the CLI and execute queries, so these are expected to take a lot longer than the default 5 seconds. This allows us to remove all the individual `jest.setTimeout` calls with different values from the test files.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
