### PR TITLE
Feed code search results into variant analysis repo lists

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -517,6 +517,10 @@
         "icon": "$(new-folder)"
       },
       {
+        "command": "codeQLVariantAnalysisRepositories.importCodeSearch",
+        "title": "Import Repos from GitHub Code Search"
+      },
+      {
         "command": "codeQLVariantAnalysisRepositories.setSelectedItem",
         "title": "Select"
       },
@@ -962,6 +966,11 @@
           "group": "2_qlContextMenu@1"
         },
         {
+          "command": "codeQLVariantAnalysisRepositories.importCodeSearch",
+          "when": "view == codeQLVariantAnalysisRepositories && viewItem =~ /canImportCodeSearch/",
+          "group": "2_qlContextMenu@1"
+        },
+        {
           "command": "codeQLDatabases.setCurrentDatabase",
           "group": "inline",
           "when": "view == codeQLDatabases && viewItem != currentDatabase"
@@ -1295,6 +1304,10 @@
         },
         {
           "command": "codeQLVariantAnalysisRepositories.removeItemContextMenu",
+          "when": "false"
+        },
+        {
+          "command": "codeQLVariantAnalysisRepositories.importCodeSearch",
           "when": "false"
         },
         {

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -517,7 +517,7 @@
         "icon": "$(new-folder)"
       },
       {
-        "command": "codeQLVariantAnalysisRepositories.importCodeSearch",
+        "command": "codeQLVariantAnalysisRepositories.importFromCodeSearch",
         "title": "Import Repos from GitHub Code Search"
       },
       {
@@ -966,7 +966,7 @@
           "group": "2_qlContextMenu@1"
         },
         {
-          "command": "codeQLVariantAnalysisRepositories.importCodeSearch",
+          "command": "codeQLVariantAnalysisRepositories.importFromCodeSearch",
           "when": "view == codeQLVariantAnalysisRepositories && viewItem =~ /canImportCodeSearch/",
           "group": "2_qlContextMenu@1"
         },
