### PR TITLE
Add `QueryDiscovery` class to find all queries in the workspace

### DIFF
--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -135,6 +135,11 @@ export interface SourceInfo {
 }
 
 /**
+ * The expected output of `codeql resolve queries`.
+ */
+export type ResolvedQueries = string[];
+
+/**
  * The expected output of `codeql resolve tests`.
  */
 export type ResolvedTests = string[];
@@ -728,6 +733,20 @@ export class CodeQLCliServer implements Disposable {
         subcommandArgs,
         "Resolving query by language",
       ),
+    );
+  }
+
+  /**
+   * Finds all available queries in a given directory.
+   * @param queryDir Root of directory tree to search for queries.
+   * @returns The list of queries that were found.
+   */
+  public async resolveQueries(queryDir: string): Promise<ResolvedQueries> {
+    const subcommandArgs = [queryDir];
+    return await this.runJsonCodeQlCliCommand<ResolvedQueries>(
+      ["resolve", "queries"],
+      subcommandArgs,
+      "Resolving queries",
     );
   }
 

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -733,7 +733,7 @@ async function activateWithInstalledDistribution(
   );
   ctx.subscriptions.push(databaseUI);
 
-  QueriesModule.initialize(app);
+  QueriesModule.initialize(app, cliServer);
 
   void extLogger.log("Initializing evaluator log viewer.");
   const evalLogViewer = new EvalLogViewer();

--- a/extensions/ql-vscode/src/queries-panel/queries-module.ts
+++ b/extensions/ql-vscode/src/queries-panel/queries-module.ts
@@ -1,17 +1,21 @@
+import { CodeQLCliServer } from "../codeql-cli/cli";
 import { extLogger } from "../common";
 import { App, AppMode } from "../common/app";
 import { isCanary, showQueriesPanel } from "../config";
 import { DisposableObject } from "../pure/disposable-object";
 import { QueriesPanel } from "./queries-panel";
