### PR TITLE
Extract `DatabaseItem.refresh` method to `DatabaseManager`

### DIFF
--- a/extensions/ql-vscode/src/databases/local-databases/database-item.ts
+++ b/extensions/ql-vscode/src/databases/local-databases/database-item.ts
@@ -27,15 +27,7 @@ export interface DatabaseItem {
 
   /** If the database is invalid, describes why. */
   readonly error: Error | undefined;
-  /**
-   * Resolves the contents of the database.
-   *
-   * @remarks
-   * The contents include the database directory, source archive, and metadata about the database.
-   * If the database is invalid, `this.error` is updated with the error object that describes why
-   * the database is invalid. This error is also thrown.
-   */
-  refresh(): Promise<void>;
+
   /**
    * Resolves a filename to its URI in the source archive.
    *

--- a/extensions/ql-vscode/src/databases/local-databases/database-manager.ts
+++ b/extensions/ql-vscode/src/databases/local-databases/database-manager.ts
@@ -83,7 +83,7 @@ export class DatabaseManager extends DisposableObject {
   readonly onDidChangeCurrentDatabaseItem =
     this._onDidChangeCurrentDatabaseItem.event;
 
-  private readonly _databaseItems: DatabaseItem[] = [];
+  private readonly _databaseItems: DatabaseItemImpl[] = [];
   private _currentDatabaseItem: DatabaseItem | undefined = undefined;
 
   constructor(
@@ -127,8 +127,8 @@ export class DatabaseManager extends DisposableObject {
    *
    * Typically, the item will have been created by {@link createOrOpenDatabaseItem} or {@link openDatabase}.
    */
-  public async addExistingDatabaseItem(
-    databaseItem: DatabaseItem,
+  private async addExistingDatabaseItem(
+    databaseItem: DatabaseItemImpl,
     progress: ProgressCallback,
     makeSelected: boolean,
     token: vscode.CancellationToken,
@@ -162,7 +162,7 @@ export class DatabaseManager extends DisposableObject {
   private async createDatabaseItem(
     uri: vscode.Uri,
     displayName: string | undefined,
-  ): Promise<DatabaseItem> {
+  ): Promise<DatabaseItemImpl> {
     const contents = await DatabaseResolver.resolveDatabaseContents(uri);
     // Ignore the source archive for QLTest databases by default.
     const isQLTestDatabase = extname(uri.fsPath) === ".testproj";
@@ -329,7 +329,7 @@ export class DatabaseManager extends DisposableObject {
     progress: ProgressCallback,
     token: vscode.CancellationToken,
     state: PersistedDatabaseItem,
-  ): Promise<DatabaseItem> {
+  ): Promise<DatabaseItemImpl> {
     let displayName: string | undefined = undefined;
     let ignoreSourceArchive = false;
     let dateAdded = undefined;
@@ -499,7 +499,7 @@ export class DatabaseManager extends DisposableObject {
   private async addDatabaseItem(
     progress: ProgressCallback,
     token: vscode.CancellationToken,
-    item: DatabaseItem,
+    item: DatabaseItemImpl,
     updatePersistedState = true,
   ) {
     this._databaseItems.push(item);

--- a/extensions/ql-vscode/test/factories/databases/databases.ts
+++ b/extensions/ql-vscode/test/factories/databases/databases.ts
@@ -33,7 +33,6 @@ export function createMockDB(
       datasetUri: databaseUri,
     } as DatabaseContents,
     dbOptions,
-    () => void 0,
   );
 }
 

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/skeleton-query-wizard.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/skeleton-query-wizard.test.ts
@@ -546,9 +546,7 @@ describe("SkeletonQueryWizard", () => {
           dateAdded: 123,
         } as FullDatabaseOptions);
 
-        jest
-          .spyOn(mockDbItem, "error", "get")
-          .mockReturnValue(asError("database go boom!"));
+        mockDbItem.error = asError("database go boom!");
 
         const sortedList =
           await SkeletonQueryWizard.sortDatabaseItemsByDateAdded([

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-databases.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-databases.test.ts
@@ -327,7 +327,7 @@ describe("local databases", () => {
         mockDbOptions(),
         Uri.parse("file:/sourceArchive-uri/"),
       );
-      (db as any)._contents.sourceArchiveUri = undefined;
+      (db as any).contents.sourceArchiveUri = undefined;
       expect(() => db.resolveSourceFile("abc")).toThrowError(
         "Scheme is missing",
       );
@@ -339,7 +339,7 @@ describe("local databases", () => {
         mockDbOptions(),
         Uri.parse("file:/sourceArchive-uri/"),
       );
-      (db as any)._contents.sourceArchiveUri = undefined;
+      (db as any).contents.sourceArchiveUri = undefined;
       expect(() => db.resolveSourceFile("http://abc")).toThrowError(
         "Invalid uri scheme",
       );
@@ -352,7 +352,7 @@ describe("local databases", () => {
           mockDbOptions(),
           Uri.parse("file:/sourceArchive-uri/"),
         );
-        (db as any)._contents.sourceArchiveUri = undefined;
+        (db as any).contents.sourceArchiveUri = undefined;
         const resolved = db.resolveSourceFile(undefined);
         expect(resolved.toString(true)).toBe(dbLocationUri(dir).toString(true));
       });
@@ -363,7 +363,7 @@ describe("local databases", () => {
           mockDbOptions(),
           Uri.parse("file:/sourceArchive-uri/"),
         );
-        (db as any)._contents.sourceArchiveUri = undefined;
+        (db as any).contents.sourceArchiveUri = undefined;
         const resolved = db.resolveSourceFile("file:");
         expect(resolved.toString()).toBe("file:///");
       });

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-testing/test-runner.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-testing/test-runner.test.ts
@@ -40,17 +40,11 @@ describe("test-runner", () => {
     Uri.file("/path/to/test/dir/dir.testproj"),
     undefined,
     mockedObject<FullDatabaseOptions>({ displayName: "custom display name" }),
-    (_) => {
-      /* no change event listener */
-    },
   );
   const postTestDatabaseItem = new DatabaseItemImpl(
     Uri.file("/path/to/test/dir/dir.testproj"),
     undefined,
     mockedObject<FullDatabaseOptions>({ displayName: "default name" }),
-    (_) => {
-      /* no change event listener */
-    },
   );
 
   beforeEach(() => {


### PR DESCRIPTION
This moves the `DatabaseItem.refresh` method out of the `DatabaseItem` interface and moves it to the `DatabaseManager` itself. This makes the `DatabaseItem` interface smaller and ensures that the `refresh` method is not called outside of the `DatabaseManager`.

It's easiest to review this commit-by-commit.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
