### PR TITLE
Code search: Sort repo lists by name when adding multiple repos

### DIFF
--- a/extensions/ql-vscode/src/databases/config/db-config-store.ts
+++ b/extensions/ql-vscode/src/databases/config/db-config-store.ts
@@ -148,7 +148,7 @@ export class DbConfigStore extends DisposableObject {
   }
 
   /**
-   * Adds a list of remote repositories to an existing repository list and removes duplicates.
+   * Adds a list of remote repositories to an existing repository list, removes duplicates and sorts the results.
    * @returns a list of repositories that were not added because the list reached 1000 entries.
    */
   public async addRemoteReposToList(
@@ -172,7 +172,7 @@ export class DbConfigStore extends DisposableObject {
       ...new Set([...parent.repositories, ...repoNwoList]),
     ];
 
-    parent.repositories = newRepositoriesList.slice(0, 1000);
+    parent.repositories = newRepositoriesList.slice(0, 1000).sort();
     const truncatedRepositories = newRepositoriesList.slice(1000);
 
     await this.writeConfig(config);

--- a/extensions/ql-vscode/test/unit-tests/databases/config/db-config-store.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/config/db-config-store.test.ts
@@ -283,6 +283,41 @@ describe("db config store", () => {
       configStore.dispose();
     });
 
+    it("should sort remote repositories by name when adding multiple to a list", async () => {
+      // Initial set up
+      const dbConfig = createDbConfig({
+        remoteLists: [
+          {
+            name: "list1",
+            repositories: ["owner/c", "owner/b"],
+          },
+        ],
+      });
+
+      const configStore = await initializeConfig(dbConfig, configPath, app);
+
+      // Add
+      const response = await configStore.addRemoteReposToList(
+        ["owner/a"],
+        "list1",
+      );
+
+      // Read the config file
+      const updatedDbConfig = (await readJSON(configPath)) as DbConfig;
+
+      // Check that the config file has been updated
+      const updatedRemoteDbs = updatedDbConfig.databases.variantAnalysis;
+      expect(updatedRemoteDbs.repositories).toHaveLength(0);
+      expect(updatedRemoteDbs.repositoryLists).toHaveLength(1);
+      expect(updatedRemoteDbs.repositoryLists[0]).toEqual({
+        name: "list1",
+        repositories: ["owner/a", "owner/b", "owner/c"],
+      });
+      expect(response).toEqual([]);
+
+      configStore.dispose();
+    });
+
     it("should add no more than 1000 repositories to a remote list when adding multiple repos", async () => {
       // Initial set up
       const dbConfig = createDbConfig({


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

When adding repos to a list using code search we want to sort the resulting list alphabetically, so that it's easier to scan with human eyes.


## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
