### PR TITLE
Allow compare view to work with quick-eval

### DIFF
--- a/extensions/ql-vscode/src/compare/compare-view.ts
+++ b/extensions/ql-vscode/src/compare/compare-view.ts
@@ -175,21 +175,40 @@ export class CompareView extends AbstractWebview<
     const commonResultSetNames = fromSchemaNames.filter((name) =>
       toSchemaNames.includes(name),
     );
+
+    // Fall back on the default result set names if there are no common ones.
+    const defaultFromResultSetName = fromSchemaNames.find((name) =>
+      name.startsWith("#"),
+    );
+    const defaultToResultSetName = toSchemaNames.find((name) =>
+      name.startsWith("#"),
+    );
+
+    if (
+      commonResultSetNames.length === 0 &&
+      !(defaultFromResultSetName || defaultToResultSetName)
+    ) {
+      throw new Error(
+        "No common result sets found between the two queries. Please check that the queries are compatible.",
+      );
+    }
+
     const currentResultSetName =
       selectedResultSetName || commonResultSetNames[0];
     const fromResultSet = await this.getResultSet(
       fromSchemas,
-      currentResultSetName,
+      currentResultSetName || defaultFromResultSetName!,
       from.completedQuery.query.resultsPaths.resultsPath,
     );
     const toResultSet = await this.getResultSet(
       toSchemas,
-      currentResultSetName,
+      currentResultSetName || defaultToResultSetName!,
       to.completedQuery.query.resultsPaths.resultsPath,
     );
     return [
       commonResultSetNames,
-      currentResultSetName,
+      currentResultSetName ||
+        `${defaultFromResultSetName} <-> ${defaultToResultSetName}`,
       fromResultSet,
       toResultSet,
     ];

--- a/extensions/ql-vscode/src/view/compare/Compare.tsx
+++ b/extensions/ql-vscode/src/view/compare/Compare.tsx
@@ -59,9 +59,7 @@ export function Compare(_: Record<string, never>): JSX.Element {
     return (
       <>
         <div className="vscode-codeql__compare-header">
-          <div className="vscode-codeql__compare-header-item">
-            Table to compare:
-          </div>
+          <div className="vscode-codeql__compare-header-item">Comparing:</div>
           <CompareSelector
             availableResultSets={comparison.commonResultSetNames}
             currentResultSetName={comparison.currentResultSetName}

--- a/extensions/ql-vscode/src/view/compare/CompareSelector.tsx
+++ b/extensions/ql-vscode/src/view/compare/CompareSelector.tsx
@@ -7,7 +7,8 @@ interface Props {
 }
 
 export default function CompareSelector(props: Props) {
-  return (
+  return props.availableResultSets.length ? (
+    // Handle case where there are shared result sets
     <select
       value={props.currentResultSetName}
       onChange={(e) => props.updateResultSet(e.target.value)}
@@ -18,5 +19,8 @@ export default function CompareSelector(props: Props) {
         </option>
       ))}
     </select>
+  ) : (
+    // Handle case where there are no shared result sets
+    <div>{props.currentResultSetName}</div>
   );
 }


### PR DESCRIPTION
The compare view typically works by matching the results sets of queries. It only allows the results sets of queries with identical names to be compared.

Manually run queries use `#select` as the default result set. However, quick eval queries use a different, generated, name. Therefore, these two kinds of queries cannot be compared.

This commit changes the heuristics so that if there are no identical;y named results sets, the first result set of each query that is prefixed with `#` is used (this is the default result set).

It also makes a slightly nicer error message if there are no comparable results sets.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [n/a] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
