### PR TITLE
Only allow scoped extension pack names

### DIFF
--- a/extensions/ql-vscode/src/data-extensions-editor/extension-pack-picker.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/extension-pack-picker.ts
@@ -19,7 +19,7 @@ const maxStep = 3;
 
 const packNamePartRegex = /[a-z0-9](?:[a-z0-9-]*[a-z0-9])?/;
 const packNameRegex = new RegExp(
-  `^(?:(?<scope>${packNamePartRegex.source})/)?(?<name>${packNamePartRegex.source})$`,
+  `^(?<scope>${packNamePartRegex.source})/(?<name>${packNamePartRegex.source})$`,
 );
 const packNameLength = 128;
 
@@ -246,11 +246,16 @@ async function pickNewExtensionPack(
     return undefined;
   }
 
+  let examplePackName = `${databaseItem.name}-extensions`;
+  if (!examplePackName.includes("/")) {
+    examplePackName = `pack/${examplePackName}`;
+  }
+
   const packName = await window.showInputBox(
     {
       title: "Create new extension pack",
       prompt: "Enter name of extension pack",
-      placeHolder: `e.g. ${databaseItem.name}-extensions`,
+      placeHolder: `e.g. ${examplePackName}`,
       validateInput: async (value: string): Promise<string | undefined> => {
         if (!value) {
           return "Pack name must not be empty";
@@ -262,6 +267,10 @@ async function pickNewExtensionPack(
 
         const matches = packNameRegex.exec(value);
         if (!matches?.groups) {
+          if (!value.includes("/")) {
+            return "Invalid package name: a pack name must contain a slash to separate the scope from the pack name";
+          }
+
           return "Invalid package name: a pack name must contain only lowercase ASCII letters, ASCII digits, and hyphens";
         }
 
@@ -296,7 +305,7 @@ async function pickNewExtensionPack(
   const extensionPack: ExtensionPack = {
     path: packPath,
     yamlPath: packYamlPath,
-    name,
+    name: packName,
     version: "0.0.0",
     extensionTargets: {
       [`codeql/${databaseItem.language}-all`]: "*",

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/data-extensions-editor/extension-pack-picker.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/data-extensions-editor/extension-pack-picker.test.ts
@@ -232,7 +232,7 @@ describe("pickExtensionPackModelFile", () => {
       label: "codeql-custom-queries-java",
       path: tmpDir.path,
     } as QuickPickItem);
-    showInputBoxSpy.mockResolvedValueOnce("new-extension-pack");
+    showInputBoxSpy.mockResolvedValueOnce("pack/new-extension-pack");
     showInputBoxSpy.mockResolvedValue("models/my-model.yml");
 
     expect(
@@ -247,7 +247,7 @@ describe("pickExtensionPackModelFile", () => {
       extensionPack: {
         path: newPackDir,
         yamlPath: join(newPackDir, "codeql-pack.yml"),
-        name: "new-extension-pack",
+        name: "pack/new-extension-pack",
         version: "0.0.0",
         extensionTargets: {
           "codeql/java-all": "*",
@@ -280,7 +280,7 @@ describe("pickExtensionPackModelFile", () => {
     expect(
       loadYaml(await readFile(join(newPackDir, "codeql-pack.yml"), "utf8")),
     ).toEqual({
-      name: "new-extension-pack",
+      name: "pack/new-extension-pack",
       version: "0.0.0",
       library: true,
       extensionTargets: {
@@ -303,7 +303,7 @@ describe("pickExtensionPackModelFile", () => {
       label: "codeql-custom-queries-java",
       path: tmpDir.path,
     } as QuickPickItem);
-    showInputBoxSpy.mockResolvedValueOnce("new-extension-pack");
+    showInputBoxSpy.mockResolvedValueOnce("pack/new-extension-pack");
     showInputBoxSpy.mockResolvedValue("models/my-model.yml");
 
     expect(
@@ -321,7 +321,7 @@ describe("pickExtensionPackModelFile", () => {
       extensionPack: {
         path: newPackDir,
         yamlPath: join(newPackDir, "codeql-pack.yml"),
-        name: "new-extension-pack",
+        name: "pack/new-extension-pack",
         version: "0.0.0",
         extensionTargets: {
           "codeql/csharp-all": "*",
@@ -354,7 +354,7 @@ describe("pickExtensionPackModelFile", () => {
     expect(
       loadYaml(await readFile(join(newPackDir, "codeql-pack.yml"), "utf8")),
     ).toEqual({
-      name: "new-extension-pack",
+      name: "pack/new-extension-pack",
       version: "0.0.0",
       library: true,
       extensionTargets: {
@@ -806,6 +806,12 @@ describe("pickExtensionPackModelFile", () => {
       "Invalid package name: a pack name must contain only lowercase ASCII letters, ASCII digits, and hyphens",
     );
     expect(await validateFile("VSCODE")).toEqual(
+      "Invalid package name: a pack name must contain a slash to separate the scope from the pack name",
+    );
+    expect(await validateFile("github/")).toEqual(
+      "Invalid package name: a pack name must contain only lowercase ASCII letters, ASCII digits, and hyphens",
+    );
+    expect(await validateFile("github/VSCODE")).toEqual(
       "Invalid package name: a pack name must contain only lowercase ASCII letters, ASCII digits, and hyphens",
     );
     expect(await validateFile("github/vscode-codeql-")).toEqual(
@@ -814,7 +820,7 @@ describe("pickExtensionPackModelFile", () => {
     expect(
       await validateFile("github/vscode-codeql-extensions"),
     ).toBeUndefined();
-    expect(await validateFile("vscode-codeql-extensions")).toBeUndefined();
+    expect(await validateFile("pack/vscode-codeql-extensions")).toBeUndefined();
   });
 
   it("validates the file input", async () => {


### PR DESCRIPTION
When packaging an extension pack, unscoped extension pack names are not allowed and calling `codeql pack bundle` will fail with an error. This command will be called when running a variant analysis, so these packs will not work for a variant analysis.

To improve the user experience, we now only allow scoped extension pack names. This means that the user will now have to enter a scope when creating a new extension pack.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
