### PR TITLE
Code search: use code search api

### DIFF
--- a/extensions/ql-vscode/src/databases/code-search-api.ts
+++ b/extensions/ql-vscode/src/databases/code-search-api.ts
@@ -1,0 +1,70 @@
+import { retry } from "@octokit/plugin-retry";
+import { throttling } from "@octokit/plugin-throttling";
+import { Octokit } from "@octokit/rest";
+import { Progress, CancellationToken } from "vscode";
+import { showAndLogWarningMessage } from "../helpers";
+import { Credentials } from "../common/authentication";
+
+export async function getCodeSearchRepositories(
+  query: string,
+  progress: Progress<{
+    message?: string | undefined;
+    increment?: number | undefined;
+  }>,
+  token: CancellationToken,
+  credentials: Credentials,
+): Promise<string[]> {
+  let nwos: string[] = [];
+  const octokit = await provideOctokitWithThrottling(credentials);
+
+  for await (const response of octokit.paginate.iterator(
+    octokit.rest.search.code,
+    {
+      q: query,
+      per_page: 100,
+    },
+  )) {
+    nwos.push(...response.data.map((item) => item.repository.full_name));
+    // calculate progress bar: 80% of the progress bar is used for the code search
+    const totalNumberOfRequests = Math.ceil(response.data.total_count / 100);
+    // Since we have a maximum of 1000 responses of the api, we can use a fixed increment whenever the totalNumberOfRequests would be greater than 10
+    const increment =
+      totalNumberOfRequests < 10 ? 80 / totalNumberOfRequests : 8;
+    progress.report({ increment });
+
+    if (token.isCancellationRequested) {
+      nwos = [];
+      break;
+    }
+  }
+
+  return [...new Set(nwos)];
+}
+
+async function provideOctokitWithThrottling(
+  credentials: Credentials,
+): Promise<Octokit> {
+  const MyOctokit = Octokit.plugin(throttling);
+  const auth = await credentials.getAccessToken();
+
+  const octokit = new MyOctokit({
+    auth,
+    retry,
+    throttle: {
+      onRateLimit: (retryAfter: number, options: any): boolean => {
+        void showAndLogWarningMessage(
+          `Request quota exhausted for request ${options.method} ${options.url}. Retrying after ${retryAfter} seconds!`,
+        );
+
+        return true;
+      },
+      onSecondaryRateLimit: (_retryAfter: number, options: any): void => {
+        void showAndLogWarningMessage(
+          `SecondaryRateLimit detected for request ${options.method} ${options.url}`,
+        );
+      },
+    },
+  });
+
+  return octokit;
+}

