### PR TITLE
Hook queries panel up to real data

### DIFF
--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -135,6 +135,11 @@ export interface SourceInfo {
 }
 
 /**
+ * The expected output of `codeql resolve queries`.
+ */
+export type ResolvedQueries = string[];
+
+/**
  * The expected output of `codeql resolve tests`.
  */
 export type ResolvedTests = string[];
@@ -728,6 +733,20 @@ export class CodeQLCliServer implements Disposable {
         subcommandArgs,
         "Resolving query by language",
       ),
+    );
+  }
+
+  /**
+   * Finds all available queries in a given directory.
+   * @param queryDir Root of directory tree to search for queries.
+   * @returns The list of queries that were found.
+   */
+  public async resolveQueries(queryDir: string): Promise<ResolvedQueries> {
+    const subcommandArgs = [queryDir];
+    return await this.runJsonCodeQlCliCommand<ResolvedQueries>(
+      ["resolve", "queries"],
+      subcommandArgs,
+      "Resolving queries",
     );
   }
 

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -733,7 +733,7 @@ async function activateWithInstalledDistribution(
   );
   ctx.subscriptions.push(databaseUI);
 
-  QueriesModule.initialize(app);
+  QueriesModule.initialize(app, cliServer);
 
   void extLogger.log("Initializing evaluator log viewer.");
   const evalLogViewer = new EvalLogViewer();

--- a/extensions/ql-vscode/src/queries-panel/queries-module.ts
+++ b/extensions/ql-vscode/src/queries-panel/queries-module.ts
@@ -26,7 +26,7 @@ export class QueriesModule extends DisposableObject {
     this.push(this.queryDiscovery);
     this.queryDiscovery.refresh();
 
-    this.queriesPanel = new QueriesPanel();
+    this.queriesPanel = new QueriesPanel(this.queryDiscovery);
     this.push(this.queriesPanel);
   }
 

--- a/extensions/ql-vscode/src/queries-panel/queries-panel.ts
+++ b/extensions/ql-vscode/src/queries-panel/queries-panel.ts
@@ -2,15 +2,16 @@ import * as vscode from "vscode";
 import { DisposableObject } from "../pure/disposable-object";
 import { QueryTreeDataProvider } from "./query-tree-data-provider";
 import { QueryTreeViewItem } from "./query-tree-view-item";
