### PR TITLE
Convert getOnDiskWorkspaceFolders to optionally use an App

### DIFF
--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -28,6 +28,7 @@ import { getQlPackPath } from "./pure/ql";
 import { dbSchemeToLanguage } from "./common/query-language";
 import { isCodespacesTemplate } from "./config";
 import { AppCommandManager } from "./common/commands";
+import { App } from "./common/app";
 
 // Shared temporary folder for the extension.
 export const tmpDir = dirSync({
@@ -297,14 +298,18 @@ export async function showNeverAskAgainDialog(
 }
 
 /** Gets all active workspace folders that are on the filesystem. */
-export function getOnDiskWorkspaceFoldersObjects() {
-  const workspaceFolders = workspace.workspaceFolders ?? [];
+export function getOnDiskWorkspaceFoldersObjects(app?: App) {
+  const workspaceFolders =
+    (app !== undefined ? app.workspaceFolders : workspace.workspaceFolders) ??
+    [];
   return workspaceFolders.filter(isWorkspaceFolderOnDisk);
 }
 
 /** Gets all active workspace folders that are on the filesystem. */
-export function getOnDiskWorkspaceFolders() {
-  return getOnDiskWorkspaceFoldersObjects().map((folder) => folder.uri.fsPath);
+export function getOnDiskWorkspaceFolders(app?: App) {
+  return getOnDiskWorkspaceFoldersObjects(app).map(
+    (folder) => folder.uri.fsPath,
+  );
 }
 
 /** Check if folder is already present in workspace */

--- a/extensions/ql-vscode/src/queries-panel/query-discovery.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-discovery.ts
@@ -43,7 +43,10 @@ export class QueryDiscovery extends Discovery<QueryDiscoveryResults> {
     new MultiFileSystemWatcher(),
   );
 
-  constructor(app: App, private readonly cliServer: CodeQLCliServer) {
+  constructor(
+    private readonly app: App,
+    private readonly cliServer: CodeQLCliServer,
+  ) {
     super("Query Discovery");
 
     this.push(app.onDidChangeWorkspaceFolders(this.refresh.bind(this)));
@@ -62,7 +65,7 @@ export class QueryDiscovery extends Discovery<QueryDiscoveryResults> {
   }
 
   protected async discover(): Promise<QueryDiscoveryResults> {
-    const workspaceFolders = getOnDiskWorkspaceFoldersObjects();
+    const workspaceFolders = getOnDiskWorkspaceFoldersObjects(this.app);
     if (workspaceFolders.length === 0) {
       return {
         queries: [],


### PR DESCRIPTION
This aims to remove a dependency that `QueryDiscovery` has on VS Code, by converting `getOnDiskWorkspaceFoldersObjects` to optionally take an app and use that instead of accessing `workspace.workspaceFolders` directly. The goal is to remove all dependencies on an actual workspace to make `QueryDiscovery` easier to test.

The reason for the `app` argument being optional is that there are a lot of existing references to `getOnDiskWorkspaceFoldersObjects` and `getOnDiskWorkspaceFolders` and it would be quite a lot of effort to convert all of them at once. Is it acceptable to do it this way and convert them gradually?

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
