### PR TITLE
Convert multi-file-system-watcher to go through the app to make a watcher

### DIFF
--- a/extensions/ql-vscode/src/common/app.ts
+++ b/extensions/ql-vscode/src/common/app.ts
@@ -8,6 +8,7 @@ import type {
   WorkspaceFolder,
   Event,
   WorkspaceFoldersChangeEvent,
+  workspace,
 } from "vscode";
 
 export interface App {
@@ -21,6 +22,7 @@ export interface App {
   readonly workspaceState: Memento;
   readonly workspaceFolders: readonly WorkspaceFolder[] | undefined;
   readonly onDidChangeWorkspaceFolders: Event<WorkspaceFoldersChangeEvent>;
+  readonly createFileSystemWatcher: typeof workspace.createFileSystemWatcher;
   readonly credentials: Credentials;
   readonly commands: AppCommandManager;
 }

--- a/extensions/ql-vscode/src/common/vscode/vscode-app.ts
+++ b/extensions/ql-vscode/src/common/vscode/vscode-app.ts
@@ -47,6 +47,10 @@ export class ExtensionApp implements App {
     return vscode.workspace.onDidChangeWorkspaceFolders;
   }
 
+  public get createFileSystemWatcher() {
+    return vscode.workspace.createFileSystemWatcher;
+  }
+
   public get subscriptions(): Disposable[] {
     return this.extensionContext.subscriptions;
   }

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -947,6 +947,7 @@ async function activateWithInstalledDistribution(
       const testAdapterFactory = new QLTestAdapterFactory(
         testHub,
         testRunner,
+        app,
         cliServer,
       );
       ctx.subscriptions.push(testAdapterFactory);

--- a/extensions/ql-vscode/src/queries-panel/query-discovery.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-discovery.ts
@@ -39,14 +39,14 @@ export class QueryDiscovery extends Discovery<QueryDiscoveryResults> {
   private readonly onDidChangeQueriesEmitter = this.push(
     new EventEmitter<void>(),
   );
-  private readonly watcher: MultiFileSystemWatcher = this.push(
-    new MultiFileSystemWatcher(),
-  );
+  private readonly watcher: MultiFileSystemWatcher;
 
   constructor(app: App, private readonly cliServer: CodeQLCliServer) {
     super("Query Discovery");
 
     this.push(app.onDidChangeWorkspaceFolders(this.refresh.bind(this)));
+
+    this.watcher = this.push(new MultiFileSystemWatcher(app));
     this.push(this.watcher.onDidChange(this.refresh.bind(this)));
   }
 

--- a/extensions/ql-vscode/src/query-testing/qltest-discovery.ts
+++ b/extensions/ql-vscode/src/query-testing/qltest-discovery.ts
@@ -11,6 +11,7 @@ import { MultiFileSystemWatcher } from "../common/vscode/multi-file-system-watch
 import { CodeQLCliServer } from "../codeql-cli/cli";
 import { pathExists } from "fs-extra";
 import { FileTreeDirectory, FileTreeLeaf } from "../common/file-tree-nodes";
+import { App } from "../common/app";
 
 /**
  * The results of discovering QL tests.
@@ -33,17 +34,17 @@ interface QLTestDiscoveryResults {
  */
 export class QLTestDiscovery extends Discovery<QLTestDiscoveryResults> {
   private readonly _onDidChangeTests = this.push(new EventEmitter<void>());
-  private readonly watcher: MultiFileSystemWatcher = this.push(
-    new MultiFileSystemWatcher(),
-  );
+  private readonly watcher: MultiFileSystemWatcher;
   private _testDirectory: FileTreeDirectory | undefined;
 
   constructor(
     private readonly workspaceFolder: WorkspaceFolder,
+    app: App,
     private readonly cliServer: CodeQLCliServer,
   ) {
     super("QL Test Discovery");
 
+    this.watcher = this.push(new MultiFileSystemWatcher(app));
     this.push(this.watcher.onDidChange(this.handleDidChange, this));
   }
 

--- a/extensions/ql-vscode/src/query-testing/test-adapter.ts
+++ b/extensions/ql-vscode/src/query-testing/test-adapter.ts
@@ -24,6 +24,7 @@ import {
   FileTreeLeaf,
   FileTreeNode,
 } from "../common/file-tree-nodes";
+import { App } from "../common/app";
 
 /**
  * Get the full path of the `.expected` file for the specified QL test.
@@ -65,6 +66,7 @@ export class QLTestAdapterFactory extends DisposableObject {
   constructor(
     testHub: TestHub,
     testRunner: TestRunner,
+    app: App,
     cliServer: CodeQLCliServer,
   ) {
     super();
@@ -74,7 +76,7 @@ export class QLTestAdapterFactory extends DisposableObject {
       new TestAdapterRegistrar(
         testHub,
         (workspaceFolder) =>
-          new QLTestAdapter(workspaceFolder, testRunner, cliServer),
+          new QLTestAdapter(workspaceFolder, testRunner, app, cliServer),
       ),
     );
   }
@@ -108,12 +110,13 @@ export class QLTestAdapter extends DisposableObject implements TestAdapter {
   constructor(
     public readonly workspaceFolder: vscode.WorkspaceFolder,
     private readonly testRunner: TestRunner,
+    app: App,
     cliServer: CodeQLCliServer,
   ) {
     super();
 
     this.qlTestDiscovery = this.push(
-      new QLTestDiscovery(workspaceFolder, cliServer),
+      new QLTestDiscovery(workspaceFolder, app, cliServer),
     );
     this.qlTestDiscovery.refresh();
 

--- a/extensions/ql-vscode/src/query-testing/test-manager-base.ts
+++ b/extensions/ql-vscode/src/query-testing/test-manager-base.ts
@@ -14,7 +14,7 @@ export type TestNode = TestTreeNode | TestItem;
  * both.
  */
 export abstract class TestManagerBase extends DisposableObject {
-  protected constructor(private readonly app: App) {
+  protected constructor(protected readonly app: App) {
     super();
   }
 

--- a/extensions/ql-vscode/src/query-testing/test-manager.ts
+++ b/extensions/ql-vscode/src/query-testing/test-manager.ts
@@ -84,11 +84,12 @@ class WorkspaceFolderHandler extends DisposableObject {
   public constructor(
     private readonly workspaceFolder: WorkspaceFolder,
     private readonly testUI: TestManager,
+    app: App,
     cliServer: CodeQLCliServer,
   ) {
     super();
 
-    this.testDiscovery = new QLTestDiscovery(workspaceFolder, cliServer);
+    this.testDiscovery = new QLTestDiscovery(workspaceFolder, app, cliServer);
     this.push(
       this.testDiscovery.onDidChangeTests(this.handleDidChangeTests, this),
     );
@@ -171,6 +172,7 @@ export class TestManager extends TestManagerBase {
         const workspaceFolderHandler = new WorkspaceFolderHandler(
           workspaceFolder,
           this,
+          this.app,
           this.cliServer,
         );
         this.track(workspaceFolderHandler);

--- a/extensions/ql-vscode/test/__mocks__/appMock.ts
+++ b/extensions/ql-vscode/test/__mocks__/appMock.ts
@@ -12,6 +12,7 @@ import type {
   Event,
   WorkspaceFolder,
   WorkspaceFoldersChangeEvent,
+  workspace,
 } from "vscode";
 
 export function createMockApp({
@@ -22,6 +23,9 @@ export function createMockApp({
   workspaceState = createMockMemento(),
   workspaceFolders = [],
   onDidChangeWorkspaceFolders = jest.fn(),
+  createFileSystemWatcher = jest.fn().mockImplementation(() => {
+    throw Error("Not implemented");
+  }),
   credentials = testCredentialsWithStub(),
   commands = createMockCommandManager(),
 }: {
@@ -32,6 +36,7 @@ export function createMockApp({
   workspaceState?: Memento;
   workspaceFolders?: readonly WorkspaceFolder[] | undefined;
   onDidChangeWorkspaceFolders?: Event<WorkspaceFoldersChangeEvent>;
+  createFileSystemWatcher?: typeof workspace.createFileSystemWatcher;
   credentials?: Credentials;
   commands?: AppCommandManager;
 }): App {
@@ -45,6 +50,7 @@ export function createMockApp({
     workspaceState,
     workspaceFolders,
     onDidChangeWorkspaceFolders,
+    createFileSystemWatcher,
     createEventEmitter,
     credentials,
     commands,

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/query-testing/qltest-discovery.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/query-testing/qltest-discovery.test.ts
@@ -8,6 +8,7 @@ import * as tmp from "tmp-promise";
 
 import "../../../matchers/toEqualPath";
 import { mockedObject } from "../../utils/mocking.helpers";
+import { createMockApp } from "../../../__mocks__/appMock";
 
 describe("qltest-discovery", () => {
   describe("discoverTests", () => {
@@ -39,6 +40,7 @@ describe("qltest-discovery", () => {
           uri: baseUri,
           name: "My tests",
         }),
+        createMockApp({}),
         {
           resolveTests() {
             return [dFile, eFile, iFile];

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-testing/test-adapter.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-testing/test-adapter.test.ts
@@ -46,6 +46,7 @@ describe("test-adapter", () => {
         uri: Uri.parse("file:/ab/c"),
       }),
       testRunner,
+      createMockApp({}),
       fakeCliServer,
     );
 


### PR DESCRIPTION
The aim here is to remove a dependency that `QueryDiscovery` has on VS Code, by adding `createFileSystemWatcher` to the `App` interface and using it from `MultiFileSystemWatcher`. This will help make `QueryDiscovery` easier to test with unit tests, because it won't rely on a real workspace existing.

This unfortunately necessitated changing `QLTestDiscovery` as well, which dramatically increased the scope of this change. Hopefully this is fine, and theoretically this should have no behavioural change.

I've made the default implementation in `createMockApp` throw an error if called, since I expect this method to get called very infrequently os providing a mock implementation is likely not needed. I was kinda expecting the file system watcher tests to then fail, but they haven't. I'm not sure if that means we're not calling the watchers from the tests. I'm putting the PR up for review now, but I want to have a little bit more of a look into this and make sure everything is ok before the PR is merged.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
