### PR TITLE
Select latest database when creating skeleton query

### DIFF
--- a/extensions/ql-vscode/src/skeleton-query-wizard.ts
+++ b/extensions/ql-vscode/src/skeleton-query-wizard.ts
@@ -261,10 +261,11 @@ export class SkeletonQueryWizard {
       throw new Error("QL Pack storage path is undefined");
     }
 
-    const existingDatabaseItem = await this.findExistingDatabaseItem(
-      this.language,
-      this.databaseManager.databaseItems,
-    );
+    const existingDatabaseItem =
+      await SkeletonQueryWizard.findExistingDatabaseItem(
+        this.language,
+        this.databaseManager.databaseItems,
+      );
 
     if (existingDatabaseItem) {
       // select the found database
@@ -275,7 +276,7 @@ export class SkeletonQueryWizard {
     }
   }
 
-  public async findDatabaseItemByNwo(
+  public static async findDatabaseItemByNwo(
     language: string,
     databaseNwo: string,
     databaseItems: readonly DatabaseItem[],
@@ -287,7 +288,7 @@ export class SkeletonQueryWizard {
     return dbs.pop();
   }
 
-  public async findDatabaseItemByLanguage(
+  public static async findDatabaseItemByLanguage(
     language: string,
     databaseItems: readonly DatabaseItem[],
   ): Promise<DatabaseItem | undefined> {
@@ -296,15 +297,17 @@ export class SkeletonQueryWizard {
     return dbs.pop();
   }
 
-  public async findExistingDatabaseItem(
+  public static async findExistingDatabaseItem(
     language: string,
     databaseItems: readonly DatabaseItem[],
   ): Promise<DatabaseItem | undefined> {
     const defaultDatabaseNwo = QUERY_LANGUAGE_TO_DATABASE_REPO[language];
 
-    const dbItems = await this.sortDatabaseItemsByDateAdded(databaseItems);
+    const dbItems = await SkeletonQueryWizard.sortDatabaseItemsByDateAdded(
+      databaseItems,
+    );
 
-    const defaultDatabaseItem = await this.findDatabaseItemByNwo(
+    const defaultDatabaseItem = await SkeletonQueryWizard.findDatabaseItemByNwo(
       language,
       defaultDatabaseNwo,
       dbItems,
@@ -314,10 +317,13 @@ export class SkeletonQueryWizard {
       return defaultDatabaseItem;
     }
 
-    return await this.findDatabaseItemByLanguage(language, dbItems);
+    return await SkeletonQueryWizard.findDatabaseItemByLanguage(
+      language,
+      dbItems,
+    );
   }
 
-  public async sortDatabaseItemsByDateAdded(
+  public static async sortDatabaseItemsByDateAdded(
     databaseItems: readonly DatabaseItem[],
   ) {
     const validDbItems = databaseItems.filter((db) => db.error === undefined);

--- a/extensions/ql-vscode/src/skeleton-query-wizard.ts
+++ b/extensions/ql-vscode/src/skeleton-query-wizard.ts
@@ -273,12 +273,8 @@ export class SkeletonQueryWizard {
     databaseNwo: string,
     databaseItems: readonly DatabaseItem[],
   ): Promise<DatabaseItem | undefined> {
-    const dbItems = databaseItems || [];
-    const dbs = dbItems.filter(
-      (db) =>
-        db.language === language &&
-        db.name === databaseNwo &&
-        db.error === undefined,
+    const dbs = databaseItems.filter(
+      (db) => db.language === language && db.name === databaseNwo,
     );
 
     if (dbs.length === 0) {
@@ -291,10 +287,7 @@ export class SkeletonQueryWizard {
     language: string,
     databaseItems: readonly DatabaseItem[],
   ): Promise<DatabaseItem | undefined> {
-    const dbItems = databaseItems || [];
-    const dbs = dbItems.filter(
-      (db) => db.language === language && db.error === undefined,
-    );
+    const dbs = databaseItems.filter((db) => db.language === language);
     if (dbs.length === 0) {
       return undefined;
     }
@@ -308,19 +301,38 @@ export class SkeletonQueryWizard {
 
     const defaultDatabaseNwo = QUERY_LANGUAGE_TO_DATABASE_REPO[this.language];
 
+    const dbItems = await this.sortDatabaseItemsByDateAdded(
+      this.databaseManager.databaseItems,
+    );
+
     const defaultDatabaseItem = await this.findDatabaseItemByNwo(
       this.language,
       defaultDatabaseNwo,
-      this.databaseManager.databaseItems,
+      dbItems,
     );
 
     if (defaultDatabaseItem !== undefined) {
       return defaultDatabaseItem;
     }
 
-    return await this.findDatabaseItemByLanguage(
-      this.language,
-      this.databaseManager.databaseItems,
-    );
+    return await this.findDatabaseItemByLanguage(this.language, dbItems);
+  }
+
+  public async sortDatabaseItemsByDateAdded(
+    databaseItems: readonly DatabaseItem[],
+  ) {
+    const validDbItems = databaseItems.filter((db) => db.error === undefined);
+
+    return validDbItems.sort((a, b) => {
+      if (a.dateAdded === undefined) {
+        return -1;
+      }
+
+      if (b.dateAdded === undefined) {
+        return 1;
+      }
+
+      return a.dateAdded - b.dateAdded;
+    });
   }
 }

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/skeleton-query-wizard.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/skeleton-query-wizard.test.ts
@@ -320,7 +320,7 @@ describe("SkeletonQueryWizard", () => {
 
         jest.spyOn(mockDbItem, "name", "get").mockReturnValue("mock-name");
 
-        const databaseItem = await wizard.findDatabaseItemByNwo(
+        const databaseItem = await SkeletonQueryWizard.findDatabaseItemByNwo(
           mockDbItem.language,
           mockDbItem.name,
           [mockDbItem, mockDbItem2],
@@ -337,7 +337,7 @@ describe("SkeletonQueryWizard", () => {
         const mockDbItem = createMockDB(dir);
         const mockDbItem2 = createMockDB(dir);
 
-        const databaseItem = await wizard.findDatabaseItemByNwo(
+        const databaseItem = await SkeletonQueryWizard.findDatabaseItemByNwo(
           "ruby",
           "mock-nwo",
           [mockDbItem, mockDbItem2],
@@ -358,10 +358,11 @@ describe("SkeletonQueryWizard", () => {
           language: "javascript",
         } as FullDatabaseOptions);
 
-        const databaseItem = await wizard.findDatabaseItemByLanguage("ruby", [
-          mockDbItem,
-          mockDbItem2,
-        ]);
+        const databaseItem =
+          await SkeletonQueryWizard.findDatabaseItemByLanguage("ruby", [
+            mockDbItem,
+            mockDbItem2,
+          ]);
 
         expect(databaseItem).toEqual(mockDbItem);
       });
@@ -372,10 +373,11 @@ describe("SkeletonQueryWizard", () => {
         const mockDbItem = createMockDB(dir);
         const mockDbItem2 = createMockDB(dir);
 
-        const databaseItem = await wizard.findDatabaseItemByLanguage("ruby", [
-          mockDbItem,
-          mockDbItem2,
-        ]);
+        const databaseItem =
+          await SkeletonQueryWizard.findDatabaseItemByLanguage("ruby", [
+            mockDbItem,
+            mockDbItem2,
+          ]);
 
         expect(databaseItem).toBeUndefined();
       });
@@ -510,12 +512,13 @@ describe("SkeletonQueryWizard", () => {
           dateAdded: 345,
         } as FullDatabaseOptions);
 
-        const sortedList = await wizard.sortDatabaseItemsByDateAdded([
-          mockDbItem,
-          mockDbItem2,
-          mockDbItem3,
-          mockDbItem4,
-        ]);
+        const sortedList =
+          await SkeletonQueryWizard.sortDatabaseItemsByDateAdded([
+            mockDbItem,
+            mockDbItem2,
+            mockDbItem3,
+            mockDbItem4,
+          ]);
 
         expect(sortedList).toEqual([
           mockDbItem3,
@@ -543,12 +546,13 @@ describe("SkeletonQueryWizard", () => {
           .spyOn(mockDbItem, "error", "get")
           .mockReturnValue(asError("database go boom!"));
 
-        const sortedList = await wizard.sortDatabaseItemsByDateAdded([
-          mockDbItem,
-          mockDbItem2,
-          mockDbItem3,
-          mockDbItem4,
-        ]);
+        const sortedList =
+          await SkeletonQueryWizard.sortDatabaseItemsByDateAdded([
+            mockDbItem,
+            mockDbItem2,
+            mockDbItem3,
+            mockDbItem4,
+          ]);
 
         expect(sortedList).toEqual([mockDbItem2, mockDbItem4, mockDbItem3]);
       });
@@ -582,7 +586,7 @@ describe("SkeletonQueryWizard", () => {
           .spyOn(mockDbItem2, "name", "get")
           .mockReturnValue(QUERY_LANGUAGE_TO_DATABASE_REPO["javascript"]);
 
-        const databaseItem = await wizard.findExistingDatabaseItem(
+        const databaseItem = await SkeletonQueryWizard.findExistingDatabaseItem(
           "javascript",
           [mockDbItem, mockDbItem2, mockDbItem3, mockDbItem4],
         );
@@ -612,7 +616,7 @@ describe("SkeletonQueryWizard", () => {
           dateAdded: undefined,
         } as FullDatabaseOptions);
 
-        const databaseItem = await wizard.findExistingDatabaseItem(
+        const databaseItem = await SkeletonQueryWizard.findExistingDatabaseItem(
           "javascript",
           [mockDbItem, mockDbItem2, mockDbItem3, mockDbItem4],
         );

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/skeleton-query-wizard.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/skeleton-query-wizard.test.ts
@@ -330,37 +330,6 @@ describe("SkeletonQueryWizard", () => {
           JSON.stringify(mockDbItem),
         );
       });
-
-      it("should ignore databases with errors", async () => {
-        const mockDbItem = createMockDB(dir, {
-          language: "ruby",
-          dateAdded: 123,
-        } as FullDatabaseOptions);
-        const mockDbItem2 = createMockDB(dir, {
-          language: "javascript",
-        } as FullDatabaseOptions);
-        const mockDbItem3 = createMockDB(dir, {
-          language: "ruby",
-          dateAdded: 345,
-        } as FullDatabaseOptions);
-
-        jest.spyOn(mockDbItem, "name", "get").mockReturnValue("mock-name");
-        jest.spyOn(mockDbItem3, "name", "get").mockReturnValue(mockDbItem.name);
-
-        jest
-          .spyOn(mockDbItem, "error", "get")
-          .mockReturnValue(asError("database go boom!"));
-
-        const databaseItem = await wizard.findDatabaseItemByNwo(
-          mockDbItem.language,
-          mockDbItem.name,
-          [mockDbItem, mockDbItem2, mockDbItem3],
-        );
-
-        expect(JSON.stringify(databaseItem)).toEqual(
-          JSON.stringify(mockDbItem3),
-        );
-      });
     });
 
     describe("when the item doesn't exist", () => {
@@ -395,32 +364,6 @@ describe("SkeletonQueryWizard", () => {
         ]);
 
         expect(databaseItem).toEqual(mockDbItem);
-      });
-
-      it("should ignore databases with errors", async () => {
-        const mockDbItem = createMockDB(dir, {
-          language: "ruby",
-        } as FullDatabaseOptions);
-        const mockDbItem2 = createMockDB(dir, {
-          language: "javascript",
-        } as FullDatabaseOptions);
-        const mockDbItem3 = createMockDB(dir, {
-          language: "ruby",
-        } as FullDatabaseOptions);
-
-        jest
-          .spyOn(mockDbItem, "error", "get")
-          .mockReturnValue(asError("database go boom!"));
-
-        const databaseItem = await wizard.findDatabaseItemByLanguage("ruby", [
-          mockDbItem,
-          mockDbItem2,
-          mockDbItem3,
-        ]);
-
-        expect(JSON.stringify(databaseItem)).toEqual(
-          JSON.stringify(mockDbItem3),
-        );
       });
     });
 
@@ -547,6 +490,67 @@ describe("SkeletonQueryWizard", () => {
           expect(showInputBoxSpy).toHaveBeenCalled();
           expect(chosenPath).toEqual(storagePath);
         });
+      });
+    });
+  });
+
+  describe("sortDatabaseItemsByDateAdded", () => {
+    describe("should return a sorted list", () => {
+      it("should sort the items by dateAdded", async () => {
+        const mockDbItem = createMockDB(dir, {
+          dateAdded: 678,
+        } as FullDatabaseOptions);
+        const mockDbItem2 = createMockDB(dir, {
+          dateAdded: 123,
+        } as FullDatabaseOptions);
+        const mockDbItem3 = createMockDB(dir, {
+          dateAdded: undefined,
+        } as FullDatabaseOptions);
+        const mockDbItem4 = createMockDB(dir, {
+          dateAdded: 345,
+        } as FullDatabaseOptions);
+
+        const sortedList = await wizard.sortDatabaseItemsByDateAdded([
+          mockDbItem,
+          mockDbItem2,
+          mockDbItem3,
+          mockDbItem4,
+        ]);
+
+        expect(sortedList).toEqual([
+          mockDbItem3,
+          mockDbItem2,
+          mockDbItem4,
+          mockDbItem,
+        ]);
+      });
+
+      it("should ignore databases with errors", async () => {
+        const mockDbItem = createMockDB(dir, {
+          dateAdded: 678,
+        } as FullDatabaseOptions);
+        const mockDbItem2 = createMockDB(dir, {
+          dateAdded: undefined,
+        } as FullDatabaseOptions);
+        const mockDbItem3 = createMockDB(dir, {
+          dateAdded: 345,
+        } as FullDatabaseOptions);
+        const mockDbItem4 = createMockDB(dir, {
+          dateAdded: 123,
+        } as FullDatabaseOptions);
+
+        jest
+          .spyOn(mockDbItem, "error", "get")
+          .mockReturnValue(asError("database go boom!"));
+
+        const sortedList = await wizard.sortDatabaseItemsByDateAdded([
+          mockDbItem,
+          mockDbItem2,
+          mockDbItem3,
+          mockDbItem4,
+        ]);
+
+        expect(sortedList).toEqual([mockDbItem2, mockDbItem4, mockDbItem3]);
       });
     });
   });

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/skeleton-query-wizard.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/skeleton-query-wizard.test.ts
@@ -554,4 +554,73 @@ describe("SkeletonQueryWizard", () => {
       });
     });
   });
+
+  describe("findExistingDatabaseItem", () => {
+    describe("when there are multiple items with the same name", () => {
+      it("should choose the latest one", async () => {
+        const mockDbItem = createMockDB(dir, {
+          language: "javascript",
+          dateAdded: 456,
+        } as FullDatabaseOptions);
+        const mockDbItem2 = createMockDB(dir, {
+          language: "ruby",
+          dateAdded: 789,
+        } as FullDatabaseOptions);
+        const mockDbItem3 = createMockDB(dir, {
+          language: "javascript",
+          dateAdded: 123,
+        } as FullDatabaseOptions);
+        const mockDbItem4 = createMockDB(dir, {
+          language: "javascript",
+          dateAdded: undefined,
+        } as FullDatabaseOptions);
+
+        jest
+          .spyOn(mockDbItem, "name", "get")
+          .mockReturnValue(QUERY_LANGUAGE_TO_DATABASE_REPO["javascript"]);
+        jest
+          .spyOn(mockDbItem2, "name", "get")
+          .mockReturnValue(QUERY_LANGUAGE_TO_DATABASE_REPO["javascript"]);
+
+        const databaseItem = await wizard.findExistingDatabaseItem(
+          "javascript",
+          [mockDbItem, mockDbItem2, mockDbItem3, mockDbItem4],
+        );
+
+        expect(JSON.stringify(databaseItem)).toEqual(
+          JSON.stringify(mockDbItem),
+        );
+      });
+    });
+
+    describe("when there are multiple items with the same language", () => {
+      it("should choose the latest one", async () => {
+        const mockDbItem = createMockDB(dir, {
+          language: "ruby",
+          dateAdded: 789,
+        } as FullDatabaseOptions);
+        const mockDbItem2 = createMockDB(dir, {
+          language: "javascript",
+          dateAdded: 456,
+        } as FullDatabaseOptions);
+        const mockDbItem3 = createMockDB(dir, {
+          language: "ruby",
+          dateAdded: 123,
+        } as FullDatabaseOptions);
+        const mockDbItem4 = createMockDB(dir, {
+          language: "javascript",
+          dateAdded: undefined,
+        } as FullDatabaseOptions);
+
+        const databaseItem = await wizard.findExistingDatabaseItem(
+          "javascript",
+          [mockDbItem, mockDbItem2, mockDbItem3, mockDbItem4],
+        );
+
+        expect(JSON.stringify(databaseItem)).toEqual(
+          JSON.stringify(mockDbItem2),
+        );
+      });
+    });
+  });
 });


### PR DESCRIPTION
The skeleton query process tries to choose an existing database for you instead of downloading a new one. 

When deciding which database to select, this is the process it goes through:
1. Is there one with the same name as the one we'd be downloading?
2. If that doesn't exist, is there one with the same language? 
3. If that doesn't exist either, it will go ahead and download one for you.

When we were designing how to find an existing database, we weren't sorting them by their creation date. This means that we might be selecting an older one, instead of the latest.

So let's sort our databases by `dateAdded` before attempting to select one. 
