### PR TITLE
Fix remaining `localeCompare` without locale set

### DIFF
--- a/extensions/ql-vscode/src/data-extensions-editor/auto-model.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/auto-model.ts
@@ -195,7 +195,8 @@ export function compareInputOutput(a: string, b: string): number {
 
     // If either one is unknown, it is sorted last
     if (aIndex === -1 && bIndex === -1) {
-      return a.localeCompare(b);
+      // Use en-US because these are well-known strings that are not localized
+      return a.localeCompare(b, "en-US");
     }
     if (aIndex === -1) {
       return 1;

--- a/extensions/ql-vscode/src/pure/variant-analysis-filter-sort.ts
+++ b/extensions/ql-vscode/src/pure/variant-analysis-filter-sort.ts
@@ -94,8 +94,9 @@ export function compareRepository(
       }
     }
 
-    // Fall back on name compare
-    return left.fullName.localeCompare(right.fullName, undefined, {
+    // Fall back on name compare. Use en-US because the repository name does not contain
+    // special characters due to restrictions in GitHub owner/repository names.
+    return left.fullName.localeCompare(right.fullName, "en-US", {
       sensitivity: "base",
     });
   };


### PR DESCRIPTION
This adds the `locales` parameter to the last two `localeCompare` which were not passing in the locale. This should make sorting more consistent and correct for non-English users.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
