### PR TITLE
Open query file on click

### DIFF
--- a/extensions/ql-vscode/src/queries-panel/query-tree-data-provider.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-tree-data-provider.ts
@@ -17,11 +17,18 @@ export class QueryTreeDataProvider
   private createTree(): QueryTreeViewItem[] {
     // Temporary mock data, just to populate the tree view.
     return [
-      new QueryTreeViewItem("name1", "path1", []),
-      new QueryTreeViewItem("name2", "path2", [
-        new QueryTreeViewItem("name3", "path3", []),
-        new QueryTreeViewItem("name4", "path4", [
-          new QueryTreeViewItem("name5", "path5", []),
+      new QueryTreeViewItem("custom-pack", [
+        new QueryTreeViewItem("custom-pack/example.ql", []),
+      ]),
+      new QueryTreeViewItem("ql", [
+        new QueryTreeViewItem("ql/javascript", [
+          new QueryTreeViewItem("ql/javascript/example.ql", []),
+        ]),
+        new QueryTreeViewItem("ql/go", [
+          new QueryTreeViewItem("ql/go/security", [
+            new QueryTreeViewItem("ql/go/security/query1.ql", []),
+            new QueryTreeViewItem("ql/go/security/query2.ql", []),
+          ]),
         ]),
       ]),
     ];

--- a/extensions/ql-vscode/src/queries-panel/query-tree-view-item.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-tree-view-item.ts
@@ -1,15 +1,17 @@
 import * as vscode from "vscode";
+import { basename } from "path";
 
 export class QueryTreeViewItem extends vscode.TreeItem {
-  constructor(
-    label: string,
-    tooltip: string | undefined,
-    public readonly children: QueryTreeViewItem[],
-  ) {
-    super(label);
-    this.tooltip = tooltip;
+  constructor(path: string, public readonly children: QueryTreeViewItem[]) {
+    super(basename(path));
+    this.tooltip = path;
     this.collapsibleState = this.children.length
       ? vscode.TreeItemCollapsibleState.Collapsed
       : vscode.TreeItemCollapsibleState.None;
+    this.command = {
+      title: "Open",
+      command: "vscode.open",
+      arguments: [vscode.Uri.file(path)],
+    };
   }
 }

--- a/extensions/ql-vscode/src/queries-panel/query-tree-view-item.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-tree-view-item.ts
@@ -8,10 +8,12 @@ export class QueryTreeViewItem extends vscode.TreeItem {
     this.collapsibleState = this.children.length
       ? vscode.TreeItemCollapsibleState.Collapsed
       : vscode.TreeItemCollapsibleState.None;
-    this.command = {
-      title: "Open",
-      command: "vscode.open",
-      arguments: [vscode.Uri.file(path)],
-    };
+    if (this.children.length === 0) {
+      this.command = {
+        title: "Open",
+        command: "vscode.open",
+        arguments: [vscode.Uri.file(path)],
+      };
+    }
   }
 }


### PR DESCRIPTION
Implements opening a file on click from the queries panel. Also adjusts how we construct `QueryTreeViewItem` a little bit and provides some different dummy data. Instead of passing in all bits separately, just pass in a file path and work out the label and tooltip from that.

I'm thinking that in the future we'll want to construct these from a file path, but if that's not the case just say and I can adjust or remove that change from this PR. I think we will need to know the file path to be able to open the file when clicked.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