+import { QueryDiscovery } from "./query-discovery";
+import * as vscode from "vscode";
 
 export class QueriesModule extends DisposableObject {
   private queriesPanel: QueriesPanel | undefined;
+  private queryDiscovery: QueryDiscovery | undefined;
 
   private constructor(readonly app: App) {
     super();
   }
 
-  private initialize(app: App): void {
+  private initialize(app: App, cliServer: CodeQLCliServer): void {
     if (app.mode === AppMode.Production || !isCanary() || !showQueriesPanel()) {
       // Currently, we only want to expose the new panel when we are in development and canary mode
       // and the developer has enabled the "Show queries panel" flag.
@@ -21,13 +25,25 @@ export class QueriesModule extends DisposableObject {
 
     this.queriesPanel = new QueriesPanel();
     this.push(this.queriesPanel);
+
+    // Temporarily just scan the first workspace folder
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    if (!workspaceFolder) {
+      throw Error("No workspace folder found.");
+    }
+
+    this.queryDiscovery = new QueryDiscovery(workspaceFolder, cliServer);
+    this.queryDiscovery.refresh();
   }
 
-  public static initialize(app: App): QueriesModule {
+  public static initialize(
+    app: App,
+    cliServer: CodeQLCliServer,
+  ): QueriesModule {
     const queriesModule = new QueriesModule(app);
     app.subscriptions.push(queriesModule);
 
-    queriesModule.initialize(app);
+    queriesModule.initialize(app, cliServer);
     return queriesModule;
   }
 }

--- a/extensions/ql-vscode/src/queries-panel/query-discovery.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-discovery.ts
@@ -1,0 +1,183 @@
+import * as vscode from "vscode";
+import { dirname, basename, join, normalize, relative } from "path";
+import { Discovery } from "../common/discovery";
+import { CodeQLCliServer } from "../codeql-cli/cli";
+import { pathExists } from "fs-extra";
+
+/**
+ * A node in the tree of queries. This will be either a `QueryDirectory` or a `QueryFile`.
+ */
+export abstract class QueryNode {
+  constructor(private _path: string, private _name: string) {}
+
+  public get path(): string {
+    return this._path;
+  }
+
+  public get name(): string {
+    return this._name;
+  }
+
+  public abstract get children(): readonly QueryNode[];
+
+  public abstract finish(): void;
+}
+
+/**
+ * A directory containing one or more query files or other query directories.
+ */
+export class QueryDirectory extends QueryNode {
+  constructor(
+    _path: string,
+    _name: string,
+    private _children: QueryNode[] = [],
+  ) {
+    super(_path, _name);
+  }
+
+  public get children(): readonly QueryNode[] {
+    return this._children;
+  }
+
+  public addChild(child: QueryNode): void {
+    this._children.push(child);
+  }
+
+  public createDirectory(relativePath: string): QueryDirectory {
+    const dirName = dirname(relativePath);
+    if (dirName === ".") {
+      return this.createChildDirectory(relativePath);
+    } else {
+      const parent = this.createDirectory(dirName);
+      return parent.createDirectory(basename(relativePath));
+    }
+  }
+
+  public finish(): void {
+    // remove empty directories
+    this._children.filter(
+      (child) => child instanceof QueryFile || child.children.length > 0,
+    );
+    this._children.sort((a, b) =>
+      a.name.localeCompare(b.name, vscode.env.language),
+    );
+    this._children.forEach((child, i) => {
+      child.finish();
+      if (
+        child.children?.length === 1 &&
+        child.children[0] instanceof QueryDirectory
+      ) {
+        // collapse children
+        const replacement = new QueryDirectory(
+          child.children[0].path,
+          `${child.name} / ${child.children[0].name}`,
+          Array.from(child.children[0].children),
+        );
+        this._children[i] = replacement;
+      }
+    });
+  }
+
+  private createChildDirectory(name: string): QueryDirectory {
+    const existingChild = this._children.find((child) => child.name === name);
+    if (existingChild !== undefined) {
+      return existingChild as QueryDirectory;
+    } else {
+      const newChild = new QueryDirectory(join(this.path, name), name);
+      this.addChild(newChild);
+      return newChild;
+    }
+  }
+}
+
+/**
+ * A single query file, i.e. a file with `.ql` extension.
+ */
+export class QueryFile extends QueryNode {
+  constructor(_path: string, _name: string) {
+    super(_path, _name);
+  }
+
+  public get children(): readonly QueryNode[] {
+    return [];
+  }
+
+  public finish(): void {
+    /**/
+  }
+}
+
+/**
+ * The results of discovering queries.
+ */
+interface QueryDiscoveryResults {
+  /**
+   * A directory that contains one or more query files or other query directories.
+   */
+  queryDirectory: QueryDirectory | undefined;
+
+  /**
+   * The file system path to a directory to watch. If any ql file changes in
+   * this directory, then this signifies a change in queries.
+   */
+  watchPath: string;
+}
+
+/**
+ * Discovers all query files contained in the QL packs in a given workspace folder.
+ */
+export class QueryDiscovery extends Discovery<QueryDiscoveryResults> {
+  private _queryDirectory: QueryDirectory | undefined;
+
+  constructor(
+    private readonly workspaceFolder: vscode.WorkspaceFolder,
+    private readonly cliServer: CodeQLCliServer,
+  ) {
+    super("Query Discovery");
+  }
+
+  /**
+   * The root directory. There is at least one query in this directory, or
+   * in a subdirectory of this.
+   */
+  public get queryDirectory(): QueryDirectory | undefined {
+    return this._queryDirectory;
+  }
+
+  protected async discover(): Promise<QueryDiscoveryResults> {
+    const queryDirectory = await this.discoverQueries();
+    return {
+      queryDirectory,
+      watchPath: this.workspaceFolder.uri.fsPath,
+    };
+  }
+
+  protected update(results: QueryDiscoveryResults): void {
+    this._queryDirectory = results.queryDirectory;
+  }
+
+  /**
+   * Discover all queries in the specified directory and its subdirectories.
+   * @returns A `QueryDirectory` object describing the contents of the directory, or `undefined` if
+   *   no queries were found.
+   */
+  private async discoverQueries(): Promise<QueryDirectory> {
+    const fullPath = this.workspaceFolder.uri.fsPath;
+    const name = this.workspaceFolder.name;
+    const rootDirectory = new QueryDirectory(fullPath, name);
+
+    // Don't try discovery on workspace folders that don't exist on the filesystem
+    if (await pathExists(fullPath)) {
+      const resolvedQueries = await this.cliServer.resolveQueries(fullPath);
+      for (const queryPath of resolvedQueries) {
+        const relativePath = normalize(relative(fullPath, queryPath));
+        const dirName = dirname(relativePath);
+        const parentDirectory = rootDirectory.createDirectory(dirName);
+        parentDirectory.addChild(new QueryFile(queryPath, basename(queryPath)));
+      }
+
+      rootDirectory.finish();
+    }
+    return rootDirectory;
+  }
+}


### PR DESCRIPTION
[🚧 DRAFT 🚧]

To populate the new (WIP) queries panel, we want to scan the workspace for any QL files. We do a similar thing for the Test Explorer, so I've copied/adapted that approach (specifically the [`qltest-discovery.ts`](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/src/query-testing/qltest-discovery.ts) file). 

This needs some more work, but I wanted to open the draft PR to get feedback/suggestions about the general approach 🔍 

## Checklist

N/A—internal only 🤠

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
