### PR TITLE
Split helpers.ts file

### DIFF
--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -22,11 +22,11 @@ import {
   getErrorMessage,
   getErrorStack,
 } from "../pure/helpers-pure";
+import { walkDirectory } from "../pure/files";
 import { QueryMetadata, SortDirection } from "../pure/interface-types";
 import { BaseLogger, Logger, ProgressReporter } from "../common";
 import { CompilationMessage } from "../pure/legacy-messages";
 import { sarifParser } from "../common/sarif-parser";
-import { walkDirectory } from "../helpers";
 import { App } from "../common/app";
 import { QueryLanguage } from "../common/query-language";
 

--- a/extensions/ql-vscode/src/common/query-language.ts
+++ b/extensions/ql-vscode/src/common/query-language.ts
@@ -35,3 +35,7 @@ export const dbSchemeToLanguage = {
   "ruby.dbscheme": "ruby",
   "swift.dbscheme": "swift",
 };
+
+export function isQueryLanguage(language: string): language is QueryLanguage {
+  return Object.values(QueryLanguage).includes(language as QueryLanguage);
+}

--- a/extensions/ql-vscode/src/data-extensions-editor/external-api-usage-query.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/external-api-usage-query.ts
@@ -4,10 +4,10 @@ import { writeFile } from "fs-extra";
 import { dump as dumpYaml } from "js-yaml";
 import {
   getOnDiskWorkspaceFolders,
-  isQueryLanguage,
   showAndLogExceptionWithTelemetry,
 } from "../helpers";
 import { TeeLogger } from "../common";
+import { isQueryLanguage } from "../common/query-language";
 import { CancellationToken } from "vscode";
 import { CodeQLCliServer } from "../codeql-cli/cli";
 import { DatabaseItem } from "../databases/local-databases";

--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -29,11 +29,13 @@ import {
   withProgress,
 } from "../common/vscode/progress";
 import {
-  isLikelyDatabaseRoot,
-  isLikelyDbLanguageFolder,
   showAndLogErrorMessage,
   showAndLogExceptionWithTelemetry,
 } from "../helpers";
