### PR TITLE
Show extension pack name in data extensions editor

### DIFF
--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -87,6 +87,7 @@ export type BuiltInVsCodeCommands = {
   ) => Promise<void>;
   "vscode.open": (uri: Uri) => Promise<void>;
   "vscode.openFolder": (uri: Uri) => Promise<void>;
+  revealInExplorer: (uri: Uri) => Promise<void>;
 };
 
 // Commands that are available before the extension is fully activated.

--- a/extensions/ql-vscode/src/pure/interface-types.ts
+++ b/extensions/ql-vscode/src/pure/interface-types.ts
@@ -483,6 +483,7 @@ export type FromDataFlowPathsMessage = CommonFromViewMessages;
 
 export interface SetDataExtensionEditorInitialDataMessage {
   t: "setDataExtensionEditorInitialData";
+  extensionPackName: string;
   modelFilename: string;
 }
 
@@ -516,6 +517,10 @@ export interface JumpToUsageMessage {
   location: ResolvableLocationValue;
 }
 
+export interface OpenExtensionPackMessage {
+  t: "openExtensionPack";
+}
+
 export interface OpenModelFileMessage {
   t: "openModelFile";
 }
@@ -539,6 +544,7 @@ export type ToDataExtensionsEditorMessage =
 export type FromDataExtensionsEditorMessage =
   | ViewLoadedMsg
   | OpenModelFileMessage
+  | OpenExtensionPackMessage
   | JumpToUsageMessage
   | SaveModeledMethods
   | GenerateExternalApiMessage;

--- a/extensions/ql-vscode/src/stories/data-extensions-editor/DataExtensionsEditor.stories.tsx
+++ b/extensions/ql-vscode/src/stories/data-extensions-editor/DataExtensionsEditor.stories.tsx
@@ -15,6 +15,7 @@ const Template: ComponentStory<typeof DataExtensionsEditorComponent> = (
 
 export const DataExtensionsEditor = Template.bind({});
 DataExtensionsEditor.args = {
+  initialExtensionPackName: "codeql/sql2o-models",
   initialModelFilename:
     "/home/user/vscode-codeql-starter/codeql-custom-queries-java/sql2o/models/sql2o.yml",
   initialExternalApiUsages: [

--- a/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
@@ -47,16 +47,21 @@ const ProgressBar = styled.div<ProgressBarProps>`
 `;
 
 type Props = {
+  initialExtensionPackName?: string;
   initialModelFilename?: string;
   initialExternalApiUsages?: ExternalApiUsage[];
   initialModeledMethods?: Record<string, ModeledMethod>;
 };
 
 export function DataExtensionsEditor({
+  initialExtensionPackName,
   initialModelFilename,
   initialExternalApiUsages = [],
   initialModeledMethods = {},
 }: Props): JSX.Element {
+  const [extensionPackName, setExtensionPackName] = useState<
+    string | undefined
+  >(initialExtensionPackName);
   const [modelFilename, setModelFilename] = useState<string | undefined>(
     initialModelFilename,
   );
@@ -79,6 +84,7 @@ export function DataExtensionsEditor({
         const msg: ToDataExtensionsEditorMessage = evt.data;
         switch (msg.t) {
           case "setDataExtensionEditorInitialData":
+            setExtensionPackName(msg.extensionPackName);
             setModelFilename(msg.modelFilename);
             break;
           case "setExternalApiUsages":
@@ -150,6 +156,12 @@ export function DataExtensionsEditor({
     });
   }, []);
 
+  const onOpenExtensionPackClick = useCallback(() => {
+    vscode.postMessage({
+      t: "openExtensionPack",
+    });
+  }, []);
+
   const onOpenModelFileClick = useCallback(() => {
     vscode.postMessage({
       t: "openModelFile",
@@ -169,6 +181,12 @@ export function DataExtensionsEditor({
         <>
           <ViewTitle>Data extensions editor</ViewTitle>
           <DetailsContainer>
+            {extensionPackName && (
+              <LinkIconButton onClick={onOpenExtensionPackClick}>
+                <span slot="start" className="codicon codicon-package"></span>
+                {extensionPackName}
+              </LinkIconButton>
+            )}
             {modelFilename && (
               <LinkIconButton onClick={onOpenModelFileClick}>
                 <span slot="start" className="codicon codicon-file-code"></span>


### PR DESCRIPTION
This will add the extension pack name to the data extensions editor and allow the user to click on it to go to the folder of the extension pack in the explorer panel.

![Screenshot 2023-04-17 at 16 36 56](https://github.com/github/vscode-codeql/assets/1112623/bfb5b55f-22d8-49e0-9e73-e1536be315a1)


Based on #2339

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
