### PR TITLE
Move createTimestampFile and walkDirectory to helpers-pure.ts

### DIFF
--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -21,12 +21,12 @@ import {
   assertNever,
   getErrorMessage,
   getErrorStack,
+  walkDirectory,
 } from "../pure/helpers-pure";
 import { QueryMetadata, SortDirection } from "../pure/interface-types";
 import { BaseLogger, Logger, ProgressReporter } from "../common";
 import { CompilationMessage } from "../pure/legacy-messages";
 import { sarifParser } from "../common/sarif-parser";
-import { walkDirectory } from "../helpers";
 import { App } from "../common/app";
 import { QueryLanguage } from "../common/query-language";
 

--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -1,11 +1,4 @@
-import {
-  ensureDirSync,
-  readFile,
-  pathExists,
-  ensureDir,
-  writeFile,
-  opendir,
-} from "fs-extra";
+import { ensureDirSync, readFile, pathExists } from "fs-extra";
 import { glob } from "glob";
 import { load } from "js-yaml";
 import { join, basename, dirname } from "path";
@@ -795,42 +788,6 @@ export async function tryGetQueryMetadata(
     // Ignore errors and provide no metadata.
     void extLogger.log(`Couldn't resolve metadata for ${queryPath}: ${e}`);
     return;
-  }
-}
-
-/**
- * Creates a file in the query directory that indicates when this query was created.
- * This is important for keeping track of when queries should be removed.
- *
- * @param queryPath The directory that will contain all files relevant to a query result.
- * It does not need to exist.
- */
-export async function createTimestampFile(storagePath: string) {
-  const timestampPath = join(storagePath, "timestamp");
-  await ensureDir(storagePath);
-  await writeFile(timestampPath, Date.now().toString(), "utf8");
-}
-
-/**
- * Recursively walk a directory and return the full path to all files found.
- * Symbolic links are ignored.
- *
- * @param dir the directory to walk
- *
- * @return An iterator of the full path to all files recursively found in the directory.
- */
-export async function* walkDirectory(
-  dir: string,
-): AsyncIterableIterator<string> {
-  const seenFiles = new Set<string>();
-  for await (const d of await opendir(dir)) {
-    const entry = join(dir, d.name);
-    seenFiles.add(entry);
-    if (d.isDirectory()) {
-      yield* walkDirectory(entry);
-    } else if (d.isFile()) {
-      yield entry;
-    }
   }
 }
 

