### PR TITLE
Simplify types around query panel

### DIFF
--- a/extensions/ql-vscode/src/queries-panel/query-tree-data-provider.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-tree-data-provider.ts
@@ -32,9 +32,7 @@ export class QueryTreeDataProvider
    * @param item The item to represent.
    * @returns The UI presentation of the item.
    */
-  public getTreeItem(
-    item: QueryTreeViewItem,
-  ): vscode.TreeItem | Thenable<vscode.TreeItem> {
+  public getTreeItem(item: QueryTreeViewItem): vscode.TreeItem {
     return item;
   }
 
@@ -43,9 +41,7 @@ export class QueryTreeDataProvider
    * @param item The item to expand.
    * @returns The children of the item.
    */
-  public getChildren(
-    item?: QueryTreeViewItem,
-  ): vscode.ProviderResult<QueryTreeViewItem[]> {
+  public getChildren(item?: QueryTreeViewItem): QueryTreeViewItem[] {
     if (!item) {
       // We're at the root.
       return this.queryTreeItems;

--- a/extensions/ql-vscode/src/queries-panel/query-tree-view-item.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-tree-view-item.ts
@@ -1,13 +1,13 @@
 import * as vscode from "vscode";
 
 export class QueryTreeViewItem extends vscode.TreeItem {
-  public collapsibleState: vscode.TreeItemCollapsibleState;
   constructor(
-    public readonly label: string,
-    public readonly tooltip: string | undefined,
+    label: string,
+    tooltip: string | undefined,
     public readonly children: QueryTreeViewItem[],
   ) {
     super(label);
+    this.tooltip = tooltip;
     this.collapsibleState = this.children.length
       ? vscode.TreeItemCollapsibleState.Collapsed
       : vscode.TreeItemCollapsibleState.None;


### PR DESCRIPTION
A couple of small changes and simplifications:
- We copied some method types from the `TreeDataProvider` class but they're more general than we need them to be. We don't need to say that we may return a promise or may not, because we know what we'll return. It still satisfies the type from the inherited class so long as it's more specific and can be cast to the other type.
- In `QueryTreeViewItem` we extend from `TreeItem` and that class already defines a bunch of fields, and it's probably best to avoid accidentally re-defining the field with `public readonly`. Instead we can do things like `this.tooltip = tooltip` to set the field in the constructor.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
