### PR TITLE
Update changelog (MRVA -> variant analysis)

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Fix bug where the `CodeQL: Compare Query` command did not work for comparing quick-eval queries. [#2422](https://github.com/github/vscode-codeql/pull/2422)
 - Update text of copy and export buttons in variant analysis results view to clarify that they only copy/export the selected/filtered results. [#2427](https://github.com/github/vscode-codeql/pull/2427)
 - Add warning when using unsupported CodeQL CLI version. [#2428](https://github.com/github/vscode-codeql/pull/2428)
-- Retry MRVA results download if connection times out. [#2440](https://github.com/github/vscode-codeql/pull/2440)
+- Retry variant analysis results download if connection times out. [#2440](https://github.com/github/vscode-codeql/pull/2440)
 
 ## 1.8.4 - 3 May 2023
 


### PR DESCRIPTION
A tiny fix to the changelog to say "variant analysis" (since we haven't been using "MRVA" in public-facing docs). As @norascheuch mentioned offline, this got fixed but accidentally overridden in https://github.com/github/vscode-codeql/pull/2466, but we didn't want to hold up the release at the time!

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
