### PR TITLE
Better error handling for unexpected query server termination.

### DIFF
--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -1539,7 +1539,7 @@ export function spawnServer(
       );
     // If the process exited abnormally, log the last stdout message,
     // It may be from the jvm.
-    if (code !== 0)
+    if (code !== 0 && lastStdout !== undefined)
       await logger.log(`Last stdout was "${lastStdout.toString()}"`);
   });
   child.stderr!.on("data", stderrListener);

--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -1532,15 +1532,15 @@ export function spawnServer(
   // Set up event listeners.
   child.on("close", async (code, signal) => {
     if (code !== null)
-      await logger.log(`Child process exited with code ${code}`);
+      void logger.log(`Child process exited with code ${code}`);
     if (signal)
-      await logger.log(
+      void logger.log(
         `Child process exited due to receipt of signal ${signal}`,
       );
     // If the process exited abnormally, log the last stdout message,
     // It may be from the jvm.
     if (code !== 0 && lastStdout !== undefined)
-      await logger.log(`Last stdout was "${lastStdout.toString()}"`);
+      void logger.log(`Last stdout was "${lastStdout.toString()}"`);
   });
   child.stderr!.on("data", stderrListener);
   if (stdoutListener !== undefined) {

--- a/extensions/ql-vscode/src/query-server/query-server-client.ts
+++ b/extensions/ql-vscode/src/query-server/query-server-client.ts
@@ -103,7 +103,7 @@ export class QueryServerClient extends DisposableObject {
 
   /**
    * Restarts the query server by disposing of the current server process and then starting a new one.
-   * This resets the unexpected termination count. As hopefulyl it is an indication that the user has fixed the
+   * This resets the unexpected termination count. As hopefully it is an indication that the user has fixed the
    * issue.
    */
   async restartQueryServer(


### PR DESCRIPTION
This tries to improve the case where the query server terminates unexpectedly by printing more information about the failure (the last stout chunk) and restarting a limited number of times.

Restarting and the backup case of a full abort have the side effect of actually rejecting any pending promises from the vscode side so crashes don't look like hangs. 

The better error reporting should apply to all severs (old, new, ide). 

I have only implemented restarting for the new queryserver. The ide server already restart itself. I didn't think it worth handling the old QS case but I could if we wanted to improve that as well. 