### PR TITLE
Fix CFG viewer

### DIFF
--- a/extensions/ql-vscode/src/language-support/ast-viewer/ast-cfg-commands.ts
+++ b/extensions/ql-vscode/src/language-support/ast-viewer/ast-cfg-commands.ts
@@ -52,6 +52,8 @@ export function getAstCfgCommands({
             progress,
             token,
             undefined,
+            undefined,
+            res[1],
           );
         }
       },

--- a/extensions/ql-vscode/src/local-queries/local-queries.ts
+++ b/extensions/ql-vscode/src/local-queries/local-queries.ts
@@ -337,6 +337,7 @@ export class LocalQueries extends DisposableObject {
     token: CancellationToken,
     databaseItem: DatabaseItem | undefined,
     range?: Range,
+    templates?: Record<string, string>,
   ): Promise<void> {
     await this.compileAndRunQueryInternal(
       quickEval,
@@ -345,6 +346,7 @@ export class LocalQueries extends DisposableObject {
       token,
       databaseItem,
       range,
+      templates,
     );
   }
 
@@ -356,6 +358,7 @@ export class LocalQueries extends DisposableObject {
     token: CancellationToken,
     databaseItem: DatabaseItem | undefined,
     range?: Range,
+    templates?: Record<string, string>,
   ): Promise<CoreCompletedQuery> {
     let queryPath: string;
     if (queryUri !== undefined) {
@@ -395,7 +398,7 @@ export class LocalQueries extends DisposableObject {
       extensionPacks,
       this.queryStorageDir,
       undefined,
-      undefined,
+      templates,
     );
 
     // handle cancellation from the history view.


### PR DESCRIPTION
After some bit of refactoring, the templates are no longer being passed to the CFG viewer and this is preventing the viewer from running.

This change fixes it.

