### PR TITLE
Prefer `#select` result set over other result sets

### DIFF
--- a/extensions/ql-vscode/src/variant-analysis/bqrs-processing.ts
+++ b/extensions/ql-vscode/src/variant-analysis/bqrs-processing.ts
@@ -3,6 +3,7 @@ import { Logger } from "../common";
 import { transformBqrsResultSet } from "../pure/bqrs-cli-types";
 import { AnalysisRawResults } from "./shared/analysis-result";
 import { MAX_RAW_RESULTS } from "./shared/result-limits";
+import { SELECT_TABLE_NAME } from "../pure/interface-types";
 
 export async function extractRawResults(
   cliServer: CodeQLCliServer,
@@ -19,11 +20,15 @@ export async function extractRawResults(
   }
   if (resultSets.length > 1) {
     void logger.log(
-      "Multiple result sets found in results file. Only the first one will be used.",
+      "Multiple result sets found in results file. Only one will be used.",
     );
   }
 
-  const schema = resultSets[0];
+  // Always prefer #select over any other result set. #select is usually the result the user
+  // wants to see since it contains the outer #select.
+  const schema =
+    resultSets.find((resultSet) => resultSet.name === SELECT_TABLE_NAME) ??
+    resultSets[0];
 
   const chunk = await cliServer.bqrsDecode(filePath, schema.name, {
     pageSize: MAX_RAW_RESULTS,


### PR DESCRIPTION
For `@kind problem` queries, it seems like the BQRS contains four result sets: `edges`, `nodes`, `subpaths`, and `#select`. The user is probably interested in the results of `#select` since that contains the direct result of the query. This changes the extraction of raw (BQRS) results to always prefer `#select` over any other result set. If it can't find a result set named `#select`, it will fall back to the first result set in the BQRS like before.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
