### PR TITLE
Remove member variables that could be local variables

### DIFF
--- a/extensions/ql-vscode/src/queries-panel/queries-module.ts
+++ b/extensions/ql-vscode/src/queries-panel/queries-module.ts
@@ -7,9 +7,6 @@ import { QueriesPanel } from "./queries-panel";
 import { QueryDiscovery } from "./query-discovery";
 
 export class QueriesModule extends DisposableObject {
-  private queriesPanel: QueriesPanel | undefined;
-  private queryDiscovery: QueryDiscovery | undefined;
-
   private constructor(readonly app: App) {
     super();
   }
@@ -22,12 +19,12 @@ export class QueriesModule extends DisposableObject {
     }
     void extLogger.log("Initializing queries panel.");
 
-    this.queryDiscovery = new QueryDiscovery(app, cliServer);
-    this.push(this.queryDiscovery);
-    this.queryDiscovery.refresh();
+    const queryDiscovery = new QueryDiscovery(app, cliServer);
+    this.push(queryDiscovery);
+    queryDiscovery.refresh();
 
-    this.queriesPanel = new QueriesPanel(this.queryDiscovery);
-    this.push(this.queriesPanel);
+    const queriesPanel = new QueriesPanel(queryDiscovery);
+    this.push(queriesPanel);
   }
 
   public static initialize(

--- a/extensions/ql-vscode/src/queries-panel/queries-panel.ts
+++ b/extensions/ql-vscode/src/queries-panel/queries-panel.ts
@@ -1,22 +1,17 @@
 import * as vscode from "vscode";
 import { DisposableObject } from "../pure/disposable-object";
 import { QueryTreeDataProvider } from "./query-tree-data-provider";
-import { QueryTreeViewItem } from "./query-tree-view-item";
 import { QueryDiscovery } from "./query-discovery";
 
 export class QueriesPanel extends DisposableObject {
-  private readonly dataProvider: QueryTreeDataProvider;
-  private readonly treeView: vscode.TreeView<QueryTreeViewItem>;
-
   public constructor(queryDiscovery: QueryDiscovery) {
     super();
 
-    this.dataProvider = new QueryTreeDataProvider(queryDiscovery);
+    const dataProvider = new QueryTreeDataProvider(queryDiscovery);
 
-    this.treeView = vscode.window.createTreeView("codeQLQueries", {
-      treeDataProvider: this.dataProvider,
+    const treeView = vscode.window.createTreeView("codeQLQueries", {
+      treeDataProvider: dataProvider,
     });
-
-    this.push(this.treeView);
+    this.push(treeView);
   }
 }


### PR DESCRIPTION
Just noticed we currently don't use any of these variables outside of the constructor, so they don't technically have to be member variables. We could make them local variables instead and I think this makes things a bit cleaner.

What do you think? We can always change them back to member variables if we need them again in the future.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
