### PR TITLE
Add initial implementation of auto-modeling

### DIFF
--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -711,3 +711,10 @@ const QUERIES_PANEL = new Setting("queriesPanel", ROOT_SETTING);
 export function showQueriesPanel(): boolean {
   return !!QUERIES_PANEL.getValue<boolean>();
 }
+
+const DATA_EXTENSIONS = new Setting("dataExtensions", ROOT_SETTING);
+const LLM_GENERATION = new Setting("llmGeneration", DATA_EXTENSIONS);
+
+export function showLlmGeneration(): boolean {
+  return !!LLM_GENERATION.getValue<boolean>();
+}

--- a/extensions/ql-vscode/src/data-extensions-editor/auto-model-api.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/auto-model-api.ts
@@ -1,0 +1,54 @@
+import { Credentials } from "../common/authentication";
+import { OctokitResponse } from "@octokit/types";
+
+export enum ClassificationType {
+  Unknown = "CLASSIFICATION_TYPE_UNKNOWN",
+  Neutral = "CLASSIFICATION_TYPE_NEUTRAL",
+  Source = "CLASSIFICATION_TYPE_SOURCE",
+  Sink = "CLASSIFICATION_TYPE_SINK",
+  Summary = "CLASSIFICATION_TYPE_SUMMARY",
+}
+
+export interface Classification {
+  type: ClassificationType;
+  kind: string;
+  explanation: string;
+}
+
+export interface Method {
+  package: string;
+  type: string;
+  name: string;
+  signature: string;
+  usages: string[];
+  classification?: Classification;
+  input?: string;
+  output?: string;
+}
+
+export interface ModelRequest {
+  language: string;
+  candidates: Method[];
+  samples: Method[];
+}
+
+export interface ModelResponse {
+  language: string;
+  predicted: Method[];
+}
+
+export async function autoModel(
+  credentials: Credentials,
+  request: ModelRequest,
+): Promise<ModelResponse> {
+  const octokit = await credentials.getOctokit();
+
+  const response: OctokitResponse<ModelResponse> = await octokit.request(
+    "POST /repos/github/codeql/code-scanning/codeql/auto-model",
+    {
+      data: request,
+    },
+  );
+
+  return response.data;
+}

--- a/extensions/ql-vscode/src/data-extensions-editor/auto-model.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/auto-model.ts
@@ -68,6 +68,14 @@ export function createAutoModelRequest(
   return request;
 }
 
+/**
+ * For now, we have a simplified model that only models methods as sinks. It does not model methods as neutral,
+ * so we aren't actually able to correctly determine that a method is neutral; it could still be a source or summary.
+ * However, to keep this method simple and give output to the user, we will model any method for which none of its
+ * arguments are modeled as sinks as neutral.
+ *
+ * If there are multiple arguments which are modeled as sinks, we will only model the first one.
+ */
 export function parsePredictedClassifications(
   predicted: Method[],
 ): Record<string, ModeledMethod> {

--- a/extensions/ql-vscode/src/data-extensions-editor/auto-model.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/auto-model.ts
@@ -149,5 +149,5 @@ function toMethodClassification(modeledMethod: ModeledMethod): Classification {
 }
 
 function toFullMethodSignature(method: Method): string {
-  return `${method.package}.${method.type}.${method.name}${method.signature}`;
+  return `${method.package}.${method.type}#${method.name}${method.signature}`;
 }

--- a/extensions/ql-vscode/src/data-extensions-editor/auto-model.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/auto-model.ts
@@ -48,13 +48,11 @@ export function createAutoModelRequest(
           modeledMethod.type === "none"
             ? undefined
             : toMethodClassification(modeledMethod),
-        usages: externalApiUsage.usages.map((usage) => usage.label),
+        usages: externalApiUsage.usages
+          .slice(0, 10)
+          .map((usage) => usage.label),
         input: `Argument[${argumentIndex}]`,
       };
-
-      if (method.usages.length > 10) {
-        method.usages = method.usages.slice(0, 10);
-      }
 
       if (modeledMethod.type === "none") {
         request.candidates.push(method);
@@ -64,12 +62,8 @@ export function createAutoModelRequest(
     }
   }
 
-  if (request.candidates.length > 100) {
-    request.candidates = request.candidates.slice(0, 100);
-  }
-  if (request.samples.length > 20) {
-    request.samples = request.samples.slice(0, 20);
-  }
+  request.candidates = request.candidates.slice(0, 100);
+  request.samples = request.samples.slice(0, 20);
 
   return request;
 }

