### PR TITLE
Move interface-utils to local-queries/webview

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -73,7 +73,11 @@ import {
   getErrorStack,
 } from "./pure/helpers-pure";
 import { ResultsView } from "./interface";
-import { WebviewReveal } from "./interface-utils";
+import {
+  WebviewReveal,
+  LocalQueries,
+  QuickEvalCodeLensProvider,
+} from "./local-queries";
 import {
   extLogger,
   ideServerLogger,
@@ -115,7 +119,6 @@ import {
   PreActivationCommands,
   QueryServerCommands,
 } from "./common/commands";
-import { LocalQueries, QuickEvalCodeLensProvider } from "./local-queries";
 import { getAstCfgCommands } from "./language-support/ast-viewer/ast-cfg-commands";
 import { App } from "./common/app";
 import { registerCommandWithErrorHandling } from "./common/vscode/commands";

--- a/extensions/ql-vscode/src/interface.ts
+++ b/extensions/ql-vscode/src/interface.ts
@@ -53,7 +53,7 @@ import {
   parseSarifLocation,
   parseSarifPlainTextMessage,
 } from "./pure/sarif-utils";
-import { WebviewReveal, fileUriToWebviewUri } from "./interface-utils";
+import { WebviewReveal, fileUriToWebviewUri } from "./local-queries/webview";
 import {
   tryResolveLocation,
   shownLocationDecoration,

--- a/extensions/ql-vscode/src/local-queries/index.ts
+++ b/extensions/ql-vscode/src/local-queries/index.ts
@@ -2,3 +2,4 @@ export * from "./local-queries";
 export * from "./local-query-run";
 export * from "./quick-eval-code-lens-provider";
 export * from "./quick-query";
+export { WebviewReveal } from "./webview";

--- a/extensions/ql-vscode/src/local-queries/local-queries.ts
+++ b/extensions/ql-vscode/src/local-queries/local-queries.ts
@@ -39,7 +39,7 @@ import {
   validateQueryUri,
 } from "../run-queries-shared";
 import { CompletedLocalQueryInfo, LocalQueryInfo } from "../query-results";
-import { WebviewReveal } from "../interface-utils";
+import { WebviewReveal } from "./webview";
 import { asError, getErrorMessage } from "../pure/helpers-pure";
 import { CodeQLCliServer } from "../codeql-cli/cli";
 import { LocalQueryCommands } from "../common/commands";

--- a/extensions/ql-vscode/src/local-queries/local-query-run.ts
+++ b/extensions/ql-vscode/src/local-queries/local-query-run.ts
@@ -16,7 +16,7 @@ import {
   QueryWithResults,
 } from "../run-queries-shared";
 import { CompletedLocalQueryInfo, LocalQueryInfo } from "../query-results";
-import { WebviewReveal } from "../interface-utils";
+import { WebviewReveal } from "./webview";
 import { CodeQLCliServer } from "../codeql-cli/cli";
 import { QueryResultType } from "../pure/new-messages";
 import { redactableError } from "../pure/errors";

--- a/extensions/ql-vscode/src/local-queries/webview.ts
+++ b/extensions/ql-vscode/src/local-queries/webview.ts
@@ -1,9 +1,4 @@
-import { Uri, WebviewPanel } from "vscode";
-
-/**
- * This module contains functions and types that are sharedd between
- * interface.ts and compare-interface.ts.
- */
+import type { Uri, WebviewPanel } from "vscode";
 
 /**
  * Whether to force webview to reveal

--- a/extensions/ql-vscode/src/query-history/query-history-manager.ts
+++ b/extensions/ql-vscode/src/query-history/query-history-manager.ts
@@ -43,7 +43,7 @@ import { pathExists } from "fs-extra";
 import { CliVersionConstraint } from "../codeql-cli/cli";
 import { HistoryItemLabelProvider } from "./history-item-label-provider";
 import { ResultsView } from "../interface";
-import { WebviewReveal } from "../interface-utils";
+import { WebviewReveal } from "../local-queries";
 import { EvalLogTreeBuilder, EvalLogViewer } from "../query-evaluation-logging";
 import { EvalLogData, parseViewerData } from "../pure/log-summary-parser";
 import { QueryWithResults } from "../run-queries-shared";

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/local-queries/webview.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/local-queries/webview.test.ts
@@ -1,8 +1,8 @@
 import { Uri, ViewColumn, WebviewPanel, window } from "vscode";
 import { basename } from "path";
 import { FileResult, fileSync } from "tmp";
-import { fileUriToWebviewUri } from "../../../src/interface-utils";
-import { getDefaultResultSetName } from "../../../src/pure/interface-types";
+import { fileUriToWebviewUri } from "../../../../src/local-queries/webview";
+import { getDefaultResultSetName } from "../../../../src/pure/interface-types";
 
 describe("interface-utils", () => {
   describe("webview uri conversion", () => {

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-manager.test.ts
@@ -22,7 +22,7 @@ import { createMockVariantAnalysisHistoryItem } from "../../../factories/query-h
 import { VariantAnalysisHistoryItem } from "../../../../src/query-history/variant-analysis-history-item";
 import { QueryStatus } from "../../../../src/query-status";
 import { VariantAnalysisStatus } from "../../../../src/variant-analysis/shared/variant-analysis";
-import { WebviewReveal } from "../../../../src/interface-utils";
+import { WebviewReveal } from "../../../../src/local-queries";
 import * as helpers from "../../../../src/helpers";
 import { mockedQuickPickItem } from "../../utils/mocking.helpers";
 import { createMockQueryHistoryDirs } from "../../../factories/query-history/query-history-dirs";


### PR DESCRIPTION
This moves the two remaining methods in `interface-utils.ts` to `local-queries/webview.ts`. This removes the ambiguously named `interface-utils.ts` file.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
