### PR TITLE
Modify QueryDiscovery to resolve queries by language

### DIFF
--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -135,11 +135,6 @@ export interface SourceInfo {
 }
 
 /**
- * The expected output of `codeql resolve queries`.
- */
-export type ResolvedQueries = string[];
-
-/**
  * The expected output of `codeql resolve tests`.
  */
 export type ResolvedTests = string[];
@@ -734,42 +729,27 @@ export class CodeQLCliServer implements Disposable {
   /**
    * Resolves the language for a query.
    * @param queryUri The URI of the query
+   * @param workspaceFolders All workspace folders, to be used to search for additional packs.
+   * @param silent If true, don't print logs to the CodeQL extension log.
    */
   async resolveQueryByLanguage(
-    workspaces: string[],
     queryUri: Uri,
+    workspaceFolders: string[],
+    silent?: boolean,
   ): Promise<QueryInfoByLanguage> {
     const subcommandArgs = [
       "--format",
       "bylanguage",
       queryUri.fsPath,
-      ...this.getAdditionalPacksArg(workspaces),
+      ...this.getAdditionalPacksArg(workspaceFolders),
     ];
     return JSON.parse(
       await this.runCodeQlCliCommand(
         ["resolve", "queries"],
         subcommandArgs,
         "Resolving query by language",
+        { silent },
       ),
-    );
-  }
-
-  /**
-   * Finds all available queries in a given directory.
-   * @param queryDir Root of directory tree to search for queries.
-   * @param silent If true, don't print logs to the CodeQL extension log.
-   * @returns The list of queries that were found.
-   */
-  public async resolveQueries(
-    queryDir: string,
-    silent?: boolean,
-  ): Promise<ResolvedQueries> {
-    const subcommandArgs = [queryDir];
-    return await this.runJsonCodeQlCliCommand<ResolvedQueries>(
-      ["resolve", "queries"],
-      subcommandArgs,
-      "Resolving queries",
-      { silent },
     );
   }
 

--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -560,8 +560,8 @@ export async function findLanguage(
   if (uri !== undefined) {
     try {
       const queryInfo = await cliServer.resolveQueryByLanguage(
-        getOnDiskWorkspaceFolders(),
         uri,
+        getOnDiskWorkspaceFolders(),
       );
       const language = Object.keys(queryInfo.byLanguage)[0];
       void extLogger.log(`Detected query language: ${language}`);

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/run-cli.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/run-cli.test.ts
@@ -49,16 +49,18 @@ describe("Use cli", () => {
 
   describe("silent logging", () => {
     it("should log command output", async () => {
-      const queryDir = getOnDiskWorkspaceFolders()[0];
-      await cli.resolveQueries(queryDir);
+      const workspaceFolders = getOnDiskWorkspaceFolders();
+      const queryDir = Uri.file(workspaceFolders[0]);
+      await cli.resolveQueryByLanguage(queryDir, workspaceFolders);
 
       expect(logSpy).toHaveBeenCalled();
     });
 
     it("shouldn't log command output if the `silent` flag is set", async () => {
-      const queryDir = getOnDiskWorkspaceFolders()[0];
+      const workspaceFolders = getOnDiskWorkspaceFolders();
+      const queryDir = Uri.file(workspaceFolders[0]);
       const silent = true;
-      await cli.resolveQueries(queryDir, silent);
+      await cli.resolveQueryByLanguage(queryDir, workspaceFolders, silent);
 
       expect(logSpy).not.toHaveBeenCalled();
     });
@@ -87,8 +89,8 @@ describe("Use cli", () => {
   itWithCodeQL()("should resolve query by language", async () => {
     const queryPath = join(__dirname, "data", "simple-javascript-query.ql");
     const queryInfo: QueryInfoByLanguage = await cli.resolveQueryByLanguage(
-      getOnDiskWorkspaceFolders(),
       Uri.file(queryPath),
+      getOnDiskWorkspaceFolders(),
     );
     expect(Object.keys(queryInfo.byLanguage)[0]).toEqual("javascript");
   });


### PR DESCRIPTION
Changes `QueryDiscovery` to pass the `--format=bylanguage` arg to `codeql resolve queries`. This makes it indicate which language each query is for, if that information is known. We're not using this new info yet, but that'll come soon so we want to have the data ready.

The tests proved to be quite fiddly to get right, and creation of mock data is a big clunky. There might be cleaner ways of doing this, and we could look into that if this solution is too awful.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