--- a/extensions/ql-vscode/src/data-extensions-editor/auto-model.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/auto-model.ts
@@ -1,0 +1,117 @@
+import { ExternalApiUsage } from "./external-api-usage";
+import { ModeledMethod, ModeledMethodType } from "./modeled-method";
+import {
+  Classification,
+  ClassificationType,
+  Method,
+  ModelRequest,
+} from "./auto-model-api";
+
+export function createAutoModelRequest(
+  language: string,
+  externalApiUsages: ExternalApiUsage[],
+  modeledMethods: Record<string, ModeledMethod>,
+): ModelRequest {
+  const request: ModelRequest = {
+    language,
+    samples: [],
+    candidates: [],
+  };
+
+  // Sort by number of usages so we always send the most used methods first
+  externalApiUsages = [...externalApiUsages];
+  externalApiUsages.sort((a, b) => b.usages.length - a.usages.length);
+
+  for (const externalApiUsage of externalApiUsages) {
+    const modeledMethod: ModeledMethod = modeledMethods[
+      externalApiUsage.signature
+    ] ?? {
+      type: "none",
+    };
+
+    const numberOfArguments =
+      externalApiUsage.methodParameters === "()"
+        ? 0
+        : externalApiUsage.methodParameters.split(",").length;
+
+    for (
+      let argumentIndex = 0;
+      argumentIndex < numberOfArguments;
+      argumentIndex++
+    ) {
+      const method: Method = {
+        package: externalApiUsage.packageName,
+        type: externalApiUsage.typeName,
+        name: externalApiUsage.methodName,
+        signature: externalApiUsage.methodParameters,
+        classification:
+          modeledMethod.type === "none"
+            ? undefined
+            : toMethodClassification(modeledMethod),
+        usages: externalApiUsage.usages.map((usage) => usage.label),
+        input: `Argument[${argumentIndex}]`,
+      };
+
+      if (method.usages.length > 10) {
+        method.usages = method.usages.slice(0, 10);
+      }
+
+      if (modeledMethod.type === "none") {
+        request.candidates.push(method);
+      } else {
+        request.samples.push(method);
+      }
+    }
+  }
+
+  if (request.candidates.length > 100) {
+    request.candidates = request.candidates.slice(0, 100);
+  }
+  if (request.samples.length > 20) {
+    request.samples = request.samples.slice(0, 20);
+  }
+
+  return request;
+}
+
+function toMethodClassificationType(
+  type: ModeledMethodType,
+): ClassificationType {
+  switch (type) {
+    case "source":
+      return ClassificationType.Source;
+    case "sink":
+      return ClassificationType.Sink;
+    case "summary":
+      return ClassificationType.Summary;
+    case "neutral":
+      return ClassificationType.Neutral;
+    default:
+      return ClassificationType.Unknown;
+  }
+}
+
+function toMethodClassification(modeledMethod: ModeledMethod): Classification {
+  return {
+    type: toMethodClassificationType(modeledMethod.type),
+    kind: modeledMethod.kind,
+    explanation: "",
+  };
+}
+
+export function classificationTypeToModeledMethodType(
+  type: ClassificationType,
+): ModeledMethodType {
+  switch (type) {
+    case ClassificationType.Source:
+      return "source";
+    case ClassificationType.Sink:
+      return "sink";
+    case ClassificationType.Summary:
+      return "summary";
+    case ClassificationType.Neutral:
+      return "neutral";
+    default:
+      return "none";
+  }
+}

