### PR TITLE
Fix not setting database as selected if it already exists

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [UNRELEASED]
 
+- Fix bug where the "CodeQL: Set Current Database" command didn't always select the database. [#2384](https://github.com/github/vscode-codeql/pull/2384)
+
 ## 1.8.3 - 26 April 2023
 
 - Added ability to filter repositories for a variant analysis to only those that have results [#2343](https://github.com/github/vscode-codeql/pull/2343)

--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -636,13 +636,7 @@ export class DatabaseUI extends DisposableObject {
               this.queryServer?.cliServer,
             );
           } else {
-            const makeSelected = true;
-            await this.databaseManager.openDatabase(
-              progress,
-              token,
-              uri,
-              makeSelected,
-            );
+            await this.databaseManager.openDatabase(progress, token, uri);
           }
         } catch (e) {
           // rethrow and let this be handled by default error handling.
@@ -757,12 +751,10 @@ export class DatabaseUI extends DisposableObject {
         if (byFolder) {
           const fixedUri = await this.fixDbUri(uri);
           // we are selecting a database folder
-          const makeSelected = true;
           return await this.databaseManager.openDatabase(
             progress,
             token,
             fixedUri,
-            makeSelected,
           );
         } else {
           // we are selecting a database archive. Must unzip into a workspace-controlled area

--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -636,7 +636,13 @@ export class DatabaseUI extends DisposableObject {
               this.queryServer?.cliServer,
             );
           } else {
-            await this.databaseManager.openDatabase(progress, token, uri);
+            const makeSelected = true;
+            await this.databaseManager.openDatabase(
+              progress,
+              token,
+              uri,
+              makeSelected,
+            );
           }
         } catch (e) {
           // rethrow and let this be handled by default error handling.
@@ -751,10 +757,12 @@ export class DatabaseUI extends DisposableObject {
         if (byFolder) {
           const fixedUri = await this.fixDbUri(uri);
           // we are selecting a database folder
+          const makeSelected = true;
           return await this.databaseManager.openDatabase(
             progress,
             token,
             fixedUri,
+            makeSelected,
           );
         } else {
           // we are selecting a database archive. Must unzip into a workspace-controlled area

--- a/extensions/ql-vscode/src/databases/local-databases.ts
+++ b/extensions/ql-vscode/src/databases/local-databases.ts
@@ -621,7 +621,7 @@ export class DatabaseManager extends DisposableObject {
     progress: ProgressCallback,
     token: vscode.CancellationToken,
     uri: vscode.Uri,
-    makeSelected = false,
+    makeSelected = true,
     displayName?: string,
     isTutorialDatabase?: boolean,
   ): Promise<DatabaseItem> {

--- a/extensions/ql-vscode/src/databases/local-databases.ts
+++ b/extensions/ql-vscode/src/databases/local-databases.ts
@@ -645,12 +645,15 @@ export class DatabaseManager extends DisposableObject {
   public async addExistingDatabaseItem(
     databaseItem: DatabaseItem,
     progress: ProgressCallback,
-    makeSelected = true,
+    makeSelected: boolean,
     token: vscode.CancellationToken,
     isTutorialDatabase?: boolean,
   ): Promise<DatabaseItem> {
     const existingItem = this.findDatabaseItem(databaseItem.databaseUri);
     if (existingItem !== undefined) {
+      if (makeSelected) {
+        await this.setCurrentDatabaseItem(existingItem);
+      }
       return existingItem;
     }
 

--- a/extensions/ql-vscode/src/test-runner.ts
+++ b/extensions/ql-vscode/src/test-runner.ts
@@ -112,6 +112,7 @@ export class TestRunner extends DisposableObject {
             },
             token,
             uri,
+            false,
           );
           await this.databaseManager.renameDatabaseItem(
             reopenedDatabase,

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-databases.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-databases.test.ts
@@ -753,13 +753,10 @@ describe("local databases", () => {
     });
 
     it("should set the database as the currently selected one", async () => {
-      const makeSelected = true;
-
       await databaseManager.openDatabase(
         {} as ProgressCallback,
         {} as CancellationToken,
         mockDbItem.databaseUri,
-        makeSelected,
       );
 
       expect(setCurrentDatabaseItemSpy).toBeCalledTimes(1);

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-databases.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-databases.test.ts
@@ -749,7 +749,7 @@ describe("local databases", () => {
         mockDbItem.databaseUri,
       );
 
-      expect(resolveDatabaseContentsSpy).toBeCalledTimes(1);
+      expect(resolveDatabaseContentsSpy).toBeCalledTimes(2);
     });
 
     it("should set the database as the currently selected one", async () => {

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/test-runner.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/test-runner.test.ts
@@ -172,6 +172,7 @@ describe("test-runner", () => {
       expect.anything(),
       expect.anything(),
       preTestDatabaseItem.databaseUri,
+      false,
     );
 
     expect(renameDatabaseItemSpy).toBeCalledTimes(1);


### PR DESCRIPTION
This PR should fix a bug where we aren't able to set a database as the selected database. There are two bugs which are each independently causing this behaviour:
- In `addExistingDatabaseItem` if we find that a database item with that URI exists already then we return immediately, without checking `makeSelected` and therefore without setting the database as selected.
- In `handleSetCurrentDatabase` and `chooseAndSetDatabase` we weren't setting `makeSelected` to true.

This PR hopefully addresses both points. We now check `makeSelected` in both branches in `addExistingDatabaseItem`. We also change the default value of `makeSelected` to true, because we believe this is always the desired behaviour, except in one case in the test runner.

I've structured the commits so that https://github.com/github/vscode-codeql/commit/92f23d18fb94cb3f896c9601f1b5d39a58b318ce where we change the default value should be 100% behaviour preserving. I hope that makes it easier to review, but if not then just ignore the commits and review the PR as a whole.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
