### PR TITLE
Prompt non-codespace users for storage path

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -345,7 +345,7 @@
           "type": "string",
           "default": "",
           "patternErrorMessage": "Please enter a valid folder",
-          "markdownDescription": "The name of the folder where we want to create queries and query packs via the \"CodeQL: Create Query\" command. The folder should exist in the workspace."
+          "markdownDescription": "The name of the folder where we want to create queries and query packs via the \"CodeQL: Create Query\" command. The folder should exist."
         }
       }
     },

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -340,6 +340,12 @@
           "type": "boolean",
           "default": false,
           "description": "Allow database to be downloaded via HTTP. Warning: enabling this option will allow downloading from insecure servers."
+        },
+        "codeQL.createQuery.Folder": {
+          "type": "string",
+          "default": "",
+          "patternErrorMessage": "Please enter a valid folder",
+          "markdownDescription": "The name of the folder where we want to create queries and query packs via the \"CodeQL: Create Query\" command. The folder should exist in the workspace.`)."
         }
       }
     },

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -341,11 +341,11 @@
           "default": false,
           "description": "Allow database to be downloaded via HTTP. Warning: enabling this option will allow downloading from insecure servers."
         },
-        "codeQL.createQuery.Folder": {
+        "codeQL.createQuery.folder": {
           "type": "string",
           "default": "",
           "patternErrorMessage": "Please enter a valid folder",
-          "markdownDescription": "The name of the folder where we want to create queries and query packs via the \"CodeQL: Create Query\" command. The folder should exist in the workspace.`)."
+          "markdownDescription": "The name of the folder where we want to create queries and query packs via the \"CodeQL: Create Query\" command. The folder should exist in the workspace."
         }
       }
     },

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -619,3 +619,19 @@ export const ALLOW_HTTP_SETTING = new Setting(
 export function allowHttp(): boolean {
   return ALLOW_HTTP_SETTING.getValue<boolean>() || false;
 }
+
+/**
+ * The name of the folder where we want to create skeleton wizard QL packs.
+ **/
+const SKELETON_WIZARD_FOLDER = new Setting(
+  "folder",
+  new Setting("skeletonWizard", ROOT_SETTING),
+);
+
+export function getSkeletonWizardFolder(): string | undefined {
+  return SKELETON_WIZARD_FOLDER.getValue<string>() || undefined;
+}
+
+export async function setSkeletonWizardFolder(folder: string | undefined) {
+  await SKELETON_WIZARD_FOLDER.updateValue(folder, ConfigurationTarget.Global);
+}

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -625,7 +625,7 @@ export function allowHttp(): boolean {
  **/
 const SKELETON_WIZARD_FOLDER = new Setting(
   "folder",
-  new Setting("skeletonWizard", ROOT_SETTING),
+  new Setting("createQuery", ROOT_SETTING),
 );
 
 export function getSkeletonWizardFolder(): string | undefined {

--- a/extensions/ql-vscode/src/skeleton-query-wizard.ts
+++ b/extensions/ql-vscode/src/skeleton-query-wizard.ts
@@ -14,7 +14,12 @@ import { QlPackGenerator } from "./qlpack-generator";
 import { DatabaseItem, DatabaseManager } from "./local-databases";
 import { ProgressCallback, UserCancellationException } from "./progress";
 import { askForGitHubRepo, downloadGitHubDatabase } from "./databaseFetcher";
-import { existsSync } from "fs";
+import {
+  getSkeletonWizardFolder,
+  isCodespacesTemplate,
+  setSkeletonWizardFolder,
+} from "./config";
+import { existsSync } from "fs-extra";
 
 type QueryLanguagesToDatabaseMap = Record<string, string>;
 
@@ -55,7 +60,7 @@ export class SkeletonQueryWizard {
       return;
     }
 
-    this.qlPackStoragePath = getFirstWorkspaceFolder();
+    this.qlPackStoragePath = await this.determineStoragePath();
 
     const skeletonPackAlreadyExists =
       existsSync(join(this.qlPackStoragePath, this.folderName)) ||
@@ -96,6 +101,38 @@ export class SkeletonQueryWizard {
     void workspace.openTextDocument(queryFileUri).then((doc) => {
       void Window.showTextDocument(doc);
     });
+  }
+
+  public async determineStoragePath() {
+    const firstStorageFolder = getFirstWorkspaceFolder();
+
+    if (isCodespacesTemplate()) {
+      return firstStorageFolder;
+    }
+
+    let storageFolder = getSkeletonWizardFolder();
+
+    if (storageFolder === undefined || !existsSync(storageFolder)) {
+      storageFolder = await Window.showInputBox({
+        title:
+          "Please choose a folder in which to create your new query pack. You can change this in the extension settings.",
+        value: firstStorageFolder,
+        ignoreFocusOut: true,
+      });
+    }
+
+    if (storageFolder === undefined) {
+      throw new UserCancellationException("No storage folder entered.");
+    }
+
+    if (!existsSync(storageFolder)) {
+      throw new UserCancellationException(
+        "Invalid folder. Must be a folder that already exists.",
+      );
+    }
+
+    await setSkeletonWizardFolder(storageFolder);
+    return storageFolder;
   }
 
   private async chooseLanguage() {

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/skeleton-query-wizard.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/skeleton-query-wizard.test.ts
@@ -466,7 +466,7 @@ describe("SkeletonQueryWizard", () => {
         ensureDirSync(storedPath);
 
         originalValue = workspace
-          .getConfiguration("codeQL.skeletonWizard")
+          .getConfiguration("codeQL.createQuery")
           .get("folder");
 
         // Set isCodespacesTemplate to true to indicate we are in the codespace template
@@ -499,16 +499,16 @@ describe("SkeletonQueryWizard", () => {
           ensureDirSync(storedPath);
 
           originalValue = workspace
-            .getConfiguration("codeQL.skeletonWizard")
+            .getConfiguration("codeQL.createQuery")
             .get("folder");
           await workspace
-            .getConfiguration("codeQL.skeletonWizard")
+            .getConfiguration("codeQL.createQuery")
             .update("folder", storedPath);
         });
 
         afterEach(async () => {
           await workspace
-            .getConfiguration("codeQL.skeletonWizard")
+            .getConfiguration("codeQL.createQuery")
             .update("folder", originalValue);
         });
 
@@ -528,16 +528,16 @@ describe("SkeletonQueryWizard", () => {
           storedPath = join(dir.name, "this-folder-does-not-exist");
 
           originalValue = workspace
-            .getConfiguration("codeQL.skeletonWizard")
+            .getConfiguration("codeQL.createQuery")
             .get("folder");
           await workspace
-            .getConfiguration("codeQL.skeletonWizard")
+            .getConfiguration("codeQL.createQuery")
             .update("folder", storedPath);
         });
 
         afterEach(async () => {
           await workspace
-            .getConfiguration("codeQL.skeletonWizard")
+            .getConfiguration("codeQL.createQuery")
             .update("folder", originalValue);
         });
 


### PR DESCRIPTION
Offer non-codespace users the option to configure their storage folder for skeleton packs.

Suggested here: https://github.com/github/vscode-codeql/pull/2310#issuecomment-1507428217

At the moment we're choosing to create our skeleton packs in the first folder in the workspace.

This is fine for the codespace template because we can control the folder structure in that repo.

For users outside of this we'd like to offer them the option to choose where to save their skeleton packs.
