### PR TITLE
Add warning when using unsupported CLI version

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [UNRELEASED]
 
 - Add settings `codeQL.variantAnalysis.defaultResultsFilter` and `codeQL.variantAnalysis.defaultResultsSort` for configuring how variant analysis results are filtered and sorted in the results view. The default is to show all repositories, and to sort by the number of results. [#2392](https://github.com/github/vscode-codeql/pull/2392)
+- Add warning when using unsupported CodeQL CLI version. [#2428](https://github.com/github/vscode-codeql/pull/2428)
 
 ## 1.8.4 - 3 May 2023
 

--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -1737,6 +1737,10 @@ export function shouldDebugCliServer() {
 }
 
 export class CliVersionConstraint {
+  // The oldest version of the CLI that we support. This is used to determine
+  // whether to show a warning about the CLI being too old on startup.
+  public static OLDEST_SUPPORTED_CLI_VERSION = new SemVer("2.7.6");
+
   /**
    * CLI version where building QLX packs for remote queries is supported.
    * (The options were _accepted_ by a few earlier versions, but only from

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -24,7 +24,7 @@ import {
   activate as archiveFilesystemProvider_activate,
   zipArchiveScheme,
 } from "./common/vscode/archive-filesystem-provider";
-import { CodeQLCliServer } from "./codeql-cli/cli";
+import { CliVersionConstraint, CodeQLCliServer } from "./codeql-cli/cli";
 import {
   CliConfigListener,
   DistributionConfigListener,
@@ -407,6 +407,28 @@ export async function activate(
     );
     codeQlExtension.cliServer.addVersionChangedListener((ver) => {
       telemetryListener.cliVersion = ver;
+    });
+
+    let unsupportedWarningShown = false;
+    codeQlExtension.cliServer.addVersionChangedListener((ver) => {
+      if (!ver) {
+        return;
+      }
+
+      if (unsupportedWarningShown) {
+        return;
+      }
+
+      if (CliVersionConstraint.OLDEST_SUPPORTED_CLI_VERSION.compare(ver) < 0) {
+        return;
+      }
+
+      void showAndLogWarningMessage(
+        `You are using an unsupported version of the CodeQL CLI (${ver}). ` +
+          `The minimum supported version is ${CliVersionConstraint.OLDEST_SUPPORTED_CLI_VERSION}. ` +
+          `Please upgrade to the latest version of the CodeQL CLI.`,
+      );
+      unsupportedWarningShown = true;
     });
   }
 

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -426,7 +426,7 @@ export async function activate(
       void showAndLogWarningMessage(
         `You are using an unsupported version of the CodeQL CLI (${ver}). ` +
           `The minimum supported version is ${CliVersionConstraint.OLDEST_SUPPORTED_CLI_VERSION}. ` +
-          `Please upgrade to the latest version of the CodeQL CLI.`,
+          `Please upgrade to a newer version of the CodeQL CLI.`,
       );
       unsupportedWarningShown = true;
     });


### PR DESCRIPTION
This adds a warning when the user is using an unsupported version of the CodeQL CLI. The warning is shown once per session, and only if the version is older than the oldest supported version.

![Screenshot 2023-05-17 at 16 26 19](https://github.com/github/vscode-codeql/assets/1112623/01c37245-7a5f-4b59-9ce6-8071082a92ce)


## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
