### PR TITLE
Ensure full stack traces are included in log messages

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [UNRELEASED]
 
 - Add settings `codeQL.variantAnalysis.defaultResultsFilter` and `codeQL.variantAnalysis.defaultResultsSort` for configuring how variant analysis results are filtered and sorted in the results view. The default is to show all repositories, and to sort by the number of results. [#2392](https://github.com/github/vscode-codeql/pull/2392)
+- Fix bug to ensure error messages have complete stack trace in message logs. [#2425](https://github.com/github/vscode-codeql/pull/2425)
 
 ## 1.8.4 - 3 May 2023
 

--- a/extensions/ql-vscode/src/common/vscode/commands.ts
+++ b/extensions/ql-vscode/src/common/vscode/commands.ts
@@ -49,7 +49,6 @@ export function registerCommandWithErrorHandling(
       const errorMessage = redactableError(error)`${
         getErrorMessage(e) || e
       } (${commandId})`;
-      const errorStack = getErrorStack(e);
       if (e instanceof UserCancellationException) {
         // User has cancelled this action manually
         if (e.silent) {
@@ -61,6 +60,7 @@ export function registerCommandWithErrorHandling(
         }
       } else {
         // Include the full stack in the error log only.
+        const errorStack = getErrorStack(e);
         const fullMessage = errorStack
           ? `${errorMessage.fullMessage}\n${errorStack}`
           : errorMessage.fullMessage;

--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -98,7 +98,7 @@ export async function showAndLogErrorMessage(
   return internalShowAndLog(
     dropLinesExceptInitial(message),
     Window.showErrorMessage,
-    options,
+    { fullMessage: message, ...options },
   );
 }
 


### PR DESCRIPTION
Pass in the `fullMessage` to `internalShowAndLog` so that stack traces aren't truncated.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [n/a] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