+import {
+  isLikelyDatabaseRoot,
+  isLikelyDbLanguageFolder,
+} from "./local-databases/db-contents-heuristics";
 import { extLogger } from "../common";
 import {
   importArchiveDatabase,

--- a/extensions/ql-vscode/src/databases/local-databases/database-item-impl.ts
+++ b/extensions/ql-vscode/src/databases/local-databases/database-item-impl.ts
@@ -10,7 +10,7 @@ import {
   zipArchiveScheme,
 } from "../../common/vscode/archive-filesystem-provider";
 import { DatabaseItem, PersistedDatabaseItem } from "./database-item";
-import { isLikelyDatabaseRoot } from "../../helpers";
+import { isLikelyDatabaseRoot } from "./db-contents-heuristics";
 import { stat } from "fs-extra";
 import { pathsEqual } from "../../pure/files";
 import { DatabaseContents } from "./database-contents";

--- a/extensions/ql-vscode/src/databases/local-databases/database-manager.ts
+++ b/extensions/ql-vscode/src/databases/local-databases/database-manager.ts
@@ -16,10 +16,10 @@ import { DatabaseItemImpl } from "./database-item-impl";
 import {
   getFirstWorkspaceFolder,
   isFolderAlreadyInWorkspace,
-  isQueryLanguage,
   showAndLogExceptionWithTelemetry,
   showNeverAskAgainDialog,
 } from "../../helpers";
+import { isQueryLanguage } from "../../common/query-language";
 import { existsSync } from "fs";
 import { QlPackGenerator } from "../../qlpack-generator";
 import { asError, getErrorMessage } from "../../pure/helpers-pure";

--- a/extensions/ql-vscode/src/databases/local-databases/db-contents-heuristics.ts
+++ b/extensions/ql-vscode/src/databases/local-databases/db-contents-heuristics.ts
@@ -1,0 +1,35 @@
+import { pathExists } from "fs-extra";
+import { basename, join } from "path";
+import { glob } from "glob";
+
+/**
+ * The following functions al heuristically determine metadata about databases.
+ */
+
+/**
+ * Heuristically determines if the directory passed in corresponds
+ * to a database root. A database root is a directory that contains
+ * a codeql-database.yml or (historically) a .dbinfo file. It also
+ * contains a folder starting with `db-`.
+ */
+export async function isLikelyDatabaseRoot(maybeRoot: string) {
+  const [a, b, c] = await Promise.all([
+    // databases can have either .dbinfo or codeql-database.yml.
+    pathExists(join(maybeRoot, ".dbinfo")),
+    pathExists(join(maybeRoot, "codeql-database.yml")),
+
+    // they *must* have a db-{language} folder
+    glob("db-*/", { cwd: maybeRoot }),
+  ]);
+
+  return (a || b) && c.length > 0;
+}
+
+/**
+ * A language folder is any folder starting with `db-` that is itself not a database root.
+ */
+export async function isLikelyDbLanguageFolder(dbPath: string) {
+  return (
+    basename(dbPath).startsWith("db-") && !(await isLikelyDatabaseRoot(dbPath))
+  );
+}

--- a/extensions/ql-vscode/src/databases/qlpack.ts
+++ b/extensions/ql-vscode/src/databases/qlpack.ts
@@ -1,0 +1,130 @@
+import { window } from "vscode";
+import { glob } from "glob";
+import { basename } from "path";
+import { load } from "js-yaml";
+import { readFile } from "fs-extra";
+import { getQlPackPath } from "../pure/ql";
+import { CodeQLCliServer, QlpacksInfo } from "../codeql-cli/cli";
+import { extLogger } from "../common";
+import { getOnDiskWorkspaceFolders } from "../helpers";
+
+export interface QlPacksForLanguage {
+  /** The name of the pack containing the dbscheme. */
+  dbschemePack: string;
+  /** `true` if `dbschemePack` is a library pack. */
+  dbschemePackIsLibraryPack: boolean;
+  /**
+   * The name of the corresponding standard query pack.
+   * Only defined if `dbschemePack` is a library pack.
+   */
+  queryPack?: string;
+}
+
+interface QlPackWithPath {
+  packName: string;
+  packDir: string | undefined;
+}
+
+async function findDbschemePack(
+  packs: QlPackWithPath[],
+  dbschemePath: string,
+): Promise<{ name: string; isLibraryPack: boolean }> {
+  for (const { packDir, packName } of packs) {
+    if (packDir !== undefined) {
+      const qlpackPath = await getQlPackPath(packDir);
+
+      if (qlpackPath !== undefined) {
+        const qlpack = load(await readFile(qlpackPath, "utf8")) as {
+          dbscheme?: string;
+          library?: boolean;
+        };
+        if (
+          qlpack.dbscheme !== undefined &&
+          basename(qlpack.dbscheme) === basename(dbschemePath)
+        ) {
+          return {
+            name: packName,
+            isLibraryPack: qlpack.library === true,
+          };
+        }
+      }
+    }
+  }
+  throw new Error(`Could not find qlpack file for dbscheme ${dbschemePath}`);
+}
+
+function findStandardQueryPack(
+  qlpacks: QlpacksInfo,
+  dbschemePackName: string,
+): string | undefined {
+  const matches = dbschemePackName.match(/^codeql\/(?<language>[a-z]+)-all$/);
+  if (matches) {
+    const queryPackName = `codeql/${matches.groups!.language}-queries`;
+    if (qlpacks[queryPackName] !== undefined) {
+      return queryPackName;
+    }
+  }
+
+  // Either the dbscheme pack didn't look like one where the queries might be in the query pack, or
+  // no query pack was found in the search path. Either is OK.
+  return undefined;
+}
+
+export async function getQlPackForDbscheme(
+  cliServer: Pick<CodeQLCliServer, "resolveQlpacks">,
+  dbschemePath: string,
+): Promise<QlPacksForLanguage> {
+  const qlpacks = await cliServer.resolveQlpacks(getOnDiskWorkspaceFolders());
+  const packs: QlPackWithPath[] = Object.entries(qlpacks).map(
+    ([packName, dirs]) => {
+      if (dirs.length < 1) {
+        void extLogger.log(
+          `In getQlPackFor ${dbschemePath}, qlpack ${packName} has no directories`,
+        );
+        return { packName, packDir: undefined };
+      }
+      if (dirs.length > 1) {
+        void extLogger.log(
+          `In getQlPackFor ${dbschemePath}, qlpack ${packName} has more than one directory; arbitrarily choosing the first`,
+        );
+      }
+      return {
+        packName,
+        packDir: dirs[0],
+      };
+    },
+  );
+  const dbschemePack = await findDbschemePack(packs, dbschemePath);
+  const queryPack = dbschemePack.isLibraryPack
+    ? findStandardQueryPack(qlpacks, dbschemePack.name)
+    : undefined;
+  return {
+    dbschemePack: dbschemePack.name,
+    dbschemePackIsLibraryPack: dbschemePack.isLibraryPack,
+    queryPack,
+  };
+}
+
+export async function getPrimaryDbscheme(
+  datasetFolder: string,
+): Promise<string> {
+  const dbschemes = await glob("*.dbscheme", {
+    cwd: datasetFolder,
+  });
+
+  if (dbschemes.length < 1) {
+    throw new Error(
+      `Can't find dbscheme for current database in ${datasetFolder}`,
+    );
+  }
+
+  dbschemes.sort();
+  const dbscheme = dbschemes[0];
+
+  if (dbschemes.length > 1) {
+    void window.showErrorMessage(
+      `Found multiple dbschemes in ${datasetFolder} during quick query; arbitrarily choosing the first, ${dbscheme}, to decide what library to use.`,
+    );
+  }
+  return dbscheme;
+}

--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -1,23 +1,20 @@
 import {
   ensureDirSync,
-  readFile,
   pathExists,
   ensureDir,
   writeFile,
   opendir,
 } from "fs-extra";
 import { glob } from "glob";
-import { load } from "js-yaml";
 import { join, basename, dirname } from "path";
 import { dirSync } from "tmp-promise";
 import { Uri, window as Window, workspace, env, WorkspaceFolder } from "vscode";
-import { CodeQLCliServer, QlpacksInfo } from "./codeql-cli/cli";
+import { CodeQLCliServer } from "./codeql-cli/cli";
 import { UserCancellationException } from "./common/vscode/progress";
 import { extLogger, OutputChannelLogger } from "./common";
 import { QueryMetadata } from "./pure/interface-types";
 import { telemetryListener } from "./telemetry";
 import { RedactableError } from "./pure/errors";
-import { getQlPackPath } from "./pure/ql";
 import { dbSchemeToLanguage, QueryLanguage } from "./common/query-language";
 import { isCodespacesTemplate } from "./config";
 import { AppCommandManager } from "./common/commands";
@@ -354,127 +351,6 @@ export async function prepareCodeTour(
       await commandManager.execute("vscode.openFolder", tutorialWorkspaceUri);
     }
   }
