### PR TITLE
Fix error when model file does not exist

### DIFF
--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
@@ -18,7 +18,7 @@ import {
   showAndLogExceptionWithTelemetry,
 } from "../helpers";
 import { extLogger } from "../common";
-import { outputFile, readFile } from "fs-extra";
+import { outputFile, pathExists, readFile } from "fs-extra";
 import { load as loadYaml } from "js-yaml";
 import { DatabaseItem, DatabaseManager } from "../local-databases";
 import { CodeQLCliServer } from "../cli";
@@ -161,6 +161,10 @@ export class DataExtensionsEditorView extends AbstractWebview<
 
   protected async loadExistingModeledMethods(): Promise<void> {
     try {
+      if (!(await pathExists(this.modelFilename))) {
+        return;
+      }
+
       const yaml = await readFile(this.modelFilename, "utf8");
 
       const data = loadYaml(yaml, {


### PR DESCRIPTION
When you have just created a model file using the quick picker/input box, the data extension editor will try to read it and fail with an error message. This adds a check to ensure the model file exists and if it doesn't, it will not try to read in the file.

This should always be safe since the model file picker will only allow you to select existing files.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
