### PR TITLE
Retry results download if connection times out

### DIFF
--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -77,6 +77,8 @@ import {
 import { GITHUB_AUTH_PROVIDER_ID } from "../common/vscode/authentication";
 import { FetchError } from "node-fetch";
 
+const maxRetryCount = 3;
+
 export class VariantAnalysisManager
   extends DisposableObject
   implements VariantAnalysisViewManager<VariantAnalysisView>
@@ -626,7 +628,7 @@ export class VariantAnalysisManager
             break;
           } catch (e) {
             if (
-              retry++ < 3 &&
+              retry++ < maxRetryCount &&
               e instanceof FetchError &&
               (e.code === "ETIMEDOUT" || e.code === "ECONNRESET")
             ) {

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -639,7 +639,7 @@ export class VariantAnalysisManager
               continue;
             }
             void extLogger.log(
-              `Failed to download variable analysis after ${retry} attempts.`,
+              `Failed to download variant analysis after ${retry} attempts.`,
             );
             throw e;
           }

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -76,6 +76,7 @@ import {
 } from "./repo-states-store";
 import { GITHUB_AUTH_PROVIDER_ID } from "../common/vscode/authentication";
 import { FetchError } from "node-fetch";
+import { extLogger } from "../common";
 
 const maxRetryCount = 3;
 
@@ -632,8 +633,14 @@ export class VariantAnalysisManager
               e instanceof FetchError &&
               (e.code === "ETIMEDOUT" || e.code === "ECONNRESET")
             ) {
+              void extLogger.log(
+                `Timeout while trying to download variant analysis with id: ${variantAnalysis.id}. Retrying...`,
+              );
               continue;
             }
+            void extLogger.log(
+              `Failed to download variable analysis after ${retry} attempts.`,
+            );
             throw e;
           }
         }

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -634,7 +634,9 @@ export class VariantAnalysisManager
               (e.code === "ETIMEDOUT" || e.code === "ECONNRESET")
             ) {
               void extLogger.log(
-                `Timeout while trying to download variant analysis with id: ${variantAnalysis.id}. Retrying...`,
+                `Timeout while trying to download variant analysis with id: ${
+                  variantAnalysis.id
+                }. Error: ${getErrorMessage(e)}. Retrying...`,
               );
               continue;
             }

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-results-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-results-manager.ts
@@ -1,4 +1,4 @@
-import { appendFile, pathExists } from "fs-extra";
+import { appendFile, pathExists, rm } from "fs-extra";
 import fetch from "node-fetch";
 import { EOL } from "os";
 import { join } from "path";
@@ -81,6 +81,9 @@ export class VariantAnalysisResultsManager extends DisposableObject {
     await writeRepoTask(resultDirectory, repoTask);
 
     const zipFilePath = join(resultDirectory, "results.zip");
+
+    // in case of restarted download delete possible artifact from previous download
+    await rm(zipFilePath, { force: true });
 
     const response = await fetch(repoTask.artifactUrl);
 


### PR DESCRIPTION
Even with a good internet connection I sometimes have seen the error "failed to download results". When doing a MRVA on a 1000 top projects this results in that either you admit your run has incomplete results or have to rerun whole 1000 repositories query run, which is time consuming.
I have noticed that the url in the error message is still valid and I'm able to download the zip manually.
The change makes up to 3 retry attempts in a specific cases like timeout.


## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
