### PR TITLE
Add tests of QueryTreeDataProvider

### DIFF
--- a/extensions/ql-vscode/src/queries-panel/query-discovery.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-discovery.ts
@@ -7,6 +7,7 @@ import { App } from "../common/app";
 import { FileTreeDirectory, FileTreeLeaf } from "../common/file-tree-nodes";
 import { getOnDiskWorkspaceFoldersObjects } from "../helpers";
 import { AppEventEmitter } from "../common/events";
+import { QueryDiscoverer } from "./query-tree-data-provider";
 
 /**
  * The results of discovering queries.
@@ -28,7 +29,10 @@ interface QueryDiscoveryResults {
 /**
  * Discovers all query files contained in the QL packs in a given workspace folder.
  */
-export class QueryDiscovery extends Discovery<QueryDiscoveryResults> {
+export class QueryDiscovery
+  extends Discovery<QueryDiscoveryResults>
+  implements QueryDiscoverer
+{
   private results: QueryDiscoveryResults | undefined;
 
   private readonly onDidChangeQueriesEmitter: AppEventEmitter<void>;

--- a/extensions/ql-vscode/src/queries-panel/query-tree-data-provider.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-tree-data-provider.ts
@@ -1,8 +1,12 @@
 import { Event, EventEmitter, TreeDataProvider, TreeItem } from "vscode";
 import { QueryTreeViewItem } from "./query-tree-view-item";
 import { DisposableObject } from "../pure/disposable-object";
-import { QueryDiscovery } from "./query-discovery";
 import { FileTreeNode } from "../common/file-tree-nodes";
+
+export interface QueryDiscoverer {
+  readonly queries: FileTreeNode[] | undefined;
+  readonly onDidChangeQueries: Event<void>;
+}
 
 export class QueryTreeDataProvider
   extends DisposableObject
@@ -14,10 +18,10 @@ export class QueryTreeDataProvider
     new EventEmitter<void>(),
   );
 
-  public constructor(private readonly queryDiscovery: QueryDiscovery) {
+  public constructor(private readonly queryDiscoverer: QueryDiscoverer) {
     super();
 
-    queryDiscovery.onDidChangeQueries(() => {
+    queryDiscoverer.onDidChangeQueries(() => {
       this.queryTreeItems = this.createTree();
       this.onDidChangeTreeDataEmitter.fire();
     });
@@ -30,7 +34,7 @@ export class QueryTreeDataProvider
   }
 
   private createTree(): QueryTreeViewItem[] {
-    return (this.queryDiscovery.queries || []).map(
+    return (this.queryDiscoverer.queries || []).map(
       this.convertFileTreeNode.bind(this),
     );
   }

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/queries-panel/query-tree-data-provider.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/queries-panel/query-tree-data-provider.test.ts
@@ -1,0 +1,93 @@
+import { EventEmitter } from "vscode";
+import {
+  FileTreeDirectory,
+  FileTreeLeaf,
+} from "../../../../src/common/file-tree-nodes";
+import {
+  QueryDiscoverer,
+  QueryTreeDataProvider,
+} from "../../../../src/queries-panel/query-tree-data-provider";
+
+describe("QueryTreeDataProvider", () => {
+  describe("getChildren", () => {
+    it("returns no children when queries is undefined", async () => {
+      const dataProvider = new QueryTreeDataProvider({
+        queries: undefined,
+        onDidChangeQueries: jest.fn(),
+      });
+
+      expect(dataProvider.getChildren()).toEqual([]);
+    });
+
+    it("returns no children when there are no queries", async () => {
+      const dataProvider = new QueryTreeDataProvider({
+        queries: [],
+        onDidChangeQueries: jest.fn(),
+      });
+
+      expect(dataProvider.getChildren()).toEqual([]);
+    });
+
+    it("converts FileTreeNode to QueryTreeViewItem", async () => {
+      const dataProvider = new QueryTreeDataProvider({
+        queries: [
+          new FileTreeDirectory("dir1", "dir1", [
+            new FileTreeDirectory("dir1/dir2", "dir2", [
+              new FileTreeLeaf("dir1/dir2/file1", "file1"),
+              new FileTreeLeaf("dir1/dir2/file1", "file2"),
+            ]),
+          ]),
+          new FileTreeDirectory("dir3", "dir3", [
+            new FileTreeLeaf("dir3/file3", "file3"),
+          ]),
+        ],
+        onDidChangeQueries: jest.fn(),
+      });
+
+      expect(dataProvider.getChildren().length).toEqual(2);
+
+      expect(dataProvider.getChildren()[0].label).toEqual("dir1");
+      expect(dataProvider.getChildren()[0].children.length).toEqual(1);
+      expect(dataProvider.getChildren()[0].children[0].label).toEqual("dir2");
+      expect(dataProvider.getChildren()[0].children[0].children.length).toEqual(
+        2,
+      );
+      expect(
+        dataProvider.getChildren()[0].children[0].children[0].label,
+      ).toEqual("file1");
+      expect(
+        dataProvider.getChildren()[0].children[0].children[1].label,
+      ).toEqual("file2");
+
+      expect(dataProvider.getChildren()[1].label).toEqual("dir3");
+      expect(dataProvider.getChildren()[1].children.length).toEqual(1);
+      expect(dataProvider.getChildren()[1].children[0].label).toEqual("file3");
+    });
+  });
+
+  describe("onDidChangeQueries", () => {
+    it("should update tree when the queries change", async () => {
+      const onDidChangeQueriesEmitter = new EventEmitter<void>();
+      const queryDiscoverer: QueryDiscoverer = {
+        queries: [
+          new FileTreeDirectory("dir1", "dir1", [
+            new FileTreeLeaf("dir1/file1", "file1"),
+          ]),
+        ],
+        onDidChangeQueries: onDidChangeQueriesEmitter.event,
+      };
+
+      const dataProvider = new QueryTreeDataProvider(queryDiscoverer);
+      expect(dataProvider.getChildren().length).toEqual(1);
+
+      queryDiscoverer.queries?.push(
+        new FileTreeDirectory("dir2", "dir2", [
+          new FileTreeLeaf("dir2/file2", "file2"),
+        ]),
+      );
+      onDidChangeQueriesEmitter.fire();
+
+      expect(dataProvider.getChildren().length).toEqual(2);
+    });
+  });
+});


### PR DESCRIPTION
This PR adds tests of the `QueryTreeDataProvider` class.

I investigated if we could make these unit tests rather than integration tests, but sadly it proved too complicated and not worth it for the benefit it gives.

To make this easier, I introduced a new `QueryDiscoverer` interface which allows us to easily instantiate `QueryTreeDataProvider` in the tests without dealing with the more complicated `QueryDiscovery` class and without Jest mocking. Do you think this interface is helpful and worth it? Suggestions on naming welcome?

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
