### PR TITLE
Update wording in the "sorting dropdown" of the variant analysis results view

### DIFF
--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -259,7 +259,7 @@ This requires running a MRVA query and seeing the results view.
 7. Can open query text
 8. Can sort repos
    1. By name
-   2. By results
+   2. By number of results
    3. By popularity
    4. By most recent commit
 9. Can filter repos

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -261,7 +261,7 @@ This requires running a MRVA query and seeing the results view.
    1. By name
    2. By results
    3. By stars
-   4. By last updated
+   4. By most recent commit
 9. Can filter repos
 10. Shows correct statistics
     1. Total number of results

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -260,7 +260,7 @@ This requires running a MRVA query and seeing the results view.
 8. Can sort repos
    1. By name
    2. By results
-   3. By stars
+   3. By popularity
    4. By most recent commit
 9. Can filter repos
 10. Shows correct statistics

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -258,7 +258,7 @@ This requires running a MRVA query and seeing the results view.
    2. When the file does not exist
 7. Can open query text
 8. Can sort repos
-   1. By name
+   1. Alphabetically
    2. By number of results
    3. By popularity
    4. By most recent commit

--- a/extensions/ql-vscode/src/view/common/LastUpdated.tsx
+++ b/extensions/ql-vscode/src/view/common/LastUpdated.tsx
@@ -34,7 +34,7 @@ export const LastUpdated = ({ lastUpdated }: Props) => {
   return (
     <div>
       <IconContainer>
-        <Codicon name="repo-push" label="Last updated" />
+        <Codicon name="repo-push" label="Most recent commit" />
       </IconContainer>
       <Duration>{humanizeRelativeTime(date.getTime() - Date.now())}</Duration>
     </div>

--- a/extensions/ql-vscode/src/view/variant-analysis/RepositoriesSort.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/RepositoriesSort.tsx
@@ -31,7 +31,7 @@ export const RepositoriesSort = ({ value, onChange, className }: Props) => {
       <Codicon name="sort-precedence" label="Sort..." slot="indicator" />
       <VSCodeOption value={SortKey.Name}>Name</VSCodeOption>
       <VSCodeOption value={SortKey.ResultsCount}>Results</VSCodeOption>
-      <VSCodeOption value={SortKey.Stars}>Stars</VSCodeOption>
+      <VSCodeOption value={SortKey.Stars}>Popularity</VSCodeOption>
       <VSCodeOption value={SortKey.LastUpdated}>
         Most recent commit
       </VSCodeOption>

--- a/extensions/ql-vscode/src/view/variant-analysis/RepositoriesSort.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/RepositoriesSort.tsx
@@ -29,7 +29,7 @@ export const RepositoriesSort = ({ value, onChange, className }: Props) => {
   return (
     <Dropdown value={value} onInput={handleInput} className={className}>
       <Codicon name="sort-precedence" label="Sort..." slot="indicator" />
-      <VSCodeOption value={SortKey.Name}>Name</VSCodeOption>
+      <VSCodeOption value={SortKey.Name}>Alphabetically</VSCodeOption>
       <VSCodeOption value={SortKey.ResultsCount}>
         Number of results
       </VSCodeOption>

--- a/extensions/ql-vscode/src/view/variant-analysis/RepositoriesSort.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/RepositoriesSort.tsx
@@ -32,7 +32,9 @@ export const RepositoriesSort = ({ value, onChange, className }: Props) => {
       <VSCodeOption value={SortKey.Name}>Name</VSCodeOption>
       <VSCodeOption value={SortKey.ResultsCount}>Results</VSCodeOption>
       <VSCodeOption value={SortKey.Stars}>Stars</VSCodeOption>
-      <VSCodeOption value={SortKey.LastUpdated}>Last updated</VSCodeOption>
+      <VSCodeOption value={SortKey.LastUpdated}>
+        Most recent commit
+      </VSCodeOption>
     </Dropdown>
   );
 };

--- a/extensions/ql-vscode/src/view/variant-analysis/RepositoriesSort.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/RepositoriesSort.tsx
@@ -30,7 +30,9 @@ export const RepositoriesSort = ({ value, onChange, className }: Props) => {
     <Dropdown value={value} onInput={handleInput} className={className}>
       <Codicon name="sort-precedence" label="Sort..." slot="indicator" />
       <VSCodeOption value={SortKey.Name}>Name</VSCodeOption>
-      <VSCodeOption value={SortKey.ResultsCount}>Results</VSCodeOption>
+      <VSCodeOption value={SortKey.ResultsCount}>
+        Number of results
+      </VSCodeOption>
       <VSCodeOption value={SortKey.Stars}>Popularity</VSCodeOption>
       <VSCodeOption value={SortKey.LastUpdated}>
         Most recent commit

--- a/extensions/ql-vscode/src/view/variant-analysis/__tests__/RepoRow.spec.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/__tests__/RepoRow.spec.tsx
@@ -39,7 +39,7 @@ describe(RepoRow.name, () => {
       screen.queryByRole("img", {
         // There should not be any icons, except for the icons which are always shown
         name: (name) =>
-          !["expand", "stars count", "last updated"].includes(
+          !["expand", "stars count", "most recent commit"].includes(
             name.toLowerCase(),
           ),
       }),
@@ -293,7 +293,7 @@ describe(RepoRow.name, () => {
     expect(screen.getByText("last month")).toBeInTheDocument();
     expect(
       screen.getByRole("img", {
-        name: "Last updated",
+        name: "Most recent commit",
       }),
     ).toBeInTheDocument();
   });
@@ -314,7 +314,7 @@ describe(RepoRow.name, () => {
     ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("img", {
-        name: "Last updated",
+        name: "Most recent commit",
       }),
     ).not.toBeInTheDocument();
   });

--- a/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisAnalyzedRepos.spec.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisAnalyzedRepos.spec.tsx
@@ -206,7 +206,7 @@ describe(VariantAnalysisAnalyzedRepos.name, () => {
     expect(rows[5]).toHaveTextContent("octodemo/hello-world-6");
   });
 
-  it("uses the results count sort key", async () => {
+  it("uses the 'Number of results' sort key", async () => {
     render({
       filterSortState: {
         ...defaultFilterSortState,

--- a/extensions/ql-vscode/test/unit-tests/variant-analysis-filter-sort.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/variant-analysis-filter-sort.test.ts
@@ -127,7 +127,7 @@ describe(compareRepository.name, () => {
     });
   });
 
-  describe("when sort key is name", () => {
+  describe("when sort key is 'Alphabetically'", () => {
     const sorter = compareRepository({
       ...defaultFilterSortState,
       sortKey: SortKey.Name,

--- a/extensions/ql-vscode/test/unit-tests/variant-analysis-filter-sort.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/variant-analysis-filter-sort.test.ts
@@ -153,7 +153,7 @@ describe(compareRepository.name, () => {
     });
   });
 
-  describe("when sort key is stars", () => {
+  describe("when sort key is 'Popularity'", () => {
     const sorter = compareRepository({
       ...defaultFilterSortState,
       sortKey: SortKey.Stars,
@@ -271,7 +271,7 @@ describe(compareWithResults.name, () => {
     });
   });
 
-  describe("when sort key is stars", () => {
+  describe("when sort key is 'Popularity'", () => {
     const sorter = compareWithResults({
       ...defaultFilterSortState,
       sortKey: SortKey.Stars,

--- a/extensions/ql-vscode/test/unit-tests/variant-analysis-filter-sort.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/variant-analysis-filter-sort.test.ts
@@ -199,7 +199,7 @@ describe(compareRepository.name, () => {
     });
   });
 
-  describe("when sort key is last updated", () => {
+  describe("when sort key is 'Most recent commit'", () => {
     const sorter = compareRepository({
       ...defaultFilterSortState,
       sortKey: SortKey.LastUpdated,
@@ -297,7 +297,7 @@ describe(compareWithResults.name, () => {
     });
   });
 
-  describe("when sort key is last updated", () => {
+  describe("when sort key is 'Most recent commit'", () => {
     const sorter = compareWithResults({
       ...defaultFilterSortState,
       sortKey: SortKey.LastUpdated,


### PR DESCRIPTION

!["Sorting" dropdown in the variant analysis results view](https://github.com/github/vscode-codeql/assets/42641846/695fec4c-0858-4350-ba1f-f7abfb55f9f2)


Renames the following "sorting keys" in the results view:

- "Name" -> "Alphabetically"
- "Results" -> "Number of results"
- "Stars" -> "Popularity"
- "Last updated" -> "Most recent commit"
  - I've also updated the hover text for the "RepoRow" component here. This wasn't necessary for the other renamings.
    ![hover text for "last updated"](https://github.com/github/vscode-codeql/assets/42641846/42785d3a-74e2-4834-a173-3129ee8faf1d)



See linked internal issue for more details! 

## Checklist

This is still in beta, so I don't think we need a changelog update. The docs will require some [screenshot updates](https://codeql.github.com/docs/codeql-for-visual-studio-code/running-codeql-queries-at-scale-with-mrva/#exploring-your-results), but we'll save that until the follow-up tasks are also complete.

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
