### PR TITLE
Use app.createEventEmitter in QueryDiscovery

### DIFF
--- a/extensions/ql-vscode/src/queries-panel/query-discovery.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-discovery.ts
@@ -6,6 +6,7 @@ import { MultiFileSystemWatcher } from "../common/vscode/multi-file-system-watch
 import { App } from "../common/app";
 import { FileTreeDirectory, FileTreeLeaf } from "../common/file-tree-nodes";
 import { getOnDiskWorkspaceFoldersObjects } from "../helpers";
+import { AppEventEmitter } from "../common/events";
 
 /**
  * The results of discovering queries.
@@ -30,7 +31,7 @@ interface QueryDiscoveryResults {
 export class QueryDiscovery extends Discovery<QueryDiscoveryResults> {
   private results: QueryDiscoveryResults | undefined;
 
-  private readonly onDidChangeQueriesEmitter;
+  private readonly onDidChangeQueriesEmitter: AppEventEmitter<void>;
   private readonly watcher: MultiFileSystemWatcher = this.push(
     new MultiFileSystemWatcher(),
   );

--- a/extensions/ql-vscode/src/queries-panel/query-discovery.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-discovery.ts
@@ -1,13 +1,7 @@
 import { dirname, basename, normalize, relative } from "path";
 import { Discovery } from "../common/discovery";
 import { CodeQLCliServer } from "../codeql-cli/cli";
-import {
-  Event,
-  EventEmitter,
-  RelativePattern,
-  Uri,
-  WorkspaceFolder,
-} from "vscode";
+import { Event, RelativePattern, Uri, WorkspaceFolder } from "vscode";
 import { MultiFileSystemWatcher } from "../common/vscode/multi-file-system-watcher";
 import { App } from "../common/app";
 import { FileTreeDirectory, FileTreeLeaf } from "../common/file-tree-nodes";
@@ -36,9 +30,7 @@ interface QueryDiscoveryResults {
 export class QueryDiscovery extends Discovery<QueryDiscoveryResults> {
   private results: QueryDiscoveryResults | undefined;
 
-  private readonly onDidChangeQueriesEmitter = this.push(
-    new EventEmitter<void>(),
-  );
+  private readonly onDidChangeQueriesEmitter;
   private readonly watcher: MultiFileSystemWatcher = this.push(
     new MultiFileSystemWatcher(),
   );
@@ -46,6 +38,7 @@ export class QueryDiscovery extends Discovery<QueryDiscoveryResults> {
   constructor(app: App, private readonly cliServer: CodeQLCliServer) {
     super("Query Discovery");
 
+    this.onDidChangeQueriesEmitter = this.push(app.createEventEmitter<void>());
     this.push(app.onDidChangeWorkspaceFolders(this.refresh.bind(this)));
     this.push(this.watcher.onDidChange(this.refresh.bind(this)));
   }


### PR DESCRIPTION
Remove a small dependency that `QueryDiscovery` has on VS Code classes. I'm not sure if this one is strictly a blocker for making unit tests, but the method on `App` is already there so it costs us nothing to use it.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