+import { QueryDiscovery } from "./query-discovery";
 
 export class QueriesPanel extends DisposableObject {
   private readonly dataProvider: QueryTreeDataProvider;
   private readonly treeView: vscode.TreeView<QueryTreeViewItem>;
 
-  public constructor() {
+  public constructor(queryDiscovery: QueryDiscovery) {
     super();
 
-    this.dataProvider = new QueryTreeDataProvider();
+    this.dataProvider = new QueryTreeDataProvider(queryDiscovery);
 
     this.treeView = vscode.window.createTreeView("codeQLQueries", {
       treeDataProvider: this.dataProvider,

--- a/extensions/ql-vscode/src/queries-panel/query-discovery.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-discovery.ts
@@ -12,6 +12,7 @@ import {
 import { MultiFileSystemWatcher } from "../common/vscode/multi-file-system-watcher";
 import { App } from "../common/app";
 import { FileTreeDirectory, FileTreeLeaf } from "../common/file-tree-nodes";
+import { getOnDiskWorkspaceFolders } from "../helpers";
 
 /**
  * The results of discovering queries.
@@ -121,7 +122,10 @@ export class QueryDiscovery extends Discovery<QueryDiscoveryResults> {
     const name = workspaceFolder.name;
 
     // Don't try discovery on workspace folders that don't exist on the filesystem
-    if (!(await pathExists(fullPath))) {
+    if (
+      !(await pathExists(fullPath)) ||
+      !getOnDiskWorkspaceFolders().includes(fullPath)
+    ) {
       return undefined;
     }
 

--- a/extensions/ql-vscode/src/queries-panel/query-tree-data-provider.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-tree-data-provider.ts
@@ -39,6 +39,7 @@ export class QueryTreeDataProvider
     fileTreeDirectory: FileTreeNode,
   ): QueryTreeViewItem {
     return new QueryTreeViewItem(
+      fileTreeDirectory.name,
       fileTreeDirectory.path,
       fileTreeDirectory.children.map(this.convertFileTreeNode.bind(this)),
     );

--- a/extensions/ql-vscode/src/queries-panel/query-tree-data-provider.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-tree-data-provider.ts
@@ -1,37 +1,47 @@
-import * as vscode from "vscode";
+import { Event, EventEmitter, TreeDataProvider, TreeItem } from "vscode";
 import { QueryTreeViewItem } from "./query-tree-view-item";
 import { DisposableObject } from "../pure/disposable-object";
+import { QueryDiscovery } from "./query-discovery";
+import { FileTreeNode } from "../common/file-tree-nodes";
 
 export class QueryTreeDataProvider
   extends DisposableObject
-  implements vscode.TreeDataProvider<QueryTreeViewItem>
+  implements TreeDataProvider<QueryTreeViewItem>
 {
   private queryTreeItems: QueryTreeViewItem[];
 
-  public constructor() {
+  private readonly onDidChangeTreeDataEmitter = this.push(
+    new EventEmitter<void>(),
+  );
+
+  public constructor(private readonly queryDiscovery: QueryDiscovery) {
     super();
+
+    queryDiscovery.onDidChangeQueries(() => {
+      this.queryTreeItems = this.createTree();
+      this.onDidChangeTreeDataEmitter.fire();
+    });
 
     this.queryTreeItems = this.createTree();
   }
 
+  public get onDidChangeTreeData(): Event<void> {
+    return this.onDidChangeTreeDataEmitter.event;
+  }
+
   private createTree(): QueryTreeViewItem[] {
-    // Temporary mock data, just to populate the tree view.
-    return [
-      new QueryTreeViewItem("custom-pack", [
-        new QueryTreeViewItem("custom-pack/example.ql", []),
-      ]),
-      new QueryTreeViewItem("ql", [
-        new QueryTreeViewItem("ql/javascript", [
-          new QueryTreeViewItem("ql/javascript/example.ql", []),
-        ]),
-        new QueryTreeViewItem("ql/go", [
-          new QueryTreeViewItem("ql/go/security", [
-            new QueryTreeViewItem("ql/go/security/query1.ql", []),
-            new QueryTreeViewItem("ql/go/security/query2.ql", []),
-          ]),
-        ]),
-      ]),
-    ];
+    return (this.queryDiscovery.queries || []).map(
+      this.convertFileTreeNode.bind(this),
+    );
+  }
+
+  private convertFileTreeNode(
+    fileTreeDirectory: FileTreeNode,
+  ): QueryTreeViewItem {
+    return new QueryTreeViewItem(
+      fileTreeDirectory.path,
+      fileTreeDirectory.children.map(this.convertFileTreeNode.bind(this)),
+    );
   }
 
   /**
@@ -39,7 +49,7 @@ export class QueryTreeDataProvider
    * @param item The item to represent.
    * @returns The UI presentation of the item.
    */
-  public getTreeItem(item: QueryTreeViewItem): vscode.TreeItem {
+  public getTreeItem(item: QueryTreeViewItem): TreeItem {
     return item;
   }
 

--- a/extensions/ql-vscode/src/queries-panel/query-tree-view-item.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-tree-view-item.ts
@@ -1,9 +1,12 @@
 import * as vscode from "vscode";
-import { basename } from "path";
 
 export class QueryTreeViewItem extends vscode.TreeItem {
-  constructor(path: string, public readonly children: QueryTreeViewItem[]) {
-    super(basename(path));
+  constructor(
+    name: string,
+    path: string,
+    public readonly children: QueryTreeViewItem[],
+  ) {
+    super(name);
     this.tooltip = path;
     this.collapsibleState = this.children.length
       ? vscode.TreeItemCollapsibleState.Collapsed


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

This PR implements supplying the queries panel with real data from the workspace. We make use of the `Discovery` class, which is already used by the QL Test panel feature and has a very similar set of requirements to us. A lot of inspiration has come directly from the `QLTestDiscovery` class.

Tested locally using the codeql starter workspace:
![Screenshot 2023-05-19 at 16 40 08](https://github.com/github/vscode-codeql/assets/3749000/1b9403f1-6cf6-431e-a72e-dfa942b0af80)

It successfully handles updating when there's changes to the filesystem, and the automatic remembering of which items are expanded or collapsed seems pretty good.

There are some rough edges that can be improved but I think this is a good starting point. The main thing I'd like to look at in future PRs is single vs multi-root workspaces. In a single-root workspace maybe we hide the top-level item which is just the workspace name.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
