### PR TITLE
Mark AppEventEmitter as disposable

### DIFF
--- a/extensions/ql-vscode/src/common/events.ts
+++ b/extensions/ql-vscode/src/common/events.ts
@@ -4,7 +4,7 @@ export interface AppEvent<T> {
   (listener: (event: T) => void): Disposable;
 }
 
-export interface AppEventEmitter<T> {
+export interface AppEventEmitter<T> extends Disposable {
   event: AppEvent<T>;
   fire(data: T): void;
 }

--- a/extensions/ql-vscode/src/databases/config/db-config-store.ts
+++ b/extensions/ql-vscode/src/databases/config/db-config-store.ts
@@ -61,7 +61,9 @@ export class DbConfigStore extends DisposableObject {
     this.configErrors = [];
     this.configWatcher = undefined;
     this.configValidator = new DbConfigValidator(app.extensionPath);
-    this.onDidChangeConfigEventEmitter = app.createEventEmitter<void>();
+    this.onDidChangeConfigEventEmitter = this.push(
+      app.createEventEmitter<void>(),
+    );
     this.onDidChangeConfig = this.onDidChangeConfigEventEmitter.event;
   }
 

--- a/extensions/ql-vscode/src/databases/db-manager.ts
+++ b/extensions/ql-vscode/src/databases/db-manager.ts
@@ -1,6 +1,7 @@
 import { App } from "../common/app";
 import { AppEvent, AppEventEmitter } from "../common/events";
 import { ValueResult } from "../common/value-result";
+import { DisposableObject } from "../pure/disposable-object";
 import { DbConfigStore } from "./config/db-config-store";
 import {
   DbItem,
@@ -23,7 +24,7 @@ import {
 import { createRemoteTree } from "./db-tree-creator";
 import { DbConfigValidationError } from "./db-validation-errors";
 
-export class DbManager {
+export class DbManager extends DisposableObject {
   public readonly onDbItemsChanged: AppEvent<void>;
   public static readonly DB_EXPANDED_STATE_KEY = "db_expanded";
   private readonly onDbItemsChangesEventEmitter: AppEventEmitter<void>;
@@ -32,7 +33,11 @@ export class DbManager {
     private readonly app: App,
     private readonly dbConfigStore: DbConfigStore,
   ) {
-    this.onDbItemsChangesEventEmitter = app.createEventEmitter<void>();
+    super();
+
+    this.onDbItemsChangesEventEmitter = this.push(
+      app.createEventEmitter<void>(),
+    );
     this.onDbItemsChanged = this.onDbItemsChangesEventEmitter.event;
 
     this.dbConfigStore.onDidChangeConfig(() => {

--- a/extensions/ql-vscode/src/databases/db-module.ts
+++ b/extensions/ql-vscode/src/databases/db-module.ts
@@ -17,7 +17,7 @@ export class DbModule extends DisposableObject {
     super();
 
     this.dbConfigStore = new DbConfigStore(app);
-    this.dbManager = new DbManager(app, this.dbConfigStore);
+    this.dbManager = this.push(new DbManager(app, this.dbConfigStore));
   }
 
   public static async initialize(app: App): Promise<DbModule> {

--- a/extensions/ql-vscode/test/__mocks__/appMock.ts
+++ b/extensions/ql-vscode/test/__mocks__/appMock.ts
@@ -63,4 +63,8 @@ export class MockAppEventEmitter<T> implements AppEventEmitter<T> {
   public fire(): void {
     // no-op
   }
+
+  public dispose() {
+    // no-op
+  }
 }


### PR DESCRIPTION
Makes `AppEventEmitter` implement `Disposable`. This class is mirroring the VS Code `EventEmitter` class, and that does have a `dispose` method.

This means in places where we use `app.createEventEmitter` we can track the object and dispose of it, which helps mirror the places where we use `EventEmitter` directly and we already do this.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
