### PR TITLE
Tweak candidate selection

### DIFF
--- a/extensions/ql-vscode/src/data-extensions-editor/auto-model.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/auto-model.ts
@@ -8,6 +8,12 @@ import {
 } from "./auto-model-api";
 import type { UsageSnippetsBySignature } from "./auto-model-usages-query";
 
+// Soft limit on the number of candidates to send to the model.
+// Note that the model may return fewer than this number of candidates.
+const candidateLimit = 20;
+// Soft limit on the number of samples to send to the model.
+const sampleLimit = 100;
+
 export function createAutoModelRequest(
   language: string,
   externalApiUsages: ExternalApiUsage[],
@@ -40,8 +46,10 @@ export function createAutoModelRequest(
         ? 0
         : externalApiUsage.methodParameters.split(",").length;
 
+    const candidates = [];
+    const samples = [];
     for (
-      let argumentIndex = 0;
+      let argumentIndex = -1; // Start at -1 which means `this` as in `this.method()`
       argumentIndex < numberOfArguments;
       argumentIndex++
     ) {
@@ -54,20 +62,28 @@ export function createAutoModelRequest(
           modeledMethod.type === "none"
             ? undefined
             : toMethodClassification(modeledMethod),
-        usages: usagesForMethod.slice(0, 10),
+        usages: usagesForMethod.slice(0, 6), // At most 6 usages per argument
         input: `Argument[${argumentIndex}]`,
       };
 
-      if (modeledMethod.type === "none") {
-        request.candidates.push(method);
+      // Candidates are methods that are not currently modeled in this model file or in any other model file.
+      if (modeledMethod.type === "none" && !externalApiUsage.supported) {
+        candidates.push(method);
       } else {
-        request.samples.push(method);
+        samples.push(method);
       }
     }
+    // If there is room for at least one candidate, add all candidates.
+    // This ensures that we send all arguments for a method together.
+    // NOTE: this might go above the candidate limit, but that's okay.
+    if (request.candidates.length < candidateLimit) {
+      request.candidates.push(...candidates);
+    }
+    // Same for samples
+    if (request.samples.length < sampleLimit) {
+      request.samples.push(...samples);
+    }
   }
-
-  request.candidates = request.candidates.slice(0, 20);
-  request.samples = request.samples.slice(0, 100);
 
   return request;
 }

--- a/extensions/ql-vscode/src/data-extensions-editor/auto-model.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/auto-model.ts
@@ -46,8 +46,8 @@ export function createAutoModelRequest(
         ? 0
         : externalApiUsage.methodParameters.split(",").length;
 
-    const candidates = [];
-    const samples = [];
+    const candidates: Method[] = [];
+    const samples: Method[] = [];
     for (
       let argumentIndex = -1; // Start at -1 which means `this` as in `this.method()`
       argumentIndex < numberOfArguments;

--- a/extensions/ql-vscode/src/data-extensions-editor/auto-model.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/auto-model.ts
@@ -66,8 +66,14 @@ export function createAutoModelRequest(
         input: `Argument[${argumentIndex}]`,
       };
 
-      // Candidates are methods that are not currently modeled in this model file or in any other model file.
-      if (modeledMethod.type === "none" && !externalApiUsage.supported) {
+      // A method that is supported is modeled outside of the model file, so it is not a candidate.
+      // We also do not want it as a sample because we do not know the classification.
+      if (modeledMethod.type === "none" && externalApiUsage.supported) {
+        continue;
+      }
+
+      // Candidates are methods that are not currently modeled
+      if (modeledMethod.type === "none") {
         candidates.push(method);
       } else {
         samples.push(method);

--- a/extensions/ql-vscode/src/data-extensions-editor/auto-model.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/auto-model.ts
@@ -53,6 +53,8 @@ export function createAutoModelRequest(
       argumentIndex < numberOfArguments;
       argumentIndex++
     ) {
+      const argumentInput: string =
+        argumentIndex === -1 ? "Argument[this]" : `Argument[${argumentIndex}]`;
       const method: Method = {
         package: externalApiUsage.packageName,
         type: externalApiUsage.typeName,
@@ -63,7 +65,7 @@ export function createAutoModelRequest(
             ? undefined
             : toMethodClassification(modeledMethod),
         usages: usagesForMethod.slice(0, 6), // At most 6 usages per argument
-        input: `Argument[${argumentIndex}]`,
+        input: argumentInput,
       };
 
       // A method that is supported is modeled outside of the model file, so it is not a candidate.

--- a/extensions/ql-vscode/test/unit-tests/data-extensions-editor/auto-model.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/data-extensions-editor/auto-model.test.ts
@@ -39,7 +39,7 @@ describe("createAutoModelRequest", () => {
       typeName: "Connection",
       methodName: "createQuery",
       methodParameters: "(String)",
-      supported: true,
+      supported: false,
       usages: [
         {
           label: "createQuery(...)",
@@ -69,7 +69,7 @@ describe("createAutoModelRequest", () => {
       typeName: "Query",
       methodName: "executeScalar",
       methodParameters: "(Class)",
-      supported: true,
+      supported: false,
       usages: [
         {
           label: "executeScalar(...)",
@@ -99,7 +99,7 @@ describe("createAutoModelRequest", () => {
       typeName: "Sql2o",
       methodName: "open",
       methodParameters: "()",
-      supported: true,
+      supported: false,
       usages: [
         {
           label: "open(...)",
@@ -129,7 +129,7 @@ describe("createAutoModelRequest", () => {
       typeName: "PrintStream",
       methodName: "println",
       methodParameters: "(String)",
-      supported: true,
+      supported: false,
       usages: [
         {
           label: "println(...)",
@@ -149,7 +149,7 @@ describe("createAutoModelRequest", () => {
       typeName: "Sql2o",
       methodName: "Sql2o",
       methodParameters: "(String,String,String)",
-      supported: true,
+      supported: false,
       usages: [
         {
           label: "new Sql2o(...)",
@@ -169,7 +169,7 @@ describe("createAutoModelRequest", () => {
       typeName: "Sql2o",
       methodName: "Sql2o",
       methodParameters: "(String)",
-      supported: true,
+      supported: false,
       usages: [
         {
           label: "new Sql2o(...)",
@@ -238,6 +238,32 @@ describe("createAutoModelRequest", () => {
         {
           package: "org.sql2o",
           type: "Sql2o",
+          name: "open",
+          signature: "()",
+          classification: {
+            type: "CLASSIFICATION_TYPE_NEUTRAL",
+            kind: "",
+            explanation: "",
+          },
+          usages: usages["org.sql2o.Sql2o#open()"],
+          input: "Argument[-1]",
+        },
+        {
+          package: "org.sql2o",
+          type: "Sql2o",
+          name: "Sql2o",
+          signature: "(String)",
+          classification: {
+            type: "CLASSIFICATION_TYPE_SINK",
+            kind: "jndi-injection",
+            explanation: "",
+          },
+          usages: usages["org.sql2o.Sql2o#Sql2o(String)"],
+          input: "Argument[-1]",
+        },
+        {
+          package: "org.sql2o",
+          type: "Sql2o",
           name: "Sql2o",
           signature: "(String)",
           classification: {
@@ -256,6 +282,15 @@ describe("createAutoModelRequest", () => {
           name: "createQuery",
           signature: "(String)",
           usages: usages["org.sql2o.Connection#createQuery(String)"],
+          input: "Argument[-1]",
+          classification: undefined,
+        },
+        {
+          package: "org.sql2o",
+          type: "Connection",
+          name: "createQuery",
+          signature: "(String)",
+          usages: usages["org.sql2o.Connection#createQuery(String)"],
           input: "Argument[0]",
           classification: undefined,
         },
@@ -265,7 +300,28 @@ describe("createAutoModelRequest", () => {
           name: "executeScalar",
           signature: "(Class)",
           usages: usages["org.sql2o.Query#executeScalar(Class)"],
+          input: "Argument[-1]",
+          classification: undefined,
+        },
+        {
+          package: "org.sql2o",
+          type: "Query",
+          name: "executeScalar",
+          signature: "(Class)",
+          usages: usages["org.sql2o.Query#executeScalar(Class)"],
           input: "Argument[0]",
+          classification: undefined,
+        },
+        {
+          package: "org.springframework.boot",
+          type: "SpringApplication",
+          name: "run",
+          signature: "(Class,String[])",
+          usages:
+            usages[
+              "org.springframework.boot.SpringApplication#run(Class,String[])"
+            ],
+          input: "Argument[-1]",
           classification: undefined,
         },
         {
@@ -298,7 +354,25 @@ describe("createAutoModelRequest", () => {
           name: "println",
           signature: "(String)",
           usages: usages["java.io.PrintStream#println(String)"],
+          input: "Argument[-1]",
+          classification: undefined,
+        },
+        {
+          package: "java.io",
+          type: "PrintStream",
+          name: "println",
+          signature: "(String)",
+          usages: usages["java.io.PrintStream#println(String)"],
           input: "Argument[0]",
+          classification: undefined,
+        },
+        {
+          package: "org.sql2o",
+          type: "Sql2o",
+          name: "Sql2o",
+          signature: "(String,String,String)",
+          usages: usages["org.sql2o.Sql2o#Sql2o(String,String,String)"],
+          input: "Argument[-1]",
           classification: undefined,
         },
         {

--- a/extensions/ql-vscode/test/unit-tests/data-extensions-editor/auto-model.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/data-extensions-editor/auto-model.test.ts
@@ -183,6 +183,26 @@ describe("createAutoModelRequest", () => {
         },
       ],
     },
+    {
+      signature: "org.test.MyClass#test()",
+      packageName: "org.test",
+      typeName: "MyClass",
+      methodName: "test",
+      methodParameters: "()",
+      supported: true,
+      usages: [
+        {
+          label: "abc.test(...)",
+          url: {
+            uri: "file:/home/runner/work/test/Test.java",
+            startLine: 23,
+            startColumn: 23,
+            endLine: 23,
+            endColumn: 36,
+          },
+        },
+      ],
+    },
   ];
 
   const modeledMethods: Record<string, ModeledMethod> = {

--- a/extensions/ql-vscode/test/unit-tests/data-extensions-editor/auto-model.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/data-extensions-editor/auto-model.test.ts
@@ -266,7 +266,7 @@ describe("createAutoModelRequest", () => {
             explanation: "",
           },
           usages: usages["org.sql2o.Sql2o#open()"],
-          input: "Argument[-1]",
+          input: "Argument[this]",
         },
         {
           package: "org.sql2o",
@@ -279,7 +279,7 @@ describe("createAutoModelRequest", () => {
             explanation: "",
           },
           usages: usages["org.sql2o.Sql2o#Sql2o(String)"],
-          input: "Argument[-1]",
+          input: "Argument[this]",
         },
         {
           package: "org.sql2o",
@@ -302,7 +302,7 @@ describe("createAutoModelRequest", () => {
           name: "createQuery",
           signature: "(String)",
           usages: usages["org.sql2o.Connection#createQuery(String)"],
-          input: "Argument[-1]",
+          input: "Argument[this]",
           classification: undefined,
         },
         {
@@ -320,7 +320,7 @@ describe("createAutoModelRequest", () => {
           name: "executeScalar",
           signature: "(Class)",
           usages: usages["org.sql2o.Query#executeScalar(Class)"],
-          input: "Argument[-1]",
+          input: "Argument[this]",
           classification: undefined,
         },
         {
@@ -341,7 +341,7 @@ describe("createAutoModelRequest", () => {
             usages[
               "org.springframework.boot.SpringApplication#run(Class,String[])"
             ],
-          input: "Argument[-1]",
+          input: "Argument[this]",
           classification: undefined,
         },
         {
@@ -374,7 +374,7 @@ describe("createAutoModelRequest", () => {
           name: "println",
           signature: "(String)",
           usages: usages["java.io.PrintStream#println(String)"],
-          input: "Argument[-1]",
+          input: "Argument[this]",
           classification: undefined,
         },
         {
@@ -392,7 +392,7 @@ describe("createAutoModelRequest", () => {
           name: "Sql2o",
           signature: "(String,String,String)",
           usages: usages["org.sql2o.Sql2o#Sql2o(String,String,String)"],
-          input: "Argument[-1]",
+          input: "Argument[this]",
           classification: undefined,
         },
         {


### PR DESCRIPTION
Tweak candidate selection:
- Do not send methods modeled outside the file as candidates.
- At most 6 usages.
- Send -1 for `this` argument.
- Do not send only some arguments for candidate or sample.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->


## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
