### PR TITLE
Add `codeQL.contextualQueries.disableCache`

### DIFF
--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -69,6 +69,10 @@ const ROOT_SETTING = new Setting("codeQL");
 // Global configuration
 const TELEMETRY_SETTING = new Setting("telemetry", ROOT_SETTING);
 const AST_VIEWER_SETTING = new Setting("astViewer", ROOT_SETTING);
+const CONTEXTUAL_QUERIES_SETTINGS = new Setting(
+  "contextualQueries",
+  ROOT_SETTING,
+);
 const GLOBAL_TELEMETRY_SETTING = new Setting("telemetry");
 const LOG_INSIGHTS_SETTING = new Setting("logInsights", ROOT_SETTING);
 
@@ -479,11 +483,19 @@ export function joinOrderWarningThreshold(): number {
 }
 
 /**
- * Avoids caching in the AST viewer if the user is also a canary user.
+ * Hidden setting: Avoids caching in the AST viewer if the user is also a canary user.
  */
 export const NO_CACHE_AST_VIEWER = new Setting(
   "disableCache",
   AST_VIEWER_SETTING,
+);
+
+/**
+ * Hidden setting: Avoids caching in jump to def and find refs contextual queries if the user is also a canary user.
+ */
+export const NO_CACHE_CONTEXTUAL_QUERIES = new Setting(
+  "disableCache",
+  CONTEXTUAL_QUERIES_SETTINGS,
 );
 
 // Settings for variant analysis

--- a/extensions/ql-vscode/src/language-support/contextual/template-provider.ts
+++ b/extensions/ql-vscode/src/language-support/contextual/template-provider.ts
@@ -30,7 +30,11 @@ import {
   resolveQueries,
   runContextualQuery,
 } from "./query-resolver";
-import { isCanary, NO_CACHE_AST_VIEWER } from "../../config";
+import {
+  isCanary,
+  NO_CACHE_AST_VIEWER,
+  NO_CACHE_CONTEXTUAL_QUERIES,
+} from "../../config";
 import { CoreCompletedQuery, QueryRunner } from "../../query-server";
 import { AstBuilder } from "../ast-viewer/ast-builder";
 
@@ -59,7 +63,10 @@ export class TemplateQueryDefinitionProvider implements DefinitionProvider {
     position: Position,
     _token: CancellationToken,
   ): Promise<LocationLink[]> {
-    const fileLinks = await this.cache.get(document.uri.toString());
+    const fileLinks = this.shouldUseCache()
+      ? await this.cache.get(document.uri.toString())
+      : await this.getDefinitions(document.uri.toString());
+
     const locLinks: LocationLink[] = [];
     for (const link of fileLinks) {
       if (link.originSelectionRange!.contains(position)) {
@@ -67,6 +74,10 @@ export class TemplateQueryDefinitionProvider implements DefinitionProvider {
       }
     }
     return locLinks;
+  }
+
+  private shouldUseCache() {
+    return !(isCanary() && NO_CACHE_CONTEXTUAL_QUERIES.getValue<boolean>());
   }
 
   private async getDefinitions(uriString: string): Promise<LocationLink[]> {
@@ -118,7 +129,10 @@ export class TemplateQueryReferenceProvider implements ReferenceProvider {
     _context: ReferenceContext,
     _token: CancellationToken,
   ): Promise<Location[]> {
-    const fileLinks = await this.cache.get(document.uri.toString());
+    const fileLinks = this.shouldUseCache()
+      ? await this.cache.get(document.uri.toString())
+      : await this.getReferences(document.uri.toString());
+
     const locLinks: Location[] = [];
     for (const link of fileLinks) {
       if (link.targetRange!.contains(position)) {
@@ -129,6 +143,10 @@ export class TemplateQueryReferenceProvider implements ReferenceProvider {
       }
     }
     return locLinks;
+  }
+
+  private shouldUseCache() {
+    return !(isCanary() && NO_CACHE_CONTEXTUAL_QUERIES.getValue<boolean>());
   }
 
   private async getReferences(uriString: string): Promise<FullLocationLink[]> {
@@ -182,7 +200,7 @@ export class TemplatePrintAstProvider {
         "Cannot view the AST. Please select a valid source file inside a CodeQL database.",
       );
     }
-    const completedQuery = this.shouldCache()
+    const completedQuery = this.shouldUseCache()
       ? await this.cache.get(fileUri.toString(), progress, token)
       : await this.getAst(fileUri.toString(), progress, token);
 
@@ -194,7 +212,7 @@ export class TemplatePrintAstProvider {
     );
   }
 
-  private shouldCache() {
+  private shouldUseCache() {
     return !(isCanary() && NO_CACHE_AST_VIEWER.getValue<boolean>());
   }
 
@@ -271,7 +289,14 @@ export class TemplatePrintCfgProvider {
     if (!document) {
       return;
     }
-    return await this.cache.get(document.uri.toString());
+
+    return this.shouldUseCache()
+      ? await this.cache.get(document.uri.toString())
+      : await this.getCfgUri(document.uri.toString());
+  }
+
+  private shouldUseCache() {
+    return !(isCanary() && NO_CACHE_AST_VIEWER.getValue<boolean>());
   }
 
   private async getCfgUri(


### PR DESCRIPTION
An internal option to help library authours to run and debug the find references and find dependencies contetextual queries without relying on the implicit cache.

Fixes https://github.com/github/vscode-codeql/issues/2378

## Checklist

- [n/a] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [n/a] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
