### PR TITLE
Handle 429 from auto-model service

### DIFF
--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
@@ -7,6 +7,7 @@ import {
   workspace,
   WorkspaceFolder,
 } from "vscode";
+import { RequestError } from "@octokit/request-error";
 import {
   AbstractWebview,
   WebviewPanelConfig,
@@ -39,7 +40,7 @@ import { createDataExtensionYaml, loadDataExtensionYaml } from "./yaml";
 import { ExternalApiUsage } from "./external-api-usage";
 import { ModeledMethod } from "./modeled-method";
 import { ExtensionPackModelFile } from "./shared/extension-pack";
-import { autoModel } from "./auto-model-api";
+import { autoModel, ModelRequest, ModelResponse } from "./auto-model-api";
 import {
   createAutoModelRequest,
   parsePredictedClassifications,
@@ -421,7 +422,10 @@ export class DataExtensionsEditorView extends AbstractWebview<
       message: "Sending request",
     });
 
-    const response = await autoModel(this.app.credentials, request);
+    const response = await this.callAutoModelApi(request);
+    if (!response) {
+      return;
+    }
 
     await this.showProgress({
       step: 2500,
@@ -478,5 +482,22 @@ export class DataExtensionsEditorView extends AbstractWebview<
       maxStep: 0,
       message: "",
     });
+  }
+
+  private async callAutoModelApi(
+    request: ModelRequest,
+  ): Promise<ModelResponse | null> {
+    try {
+      return await autoModel(this.app.credentials, request);
+    } catch (e) {
+      if (e instanceof RequestError && e.status === 429) {
+        void showAndLogExceptionWithTelemetry(
+          redactableError(e)`Rate limit hit, please try again soon.`,
+        );
+        return null;
+      } else {
+        throw e;
+      }
+    }
   }
 }

--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
@@ -490,6 +490,8 @@ export class DataExtensionsEditorView extends AbstractWebview<
     try {
       return await autoModel(this.app.credentials, request);
     } catch (e) {
+      await this.clearProgress();
+
       if (e instanceof RequestError && e.status === 429) {
         void showAndLogExceptionWithTelemetry(
           redactableError(e)`Rate limit hit, please try again soon.`,


### PR DESCRIPTION
Shows a slightly more helpful message when we receive 429s from the auto-model endpoint.

## Checklist
N/A - internal only:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
