### PR TITLE
Add a new blank "queries" panel

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -36,6 +36,7 @@
   "activationEvents": [
     "onLanguage:ql",
     "onLanguage:ql-summary",
+    "onView:codeQLQueries",
     "onView:codeQLDatabases",
     "onView:codeQLVariantAnalysisRepositories",
     "onView:codeQLQueryHistory",
@@ -1555,6 +1556,11 @@
     },
     "views": {
       "ql-container": [
+        {
+          "id": "codeQLQueries",
+          "name": "Queries",
+          "when": "config.codeQL.canary && config.codeQL.queriesPanel"
+        },
         {
           "id": "codeQLDatabases",
           "name": "Databases"

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -702,3 +702,12 @@ export function getAutogenerateQlPacks(): AutogenerateQLPacks {
 export async function setAutogenerateQlPacks(choice: AutogenerateQLPacks) {
   await AUTOGENERATE_QL_PACKS.updateValue(choice, ConfigurationTarget.Global);
 }
+
+/**
+ * A flag indicating whether to show the queries panel in the QL view container.
+ */
+const QUERIES_PANEL = new Setting("queriesPanel", ROOT_SETTING);
+
+export function showQueriesPanel(): boolean {
+  return !!QUERIES_PANEL.getValue<boolean>();
+}


### PR DESCRIPTION
This is currently an empty placeholder, and is hidden behind a feature flag (the `codeQL.queriesPanel` setting). This will let us work on the functionality without disrupting users. (Inspired by https://github.com/github/vscode-codeql/pull/1682)

So beautiful:
![screenshot of empty "queries" panel](https://github.com/github/vscode-codeql/assets/42641846/3072ead3-9e2c-42d4-838b-0b6fa71e3e3f)


## Checklist

N/A—not user-facing. See linked internal issue for more details.

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