--- a/extensions/ql-vscode/src/data-extensions-editor/auto-model.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/auto-model.ts
@@ -62,8 +62,8 @@ export function createAutoModelRequest(
     }
   }
 
-  request.candidates = request.candidates.slice(0, 100);
-  request.samples = request.samples.slice(0, 20);
+  request.candidates = request.candidates.slice(0, 20);
+  request.samples = request.samples.slice(0, 100);
 
   return request;
 }

--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
@@ -41,8 +41,8 @@ import { ModeledMethod } from "./modeled-method";
 import { ExtensionPackModelFile } from "./shared/extension-pack";
 import { autoModel } from "./auto-model-api";
 import {
-  classificationTypeToModeledMethodType,
   createAutoModelRequest,
+  parsePredictedClassifications,
 } from "./auto-model";
 import { showLlmGeneration } from "../config";
 
@@ -393,24 +393,13 @@ export class DataExtensionsEditorView extends AbstractWebview<
 
     const response = await autoModel(this.app.credentials, request);
 
-    const modeledMethodsByName: Record<string, ModeledMethod> = {};
-
-    for (const method of response.predicted) {
-      if (method.classification === undefined) {
-        continue;
-      }
-
-      modeledMethodsByName[method.signature] = {
-        type: classificationTypeToModeledMethodType(method.classification.type),
-        kind: method.classification.kind,
-        input: method.input ?? "",
-        output: method.output ?? "",
-      };
-    }
+    const predictedModeledMethods = parsePredictedClassifications(
+      response.predicted,
+    );
 
     await this.postMessage({
       t: "addModeledMethods",
-      modeledMethods: modeledMethodsByName,
+      modeledMethods: predictedModeledMethods,
       overrideNone: true,
     });
   }

--- a/extensions/ql-vscode/src/data-extensions-editor/shared/view-state.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/shared/view-state.ts
@@ -3,4 +3,5 @@ import { ExtensionPackModelFile } from "./extension-pack";
 export interface DataExtensionEditorViewState {
   extensionPackModelFile: ExtensionPackModelFile;
   modelFileExists: boolean;
+  showLlmButton: boolean;
 }

--- a/extensions/ql-vscode/src/pure/interface-types.ts
+++ b/extensions/ql-vscode/src/pure/interface-types.ts
@@ -544,6 +544,12 @@ export interface GenerateExternalApiMessage {
   t: "generateExternalApi";
 }
 
+export interface GenerateExternalApiFromLlmMessage {
+  t: "generateExternalApiFromLlm";
+  externalApiUsages: ExternalApiUsage[];
+  modeledMethods: Record<string, ModeledMethod>;
+}
+
 export type ToDataExtensionsEditorMessage =
   | SetExtensionPackStateMessage
   | SetExternalApiUsagesMessage
@@ -556,4 +562,5 @@ export type FromDataExtensionsEditorMessage =
   | OpenExtensionPackMessage
   | JumpToUsageMessage
   | SaveModeledMethods
-  | GenerateExternalApiMessage;
+  | GenerateExternalApiMessage
+  | GenerateExternalApiFromLlmMessage;

--- a/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
@@ -157,6 +157,14 @@ export function DataExtensionsEditor({
     });
   }, []);
 
