### PR TITLE
Fix hang/crash when using `--check-databases` option for test run

### DIFF
--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -476,7 +476,11 @@ export class CodeQLCliServer implements Disposable {
       for await (const event of splitStreamAtSeparators(child.stdout!, [
         "\0",
       ])) {
-        yield event;
+        // We sometimes see an empty string emitted as an output record from the CLI. Just ignore
+        // it.
+        if (event !== "") {
+          yield event;
+        }
       }
 
       await childPromise;


### PR DESCRIPTION
Trivial fix is to ignore events for tests we didn't explicitly request in the run.

I also discovered that sometimes the CLI emits an empty null-terminated string as an event. We should just ignore those.
