### PR TITLE
Ensure we're selecting database in single rooted workspace

### DIFF
--- a/extensions/ql-vscode/src/databaseFetcher.ts
+++ b/extensions/ql-vscode/src/databaseFetcher.ts
@@ -317,13 +317,15 @@ async function databaseArchiveFetcher(
     });
     await ensureZippedSourceLocation(dbPath);
 
+    const makeSelected = true;
+
     const item = await databaseManager.openDatabase(
       progress,
       token,
       Uri.file(dbPath),
+      makeSelected,
       nameOverride,
     );
-    await databaseManager.setCurrentDatabaseItem(item);
     return item;
   } else {
     throw new Error("Database not found in archive.");

--- a/extensions/ql-vscode/src/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/local-databases-ui.ts
@@ -306,13 +306,13 @@ export class DatabaseUI extends DisposableObject {
               `${workspace.workspaceFolders[0].uri}/.tours/codeql-tutorial-database`,
             );
 
-            let databaseItem = this.databaseManager.findDatabaseItem(uri);
+            const databaseItem = this.databaseManager.findDatabaseItem(uri);
             if (databaseItem === undefined) {
               const makeSelected = true;
               const nameOverride = "CodeQL Tutorial Database";
               const isTutorialDatabase = true;
 
-              databaseItem = await this.databaseManager.openDatabase(
+              await this.databaseManager.openDatabase(
                 progress,
                 token,
                 uri,

--- a/extensions/ql-vscode/src/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/local-databases-ui.ts
@@ -307,17 +307,20 @@ export class DatabaseUI extends DisposableObject {
             );
 
             let databaseItem = this.databaseManager.findDatabaseItem(uri);
-            const isTutorialDatabase = true;
             if (databaseItem === undefined) {
+              const makeSelected = true;
+              const nameOverride = "CodeQL Tutorial Database";
+              const isTutorialDatabase = true;
+
               databaseItem = await this.databaseManager.openDatabase(
                 progress,
                 token,
                 uri,
-                "CodeQL Tutorial Database",
+                makeSelected,
+                nameOverride,
                 isTutorialDatabase,
               );
             }
-            await this.databaseManager.setCurrentDatabaseItem(databaseItem);
             await this.handleTourDependencies();
           }
         } catch (e) {
@@ -758,14 +761,17 @@ export class DatabaseUI extends DisposableObject {
     uri: Uri,
   ): Promise<DatabaseItem | undefined> {
     let databaseItem = this.databaseManager.findDatabaseItem(uri);
+
+    const makeSelected = true;
+
     if (databaseItem === undefined) {
       databaseItem = await this.databaseManager.openDatabase(
         progress,
         token,
         uri,
+        makeSelected,
       );
     }
-    await this.databaseManager.setCurrentDatabaseItem(databaseItem);
 
     return databaseItem;
   }

--- a/extensions/ql-vscode/src/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/local-databases-ui.ts
@@ -633,7 +633,7 @@ export class DatabaseUI extends DisposableObject {
               this.queryServer?.cliServer,
             );
           } else {
-            await this.setCurrentDatabase(progress, token, uri);
+            await this.databaseManager.openDatabase(progress, token, uri);
           }
         } catch (e) {
           // rethrow and let this be handled by default error handling.
@@ -755,27 +755,6 @@ export class DatabaseUI extends DisposableObject {
     return this.databaseManager.currentDatabaseItem;
   }
 
-  private async setCurrentDatabase(
-    progress: ProgressCallback,
-    token: CancellationToken,
-    uri: Uri,
-  ): Promise<DatabaseItem | undefined> {
-    let databaseItem = this.databaseManager.findDatabaseItem(uri);
-
-    const makeSelected = true;
-
-    if (databaseItem === undefined) {
-      databaseItem = await this.databaseManager.openDatabase(
-        progress,
-        token,
-        uri,
-        makeSelected,
-      );
-    }
-
-    return databaseItem;
-  }
-
   /**
    * Ask the user for a database directory. Returns the chosen database, or `undefined` if the
    * operation was canceled.
@@ -795,7 +774,11 @@ export class DatabaseUI extends DisposableObject {
         if (byFolder) {
           const fixedUri = await this.fixDbUri(uri);
           // we are selecting a database folder
-          return await this.setCurrentDatabase(progress, token, fixedUri);
+          return await this.databaseManager.openDatabase(
+            progress,
+            token,
+            fixedUri,
+          );
         } else {
           // we are selecting a database archive. Must unzip into a workspace-controlled area
           // before importing.

--- a/extensions/ql-vscode/src/local-databases.ts
+++ b/extensions/ql-vscode/src/local-databases.ts
@@ -621,6 +621,7 @@ export class DatabaseManager extends DisposableObject {
     progress: ProgressCallback,
     token: vscode.CancellationToken,
     uri: vscode.Uri,
+    makeSelected = false,
     displayName?: string,
     isTutorialDatabase?: boolean,
   ): Promise<DatabaseItem> {
@@ -629,6 +630,7 @@ export class DatabaseManager extends DisposableObject {
     return await this.addExistingDatabaseItem(
       databaseItem,
       progress,
+      makeSelected,
       token,
       isTutorialDatabase,
     );
@@ -643,6 +645,7 @@ export class DatabaseManager extends DisposableObject {
   public async addExistingDatabaseItem(
     databaseItem: DatabaseItem,
     progress: ProgressCallback,
+    makeSelected = true,
     token: vscode.CancellationToken,
     isTutorialDatabase?: boolean,
   ): Promise<DatabaseItem> {
@@ -652,6 +655,9 @@ export class DatabaseManager extends DisposableObject {
     }
 
     await this.addDatabaseItem(progress, token, databaseItem);
+    if (makeSelected) {
+      await this.setCurrentDatabaseItem(databaseItem);
+    }
     await this.addDatabaseSourceArchiveFolder(databaseItem);
 
     if (isCodespacesTemplate() && !isTutorialDatabase) {

--- a/extensions/ql-vscode/src/skeleton-query-wizard.ts
+++ b/extensions/ql-vscode/src/skeleton-query-wizard.ts
@@ -217,40 +217,18 @@ export class SkeletonQueryWizard {
   }
 
   private async selectExistingDatabase() {
-    if (this.language === undefined) {
-      throw new Error("Language is undefined");
-    }
-
     if (this.qlPackStoragePath === undefined) {
       throw new Error("QL Pack storage path is undefined");
     }
 
-    const databaseNwo = QUERY_LANGUAGE_TO_DATABASE_REPO[this.language];
-
-    const existingDatabaseItem = await this.findDatabaseItemByNwo(
-      this.language,
-      databaseNwo,
-      this.databaseManager.databaseItems,
-    );
+    const existingDatabaseItem = await this.findExistingDatabaseItem();
 
     if (existingDatabaseItem) {
       // select the found database
       await this.databaseManager.setCurrentDatabaseItem(existingDatabaseItem);
     } else {
-      const sameLanguageDatabaseItem = await this.findDatabaseItemByLanguage(
-        this.language,
-        this.databaseManager.databaseItems,
-      );
-
-      if (sameLanguageDatabaseItem) {
-        // select the found database
-        await this.databaseManager.setCurrentDatabaseItem(
-          sameLanguageDatabaseItem,
-        );
-      } else {
-        // download new database and select it
-        await this.downloadDatabase();
-      }
+      // download new database and select it
+      await this.downloadDatabase();
     }
   }
 
@@ -285,5 +263,25 @@ export class SkeletonQueryWizard {
       return undefined;
     }
     return dbs[0];
+  }
+
+  private async findExistingDatabaseItem() {
+    if (this.language === undefined) {
+      throw new Error("Language is undefined");
+    }
+
+    const databaseNwo = QUERY_LANGUAGE_TO_DATABASE_REPO[this.language];
+
+    return (
+      (await this.findDatabaseItemByNwo(
+        this.language,
+        databaseNwo,
+        this.databaseManager.databaseItems,
+      )) ||
+      (await this.findDatabaseItemByLanguage(
+        this.language,
+        this.databaseManager.databaseItems,
+      ))
+    );
   }
 }

--- a/extensions/ql-vscode/src/skeleton-query-wizard.ts
+++ b/extensions/ql-vscode/src/skeleton-query-wizard.ts
@@ -65,7 +65,7 @@ export class SkeletonQueryWizard {
       // just create a new example query file in skeleton QL pack
       await this.createExampleFile();
       // select existing database for language
-      await this.selectExistingDatabase();
+      await this.selectOrDownloadDatabase();
     } else {
       // generate a new skeleton QL pack with query file
       await this.createQlPack();
@@ -216,7 +216,7 @@ export class SkeletonQueryWizard {
     );
   }
 
-  private async selectExistingDatabase() {
+  private async selectOrDownloadDatabase() {
     if (this.qlPackStoragePath === undefined) {
       throw new Error("QL Pack storage path is undefined");
     }

--- a/extensions/ql-vscode/src/skeleton-query-wizard.ts
+++ b/extensions/ql-vscode/src/skeleton-query-wizard.ts
@@ -64,14 +64,13 @@ export class SkeletonQueryWizard {
     if (skeletonPackAlreadyExists) {
       // just create a new example query file in skeleton QL pack
       await this.createExampleFile();
-      // select existing database for language
-      await this.selectOrDownloadDatabase();
     } else {
       // generate a new skeleton QL pack with query file
       await this.createQlPack();
-      // download database based on language and select it
-      await this.downloadDatabase();
     }
+
+    // select existing database for language or download a new one
+    await this.selectOrDownloadDatabase();
 
     // open a query file
 

--- a/extensions/ql-vscode/src/skeleton-query-wizard.ts
+++ b/extensions/ql-vscode/src/skeleton-query-wizard.ts
@@ -269,18 +269,21 @@ export class SkeletonQueryWizard {
       throw new Error("Language is undefined");
     }
 
-    const databaseNwo = QUERY_LANGUAGE_TO_DATABASE_REPO[this.language];
+    const defaultDatabaseNwo = QUERY_LANGUAGE_TO_DATABASE_REPO[this.language];
 
-    return (
-      (await this.findDatabaseItemByNwo(
-        this.language,
-        databaseNwo,
-        this.databaseManager.databaseItems,
-      )) ||
-      (await this.findDatabaseItemByLanguage(
-        this.language,
-        this.databaseManager.databaseItems,
-      ))
+    const defaultDatabaseItem = await this.findDatabaseItemByNwo(
+      this.language,
+      defaultDatabaseNwo,
+      this.databaseManager.databaseItems,
+    );
+
+    if (defaultDatabaseItem !== undefined) {
+      return defaultDatabaseItem;
+    }
+
+    return await this.findDatabaseItemByLanguage(
+      this.language,
+      this.databaseManager.databaseItems,
     );
   }
 }

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-databases.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-databases.test.ts
@@ -708,6 +708,7 @@ describe("local databases", () => {
   describe("openDatabase", () => {
     let createSkeletonPacksSpy: jest.SpyInstance;
     let resolveDatabaseContentsSpy: jest.SpyInstance;
+    let setCurrentDatabaseItemSpy: jest.SpyInstance;
     let addDatabaseSourceArchiveFolderSpy: jest.SpyInstance;
     let mockDbItem: DatabaseItemImpl;
 
@@ -721,6 +722,11 @@ describe("local databases", () => {
       resolveDatabaseContentsSpy = jest
         .spyOn(DatabaseResolver, "resolveDatabaseContents")
         .mockResolvedValue({} as DatabaseContentsWithDbScheme);
+
+      setCurrentDatabaseItemSpy = jest.spyOn(
+        databaseManager,
+        "setCurrentDatabaseItem",
+      );
 
       addDatabaseSourceArchiveFolderSpy = jest.spyOn(
         databaseManager,
@@ -746,6 +752,19 @@ describe("local databases", () => {
       expect(resolveDatabaseContentsSpy).toBeCalledTimes(1);
     });
 
+    it("should set the database as the currently selected one", async () => {
+      const makeSelected = true;
+
+      await databaseManager.openDatabase(
+        {} as ProgressCallback,
+        {} as CancellationToken,
+        mockDbItem.databaseUri,
+        makeSelected,
+      );
+
+      expect(setCurrentDatabaseItemSpy).toBeCalledTimes(1);
+    });
+
     it("should add database source archive folder", async () => {
       await databaseManager.openDatabase(
         {} as ProgressCallback,
@@ -762,12 +781,15 @@ describe("local databases", () => {
           jest.spyOn(Setting.prototype, "getValue").mockReturnValue(true);
 
           const isTutorialDatabase = true;
+          const makeSelected = true;
+          const nameOverride = "CodeQL Tutorial Database";
 
           await databaseManager.openDatabase(
             {} as ProgressCallback,
             {} as CancellationToken,
             mockDbItem.databaseUri,
-            "CodeQL Tutorial Database",
+            makeSelected,
+            nameOverride,
             isTutorialDatabase,
           );
 


### PR DESCRIPTION
After some testing of the skeleton pack wizard with a single rooted 
workspace (`github/code-scanning`) we discovered a general VSCode 
extension bug whereby after we download a database, we don't select it.

This isn't an issue in the wizard, but it does affect us as it means
we'll generate the QL pack, download the db for you but then you won't
know that we haven't selected your database.

So let's make sure our flow works for this case by explicitly selecting
the database once it's downloaded.