### PR TITLE
Queries panel: Expand/collapse child nodes

### DIFF
--- a/extensions/ql-vscode/src/queries-panel/query-tree-data-provider.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-tree-data-provider.ts
@@ -17,33 +17,13 @@ export class QueryTreeDataProvider
   private createTree(): QueryTreeViewItem[] {
     // Temporary mock data, just to populate the tree view.
     return [
-      {
-        label: "name1",
-        tooltip: "path1",
-        children: [],
-      },
-      {
-        label: "name2",
-        tooltip: "path2",
-        children: [
-          {
-            label: "name3",
-            tooltip: "path3",
-            children: [],
-          },
-          {
-            label: "name4",
-            tooltip: "path4",
-            children: [
-              {
-                label: "name5",
-                tooltip: "path5",
-                children: [],
-              },
-            ],
-          },
-        ],
-      },
+      new QueryTreeViewItem("name1", "path1", []),
+      new QueryTreeViewItem("name2", "path2", [
+        new QueryTreeViewItem("name3", "path3", []),
+        new QueryTreeViewItem("name4", "path4", [
+          new QueryTreeViewItem("name5", "path5", []),
+        ]),
+      ]),
     ];
   }
 
@@ -55,14 +35,7 @@ export class QueryTreeDataProvider
   public getTreeItem(
     item: QueryTreeViewItem,
   ): vscode.TreeItem | Thenable<vscode.TreeItem> {
-    const state = item.children.length
-      ? vscode.TreeItemCollapsibleState.Collapsed
-      : vscode.TreeItemCollapsibleState.None;
-
-    const treeItem = new vscode.TreeItem(item.label, state);
-    treeItem.tooltip = item.tooltip;
-
-    return treeItem;
+    return item;
   }
 
   /**

--- a/extensions/ql-vscode/src/queries-panel/query-tree-data-provider.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-tree-data-provider.ts
@@ -22,6 +22,28 @@ export class QueryTreeDataProvider
         tooltip: "path1",
         children: [],
       },
+      {
+        label: "name2",
+        tooltip: "path2",
+        children: [
+          {
+            label: "name3",
+            tooltip: "path3",
+            children: [],
+          },
+          {
+            label: "name4",
+            tooltip: "path4",
+            children: [
+              {
+                label: "name5",
+                tooltip: "path5",
+                children: [],
+              },
+            ],
+          },
+        ],
+      },
     ];
   }
 
@@ -33,7 +55,14 @@ export class QueryTreeDataProvider
   public getTreeItem(
     item: QueryTreeViewItem,
   ): vscode.TreeItem | Thenable<vscode.TreeItem> {
-    return item;
+    const state = item.children.length
+      ? vscode.TreeItemCollapsibleState.Collapsed
+      : vscode.TreeItemCollapsibleState.None;
+
+    const treeItem = new vscode.TreeItem(item.label, state);
+    treeItem.tooltip = item.tooltip;
+
+    return treeItem;
   }
 
   /**
@@ -46,9 +75,9 @@ export class QueryTreeDataProvider
   ): vscode.ProviderResult<QueryTreeViewItem[]> {
     if (!item) {
       // We're at the root.
-      return Promise.resolve(this.queryTreeItems);
+      return this.queryTreeItems;
     } else {
-      return Promise.resolve(item.children);
+      return item.children;
     }
   }
 }

--- a/extensions/ql-vscode/src/queries-panel/query-tree-view-item.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-tree-view-item.ts
@@ -1,11 +1,15 @@
 import * as vscode from "vscode";
 
 export class QueryTreeViewItem extends vscode.TreeItem {
+  public collapsibleState: vscode.TreeItemCollapsibleState;
   constructor(
     public readonly label: string,
     public readonly tooltip: string | undefined,
     public readonly children: QueryTreeViewItem[],
   ) {
     super(label);
+    this.collapsibleState = this.children.length
+      ? vscode.TreeItemCollapsibleState.Collapsed
+      : vscode.TreeItemCollapsibleState.None;
   }
 }


### PR DESCRIPTION
Small follow-up to https://github.com/github/vscode-codeql/pull/2418, to handle expanding/collapsing nodes in the Queries panel. (Still using mock data for now.)

![nested nodes in Queries panel](https://github.com/github/vscode-codeql/assets/42641846/ae62b049-63e3-4828-89f0-1ef25b6c3cce)


## Checklist

N/A—internal only ✨ 🦄

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
