### PR TITLE
Replace deprecated `storagePath` by `storageUri`

### DIFF
--- a/extensions/ql-vscode/src/codeql-cli/distribution.ts
+++ b/extensions/ql-vscode/src/codeql-cli/distribution.ts
@@ -505,7 +505,7 @@ class ExtensionSpecificDistributionManager {
         0,
       ) || "";
     return join(
-      this.extensionContext.globalStoragePath,
+      this.extensionContext.globalStorageUri.fsPath,
       ExtensionSpecificDistributionManager._currentDistributionFolderBaseName +
         distributionFolderIndex,
     );

--- a/extensions/ql-vscode/src/databases/local-databases.ts
+++ b/extensions/ql-vscode/src/databases/local-databases.ts
@@ -24,7 +24,7 @@ import { DisposableObject } from "../pure/disposable-object";
 import { Logger, extLogger } from "../common";
 import { asError, getErrorMessage } from "../pure/helpers-pure";
 import { QueryRunner } from "../query-server";
-import { pathsEqual } from "../pure/files";
+import { containsPath, pathsEqual } from "../pure/files";
 import { redactableError } from "../pure/errors";
 import {
   getAutogenerateQlPacks,
@@ -1157,7 +1157,7 @@ export class DatabaseManager extends DisposableObject {
     // but storagePath will have an uppercase drive letter. Be sure to compare
     // URIs to URIs only
     if (storageUri) {
-      return uri.fsPath.startsWith(storageUri.fsPath);
+      return containsPath(storageUri.fsPath, uri.fsPath, process.platform);
     }
     return false;
   }

--- a/extensions/ql-vscode/src/databases/local-databases.ts
+++ b/extensions/ql-vscode/src/databases/local-databases.ts
@@ -1153,9 +1153,6 @@ export class DatabaseManager extends DisposableObject {
 
   private isExtensionControlledLocation(uri: vscode.Uri) {
     const storageUri = this.ctx.storageUri || this.ctx.globalStorageUri;
-    // the uri.fsPath function on windows returns a lowercase drive letter,
-    // but storagePath will have an uppercase drive letter. Be sure to compare
-    // URIs to URIs only
     if (storageUri) {
       return containsPath(storageUri.fsPath, uri.fsPath, process.platform);
     }

--- a/extensions/ql-vscode/src/databases/local-databases.ts
+++ b/extensions/ql-vscode/src/databases/local-databases.ts
@@ -1152,12 +1152,12 @@ export class DatabaseManager extends DisposableObject {
   }
 
   private isExtensionControlledLocation(uri: vscode.Uri) {
-    const storagePath = this.ctx.storagePath || this.ctx.globalStoragePath;
+    const storageUri = this.ctx.storageUri || this.ctx.globalStorageUri;
     // the uri.fsPath function on windows returns a lowercase drive letter,
     // but storagePath will have an uppercase drive letter. Be sure to compare
     // URIs to URIs only
-    if (storagePath) {
-      return uri.fsPath.startsWith(vscode.Uri.file(storagePath).fsPath);
+    if (storageUri) {
+      return uri.fsPath.startsWith(storageUri.fsPath);
     }
     return false;
   }

--- a/extensions/ql-vscode/src/pure/files.ts
+++ b/extensions/ql-vscode/src/pure/files.ts
@@ -51,21 +51,37 @@ export async function getDirectoryNamesInsidePath(
   return dirNames;
 }
 
+function normalizePath(path: string, platform: NodeJS.Platform): string {
+  // On Windows, "C:/", "C:\", and "c:/" are all equivalent. We need
+  // to normalize the paths to ensure they all get resolved to the
+  // same format. On Windows, we also need to do the comparison
+  // case-insensitively.
+  path = resolve(path);
+  if (platform === "win32") {
+    path = path.toLowerCase();
+  }
+  return path;
+}
+
 export function pathsEqual(
   path1: string,
   path2: string,
   platform: NodeJS.Platform,
 ): boolean {
-  // On Windows, "C:/", "C:\", and "c:/" are all equivalent. We need
-  // to normalize the paths to ensure they all get resolved to the
-  // same format. On Windows, we also need to do the comparison
-  // case-insensitively.
-  path1 = resolve(path1);
-  path2 = resolve(path2);
-  if (platform === "win32") {
-    return path1.toLowerCase() === path2.toLowerCase();
-  }
-  return path1 === path2;
+  return normalizePath(path1, platform) === normalizePath(path2, platform);
+}
+
+/**
+ * Returns true if path1 contains path2.
+ */
+export function containsPath(
+  path1: string,
+  path2: string,
+  platform: NodeJS.Platform,
+): boolean {
+  return normalizePath(path2, platform).startsWith(
+    normalizePath(path1, platform),
+  );
 }
 
 export async function readDirFullPaths(path: string): Promise<string[]> {

--- a/extensions/ql-vscode/test/unit-tests/pure/files.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/pure/files.test.ts
@@ -1,6 +1,7 @@
 import { join } from "path";
 
 import {
+  containsPath,
   gatherQlFiles,
   getDirectoryNamesInsidePath,
   pathsEqual,
@@ -200,6 +201,101 @@ describe("pathsEqual", () => {
       }
 
       expect(pathsEqual(path1, path2, platform)).toEqual(expected);
+    },
+  );
+});
+
+describe("containsPath", () => {
+  const testCases: Array<{
+    path1: string;
+    path2: string;
+    platform: NodeJS.Platform;
+    expected: boolean;
+  }> = [
+    {
+      path1:
+        "/home/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript",
+      path2:
+        "/home/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript/example.ql",
+      platform: "linux",
+      expected: true,
+    },
+    {
+      path1:
+        "/HOME/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript",
+      path2:
+        "/home/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript/example.ql",
+      platform: "linux",
+      expected: false,
+    },
+    {
+      path1:
+        "/home/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript/example.ql",
+      path2:
+        "/home/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript",
+      platform: "linux",
+      expected: false,
+    },
+    {
+      path1:
+        "C:/Users/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript",
+      path2:
+        "C:/Users/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript/example.ql",
+      platform: "win32",
+      expected: true,
+    },
+    {
+      path1:
+        "C:/Users/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript",
+      path2:
+        "c:/Users/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript/example.ql",
+      platform: "win32",
+      expected: true,
+    },
+    {
+      path1:
+        "C:/Users/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript",
+      path2:
+        "D:/Users/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript/example.ql",
+      platform: "win32",
+      expected: false,
+    },
+    {
+      path1:
+        "C:/Users/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript/example.ql",
+      path2:
+        "C:/Users/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript",
+      platform: "win32",
+      expected: false,
+    },
+    {
+      path1:
+        "C:/Users/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript",
+      path2:
+        "C:\\Users\\github\\projects\\vscode-codeql-starter\\codeql-custom-queries-javascript\\example.ql",
+      platform: "win32",
+      expected: true,
+    },
+    {
+      path1:
+        "C:/Users/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript",
+      path2:
+        "D:\\Users\\github\\projects\\vscode-codeql-starter\\codeql-custom-queries-javascript\\example.ql",
+      platform: "win32",
+      expected: false,
+    },
+  ];
+
+  test.each(testCases)(
+    "$path1 contains $path2 on $platform = $expected",
+    ({ path1, path2, platform, expected }) => {
+      if (platform !== process.platform) {
+        // We're using the platform-specific path.resolve, so we can't really run
+        // these tests on all platforms.
+        return;
+      }
+
+      expect(containsPath(path1, path2, platform)).toEqual(expected);
     },
   );
 });

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-databases.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-databases.test.ts
@@ -80,8 +80,7 @@ describe("local databases", () => {
         dynamicProperties: {
           // pretend like databases added in the temp dir are controlled by the extension
           // so that they are deleted upon removal
-          storagePath: () => extensionContextStoragePath,
-          storageUri: () => Uri.parse(extensionContextStoragePath),
+          storageUri: () => Uri.file(extensionContextStoragePath),
         },
       },
     );

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-databases.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-databases.test.ts
@@ -277,7 +277,7 @@ describe("local databases", () => {
       updateSpy.mockClear();
 
       // pretend that the database location is not controlled by the extension
-      (databaseManager as any).ctx.storagePath = "hucairz";
+      (databaseManager as any).ctx.storageUri = Uri.file("hucairz");
       extensionContextStoragePath = "hucairz";
 
       await databaseManager.removeDatabaseItem(


### PR DESCRIPTION
This replaces access to the deprecated `storagePath` and `globalStoragePath` to use `storageUri` and `globalStorageUri` instead.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
