### PR TITLE
Add better support for different languages in data extension editor

### DIFF
--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
@@ -148,7 +148,11 @@ export class DataExtensionsEditorView extends AbstractWebview<
     externalApiUsages: ExternalApiUsage[],
     modeledMethods: Record<string, ModeledMethod>,
   ): Promise<void> {
-    const yaml = createDataExtensionYaml(externalApiUsages, modeledMethods);
+    const yaml = createDataExtensionYaml(
+      this.databaseItem.language,
+      externalApiUsages,
+      modeledMethods,
+    );
 
     await outputFile(this.modelFilename, yaml);
 

--- a/extensions/ql-vscode/src/data-extensions-editor/extension-pack-picker.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/extension-pack-picker.ts
@@ -23,7 +23,7 @@ const packNameLength = 128;
 
 export async function pickExtensionPackModelFile(
   cliServer: Pick<CodeQLCliServer, "resolveQlpacks" | "resolveExtensions">,
-  databaseItem: Pick<DatabaseItem, "name">,
+  databaseItem: Pick<DatabaseItem, "name" | "language">,
   progress: ProgressCallback,
   token: CancellationToken,
 ): Promise<string | undefined> {
@@ -53,7 +53,7 @@ export async function pickExtensionPackModelFile(
 
 async function pickExtensionPack(
   cliServer: Pick<CodeQLCliServer, "resolveQlpacks">,
-  databaseItem: Pick<DatabaseItem, "name">,
+  databaseItem: Pick<DatabaseItem, "name" | "language">,
   progress: ProgressCallback,
   token: CancellationToken,
 ): Promise<string | undefined> {
@@ -184,7 +184,7 @@ async function pickModelFile(
 }
 
 async function pickNewExtensionPack(
-  databaseItem: Pick<DatabaseItem, "name">,
+  databaseItem: Pick<DatabaseItem, "name" | "language">,
   token: CancellationToken,
 ): Promise<string | undefined> {
   const workspaceFolders = getOnDiskWorkspaceFoldersObjects();
@@ -257,7 +257,7 @@ async function pickNewExtensionPack(
       version: "0.0.0",
       library: true,
       extensionTargets: {
-        "codeql/java-all": "*",
+        [`codeql/${databaseItem.language}-all`]: "*",
       },
       dataExtensions: ["models/**/*.yml"],
     }),

--- a/extensions/ql-vscode/src/data-extensions-editor/yaml.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/yaml.ts
@@ -43,6 +43,7 @@ function createDataProperty(
 }
 
 export function createDataExtensionYaml(
+  language: string,
   externalApiUsages: ExternalApiUsage[],
   modeledMethods: Record<string, ModeledMethod>,
 ) {
@@ -69,7 +70,7 @@ export function createDataExtensionYaml(
 
   const extensions = Object.entries(extensiblePredicateDefinitions).map(
     ([type, definition]) => `  - addsTo:
-      pack: codeql/java-all
+      pack: codeql/${language}-all
       extensible: ${definition.extensiblePredicate}
     data:${createDataProperty(
       methodsByType[type as Exclude<ModeledMethodType, "none">],

--- a/extensions/ql-vscode/test/unit-tests/data-extensions-editor/yaml.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/data-extensions-editor/yaml.test.ts
@@ -6,6 +6,7 @@ import {
 describe("createDataExtensionYaml", () => {
   it("creates the correct YAML file", () => {
     const yaml = createDataExtensionYaml(
+      "java",
       [
         {
           signature: "org.sql2o.Connection#createQuery(String)",
@@ -97,6 +98,32 @@ describe("createDataExtensionYaml", () => {
 
   - addsTo:
       pack: codeql/java-all
+      extensible: neutralModel
+    data: []
+`);
+  });
+
+  it("includes the correct language", () => {
+    const yaml = createDataExtensionYaml("csharp", [], {});
+
+    expect(yaml).toEqual(`extensions:
+  - addsTo:
+      pack: codeql/csharp-all
+      extensible: sourceModel
+    data: []
+
+  - addsTo:
+      pack: codeql/csharp-all
+      extensible: sinkModel
+    data: []
+
+  - addsTo:
+      pack: codeql/csharp-all
+      extensible: summaryModel
+    data: []
+
+  - addsTo:
+      pack: codeql/csharp-all
       extensible: neutralModel
     data: []
 `);


### PR DESCRIPTION
There were still some places where we were hardcoding Java in the data extension editor. This changes these places to use the database item language instead.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
