### PR TITLE
Show model filename in data extensions editor

### DIFF
--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
@@ -94,6 +94,12 @@ export class DataExtensionsEditorView extends AbstractWebview<
         await this.onWebViewLoaded();
 
         break;
+      case "openModelFile":
+        await window.showTextDocument(
+          await workspace.openTextDocument(this.modelFilename),
+        );
+
+        break;
       case "jumpToUsage":
         await this.jumpToUsage(msg.location);
 
@@ -119,6 +125,10 @@ export class DataExtensionsEditorView extends AbstractWebview<
     super.onWebViewLoaded();
 
     await Promise.all([
+      this.postMessage({
+        t: "setDataExtensionEditorInitialData",
+        modelFilename: this.modelFilename,
+      }),
       this.loadExternalApiUsages(),
       this.loadExistingModeledMethods(),
     ]);

--- a/extensions/ql-vscode/src/pure/interface-types.ts
+++ b/extensions/ql-vscode/src/pure/interface-types.ts
@@ -481,6 +481,11 @@ export type ToDataFlowPathsMessage = SetDataFlowPathsMessage;
 
 export type FromDataFlowPathsMessage = CommonFromViewMessages;
 
+export interface SetDataExtensionEditorInitialDataMessage {
+  t: "setDataExtensionEditorInitialData";
+  modelFilename: string;
+}
+
 export interface SetExternalApiUsagesMessage {
   t: "setExternalApiUsages";
   externalApiUsages: ExternalApiUsage[];
@@ -511,9 +516,8 @@ export interface JumpToUsageMessage {
   location: ResolvableLocationValue;
 }
 
-export interface SetExistingModeledMethods {
-  t: "setExistingModeledMethods";
-  existingModeledMethods: Record<string, ModeledMethod>;
+export interface OpenModelFileMessage {
+  t: "openModelFile";
 }
 
 export interface SaveModeledMethods {
@@ -527,12 +531,14 @@ export interface GenerateExternalApiMessage {
 }
 
 export type ToDataExtensionsEditorMessage =
+  | SetDataExtensionEditorInitialDataMessage
   | SetExternalApiUsagesMessage
   | ShowProgressMessage
   | AddModeledMethodsMessage;
 
 export type FromDataExtensionsEditorMessage =
   | ViewLoadedMsg
+  | OpenModelFileMessage
   | JumpToUsageMessage
   | SaveModeledMethods
   | GenerateExternalApiMessage;

--- a/extensions/ql-vscode/src/stories/data-extensions-editor/DataExtensionsEditor.stories.tsx
+++ b/extensions/ql-vscode/src/stories/data-extensions-editor/DataExtensionsEditor.stories.tsx
@@ -15,6 +15,8 @@ const Template: ComponentStory<typeof DataExtensionsEditorComponent> = (
 
 export const DataExtensionsEditor = Template.bind({});
 DataExtensionsEditor.args = {
+  initialModelFilename:
+    "/home/user/vscode-codeql-starter/codeql-custom-queries-java/sql2o/models/sql2o.yml",
   initialExternalApiUsages: [
     {
       signature: "org.sql2o.Connection#createQuery(String)",


### PR DESCRIPTION
This adds the model filename to the data extensions editor and will also allow the user to go to the model file by clicking on the filename.

This also updates the general UI to be somewhat more compact by moving the modeled percentages to be below the header in 1 line:

![Screenshot 2023-04-17 at 16 20 50](https://github.com/github/vscode-codeql/assets/1112623/dd1c0155-5d91-4f33-874a-588b3b60a8c8)


## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
