### PR TITLE
Consume new rich test events in new Test Explorer UI

### DIFF
--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -1855,7 +1855,7 @@ export class CliVersionConstraint {
   /**
    * CLI version that supports the `--format betterjsonz` option for the `codeql test run` command.
    */
-  public static CLI_VERSION_WITH_RICH_TEST_EVENTS = new SemVer("2.13.1-dev");
+  public static CLI_VERSION_WITH_RICH_TEST_EVENTS = new SemVer("2.13.1");
 
   constructor(private readonly cli: CodeQLCliServer) {
     /**/
@@ -1928,11 +1928,8 @@ export class CliVersionConstraint {
   }
 
   async supportsRichTestEvents() {
-    /*
     return this.isVersionAtLeast(
       CliVersionConstraint.CLI_VERSION_WITH_RICH_TEST_EVENTS,
     );
-    */
-    return true;
   }
 }

--- a/extensions/ql-vscode/src/query-testing/test-runner.ts
+++ b/extensions/ql-vscode/src/query-testing/test-runner.ts
@@ -1,5 +1,5 @@
 import { CancellationToken, Uri } from "vscode";
-import { CodeQLCliServer, TestCompleted } from "../codeql-cli/cli";
+import { CodeQLCliServer, AnyTestEvent } from "../codeql-cli/cli";
 import { DatabaseItem, DatabaseManager } from "../databases/local-databases";
 import {
   getOnDiskWorkspaceFolders,
@@ -33,7 +33,7 @@ export class TestRunner extends DisposableObject {
     tests: string[],
     logger: BaseLogger,
     token: CancellationToken,
-    eventHandler: (event: TestCompleted) => Promise<void>,
+    eventHandler: (event: AnyTestEvent) => Promise<void>,
   ): Promise<void> {
     const currentDatabaseUri =
       this.databaseManager.currentDatabaseItem?.databaseUri;


### PR DESCRIPTION
This PR updates the new test UI to consume the richer events emitted by `codeql test run` starting in CLI 2.13.1. We now get a notification when a test _starts_ executing, so we can update the Test Explorer with the right spinning icon.

I had to do a little work in the CLI server client code to handle multiple streaming output formats.

I refactored some of the tracking of which tests are in which directory into a new `TestRunContext` class.

The legacy test adapter code has been updated to consume the new format for the existing `TestCompleted` event, but has not been updated to consume the new events.
