### PR TITLE
Make assert-pure.ql ignore all /vscode/ directories

### DIFF
--- a/.github/codeql/queries/assert-pure.ql
+++ b/.github/codeql/queries/assert-pure.ql
@@ -19,7 +19,7 @@ class PureFile extends File {
       this.getRelativePath().regexpMatch(".*/src/pure/.*") or
       this.getRelativePath().regexpMatch(".*/src/common/.*")
     ) and
-    not this.getRelativePath().regexpMatch(".*/src/common/vscode/.*")
+    not this.getRelativePath().regexpMatch(".*/vscode/.*")
   }
 }
 


### PR DESCRIPTION
In https://github.com/github/vscode-codeql/pull/2455 I made `assert-pure.ql` cover all of `/src/common` except for `/src/common/vscode` but I didn't realise we also have directories like `/src/common/logging/vscode`. So in this PR I change the query to ignore all directories containing `/vscode/` anywhere in their path, and not just `/src/common/vscode`.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
