### PR TITLE
Only attempt to discover QL tests in on-disk workspace folders

### DIFF
--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -249,15 +249,17 @@ export async function showInformationMessageWithAction(
   return chosenItem === actionItem;
 }
 
+/** Returns true if the specified workspace folder is on the file system. */
+export function isWorkspaceFolderOnDisk(
+  workspaceFolder: WorkspaceFolder,
+): boolean {
+  return workspaceFolder.uri.scheme === "file";
+}
+
 /** Gets all active workspace folders that are on the filesystem. */
 export function getOnDiskWorkspaceFoldersObjects() {
-  const workspaceFolders = workspace.workspaceFolders || [];
-  const diskWorkspaceFolders: WorkspaceFolder[] = [];
-  for (const workspaceFolder of workspaceFolders) {
-    if (workspaceFolder.uri.scheme === "file")
-      diskWorkspaceFolders.push(workspaceFolder);
-  }
-  return diskWorkspaceFolders;
+  const workspaceFolders = workspace.workspaceFolders ?? [];
+  return workspaceFolders.filter(isWorkspaceFolderOnDisk);
 }
 
 /** Gets all active workspace folders that are on the filesystem. */

--- a/extensions/ql-vscode/src/test-manager.ts
+++ b/extensions/ql-vscode/src/test-manager.ts
@@ -28,6 +28,7 @@ import { BaseLogger, LogOptions } from "./common";
 import { TestRunner } from "./test-runner";
 import { TestManagerBase } from "./test-manager-base";
 import { App } from "./common/app";
+import { isWorkspaceFolderOnDisk } from "./helpers";
 
 /**
  * Returns the complete text content of the specified file. If there is an error reading the file,
@@ -162,15 +163,22 @@ export class TestManager extends TestManagerBase {
   private startTrackingWorkspaceFolders(
     workspaceFolders: readonly WorkspaceFolder[],
   ): void {
-    for (const workspaceFolder of workspaceFolders) {
-      const workspaceFolderHandler = new WorkspaceFolderHandler(
-        workspaceFolder,
-        this,
-        this.cliServer,
-      );
-      this.track(workspaceFolderHandler);
-      this.workspaceFolderHandlers.set(workspaceFolder, workspaceFolderHandler);
-    }
+    // Only track on-disk workspace folders, to avoid trying to run the CLI test discovery command
+    // on random URIs.
+    workspaceFolders
+      .filter(isWorkspaceFolderOnDisk)
+      .forEach((workspaceFolder) => {
+        const workspaceFolderHandler = new WorkspaceFolderHandler(
+          workspaceFolder,
+          this,
+          this.cliServer,
+        );
+        this.track(workspaceFolderHandler);
+        this.workspaceFolderHandlers.set(
+          workspaceFolder,
+          workspaceFolderHandler,
+        );
+      });
   }
 
   /** Stop tracking tests in the specified workspace folders. */


### PR DESCRIPTION
This was only a problem for the new test UI, because the third-party Test Explorer extension we used before must have had this filter in its implementation.
