### PR TITLE
Clear pack cache after creating extension pack

### DIFF
--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-module.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-module.ts
@@ -78,6 +78,7 @@ export class DataExtensionsEditorModule {
 
             const modelFile = await pickExtensionPackModelFile(
               this.cliServer,
+              this.queryRunner,
               db,
               progress,
               token,

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/data-extensions-editor/extension-pack-picker.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/data-extensions-editor/extension-pack-picker.test.ts
@@ -32,6 +32,9 @@ describe("pickExtensionPackModelFile", () => {
   let showAndLogErrorMessageSpy: jest.SpiedFunction<
     typeof helpers.showAndLogErrorMessage
   >;
+  const extensionPackClearer = {
+    clearPackCache: jest.fn(),
+  };
 
   beforeEach(async () => {
     tmpDir = (
@@ -99,6 +102,7 @@ describe("pickExtensionPackModelFile", () => {
     expect(
       await pickExtensionPackModelFile(
         cliServer,
+        extensionPackClearer,
         databaseItem,
         progress,
         token,
@@ -173,6 +177,7 @@ describe("pickExtensionPackModelFile", () => {
     expect(
       await pickExtensionPackModelFile(
         cliServer,
+        extensionPackClearer,
         databaseItem,
         progress,
         token,
@@ -207,6 +212,7 @@ describe("pickExtensionPackModelFile", () => {
     expect(
       await pickExtensionPackModelFile(
         cliServer,
+        extensionPackClearer,
         databaseItem,
         progress,
         token,
@@ -235,6 +241,7 @@ describe("pickExtensionPackModelFile", () => {
     expect(
       await pickExtensionPackModelFile(
         cliServer,
+        extensionPackClearer,
         databaseItem,
         progress,
         token,
@@ -273,6 +280,7 @@ describe("pickExtensionPackModelFile", () => {
     );
     expect(cliServer.resolveQlpacks).toHaveBeenCalled();
     expect(cliServer.resolveExtensions).toHaveBeenCalled();
+    expect(extensionPackClearer.clearPackCache).toHaveBeenCalledTimes(1);
 
     expect(
       loadYaml(await readFile(join(newPackDir, "codeql-pack.yml"), "utf8")),
@@ -306,6 +314,7 @@ describe("pickExtensionPackModelFile", () => {
     expect(
       await pickExtensionPackModelFile(
         cliServer,
+        extensionPackClearer,
         {
           ...databaseItem,
           language: "csharp",
@@ -369,6 +378,7 @@ describe("pickExtensionPackModelFile", () => {
     expect(
       await pickExtensionPackModelFile(
         cliServer,
+        extensionPackClearer,
         databaseItem,
         progress,
         token,
@@ -392,6 +402,7 @@ describe("pickExtensionPackModelFile", () => {
     expect(
       await pickExtensionPackModelFile(
         cliServer,
+        extensionPackClearer,
         databaseItem,
         progress,
         token,
@@ -421,6 +432,7 @@ describe("pickExtensionPackModelFile", () => {
     expect(
       await pickExtensionPackModelFile(
         cliServer,
+        extensionPackClearer,
         databaseItem,
         progress,
         token,
@@ -460,6 +472,7 @@ describe("pickExtensionPackModelFile", () => {
     expect(
       await pickExtensionPackModelFile(
         cliServer,
+        extensionPackClearer,
         databaseItem,
         progress,
         token,
@@ -496,6 +509,7 @@ describe("pickExtensionPackModelFile", () => {
     expect(
       await pickExtensionPackModelFile(
         cliServer,
+        extensionPackClearer,
         databaseItem,
         progress,
         token,
@@ -535,6 +549,7 @@ describe("pickExtensionPackModelFile", () => {
     expect(
       await pickExtensionPackModelFile(
         cliServer,
+        extensionPackClearer,
         databaseItem,
         progress,
         token,
@@ -583,6 +598,7 @@ describe("pickExtensionPackModelFile", () => {
     expect(
       await pickExtensionPackModelFile(
         cliServer,
+        extensionPackClearer,
         databaseItem,
         progress,
         token,
@@ -641,6 +657,7 @@ describe("pickExtensionPackModelFile", () => {
     expect(
       await pickExtensionPackModelFile(
         cliServer,
+        extensionPackClearer,
         databaseItem,
         progress,
         token,
@@ -702,6 +719,7 @@ describe("pickExtensionPackModelFile", () => {
     expect(
       await pickExtensionPackModelFile(
         cliServer,
+        extensionPackClearer,
         databaseItem,
         progress,
         token,
@@ -760,6 +778,7 @@ describe("pickExtensionPackModelFile", () => {
     expect(
       await pickExtensionPackModelFile(
         cliServer,
+        extensionPackClearer,
         databaseItem,
         progress,
         token,
@@ -783,6 +802,7 @@ describe("pickExtensionPackModelFile", () => {
     expect(
       await pickExtensionPackModelFile(
         cliServer,
+        extensionPackClearer,
         databaseItem,
         progress,
         token,
@@ -851,6 +871,7 @@ describe("pickExtensionPackModelFile", () => {
     expect(
       await pickExtensionPackModelFile(
         cliServer,
+        extensionPackClearer,
         databaseItem,
         progress,
         token,
@@ -935,6 +956,7 @@ describe("pickExtensionPackModelFile", () => {
     expect(
       await pickExtensionPackModelFile(
         cliServer,
+        extensionPackClearer,
         databaseItem,
         progress,
         token,
@@ -975,6 +997,7 @@ describe("pickExtensionPackModelFile", () => {
     expect(
       await pickExtensionPackModelFile(
         cliServer,
+        extensionPackClearer,
         {
           ...databaseItem,
           language: "csharp",


### PR DESCRIPTION
After creating a new extension pack, the query server will not pick up the new pack until the cache is cleared. The CLI server will pick up the change, so this results in an internal error.

This will clear the pack cache after creating the extension pack to ensure we don't end up in this inconsistent state and the extension pack is used for queries.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
