### PR TITLE
Cancel monitoring variant analysis on 404 response

### DIFF
--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -251,6 +251,9 @@ export type VariantAnalysisCommands = {
   "codeQL.monitorRehydratedVariantAnalysis": (
     variantAnalysis: VariantAnalysis,
   ) => Promise<void>;
+  "codeQL.monitorReauthenticatedVariantAnalysis": (
+    variantAnalysis: VariantAnalysis,
+  ) => Promise<void>;
   "codeQL.openVariantAnalysisLogs": (
     variantAnalysisId: number,
   ) => Promise<void>;

--- a/extensions/ql-vscode/src/common/vscode/authentication.ts
+++ b/extensions/ql-vscode/src/common/vscode/authentication.ts
@@ -3,7 +3,7 @@ import * as Octokit from "@octokit/rest";
 import { retry } from "@octokit/plugin-retry";
 import { Credentials } from "../authentication";
 
-const GITHUB_AUTH_PROVIDER_ID = "github";
+export const GITHUB_AUTH_PROVIDER_ID = "github";
 
 // We need 'repo' scope for triggering workflows, 'gist' scope for exporting results to Gist,
 // and 'read:packages' for reading private CodeQL packages.

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-monitor.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-monitor.ts
@@ -27,6 +27,8 @@ export class VariantAnalysisMonitor extends DisposableObject {
   );
   readonly onVariantAnalysisChange = this._onVariantAnalysisChange.event;
 
+  private readonly monitoringVariantAnalyses = new Set<number>();
+
   constructor(
     private readonly app: App,
     private readonly shouldCancelMonitor: (
@@ -37,6 +39,24 @@ export class VariantAnalysisMonitor extends DisposableObject {
   }
 
   public async monitorVariantAnalysis(
+    variantAnalysis: VariantAnalysis,
+  ): Promise<void> {
+    if (this.monitoringVariantAnalyses.has(variantAnalysis.id)) {
+      void extLogger.log(
+        `Already monitoring variant analysis ${variantAnalysis.id}`,
+      );
+      return;
+    }
+
+    this.monitoringVariantAnalyses.add(variantAnalysis.id);
+    try {
+      await this._monitorVariantAnalysis(variantAnalysis);
+    } finally {
+      this.monitoringVariantAnalyses.delete(variantAnalysis.id);
+    }
+  }
+
+  private async _monitorVariantAnalysis(
     variantAnalysis: VariantAnalysis,
   ): Promise<void> {
     let attemptCount = 0;

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-monitor.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-monitor.ts
@@ -39,6 +39,10 @@ export class VariantAnalysisMonitor extends DisposableObject {
     super();
   }
 
+  public isMonitoringVariantAnalysis(variantAnalysisId: number): boolean {
+    return this.monitoringVariantAnalyses.has(variantAnalysisId);
+  }
+
   public async monitorVariantAnalysis(
     variantAnalysis: VariantAnalysis,
   ): Promise<void> {


### PR DESCRIPTION
This will cancel the monitoring of a variant analysis when a 404 response is returned. If a 404 response is returned, that probably means the user lost access or the repository has been deleted. We would almost never expect a variant analysis to start returning a 200 response after a 404 has been encountered, unless the user switches user accounts.

Therefore, this will stop monitoring a variant analysis when a 404 is encountered. When the user changes their VS Code GitHub session, we will restart monitoring.

It's easiest to review this commit-by-commit.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
