### PR TITLE
Add Localizer class to avoid dependency on vscode.env.language

### DIFF
--- a/extensions/ql-vscode/src/common/file-tree-nodes.ts
+++ b/extensions/ql-vscode/src/common/file-tree-nodes.ts
@@ -1,5 +1,5 @@
 import { basename, dirname, join } from "path";
-import { env } from "vscode";
+import { Localizer } from "./localizer";
 
 /**
  * A node in the tree of files. This will be either a `FileTreeDirectory` or a `FileTreeLeaf`.
@@ -35,6 +35,7 @@ export class FileTreeDirectory<T = undefined> extends FileTreeNode<T> {
   constructor(
     _path: string,
     _name: string,
+    private readonly localizer: Localizer,
     private _children: Array<FileTreeNode<T>> = [],
   ) {
     super(_path, _name);
@@ -66,7 +67,7 @@ export class FileTreeDirectory<T = undefined> extends FileTreeNode<T> {
     this._children.filter(
       (child) => child instanceof FileTreeLeaf || child.children.length > 0,
     );
-    this._children.sort((a, b) => a.name.localeCompare(b.name, env.language));
+    this._children.sort((a, b) => this.localizer.localeCompare(a.name, b.name));
     this._children.forEach((child, i) => {
       child.finish();
       if (
@@ -77,6 +78,7 @@ export class FileTreeDirectory<T = undefined> extends FileTreeNode<T> {
         const replacement = new FileTreeDirectory<T>(
           child.children[0].path,
           `${child.name} / ${child.children[0].name}`,
+          this.localizer,
           Array.from(child.children[0].children),
         );
         this._children[i] = replacement;
@@ -89,7 +91,11 @@ export class FileTreeDirectory<T = undefined> extends FileTreeNode<T> {
     if (existingChild !== undefined) {
       return existingChild as FileTreeDirectory<T>;
     } else {
-      const newChild = new FileTreeDirectory<T>(join(this.path, name), name);
+      const newChild = new FileTreeDirectory<T>(
+        join(this.path, name),
+        name,
+        this.localizer,
+      );
       this.addChild(newChild);
       return newChild;
     }

--- a/extensions/ql-vscode/src/common/localizer.ts
+++ b/extensions/ql-vscode/src/common/localizer.ts
@@ -1,0 +1,11 @@
+export abstract class Localizer {
+  protected abstract locales(): string | string[] | undefined;
+
+  public localeCompare(
+    a: string,
+    b: string,
+    options?: Intl.CollatorOptions,
+  ): number {
+    return a.localeCompare(b, this.locales(), options);
+  }
+}

--- a/extensions/ql-vscode/src/common/vscode/vscode-localizer.ts
+++ b/extensions/ql-vscode/src/common/vscode/vscode-localizer.ts
@@ -1,0 +1,8 @@
+import { env } from "vscode";
+import { Localizer } from "../localizer";
+
+export class VSCodeLocalizer extends Localizer {
+  protected locales(): string | string[] | undefined {
+    return env.language;
+  }
+}

--- a/extensions/ql-vscode/src/queries-panel/query-discovery.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-discovery.ts
@@ -9,6 +9,7 @@ import { getOnDiskWorkspaceFoldersObjects } from "../helpers";
 import { AppEventEmitter } from "../common/events";
 import { QueryDiscoverer } from "./query-tree-data-provider";
 import { extLogger } from "../common";
+import { VSCodeLocalizer } from "../common/vscode/vscode-localizer";
 
 /**
  * The results of discovering queries.
@@ -124,7 +125,11 @@ export class QueryDiscovery
       return undefined;
     }
 
-    const rootDirectory = new FileTreeDirectory<string>(fullPath, name);
+    const rootDirectory = new FileTreeDirectory<string>(
+      fullPath,
+      name,
+      new VSCodeLocalizer(),
+    );
     for (const queryPath of resolvedQueries) {
       const relativePath = normalize(relative(fullPath, queryPath));
       const dirName = dirname(relativePath);

--- a/extensions/ql-vscode/src/query-testing/qltest-discovery.ts
+++ b/extensions/ql-vscode/src/query-testing/qltest-discovery.ts
@@ -12,6 +12,7 @@ import { CodeQLCliServer } from "../codeql-cli/cli";
 import { pathExists } from "fs-extra";
 import { FileTreeDirectory, FileTreeLeaf } from "../common/file-tree-nodes";
 import { extLogger } from "../common";
+import { VSCodeLocalizer } from "../common/vscode/vscode-localizer";
 
 /**
  * The results of discovering QL tests.
@@ -97,7 +98,11 @@ export class QLTestDiscovery extends Discovery<QLTestDiscoveryResults> {
   private async discoverTests(): Promise<FileTreeDirectory> {
     const fullPath = this.workspaceFolder.uri.fsPath;
     const name = this.workspaceFolder.name;
-    const rootDirectory = new FileTreeDirectory(fullPath, name);
+    const rootDirectory = new FileTreeDirectory(
+      fullPath,
+      name,
+      new VSCodeLocalizer(),
+    );
 
     // Don't try discovery on workspace folders that don't exist on the filesystem
     if (await pathExists(fullPath)) {

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/queries-panel/query-tree-data-provider.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/queries-panel/query-tree-data-provider.test.ts
@@ -7,8 +7,11 @@ import {
   QueryDiscoverer,
   QueryTreeDataProvider,
 } from "../../../../src/queries-panel/query-tree-data-provider";
+import { VSCodeLocalizer } from "../../../../src/common/vscode/vscode-localizer";
 
 describe("QueryTreeDataProvider", () => {
+  const localizer = new VSCodeLocalizer();
+
   describe("getChildren", () => {
     it("returns no children when queries is undefined", async () => {
       const dataProvider = new QueryTreeDataProvider({
@@ -31,8 +34,8 @@ describe("QueryTreeDataProvider", () => {
     it("converts FileTreeNode to QueryTreeViewItem", async () => {
       const dataProvider = new QueryTreeDataProvider({
         queries: [
-          new FileTreeDirectory<string>("dir1", "dir1", [
-            new FileTreeDirectory<string>("dir1/dir2", "dir2", [
+          new FileTreeDirectory<string>("dir1", "dir1", localizer, [
+            new FileTreeDirectory<string>("dir1/dir2", "dir2", localizer, [
               new FileTreeLeaf<string>(
                 "dir1/dir2/file1",
                 "file1",
@@ -45,7 +48,7 @@ describe("QueryTreeDataProvider", () => {
               ),
             ]),
           ]),
-          new FileTreeDirectory<string>("dir3", "dir3", [
+          new FileTreeDirectory<string>("dir3", "dir3", localizer, [
             new FileTreeLeaf<string>("dir3/file3", "file3", "javascript"),
           ]),
         ],
@@ -78,7 +81,7 @@ describe("QueryTreeDataProvider", () => {
       const onDidChangeQueriesEmitter = new EventEmitter<void>();
       const queryDiscoverer: QueryDiscoverer = {
         queries: [
-          new FileTreeDirectory<string>("dir1", "dir1", [
+          new FileTreeDirectory<string>("dir1", "dir1", localizer, [
             new FileTreeLeaf<string>("dir1/file1", "file1", "javascript"),
           ]),
         ],
@@ -89,7 +92,7 @@ describe("QueryTreeDataProvider", () => {
       expect(dataProvider.getChildren().length).toEqual(1);
 
       queryDiscoverer.queries?.push(
-        new FileTreeDirectory<string>("dir2", "dir2", [
+        new FileTreeDirectory<string>("dir2", "dir2", localizer, [
           new FileTreeLeaf<string>("dir2/file2", "file2", "javascript"),
         ]),
       );


### PR DESCRIPTION
Potential alternative to https://github.com/github/vscode-codeql/pull/2480 exploring a different solution. See https://github.com/github/vscode-codeql/pull/2480#discussion_r1218046199.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
