### PR TITLE
Add config options for default sorting/filtering values in variant analysis results view

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [UNRELEASED]
 
+- Add settings `codeQL.variantAnalysis.filterResults` and `codeQL.variantAnalysis.sortResults` for configuring how variant analysis results are filtered and sorted in the results view. The default is to show only repositories with results, and to sort by the number of results. [#2392](https://github.com/github/vscode-codeql/pull/2392)
 - On the variant analysis results page, show the count of successful analyses instead of completed analyses, and indicate the reason why analyses were not successful. [#2349](https://github.com/github/vscode-codeql/pull/2349)
 - Fix bug where the "CodeQL: Set Current Database" command didn't always select the database. [#2384](https://github.com/github/vscode-codeql/pull/2384)
 

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -329,6 +329,36 @@
           "patternErrorMessage": "Please enter a valid GitHub repository",
           "markdownDescription": "[For internal use only] The name of the GitHub repository in which the GitHub Actions workflow is run when using the \"Run Variant Analysis\" command. The repository should be of the form `<owner>/<repo>`)."
         },
+        "codeQL.variantAnalysis.filterResults": {
+          "type": "string",
+          "default": "withResults",
+          "enum": [
+            "all",
+            "withResults"
+          ],
+          "enumDescriptions": [
+            "Show all repositories in the results view.",
+            "Show only repositories with results in the results view."
+          ],
+          "description": "The filter to apply to the variant analysis results view."
+        },
+        "codeQL.variantAnalysis.sortResults": {
+          "type": "string",
+          "default": "numberOfResults",
+          "enum": [
+            "alphabetically",
+            "popularity",
+            "mostRecentCommit",
+            "numberOfResults"
+          ],
+          "enumDescriptions": [
+            "Sort repositories alphabetically in the results view.",
+            "Sort repositories by popularity in the results view.",
+            "Sort repositories by most recent commit in the results view.",
+            "Sort repositories by number of results in the results view."
+          ],
+          "description": "The default sorting order for repositories in the variant analysis results view."
+        },
         "codeQL.logInsights.joinOrderWarningThreshold": {
           "type": "number",
           "default": 50,

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -9,6 +9,7 @@ import {
 import { DistributionManager } from "./codeql-cli/distribution";
 import { extLogger } from "./common";
 import { ONE_DAY_IN_MS } from "./pure/time";
+import { FilterKey, SortKey } from "./pure/variant-analysis-filter-sort";
 
 export const ALL_SETTINGS: Setting[] = [];
 
@@ -526,6 +527,34 @@ export class VariantAnalysisConfigListener
 
   public get controllerRepo(): string | undefined {
     return getRemoteControllerRepo();
+  }
+}
+
+const VARIANT_ANALYSIS_FILTER_RESULTS = new Setting(
+  "filterResults",
+  VARIANT_ANALYSIS_SETTING,
+);
+
+export function getVariantAnalysisFilterResults(): FilterKey {
+  const value = VARIANT_ANALYSIS_FILTER_RESULTS.getValue<string>();
+  if (Object.values(FilterKey).includes(value as FilterKey)) {
+    return value as FilterKey;
+  } else {
+    return FilterKey.WithResults;
+  }
+}
+
+const VARIANT_ANALYSIS_SORT_RESULTS = new Setting(
+  "sortResults",
+  VARIANT_ANALYSIS_SETTING,
+);
+
+export function getVariantAnalysisSortResults(): SortKey {
+  const value = VARIANT_ANALYSIS_SORT_RESULTS.getValue<string>();
+  if (Object.values(SortKey).includes(value as SortKey)) {
+    return value as SortKey;
+  } else {
+    return SortKey.NumberOfResults;
   }
 }
 

--- a/extensions/ql-vscode/src/pure/interface-types.ts
+++ b/extensions/ql-vscode/src/pure/interface-types.ts
@@ -11,7 +11,10 @@ import {
   VariantAnalysisScannedRepositoryResult,
   VariantAnalysisScannedRepositoryState,
 } from "../variant-analysis/shared/variant-analysis";
-import { RepositoriesFilterSortStateWithIds } from "./variant-analysis-filter-sort";
+import {
+  RepositoriesFilterSortState,
+  RepositoriesFilterSortStateWithIds,
+} from "./variant-analysis-filter-sort";
 import { ErrorLike } from "./errors";
 import { DataFlowPaths } from "../variant-analysis/shared/data-flow-paths";
 import { ExternalApiUsage } from "../data-extensions-editor/external-api-usage";
@@ -405,6 +408,7 @@ export interface ParsedResultSets {
 export interface SetVariantAnalysisMessage {
   t: "setVariantAnalysis";
   variantAnalysis: VariantAnalysis;
+  filterSortState?: RepositoriesFilterSortState;
 }
 
 export type VariantAnalysisState = {

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-view.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-view.ts
@@ -27,6 +27,10 @@ import { redactableError } from "../pure/errors";
 import { DataFlowPathsView } from "./data-flow-paths-view";
 import { DataFlowPaths } from "./shared/data-flow-paths";
 import { App } from "../common/app";
+import {
+  getVariantAnalysisFilterResults,
+  getVariantAnalysisSortResults,
+} from "../config";
 
 export class VariantAnalysisView
   extends AbstractWebview<ToVariantAnalysisMessage, FromVariantAnalysisMessage>
@@ -186,9 +190,16 @@ export class VariantAnalysisView
       return;
     }
 
+    const filterSortState = {
+      searchValue: "",
+      filterKey: getVariantAnalysisFilterResults(),
+      sortKey: getVariantAnalysisSortResults(),
+    };
+
     await this.postMessage({
       t: "setVariantAnalysis",
       variantAnalysis,
+      filterSortState,
     });
 
     const repoStates = await this.manager.getRepoStates(this.variantAnalysisId);

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
@@ -84,6 +84,9 @@ export function VariantAnalysis({
         const msg: ToVariantAnalysisMessage = evt.data;
         if (msg.t === "setVariantAnalysis") {
           setVariantAnalysis(msg.variantAnalysis);
+          if (msg.filterSortState) {
+            setFilterSortState(msg.filterSortState);
+          }
           vscode.setState({
             variantAnalysisId: msg.variantAnalysis.id,
           });


### PR DESCRIPTION
Adds new settings for configuring the default display of variant analysis results:

![image](https://github.com/github/vscode-codeql/assets/42641846/cfe7b595-9090-4d81-8c5b-81bc0b8d2e04)

This also changes the default display to show repos with results (instead of all), sorted by number of results (instead of by name).


## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
