### PR TITLE
Clear pack cache on create and delete

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -707,9 +707,14 @@ async function activateWithInstalledDistribution(
   for (const glob of PACK_GLOBS) {
     const fsWatcher = workspace.createFileSystemWatcher(glob);
     ctx.subscriptions.push(fsWatcher);
-    fsWatcher.onDidChange(async (_uri) => {
+
+    const clearPackCache = async (_uri: Uri) => {
       await qs.clearPackCache();
-    });
+    };
+
+    fsWatcher.onDidCreate(clearPackCache);
+    fsWatcher.onDidChange(clearPackCache);
+    fsWatcher.onDidDelete(clearPackCache);
   }
 
   void extLogger.log("Initializing database manager.");


### PR DESCRIPTION
We were only clearing the pack cache when a pack file was modified. When using a script to create a new pack, the pack file is created at once without a change event firing. This will change the behavior to also clear the pack cache when a pack file is created or deleted.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
