### PR TITLE
Expand assert-pure.ql to cover common and be a path-problem query

### DIFF
--- a/.github/codeql/queries/assert-pure.ql
+++ b/.github/codeql/queries/assert-pure.ql
@@ -9,8 +9,8 @@
 
 import javascript
 
-class VSCodeImport extends AstNode {
-  VSCodeImport() { this.(Import).getImportedPath().getValue() = "vscode" }
+class VSCodeImport extends ImportDeclaration {
+  VSCodeImport() { this.getImportedPath().getValue() = "vscode" }
 }
 
 class PureFile extends File {

--- a/.github/codeql/queries/assert-pure.ql
+++ b/.github/codeql/queries/assert-pure.ql
@@ -27,10 +27,6 @@ Import getANonTypeOnlyImport(Module m) {
   result = m.getAnImport() and not result.(ImportDeclaration).isTypeOnly()
 }
 
-Module getANonTypeOnlyImportedModule(Module m) {
-  result = getANonTypeOnlyImport(m).getImportedModule()
-}
-
 query predicate edges(AstNode a, AstNode b) {
   getANonTypeOnlyImport(a) = b or
   a.(Import).getImportedModule() = b
@@ -39,6 +35,6 @@ query predicate edges(AstNode a, AstNode b) {
 from Module m, VSCodeImport v
 where
   m.getFile() instanceof PureFile and
-  getANonTypeOnlyImport(getANonTypeOnlyImportedModule*(m)) = v
+  edges+(m, v)
 select m, m, v,
   "This module is not pure: it has a transitive dependency on the vscode API imported $@", v, "here"


### PR DESCRIPTION
Expands the `assert-pure.ql` query in a couple of ways:
- Covers stuff in the `src/common` directory as well as `src/pure`. Stuff in this directory should also be independent of vscode, unless it is in the `src/common/vscode` directory.
- Convert the query to a `path-problem` query. My aim here is to make this query easier to use, by explaining where an import comes from. It can otherwise be a bit hard to understand when the import chain gets more than a couple of files.

The query now has 10 alerts 🎉 😱 

<img width="1213" alt="Screenshot 2023-05-26 at 16 44 37" src="https://github.com/github/vscode-codeql/assets/3749000/eb8a67bf-afc8-49a5-8f89-eb8d6b15e9af">

All of these alerts are because of logging, either from importing `extLogger` or `OutputChannelLogger` or `showAndLogErrorMessage`.

The reason there's 6 alerts for `selection-commands.ts` is because there's 6 separate vscode imports that it transitively imports, via the giant `helpers.ts` file. I believe there's not a good way to compress these into a single alert without losing the information of which import it's connected to.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