@@ -1307,7 +1307,7 @@
           "when": "false"
         },
         {
-          "command": "codeQLVariantAnalysisRepositories.importCodeSearch",
+          "command": "codeQLVariantAnalysisRepositories.importFromCodeSearch",
           "when": "false"
         },
         {

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -518,7 +518,7 @@
       },
       {
         "command": "codeQLVariantAnalysisRepositories.importFromCodeSearch",
-        "title": "Import Repos from GitHub Code Search"
+        "title": "Add repositories with GitHub Code Search"
       },
       {
         "command": "codeQLVariantAnalysisRepositories.setSelectedItem",

--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -275,7 +275,7 @@ export type DatabasePanelCommands = {
   "codeQLVariantAnalysisRepositories.openOnGitHubContextMenu": TreeViewContextSingleSelectionCommandFunction<DbTreeViewItem>;
   "codeQLVariantAnalysisRepositories.renameItemContextMenu": TreeViewContextSingleSelectionCommandFunction<DbTreeViewItem>;
   "codeQLVariantAnalysisRepositories.removeItemContextMenu": TreeViewContextSingleSelectionCommandFunction<DbTreeViewItem>;
-  "codeQLVariantAnalysisRepositories.importCodeSearch": TreeViewContextSingleSelectionCommandFunction<DbTreeViewItem>;
+  "codeQLVariantAnalysisRepositories.importFromCodeSearch": TreeViewContextSingleSelectionCommandFunction<DbTreeViewItem>;
 };
 
 export type AstCfgCommands = {

--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -275,6 +275,7 @@ export type DatabasePanelCommands = {
   "codeQLVariantAnalysisRepositories.openOnGitHubContextMenu": TreeViewContextSingleSelectionCommandFunction<DbTreeViewItem>;
   "codeQLVariantAnalysisRepositories.renameItemContextMenu": TreeViewContextSingleSelectionCommandFunction<DbTreeViewItem>;
   "codeQLVariantAnalysisRepositories.removeItemContextMenu": TreeViewContextSingleSelectionCommandFunction<DbTreeViewItem>;
+  "codeQLVariantAnalysisRepositories.importCodeSearch": TreeViewContextSingleSelectionCommandFunction<DbTreeViewItem>;
 };
 
 export type AstCfgCommands = {

--- a/extensions/ql-vscode/src/databases/config/db-config-store.ts
+++ b/extensions/ql-vscode/src/databases/config/db-config-store.ts
@@ -165,8 +165,12 @@ export class DbConfigStore extends DisposableObject {
       ...new Set(parent.repositories),
       ...new Set(repoNwoList),
     ]);
-    parent.repositories = [...newRepositoriesList];
 
+    if (newRepositoriesList.size > 1000) {
+      parent.repositories = [...Array.from(newRepositoriesList).slice(0, 1000)];
+    } else {
+      parent.repositories = [...newRepositoriesList];
+    }
     await this.writeConfig(config);
   }
 

--- a/extensions/ql-vscode/src/databases/config/db-config-store.ts
+++ b/extensions/ql-vscode/src/databases/config/db-config-store.ts
@@ -145,6 +145,10 @@ export class DbConfigStore extends DisposableObject {
     await this.writeConfig(config);
   }
 
+  /**
+   * Adds a list of remote repositories to an existing repository list and removes duplicates.
+   * @returns a list of repositories that were not added because the list reached 1000 entries.
+   */
   public async addRemoteReposToList(
     repoNwoList: string[],
     parentList: string,
@@ -173,6 +177,10 @@ export class DbConfigStore extends DisposableObject {
     return truncatedRepositories;
   }
 
+  /**
+   * Adds one remote repository
+   * @returns either nothing, or, if a parentList is given AND the number of repos on that list reaches 1000 returns the repo that was not added.
+   */
   public async addRemoteRepo(
     repoNwo: string,
     parentList?: string,

--- a/extensions/ql-vscode/src/databases/config/db-config-store.ts
+++ b/extensions/ql-vscode/src/databases/config/db-config-store.ts
@@ -163,7 +163,7 @@ export class DbConfigStore extends DisposableObject {
 
     // Remove duplicates from the list of repositories.
     const newRepositoriesList = [
-      ...new Set([...new Set(parent.repositories), ...new Set(repoNwoList)]),
+      ...new Set([...parent.repositories, ...repoNwoList]),
     ];
 
     parent.repositories = newRepositoriesList.slice(0, 1000);

--- a/extensions/ql-vscode/src/databases/config/db-config-store.ts
+++ b/extensions/ql-vscode/src/databases/config/db-config-store.ts
@@ -145,6 +145,31 @@ export class DbConfigStore extends DisposableObject {
     await this.writeConfig(config);
   }
 
+  public async addRemoteReposToList(
+    repoNwoList: string[],
+    parentList: string,
+  ): Promise<void> {
+    if (!this.config) {
+      throw Error("Cannot add variant analysis repos if config is not loaded");
+    }
+
+    const config = cloneDbConfig(this.config);
+    const parent = config.databases.variantAnalysis.repositoryLists.find(
+      (list) => list.name === parentList,
+    );
+    if (!parent) {
+      throw Error(`Cannot find parent list '${parentList}'`);
+    }
+
+    const newRepositoriesList = new Set([
+      ...new Set(parent.repositories),
+      ...new Set(repoNwoList),
+    ]);
+    parent.repositories = [...newRepositoriesList];
+
+    await this.writeConfig(config);
+  }
+
   public async addRemoteRepo(
     repoNwo: string,
     parentList?: string,

--- a/extensions/ql-vscode/src/databases/db-manager.ts
+++ b/extensions/ql-vscode/src/databases/db-manager.ts
@@ -96,15 +96,15 @@ export class DbManager {
   public async addNewRemoteRepo(
     nwo: string,
     parentList?: string,
-  ): Promise<void> {
-    await this.dbConfigStore.addRemoteRepo(nwo, parentList);
+  ): Promise<string[]> {
+    return await this.dbConfigStore.addRemoteRepo(nwo, parentList);
   }
 
   public async addNewRemoteReposToList(
     nwoList: string[],
     parentList: string,
-  ): Promise<void> {
-    await this.dbConfigStore.addRemoteReposToList(nwoList, parentList);
+  ): Promise<string[]> {
+    return await this.dbConfigStore.addRemoteReposToList(nwoList, parentList);
   }
 
   public async addNewRemoteOwner(owner: string): Promise<void> {

--- a/extensions/ql-vscode/src/databases/db-manager.ts
+++ b/extensions/ql-vscode/src/databases/db-manager.ts
@@ -100,6 +100,13 @@ export class DbManager {
     await this.dbConfigStore.addRemoteRepo(nwo, parentList);
   }
 
+  public async addNewRemoteReposToList(
+    nwoList: string[],
+    parentList: string,
+  ): Promise<void> {
+    await this.dbConfigStore.addRemoteReposToList(nwoList, parentList);
+  }
+
   public async addNewRemoteOwner(owner: string): Promise<void> {
     await this.dbConfigStore.addRemoteOwner(owner);
   }

--- a/extensions/ql-vscode/src/databases/ui/db-panel.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-panel.ts
@@ -93,6 +93,8 @@ export class DbPanel extends DisposableObject {
         this.renameItem.bind(this),
       "codeQLVariantAnalysisRepositories.removeItemContextMenu":
         this.removeItem.bind(this),
+      "codeQLVariantAnalysisRepositories.importCodeSearch":
+        this.importCodeSearch.bind(this),
     };
   }
 
@@ -321,6 +323,12 @@ export class DbPanel extends DisposableObject {
       );
     }
     await this.dbManager.removeDbItem(treeViewItem.dbItem);
+  }
+
+  private async importCodeSearch(treeViewItem: DbTreeViewItem): Promise<void> {
+    if (treeViewItem.dbItem === undefined) {
+      throw new Error("Please select a valid list to add code search results.");
+    }
   }
 
   private async onDidCollapseElement(

--- a/extensions/ql-vscode/src/databases/ui/db-panel.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-panel.ts
@@ -189,7 +189,7 @@ export class DbPanel extends DisposableObject {
     );
 
     if (parentList) {
-      this.truncatedReposNote(truncatedRepositories, parentList);
+      this.reportAnyTruncatedRepos(truncatedRepositories, parentList);
     }
   }
 
@@ -369,9 +369,7 @@ export class DbPanel extends DisposableObject {
         },
       );
     if (!codeSearchLanguage) {
-      // We don't need to display a warning pop-up in this case, since the user just escaped out of the operation.
-      // We set 'true' to make this a silent exception.
-      throw new UserCancellationException("No language selected", true);
+      return;
     }
 
     const codeSearchQuery = await window.showInputBox({
@@ -408,12 +406,12 @@ export class DbPanel extends DisposableObject {
 
         const truncatedRepositories =
           await this.dbManager.addNewRemoteReposToList(repositories, listName);
-        this.truncatedReposNote(truncatedRepositories, listName);
+        this.reportAnyTruncatedRepos(truncatedRepositories, listName);
       },
     );
   }
 
-  private truncatedReposNote(
+  private reportAnyTruncatedRepos(
     truncatedRepositories: string[],
     listName: string,
   ) {

--- a/extensions/ql-vscode/src/databases/ui/db-panel.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-panel.ts
@@ -103,8 +103,8 @@ export class DbPanel extends DisposableObject {
         this.renameItem.bind(this),
       "codeQLVariantAnalysisRepositories.removeItemContextMenu":
         this.removeItem.bind(this),
-      "codeQLVariantAnalysisRepositories.importCodeSearch":
-        this.importCodeSearch.bind(this),
+      "codeQLVariantAnalysisRepositories.importFromCodeSearch":
+        this.importFromCodeSearch.bind(this),
     };
   }
 
@@ -342,7 +342,9 @@ export class DbPanel extends DisposableObject {
     await this.dbManager.removeDbItem(treeViewItem.dbItem);
   }
 
-  private async importCodeSearch(treeViewItem: DbTreeViewItem): Promise<void> {
+  private async importFromCodeSearch(
+    treeViewItem: DbTreeViewItem,
+  ): Promise<void> {
     if (treeViewItem.dbItem?.kind !== DbItemKind.RemoteUserDefinedList) {
       throw new Error("Please select a valid list to add code search results.");
     }

--- a/extensions/ql-vscode/src/databases/ui/db-panel.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-panel.ts
@@ -363,7 +363,7 @@ export class DbPanel extends DisposableObject {
       await window.showQuickPick<CodeSearchQuickPickItem>(
         languageQuickPickItems,
         {
-          title: "Select the language you want to query",
+          title: "Select a language for your search",
           placeHolder: "Select an option",
           ignoreFocusOut: true,
         },
@@ -373,8 +373,9 @@ export class DbPanel extends DisposableObject {
     }
 
     const codeSearchQuery = await window.showInputBox({
-      title: "Code search query",
-      prompt: "Insert code search query",
+      title: "GitHub Code Search",
+      prompt:
+        "Use [GitHub's Code Search syntax](https://docs.github.com/en/search-github/github-code-search/understanding-github-code-search-syntax), including code qualifiers, regular expressions, and boolean operations, to search for repositories.",
       placeHolder: "org:github",
     });
     if (codeSearchQuery === undefined || codeSearchQuery === "") {

--- a/extensions/ql-vscode/src/databases/ui/db-panel.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-panel.ts
@@ -179,7 +179,14 @@ export class DbPanel extends DisposableObject {
       return;
     }
 
-    await this.dbManager.addNewRemoteRepo(nwo, parentList);
+    const truncatedRepositories = await this.dbManager.addNewRemoteRepo(
+      nwo,
+      parentList,
+    );
+
+    if (parentList) {
+      this.truncatedReposNote(truncatedRepositories, parentList);
+    }
   }
 
   private async addNewRemoteOwner(): Promise<void> {
@@ -373,10 +380,27 @@ export class DbPanel extends DisposableObject {
       `${codeSearchQuery} language:${codeSearchLanguage.language}`,
     );
 
-    await this.dbManager.addNewRemoteReposToList(
+    const truncatedRepositories = await this.dbManager.addNewRemoteReposToList(
       repositories,
       treeViewItem.dbItem.listName,
     );
+    this.truncatedReposNote(
+      truncatedRepositories,
+      treeViewItem.dbItem.listName,
+    );
+  }
+
+  private truncatedReposNote(
+    truncatedRepositories: string[],
+    listName: string,
+  ) {
+    if (truncatedRepositories.length > 0) {
+      void showAndLogErrorMessage(
+        `Some repositories were not added to '${listName}' because a list can only have 1000 entries. Excluded repositories: ${truncatedRepositories.join(
+          ", ",
+        )}`,
+      );
+    }
   }
 
   private async onDidCollapseElement(

--- a/extensions/ql-vscode/src/databases/ui/db-tree-view-item-action.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-tree-view-item-action.ts
@@ -4,7 +4,8 @@ export type DbTreeViewItemAction =
   | "canBeSelected"
   | "canBeRemoved"
   | "canBeRenamed"
-  | "canBeOpenedOnGitHub";
+  | "canBeOpenedOnGitHub"
+  | "canImportCodeSearch";
 
 export function getDbItemActions(dbItem: DbItem): DbTreeViewItemAction[] {
   const actions: DbTreeViewItemAction[] = [];
@@ -21,7 +22,9 @@ export function getDbItemActions(dbItem: DbItem): DbTreeViewItemAction[] {
   if (canBeOpenedOnGitHub(dbItem)) {
     actions.push("canBeOpenedOnGitHub");
   }
-
+  if (canImportCodeSearch(dbItem)) {
+    actions.push("canImportCodeSearch");
+  }
   return actions;
 }
 
@@ -58,6 +61,10 @@ function canBeRenamed(dbItem: DbItem): boolean {
 
 function canBeOpenedOnGitHub(dbItem: DbItem): boolean {
   return dbItemKindsThatCanBeOpenedOnGitHub.includes(dbItem.kind);
+}
+
+function canImportCodeSearch(dbItem: DbItem): boolean {
+  return DbItemKind.RemoteUserDefinedList === dbItem.kind;
 }
 
 export function getGitHubUrl(dbItem: DbItem): string | undefined {

--- a/extensions/ql-vscode/src/variant-analysis/gh-api/gh-api-client.ts
+++ b/extensions/ql-vscode/src/variant-analysis/gh-api/gh-api-client.ts
@@ -29,9 +29,13 @@ export async function getCodeSearchRepositories(
     },
   )) {
     nwos.push(...response.data.map((item) => item.full_name));
-    const numberOfRequests = Math.ceil(response.data.total_count / 99);
-    const increment = numberOfRequests < 10 ? 80 / numberOfRequests : 8;
+    // calculate progress bar: 80% of the progress bar is used for the code search
+    const totalNumberOfRequests = Math.ceil(response.data.total_count / 100);
+    // Since we have a maximum 10 of requests, we use a fixed increment whenever the totalNumberOfRequests is greater than 10
+    const increment =
+      totalNumberOfRequests < 10 ? 80 / totalNumberOfRequests : 8;
     progress.report({ increment });
+
     if (token.isCancellationRequested) {
       nwos = [];
       break;

--- a/extensions/ql-vscode/src/variant-analysis/gh-api/gh-api-client.ts
+++ b/extensions/ql-vscode/src/variant-analysis/gh-api/gh-api-client.ts
@@ -14,18 +14,16 @@ export async function getCodeSearchRepositories(
 ): Promise<string[]> {
   const octokit = await credentials.getOctokit();
 
-  const response = await octokit.rest.search.repos({
-    q: query,
-    per_page: 100,
-  });
+  const nwos = await octokit.paginate(
+    octokit.rest.search.repos,
+    {
+      q: query,
+      per_page: 100,
+    },
+    (response) => response.data.map((item) => item.full_name),
+  );
 
-  if (response.status === 200) {
-    const nwos = response.data.items.map((item) => item.full_name);
-
-    return [...new Set(nwos)];
-  }
-
-  return [];
+  return [...new Set(nwos)];
 }
 
 export async function submitVariantAnalysis(

--- a/extensions/ql-vscode/src/variant-analysis/gh-api/gh-api-client.ts
+++ b/extensions/ql-vscode/src/variant-analysis/gh-api/gh-api-client.ts
@@ -8,6 +8,26 @@ import {
 } from "./variant-analysis";
 import { Repository } from "./repository";
 
+export async function getCodeSearchRepositories(
+  credentials: Credentials,
+  query: string,
+): Promise<string[]> {
+  const octokit = await credentials.getOctokit();
+
+  const response = await octokit.rest.search.repos({
+    q: query,
+    per_page: 100,
+  });
+
+  if (response.status === 200) {
+    const nwos = response.data.items.map((item) => item.full_name);
+
+    return [...new Set(nwos)];
+  }
+
+  return [];
+}
+
 export async function submitVariantAnalysis(
   credentials: Credentials,
   submissionDetails: VariantAnalysisSubmission,

--- a/extensions/ql-vscode/test/unit-tests/databases/config/db-config-store.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/config/db-config-store.test.ts
@@ -262,7 +262,7 @@ describe("db config store", () => {
       });
 
       // Add
-      await configStore.addRemoteReposToList(
+      const response = await configStore.addRemoteReposToList(
         ["owner/repo1", "owner/repo2"],
         "list1",
       );
@@ -278,11 +278,12 @@ describe("db config store", () => {
         name: "list1",
         repositories: ["owner/repo1", "owner/repo2"],
       });
+      expect(response).toEqual([]);
 
       configStore.dispose();
     });
 
-    it("should add no more than 1000 repositories to a remote list using #addRemoteReposToList", async () => {
+    it("should add no more than 1000 repositories to a remote list when adding multiple repos", async () => {
       // Initial set up
       const dbConfig = createDbConfig({
         remoteLists: [
@@ -296,7 +297,7 @@ describe("db config store", () => {
       const configStore = await initializeConfig(dbConfig, configPath, app);
 
       // Add
-      const reponse = await configStore.addRemoteReposToList(
+      const response = await configStore.addRemoteReposToList(
         [...Array(1001).keys()].map((i) => `owner/db${i}`),
         "list1",
       );
@@ -311,12 +312,12 @@ describe("db config store", () => {
       expect(updatedRemoteDbs.repositoryLists[0].repositories).toHaveLength(
         1000,
       );
-      expect(reponse).toEqual(["owner/db1000"]);
+      expect(response).toEqual(["owner/db1000"]);
 
       configStore.dispose();
     });
 
-    it("should add no more than 1000 repositories to a remote list using #addRemoteRepo", async () => {
+    it("should add no more than 1000 repositories to a remote list when adding one repo", async () => {
       // Initial set up
       const dbConfig = createDbConfig({
         remoteLists: [

--- a/extensions/ql-vscode/test/unit-tests/databases/config/db-config-store.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/config/db-config-store.test.ts
@@ -282,7 +282,7 @@ describe("db config store", () => {
       configStore.dispose();
     });
 
-    it("should add no more than 1000 repositories to a list", async () => {
+    it("should add no more than 1000 repositories to a remote list using #addRemoteReposToList", async () => {
       // Initial set up
       const dbConfig = createDbConfig({
         remoteLists: [
@@ -296,7 +296,7 @@ describe("db config store", () => {
       const configStore = await initializeConfig(dbConfig, configPath, app);
 
       // Add
-      await configStore.addRemoteReposToList(
+      const reponse = await configStore.addRemoteReposToList(
         [...Array(1001).keys()].map((i) => `owner/db${i}`),
         "list1",
       );
@@ -311,6 +311,38 @@ describe("db config store", () => {
       expect(updatedRemoteDbs.repositoryLists[0].repositories).toHaveLength(
         1000,
       );
+      expect(reponse).toEqual(["owner/db1000"]);
+
+      configStore.dispose();
+    });
+
+    it("should add no more than 1000 repositories to a remote list using #addRemoteRepo", async () => {
+      // Initial set up
+      const dbConfig = createDbConfig({
+        remoteLists: [
+          {
+            name: "list1",
+            repositories: [...Array(1000).keys()].map((i) => `owner/db${i}`),
+          },
+        ],
+      });
+
+      const configStore = await initializeConfig(dbConfig, configPath, app);
+
+      // Add
+      const reponse = await configStore.addRemoteRepo("owner/db1000", "list1");
+
+      // Read the config file
+      const updatedDbConfig = (await readJSON(configPath)) as DbConfig;
+
+      // Check that the config file has been updated
+      const updatedRemoteDbs = updatedDbConfig.databases.variantAnalysis;
+      expect(updatedRemoteDbs.repositories).toHaveLength(0);
+      expect(updatedRemoteDbs.repositoryLists).toHaveLength(1);
+      expect(updatedRemoteDbs.repositoryLists[0].repositories).toHaveLength(
+        1000,
+      );
+      expect(reponse).toEqual(["owner/db1000"]);
 
       configStore.dispose();
     });

--- a/extensions/ql-vscode/test/unit-tests/databases/db-manager.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/db-manager.test.ts
@@ -88,6 +88,33 @@ describe("db manager", () => {
         ).toEqual("owner2/repo2");
       });
 
+      it("should add new remote repos to a user defined list", async () => {
+        const dbConfig: DbConfig = createDbConfig({
+          remoteLists: [
+            {
+              name: "my-list-1",
+              repositories: ["owner1/repo1"],
+            },
+          ],
+        });
+
+        await saveDbConfig(dbConfig);
+
+        await dbManager.addNewRemoteReposToList(["owner2/repo2"], "my-list-1");
+
+        const dbConfigFileContents = await readDbConfigDirectly();
+        expect(
+          dbConfigFileContents.databases.variantAnalysis.repositoryLists.length,
+        ).toBe(1);
+
+        expect(
+          dbConfigFileContents.databases.variantAnalysis.repositoryLists[0],
+        ).toEqual({
+          name: "my-list-1",
+          repositories: ["owner1/repo1", "owner2/repo2"],
+        });
+      });
+
       it("should add a new remote repo to a user defined list", async () => {
         const dbConfig: DbConfig = createDbConfig({
           remoteLists: [

--- a/extensions/ql-vscode/test/unit-tests/databases/db-manager.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/db-manager.test.ts
@@ -115,6 +115,46 @@ describe("db manager", () => {
         });
       });
 
+      it("should return truncated repos when adding to a user defined list using #addNewRemoteReposToList", async () => {
+        const dbConfig: DbConfig = createDbConfig({
+          remoteLists: [
+            {
+              name: "my-list-1",
+              repositories: [...Array(1000).keys()].map((i) => `owner/db${i}`),
+            },
+          ],
+        });
+
+        await saveDbConfig(dbConfig);
+
+        const response = await dbManager.addNewRemoteReposToList(
+          ["owner2/repo2"],
+          "my-list-1",
+        );
+
+        expect(response).toEqual(["owner2/repo2"]);
+      });
+
+      it("should return truncated repos when adding to a user defined list using #addNewRemoteRepo", async () => {
+        const dbConfig: DbConfig = createDbConfig({
+          remoteLists: [
+            {
+              name: "my-list-1",
+              repositories: [...Array(1000).keys()].map((i) => `owner/db${i}`),
+            },
+          ],
+        });
+
+        await saveDbConfig(dbConfig);
+
+        const response = await dbManager.addNewRemoteRepo(
+          "owner2/repo2",
+          "my-list-1",
+        );
+
+        expect(response).toEqual(["owner2/repo2"]);
+      });
+
       it("should add a new remote repo to a user defined list", async () => {
         const dbConfig: DbConfig = createDbConfig({
           remoteLists: [

--- a/extensions/ql-vscode/test/unit-tests/databases/db-manager.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/db-manager.test.ts
@@ -115,7 +115,7 @@ describe("db manager", () => {
         });
       });
 
-      it("should return truncated repos when adding to a user defined list using #addNewRemoteReposToList", async () => {
+      it("should return truncated repos when adding multiple repos to a user defined list", async () => {
         const dbConfig: DbConfig = createDbConfig({
           remoteLists: [
             {
@@ -135,7 +135,7 @@ describe("db manager", () => {
         expect(response).toEqual(["owner2/repo2"]);
       });
 
-      it("should return truncated repos when adding to a user defined list using #addNewRemoteRepo", async () => {
+      it("should return truncated repos when adding one repo to a user defined list", async () => {
         const dbConfig: DbConfig = createDbConfig({
           remoteLists: [
             {

--- a/extensions/ql-vscode/test/unit-tests/databases/ui/db-tree-view-item-action.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/ui/db-tree-view-item-action.test.ts
@@ -62,12 +62,17 @@ describe("getDbItemActions", () => {
     expect(actions.length).toEqual(0);
   });
 
-  it("should set canBeSelected, canBeRemoved and canBeRenamed for remote user defined db list", () => {
+  it("should set canBeSelected, canBeRemoved, canBeRenamed and canImportCodeSearch for remote user defined db list", () => {
     const dbItem = createRemoteUserDefinedListDbItem();
 
     const actions = getDbItemActions(dbItem);
 
-    expect(actions).toEqual(["canBeSelected", "canBeRemoved", "canBeRenamed"]);
+    expect(actions).toEqual([
+      "canBeSelected",
+      "canBeRemoved",
+      "canBeRenamed",
+      "canImportCodeSearch",
+    ]);
   });
 
   it("should not set canBeSelected for remote user defined db list that is already selected", () => {

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/databases/db-panel-rendering.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/databases/db-panel-rendering.test.ts
@@ -349,7 +349,12 @@ describe("db panel rendering nodes", () => {
     expect(item.tooltip).toBeUndefined();
     expect(item.iconPath).toBeUndefined();
     expect(item.collapsibleState).toBe(TreeItemCollapsibleState.Collapsed);
-    checkDbItemActions(item, ["canBeSelected", "canBeRenamed", "canBeRemoved"]);
+    checkDbItemActions(item, [
+      "canBeSelected",
+      "canBeRenamed",
+      "canBeRemoved",
+      "canImportCodeSearch",
+    ]);
     expect(item.children).toBeTruthy();
     expect(item.children.length).toBe(repos.length);
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

This PR adds the option to feed code search results directly to an existing variant analysis repositories list. By entering a code language and a search query that can be developed and refined using the GitHub Code Search UI the user can now feed results directly into a MRVA list.

Additionally this PR introduces a restriction on list size. When using the new code search or adding a repo using the UI actions only up to 1000 items will be stored on a list. This restriction can be circumvented by adding repos to the config json directly and is not enforced with validation. 


## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
