### PR TITLE
Don't log the `resolve queries` CLI command

### DIFF
--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -412,10 +412,10 @@ export class CodeQLCliServer implements Disposable {
         const newError =
           stderrBuffers.length === 0
             ? new Error(
-                `${description} failed with args ${argsString}:${EOL}${err}`,
+                `${description} failed with args:${EOL}    ${argsString}${EOL}${err}`,
               )
             : new Error(
-                `${description} failed with args ${argsString}:${EOL}${Buffer.concat(
+                `${description} failed with args:${EOL}    ${argsString}${EOL}${Buffer.concat(
                   stderrBuffers,
                 ).toString("utf8")}`,
               );

--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -218,7 +218,7 @@ export class CodeQLCliServer implements Disposable {
     private readonly app: App,
     private distributionProvider: DistributionProvider,
     private cliConfig: CliConfig,
-    private logger: Logger,
+    public readonly logger: Logger,
   ) {
     this.commandQueue = [];
     this.commandInProcess = false;

--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -408,14 +408,16 @@ export class CodeQLCliServer implements Disposable {
       } catch (err) {
         // Kill the process if it isn't already dead.
         this.killProcessIfRunning();
-        // Report the error (if there is a stderr then use that otherwise just report the error cod or nodejs error)
+        // Report the error (if there is a stderr then use that otherwise just report the error code or nodejs error)
         const newError =
           stderrBuffers.length === 0
-            ? new Error(`${description} failed: ${err}`)
+            ? new Error(
+                `${description} failed with args ${argsString}:${EOL}${err}`,
+              )
             : new Error(
-                `${description} failed: ${Buffer.concat(stderrBuffers).toString(
-                  "utf8",
-                )}`,
+                `${description} failed with args ${argsString}:${EOL}${Buffer.concat(
+                  stderrBuffers,
+                ).toString("utf8")}`,
               );
         newError.stack += getErrorStack(err);
         throw newError;

--- a/extensions/ql-vscode/src/queries-panel/query-discovery.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-discovery.ts
@@ -113,7 +113,12 @@ export class QueryDiscovery
     const fullPath = workspaceFolder.uri.fsPath;
     const name = workspaceFolder.name;
 
-    const resolvedQueries = await this.cliServer.resolveQueries(fullPath);
+    // We don't want to log each invocation of resolveQueries, since it clutters up the log.
+    const silent = true;
+    const resolvedQueries = await this.cliServer.resolveQueries(
+      fullPath,
+      silent,
+    );
     if (resolvedQueries.length === 0) {
       return undefined;
     }


### PR DESCRIPTION
To keep the Queries Panel up to date, the CLI runs the `resolve queries` command every time a `.ql` file or surrounding folder changes.

The logging output is very noisy, so we'd like to remove it from the CodeQL Extension Log. I've passed in an optional `silent` flag to the `runCodeQlCliInternal` method, which just skips calling `logger.log`.

I've also added a basic test to check the behaviour with/without the flag.

## Checklist

N/A—internal only 🐕

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
