### PR TITLE
Avoid vscode reference rfom discovery.ts

### DIFF
--- a/extensions/ql-vscode/src/common/discovery.ts
+++ b/extensions/ql-vscode/src/common/discovery.ts
@@ -1,6 +1,6 @@
 import { DisposableObject } from "../pure/disposable-object";
-import { extLogger } from "./logging/vscode/loggers";
 import { getErrorMessage } from "../pure/helpers-pure";
+import { Logger } from "./logging";
 
 /**
  * Base class for "discovery" operations, which scan the file system to find specific kinds of
@@ -11,7 +11,7 @@ export abstract class Discovery<T> extends DisposableObject {
   private retry = false;
   private discoveryInProgress = false;
 
-  constructor(private readonly name: string) {
+  constructor(private readonly name: string, private readonly logger: Logger) {
     super();
   }
 
@@ -63,7 +63,7 @@ export abstract class Discovery<T> extends DisposableObject {
       })
 
       .catch((err: unknown) => {
-        void extLogger.log(
+        void this.logger.log(
           `${this.name} failed. Reason: ${getErrorMessage(err)}`,
         );
       })

--- a/extensions/ql-vscode/src/queries-panel/query-discovery.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-discovery.ts
@@ -8,6 +8,7 @@ import { FileTreeDirectory, FileTreeLeaf } from "../common/file-tree-nodes";
 import { getOnDiskWorkspaceFoldersObjects } from "../helpers";
 import { AppEventEmitter } from "../common/events";
 import { QueryDiscoverer } from "./query-tree-data-provider";
+import { extLogger } from "../common";
 
 /**
  * The results of discovering queries.
@@ -41,7 +42,7 @@ export class QueryDiscovery
   );
 
   constructor(app: App, private readonly cliServer: CodeQLCliServer) {
-    super("Query Discovery");
+    super("Query Discovery", extLogger);
 
     this.onDidChangeQueriesEmitter = this.push(app.createEventEmitter<void>());
     this.push(app.onDidChangeWorkspaceFolders(this.refresh.bind(this)));

--- a/extensions/ql-vscode/src/query-testing/qltest-discovery.ts
+++ b/extensions/ql-vscode/src/query-testing/qltest-discovery.ts
@@ -11,6 +11,7 @@ import { MultiFileSystemWatcher } from "../common/vscode/multi-file-system-watch
 import { CodeQLCliServer } from "../codeql-cli/cli";
 import { pathExists } from "fs-extra";
 import { FileTreeDirectory, FileTreeLeaf } from "../common/file-tree-nodes";
+import { extLogger } from "../common";
 
 /**
  * The results of discovering QL tests.
@@ -42,7 +43,7 @@ export class QLTestDiscovery extends Discovery<QLTestDiscoveryResults> {
     private readonly workspaceFolder: WorkspaceFolder,
     private readonly cliServer: CodeQLCliServer,
   ) {
-    super("QL Test Discovery");
+    super("QL Test Discovery", extLogger);
 
     this.push(this.watcher.onDidChange(this.handleDidChange, this));
   }


### PR DESCRIPTION
This should fix https://github.com/github/vscode-codeql/security/code-scanning/517

Instead of referencing `extLogger` directly, we can accept a logger in the constructor. It's a little clunky but I think it's the only way unless we want to remove that logging call.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
