### PR TITLE
Add workspace folders to App interface

### DIFF
--- a/extensions/ql-vscode/src/common/app.ts
+++ b/extensions/ql-vscode/src/common/app.ts
@@ -4,6 +4,11 @@ import { AppEventEmitter } from "./events";
 import { Logger } from "./logging";
 import { Memento } from "./memento";
 import { AppCommandManager } from "./commands";
+import type {
+  WorkspaceFolder,
+  Event,
+  WorkspaceFoldersChangeEvent,
+} from "vscode";
 
 export interface App {
   createEventEmitter<T>(): AppEventEmitter<T>;
@@ -14,6 +19,8 @@ export interface App {
   readonly globalStoragePath: string;
   readonly workspaceStoragePath?: string;
   readonly workspaceState: Memento;
+  readonly workspaceFolders: readonly WorkspaceFolder[] | undefined;
+  readonly onDidChangeWorkspaceFolders: Event<WorkspaceFoldersChangeEvent>;
   readonly credentials: Credentials;
   readonly commands: AppCommandManager;
 }

--- a/extensions/ql-vscode/src/common/vscode/vscode-app.ts
+++ b/extensions/ql-vscode/src/common/vscode/vscode-app.ts
@@ -39,6 +39,14 @@ export class ExtensionApp implements App {
     return this.extensionContext.workspaceState;
   }
 
+  public get workspaceFolders(): readonly vscode.WorkspaceFolder[] | undefined {
+    return vscode.workspace.workspaceFolders;
+  }
+
+  public get onDidChangeWorkspaceFolders(): vscode.Event<vscode.WorkspaceFoldersChangeEvent> {
+    return vscode.workspace.onDidChangeWorkspaceFolders;
+  }
+
   public get subscriptions(): Disposable[] {
     return this.extensionContext.subscriptions;
   }

--- a/extensions/ql-vscode/test/__mocks__/appMock.ts
+++ b/extensions/ql-vscode/test/__mocks__/appMock.ts
@@ -8,6 +8,11 @@ import { testCredentialsWithStub } from "../factories/authentication";
 import { Credentials } from "../../src/common/authentication";
 import { AppCommandManager } from "../../src/common/commands";
 import { createMockCommandManager } from "./commandsMock";
+import type {
+  Event,
+  WorkspaceFolder,
+  WorkspaceFoldersChangeEvent,
+} from "vscode";
 
 export function createMockApp({
   extensionPath = "/mock/extension/path",
@@ -15,6 +20,8 @@ export function createMockApp({
   globalStoragePath = "/mock/global/storage/path",
   createEventEmitter = <T>() => new MockAppEventEmitter<T>(),
   workspaceState = createMockMemento(),
+  workspaceFolders = [],
+  onDidChangeWorkspaceFolders = jest.fn(),
   credentials = testCredentialsWithStub(),
   commands = createMockCommandManager(),
 }: {
@@ -23,6 +30,8 @@ export function createMockApp({
   globalStoragePath?: string;
   createEventEmitter?: <T>() => AppEventEmitter<T>;
   workspaceState?: Memento;
+  workspaceFolders?: readonly WorkspaceFolder[] | undefined;
+  onDidChangeWorkspaceFolders?: Event<WorkspaceFoldersChangeEvent>;
   credentials?: Credentials;
   commands?: AppCommandManager;
 }): App {
@@ -34,6 +43,8 @@ export function createMockApp({
     workspaceStoragePath,
     globalStoragePath,
     workspaceState,
+    workspaceFolders,
+    onDidChangeWorkspaceFolders,
     createEventEmitter,
     credentials,
     commands,


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Adds knowledge of workspace folders to the `App` interface. This is going to be used very soon by the queries panel, and adding this to the `App` means that the queries panel itself will depend less on VS Code internals and will be easier to test.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
