### PR TITLE
Update export/copy buttons copy when repositories are selected

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [UNRELEASED]
 
 - Add settings `codeQL.variantAnalysis.defaultResultsFilter` and `codeQL.variantAnalysis.defaultResultsSort` for configuring how variant analysis results are filtered and sorted in the results view. The default is to show all repositories, and to sort by the number of results. [#2392](https://github.com/github/vscode-codeql/pull/2392)
+- Update text of copy and export buttons in variant analysis results view to clarify that they only copy/export the selected/filtered results. [#2427](https://github.com/github/vscode-codeql/pull/2427)
 
 ## 1.8.4 - 3 May 2023
 

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisActions.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisActions.tsx
@@ -16,6 +16,7 @@ export type VariantAnalysisActionsProps = {
   exportResultsDisabled?: boolean;
 
   hasSelectedRepositories?: boolean;
+  hasFilteredRepositories?: boolean;
 };
 
 const Container = styled.div`
@@ -28,6 +29,28 @@ const Button = styled(VSCodeButton)`
   white-space: nowrap;
 `;
 
+const chooseText = ({
+  hasSelectedRepositories,
+  hasFilteredRepositories,
+  normalText,
+  selectedText,
+  filteredText,
+}: {
+  hasSelectedRepositories?: boolean;
+  hasFilteredRepositories?: boolean;
+  normalText: string;
+  selectedText: string;
+  filteredText: string;
+}) => {
+  if (hasSelectedRepositories) {
+    return selectedText;
+  }
+  if (hasFilteredRepositories) {
+    return filteredText;
+  }
+  return normalText;
+};
+
 export const VariantAnalysisActions = ({
   variantAnalysisStatus,
   onStopQueryClick,
@@ -38,6 +61,7 @@ export const VariantAnalysisActions = ({
   copyRepositoryListDisabled,
   exportResultsDisabled,
   hasSelectedRepositories,
+  hasFilteredRepositories,
 }: VariantAnalysisActionsProps) => {
   return (
     <Container>
@@ -48,18 +72,26 @@ export const VariantAnalysisActions = ({
             onClick={onCopyRepositoryListClick}
             disabled={copyRepositoryListDisabled}
           >
-            {hasSelectedRepositories
-              ? "Copy selected repositories as a list"
-              : "Copy repository list"}
+            {chooseText({
+              hasSelectedRepositories,
+              hasFilteredRepositories,
+              normalText: "Copy repository list",
+              selectedText: "Copy selected repositories as a list",
+              filteredText: "Copy filtered repositories as a list",
+            })}
           </Button>
           <Button
             appearance="primary"
             onClick={onExportResultsClick}
             disabled={exportResultsDisabled}
           >
-            {hasSelectedRepositories
-              ? "Export selected results"
-              : "Export results"}
+            {chooseText({
+              hasSelectedRepositories,
+              hasFilteredRepositories,
+              normalText: "Export results",
+              selectedText: "Export selected results",
+              filteredText: "Export filtered results",
+            })}
           </Button>
         </>
       )}

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisActions.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisActions.tsx
@@ -14,6 +14,8 @@ export type VariantAnalysisActionsProps = {
   onExportResultsClick: () => void;
   copyRepositoryListDisabled?: boolean;
   exportResultsDisabled?: boolean;
+
+  hasSelectedRepositories?: boolean;
 };
 
 const Container = styled.div`
@@ -35,6 +37,7 @@ export const VariantAnalysisActions = ({
   onExportResultsClick,
   copyRepositoryListDisabled,
   exportResultsDisabled,
+  hasSelectedRepositories,
 }: VariantAnalysisActionsProps) => {
   return (
     <Container>
@@ -45,14 +48,18 @@ export const VariantAnalysisActions = ({
             onClick={onCopyRepositoryListClick}
             disabled={copyRepositoryListDisabled}
           >
-            Copy repository list
+            {hasSelectedRepositories
+              ? "Copy selected repositories as a list"
+              : "Copy repository list"}
           </Button>
           <Button
             appearance="primary"
             onClick={onExportResultsClick}
             disabled={exportResultsDisabled}
           >
-            Export results
+            {hasSelectedRepositories
+              ? "Export selected results"
+              : "Export results"}
           </Button>
         </>
       )}

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisHeader.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisHeader.tsx
@@ -131,6 +131,9 @@ export const VariantAnalysisHeader = ({
           stopQueryDisabled={!variantAnalysis.actionsWorkflowRunId}
           exportResultsDisabled={!hasDownloadedRepos}
           copyRepositoryListDisabled={!hasReposWithResults}
+          hasSelectedRepositories={
+            selectedRepositoryIds && selectedRepositoryIds.length > 0
+          }
         />
       </Row>
       <VariantAnalysisStats

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisHeader.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisHeader.tsx
@@ -131,6 +131,10 @@ export const VariantAnalysisHeader = ({
           stopQueryDisabled={!variantAnalysis.actionsWorkflowRunId}
           exportResultsDisabled={!hasDownloadedRepos}
           copyRepositoryListDisabled={!hasReposWithResults}
+          hasFilteredRepositories={
+            variantAnalysis.scannedRepos?.length !==
+            filteredRepositories?.length
+          }
           hasSelectedRepositories={
             selectedRepositoryIds && selectedRepositoryIds.length > 0
           }

--- a/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisActions.spec.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisActions.spec.tsx
@@ -93,4 +93,17 @@ describe(VariantAnalysisActions.name, () => {
 
     expect(container.querySelectorAll("vscode-button").length).toEqual(0);
   });
+
+  it("changes the text on the buttons when repositories are selected", async () => {
+    render({
+      variantAnalysisStatus: VariantAnalysisStatus.Succeeded,
+      showResultActions: true,
+      hasSelectedRepositories: true,
+    });
+
+    expect(screen.getByText("Export selected results")).toBeInTheDocument();
+    expect(
+      screen.getByText("Copy selected repositories as a list"),
+    ).toBeInTheDocument();
+  });
 });

--- a/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisActions.spec.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisActions.spec.tsx
@@ -99,11 +99,26 @@ describe(VariantAnalysisActions.name, () => {
       variantAnalysisStatus: VariantAnalysisStatus.Succeeded,
       showResultActions: true,
       hasSelectedRepositories: true,
+      hasFilteredRepositories: true,
     });
 
     expect(screen.getByText("Export selected results")).toBeInTheDocument();
     expect(
       screen.getByText("Copy selected repositories as a list"),
+    ).toBeInTheDocument();
+  });
+
+  it("changes the text on the buttons when repositories are filtered", async () => {
+    render({
+      variantAnalysisStatus: VariantAnalysisStatus.Succeeded,
+      showResultActions: true,
+      hasSelectedRepositories: false,
+      hasFilteredRepositories: true,
+    });
+
+    expect(screen.getByText("Export filtered results")).toBeInTheDocument();
+    expect(
+      screen.getByText("Copy filtered repositories as a list"),
     ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
This changes the text of the export/copy buttons on a variant analysis when at least one repository is selected or a filter is applied which filters out part of the repositories. This makes it more clear that the user is only exporting/copying the results of the selected/filtered repositories.

https://github.com/github/vscode-codeql/assets/1112623/1e036099-4e4b-4919-9d98-c3626b980118

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
