### PR TITLE
Don't create `"."` directory in queries/tests tree view

### DIFF
--- a/extensions/ql-vscode/src/common/file-tree-nodes.ts
+++ b/extensions/ql-vscode/src/common/file-tree-nodes.ts
@@ -41,6 +41,9 @@ export class FileTreeDirectory extends FileTreeNode {
   }
 
   public createDirectory(relativePath: string): FileTreeDirectory {
+    if (relativePath === ".") {
+      return this;
+    }
     const dirName = dirname(relativePath);
     if (dirName === ".") {
       return this.createChildDirectory(relativePath);


### PR DESCRIPTION
The `createDirectory` method that we use for populating the Queries Panel and Test Explorer tree view had a slight bug. If a query/test was directly under the root directory, we'd unnecessarily create an empty subdirectory called `.` 
(instead of directly adding the query/test). 

This PR prevents us from creating a directory when there's none to create. Thanks to @robertbrignull for the fix 🙇🏽‍♀️ 

(see internal linked issue for more details)

## Checklist

N/A—feature-flagged for internal development only 🎏 

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
