### PR TITLE
Add database language check to data extensions editor

### DIFF
--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-module.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-module.ts
@@ -11,6 +11,8 @@ import { showAndLogErrorMessage } from "../helpers";
 import { withProgress } from "../progress";
 import { pickExtensionPackModelFile } from "./extension-pack-picker";
 
+const SUPPORTED_LANGUAGES: string[] = ["java", "csharp"];
+
 export class DataExtensionsEditorModule {
   private readonly queryStorageDir: string;
 
@@ -51,15 +53,22 @@ export class DataExtensionsEditorModule {
 
   public getCommands(): DataExtensionsEditorCommands {
     return {
-      "codeQL.openDataExtensionsEditor": async () =>
-        withProgress(
-          async (progress, token) => {
-            const db = this.databaseManager.currentDatabaseItem;
-            if (!db) {
-              void showAndLogErrorMessage("No database selected");
-              return;
-            }
+      "codeQL.openDataExtensionsEditor": async () => {
+        const db = this.databaseManager.currentDatabaseItem;
+        if (!db) {
+          void showAndLogErrorMessage("No database selected");
+          return;
+        }
 
+        if (!SUPPORTED_LANGUAGES.includes(db.language)) {
+          void showAndLogErrorMessage(
+            `The data extensions editor is not supported for ${db.language} databases.`,
+          );
+          return;
+        }
+
+        return withProgress(
+          async (progress, token) => {
             if (!(await this.cliServer.cliConstraints.supportsQlpacksKind())) {
               void showAndLogErrorMessage(
                 `This feature requires CodeQL CLI version ${CliVersionConstraint.CLI_VERSION_WITH_QLPACKS_KIND.format()} or later.`,
@@ -92,7 +101,8 @@ export class DataExtensionsEditorModule {
           {
             title: "Opening Data Extensions Editor",
           },
-        ),
+        );
+      },
     };
   }
 


### PR DESCRIPTION
This will not allow the user to open the data extensions editor for a database if it is not one of the supported languages. The supported languages is a list of `string` rather than a list of `QueryLanguage` because a database item's language is also a `string`.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
