### PR TITLE
Fix C# query to give results in the same format as java.

### DIFF
--- a/extensions/ql-vscode/src/data-extensions-editor/queries/csharp.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/queries/csharp.ts
@@ -78,16 +78,6 @@ class ExternalApi extends DotNet::Callable {
   }
 
   /**
-   * Gets the unbound type, name and parameter types of this API.
-   */
-  bindingset[this]
-  private string getSignature() {
-    result =
-      this.getDeclaringType().getUnboundDeclaration() + "." + this.getName() + "(" +
-        parameterQualifiedTypeNamesToString(this) + ")"
-  }
-
-  /**
    * Gets the namespace of this API.
    */
   bindingset[this]
@@ -97,7 +87,8 @@ class ExternalApi extends DotNet::Callable {
    * Gets the namespace and signature of this API.
    */
   bindingset[this]
-  string getApiName() { result = this.getNamespace() + "#" + this.getSignature() }
+  string getApiName() { result = this.getNamespace() + "." + this.getDeclaringType().getUnboundDeclaration() + "#" + this.getName() + "(" +
+  parameterQualifiedTypeNamesToString(this) + ")" }
 
   /** Gets a node that is an input to a call to this API. */
   private ArgumentNode getAnInput() {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

C# didnt recognize the modeled methods because the api name differed from the Java one and therefore the split up didnt work as expected. This makes a change to fix that. We'll look at whether this is something that should be upstreamed or whether it only makes sense for the extension.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