+  const onGenerateFromLlmClick = useCallback(() => {
+    vscode.postMessage({
+      t: "generateExternalApiFromLlm",
+      externalApiUsages,
+      modeledMethods,
+    });
+  }, [externalApiUsages, modeledMethods]);
+
   const onOpenExtensionPackClick = useCallback(() => {
     vscode.postMessage({
       t: "openExtensionPack",
@@ -214,6 +222,14 @@ export function DataExtensionsEditor({
             <VSCodeButton onClick={onGenerateClick}>
               Download and generate
             </VSCodeButton>
+            {viewState?.showLlmButton && (
+              <>
+                &nbsp;
+                <VSCodeButton onClick={onGenerateFromLlmClick}>
+                  Generate using LLM
+                </VSCodeButton>
+              </>
+            )}
             <br />
             <br />
             <VSCodeDataGrid>

--- a/extensions/ql-vscode/test/unit-tests/data-extensions-editor/auto-model.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/data-extensions-editor/auto-model.test.ts
@@ -341,7 +341,7 @@ describe("parsePredictedClassifications", () => {
       classification: {
         type: ClassificationType.Sink,
         kind: "sql injection sink",
-        explanation: "not a sink",
+        explanation: "",
       },
     },
     {
@@ -354,7 +354,7 @@ describe("parsePredictedClassifications", () => {
       classification: {
         type: ClassificationType.Sink,
         kind: "sql injection sink",
-        explanation: "not a sink",
+        explanation: "",
       },
     },
   ];

--- a/extensions/ql-vscode/test/unit-tests/data-extensions-editor/auto-model.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/data-extensions-editor/auto-model.test.ts
@@ -1,6 +1,13 @@
-import { createAutoModelRequest } from "../../../src/data-extensions-editor/auto-model";
+import {
+  createAutoModelRequest,
+  parsePredictedClassifications,
+} from "../../../src/data-extensions-editor/auto-model";
 import { ExternalApiUsage } from "../../../src/data-extensions-editor/external-api-usage";
 import { ModeledMethod } from "../../../src/data-extensions-editor/modeled-method";
+import {
+  ClassificationType,
+  Method,
+} from "../../../src/data-extensions-editor/auto-model-api";
 
 describe("createAutoModelRequest", () => {
   const externalApiUsages: ExternalApiUsage[] = [
@@ -278,6 +285,99 @@ describe("createAutoModelRequest", () => {
           input: "Argument[2]",
         },
       ],
+    });
+  });
+});
+
+describe("parsePredictedClassifications", () => {
+  const predictions: Method[] = [
+    {
+      package: "org.sql2o",
+      type: "Sql2o",
+      name: "createQuery",
+      signature: "(String)",
+      usages: ["createQuery(...)", "createQuery(...)"],
+      input: "Argument[0]",
+      classification: {
+        type: ClassificationType.Sink,
+        kind: "sql injection sink",
+        explanation: "",
+      },
+    },
+    {
+      package: "org.sql2o",
+      type: "Sql2o",
+      name: "executeScalar",
+      signature: "(Class)",
+      usages: ["executeScalar(...)", "executeScalar(...)"],
+      input: "Argument[0]",
+      classification: {
+        type: ClassificationType.Neutral,
+        kind: "",
+        explanation: "not a sink",
+      },
+    },
+    {
+      package: "org.sql2o",
+      type: "Sql2o",
+      name: "Sql2o",
+      signature: "(String,String,String)",
+      usages: ["new Sql2o(...)"],
+      input: "Argument[0]",
+      classification: {
+        type: ClassificationType.Neutral,
+        kind: "",
+        explanation: "not a sink",
+      },
+    },
+    {
+      package: "org.sql2o",
+      type: "Sql2o",
+      name: "Sql2o",
+      signature: "(String,String,String)",
+      usages: ["new Sql2o(...)"],
+      input: "Argument[1]",
+      classification: {
+        type: ClassificationType.Sink,
+        kind: "sql injection sink",
+        explanation: "not a sink",
+      },
+    },
+    {
+      package: "org.sql2o",
+      type: "Sql2o",
+      name: "Sql2o",
+      signature: "(String,String,String)",
+      usages: ["new Sql2o(...)"],
+      input: "Argument[2]",
+      classification: {
+        type: ClassificationType.Sink,
+        kind: "sql injection sink",
+        explanation: "not a sink",
+      },
+    },
+  ];
+
+  it("correctly parses the output", () => {
+    expect(parsePredictedClassifications(predictions)).toEqual({
+      "org.sql2o.Sql2o.createQuery(String)": {
+        type: "sink",
+        kind: "sql injection sink",
+        input: "Argument[0]",
+        output: "",
+      },
+      "org.sql2o.Sql2o.executeScalar(Class)": {
+        type: "neutral",
+        kind: "",
+        input: "",
+        output: "",
+      },
+      "org.sql2o.Sql2o.Sql2o(String,String,String)": {
+        type: "sink",
+        kind: "sql injection sink",
+        input: "Argument[1]",
+        output: "",
+      },
     });
   });
 });

--- a/extensions/ql-vscode/test/unit-tests/data-extensions-editor/auto-model.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/data-extensions-editor/auto-model.test.ts
@@ -360,19 +360,19 @@ describe("parsePredictedClassifications", () => {
 
   it("correctly parses the output", () => {
     expect(parsePredictedClassifications(predictions)).toEqual({
-      "org.sql2o.Sql2o.createQuery(String)": {
+      "org.sql2o.Sql2o#createQuery(String)": {
         type: "sink",
         kind: "sql injection sink",
         input: "Argument[0]",
         output: "",
       },
-      "org.sql2o.Sql2o.executeScalar(Class)": {
+      "org.sql2o.Sql2o#executeScalar(Class)": {
         type: "neutral",
         kind: "",
         input: "",
         output: "",
       },
-      "org.sql2o.Sql2o.Sql2o(String,String,String)": {
+      "org.sql2o.Sql2o#Sql2o(String,String,String)": {
         type: "sink",
         kind: "sql injection sink",
         input: "Argument[1]",

--- a/extensions/ql-vscode/test/unit-tests/data-extensions-editor/auto-model.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/data-extensions-editor/auto-model.test.ts
@@ -1,4 +1,5 @@
 import {
+  compareInputOutput,
   createAutoModelRequest,
   parsePredictedClassifications,
 } from "../../../src/data-extensions-editor/auto-model";
@@ -379,5 +380,51 @@ describe("parsePredictedClassifications", () => {
         output: "",
       },
     });
+  });
+});
+
+describe("compareInputOutput", () => {
+  it("with two small numeric arguments", () => {
+    expect(
+      compareInputOutput("Argument[0]", "Argument[1]"),
+    ).toBeLessThanOrEqual(-1);
+  });
+
+  it("with one larger non-alphabetic argument", () => {
+    expect(
+      compareInputOutput("Argument[10]", "Argument[2]"),
+    ).toBeGreaterThanOrEqual(1);
+  });
+
+  it("with one non-numeric arguments", () => {
+    expect(
+      compareInputOutput("Argument[5]", "Argument[this]"),
+    ).toBeLessThanOrEqual(-1);
+  });
+
+  it("with two non-numeric arguments", () => {
+    expect(
+      compareInputOutput("ReturnValue", "Argument[this]"),
+    ).toBeGreaterThanOrEqual(1);
+  });
+
+  it("with one unknown argument in the a position", () => {
+    expect(
+      compareInputOutput("FooBar", "Argument[this]"),
+    ).toBeGreaterThanOrEqual(1);
+  });
+
+  it("with one unknown argument in the b position", () => {
+    expect(compareInputOutput("Argument[this]", "FooBar")).toBeLessThanOrEqual(
+      -1,
+    );
+  });
+
+  it("with one empty string arguments", () => {
+    expect(compareInputOutput("Argument[5]", "")).toBeLessThanOrEqual(-1);
+  });
+
+  it("with two unknown arguments", () => {
+    expect(compareInputOutput("FooBar", "BarFoo")).toBeGreaterThanOrEqual(1);
   });
 });


### PR DESCRIPTION
This adds an initial implementation of auto-modeling using the `/repos/:owner/:name/code-scanning/codeql/auto-model` endpoint. The button is hidden behind the `codeQL.dataExtensions.llmGeneration` setting.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
