### PR TITLE
Remove workspaceFolders from app because it turned out not to be useful

### DIFF
--- a/extensions/ql-vscode/src/common/app.ts
+++ b/extensions/ql-vscode/src/common/app.ts
@@ -4,7 +4,6 @@ import { AppEventEmitter } from "./events";
 import { Logger } from "./logging";
 import { Memento } from "./memento";
 import { AppCommandManager } from "./commands";
-import type { Event, WorkspaceFoldersChangeEvent } from "vscode";
 
 export interface App {
   createEventEmitter<T>(): AppEventEmitter<T>;
@@ -15,7 +14,6 @@ export interface App {
   readonly globalStoragePath: string;
   readonly workspaceStoragePath?: string;
   readonly workspaceState: Memento;
-  readonly onDidChangeWorkspaceFolders: Event<WorkspaceFoldersChangeEvent>;
   readonly credentials: Credentials;
   readonly commands: AppCommandManager;
   readonly environment: EnvironmentContext;

--- a/extensions/ql-vscode/src/common/app.ts
+++ b/extensions/ql-vscode/src/common/app.ts
@@ -4,11 +4,7 @@ import { AppEventEmitter } from "./events";
 import { Logger } from "./logging";
 import { Memento } from "./memento";
 import { AppCommandManager } from "./commands";
-import type {
-  WorkspaceFolder,
-  Event,
-  WorkspaceFoldersChangeEvent,
-} from "vscode";
+import type { Event, WorkspaceFoldersChangeEvent } from "vscode";
 
 export interface App {
   createEventEmitter<T>(): AppEventEmitter<T>;
@@ -19,7 +15,6 @@ export interface App {
   readonly globalStoragePath: string;
   readonly workspaceStoragePath?: string;
   readonly workspaceState: Memento;
-  readonly workspaceFolders: readonly WorkspaceFolder[] | undefined;
   readonly onDidChangeWorkspaceFolders: Event<WorkspaceFoldersChangeEvent>;
   readonly credentials: Credentials;
   readonly commands: AppCommandManager;

--- a/extensions/ql-vscode/src/common/vscode/vscode-app.ts
+++ b/extensions/ql-vscode/src/common/vscode/vscode-app.ts
@@ -40,10 +40,6 @@ export class ExtensionApp implements App {
     return this.extensionContext.workspaceState;
   }
 
-  public get onDidChangeWorkspaceFolders(): vscode.Event<vscode.WorkspaceFoldersChangeEvent> {
-    return vscode.workspace.onDidChangeWorkspaceFolders;
-  }
-
   public get subscriptions(): Disposable[] {
     return this.extensionContext.subscriptions;
   }

--- a/extensions/ql-vscode/src/common/vscode/vscode-app.ts
+++ b/extensions/ql-vscode/src/common/vscode/vscode-app.ts
@@ -40,10 +40,6 @@ export class ExtensionApp implements App {
     return this.extensionContext.workspaceState;
   }
 
-  public get workspaceFolders(): readonly vscode.WorkspaceFolder[] | undefined {
-    return vscode.workspace.workspaceFolders;
-  }
-
   public get onDidChangeWorkspaceFolders(): vscode.Event<vscode.WorkspaceFoldersChangeEvent> {
     return vscode.workspace.onDidChangeWorkspaceFolders;
   }

--- a/extensions/ql-vscode/src/queries-panel/queries-module.ts
+++ b/extensions/ql-vscode/src/queries-panel/queries-module.ts
@@ -19,7 +19,7 @@ export class QueriesModule extends DisposableObject {
     }
     void extLogger.log("Initializing queries panel.");
 
-    const queryDiscovery = new QueryDiscovery(app, cliServer);
+    const queryDiscovery = new QueryDiscovery(app.environment, cliServer);
     this.push(queryDiscovery);
     void queryDiscovery.refresh();
 

--- a/extensions/ql-vscode/src/queries-panel/query-discovery.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-discovery.ts
@@ -3,6 +3,7 @@ import { Discovery } from "../common/discovery";
 import { CodeQLCliServer } from "../codeql-cli/cli";
 import {
   Event,
+  EventEmitter,
   RelativePattern,
   Uri,
   WorkspaceFolder,
@@ -53,7 +54,7 @@ export class QueryDiscovery
   ) {
     super("Query Discovery", extLogger);
 
-    this.onDidChangeQueriesEmitter = this.push(app.createEventEmitter<void>());
+    this.onDidChangeQueriesEmitter = this.push(new EventEmitter<void>());
     this.push(workspace.onDidChangeWorkspaceFolders(this.refresh.bind(this)));
     this.push(this.watcher.onDidChange(this.refresh.bind(this)));
   }

--- a/extensions/ql-vscode/src/queries-panel/query-discovery.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-discovery.ts
@@ -1,7 +1,13 @@
 import { dirname, basename, normalize, relative } from "path";
 import { Discovery } from "../common/discovery";
 import { CodeQLCliServer } from "../codeql-cli/cli";
-import { Event, RelativePattern, Uri, WorkspaceFolder } from "vscode";
+import {
+  Event,
+  RelativePattern,
+  Uri,
+  WorkspaceFolder,
+  workspace,
+} from "vscode";
 import { MultiFileSystemWatcher } from "../common/vscode/multi-file-system-watcher";
 import { App } from "../common/app";
 import { FileTreeDirectory, FileTreeLeaf } from "../common/file-tree-nodes";
@@ -48,7 +54,7 @@ export class QueryDiscovery
     super("Query Discovery", extLogger);
 
     this.onDidChangeQueriesEmitter = this.push(app.createEventEmitter<void>());
-    this.push(app.onDidChangeWorkspaceFolders(this.refresh.bind(this)));
+    this.push(workspace.onDidChangeWorkspaceFolders(this.refresh.bind(this)));
     this.push(this.watcher.onDidChange(this.refresh.bind(this)));
   }
 

--- a/extensions/ql-vscode/src/queries-panel/query-discovery.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-discovery.ts
@@ -10,7 +10,7 @@ import {
   workspace,
 } from "vscode";
 import { MultiFileSystemWatcher } from "../common/vscode/multi-file-system-watcher";
-import { App } from "../common/app";
+import { EnvironmentContext } from "../common/app";
 import { FileTreeDirectory, FileTreeLeaf } from "../common/file-tree-nodes";
 import { getOnDiskWorkspaceFoldersObjects } from "../helpers";
 import { AppEventEmitter } from "../common/events";
@@ -49,7 +49,7 @@ export class QueryDiscovery
   );
 
   constructor(
-    private readonly app: App,
+    private readonly env: EnvironmentContext,
     private readonly cliServer: CodeQLCliServer,
   ) {
     super("Query Discovery", extLogger);
@@ -137,7 +137,7 @@ export class QueryDiscovery
     const rootDirectory = new FileTreeDirectory<string>(
       fullPath,
       name,
-      this.app.environment,
+      this.env,
     );
     for (const queryPath of resolvedQueries) {
       const relativePath = normalize(relative(fullPath, queryPath));

--- a/extensions/ql-vscode/test/__mocks__/appMock.ts
+++ b/extensions/ql-vscode/test/__mocks__/appMock.ts
@@ -8,11 +8,7 @@ import { testCredentialsWithStub } from "../factories/authentication";
 import { Credentials } from "../../src/common/authentication";
 import { AppCommandManager } from "../../src/common/commands";
 import { createMockCommandManager } from "./commandsMock";
-import type {
-  Event,
-  WorkspaceFolder,
-  WorkspaceFoldersChangeEvent,
-} from "vscode";
+import type { Event, WorkspaceFoldersChangeEvent } from "vscode";
 
 export function createMockApp({
   extensionPath = "/mock/extension/path",
@@ -20,7 +16,6 @@ export function createMockApp({
   globalStoragePath = "/mock/global/storage/path",
   createEventEmitter = <T>() => new MockAppEventEmitter<T>(),
   workspaceState = createMockMemento(),
-  workspaceFolders = [],
   onDidChangeWorkspaceFolders = jest.fn(),
   credentials = testCredentialsWithStub(),
   commands = createMockCommandManager(),
@@ -31,7 +26,6 @@ export function createMockApp({
   globalStoragePath?: string;
   createEventEmitter?: <T>() => AppEventEmitter<T>;
   workspaceState?: Memento;
-  workspaceFolders?: readonly WorkspaceFolder[] | undefined;
   onDidChangeWorkspaceFolders?: Event<WorkspaceFoldersChangeEvent>;
   credentials?: Credentials;
   commands?: AppCommandManager;
@@ -45,7 +39,6 @@ export function createMockApp({
     workspaceStoragePath,
     globalStoragePath,
     workspaceState,
-    workspaceFolders,
     onDidChangeWorkspaceFolders,
     createEventEmitter,
     credentials,

--- a/extensions/ql-vscode/test/__mocks__/appMock.ts
+++ b/extensions/ql-vscode/test/__mocks__/appMock.ts
@@ -8,7 +8,6 @@ import { testCredentialsWithStub } from "../factories/authentication";
 import { Credentials } from "../../src/common/authentication";
 import { AppCommandManager } from "../../src/common/commands";
 import { createMockCommandManager } from "./commandsMock";
-import type { Event, WorkspaceFoldersChangeEvent } from "vscode";
 
 export function createMockApp({
   extensionPath = "/mock/extension/path",
@@ -16,7 +15,6 @@ export function createMockApp({
   globalStoragePath = "/mock/global/storage/path",
   createEventEmitter = <T>() => new MockAppEventEmitter<T>(),
   workspaceState = createMockMemento(),
-  onDidChangeWorkspaceFolders = jest.fn(),
   credentials = testCredentialsWithStub(),
   commands = createMockCommandManager(),
   environment = createMockEnvironmentContext(),
@@ -26,7 +24,6 @@ export function createMockApp({
   globalStoragePath?: string;
   createEventEmitter?: <T>() => AppEventEmitter<T>;
   workspaceState?: Memento;
-  onDidChangeWorkspaceFolders?: Event<WorkspaceFoldersChangeEvent>;
   credentials?: Credentials;
   commands?: AppCommandManager;
   environment?: EnvironmentContext;
@@ -39,7 +36,6 @@ export function createMockApp({
     workspaceStoragePath,
     globalStoragePath,
     workspaceState,
-    onDidChangeWorkspaceFolders,
     createEventEmitter,
     credentials,
     commands,

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/queries-panel/query-discovery.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/queries-panel/query-discovery.test.ts
@@ -7,7 +7,7 @@ import {
 } from "vscode";
 import { CodeQLCliServer } from "../../../../src/codeql-cli/cli";
 import { QueryDiscovery } from "../../../../src/queries-panel/query-discovery";
-import { createMockApp } from "../../../__mocks__/appMock";
+import { createMockEnvironmentContext } from "../../../__mocks__/appMock";
 import { mockedObject } from "../../utils/mocking.helpers";
 import { basename, join, sep } from "path";
 
@@ -23,7 +23,7 @@ describe("QueryDiscovery", () => {
         resolveQueries,
       });
 
-      const discovery = new QueryDiscovery(createMockApp({}), cli);
+      const discovery = new QueryDiscovery(createMockEnvironmentContext(), cli);
       await discovery.refresh();
       const queries = discovery.queries;
 
@@ -43,7 +43,7 @@ describe("QueryDiscovery", () => {
           ]),
       });
 
-      const discovery = new QueryDiscovery(createMockApp({}), cli);
+      const discovery = new QueryDiscovery(createMockEnvironmentContext(), cli);
       await discovery.refresh();
       const queries = discovery.queries;
       expect(queries).toBeDefined();
@@ -69,7 +69,7 @@ describe("QueryDiscovery", () => {
           ]),
       });
 
-      const discovery = new QueryDiscovery(createMockApp({}), cli);
+      const discovery = new QueryDiscovery(createMockEnvironmentContext(), cli);
       await discovery.refresh();
       const queries = discovery.queries;
       expect(queries).toBeDefined();
@@ -114,7 +114,7 @@ describe("QueryDiscovery", () => {
         resolveQueries,
       });
 
-      const discovery = new QueryDiscovery(createMockApp({}), cli);
+      const discovery = new QueryDiscovery(createMockEnvironmentContext(), cli);
       await discovery.refresh();
       const queries = discovery.queries;
       expect(queries).toBeDefined();
@@ -153,7 +153,7 @@ describe("QueryDiscovery", () => {
           .mockResolvedValue([join(workspaceRoot, "query1.ql")]),
       });
 
-      const discovery = new QueryDiscovery(createMockApp({}), cli);
+      const discovery = new QueryDiscovery(createMockEnvironmentContext(), cli);
 
       const onDidChangeQueriesSpy = jest.fn();
       discovery.onDidChangeQueries(onDidChangeQueriesSpy);
@@ -180,7 +180,7 @@ describe("QueryDiscovery", () => {
         .mockImplementation(onDidChangeWorkspaceFoldersEvent.event);
 
       const discovery = new QueryDiscovery(
-        createMockApp({}),
+        createMockEnvironmentContext(),
         mockedObject<CodeQLCliServer>({
           resolveQueries: jest.fn().mockResolvedValue([]),
         }),

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/queries-panel/query-discovery.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/queries-panel/query-discovery.test.ts
@@ -153,12 +153,7 @@ describe("QueryDiscovery", () => {
           .mockResolvedValue([join(workspaceRoot, "query1.ql")]),
       });
 
-      const discovery = new QueryDiscovery(
-        createMockApp({
-          createEventEmitter: () => new EventEmitter(),
-        }),
-        cli,
-      );
+      const discovery = new QueryDiscovery(createMockApp({}), cli);
 
       const onDidChangeQueriesSpy = jest.fn();
       discovery.onDidChangeQueries(onDidChangeQueriesSpy);
@@ -185,9 +180,7 @@ describe("QueryDiscovery", () => {
         .mockImplementation(onDidChangeWorkspaceFoldersEvent.event);
 
       const discovery = new QueryDiscovery(
-        createMockApp({
-          createEventEmitter: () => new EventEmitter(),
-        }),
+        createMockApp({}),
         mockedObject<CodeQLCliServer>({
           resolveQueries: jest.fn().mockResolvedValue([]),
         }),

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/queries-panel/query-discovery.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/queries-panel/query-discovery.test.ts
@@ -180,11 +180,13 @@ describe("QueryDiscovery", () => {
     it("should refresh when workspace folders change", async () => {
       const onDidChangeWorkspaceFoldersEvent =
         new EventEmitter<WorkspaceFoldersChangeEvent>();
+      jest
+        .spyOn(workspace, "onDidChangeWorkspaceFolders")
+        .mockImplementation(onDidChangeWorkspaceFoldersEvent.event);
 
       const discovery = new QueryDiscovery(
         createMockApp({
           createEventEmitter: () => new EventEmitter(),
-          onDidChangeWorkspaceFolders: onDidChangeWorkspaceFoldersEvent.event,
         }),
         mockedObject<CodeQLCliServer>({
           resolveQueries: jest.fn().mockResolvedValue([]),


### PR DESCRIPTION
This PR basically just reverts https://github.com/github/vscode-codeql/pull/2431 and https://github.com/github/vscode-codeql/pull/2437. Since we've decided to use integration tests for the queries panel and not try to push for unit tests it's meant that neither of those changes were particularly useful, or are possibly detrimental.

- `workspaceFolders` was completely unused, because we have the `getOnDiskWorkspaceFoldersObjects` helper and it made much more sense to call that.
- `onDidChangeWorkspaceFolders`made little difference, since mocking the VS Code version was just as easy.
- `createEventEmitter` wasn't terribly helpful because mocking the VS Code version wasn't hard. It was actually possibly harmful because the default implementation in `createMockApp` silently does nothing, which tripped me up when writing tests and my listeners weren't firing. You haven't to know to pass a working emitter constructor when making the mock app, but there's no error that will point you in that direction.

This PR will conflict with https://github.com/github/vscode-codeql/pull/2490, but it's not a big problem. I still want to make these changes and I'll fix any conflicts on that PR.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
