### PR TITLE
Add quick eval count to the command palette

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [UNRELEASED]
 
+- Add `CodeQL: Quick Evaluation Count` command to generate the count summary statistics of the results set
+  without speding the time to compute locations and strings.
+
 ## 1.8.6 - 14 June 2023
 
 - Add repositories to a variant analysis list with GitHub Code Search. [#2439](https://github.com/github/vscode-codeql/pull/2439) and [#2476](https://github.com/github/vscode-codeql/pull/2476)
@@ -14,9 +17,6 @@
 - Update text of copy and export buttons in variant analysis results view to clarify that they only copy/export the selected/filtered results. [#2427](https://github.com/github/vscode-codeql/pull/2427)
 - Add warning when using unsupported CodeQL CLI version. [#2428](https://github.com/github/vscode-codeql/pull/2428)
 - Retry variant analysis results download if connection times out. [#2440](https://github.com/github/vscode-codeql/pull/2440)
-- Add `CodeQL: Quick Evaluation Count` command to generate the count of the selected item without having to compute locations or strings.
-- Add `CodeQL: Quick Evaluation Count` command to generate the count summary statistics of the results set
-  without speding the time to compute locations and strings.
 
 ## 1.8.4 - 3 May 2023
 

--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Update text of copy and export buttons in variant analysis results view to clarify that they only copy/export the selected/filtered results. [#2427](https://github.com/github/vscode-codeql/pull/2427)
 - Add warning when using unsupported CodeQL CLI version. [#2428](https://github.com/github/vscode-codeql/pull/2428)
 - Retry variant analysis results download if connection times out. [#2440](https://github.com/github/vscode-codeql/pull/2440)
+- Add `CodeQL: Quick Evaluation Count` command to generate the count of the selected item without having to compute locations or strings.
 
 ## 1.8.4 - 3 May 2023
 

--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -15,6 +15,8 @@
 - Add warning when using unsupported CodeQL CLI version. [#2428](https://github.com/github/vscode-codeql/pull/2428)
 - Retry variant analysis results download if connection times out. [#2440](https://github.com/github/vscode-codeql/pull/2440)
 - Add `CodeQL: Quick Evaluation Count` command to generate the count of the selected item without having to compute locations or strings.
+- Add `CodeQL: Quick Evaluation Count` command to generate the count summary statistics of the results set
+  without speding the time to compute locations and strings.
 
 ## 1.8.4 - 3 May 2023
 

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -458,6 +458,10 @@
         "title": "CodeQL: Quick Evaluation"
       },
       {
+        "command": "codeQL.quickEvalCount",
+        "title": "CodeQL: Quick Evaluation Count"
+      },
+      {
         "command": "codeQL.quickEvalContextEditor",
         "title": "CodeQL: Quick Evaluation"
       },
@@ -1219,6 +1223,10 @@
         {
           "command": "codeQL.quickEval",
           "when": "editorLangId == ql"
+        },
+        {
+          "command": "codeQL.quickEvalCount",
+          "when": "editorLangId == ql && codeql.supportsQuickEvalCount"
         },
         {
           "command": "codeQL.quickEvalContextEditor",

--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -1483,6 +1483,13 @@ export class CodeQLCliServer implements Disposable {
             CliVersionConstraint.CLI_VERSION_WITH_PER_QUERY_EVAL_LOG,
           ) >= 0,
         );
+        await this.app.commands.execute(
+          "setContext",
+          "codeql.supportsQuickEvalCount",
+          newVersion.compare(
+            CliVersionConstraint.CLI_VERSION_WITH_QUICK_EVAL_COUNT,
+          ) >= 0,
+        );
       } catch (e) {
         this._versionChangedListeners.forEach((listener) =>
           listener(undefined),

--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -1845,6 +1845,11 @@ export class CliVersionConstraint {
 
   public static CLI_VERSION_GLOBAL_CACHE = new SemVer("2.12.4");
 
+  /**
+   * CLI version where the query server supports quick-eval count mode.
+   */
+  public static CLI_VERSION_WITH_QUICK_EVAL_COUNT = new SemVer("2.13.3");
+
   constructor(private readonly cli: CodeQLCliServer) {
     /**/
   }
@@ -1917,5 +1922,11 @@ export class CliVersionConstraint {
 
   async usesGlobalCompilationCache() {
     return this.isVersionAtLeast(CliVersionConstraint.CLI_VERSION_GLOBAL_CACHE);
+  }
+
+  async supportsQuickEvalCount() {
+    return this.isVersionAtLeast(
+      CliVersionConstraint.CLI_VERSION_WITH_QUICK_EVAL_COUNT,
+    );
   }
 }

--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -133,6 +133,7 @@ export type LocalQueryCommands = {
   "codeQLQueries.runLocalQueryFromQueriesPanel": TreeViewContextSingleSelectionCommandFunction<QueryTreeViewItem>;
   "codeQL.runQueries": ExplorerSelectionCommandFunction<Uri>;
   "codeQL.quickEval": (uri: Uri) => Promise<void>;
+  "codeQL.quickEvalCount": (uri: Uri) => Promise<void>;
   "codeQL.quickEvalContextEditor": (uri: Uri) => Promise<void>;
   "codeQL.codeLensQuickEval": (uri: Uri, range: Range) => Promise<void>;
   "codeQL.quickQuery": () => Promise<void>;

--- a/extensions/ql-vscode/src/local-queries/local-queries.ts
+++ b/extensions/ql-vscode/src/local-queries/local-queries.ts
@@ -40,7 +40,7 @@ import {
 import { CompletedLocalQueryInfo, LocalQueryInfo } from "../query-results";
 import { WebviewReveal } from "./webview";
 import { asError, getErrorMessage } from "../common/helpers-pure";
-import { CodeQLCliServer } from "../codeql-cli/cli";
+import { CliVersionConstraint, CodeQLCliServer } from "../codeql-cli/cli";
 import { LocalQueryCommands } from "../common/commands";
 import { App } from "../common/app";
 import { DisposableObject } from "../common/disposable-object";
@@ -246,7 +246,7 @@ export class LocalQueries extends DisposableObject {
       async (progress, token) => {
         if (!(await this.cliServer.cliConstraints.supportsQuickEvalCount())) {
           throw new Error(
-            "Quick evaluation counts is not supported by this version of CodeQL CLI.",
+            `Quick evaluation count is only supported by CodeQL CLI v${CliVersionConstraint.CLI_VERSION_WITH_QUICK_EVAL_COUNT} or later.`,
           );
         }
         await this.compileAndRunQuery(

--- a/extensions/ql-vscode/src/local-queries/local-queries.ts
+++ b/extensions/ql-vscode/src/local-queries/local-queries.ts
@@ -107,6 +107,7 @@ export class LocalQueries extends DisposableObject {
         this.runQueries.bind(this),
       ),
       "codeQL.quickEval": this.quickEval.bind(this),
+      "codeQL.quickEvalCount": this.quickEvalCount.bind(this),
       "codeQL.quickEvalContextEditor": this.quickEval.bind(this),
       "codeQL.codeLensQuickEval": this.codeLensQuickEval.bind(this),
       "codeQL.quickQuery": this.quickQuery.bind(this),
@@ -227,6 +228,29 @@ export class LocalQueries extends DisposableObject {
       async (progress, token) => {
         await this.compileAndRunQuery(
           QuickEvalType.QuickEval,
+          uri,
+          progress,
+          token,
+          undefined,
+        );
+      },
+      {
+        title: "Running query",
+        cancellable: true,
+      },
+    );
+  }
+
+  private async quickEvalCount(uri: Uri): Promise<void> {
+    await withProgress(
+      async (progress, token) => {
+        if (!(await this.cliServer.cliConstraints.supportsQuickEvalCount())) {
+          throw new Error(
+            "Quick evaluation counts is not supported by this version of CodeQL CLI.",
+          );
+        }
+        await this.compileAndRunQuery(
+          QuickEvalType.QuickEvalCount,
           uri,
           progress,
           token,

--- a/extensions/ql-vscode/src/query-results.ts
+++ b/extensions/ql-vscode/src/query-results.ts
@@ -41,6 +41,7 @@ export interface InitialQueryInfo {
   readonly queryText: string; // text of the selected file, or the selected text when doing quick eval
   readonly isQuickQuery: boolean;
   readonly isQuickEval: boolean;
+  readonly isQuickEvalCount?: boolean; // Missing is false for backwards compatibility
   readonly quickEvalPosition?: messages.Position;
   readonly queryPath: string;
   readonly databaseInfo: DatabaseInfo;
@@ -270,7 +271,9 @@ export class LocalQueryInfo {
    * - Otherwise, return the query file name.
    */
   getQueryName() {
-    if (this.initialInfo.quickEvalPosition) {
+    if (this.initialInfo.isQuickEvalCount) {
+      return `Quick evaluation counts of ${this.getQueryFileName()}`;
+    } else if (this.initialInfo.isQuickEval) {
       return `Quick evaluation of ${this.getQueryFileName()}`;
     } else if (this.completedQuery?.query.metadata?.name) {
       return this.completedQuery?.query.metadata?.name;

--- a/extensions/ql-vscode/src/run-queries-shared.ts
+++ b/extensions/ql-vscode/src/run-queries-shared.ts
@@ -585,9 +585,12 @@ export async function createInitialQueryInfo(
   databaseInfo: DatabaseInfo,
 ): Promise<InitialQueryInfo> {
   const isQuickEval = selectedQuery.quickEval !== undefined;
+  const isQuickEvalCount =
+    selectedQuery.quickEval?.quickEvalCount !== undefined;
   return {
     queryPath: selectedQuery.queryPath,
     isQuickEval,
+    isQuickEvalCount,
     isQuickQuery: isQuickQueryPath(selectedQuery.queryPath),
     databaseInfo,
     id: `${basename(selectedQuery.queryPath)}-${nanoid()}`,

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-results.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-results.test.ts
@@ -58,6 +58,7 @@ describe("query-results", () => {
         endLine: 2,
         fileName: "/home/users/yz",
       };
+      (fqi.initialInfo as any).isQuickEval = true;
       expect(fqi.getQueryName()).toBe("Quick evaluation of yz:1-2");
       (fqi.initialInfo as any).quickEvalPosition.endLine = 1;
       expect(fqi.getQueryName()).toBe("Quick evaluation of yz:1");


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

This allows using quick-eval-count via the command palette. Quick eval count generates column counts and overall count of the results instead of generating locations and strings. As generating locations and strings can be expensive and the number of results is often more useful this can shave time off debugging complex queries. As this is fairly advanced and to avoid cluttering the context menu I have not added a context menu. We can revisit this in future.

@dbartol I am leaving it to you to decide how to integrate this into the debugging workflow. This should probably be treated like a quick-eval option there.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
