### PR TITLE
Move selection-commands.ts to be in the vscode directory

### DIFF
--- a/extensions/ql-vscode/src/common/vscode/selection-commands.ts
+++ b/extensions/ql-vscode/src/common/vscode/selection-commands.ts
@@ -1,9 +1,9 @@
-import { showAndLogErrorMessage } from "../helpers";
+import { showAndLogErrorMessage } from "../../helpers";
 import {
   ExplorerSelectionCommandFunction,
   TreeViewContextMultiSelectionCommandFunction,
   TreeViewContextSingleSelectionCommandFunction,
-} from "./commands";
+} from "../commands";
 
 // A hack to match types that are not an array, which is useful to help avoid
 // misusing createSingleSelectionCommand, e.g. where T accidentally gets instantiated

--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -49,7 +49,7 @@ import { LocalDatabasesCommands } from "../common/commands";
 import {
   createMultiSelectionCommand,
   createSingleSelectionCommand,
-} from "../common/selection-commands";
+} from "../common/vscode/selection-commands";
 
 enum SortOrder {
   NameAsc = "NameAsc",

--- a/extensions/ql-vscode/src/local-queries/local-queries.ts
+++ b/extensions/ql-vscode/src/local-queries/local-queries.ts
@@ -47,7 +47,7 @@ import { App } from "../common/app";
 import { DisposableObject } from "../pure/disposable-object";
 import { SkeletonQueryWizard } from "../skeleton-query-wizard";
 import { LocalQueryRun } from "./local-query-run";
-import { createMultiSelectionCommand } from "../common/selection-commands";
+import { createMultiSelectionCommand } from "../common/vscode/selection-commands";
 
 interface DatabaseQuickPickItem extends QuickPickItem {
   databaseItem: DatabaseItem;

--- a/extensions/ql-vscode/src/query-history/query-history-manager.ts
+++ b/extensions/ql-vscode/src/query-history/query-history-manager.ts
@@ -59,7 +59,7 @@ import { tryOpenExternalFile } from "../common/vscode/external-files";
 import {
   createMultiSelectionCommand,
   createSingleSelectionCommand,
-} from "../common/selection-commands";
+} from "../common/vscode/selection-commands";
 
 /**
  * query-history-manager.ts


### PR DESCRIPTION
Should fix https://github.com/github/vscode-codeql/security/code-scanning/521

The VS Code dependency we have is on `showAndLogErrorMessage` and I can't see a way to remove it without reducing functionality. But we can move it to the vscode directory and I don't think this is a huge problem compared to it being just in the common directory. The places where we'll want to use these methods from are going to already have VS Code dependencies.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
