### PR TITLE
Rename `Argument[-1]` to `Argument[this]`

### DIFF
--- a/extensions/ql-vscode/src/stories/data-extensions-editor/DataExtensionsEditor.stories.tsx
+++ b/extensions/ql-vscode/src/stories/data-extensions-editor/DataExtensionsEditor.stories.tsx
@@ -213,13 +213,13 @@ DataExtensionsEditor.args = {
     },
     "org.sql2o.Connection#createQuery(String)": {
       type: "summary",
-      input: "Argument[-1]",
+      input: "Argument[this]",
       output: "ReturnValue",
       kind: "taint",
     },
     "org.sql2o.Sql2o#open()": {
       type: "summary",
-      input: "Argument[-1]",
+      input: "Argument[this]",
       output: "ReturnValue",
       kind: "taint",
     },

--- a/extensions/ql-vscode/src/stories/data-extensions-editor/MethodRow.stories.tsx
+++ b/extensions/ql-vscode/src/stories/data-extensions-editor/MethodRow.stories.tsx
@@ -47,7 +47,7 @@ MethodRow.args = {
   },
   modeledMethod: {
     type: "summary",
-    input: "Argument[-1]",
+    input: "Argument[this]",
     output: "ReturnValue",
     kind: "taint",
   },

--- a/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
@@ -64,8 +64,8 @@ export const MethodRow = ({
       const target = e.target as HTMLSelectElement;
 
       onChange(externalApiUsage, {
-        // If there are no arguments, we will default to "this", which is Argument[-1]
-        input: argumentsList.length === 0 ? "Argument[-1]" : "Argument[0]",
+        // If there are no arguments, we will default to "Argument[this]"
+        input: argumentsList.length === 0 ? "Argument[this]" : "Argument[0]",
         output: "ReturnType",
         kind: "value",
         ...modeledMethod,
@@ -167,9 +167,7 @@ export const MethodRow = ({
         {modeledMethod?.type &&
           ["sink", "summary"].includes(modeledMethod?.type) && (
             <Dropdown value={modeledMethod?.input} onInput={handleInputInput}>
-              <VSCodeOption value="Argument[-1]">
-                Argument[-1]: this
-              </VSCodeOption>
+              <VSCodeOption value="Argument[this]">Argument[this]</VSCodeOption>
               {argumentsList.map((argument, index) => (
                 <VSCodeOption key={argument} value={`Argument[${index}]`}>
                   Argument[{index}]: {argument}
@@ -183,9 +181,7 @@ export const MethodRow = ({
           ["source", "summary"].includes(modeledMethod?.type) && (
             <Dropdown value={modeledMethod?.output} onInput={handleOutputInput}>
               <VSCodeOption value="ReturnValue">ReturnValue</VSCodeOption>
-              <VSCodeOption value="Argument[-1]">
-                Argument[-1]: this
-              </VSCodeOption>
+              <VSCodeOption value="Argument[this]">Argument[this]</VSCodeOption>
               {argumentsList.map((argument, index) => (
                 <VSCodeOption key={argument} value={`Argument[${index}]`}>
                   Argument[{index}]: {argument}


### PR DESCRIPTION
This renames `Argument[-1]` to `Argument[this]` to match the corresponding change in CodeQL.

See: https://github.com/github/codeql/pull/12556

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
