### PR TITLE
Don't throw error if user cancels out of choosing a language

### DIFF
--- a/extensions/ql-vscode/src/skeleton-query-wizard.ts
+++ b/extensions/ql-vscode/src/skeleton-query-wizard.ts
@@ -141,7 +141,7 @@ export class SkeletonQueryWizard {
       maxStep: 3,
     });
 
-    return await askForLanguage(this.cliServer, false);
+    return await askForLanguage(this.cliServer, true);
   }
 
   private async createQlPack() {


### PR DESCRIPTION
Small tweak: When running "Create Query", if the user escapes out of the language quickpick we don't need to throw an error. Instead we can just show a [`UserCancellationException`](https://github.com/github/vscode-codeql/blob/dbdab13d03cd38032bf6e8f427bc4a2d92f7535c/extensions/ql-vscode/src/helpers.ts#L728-L730) notice.

## Checklist

N/A—this is still behind a feature-flag. 

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
