### PR TITLE
Add ability to await the discovery refresh promise

### DIFF
--- a/extensions/ql-vscode/src/common/discovery.ts
+++ b/extensions/ql-vscode/src/common/discovery.ts
@@ -19,7 +19,7 @@ export abstract class Discovery<T> extends DisposableObject {
    * Returns the promise of the currently running refresh operation, if one is in progress.
    * Otherwise returns a promise that resolves immediately.
    */
-  public getCurrentRefreshPromise(): Promise<void> {
+  public waitForCurrentRefresh(): Promise<void> {
     return this.currentDiscoveryPromise ?? Promise.resolve();
   }
 

--- a/extensions/ql-vscode/src/common/discovery.ts
+++ b/extensions/ql-vscode/src/common/discovery.ts
@@ -16,6 +16,14 @@ export abstract class Discovery<T> extends DisposableObject {
   }
 
   /**
+   * Returns the promise of the currently running refresh operation, if one is in progress.
+   * Otherwise returns a promise that resolves immediately.
+   */
+  public getCurrentRefreshPromise(): Promise<void> {
+    return this.currentDiscoveryPromise ?? Promise.resolve();
+  }
+
+  /**
    * Force the discovery process to run. Normally invoked by the derived class when a relevant file
    * system change is detected.
    *

--- a/extensions/ql-vscode/src/common/discovery.ts
+++ b/extensions/ql-vscode/src/common/discovery.ts
@@ -51,7 +51,9 @@ export abstract class Discovery<T> extends DisposableObject {
       this.restartWhenFinished = true;
     } else {
       // No discovery in progress, so start one now.
-      this.currentDiscoveryPromise = this.launchDiscovery();
+      this.currentDiscoveryPromise = this.launchDiscovery().finally(() => {
+        this.currentDiscoveryPromise = undefined;
+      });
     }
     return this.currentDiscoveryPromise;
   }
@@ -81,8 +83,6 @@ export abstract class Discovery<T> extends DisposableObject {
       this.restartWhenFinished = false;
       await this.launchDiscovery();
     } else {
-      this.currentDiscoveryPromise = undefined;
-
       // If the discovery was successful, then update any listeners with the results.
       if (results !== undefined) {
         this.update(results);

--- a/extensions/ql-vscode/src/queries-panel/queries-module.ts
+++ b/extensions/ql-vscode/src/queries-panel/queries-module.ts
@@ -21,7 +21,7 @@ export class QueriesModule extends DisposableObject {
 
     const queryDiscovery = new QueryDiscovery(app, cliServer);
     this.push(queryDiscovery);
-    queryDiscovery.refresh();
+    void queryDiscovery.refresh();
 
     const queriesPanel = new QueriesPanel(queryDiscovery);
     this.push(queriesPanel);

--- a/extensions/ql-vscode/src/query-testing/qltest-discovery.ts
+++ b/extensions/ql-vscode/src/query-testing/qltest-discovery.ts
@@ -64,7 +64,7 @@ export class QLTestDiscovery extends Discovery<QLTestDiscoveryResults> {
 
   private handleDidChange(uri: Uri): void {
     if (!QLTestDiscovery.ignoreTestPath(uri.fsPath)) {
-      this.refresh();
+      void this.refresh();
     }
   }
   protected async discover(): Promise<QLTestDiscoveryResults> {

--- a/extensions/ql-vscode/src/query-testing/test-adapter.ts
+++ b/extensions/ql-vscode/src/query-testing/test-adapter.ts
@@ -115,7 +115,7 @@ export class QLTestAdapter extends DisposableObject implements TestAdapter {
     this.qlTestDiscovery = this.push(
       new QLTestDiscovery(workspaceFolder, cliServer),
     );
-    this.qlTestDiscovery.refresh();
+    void this.qlTestDiscovery.refresh();
 
     this.push(this.qlTestDiscovery.onDidChangeTests(this.discoverTests, this));
   }

--- a/extensions/ql-vscode/src/query-testing/test-manager.ts
+++ b/extensions/ql-vscode/src/query-testing/test-manager.ts
@@ -92,7 +92,7 @@ class WorkspaceFolderHandler extends DisposableObject {
     this.push(
       this.testDiscovery.onDidChangeTests(this.handleDidChangeTests, this),
     );
-    this.testDiscovery.refresh();
+    void this.testDiscovery.refresh();
   }
 
   private handleDidChangeTests(): void {

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/queries-panel/query-discovery.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/queries-panel/query-discovery.test.ts
@@ -10,7 +10,6 @@ import { QueryDiscovery } from "../../../../src/queries-panel/query-discovery";
 import { createMockApp } from "../../../__mocks__/appMock";
 import { mockedObject } from "../../utils/mocking.helpers";
 import { basename, join, sep } from "path";
-import { sleep } from "../../../../src/pure/time";
 
 describe("QueryDiscovery", () => {
   beforeEach(() => {
@@ -171,8 +170,7 @@ describe("QueryDiscovery", () => {
 
       onWatcherDidChangeEvent.fire(workspace.workspaceFolders![0].uri);
 
-      // Wait for refresh to finish
-      await sleep(100);
+      await discovery.getCurrentRefreshPromise();
 
       expect(onDidChangeQueriesSpy).toHaveBeenCalledTimes(2);
     });
@@ -202,8 +200,7 @@ describe("QueryDiscovery", () => {
 
       onDidChangeWorkspaceFoldersEvent.fire({ added: [], removed: [] });
 
-      // Wait for refresh to finish
-      await sleep(100);
+      await discovery.getCurrentRefreshPromise();
 
       expect(onDidChangeQueriesSpy).toHaveBeenCalledTimes(2);
     });

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/queries-panel/query-discovery.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/queries-panel/query-discovery.test.ts
@@ -170,7 +170,7 @@ describe("QueryDiscovery", () => {
 
       onWatcherDidChangeEvent.fire(workspace.workspaceFolders![0].uri);
 
-      await discovery.getCurrentRefreshPromise();
+      await discovery.waitForCurrentRefresh();
 
       expect(onDidChangeQueriesSpy).toHaveBeenCalledTimes(2);
     });
@@ -200,7 +200,7 @@ describe("QueryDiscovery", () => {
 
       onDidChangeWorkspaceFoldersEvent.fire({ added: [], removed: [] });
 
-      await discovery.getCurrentRefreshPromise();
+      await discovery.waitForCurrentRefresh();
 
       expect(onDidChangeQueriesSpy).toHaveBeenCalledTimes(2);
     });

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/query-testing/qltest-discovery.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/query-testing/qltest-discovery.test.ts
@@ -52,12 +52,14 @@ describe("qltest-discovery", () => {
     });
 
     it("should run discovery", async () => {
-      const result = await (qlTestDiscover as any).discover();
-      expect(result.watchPath).toEqualPath(baseDir);
-      expect(result.testDirectory.path).toEqualPath(baseDir);
-      expect(result.testDirectory.name).toBe("My tests");
+      await qlTestDiscover.refresh();
+      const testDirectory = qlTestDiscover.testDirectory;
+      expect(testDirectory).toBeDefined();
 
-      let children = result.testDirectory.children;
+      expect(testDirectory!.path).toEqualPath(baseDir);
+      expect(testDirectory!.name).toBe("My tests");
+
+      let children = testDirectory!.children;
       expect(children.length).toBe(1);
 
       expect(children[0].path).toEqualPath(cDir);
@@ -83,12 +85,14 @@ describe("qltest-discovery", () => {
     it("should avoid discovery if a folder does not exist", async () => {
       await fs.remove(baseDir);
 
-      const result = await (qlTestDiscover as any).discover();
-      expect(result.watchPath).toEqualPath(baseDir);
-      expect(result.testDirectory.path).toEqualPath(baseDir);
-      expect(result.testDirectory.name).toBe("My tests");
+      await qlTestDiscover.refresh();
+      const testDirectory = qlTestDiscover.testDirectory;
+      expect(testDirectory).toBeDefined();
 
-      expect(result.testDirectory.children.length).toBe(0);
+      expect(testDirectory!.path).toEqualPath(baseDir);
+      expect(testDirectory!.name).toBe("My tests");
+
+      expect(testDirectory!.children.length).toBe(0);
     });
   });
 });


### PR DESCRIPTION
The intent of this PR is to give you access to a promise for the `Discovery` class refresh. This allows us to make the tests more type safe and less prone to flakiness.

One part of this PR is making `refresh` itself return a promise. This means in the tests we can do `await discovery.refresh()` instead of having to do `await (discovery as any).discover()` and calling the private `discover` method. This means we're no longer circumventing the public interface of the `Discover` class.

Another part of this PR is adding a `getCurrentRefreshPromise` method which means even if we weren't the ones to kick off the refresh directly we can still safely wait for it to be finished. This is useful when we are testing listeners to events that trigger a refresh, such as the listener for files changing on disk. We can now do `await discovery.getCurrentRefreshPromise()` instead of having to do `await sleep(100)` and hope for the best.

The commits are split up into separate changes, if you prefer to review commit-by-commit.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
