### PR TITLE
Add welcome text for the queries panel

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1594,6 +1594,10 @@
         "contents": "You have no query history items at the moment.\n\nSelect a database to run a CodeQL query and get your first results."
       },
       {
+        "view": "codeQLQueries",
+        "contents": "This workspace doesn't contain any CodeQL queries at the moment."
+      },
+      {
         "view": "codeQLDatabases",
         "contents": "Add a CodeQL database:\n[From a folder](command:codeQLDatabases.chooseDatabaseFolder)\n[From an archive](command:codeQLDatabases.chooseDatabaseArchive)\n[From a URL (as a zip file)](command:codeQLDatabases.chooseDatabaseInternet)\n[From GitHub](command:codeQLDatabases.chooseDatabaseGithub)"
       },


### PR DESCRIPTION

This gives some default text to display in the queries panel where there aren't any queries in the workspace. Suggestions welcome for what to put as the text, and we can always change the text later on.

<img width="367" alt="Screenshot 2023-05-25 at 12 48 17" src="https://github.com/github/vscode-codeql/assets/3749000/074fa10a-d341-4064-a8fb-da78a3669604">

This shows whenever `QueryTreeDataProvider` returns no children for the root node, with no extra configuration needed. One complication is it also shows while the CodeQL extension is loading, so ideally the text shouldn't be confusing in this situation.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
