### PR TITLE
Run integration tests on 1.77.3

### DIFF
--- a/extensions/ql-vscode/test/vscode-tests/jest-runner-vscode.config.base.js
+++ b/extensions/ql-vscode/test/vscode-tests/jest-runner-vscode.config.base.js
@@ -7,7 +7,9 @@ const rootDir = path.resolve(__dirname, "../..");
 
 /** @type import("jest-runner-vscode").RunnerOptions */
 const config = {
-  version: "stable",
+  // Temporary until https://github.com/github/vscode-codeql/issues/2402 is fixed
+  // version: "stable",
+  version: "1.77.3",
   launchArgs: [
     "--disable-gpu",
     "--extensions-dir=" + path.join(rootDir, ".vscode-test", "extensions"),


### PR DESCRIPTION
This avoids a bug on 1.78.0 on linux. See
https://github.com/github/vscode-codeql/issues/2402

This should fix the integration tests.
