### PR TITLE
Change internal name for variant analysis `SortKey` values

### DIFF
--- a/extensions/ql-vscode/src/pure/variant-analysis-filter-sort.ts
+++ b/extensions/ql-vscode/src/pure/variant-analysis-filter-sort.ts
@@ -11,10 +11,10 @@ export enum FilterKey {
 }
 
 export enum SortKey {
-  Name = "name",
-  Stars = "stars",
-  LastUpdated = "lastUpdated",
-  ResultsCount = "resultsCount",
+  Alphabetically = "alphabetically",
+  Popularity = "popularity",
+  MostRecentCommit = "mostRecentCommit",
+  NumberOfResults = "numberOfResults",
 }
 
 export type RepositoriesFilterSortState = {
@@ -30,7 +30,7 @@ export type RepositoriesFilterSortStateWithIds = RepositoriesFilterSortState & {
 export const defaultFilterSortState: RepositoriesFilterSortState = {
   searchValue: "",
   filterKey: FilterKey.All,
-  sortKey: SortKey.Name,
+  sortKey: SortKey.Alphabetically,
 };
 
 export function matchesFilter(
@@ -76,7 +76,7 @@ export function compareRepository(
 ): (left: SortableRepository, right: SortableRepository) => number {
   return (left: SortableRepository, right: SortableRepository) => {
     // Highest to lowest
-    if (filterSortState?.sortKey === SortKey.Stars) {
+    if (filterSortState?.sortKey === SortKey.Popularity) {
       const stargazersCount =
         (right.stargazersCount ?? 0) - (left.stargazersCount ?? 0);
       if (stargazersCount !== 0) {
@@ -85,7 +85,7 @@ export function compareRepository(
     }
 
     // Newest to oldest
-    if (filterSortState?.sortKey === SortKey.LastUpdated) {
+    if (filterSortState?.sortKey === SortKey.MostRecentCommit) {
       const lastUpdated =
         (parseDate(right.updatedAt)?.getTime() ?? 0) -
         (parseDate(left.updatedAt)?.getTime() ?? 0);
@@ -118,7 +118,7 @@ export function compareWithResults(
 
   return (left: FilterAndSortableResult, right: FilterAndSortableResult) => {
     // Highest to lowest
-    if (filterSortState?.sortKey === SortKey.ResultsCount) {
+    if (filterSortState?.sortKey === SortKey.NumberOfResults) {
       const resultCount = (right.resultCount ?? 0) - (left.resultCount ?? 0);
       if (resultCount !== 0) {
         return resultCount;

--- a/extensions/ql-vscode/src/stories/variant-analysis/RepositoriesSort.stories.tsx
+++ b/extensions/ql-vscode/src/stories/variant-analysis/RepositoriesSort.stories.tsx
@@ -19,7 +19,7 @@ export default {
 } as ComponentMeta<typeof RepositoriesSortComponent>;
 
 export const RepositoriesSort = () => {
-  const [value, setValue] = useState(SortKey.Name);
+  const [value, setValue] = useState(SortKey.Alphabetically);
 
   return <RepositoriesSortComponent value={value} onChange={setValue} />;
 };

--- a/extensions/ql-vscode/src/view/variant-analysis/RepositoriesSort.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/RepositoriesSort.tsx
@@ -29,12 +29,12 @@ export const RepositoriesSort = ({ value, onChange, className }: Props) => {
   return (
     <Dropdown value={value} onInput={handleInput} className={className}>
       <Codicon name="sort-precedence" label="Sort..." slot="indicator" />
-      <VSCodeOption value={SortKey.Name}>Alphabetically</VSCodeOption>
-      <VSCodeOption value={SortKey.ResultsCount}>
+      <VSCodeOption value={SortKey.Alphabetically}>Alphabetically</VSCodeOption>
+      <VSCodeOption value={SortKey.NumberOfResults}>
         Number of results
       </VSCodeOption>
-      <VSCodeOption value={SortKey.Stars}>Popularity</VSCodeOption>
-      <VSCodeOption value={SortKey.LastUpdated}>
+      <VSCodeOption value={SortKey.Popularity}>Popularity</VSCodeOption>
+      <VSCodeOption value={SortKey.MostRecentCommit}>
         Most recent commit
       </VSCodeOption>
     </Dropdown>

--- a/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisAnalyzedRepos.spec.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisAnalyzedRepos.spec.tsx
@@ -191,7 +191,7 @@ describe(VariantAnalysisAnalyzedRepos.name, () => {
     render({
       filterSortState: {
         ...defaultFilterSortState,
-        sortKey: SortKey.Stars,
+        sortKey: SortKey.Popularity,
       },
     });
 
@@ -210,7 +210,7 @@ describe(VariantAnalysisAnalyzedRepos.name, () => {
     render({
       filterSortState: {
         ...defaultFilterSortState,
-        sortKey: SortKey.ResultsCount,
+        sortKey: SortKey.NumberOfResults,
       },
     });
 

--- a/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisSkippedRepositoriesTab.spec.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisSkippedRepositoriesTab.spec.tsx
@@ -178,7 +178,7 @@ describe(VariantAnalysisSkippedRepositoriesTab.name, () => {
       },
       filterSortState: {
         ...defaultFilterSortState,
-        sortKey: SortKey.Stars,
+        sortKey: SortKey.Popularity,
       },
     });
 
@@ -190,7 +190,7 @@ describe(VariantAnalysisSkippedRepositoriesTab.name, () => {
     expect(rows[2]).toHaveTextContent("octodemo/hello-galaxy");
   });
 
-  it("does not use the result count sort key", async () => {
+  it("does not use the 'number of results' sort key", async () => {
     render({
       alertTitle: "No database",
       alertMessage:
@@ -211,7 +211,7 @@ describe(VariantAnalysisSkippedRepositoriesTab.name, () => {
       },
       filterSortState: {
         ...defaultFilterSortState,
-        sortKey: SortKey.ResultsCount,
+        sortKey: SortKey.NumberOfResults,
       },
     });
 

--- a/extensions/ql-vscode/test/unit-tests/variant-analysis-filter-sort.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/variant-analysis-filter-sort.test.ts
@@ -130,7 +130,7 @@ describe(compareRepository.name, () => {
   describe("when sort key is 'Alphabetically'", () => {
     const sorter = compareRepository({
       ...defaultFilterSortState,
-      sortKey: SortKey.Name,
+      sortKey: SortKey.Alphabetically,
     });
 
     const left = {
@@ -156,7 +156,7 @@ describe(compareRepository.name, () => {
   describe("when sort key is 'Popularity'", () => {
     const sorter = compareRepository({
       ...defaultFilterSortState,
-      sortKey: SortKey.Stars,
+      sortKey: SortKey.Popularity,
     });
 
     const left = {
@@ -202,7 +202,7 @@ describe(compareRepository.name, () => {
   describe("when sort key is 'Most recent commit'", () => {
     const sorter = compareRepository({
       ...defaultFilterSortState,
-      sortKey: SortKey.LastUpdated,
+      sortKey: SortKey.MostRecentCommit,
     });
 
     const left = {
@@ -274,7 +274,7 @@ describe(compareWithResults.name, () => {
   describe("when sort key is 'Popularity'", () => {
     const sorter = compareWithResults({
       ...defaultFilterSortState,
-      sortKey: SortKey.Stars,
+      sortKey: SortKey.Popularity,
     });
 
     const left = {
@@ -300,7 +300,7 @@ describe(compareWithResults.name, () => {
   describe("when sort key is 'Most recent commit'", () => {
     const sorter = compareWithResults({
       ...defaultFilterSortState,
-      sortKey: SortKey.LastUpdated,
+      sortKey: SortKey.MostRecentCommit,
     });
 
     const left = {
@@ -326,7 +326,7 @@ describe(compareWithResults.name, () => {
   describe("when sort key is results count", () => {
     const sorter = compareWithResults({
       ...defaultFilterSortState,
-      sortKey: SortKey.ResultsCount,
+      sortKey: SortKey.NumberOfResults,
     });
 
     const left = {
@@ -416,7 +416,7 @@ describe(filterAndSortRepositoriesWithResultsByName.name, () => {
       expect(
         filterAndSortRepositoriesWithResultsByName(repositories, {
           ...defaultFilterSortState,
-          sortKey: SortKey.ResultsCount,
+          sortKey: SortKey.NumberOfResults,
         }),
       ).toEqual([
         repositories[3],
@@ -432,7 +432,7 @@ describe(filterAndSortRepositoriesWithResultsByName.name, () => {
       expect(
         filterAndSortRepositoriesWithResultsByName(repositories, {
           ...defaultFilterSortState,
-          sortKey: SortKey.ResultsCount,
+          sortKey: SortKey.NumberOfResults,
           searchValue: "la",
         }),
       ).toEqual([repositories[2], repositories[0]]);
@@ -444,7 +444,7 @@ describe(filterAndSortRepositoriesWithResultsByName.name, () => {
       expect(
         filterAndSortRepositoriesWithResultsByName(repositories, {
           ...defaultFilterSortState,
-          sortKey: SortKey.ResultsCount,
+          sortKey: SortKey.NumberOfResults,
           filterKey: FilterKey.WithResults,
         }),
       ).toEqual([repositories[3], repositories[2], repositories[0]]);
@@ -455,7 +455,7 @@ describe(filterAndSortRepositoriesWithResultsByName.name, () => {
     it("returns the correct results", () => {
       expect(
         filterAndSortRepositoriesWithResultsByName(repositories, {
-          sortKey: SortKey.ResultsCount,
+          sortKey: SortKey.NumberOfResults,
           filterKey: FilterKey.WithResults,
           searchValue: "r",
         }),
@@ -501,7 +501,7 @@ describe(filterAndSortRepositoriesWithResults.name, () => {
       expect(
         filterAndSortRepositoriesWithResults(repositories, {
           ...defaultFilterSortState,
-          sortKey: SortKey.ResultsCount,
+          sortKey: SortKey.NumberOfResults,
         }),
       ).toEqual([
         repositories[3],
@@ -517,7 +517,7 @@ describe(filterAndSortRepositoriesWithResults.name, () => {
       expect(
         filterAndSortRepositoriesWithResults(repositories, {
           ...defaultFilterSortState,
-          sortKey: SortKey.ResultsCount,
+          sortKey: SortKey.NumberOfResults,
           searchValue: "la",
         }),
       ).toEqual([repositories[2], repositories[0]]);
@@ -529,7 +529,7 @@ describe(filterAndSortRepositoriesWithResults.name, () => {
       expect(
         filterAndSortRepositoriesWithResults(repositories, {
           ...defaultFilterSortState,
-          sortKey: SortKey.ResultsCount,
+          sortKey: SortKey.NumberOfResults,
           filterKey: FilterKey.WithResults,
         }),
       ).toEqual([repositories[3], repositories[2], repositories[0]]);
@@ -541,7 +541,7 @@ describe(filterAndSortRepositoriesWithResults.name, () => {
       expect(
         filterAndSortRepositoriesWithResults(repositories, {
           ...defaultFilterSortState,
-          sortKey: SortKey.ResultsCount,
+          sortKey: SortKey.NumberOfResults,
           filterKey: FilterKey.WithResults,
         }),
       ).toEqual([repositories[3], repositories[2], repositories[0]]);
@@ -553,7 +553,7 @@ describe(filterAndSortRepositoriesWithResults.name, () => {
       expect(
         filterAndSortRepositoriesWithResults(repositories, {
           ...defaultFilterSortState,
-          sortKey: SortKey.ResultsCount,
+          sortKey: SortKey.NumberOfResults,
           filterKey: FilterKey.WithResults,
           searchValue: "r",
         }),
@@ -565,7 +565,7 @@ describe(filterAndSortRepositoriesWithResults.name, () => {
     it("returns the correct results", () => {
       expect(
         filterAndSortRepositoriesWithResults(repositories, {
-          sortKey: SortKey.ResultsCount,
+          sortKey: SortKey.NumberOfResults,
           filterKey: FilterKey.WithResults,
           searchValue: "la",
           repositoryIds: [

--- a/extensions/ql-vscode/test/vscode-tests/activated-extension/variant-analysis/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/activated-extension/variant-analysis/variant-analysis-manager.test.ts
@@ -750,7 +750,7 @@ describe("Variant Analysis Manager", () => {
           variantAnalysis.id,
           {
             ...defaultFilterSortState,
-            sortKey: SortKey.ResultsCount,
+            sortKey: SortKey.NumberOfResults,
           },
         );
 


### PR DESCRIPTION
Follow-up to https://github.com/github/vscode-codeql/pull/2373. That PR changed the user visible elements—this one also changes the internal names, for consistency (as suggested [here](https://github.com/github/vscode-codeql/pull/2373#pullrequestreview-1403558327)).

@robertbrignull, I've just changed the `SortKey` enum values here. I haven't updated the name of the [`LastUpdated`](https://github.com/github/vscode-codeql/blob/af75fa9f2fa65f9baf1c9567a4d5a895b56cdc67/extensions/ql-vscode/src/view/common/LastUpdated.tsx) or [`StarCount`](https://github.com/github/vscode-codeql/blob/af75fa9f2fa65f9baf1c9567a4d5a895b56cdc67/extensions/ql-vscode/src/view/common/StarCount.tsx) components themselves yet, but do you think that would also make sense? 


## Checklist

N/A—no user-visible changes

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