--- a/extensions/ql-vscode/src/databases/code-search-api.ts
+++ b/extensions/ql-vscode/src/databases/code-search-api.ts
@@ -53,14 +53,14 @@ async function provideOctokitWithThrottling(
     throttle: {
       onRateLimit: (retryAfter: number, options: any): boolean => {
         void showAndLogWarningMessage(
-          `Request quota exhausted for request ${options.method} ${options.url}. Retrying after ${retryAfter} seconds!`,
+          `Rate Limit detected for request ${options.method} ${options.url}. Retrying after ${retryAfter} seconds!`,
         );
 
         return true;
       },
       onSecondaryRateLimit: (_retryAfter: number, options: any): void => {
         void showAndLogWarningMessage(
-          `SecondaryRateLimit detected for request ${options.method} ${options.url}`,
+          `Secondary Rate Limit detected for request ${options.method} ${options.url}`,
         );
       },
     },

--- a/extensions/ql-vscode/src/databases/ui/db-panel.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-panel.ts
@@ -351,13 +351,19 @@ export class DbPanel extends DisposableObject {
 
     const listName = treeViewItem.dbItem.listName;
 
-    const languageQuickPickItems: CodeSearchQuickPickItem[] = Object.values(
-      QueryLanguage,
-    ).map((language) => ({
-      label: language.toString(),
-      alwaysShow: true,
-      language: language.toString(),
-    }));
+    const languageQuickPickItems: CodeSearchQuickPickItem[] = [
+      {
+        label: "No specific language",
+        alwaysShow: true,
+        language: "",
+      },
+    ].concat(
+      Object.values(QueryLanguage).map((language) => ({
+        label: language.toString(),
+        alwaysShow: true,
+        language: language.toString(),
+      })),
+    );
 
     const codeSearchLanguage =
       await window.showQuickPick<CodeSearchQuickPickItem>(
@@ -371,6 +377,10 @@ export class DbPanel extends DisposableObject {
     if (!codeSearchLanguage) {
       return;
     }
+
+    const languagePrompt = codeSearchLanguage.language
+      ? `language:${codeSearchLanguage.language}`
+      : "";
 
     const codeSearchQuery = await window.showInputBox({
       title: "GitHub Code Search",
@@ -393,7 +403,7 @@ export class DbPanel extends DisposableObject {
 
         const repositories = await getCodeSearchRepositories(
           this.app.credentials,
-          `${codeSearchQuery} language:${codeSearchLanguage.language}`,
+          `${codeSearchQuery} ${languagePrompt}`,
           progress,
           token,
         );

--- a/extensions/ql-vscode/src/variant-analysis/gh-api/gh-api-client.ts
+++ b/extensions/ql-vscode/src/variant-analysis/gh-api/gh-api-client.ts
@@ -9,40 +9,18 @@ import {
 import { Repository } from "./repository";
 import { Progress } from "vscode";
 import { CancellationToken } from "vscode-jsonrpc";
-import { throttling } from "@octokit/plugin-throttling";
 import { Octokit } from "@octokit/rest";
-import { showAndLogWarningMessage } from "../../helpers";
 
 export async function getCodeSearchRepositories(
-  credentials: Credentials,
   query: string,
   progress: Progress<{
     message?: string | undefined;
     increment?: number | undefined;
   }>,
   token: CancellationToken,
+  octokit: Octokit,
 ): Promise<string[]> {
   let nwos: string[] = [];
-  const MyOctokit = Octokit.plugin(throttling);
-  const auth = await credentials.getAccessToken();
-
-  const octokit = new MyOctokit({
-    auth,
-    throttle: {
-      onRateLimit: (retryAfter: number, options: any): boolean => {
-        void showAndLogWarningMessage(
-          `Request quota exhausted for request ${options.method} ${options.url}. Retrying after ${retryAfter} seconds!`,
-        );
-
-        return true;
-      },
-      onSecondaryRateLimit: (_retryAfter: number, options: any): void => {
-        void showAndLogWarningMessage(
-          `SecondaryRateLimit detected for request ${options.method} ${options.url}`,
-        );
-      },
-    },
-  });
 
   for await (const response of octokit.paginate.iterator(
     octokit.rest.search.code,

--- a/extensions/ql-vscode/src/variant-analysis/gh-api/gh-api-client.ts
+++ b/extensions/ql-vscode/src/variant-analysis/gh-api/gh-api-client.ts
@@ -7,44 +7,6 @@ import {
   VariantAnalysisSubmissionRequest,
 } from "./variant-analysis";
 import { Repository } from "./repository";
-import { Progress } from "vscode";
-import { CancellationToken } from "vscode-jsonrpc";
-import { Octokit } from "@octokit/rest";
-
-export async function getCodeSearchRepositories(
-  query: string,
-  progress: Progress<{
-    message?: string | undefined;
-    increment?: number | undefined;
-  }>,
-  token: CancellationToken,
-  octokit: Octokit,
-): Promise<string[]> {
-  let nwos: string[] = [];
-
-  for await (const response of octokit.paginate.iterator(
-    octokit.rest.search.code,
-    {
-      q: query,
-      per_page: 100,
-    },
-  )) {
-    nwos.push(...response.data.map((item) => item.repository.full_name));
-    // calculate progress bar: 80% of the progress bar is used for the code search
-    const totalNumberOfRequests = Math.ceil(response.data.total_count / 100);
-    // Since we have a maximum of 1000 responses of the api, we can use a fixed increment whenever the totalNumberOfRequests would be greater than 10
-    const increment =
-      totalNumberOfRequests < 10 ? 80 / totalNumberOfRequests : 8;
-    progress.report({ increment });
-
-    if (token.isCancellationRequested) {
-      nwos = [];
-      break;
-    }
-  }
-
-  return [...new Set(nwos)];
-}
 
 export async function submitVariantAnalysis(
   credentials: Credentials,

--- a/extensions/ql-vscode/src/variant-analysis/gh-api/gh-api-client.ts
+++ b/extensions/ql-vscode/src/variant-analysis/gh-api/gh-api-client.ts
@@ -9,6 +9,8 @@ import {
 import { Repository } from "./repository";
 import { Progress } from "vscode";
 import { CancellationToken } from "vscode-jsonrpc";
+import { throttling } from "@octokit/plugin-throttling";
+import { Octokit } from "@octokit/rest";
 
 export async function getCodeSearchRepositories(
   credentials: Credentials,
@@ -20,18 +22,46 @@ export async function getCodeSearchRepositories(
   token: CancellationToken,
 ): Promise<string[]> {
   let nwos: string[] = [];
-  const octokit = await credentials.getOctokit();
+  const MyOctokit = Octokit.plugin(throttling);
+  const auth = await credentials.getAccessToken();
+
+  const octokit = new MyOctokit({
+    auth,
+    throttle: {
+      onRateLimit: (
+        retryAfter: number,
+        options: any,
+        octokit: Octokit,
+      ): boolean => {
+        octokit.log.warn(
+          `Request quota exhausted for request ${options.method} ${options.url}. Retrying after ${retryAfter} seconds!`,
+        );
+
+        return true;
+      },
+      onSecondaryRateLimit: (
+        _retryAfter: number,
+        options: any,
+        octokit: Octokit,
+      ): void => {
+        octokit.log.warn(
+          `SecondaryRateLimit detected for request ${options.method} ${options.url}`,
+        );
+      },
+    },
+  });
+
   for await (const response of octokit.paginate.iterator(
-    octokit.rest.search.repos,
+    octokit.rest.search.code,
     {
       q: query,
       per_page: 100,
     },
   )) {
-    nwos.push(...response.data.map((item) => item.full_name));
+    nwos.push(...response.data.map((item) => item.repository.full_name));
     // calculate progress bar: 80% of the progress bar is used for the code search
     const totalNumberOfRequests = Math.ceil(response.data.total_count / 100);
-    // Since we have a maximum 10 of requests, we use a fixed increment whenever the totalNumberOfRequests is greater than 10
+    // Since we have a maximum of 1000 responses of the api, we can use a fixed increment whenever the totalNumberOfRequests would be greater than 10
     const increment =
       totalNumberOfRequests < 10 ? 80 / totalNumberOfRequests : 8;
     progress.report({ increment });

--- a/extensions/ql-vscode/src/variant-analysis/gh-api/gh-api-client.ts
+++ b/extensions/ql-vscode/src/variant-analysis/gh-api/gh-api-client.ts
@@ -11,6 +11,7 @@ import { Progress } from "vscode";
 import { CancellationToken } from "vscode-jsonrpc";
 import { throttling } from "@octokit/plugin-throttling";
 import { Octokit } from "@octokit/rest";
+import { showAndLogWarningMessage } from "../../helpers";
 
 export async function getCodeSearchRepositories(
   credentials: Credentials,
@@ -28,23 +29,15 @@ export async function getCodeSearchRepositories(
   const octokit = new MyOctokit({
     auth,
     throttle: {
-      onRateLimit: (
-        retryAfter: number,
-        options: any,
-        octokit: Octokit,
-      ): boolean => {
-        octokit.log.warn(
+      onRateLimit: (retryAfter: number, options: any): boolean => {
+        void showAndLogWarningMessage(
           `Request quota exhausted for request ${options.method} ${options.url}. Retrying after ${retryAfter} seconds!`,
         );
 
         return true;
       },
-      onSecondaryRateLimit: (
-        _retryAfter: number,
-        options: any,
-        octokit: Octokit,
-      ): void => {
-        octokit.log.warn(
+      onSecondaryRateLimit: (_retryAfter: number, options: any): void => {
+        void showAndLogWarningMessage(
           `SecondaryRateLimit detected for request ${options.method} ${options.url}`,
         );
       },


### PR DESCRIPTION
Instead of using repo search we want to use the code search api for this feature. Since the search api returns an error if two language parameters are added we made the entry of a language through the UI optional.

Items:
- uses correct api
- implements throttling
- makes 'no language' available

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
