### PR TITLE
Move language support files

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -72,7 +72,7 @@ import {
   getErrorMessage,
   getErrorStack,
 } from "./pure/helpers-pure";
-import { spawnIdeServer } from "./ide-server";
+import { spawnIdeServer } from "./language-support/ide-server";
 import { ResultsView } from "./interface";
 import { WebviewReveal } from "./interface-utils";
 import {

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -36,7 +36,7 @@ import {
   QueryHistoryConfigListener,
   QueryServerConfigListener,
 } from "./config";
-import { install } from "./languageSupport";
+import { install } from "./language-support/language-support";
 import { DatabaseManager } from "./local-databases";
 import { DatabaseUI } from "./local-databases-ui";
 import {

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -118,7 +118,7 @@ import {
 } from "./common/commands";
 import { LocalQueries } from "./local-queries";
 import { getAstCfgCommands } from "./ast-cfg-commands";
-import { getQueryEditorCommands } from "./query-editor";
+import { getQueryEditorCommands } from "./language-support/query-editor";
 import { App } from "./common/app";
 import { registerCommandWithErrorHandling } from "./common/vscode/commands";
 import { DebuggerUI } from "./debugger/debugger-ui";

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -36,7 +36,11 @@ import {
   QueryHistoryConfigListener,
   QueryServerConfigListener,
 } from "./config";
-import { install } from "./language-support/language-support";
+import {
+  install,
+  spawnIdeServer,
+  getQueryEditorCommands,
+} from "./language-support";
 import { DatabaseManager } from "./local-databases";
 import { DatabaseUI } from "./local-databases-ui";
 import {
@@ -72,7 +76,6 @@ import {
   getErrorMessage,
   getErrorStack,
 } from "./pure/helpers-pure";
-import { spawnIdeServer } from "./language-support/ide-server";
 import { ResultsView } from "./interface";
 import { WebviewReveal } from "./interface-utils";
 import {
@@ -118,7 +121,6 @@ import {
 } from "./common/commands";
 import { LocalQueries } from "./local-queries";
 import { getAstCfgCommands } from "./ast-cfg-commands";
-import { getQueryEditorCommands } from "./language-support/query-editor";
 import { App } from "./common/app";
 import { registerCommandWithErrorHandling } from "./common/vscode/commands";
 import { DebuggerUI } from "./debugger/debugger-ui";

--- a/extensions/ql-vscode/src/language-support/ide-server.ts
+++ b/extensions/ql-vscode/src/language-support/ide-server.ts
@@ -1,8 +1,8 @@
 import { ProgressLocation, window } from "vscode";
 import { StreamInfo } from "vscode-languageclient/node";
-import { shouldDebugIdeServer, spawnServer } from "./cli";
-import { QueryServerConfig } from "./config";
-import { ideServerLogger } from "./common";
+import { shouldDebugIdeServer, spawnServer } from "../cli";
+import { QueryServerConfig } from "../config";
+import { ideServerLogger } from "../common";
 
 /**
  * Managing the language server for CodeQL.

--- a/extensions/ql-vscode/src/language-support/index.ts
+++ b/extensions/ql-vscode/src/language-support/index.ts
@@ -1,0 +1,3 @@
+export * from "./ide-server";
+export * from "./language-support";
+export * from "./query-editor";

--- a/extensions/ql-vscode/src/language-support/language-support.ts
+++ b/extensions/ql-vscode/src/language-support/language-support.ts
@@ -12,7 +12,7 @@ import { languages, IndentAction, OnEnterRule } from "vscode";
  */
 export function install() {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const langConfig = require("../language-configuration.json");
+  const langConfig = require("../../language-configuration.json");
   // setLanguageConfiguration requires a regexp for the wordpattern, not a string
   langConfig.wordPattern = new RegExp(langConfig.wordPattern);
   langConfig.onEnterRules = onEnterRules;

--- a/extensions/ql-vscode/src/language-support/query-editor.ts
+++ b/extensions/ql-vscode/src/language-support/query-editor.ts
@@ -1,11 +1,11 @@
 import { Uri, window } from "vscode";
-import { CodeQLCliServer } from "./cli";
-import { QueryRunner } from "./query-server";
+import { CodeQLCliServer } from "../cli";
+import { QueryRunner } from "../query-server";
 import { basename, join } from "path";
-import { getErrorMessage } from "./pure/helpers-pure";
-import { redactableError } from "./pure/errors";
-import { showAndLogExceptionWithTelemetry } from "./helpers";
-import { AppCommandManager, QueryEditorCommands } from "./common/commands";
+import { getErrorMessage } from "../pure/helpers-pure";
+import { redactableError } from "../pure/errors";
+import { showAndLogExceptionWithTelemetry } from "../helpers";
+import { AppCommandManager, QueryEditorCommands } from "../common/commands";
 
 type QueryEditorOptions = {
   commandManager: AppCommandManager;


### PR DESCRIPTION
This PR is part of an endeavour to order files in the codebase according to the domain model. Here files related to the language support are moved to one folder.

Nothing unexpected came up during the work.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
