### PR TITLE
Add EnvironmentContext so common code can do localisation

### DIFF
--- a/extensions/ql-vscode/src/common/app.ts
+++ b/extensions/ql-vscode/src/common/app.ts
@@ -23,10 +23,15 @@ export interface App {
   readonly onDidChangeWorkspaceFolders: Event<WorkspaceFoldersChangeEvent>;
   readonly credentials: Credentials;
   readonly commands: AppCommandManager;
+  readonly environment: EnvironmentContext;
 }
 
 export enum AppMode {
   Production = 1,
   Development = 2,
   Test = 3,
+}
+
+export interface EnvironmentContext {
+  language: string;
 }

--- a/extensions/ql-vscode/src/common/file-tree-nodes.ts
+++ b/extensions/ql-vscode/src/common/file-tree-nodes.ts
@@ -1,5 +1,5 @@
 import { basename, dirname, join } from "path";
-import { env } from "vscode";
+import { EnvironmentContext } from "./app";
 
 /**
  * A node in the tree of files. This will be either a `FileTreeDirectory` or a `FileTreeLeaf`.
@@ -35,6 +35,7 @@ export class FileTreeDirectory<T = undefined> extends FileTreeNode<T> {
   constructor(
     _path: string,
     _name: string,
+    protected readonly env: EnvironmentContext,
     private _children: Array<FileTreeNode<T>> = [],
   ) {
     super(_path, _name);
@@ -66,7 +67,9 @@ export class FileTreeDirectory<T = undefined> extends FileTreeNode<T> {
     this._children.filter(
       (child) => child instanceof FileTreeLeaf || child.children.length > 0,
     );
-    this._children.sort((a, b) => a.name.localeCompare(b.name, env.language));
+    this._children.sort((a, b) =>
+      a.name.localeCompare(b.name, this.env.language),
+    );
     this._children.forEach((child, i) => {
       child.finish();
       if (
@@ -77,6 +80,7 @@ export class FileTreeDirectory<T = undefined> extends FileTreeNode<T> {
         const replacement = new FileTreeDirectory<T>(
           child.children[0].path,
           `${child.name} / ${child.children[0].name}`,
+          this.env,
           Array.from(child.children[0].children),
         );
         this._children[i] = replacement;
@@ -89,7 +93,11 @@ export class FileTreeDirectory<T = undefined> extends FileTreeNode<T> {
     if (existingChild !== undefined) {
       return existingChild as FileTreeDirectory<T>;
     } else {
-      const newChild = new FileTreeDirectory<T>(join(this.path, name), name);
+      const newChild = new FileTreeDirectory<T>(
+        join(this.path, name),
+        name,
+        this.env,
+      );
       this.addChild(newChild);
       return newChild;
     }

--- a/extensions/ql-vscode/src/common/vscode/environment-context.ts
+++ b/extensions/ql-vscode/src/common/vscode/environment-context.ts
@@ -1,0 +1,8 @@
+import { env } from "vscode";
+import { EnvironmentContext } from "../app";
+
+export class AppEnvironmentContext implements EnvironmentContext {
+  public get language(): string {
+    return env.language;
+  }
+}

--- a/extensions/ql-vscode/src/common/vscode/vscode-app.ts
+++ b/extensions/ql-vscode/src/common/vscode/vscode-app.ts
@@ -8,6 +8,7 @@ import { Memento } from "../memento";
 import { VSCodeAppEventEmitter } from "./events";
 import { AppCommandManager, QueryServerCommandManager } from "../commands";
 import { createVSCodeCommandManager } from "./commands";
+import { AppEnvironmentContext } from "./environment-context";
 
 export class ExtensionApp implements App {
   public readonly credentials: VSCodeCredentials;
@@ -71,8 +72,6 @@ export class ExtensionApp implements App {
   }
 
   public get environment(): EnvironmentContext {
-    return {
-      language: vscode.env.language,
-    };
+    return new AppEnvironmentContext();
   }
 }

--- a/extensions/ql-vscode/src/common/vscode/vscode-app.ts
+++ b/extensions/ql-vscode/src/common/vscode/vscode-app.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import { VSCodeCredentials } from "./authentication";
 import { Disposable } from "../../pure/disposable-object";
-import { App, AppMode } from "../app";
+import { App, AppMode, EnvironmentContext } from "../app";
 import { AppEventEmitter } from "../events";
 import { extLogger, Logger, queryServerLogger } from "../logging";
 import { Memento } from "../memento";
@@ -68,5 +68,11 @@ export class ExtensionApp implements App {
 
   public createEventEmitter<T>(): AppEventEmitter<T> {
     return new VSCodeAppEventEmitter<T>();
+  }
+
+  public get environment(): EnvironmentContext {
+    return {
+      language: vscode.env.language,
+    };
   }
 }

--- a/extensions/ql-vscode/src/queries-panel/query-discovery.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-discovery.ts
@@ -1,7 +1,7 @@
 import { dirname, basename, normalize, relative } from "path";
 import { Discovery } from "../common/discovery";
 import { CodeQLCliServer } from "../codeql-cli/cli";
-import { Event, RelativePattern, Uri, WorkspaceFolder } from "vscode";
+import { Event, RelativePattern, Uri, WorkspaceFolder, env } from "vscode";
 import { MultiFileSystemWatcher } from "../common/vscode/multi-file-system-watcher";
 import { App } from "../common/app";
 import { FileTreeDirectory, FileTreeLeaf } from "../common/file-tree-nodes";
@@ -124,7 +124,7 @@ export class QueryDiscovery
       return undefined;
     }
 
-    const rootDirectory = new FileTreeDirectory<string>(fullPath, name);
+    const rootDirectory = new FileTreeDirectory<string>(fullPath, name, env);
     for (const queryPath of resolvedQueries) {
       const relativePath = normalize(relative(fullPath, queryPath));
       const dirName = dirname(relativePath);

--- a/extensions/ql-vscode/src/queries-panel/query-discovery.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-discovery.ts
@@ -1,7 +1,7 @@
 import { dirname, basename, normalize, relative } from "path";
 import { Discovery } from "../common/discovery";
 import { CodeQLCliServer } from "../codeql-cli/cli";
-import { Event, RelativePattern, Uri, WorkspaceFolder, env } from "vscode";
+import { Event, RelativePattern, Uri, WorkspaceFolder } from "vscode";
 import { MultiFileSystemWatcher } from "../common/vscode/multi-file-system-watcher";
 import { App } from "../common/app";
 import { FileTreeDirectory, FileTreeLeaf } from "../common/file-tree-nodes";
@@ -41,7 +41,10 @@ export class QueryDiscovery
     new MultiFileSystemWatcher(),
   );
 
-  constructor(app: App, private readonly cliServer: CodeQLCliServer) {
+  constructor(
+    private readonly app: App,
+    private readonly cliServer: CodeQLCliServer,
+  ) {
     super("Query Discovery", extLogger);
 
     this.onDidChangeQueriesEmitter = this.push(app.createEventEmitter<void>());
@@ -124,7 +127,11 @@ export class QueryDiscovery
       return undefined;
     }
 
-    const rootDirectory = new FileTreeDirectory<string>(fullPath, name, env);
+    const rootDirectory = new FileTreeDirectory<string>(
+      fullPath,
+      name,
+      this.app.environment,
+    );
     for (const queryPath of resolvedQueries) {
       const relativePath = normalize(relative(fullPath, queryPath));
       const dirName = dirname(relativePath);

--- a/extensions/ql-vscode/src/query-testing/qltest-discovery.ts
+++ b/extensions/ql-vscode/src/query-testing/qltest-discovery.ts
@@ -6,6 +6,7 @@ import {
   Uri,
   RelativePattern,
   WorkspaceFolder,
+  env,
 } from "vscode";
 import { MultiFileSystemWatcher } from "../common/vscode/multi-file-system-watcher";
 import { CodeQLCliServer } from "../codeql-cli/cli";
@@ -97,7 +98,7 @@ export class QLTestDiscovery extends Discovery<QLTestDiscoveryResults> {
   private async discoverTests(): Promise<FileTreeDirectory> {
     const fullPath = this.workspaceFolder.uri.fsPath;
     const name = this.workspaceFolder.name;
-    const rootDirectory = new FileTreeDirectory(fullPath, name);
+    const rootDirectory = new FileTreeDirectory(fullPath, name, env);
 
     // Don't try discovery on workspace folders that don't exist on the filesystem
     if (await pathExists(fullPath)) {

--- a/extensions/ql-vscode/test/__mocks__/appMock.ts
+++ b/extensions/ql-vscode/test/__mocks__/appMock.ts
@@ -1,4 +1,4 @@
-import { App, AppMode } from "../../src/common/app";
+import { App, AppMode, EnvironmentContext } from "../../src/common/app";
 import { AppEvent, AppEventEmitter } from "../../src/common/events";
 import { Memento } from "../../src/common/memento";
 import { Disposable } from "../../src/pure/disposable-object";
@@ -24,6 +24,7 @@ export function createMockApp({
   onDidChangeWorkspaceFolders = jest.fn(),
   credentials = testCredentialsWithStub(),
   commands = createMockCommandManager(),
+  environment = createMockEnvironmentContext(),
 }: {
   extensionPath?: string;
   workspaceStoragePath?: string;
@@ -34,6 +35,7 @@ export function createMockApp({
   onDidChangeWorkspaceFolders?: Event<WorkspaceFoldersChangeEvent>;
   credentials?: Credentials;
   commands?: AppCommandManager;
+  environment?: EnvironmentContext;
 }): App {
   return {
     mode: AppMode.Test,
@@ -48,6 +50,7 @@ export function createMockApp({
     createEventEmitter,
     credentials,
     commands,
+    environment,
   };
 }
 
@@ -67,4 +70,10 @@ export class MockAppEventEmitter<T> implements AppEventEmitter<T> {
   public dispose() {
     // no-op
   }
+}
+
+export function createMockEnvironmentContext(): EnvironmentContext {
+  return {
+    language: "en-US",
+  };
 }

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/queries-panel/query-tree-data-provider.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/queries-panel/query-tree-data-provider.test.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from "vscode";
+import { EventEmitter, env } from "vscode";
 import {
   FileTreeDirectory,
   FileTreeLeaf,
@@ -31,8 +31,8 @@ describe("QueryTreeDataProvider", () => {
     it("converts FileTreeNode to QueryTreeViewItem", async () => {
       const dataProvider = new QueryTreeDataProvider({
         queries: [
-          new FileTreeDirectory<string>("dir1", "dir1", [
-            new FileTreeDirectory<string>("dir1/dir2", "dir2", [
+          new FileTreeDirectory<string>("dir1", "dir1", env, [
+            new FileTreeDirectory<string>("dir1/dir2", "dir2", env, [
               new FileTreeLeaf<string>(
                 "dir1/dir2/file1",
                 "file1",
@@ -45,7 +45,7 @@ describe("QueryTreeDataProvider", () => {
               ),
             ]),
           ]),
-          new FileTreeDirectory<string>("dir3", "dir3", [
+          new FileTreeDirectory<string>("dir3", "dir3", env, [
             new FileTreeLeaf<string>("dir3/file3", "file3", "javascript"),
           ]),
         ],
@@ -78,7 +78,7 @@ describe("QueryTreeDataProvider", () => {
       const onDidChangeQueriesEmitter = new EventEmitter<void>();
       const queryDiscoverer: QueryDiscoverer = {
         queries: [
-          new FileTreeDirectory<string>("dir1", "dir1", [
+          new FileTreeDirectory<string>("dir1", "dir1", env, [
             new FileTreeLeaf<string>("dir1/file1", "file1", "javascript"),
           ]),
         ],
@@ -89,7 +89,7 @@ describe("QueryTreeDataProvider", () => {
       expect(dataProvider.getChildren().length).toEqual(1);
 
       queryDiscoverer.queries?.push(
-        new FileTreeDirectory<string>("dir2", "dir2", [
+        new FileTreeDirectory<string>("dir2", "dir2", env, [
           new FileTreeLeaf<string>("dir2/file2", "file2", "javascript"),
         ]),
       );


### PR DESCRIPTION
Adds `EnvironmentContext` to the `App` which allows access to the `vscode.env.language`, for use with calls to `localeCompare` and similar. This PR shows how much change is needed in order to support passing the env data to where it's needed in `FileTreeNode`.

I've done just this one usage because it will fix https://github.com/github/vscode-codeql/security/code-scanning/518, but obviously in future we could use this in more places. we've got an internal issue to track this and make sure we're doing localisation consistently.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