-}
-
-export interface QlPacksForLanguage {
-  /** The name of the pack containing the dbscheme. */
-  dbschemePack: string;
-  /** `true` if `dbschemePack` is a library pack. */
-  dbschemePackIsLibraryPack: boolean;
-  /**
-   * The name of the corresponding standard query pack.
-   * Only defined if `dbschemePack` is a library pack.
-   */
-  queryPack?: string;
-}
-
-interface QlPackWithPath {
-  packName: string;
-  packDir: string | undefined;
-}
-
-async function findDbschemePack(
-  packs: QlPackWithPath[],
-  dbschemePath: string,
-): Promise<{ name: string; isLibraryPack: boolean }> {
-  for (const { packDir, packName } of packs) {
-    if (packDir !== undefined) {
-      const qlpackPath = await getQlPackPath(packDir);
-
-      if (qlpackPath !== undefined) {
-        const qlpack = load(await readFile(qlpackPath, "utf8")) as {
-          dbscheme?: string;
-          library?: boolean;
-        };
-        if (
-          qlpack.dbscheme !== undefined &&
-          basename(qlpack.dbscheme) === basename(dbschemePath)
-        ) {
-          return {
-            name: packName,
-            isLibraryPack: qlpack.library === true,
-          };
-        }
-      }
-    }
-  }
-  throw new Error(`Could not find qlpack file for dbscheme ${dbschemePath}`);
-}
-
-function findStandardQueryPack(
-  qlpacks: QlpacksInfo,
-  dbschemePackName: string,
-): string | undefined {
-  const matches = dbschemePackName.match(/^codeql\/(?<language>[a-z]+)-all$/);
-  if (matches) {
-    const queryPackName = `codeql/${matches.groups!.language}-queries`;
-    if (qlpacks[queryPackName] !== undefined) {
-      return queryPackName;
-    }
-  }
-
-  // Either the dbscheme pack didn't look like one where the queries might be in the query pack, or
-  // no query pack was found in the search path. Either is OK.
-  return undefined;
-}
-
-export async function getQlPackForDbscheme(
-  cliServer: Pick<CodeQLCliServer, "resolveQlpacks">,
-  dbschemePath: string,
-): Promise<QlPacksForLanguage> {
-  const qlpacks = await cliServer.resolveQlpacks(getOnDiskWorkspaceFolders());
-  const packs: QlPackWithPath[] = Object.entries(qlpacks).map(
-    ([packName, dirs]) => {
-      if (dirs.length < 1) {
-        void extLogger.log(
-          `In getQlPackFor ${dbschemePath}, qlpack ${packName} has no directories`,
-        );
-        return { packName, packDir: undefined };
-      }
-      if (dirs.length > 1) {
-        void extLogger.log(
-          `In getQlPackFor ${dbschemePath}, qlpack ${packName} has more than one directory; arbitrarily choosing the first`,
-        );
-      }
-      return {
-        packName,
-        packDir: dirs[0],
-      };
-    },
-  );
-  const dbschemePack = await findDbschemePack(packs, dbschemePath);
-  const queryPack = dbschemePack.isLibraryPack
-    ? findStandardQueryPack(qlpacks, dbschemePack.name)
-    : undefined;
-  return {
-    dbschemePack: dbschemePack.name,
-    dbschemePackIsLibraryPack: dbschemePack.isLibraryPack,
-    queryPack,
-  };
-}
-
-export async function getPrimaryDbscheme(
-  datasetFolder: string,
-): Promise<string> {
-  const dbschemes = await glob("*.dbscheme", {
-    cwd: datasetFolder,
-  });
-
-  if (dbschemes.length < 1) {
-    throw new Error(
-      `Can't find dbscheme for current database in ${datasetFolder}`,
-    );
-  }
-
-  dbschemes.sort();
-  const dbscheme = dbschemes[0];
-
-  if (dbschemes.length > 1) {
-    void Window.showErrorMessage(
-      `Found multiple dbschemes in ${datasetFolder} during quick query; arbitrarily choosing the first, ${dbscheme}, to decide what library to use.`,
-    );
-  }
-  return dbscheme;
 }
 
 /**

--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -5,7 +5,7 @@ import {
   writeFile,
   opendir,
 } from "fs-extra";
-import { join, basename, dirname } from "path";
+import { join, dirname } from "path";
 import { dirSync } from "tmp-promise";
 import { Uri, window as Window, workspace, env, WorkspaceFolder } from "vscode";
 import { CodeQLCliServer } from "./codeql-cli/cli";
@@ -14,7 +14,7 @@ import { extLogger, OutputChannelLogger } from "./common";
 import { QueryMetadata } from "./pure/interface-types";
 import { telemetryListener } from "./telemetry";
 import { RedactableError } from "./pure/errors";
-import { dbSchemeToLanguage, QueryLanguage } from "./common/query-language";
+import { QueryLanguage } from "./common/query-language";
 import { isCodespacesTemplate } from "./config";
 import { AppCommandManager } from "./common/commands";
 
@@ -350,27 +350,6 @@ export async function prepareCodeTour(
       await commandManager.execute("vscode.openFolder", tutorialWorkspaceUri);
     }
   }
-}
-
-/**
- * Returns the initial contents for an empty query, based on the language of the selected
- * databse.
- *
- * First try to use the given language name. If that doesn't exist, try to infer it based on
- * dbscheme. Otherwise return no import statement.
- *
- * @param language the database language or empty string if unknown
- * @param dbscheme path to the dbscheme file
- *
- * @returns an import and empty select statement appropriate for the selected language
- */
-export function getInitialQueryContents(language: string, dbscheme: string) {
-  if (!language) {
-    const dbschemeBase = basename(dbscheme) as keyof typeof dbSchemeToLanguage;
-    language = dbSchemeToLanguage[dbschemeBase];
-  }
-
-  return language ? `import ${language}\n\nselect ""` : 'select ""';
 }
 
 export function isQueryLanguage(language: string): language is QueryLanguage {

--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -5,7 +5,6 @@ import {
   writeFile,
   opendir,
 } from "fs-extra";
-import { glob } from "glob";
 import { join, basename, dirname } from "path";
 import { dirSync } from "tmp-promise";
 import { Uri, window as Window, workspace, env, WorkspaceFolder } from "vscode";
@@ -354,10 +353,6 @@ export async function prepareCodeTour(
 }
 
 /**
- * The following functions al heuristically determine metadata about databases.
- */
-
-/**
  * Returns the initial contents for an empty query, based on the language of the selected
  * databse.
  *
@@ -376,34 +371,6 @@ export function getInitialQueryContents(language: string, dbscheme: string) {
   }
 
   return language ? `import ${language}\n\nselect ""` : 'select ""';
-}
-
-/**
- * Heuristically determines if the directory passed in corresponds
- * to a database root. A database root is a directory that contains
- * a codeql-database.yml or (historically) a .dbinfo file. It also
- * contains a folder starting with `db-`.
- */
-export async function isLikelyDatabaseRoot(maybeRoot: string) {
-  const [a, b, c] = await Promise.all([
-    // databases can have either .dbinfo or codeql-database.yml.
-    pathExists(join(maybeRoot, ".dbinfo")),
-    pathExists(join(maybeRoot, "codeql-database.yml")),
-
-    // they *must* have a db-{language} folder
-    glob("db-*/", { cwd: maybeRoot }),
-  ]);
-
-  return (a || b) && c.length > 0;
-}
-
-/**
- * A language folder is any folder starting with `db-` that is itself not a database root.
- */
-export async function isLikelyDbLanguageFolder(dbPath: string) {
-  return (
-    basename(dbPath).startsWith("db-") && !(await isLikelyDatabaseRoot(dbPath))
-  );
 }
 
 export function isQueryLanguage(language: string): language is QueryLanguage {

--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -1,10 +1,4 @@
-import {
-  ensureDirSync,
-  pathExists,
-  ensureDir,
-  writeFile,
-  opendir,
-} from "fs-extra";
+import { ensureDirSync, pathExists, ensureDir, writeFile } from "fs-extra";
 import { join, dirname } from "path";
 import { dirSync } from "tmp-promise";
 import { Uri, window as Window, workspace, env, WorkspaceFolder } from "vscode";
@@ -453,29 +447,6 @@ export async function createTimestampFile(storagePath: string) {
   const timestampPath = join(storagePath, "timestamp");
   await ensureDir(storagePath);
   await writeFile(timestampPath, Date.now().toString(), "utf8");
-}
-
-/**
- * Recursively walk a directory and return the full path to all files found.
- * Symbolic links are ignored.
- *
- * @param dir the directory to walk
- *
- * @return An iterator of the full path to all files recursively found in the directory.
- */
-export async function* walkDirectory(
-  dir: string,
-): AsyncIterableIterator<string> {
-  const seenFiles = new Set<string>();
-  for await (const d of await opendir(dir)) {
-    const entry = join(dir, d.name);
-    seenFiles.add(entry);
-    if (d.isDirectory()) {
-      yield* walkDirectory(entry);
-    } else if (d.isFile()) {
-      yield entry;
-    }
-  }
 }
 
 /**

--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -358,24 +358,6 @@ export async function prepareCodeTour(
  */
 
 /**
- * Note that this heuristic is only being used for backwards compatibility with
- * CLI versions before the langauge name was introduced to dbInfo. Features
- * that do not require backwards compatibility should call
- * `cli.CodeQLCliServer.resolveDatabase` and use the first entry in the
- * `languages` property.
- *
- * @see cli.CodeQLCliServer.resolveDatabase
- */
-
-export const languageToDbScheme = Object.entries(dbSchemeToLanguage).reduce(
-  (acc, [k, v]) => {
-    acc[v] = k;
-    return acc;
-  },
-  {} as { [k: string]: string },
-);
-
-/**
  * Returns the initial contents for an empty query, based on the language of the selected
  * databse.
  *

--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -14,7 +14,7 @@ import { extLogger, OutputChannelLogger } from "./common";
 import { QueryMetadata } from "./pure/interface-types";
 import { telemetryListener } from "./telemetry";
 import { RedactableError } from "./pure/errors";
-import { QueryLanguage } from "./common/query-language";
+import { isQueryLanguage, QueryLanguage } from "./common/query-language";
 import { isCodespacesTemplate } from "./config";
 import { AppCommandManager } from "./common/commands";
 
@@ -350,10 +350,6 @@ export async function prepareCodeTour(
       await commandManager.execute("vscode.openFolder", tutorialWorkspaceUri);
     }
   }
-}
-
-export function isQueryLanguage(language: string): language is QueryLanguage {
-  return Object.values(QueryLanguage).includes(language as QueryLanguage);
 }
 
 /**

--- a/extensions/ql-vscode/src/language-support/contextual/query-resolver.ts
+++ b/extensions/ql-vscode/src/language-support/contextual/query-resolver.ts
@@ -4,12 +4,14 @@ import { file } from "tmp-promise";
 import { basename, dirname, resolve } from "path";
 
 import {
-  getPrimaryDbscheme,
-  getQlPackForDbscheme,
   getOnDiskWorkspaceFolders,
-  QlPacksForLanguage,
   showAndLogExceptionWithTelemetry,
 } from "../../helpers";
+import {
+  getPrimaryDbscheme,
+  getQlPackForDbscheme,
+  QlPacksForLanguage,
+} from "../../databases/qlpack";
 import {
   KeyType,
   kindOfKeyType,

--- a/extensions/ql-vscode/src/local-queries/query-contents.ts
+++ b/extensions/ql-vscode/src/local-queries/query-contents.ts
@@ -1,0 +1,23 @@
+import { basename } from "path";
+import { dbSchemeToLanguage } from "../common/query-language";
+
+/**
+ * Returns the initial contents for an empty query, based on the language of the selected
+ * databse.
+ *
+ * First try to use the given language name. If that doesn't exist, try to infer it based on
+ * dbscheme. Otherwise return no import statement.
+ *
+ * @param language the database language or empty string if unknown
+ * @param dbscheme path to the dbscheme file
+ *
+ * @returns an import and empty select statement appropriate for the selected language
+ */
+export function getInitialQueryContents(language: string, dbscheme: string) {
+  if (!language) {
+    const dbschemeBase = basename(dbscheme) as keyof typeof dbSchemeToLanguage;
+    language = dbSchemeToLanguage[dbschemeBase];
+  }
+
+  return language ? `import ${language}\n\nselect ""` : 'select ""';
+}

--- a/extensions/ql-vscode/src/local-queries/quick-query.ts
+++ b/extensions/ql-vscode/src/local-queries/quick-query.ts
@@ -5,7 +5,8 @@ import { CancellationToken, window as Window, workspace, Uri } from "vscode";
 import { LSPErrorCodes, ResponseError } from "vscode-languageclient";
 import { CodeQLCliServer } from "../codeql-cli/cli";
 import { DatabaseUI } from "../databases/local-databases-ui";
-import { getInitialQueryContents, showBinaryChoiceDialog } from "../helpers";
+import { showBinaryChoiceDialog } from "../helpers";
+import { getInitialQueryContents } from "./query-contents";
 import { getPrimaryDbscheme, getQlPackForDbscheme } from "../databases/qlpack";
 import {
   ProgressCallback,

--- a/extensions/ql-vscode/src/local-queries/quick-query.ts
+++ b/extensions/ql-vscode/src/local-queries/quick-query.ts
@@ -5,12 +5,8 @@ import { CancellationToken, window as Window, workspace, Uri } from "vscode";
 import { LSPErrorCodes, ResponseError } from "vscode-languageclient";
 import { CodeQLCliServer } from "../codeql-cli/cli";
 import { DatabaseUI } from "../databases/local-databases-ui";
-import {
-  getInitialQueryContents,
-  getPrimaryDbscheme,
-  getQlPackForDbscheme,
-  showBinaryChoiceDialog,
-} from "../helpers";
+import { getInitialQueryContents, showBinaryChoiceDialog } from "../helpers";
+import { getPrimaryDbscheme, getQlPackForDbscheme } from "../databases/qlpack";
 import {
   ProgressCallback,
   UserCancellationException,

--- a/extensions/ql-vscode/test/unit-tests/databases/local-databases/db-contents-heuristics.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/local-databases/db-contents-heuristics.test.ts
@@ -1,0 +1,76 @@
+import * as tmp from "tmp";
+import { join } from "path";
+import { mkdirSync, writeFileSync } from "fs-extra";
+import {
+  isLikelyDatabaseRoot,
+  isLikelyDbLanguageFolder,
+} from "../../../../src/databases/local-databases/db-contents-heuristics";
+
+describe("isLikelyDatabaseRoot", () => {
+  let dir: tmp.DirResult;
+  beforeEach(() => {
+    dir = tmp.dirSync();
+  });
+
+  afterEach(() => {
+    dir.removeCallback();
+  });
+
+  it("should likely be a database root: codeql-database.yml", async () => {
+    const dbFolder = join(dir.name, "db");
+    mkdirSync(dbFolder);
+    mkdirSync(join(dbFolder, "db-python"));
+    writeFileSync(join(dbFolder, "codeql-database.yml"), "", "utf8");
+
+    expect(await isLikelyDatabaseRoot(dbFolder)).toBe(true);
+  });
+
+  it("should likely be a database root: .dbinfo", async () => {
+    const dbFolder = join(dir.name, "db");
+    mkdirSync(dbFolder);
+    mkdirSync(join(dbFolder, "db-python"));
+    writeFileSync(join(dbFolder, ".dbinfo"), "", "utf8");
+
+    expect(await isLikelyDatabaseRoot(dbFolder)).toBe(true);
+  });
+
+  it("should likely NOT be a database root: empty dir", async () => {
+    const dbFolder = join(dir.name, "db");
+    mkdirSync(dbFolder);
+    mkdirSync(join(dbFolder, "db-python"));
+
+    expect(await isLikelyDatabaseRoot(dbFolder)).toBe(false);
+  });
+
+  it("should likely NOT be a database root: no db language folder", async () => {
+    const dbFolder = join(dir.name, "db");
+    mkdirSync(dbFolder);
+    writeFileSync(join(dbFolder, ".dbinfo"), "", "utf8");
+
+    expect(await isLikelyDatabaseRoot(dbFolder)).toBe(false);
+  });
+});
+
+describe("isLikelyDbLanguageFolder", () => {
+  let dir: tmp.DirResult;
+  beforeEach(() => {
+    dir = tmp.dirSync();
+  });
+
+  afterEach(() => {
+    dir.removeCallback();
+  });
+
+  it("should find likely db language folder", async () => {
+    const dbFolder = join(dir.name, "db-python");
+    mkdirSync(dbFolder);
+    mkdirSync(join(dbFolder, "db-python"));
+    writeFileSync(join(dbFolder, "codeql-database.yml"), "", "utf8");
+
+    // not a db folder since there is a db-python folder inside this one
+    expect(await isLikelyDbLanguageFolder(dbFolder)).toBe(false);
+
+    const nestedDbPythonFolder = join(dbFolder, "db-python");
+    expect(await isLikelyDbLanguageFolder(nestedDbPythonFolder)).toBe(true);
+  });
+});

--- a/extensions/ql-vscode/test/unit-tests/local-queries/query-contents.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/local-queries/query-contents.test.ts
@@ -1,0 +1,41 @@
+import * as tmp from "tmp";
+import { dump } from "js-yaml";
+import { writeFileSync } from "fs-extra";
+import { join } from "path";
+import { QueryLanguage } from "../../../src/common/query-language";
+import { getInitialQueryContents } from "../../../src/local-queries/query-contents";
+
+describe("getInitialQueryContents", () => {
+  let dir: tmp.DirResult;
+  let language: QueryLanguage;
+
+  beforeEach(() => {
+    dir = tmp.dirSync();
+    language = QueryLanguage.Cpp;
+
+    const contents = dump({
+      primaryLanguage: language,
+    });
+    writeFileSync(join(dir.name, "codeql-database.yml"), contents, "utf8");
+  });
+
+  afterEach(() => {
+    dir.removeCallback();
+  });
+
+  it("should get initial query contents when language is known", () => {
+    expect(getInitialQueryContents(language, "hucairz")).toBe(
+      'import cpp\n\nselect ""',
+    );
+  });
+
+  it("should get initial query contents when dbscheme is known", () => {
+    expect(getInitialQueryContents("", "semmlecode.cpp.dbscheme")).toBe(
+      'import cpp\n\nselect ""',
+    );
+  });
+
+  it("should get initial query contents when nothing is known", () => {
+    expect(getInitialQueryContents("", "hucairz")).toBe('select ""');
+  });
+});

--- a/extensions/ql-vscode/test/unit-tests/pure/files.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/pure/files.test.ts
@@ -6,7 +6,11 @@ import {
   getDirectoryNamesInsidePath,
   pathsEqual,
   readDirFullPaths,
+  walkDirectory,
 } from "../../../src/pure/files";
+import { DirResult } from "tmp";
+import * as tmp from "tmp";
+import { ensureDirSync, symlinkSync, writeFileSync } from "fs-extra";
 
 describe("files", () => {
   const dataDir = join(__dirname, "../../data");
@@ -298,4 +302,68 @@ describe("containsPath", () => {
       expect(containsPath(path1, path2, platform)).toEqual(expected);
     },
   );
+});
+
+describe("walkDirectory", () => {
+  let tmpDir: DirResult;
+  let dir: string;
+  let dir2: string;
+
+  beforeEach(() => {
+    tmpDir = tmp.dirSync({ unsafeCleanup: true });
+    dir = join(tmpDir.name, "dir");
+    ensureDirSync(dir);
+    dir2 = join(tmpDir.name, "dir2");
+  });
+
+  afterEach(() => {
+    tmpDir.removeCallback();
+  });
+
+  it("should walk a directory", async () => {
+    const file1 = join(dir, "file1");
+    const file2 = join(dir, "file2");
+    const file3 = join(dir, "file3");
+    const dir3 = join(dir, "dir3");
+    const file4 = join(dir, "file4");
+    const file5 = join(dir, "file5");
+    const file6 = join(dir, "file6");
+
+    // These symlinks link back to paths that are already existing, so ignore.
+    const symLinkFile7 = join(dir, "symlink0");
+    const symlinkDir = join(dir2, "symlink1");
+
+    // some symlinks that point outside of the base dir.
+    const file8 = join(tmpDir.name, "file8");
+    const file9 = join(dir2, "file8");
+    const symlinkDir2 = join(dir2, "symlink2");
+    const symlinkFile2 = join(dir2, "symlinkFile3");
+
+    ensureDirSync(dir2);
+    ensureDirSync(dir3);
+
+    writeFileSync(file1, "file1");
+    writeFileSync(file2, "file2");
+    writeFileSync(file3, "file3");
+    writeFileSync(file4, "file4");
+    writeFileSync(file5, "file5");
+    writeFileSync(file6, "file6");
+    writeFileSync(file8, "file8");
+    writeFileSync(file9, "file9");
+
+    // We don't really need to be testing all of these variants of symlinks,
+    // but it doesn't hurt, and will help us if we ever do decide to support them.
+    symlinkSync(file6, symLinkFile7, "file");
+    symlinkSync(dir3, symlinkDir, "dir");
+    symlinkSync(file8, symlinkFile2, "file");
+    symlinkSync(dir2, symlinkDir2, "dir");
+
+    const files = [];
+    for await (const file of walkDirectory(dir)) {
+      files.push(file);
+    }
+
+    // Only real files should be returned.
+    expect(files.sort()).toEqual([file1, file2, file3, file4, file5, file6]);
+  });
 });

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/run-cli.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/run-cli.test.ts
@@ -7,15 +7,13 @@ import {
   QueryInfoByLanguage,
 } from "../../../src/codeql-cli/cli";
 import { itWithCodeQL } from "../cli";
-import {
-  getOnDiskWorkspaceFolders,
-  languageToDbScheme,
-} from "../../../src/helpers";
+import { getOnDiskWorkspaceFolders } from "../../../src/helpers";
 import { KeyType, resolveQueries } from "../../../src/language-support";
 import { faker } from "@faker-js/faker";
 import { getActivatedExtension } from "../global.helper";
 import { BaseLogger } from "../../../src/common";
 import { getQlPackForDbscheme } from "../../../src/databases/qlpack";
+import { dbSchemeToLanguage } from "../../../src/common/query-language";
 
 /**
  * Perform proper integration tests by running the CLI
@@ -25,6 +23,14 @@ describe("Use cli", () => {
   let supportedLanguages: string[];
 
   let logSpy: jest.SpiedFunction<BaseLogger["log"]>;
+
+  const languageToDbScheme = Object.entries(dbSchemeToLanguage).reduce(
+    (acc, [k, v]) => {
+      acc[v] = k;
+      return acc;
+    },
+    {} as { [k: string]: string },
+  );
 
   beforeEach(async () => {
     const extension = await getActivatedExtension();

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/run-cli.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/run-cli.test.ts
@@ -9,13 +9,13 @@ import {
 import { itWithCodeQL } from "../cli";
 import {
   getOnDiskWorkspaceFolders,
-  getQlPackForDbscheme,
   languageToDbScheme,
 } from "../../../src/helpers";
 import { KeyType, resolveQueries } from "../../../src/language-support";
 import { faker } from "@faker-js/faker";
 import { getActivatedExtension } from "../global.helper";
 import { BaseLogger } from "../../../src/common";
+import { getQlPackForDbscheme } from "../../../src/databases/qlpack";
 
 /**
  * Perform proper integration tests by running the CLI

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/helpers.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/helpers.test.ts
@@ -4,7 +4,6 @@ import * as tmp from "tmp";
 import { join } from "path";
 import {
   writeFileSync,
-  mkdirSync,
   ensureDirSync,
   symlinkSync,
   writeFile,
@@ -16,8 +15,6 @@ import {
   getFirstWorkspaceFolder,
   getInitialQueryContents,
   isFolderAlreadyInWorkspace,
-  isLikelyDatabaseRoot,
-  isLikelyDbLanguageFolder,
   prepareCodeTour,
   showBinaryChoiceDialog,
   showBinaryChoiceWithUrlDialog,
@@ -63,64 +60,6 @@ describe("helpers", () => {
 
     it("should get initial query contents when nothing is known", () => {
       expect(getInitialQueryContents("", "hucairz")).toBe('select ""');
-    });
-  });
-
-  describe("likely database tests", () => {
-    let dir: tmp.DirResult;
-    beforeEach(() => {
-      dir = tmp.dirSync();
-    });
-
-    afterEach(() => {
-      dir.removeCallback();
-    });
-
-    it("should likely be a database root: codeql-database.yml", async () => {
-      const dbFolder = join(dir.name, "db");
-      mkdirSync(dbFolder);
-      mkdirSync(join(dbFolder, "db-python"));
-      writeFileSync(join(dbFolder, "codeql-database.yml"), "", "utf8");
-
-      expect(await isLikelyDatabaseRoot(dbFolder)).toBe(true);
-    });
-
-    it("should likely be a database root: .dbinfo", async () => {
-      const dbFolder = join(dir.name, "db");
-      mkdirSync(dbFolder);
-      mkdirSync(join(dbFolder, "db-python"));
-      writeFileSync(join(dbFolder, ".dbinfo"), "", "utf8");
-
-      expect(await isLikelyDatabaseRoot(dbFolder)).toBe(true);
-    });
-
-    it("should likely NOT be a database root: empty dir", async () => {
-      const dbFolder = join(dir.name, "db");
-      mkdirSync(dbFolder);
-      mkdirSync(join(dbFolder, "db-python"));
-
-      expect(await isLikelyDatabaseRoot(dbFolder)).toBe(false);
-    });
-
-    it("should likely NOT be a database root: no db language folder", async () => {
-      const dbFolder = join(dir.name, "db");
-      mkdirSync(dbFolder);
-      writeFileSync(join(dbFolder, ".dbinfo"), "", "utf8");
-
-      expect(await isLikelyDatabaseRoot(dbFolder)).toBe(false);
-    });
-
-    it("should find likely db language folder", async () => {
-      const dbFolder = join(dir.name, "db-python");
-      mkdirSync(dbFolder);
-      mkdirSync(join(dbFolder, "db-python"));
-      writeFileSync(join(dbFolder, "codeql-database.yml"), "", "utf8");
-
-      // not a db folder since there is a db-python folder inside this one
-      expect(await isLikelyDbLanguageFolder(dbFolder)).toBe(false);
-
-      const nestedDbPythonFolder = join(dbFolder, "db-python");
-      expect(await isLikelyDbLanguageFolder(nestedDbPythonFolder)).toBe(true);
     });
   });
 

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/helpers.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/helpers.test.ts
@@ -1,5 +1,4 @@
 import { Uri, window, workspace, WorkspaceFolder } from "vscode";
-import { dump } from "js-yaml";
 import * as tmp from "tmp";
 import { join } from "path";
 import {
@@ -13,7 +12,6 @@ import { DirResult } from "tmp";
 
 import {
   getFirstWorkspaceFolder,
-  getInitialQueryContents,
   isFolderAlreadyInWorkspace,
   prepareCodeTour,
   showBinaryChoiceDialog,
@@ -23,46 +21,10 @@ import {
   walkDirectory,
 } from "../../../src/helpers";
 import { reportStreamProgress } from "../../../src/common/vscode/progress";
-import { QueryLanguage } from "../../../src/common/query-language";
 import { Setting } from "../../../src/config";
 import { createMockCommandManager } from "../../__mocks__/commandsMock";
 
 describe("helpers", () => {
-  describe("codeql-database.yml tests", () => {
-    let dir: tmp.DirResult;
-    let language: QueryLanguage;
-
-    beforeEach(() => {
-      dir = tmp.dirSync();
-      language = QueryLanguage.Cpp;
-
-      const contents = dump({
-        primaryLanguage: language,
-      });
-      writeFileSync(join(dir.name, "codeql-database.yml"), contents, "utf8");
-    });
-
-    afterEach(() => {
-      dir.removeCallback();
-    });
-
-    it("should get initial query contents when language is known", () => {
-      expect(getInitialQueryContents(language, "hucairz")).toBe(
-        'import cpp\n\nselect ""',
-      );
-    });
-
-    it("should get initial query contents when dbscheme is known", () => {
-      expect(getInitialQueryContents("", "semmlecode.cpp.dbscheme")).toBe(
-        'import cpp\n\nselect ""',
-      );
-    });
-
-    it("should get initial query contents when nothing is known", () => {
-      expect(getInitialQueryContents("", "hucairz")).toBe('select ""');
-    });
-  });
-
   it("should report stream progress", () => {
     const progressSpy = jest.fn();
     const mockReadable = {

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/helpers.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/helpers.test.ts
@@ -1,14 +1,7 @@
 import { Uri, window, workspace, WorkspaceFolder } from "vscode";
 import * as tmp from "tmp";
 import { join } from "path";
-import {
-  writeFileSync,
-  ensureDirSync,
-  symlinkSync,
-  writeFile,
-  mkdir,
-} from "fs-extra";
-import { DirResult } from "tmp";
+import { writeFile, mkdir } from "fs-extra";
 
 import {
   getFirstWorkspaceFolder,
@@ -18,7 +11,6 @@ import {
   showBinaryChoiceWithUrlDialog,
   showInformationMessageWithAction,
   showNeverAskAgainDialog,
-  walkDirectory,
 } from "../../../src/helpers";
 import { reportStreamProgress } from "../../../src/common/vscode/progress";
 import { Setting } from "../../../src/config";
@@ -240,70 +232,6 @@ describe("helpers", () => {
       const answer = await showNeverAskAgainDialog(title);
       expect(answer).toBe("No, and never ask me again");
     });
-  });
-});
-
-describe("walkDirectory", () => {
-  let tmpDir: DirResult;
-  let dir: string;
-  let dir2: string;
-
-  beforeEach(() => {
-    tmpDir = tmp.dirSync({ unsafeCleanup: true });
-    dir = join(tmpDir.name, "dir");
-    ensureDirSync(dir);
-    dir2 = join(tmpDir.name, "dir2");
-  });
-
-  afterEach(() => {
-    tmpDir.removeCallback();
-  });
-
-  it("should walk a directory", async () => {
-    const file1 = join(dir, "file1");
-    const file2 = join(dir, "file2");
-    const file3 = join(dir, "file3");
-    const dir3 = join(dir, "dir3");
-    const file4 = join(dir, "file4");
-    const file5 = join(dir, "file5");
-    const file6 = join(dir, "file6");
-
-    // These symlinks link back to paths that are already existing, so ignore.
-    const symLinkFile7 = join(dir, "symlink0");
-    const symlinkDir = join(dir2, "symlink1");
-
-    // some symlinks that point outside of the base dir.
-    const file8 = join(tmpDir.name, "file8");
-    const file9 = join(dir2, "file8");
-    const symlinkDir2 = join(dir2, "symlink2");
-    const symlinkFile2 = join(dir2, "symlinkFile3");
-
-    ensureDirSync(dir2);
-    ensureDirSync(dir3);
-
-    writeFileSync(file1, "file1");
-    writeFileSync(file2, "file2");
-    writeFileSync(file3, "file3");
-    writeFileSync(file4, "file4");
-    writeFileSync(file5, "file5");
-    writeFileSync(file6, "file6");
-    writeFileSync(file8, "file8");
-    writeFileSync(file9, "file9");
-
-    // We don't really need to be testing all of these variants of symlinks,
-    // but it doesn't hurt, and will help us if we ever do decide to support them.
-    symlinkSync(file6, symLinkFile7, "file");
-    symlinkSync(dir3, symlinkDir, "dir");
-    symlinkSync(file8, symlinkFile2, "file");
-    symlinkSync(dir2, symlinkDir2, "dir");
-
-    const files = [];
-    for await (const file of walkDirectory(dir)) {
-      files.push(file);
-    }
-
-    // Only real files should be returned.
-    expect(files.sort()).toEqual([file1, file2, file3, file4, file5, file6]);
   });
 });
 

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/language-support/contextual/query-resolver.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/language-support/contextual/query-resolver.test.ts
@@ -4,6 +4,7 @@ import * as fs from "fs-extra";
 import { getErrorMessage } from "../../../../../src/pure/helpers-pure";
 
 import * as helpers from "../../../../../src/helpers";
+import * as qlpack from "../../../../../src/databases/qlpack";
 import {
   KeyType,
   qlpackOfDatabase,
@@ -14,10 +15,10 @@ import { mockDatabaseItem, mockedObject } from "../../../utils/mocking.helpers";
 
 describe("queryResolver", () => {
   let getQlPackForDbschemeSpy: jest.SpiedFunction<
-    typeof helpers.getQlPackForDbscheme
+    typeof qlpack.getQlPackForDbscheme
   >;
   let getPrimaryDbschemeSpy: jest.SpiedFunction<
-    typeof helpers.getPrimaryDbscheme
+    typeof qlpack.getPrimaryDbscheme
   >;
 
   const resolveQueriesInSuite = jest.fn();
@@ -28,13 +29,13 @@ describe("queryResolver", () => {
 
   beforeEach(() => {
     getQlPackForDbschemeSpy = jest
-      .spyOn(helpers, "getQlPackForDbscheme")
+      .spyOn(qlpack, "getQlPackForDbscheme")
       .mockResolvedValue({
         dbschemePack: "dbschemePack",
         dbschemePackIsLibraryPack: false,
       });
     getPrimaryDbschemeSpy = jest
-      .spyOn(helpers, "getPrimaryDbscheme")
+      .spyOn(qlpack, "getPrimaryDbscheme")
       .mockResolvedValue("primaryDbscheme");
 
     jest.spyOn(helpers, "getOnDiskWorkspaceFolders").mockReturnValue([]);

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/variant-analysis-history.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/variant-analysis-history.test.ts
@@ -10,7 +10,8 @@ import { join } from "path";
 
 import { ExtensionContext, Uri } from "vscode";
 import { DatabaseManager } from "../../../../src/databases/local-databases";
-import { tmpDir, walkDirectory } from "../../../../src/helpers";
+import { tmpDir } from "../../../../src/helpers";
+import { walkDirectory } from "../../../../src/pure/files";
 import { DisposableBucket } from "../../disposable-bucket";
 import { testDisposeHandler } from "../../test-dispose-handler";
 import { HistoryItemLabelProvider } from "../../../../src/query-history/history-item-label-provider";


### PR DESCRIPTION
This is the first part in a series that will split the `helpers.ts` file. Each commit splits one or more methods to a separate file or moves it to a more appropriate existing file. This makes them easier to test and decreases the number of things the `helpers.ts` file is doing.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