--- a/extensions/ql-vscode/src/local-queries/local-queries.ts
+++ b/extensions/ql-vscode/src/local-queries/local-queries.ts
@@ -17,7 +17,6 @@ import { isCanary, MAX_QUERIES } from "../config";
 import { gatherQlFiles } from "../pure/files";
 import { basename } from "path";
 import {
-  createTimestampFile,
   findLanguage,
   getOnDiskWorkspaceFolders,
   showAndLogErrorMessage,
@@ -40,7 +39,11 @@ import {
 } from "../run-queries-shared";
 import { CompletedLocalQueryInfo, LocalQueryInfo } from "../query-results";
 import { WebviewReveal } from "../interface-utils";
-import { asError, getErrorMessage } from "../pure/helpers-pure";
+import {
+  asError,
+  createTimestampFile,
+  getErrorMessage,
+} from "../pure/helpers-pure";
 import { CodeQLCliServer } from "../codeql-cli/cli";
 import { LocalQueryCommands } from "../common/commands";
 import { App } from "../common/app";

--- a/extensions/ql-vscode/src/run-queries-shared.ts
+++ b/extensions/ql-vscode/src/run-queries-shared.ts
@@ -2,7 +2,7 @@ import * as messages from "./pure/messages-shared";
 import * as legacyMessages from "./pure/legacy-messages";
 import { DatabaseInfo, QueryMetadata } from "./pure/interface-types";
 import { join, parse, dirname, basename } from "path";
-import { createTimestampFile, showAndLogWarningMessage } from "./helpers";
+import { showAndLogWarningMessage } from "./helpers";
 import {
   ConfigurationTarget,
   Range,
@@ -29,7 +29,7 @@ import { DatabaseManager } from "./databases/local-databases";
 import { DecodedBqrsChunk, EntityValue } from "./pure/bqrs-cli-types";
 import { BaseLogger, extLogger } from "./common";
 import { generateSummarySymbolsFile } from "./log-insights/summary-parser";
-import { getErrorMessage } from "./pure/helpers-pure";
+import { createTimestampFile, getErrorMessage } from "./pure/helpers-pure";
 
 /**
  * run-queries.ts

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -30,7 +30,7 @@ import {
   VariantAnalysisScannedRepositoryState,
   VariantAnalysisSubmission,
 } from "./shared/variant-analysis";
-import { getErrorMessage } from "../pure/helpers-pure";
+import { createTimestampFile, getErrorMessage } from "../pure/helpers-pure";
 import { VariantAnalysisView } from "./variant-analysis-view";
 import { VariantAnalysisViewManager } from "./variant-analysis-view-manager";
 import {
@@ -44,7 +44,6 @@ import {
 } from "./variant-analysis-processor";
 import PQueue from "p-queue";
 import {
-  createTimestampFile,
   showAndLogExceptionWithTelemetry,
   showAndLogInformationMessage,
   showAndLogWarningMessage,

--- a/extensions/ql-vscode/test/unit-tests/pure/helpers-pure.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/pure/helpers-pure.test.ts
@@ -1,4 +1,11 @@
-import { asyncFilter, getErrorMessage } from "../../../src/pure/helpers-pure";
+import { DirResult, dirSync } from "tmp";
+import {
+  asyncFilter,
+  getErrorMessage,
+  walkDirectory,
+} from "../../../src/pure/helpers-pure";
+import { join } from "path";
+import { ensureDirSync, symlinkSync, writeFileSync } from "fs-extra";
 
 describe("helpers-pure", () => {
   it("should filter asynchronously", async () => {
@@ -17,5 +24,69 @@ describe("helpers-pure", () => {
     } catch (e) {
       expect(getErrorMessage(e)).toBe("opps");
     }
+  });
+
+  describe("walkDirectory", () => {
+    let tmpDir: DirResult;
+    let dir: string;
+    let dir2: string;
+
+    beforeEach(() => {
+      tmpDir = dirSync({ unsafeCleanup: true });
+      dir = join(tmpDir.name, "dir");
+      ensureDirSync(dir);
+      dir2 = join(tmpDir.name, "dir2");
+    });
+
+    afterEach(() => {
+      tmpDir.removeCallback();
+    });
+
+    it("should walk a directory", async () => {
+      const file1 = join(dir, "file1");
+      const file2 = join(dir, "file2");
+      const file3 = join(dir, "file3");
+      const dir3 = join(dir, "dir3");
+      const file4 = join(dir, "file4");
+      const file5 = join(dir, "file5");
+      const file6 = join(dir, "file6");
+
+      // These symlinks link back to paths that are already existing, so ignore.
+      const symLinkFile7 = join(dir, "symlink0");
+      const symlinkDir = join(dir2, "symlink1");
+
+      // some symlinks that point outside of the base dir.
+      const file8 = join(tmpDir.name, "file8");
+      const file9 = join(dir2, "file8");
+      const symlinkDir2 = join(dir2, "symlink2");
+      const symlinkFile2 = join(dir2, "symlinkFile3");
+
+      ensureDirSync(dir2);
+      ensureDirSync(dir3);
+
+      writeFileSync(file1, "file1");
+      writeFileSync(file2, "file2");
+      writeFileSync(file3, "file3");
+      writeFileSync(file4, "file4");
+      writeFileSync(file5, "file5");
+      writeFileSync(file6, "file6");
+      writeFileSync(file8, "file8");
+      writeFileSync(file9, "file9");
+
+      // We don't really need to be testing all of these variants of symlinks,
+      // but it doesn't hurt, and will help us if we ever do decide to support them.
+      symlinkSync(file6, symLinkFile7, "file");
+      symlinkSync(dir3, symlinkDir, "dir");
+      symlinkSync(file8, symlinkFile2, "file");
+      symlinkSync(dir2, symlinkDir2, "dir");
+
+      const files = [];
+      for await (const file of walkDirectory(dir)) {
+        files.push(file);
+      }
+
+      // Only real files should be returned.
+      expect(files.sort()).toEqual([file1, file2, file3, file4, file5, file6]);
+    });
   });
 });

--- a/extensions/ql-vscode/test/vscode-tests/activated-extension/variant-analysis/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/activated-extension/variant-analysis/variant-analysis-manager.test.ts
@@ -33,7 +33,6 @@ import {
   createMockScannedRepo,
   createMockScannedRepos,
 } from "../../../factories/variant-analysis/shared/scanned-repositories";
-import { createTimestampFile } from "../../../../src/helpers";
 import { createMockVariantAnalysisRepoTask } from "../../../factories/variant-analysis/gh-api/variant-analysis-repo-task";
 import { VariantAnalysisRepoTask } from "../../../../src/variant-analysis/gh-api/variant-analysis";
 import { SortKey } from "../../../../src/pure/variant-analysis-filter-sort";
@@ -47,6 +46,7 @@ import {
   writeRepoStates,
 } from "../../../../src/variant-analysis/repo-states-store";
 import { permissiveFilterSortState } from "../../../unit-tests/variant-analysis-filter-sort.test";
+import { createTimestampFile } from "../../../../src/pure/helpers-pure";
 
 // up to 3 minutes per test
 jest.setTimeout(3 * 60 * 1000);

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/helpers.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/helpers.test.ts
@@ -15,15 +15,7 @@ import {
 import { dump } from "js-yaml";
 import * as tmp from "tmp";
 import { join } from "path";
-import {
-  writeFileSync,
-  mkdirSync,
-  ensureDirSync,
-  symlinkSync,
-  writeFile,
-  mkdir,
-} from "fs-extra";
-import { DirResult } from "tmp";
+import { writeFileSync, mkdirSync, writeFile, mkdir } from "fs-extra";
 
 import {
   getFirstWorkspaceFolder,
@@ -37,7 +29,6 @@ import {
   showBinaryChoiceWithUrlDialog,
   showInformationMessageWithAction,
   showNeverAskAgainDialog,
-  walkDirectory,
 } from "../../../src/helpers";
 import { reportStreamProgress } from "../../../src/common/vscode/progress";
 import { QueryLanguage } from "../../../src/common/query-language";
@@ -575,70 +566,6 @@ describe("helpers", () => {
       const answer = await showNeverAskAgainDialog(title);
       expect(answer).toBe("No, and never ask me again");
     });
-  });
-});
-
-describe("walkDirectory", () => {
-  let tmpDir: DirResult;
-  let dir: string;
-  let dir2: string;
-
-  beforeEach(() => {
-    tmpDir = tmp.dirSync({ unsafeCleanup: true });
-    dir = join(tmpDir.name, "dir");
-    ensureDirSync(dir);
-    dir2 = join(tmpDir.name, "dir2");
-  });
-
-  afterEach(() => {
-    tmpDir.removeCallback();
-  });
-
-  it("should walk a directory", async () => {
-    const file1 = join(dir, "file1");
-    const file2 = join(dir, "file2");
-    const file3 = join(dir, "file3");
-    const dir3 = join(dir, "dir3");
-    const file4 = join(dir, "file4");
-    const file5 = join(dir, "file5");
-    const file6 = join(dir, "file6");
-
-    // These symlinks link back to paths that are already existing, so ignore.
-    const symLinkFile7 = join(dir, "symlink0");
-    const symlinkDir = join(dir2, "symlink1");
-
-    // some symlinks that point outside of the base dir.
-    const file8 = join(tmpDir.name, "file8");
-    const file9 = join(dir2, "file8");
-    const symlinkDir2 = join(dir2, "symlink2");
-    const symlinkFile2 = join(dir2, "symlinkFile3");
-
-    ensureDirSync(dir2);
-    ensureDirSync(dir3);
-
-    writeFileSync(file1, "file1");
-    writeFileSync(file2, "file2");
-    writeFileSync(file3, "file3");
-    writeFileSync(file4, "file4");
-    writeFileSync(file5, "file5");
-    writeFileSync(file6, "file6");
-    writeFileSync(file8, "file8");
-    writeFileSync(file9, "file9");
-
-    // We don't really need to be testing all of these variants of symlinks,
-    // but it doesn't hurt, and will help us if we ever do decide to support them.
-    symlinkSync(file6, symLinkFile7, "file");
-    symlinkSync(dir3, symlinkDir, "dir");
-    symlinkSync(file8, symlinkFile2, "file");
-    symlinkSync(dir2, symlinkDir2, "dir");
-
-    const files = [];
-    for await (const file of walkDirectory(dir)) {
-      files.push(file);
-    }
-
-    // Only real files should be returned.
-    expect(files.sort()).toEqual([file1, file2, file3, file4, file5, file6]);
   });
 });
 

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/variant-analysis-history.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/variant-analysis-history.test.ts
@@ -10,7 +10,7 @@ import { join } from "path";
 
 import { ExtensionContext, Uri } from "vscode";
 import { DatabaseManager } from "../../../../src/databases/local-databases";
-import { tmpDir, walkDirectory } from "../../../../src/helpers";
+import { tmpDir } from "../../../../src/helpers";
 import { DisposableBucket } from "../../disposable-bucket";
 import { testDisposeHandler } from "../../test-dispose-handler";
 import { HistoryItemLabelProvider } from "../../../../src/query-history/history-item-label-provider";
@@ -22,6 +22,7 @@ import { QueryHistoryManager } from "../../../../src/query-history/query-history
 import { mockedObject } from "../../utils/mocking.helpers";
 import { createMockQueryHistoryDirs } from "../../../factories/query-history/query-history-dirs";
 import { createMockApp } from "../../../__mocks__/appMock";
+import { walkDirectory } from "../../../../src/pure/helpers-pure";
 
 // set a higher timeout since recursive delete may take a while, expecially on Windows.
 jest.setTimeout(120000);


### PR DESCRIPTION
The idea here is to pull out functions from `helpers.ts` and into `helpers-pure.ts` where possible and it makes sense. These two functions perform filesystem operations that don't rely on vscode.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
