### PR TITLE
Suggest smaller databases in "create query" setup

### DIFF
--- a/extensions/ql-vscode/src/skeleton-query-wizard.ts
+++ b/extensions/ql-vscode/src/skeleton-query-wizard.ts
@@ -19,13 +19,13 @@ import { existsSync } from "fs";
 type QueryLanguagesToDatabaseMap = Record<string, string>;
 
 export const QUERY_LANGUAGE_TO_DATABASE_REPO: QueryLanguagesToDatabaseMap = {
-  cpp: "protocolbuffers/protobuf",
-  csharp: "dotnet/efcore",
-  go: "evanw/esbuild",
-  java: "google/guava",
-  javascript: "facebook/react",
+  cpp: "google/brotli",
+  csharp: "restsharp/RestSharp",
+  go: "spf13/cobra",
+  java: "projectlombok/lombok",
+  javascript: "d3/d3",
   python: "pallets/flask",
-  ruby: "rails/rails",
+  ruby: "jekyll/jekyll",
   swift: "Alamofire/Alamofire",
 };
 


### PR DESCRIPTION
We want users to be able to quickly get started with running queries, so let's suggest smaller databases (which won't take too long to download). 

These databases come from the "Top XXX" lists that we use for variant analysis. See internal issue for more details 👀 

## Checklist

N/A—this is still feature-flagged 🎏 

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
