### PR TITLE
Move show and log functions out of helpers

### DIFF
--- a/extensions/ql-vscode/src/codeql-cli/distribution.ts
+++ b/extensions/ql-vscode/src/codeql-cli/distribution.ts
@@ -6,7 +6,6 @@ import * as semver from "semver";
 import { URL } from "url";
 import { ExtensionContext, Event } from "vscode";
 import { DistributionConfig } from "../config";
-import { showAndLogErrorMessage, showAndLogWarningMessage } from "../helpers";
 import { extLogger } from "../common";
 import { getCodeQlCliVersion } from "./cli-version";
 import {
@@ -23,6 +22,10 @@ import {
   InvocationRateLimiter,
   InvocationRateLimiterResultKind,
 } from "../common/invocation-rate-limiter";
+import {
+  showAndLogErrorMessage,
+  showAndLogWarningMessage,
+} from "../common/vscode/log";
 
 /**
  * distribution.ts

--- a/extensions/ql-vscode/src/common/vscode/commands.ts
+++ b/extensions/ql-vscode/src/common/vscode/commands.ts
@@ -8,11 +8,11 @@ import {
 } from "../../pure/helpers-pure";
 import { redactableError } from "../../pure/errors";
 import { UserCancellationException } from "./progress";
+import { telemetryListener } from "../../telemetry";
 import {
   showAndLogExceptionWithTelemetry,
   showAndLogWarningMessage,
-} from "../../helpers";
-import { telemetryListener } from "../../telemetry";
+} from "./log";
 
 /**
  * Create a command manager for VSCode, wrapping registerCommandWithErrorHandling

--- a/extensions/ql-vscode/src/common/vscode/external-files.ts
+++ b/extensions/ql-vscode/src/common/vscode/external-files.ts
@@ -1,6 +1,5 @@
 import { Uri, window } from "vscode";
 import { AppCommandManager } from "../commands";
-import { showAndLogExceptionWithTelemetry } from "../../helpers";
 import { showBinaryChoiceDialog } from "./dialog";
 import { redactableError } from "../../pure/errors";
 import {
@@ -8,6 +7,7 @@ import {
   getErrorMessage,
   getErrorStack,
 } from "../../pure/helpers-pure";
+import { showAndLogExceptionWithTelemetry } from "./log";
 
 export async function tryOpenExternalFile(
   commandManager: AppCommandManager,

--- a/extensions/ql-vscode/src/common/vscode/log.ts
+++ b/extensions/ql-vscode/src/common/vscode/log.ts
@@ -1,0 +1,109 @@
+import { window } from "vscode";
+import { RedactableError } from "../../pure/errors";
+import { telemetryListener } from "../../telemetry";
+import { extLogger, OutputChannelLogger } from "../logging";
+
+interface ShowAndLogExceptionOptions extends ShowAndLogOptions {
+  /** Custom properties to include in the telemetry report. */
+  extraTelemetryProperties?: { [key: string]: string };
+}
+
+interface ShowAndLogOptions {
+  /** The output logger that will receive the message. */
+  outputLogger?: OutputChannelLogger;
+  /** A set of items that will be rendered as actions in the message. */
+  items?: string[];
+  /**
+   * An alternate message that is added to the log, but not displayed in the popup.
+   * This is useful for adding extra detail to the logs that would be too noisy for the popup.
+   */
+  fullMessage?: string;
+}
+
+/**
+ * Show an error message, log it to the console, and emit redacted information as telemetry
+ *
+ * @param error The error to show. Only redacted information will be included in the telemetry.
+ * @param options See individual fields on `ShowAndLogExceptionOptions` type.
+ *
+ * @return A promise that resolves to the selected item or undefined when being dismissed.
+ */
+export async function showAndLogExceptionWithTelemetry(
+  error: RedactableError,
+  options: ShowAndLogExceptionOptions = {},
+): Promise<string | undefined> {
+  telemetryListener?.sendError(error, options.extraTelemetryProperties);
+  return showAndLogErrorMessage(error.fullMessage, options);
+}
+
+/**
+ * Show an error message and log it to the console
+ *
+ * @param message The message to show.
+ * @param options See individual fields on `ShowAndLogOptions` type.
+ *
+ * @return A promise that resolves to the selected item or undefined when being dismissed.
+ */
+export async function showAndLogErrorMessage(
+  message: string,
+  options?: ShowAndLogOptions,
+): Promise<string | undefined> {
+  return internalShowAndLog(
+    dropLinesExceptInitial(message),
+    window.showErrorMessage,
+    { fullMessage: message, ...options },
+  );
+}
+
+function dropLinesExceptInitial(message: string, n = 2) {
+  return message.toString().split(/\r?\n/).slice(0, n).join("\n");
+}
+
+/**
+ * Show a warning message and log it to the console
+ *
+ * @param message The message to show.
+ * @param options See individual fields on `ShowAndLogOptions` type.
+ *
+ * @return A promise that resolves to the selected item or undefined when being dismissed.
+ */
+export async function showAndLogWarningMessage(
+  message: string,
+  options?: ShowAndLogOptions,
+): Promise<string | undefined> {
+  return internalShowAndLog(message, window.showWarningMessage, options);
+}
+
+/**
+ * Show an information message and log it to the console
+ *
+ * @param message The message to show.
+ * @param options See individual fields on `ShowAndLogOptions` type.
+ *
+ * @return A promise that resolves to the selected item or undefined when being dismissed.
+ */
+export async function showAndLogInformationMessage(
+  message: string,
+  options?: ShowAndLogOptions,
+): Promise<string | undefined> {
+  return internalShowAndLog(message, window.showInformationMessage, options);
+}
+
+type ShowMessageFn = (
+  message: string,
+  ...items: string[]
+) => Thenable<string | undefined>;
+
+async function internalShowAndLog(
+  message: string,
+  fn: ShowMessageFn,
+  { items = [], outputLogger = extLogger, fullMessage }: ShowAndLogOptions = {},
+): Promise<string | undefined> {
+  const label = "Show Log";
+  void outputLogger.log(fullMessage || message);
+  const result = await fn(message, label, ...items);
+  if (result === label) {
+    outputLogger.show();
+  }
+  return result;
+}

--- a/extensions/ql-vscode/src/common/vscode/selection-commands.ts
+++ b/extensions/ql-vscode/src/common/vscode/selection-commands.ts
@@ -1,9 +1,9 @@
-import { showAndLogErrorMessage } from "../../helpers";
 import {
   ExplorerSelectionCommandFunction,
   TreeViewContextMultiSelectionCommandFunction,
   TreeViewContextSingleSelectionCommandFunction,
 } from "../commands";
+import { showAndLogErrorMessage } from "./log";
 
 // A hack to match types that are not an array, which is useful to help avoid
 // misusing createSingleSelectionCommand, e.g. where T accidentally gets instantiated

--- a/extensions/ql-vscode/src/compare/compare-view.ts
+++ b/extensions/ql-vscode/src/compare/compare-view.ts
@@ -24,7 +24,8 @@ import {
 } from "../common/vscode/abstract-webview";
 import { telemetryListener } from "../telemetry";
 import { redactableError } from "../pure/errors";
-import { showAndLogExceptionWithTelemetry } from "../helpers";
+
+import { showAndLogExceptionWithTelemetry } from "../common/vscode/log";
 
 interface ComparePair {
   from: CompletedLocalQueryInfo;

--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-module.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-module.ts
@@ -7,9 +7,9 @@ import { DatabaseManager } from "../databases/local-databases";
 import { ensureDir } from "fs-extra";
 import { join } from "path";
 import { App } from "../common/app";
-import { showAndLogErrorMessage } from "../helpers";
 import { withProgress } from "../common/vscode/progress";
 import { pickExtensionPackModelFile } from "./extension-pack-picker";
+import { showAndLogErrorMessage } from "../common/vscode/log";
 
 const SUPPORTED_LANGUAGES: string[] = ["java", "csharp"];
 

--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
@@ -17,10 +17,6 @@ import {
 } from "../pure/interface-types";
 import { ProgressUpdate } from "../common/vscode/progress";
 import { QueryRunner } from "../query-server";
-import {
-  showAndLogErrorMessage,
-  showAndLogExceptionWithTelemetry,
-} from "../helpers";
 import { extLogger } from "../common";
 import { outputFile, pathExists, readFile } from "fs-extra";
 import { load as loadYaml } from "js-yaml";
@@ -46,6 +42,10 @@ import {
 } from "./auto-model";
 import { showLlmGeneration } from "../config";
 import { getAutoModelUsages } from "./auto-model-usages-query";
+import {
+  showAndLogErrorMessage,
+  showAndLogExceptionWithTelemetry,
+} from "../common/vscode/log";
 
 export class DataExtensionsEditorView extends AbstractWebview<
   ToDataExtensionsEditorMessage,

--- a/extensions/ql-vscode/src/data-extensions-editor/extension-pack-picker.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/extension-pack-picker.ts
@@ -4,7 +4,6 @@ import { dump as dumpYaml, load as loadYaml } from "js-yaml";
 import { minimatch } from "minimatch";
 import { CancellationToken, window } from "vscode";
 import { CodeQLCliServer } from "../codeql-cli/cli";
-import { showAndLogErrorMessage } from "../helpers";
 import {
   getOnDiskWorkspaceFolders,
   getOnDiskWorkspaceFoldersObjects,
@@ -14,6 +13,7 @@ import { DatabaseItem } from "../databases/local-databases";
 import { getQlPackPath, QLPACK_FILENAMES } from "../pure/ql";
 import { getErrorMessage } from "../pure/helpers-pure";
 import { ExtensionPack, ExtensionPackModelFile } from "./shared/extension-pack";
+import { showAndLogErrorMessage } from "../common/vscode/log";
 
 const maxStep = 3;
 

--- a/extensions/ql-vscode/src/data-extensions-editor/external-api-usage-query.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/external-api-usage-query.ts
@@ -2,7 +2,6 @@ import { CoreCompletedQuery, QueryRunner } from "../query-server";
 import { dir } from "tmp-promise";
 import { writeFile } from "fs-extra";
 import { dump as dumpYaml } from "js-yaml";
-import { showAndLogExceptionWithTelemetry } from "../helpers";
 import { getOnDiskWorkspaceFolders } from "../common/vscode/workspace-folders";
 import { TeeLogger } from "../common";
 import { isQueryLanguage } from "../common/query-language";
@@ -14,6 +13,7 @@ import { fetchExternalApiQueries } from "./queries";
 import { QueryResultType } from "../pure/new-messages";
 import { join } from "path";
 import { redactableError } from "../pure/errors";
+import { showAndLogExceptionWithTelemetry } from "../common/vscode/log";
 
 export type RunQueryOptions = {
   cliServer: Pick<CodeQLCliServer, "resolveQlpacks">;

--- a/extensions/ql-vscode/src/data-extensions-editor/generate-flow-model.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/generate-flow-model.ts
@@ -6,7 +6,6 @@ import { CodeQLCliServer } from "../codeql-cli/cli";
 import { TeeLogger } from "../common";
 import { extensiblePredicateDefinitions } from "./predicates";
 import { ProgressCallback } from "../common/vscode/progress";
-import { showAndLogExceptionWithTelemetry } from "../helpers";
 import { getOnDiskWorkspaceFolders } from "../common/vscode/workspace-folders";
 import {
   ModeledMethodType,
@@ -18,6 +17,7 @@ import { file } from "tmp-promise";
 import { writeFile } from "fs-extra";
 import { dump } from "js-yaml";
 import { qlpackOfDatabase } from "../language-support";
+import { showAndLogExceptionWithTelemetry } from "../common/vscode/log";
 
 type FlowModelOptions = {
   cliServer: CodeQLCliServer;

--- a/extensions/ql-vscode/src/databases/code-search-api.ts
+++ b/extensions/ql-vscode/src/databases/code-search-api.ts
@@ -2,8 +2,8 @@ import { retry } from "@octokit/plugin-retry";
 import { throttling } from "@octokit/plugin-throttling";
 import { Octokit } from "@octokit/rest";
 import { Progress, CancellationToken } from "vscode";
-import { showAndLogWarningMessage } from "../helpers";
 import { Credentials } from "../common/authentication";
+import { showAndLogWarningMessage } from "../common/vscode/log";
 
 export async function getCodeSearchRepositories(
   query: string,

--- a/extensions/ql-vscode/src/databases/database-fetcher.ts
+++ b/extensions/ql-vscode/src/databases/database-fetcher.ts
@@ -17,7 +17,7 @@ import * as Octokit from "@octokit/rest";
 import { retry } from "@octokit/plugin-retry";
 
 import { DatabaseManager, DatabaseItem } from "./local-databases";
-import { showAndLogInformationMessage, tmpDir } from "../helpers";
+import { tmpDir } from "../helpers";
 import {
   reportStreamProgress,
   ProgressCallback,
@@ -31,6 +31,7 @@ import {
 import { Credentials } from "../common/authentication";
 import { AppCommandManager } from "../common/commands";
 import { ALLOW_HTTP_SETTING } from "../config";
+import { showAndLogInformationMessage } from "../common/vscode/log";
 
 /**
  * Prompts a user to fetch a database from a remote location. Database is assumed to be an archive file.

--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -29,10 +29,6 @@ import {
   withProgress,
 } from "../common/vscode/progress";
 import {
-  showAndLogErrorMessage,
-  showAndLogExceptionWithTelemetry,
-} from "../helpers";
-import {
   isLikelyDatabaseRoot,
   isLikelyDbLanguageFolder,
 } from "./local-databases/db-contents-heuristics";
@@ -52,6 +48,10 @@ import {
   createMultiSelectionCommand,
   createSingleSelectionCommand,
 } from "../common/vscode/selection-commands";
+import {
+  showAndLogErrorMessage,
+  showAndLogExceptionWithTelemetry,
+} from "../common/vscode/log";
 
 enum SortOrder {
   NameAsc = "NameAsc",

--- a/extensions/ql-vscode/src/databases/local-databases/database-manager.ts
+++ b/extensions/ql-vscode/src/databases/local-databases/database-manager.ts
@@ -13,7 +13,6 @@ import {
 import { join } from "path";
 import { FullDatabaseOptions } from "./database-options";
 import { DatabaseItemImpl } from "./database-item-impl";
-import { showAndLogExceptionWithTelemetry } from "../../helpers";
 import { showNeverAskAgainDialog } from "../../common/vscode/dialog";
 import {
   getFirstWorkspaceFolder,
@@ -29,6 +28,7 @@ import { remove } from "fs-extra";
 import { containsPath } from "../../pure/files";
 import { DatabaseChangedEvent, DatabaseEventKind } from "./database-events";
 import { DatabaseResolver } from "./database-resolver";
+import { showAndLogExceptionWithTelemetry } from "../../common/vscode/log";
 
 /**
  * The name of the key in the workspaceState dictionary in which we

--- a/extensions/ql-vscode/src/databases/local-databases/database-resolver.ts
+++ b/extensions/ql-vscode/src/databases/local-databases/database-resolver.ts
@@ -7,11 +7,11 @@ import {
   DatabaseKind,
 } from "./database-contents";
 import { glob } from "glob";
+import { encodeArchiveBasePath } from "../../common/vscode/archive-filesystem-provider";
 import {
   showAndLogInformationMessage,
   showAndLogWarningMessage,
-} from "../../helpers";
-import { encodeArchiveBasePath } from "../../common/vscode/archive-filesystem-provider";
+} from "../../common/vscode/log";
 
 export class DatabaseResolver {
   public static async resolveDatabaseContents(

--- a/extensions/ql-vscode/src/databases/ui/db-panel.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-panel.ts
@@ -14,10 +14,6 @@ import {
   getOwnerFromGitHubUrl,
   isValidGitHubOwner,
 } from "../../common/github-url-identifier-helper";
-import {
-  showAndLogErrorMessage,
-  showAndLogInformationMessage,
-} from "../../helpers";
 import { DisposableObject } from "../../pure/disposable-object";
 import {
   DbItem,
@@ -38,6 +34,10 @@ import { DatabasePanelCommands } from "../../common/commands";
 import { App } from "../../common/app";
 import { QueryLanguage } from "../../common/query-language";
 import { getCodeSearchRepositories } from "../code-search-api";
+import {
+  showAndLogErrorMessage,
+  showAndLogInformationMessage,
+} from "../../common/vscode/log";
 
 export interface RemoteDatabaseQuickPickItem extends QuickPickItem {
   remoteDatabaseKind: string;

--- a/extensions/ql-vscode/src/debugger/debug-configuration.ts
+++ b/extensions/ql-vscode/src/debugger/debug-configuration.ts
@@ -4,12 +4,12 @@ import {
   DebugConfigurationProvider,
   WorkspaceFolder,
 } from "vscode";
-import { showAndLogErrorMessage } from "../helpers";
 import { getOnDiskWorkspaceFolders } from "../common/vscode/workspace-folders";
 import { LocalQueries } from "../local-queries";
 import { getQuickEvalContext, validateQueryPath } from "../run-queries-shared";
 import * as CodeQLProtocol from "./debug-protocol";
 import { getErrorMessage } from "../pure/helpers-pure";
+import { showAndLogErrorMessage } from "../common/vscode/log";
 
 /**
  * The CodeQL launch arguments, as specified in "launch.json".

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -55,14 +55,7 @@ import {
   GithubApiError,
   GithubRateLimitedError,
 } from "./codeql-cli/distribution";
-import {
-  showAndLogErrorMessage,
-  showAndLogExceptionWithTelemetry,
-  showAndLogInformationMessage,
-  showAndLogWarningMessage,
-  tmpDir,
-  tmpDirDisposal,
-} from "./helpers";
+import { tmpDir, tmpDirDisposal } from "./helpers";
 import { prepareCodeTour } from "./code-tour";
 import {
   showBinaryChoiceDialog,
@@ -131,6 +124,12 @@ import { TestRunner } from "./query-testing/test-runner";
 import { TestManagerBase } from "./query-testing/test-manager-base";
 import { NewQueryRunner, QueryRunner, QueryServerClient } from "./query-server";
 import { QueriesModule } from "./queries-panel/queries-module";
+import {
+  showAndLogErrorMessage,
+  showAndLogExceptionWithTelemetry,
+  showAndLogInformationMessage,
+  showAndLogWarningMessage,
+} from "./common/vscode/log";
 
 /**
  * extension.ts

--- a/extensions/ql-vscode/src/helpers.ts
+++ b/extensions/ql-vscode/src/helpers.ts
@@ -1,15 +1,14 @@
-import { ensureDirSync, ensureDir, writeFile } from "fs-extra";
+import { ensureDir, ensureDirSync, writeFile } from "fs-extra";
 import { join } from "path";
 import { dirSync } from "tmp-promise";
 import { Uri, window as Window } from "vscode";
 import { CodeQLCliServer } from "./codeql-cli/cli";
 import { UserCancellationException } from "./common/vscode/progress";
-import { extLogger, OutputChannelLogger } from "./common";
+import { extLogger } from "./common";
 import { QueryMetadata } from "./pure/interface-types";
-import { telemetryListener } from "./telemetry";
-import { RedactableError } from "./pure/errors";
 import { isQueryLanguage, QueryLanguage } from "./common/query-language";
 import { getOnDiskWorkspaceFolders } from "./common/vscode/workspace-folders";
+import { showAndLogErrorMessage } from "./common/vscode/log";
 
 // Shared temporary folder for the extension.
 export const tmpDir = dirSync({
@@ -31,111 +30,6 @@ export const tmpDirDisposal = {
     }
   },
 };
-
-interface ShowAndLogExceptionOptions extends ShowAndLogOptions {
-  /** Custom properties to include in the telemetry report. */
-  extraTelemetryProperties?: { [key: string]: string };
-}
-
-interface ShowAndLogOptions {
-  /** The output logger that will receive the message. */
-  outputLogger?: OutputChannelLogger;
-  /** A set of items that will be rendered as actions in the message. */
-  items?: string[];
-  /**
-   * An alternate message that is added to the log, but not displayed in the popup.
-   * This is useful for adding extra detail to the logs that would be too noisy for the popup.
-   */
-  fullMessage?: string;
-}
-
-/**
- * Show an error message, log it to the console, and emit redacted information as telemetry
- *
- * @param error The error to show. Only redacted information will be included in the telemetry.
- * @param options See individual fields on `ShowAndLogExceptionOptions` type.
- *
- * @return A promise that resolves to the selected item or undefined when being dismissed.
- */
-export async function showAndLogExceptionWithTelemetry(
-  error: RedactableError,
-  options: ShowAndLogExceptionOptions = {},
-): Promise<string | undefined> {
-  telemetryListener?.sendError(error, options.extraTelemetryProperties);
-  return showAndLogErrorMessage(error.fullMessage, options);
-}
-
-/**
- * Show an error message and log it to the console
- *
- * @param message The message to show.
- * @param options See individual fields on `ShowAndLogOptions` type.
- *
- * @return A promise that resolves to the selected item or undefined when being dismissed.
- */
-export async function showAndLogErrorMessage(
-  message: string,
-  options?: ShowAndLogOptions,
-): Promise<string | undefined> {
-  return internalShowAndLog(
-    dropLinesExceptInitial(message),
-    Window.showErrorMessage,
-    { fullMessage: message, ...options },
-  );
-}
-
-function dropLinesExceptInitial(message: string, n = 2) {
-  return message.toString().split(/\r?\n/).slice(0, n).join("\n");
-}
-
-/**
- * Show a warning message and log it to the console
- *
- * @param message The message to show.
- * @param options See individual fields on `ShowAndLogOptions` type.
- *
- * @return A promise that resolves to the selected item or undefined when being dismissed.
- */
-export async function showAndLogWarningMessage(
-  message: string,
-  options?: ShowAndLogOptions,
-): Promise<string | undefined> {
-  return internalShowAndLog(message, Window.showWarningMessage, options);
-}
-
-/**
- * Show an information message and log it to the console
- *
- * @param message The message to show.
- * @param options See individual fields on `ShowAndLogOptions` type.
- *
- * @return A promise that resolves to the selected item or undefined when being dismissed.
- */
-export async function showAndLogInformationMessage(
-  message: string,
-  options?: ShowAndLogOptions,
-): Promise<string | undefined> {
-  return internalShowAndLog(message, Window.showInformationMessage, options);
-}
-
-type ShowMessageFn = (
-  message: string,
-  ...items: string[]
-) => Thenable<string | undefined>;
-
-async function internalShowAndLog(
-  message: string,
-  fn: ShowMessageFn,
-  { items = [], outputLogger = extLogger, fullMessage }: ShowAndLogOptions = {},
-): Promise<string | undefined> {
-  const label = "Show Log";
-  void outputLogger.log(fullMessage || message);
-  const result = await fn(message, label, ...items);
-  if (result === label) {
-    outputLogger.show();
-  }
-  return result;
-}
 
 /**
  * Finds the language that a query targets.

--- a/extensions/ql-vscode/src/language-support/ast-viewer/ast-viewer.ts
+++ b/extensions/ql-vscode/src/language-support/ast-viewer/ast-viewer.ts
@@ -24,10 +24,10 @@ import {
   isLineColumnLoc,
 } from "../../pure/bqrs-utils";
 import { DisposableObject } from "../../pure/disposable-object";
-import { showAndLogExceptionWithTelemetry } from "../../helpers";
 import { asError, getErrorMessage } from "../../pure/helpers-pure";
 import { redactableError } from "../../pure/errors";
 import { AstViewerCommands } from "../../common/commands";
+import { showAndLogExceptionWithTelemetry } from "../../common/vscode/log";
 
 export interface AstItem {
   id: BqrsId;

--- a/extensions/ql-vscode/src/language-support/contextual/query-resolver.ts
+++ b/extensions/ql-vscode/src/language-support/contextual/query-resolver.ts
@@ -3,7 +3,6 @@ import { dump } from "js-yaml";
 import { file } from "tmp-promise";
 import { basename, dirname, resolve } from "path";
 
-import { showAndLogExceptionWithTelemetry } from "../../helpers";
 import { getOnDiskWorkspaceFolders } from "../../common/vscode/workspace-folders";
 import {
   getPrimaryDbscheme,
@@ -24,6 +23,7 @@ import { ProgressCallback } from "../../common/vscode/progress";
 import { CoreCompletedQuery, QueryRunner } from "../../query-server";
 import { redactableError } from "../../pure/errors";
 import { QLPACK_FILENAMES } from "../../pure/ql";
+import { showAndLogExceptionWithTelemetry } from "../../common/vscode/log";
 
 export async function qlpackOfDatabase(
   cli: Pick<CodeQLCliServer, "resolveQlpacks">,

--- a/extensions/ql-vscode/src/language-support/query-editor.ts
+++ b/extensions/ql-vscode/src/language-support/query-editor.ts
@@ -4,8 +4,8 @@ import { QueryRunner } from "../query-server";
 import { basename, join } from "path";
 import { getErrorMessage } from "../pure/helpers-pure";
 import { redactableError } from "../pure/errors";
-import { showAndLogExceptionWithTelemetry } from "../helpers";
 import { AppCommandManager, QueryEditorCommands } from "../common/commands";
+import { showAndLogExceptionWithTelemetry } from "../common/vscode/log";
 
 type QueryEditorOptions = {
   commandManager: AppCommandManager;

--- a/extensions/ql-vscode/src/local-queries/local-queries.ts
+++ b/extensions/ql-vscode/src/local-queries/local-queries.ts
@@ -16,12 +16,7 @@ import { extLogger, TeeLogger } from "../common";
 import { isCanary, MAX_QUERIES } from "../config";
 import { gatherQlFiles } from "../pure/files";
 import { basename } from "path";
-import {
-  createTimestampFile,
-  findLanguage,
-  showAndLogErrorMessage,
-  showAndLogWarningMessage,
-} from "../helpers";
+import { createTimestampFile, findLanguage } from "../helpers";
 import { showBinaryChoiceDialog } from "../common/vscode/dialog";
 import { getOnDiskWorkspaceFolders } from "../common/vscode/workspace-folders";
 import { displayQuickQuery } from "./quick-query";
@@ -48,6 +43,10 @@ import { DisposableObject } from "../pure/disposable-object";
 import { SkeletonQueryWizard } from "../skeleton-query-wizard";
 import { LocalQueryRun } from "./local-query-run";
 import { createMultiSelectionCommand } from "../common/vscode/selection-commands";
+import {
+  showAndLogErrorMessage,
+  showAndLogWarningMessage,
+} from "../common/vscode/log";
 
 interface DatabaseQuickPickItem extends QuickPickItem {
   databaseItem: DatabaseItem;

--- a/extensions/ql-vscode/src/local-queries/local-query-run.ts
+++ b/extensions/ql-vscode/src/local-queries/local-query-run.ts
@@ -1,9 +1,5 @@
 import { BaseLogger, Logger } from "../common";
-import {
-  showAndLogExceptionWithTelemetry,
-  showAndLogWarningMessage,
-  tryGetQueryMetadata,
-} from "../helpers";
+import { tryGetQueryMetadata } from "../helpers";
 import { CoreQueryResults } from "../query-server";
 import { QueryHistoryManager } from "../query-history/query-history-manager";
 import { DatabaseItem } from "../databases/local-databases";
@@ -21,6 +17,10 @@ import { CodeQLCliServer } from "../codeql-cli/cli";
 import { QueryResultType } from "../pure/new-messages";
 import { redactableError } from "../pure/errors";
 import { LocalQueries } from "./local-queries";
+import {
+  showAndLogExceptionWithTelemetry,
+  showAndLogWarningMessage,
+} from "../common/vscode/log";
 
 function formatResultMessage(result: CoreQueryResults): string {
   switch (result.resultType) {

--- a/extensions/ql-vscode/src/local-queries/results-view.ts
+++ b/extensions/ql-vscode/src/local-queries/results-view.ts
@@ -17,7 +17,6 @@ import {
   DatabaseItem,
   DatabaseManager,
 } from "../databases/local-databases";
-import { showAndLogExceptionWithTelemetry } from "../helpers";
 import {
   asError,
   assertNever,
@@ -74,6 +73,7 @@ import { HistoryItemLabelProvider } from "../query-history/history-item-label-pr
 import { telemetryListener } from "../telemetry";
 import { redactableError } from "../pure/errors";
 import { ResultsViewCommands } from "../common/commands";
+import { showAndLogExceptionWithTelemetry } from "../common/vscode/log";
 
 /**
  * results-view.ts

--- a/extensions/ql-vscode/src/packaging/packaging.ts
+++ b/extensions/ql-vscode/src/packaging/packaging.ts
@@ -1,8 +1,4 @@
 import { CodeQLCliServer } from "../codeql-cli/cli";
-import {
-  showAndLogExceptionWithTelemetry,
-  showAndLogInformationMessage,
-} from "../helpers";
 import { getOnDiskWorkspaceFolders } from "../common/vscode/workspace-folders";
 import { QuickPickItem, window } from "vscode";
 import {
@@ -15,6 +11,10 @@ import { asError, getErrorStack } from "../pure/helpers-pure";
 import { redactableError } from "../pure/errors";
 import { PACKS_BY_QUERY_LANGUAGE } from "../common/query-language";
 import { PackagingCommands } from "../common/commands";
+import {
+  showAndLogExceptionWithTelemetry,
+  showAndLogInformationMessage,
+} from "../common/vscode/log";
 
 type PackagingOptions = {
   cliServer: CodeQLCliServer;

--- a/extensions/ql-vscode/src/query-evaluation-logging/eval-log-viewer.ts
+++ b/extensions/ql-vscode/src/query-evaluation-logging/eval-log-viewer.ts
@@ -9,10 +9,10 @@ import {
   TreeItemCollapsibleState,
 } from "vscode";
 import { DisposableObject } from "../pure/disposable-object";
-import { showAndLogExceptionWithTelemetry } from "../helpers";
 import { asError, getErrorMessage } from "../pure/helpers-pure";
 import { redactableError } from "../pure/errors";
 import { EvalLogViewerCommands } from "../common/commands";
+import { showAndLogExceptionWithTelemetry } from "../common/vscode/log";
 
 export interface EvalLogTreeItem {
   label?: string;

--- a/extensions/ql-vscode/src/query-history/query-history-manager.ts
+++ b/extensions/ql-vscode/src/query-history/query-history-manager.ts
@@ -14,11 +14,6 @@ import {
 } from "vscode";
 import { QueryHistoryConfig } from "../config";
 import {
-  showAndLogErrorMessage,
-  showAndLogInformationMessage,
-  showAndLogWarningMessage,
-} from "../helpers";
-import {
   showBinaryChoiceDialog,
   showInformationMessageWithAction,
 } from "../common/vscode/dialog";
@@ -61,6 +56,11 @@ import {
   createMultiSelectionCommand,
   createSingleSelectionCommand,
 } from "../common/vscode/selection-commands";
+import {
+  showAndLogErrorMessage,
+  showAndLogInformationMessage,
+  showAndLogWarningMessage,
+} from "../common/vscode/log";
 
 /**
  * query-history-manager.ts

--- a/extensions/ql-vscode/src/query-history/store/query-history-store.ts
+++ b/extensions/ql-vscode/src/query-history/store/query-history-store.ts
@@ -1,7 +1,6 @@
 import { pathExists, remove, mkdir, writeFile, readJson } from "fs-extra";
 import { dirname } from "path";
 
-import { showAndLogExceptionWithTelemetry } from "../../helpers";
 import {
   asError,
   asyncFilter,
@@ -13,6 +12,7 @@ import { redactableError } from "../../pure/errors";
 import { QueryHistoryDto, QueryHistoryItemDto } from "./query-history-dto";
 import { mapQueryHistoryToDomainModel } from "./query-history-dto-mapper";
 import { mapQueryHistoryToDto } from "./query-history-domain-mapper";
+import { showAndLogExceptionWithTelemetry } from "../../common/vscode/log";
 
 const ALLOWED_QUERY_HISTORY_VERSIONS = [1, 2];
 

--- a/extensions/ql-vscode/src/query-server/legacy/run-queries.ts
+++ b/extensions/ql-vscode/src/query-server/legacy/run-queries.ts
@@ -9,11 +9,7 @@ import {
   DatabaseItem,
   DatabaseResolver,
 } from "../../databases/local-databases";
-import {
-  showAndLogExceptionWithTelemetry,
-  showAndLogWarningMessage,
-  upgradesTmpDir,
-} from "../../helpers";
+import { upgradesTmpDir } from "../../helpers";
 import { ProgressCallback } from "../../common/vscode/progress";
 import { QueryMetadata } from "../../pure/interface-types";
 import { extLogger, Logger } from "../../common";
@@ -26,6 +22,10 @@ import { QueryEvaluationInfo, QueryOutputDir } from "../../run-queries-shared";
 import { redactableError } from "../../pure/errors";
 import { CoreQueryResults, CoreQueryTarget } from "../query-runner";
 import { Position } from "../../pure/messages-shared";
+import {
+  showAndLogExceptionWithTelemetry,
+  showAndLogWarningMessage,
+} from "../../common/vscode/log";
 
 export async function compileQuery(
   qs: qsClient.QueryServerClient,

--- a/extensions/ql-vscode/src/query-server/legacy/upgrades.ts
+++ b/extensions/ql-vscode/src/query-server/legacy/upgrades.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { showAndLogExceptionWithTelemetry, tmpDir } from "../../helpers";
+import { tmpDir } from "../../helpers";
 import { getOnDiskWorkspaceFolders } from "../../common/vscode/workspace-folders";
 import {
   ProgressCallback,
@@ -13,6 +13,7 @@ import { dirname } from "path";
 import { DatabaseItem } from "../../databases/local-databases";
 import { asError, getErrorMessage } from "../../pure/helpers-pure";
 import { redactableError } from "../../pure/errors";
+import { showAndLogExceptionWithTelemetry } from "../../common/vscode/log";
 
 /**
  * Maximum number of lines to include from database upgrade message,

--- a/extensions/ql-vscode/src/query-server/query-server-client.ts
+++ b/extensions/ql-vscode/src/query-server/query-server-client.ts
@@ -18,7 +18,8 @@ import {
 } from "../common/vscode/progress";
 import { ServerProcess } from "./server-process";
 import { App } from "../common/app";
-import { showAndLogErrorMessage } from "../helpers";
+
+import { showAndLogErrorMessage } from "../common/vscode/log";
 
 type ServerOpts = {
   logger: Logger;

--- a/extensions/ql-vscode/src/query-testing/test-runner.ts
+++ b/extensions/ql-vscode/src/query-testing/test-runner.ts
@@ -1,16 +1,16 @@
 import { CancellationToken, Uri } from "vscode";
 import { CodeQLCliServer, TestCompleted } from "../codeql-cli/cli";
 import { DatabaseItem, DatabaseManager } from "../databases/local-databases";
-import {
-  showAndLogExceptionWithTelemetry,
-  showAndLogWarningMessage,
-} from "../helpers";
 import { getOnDiskWorkspaceFolders } from "../common/vscode/workspace-folders";
 import { asError, getErrorMessage } from "../pure/helpers-pure";
 import { redactableError } from "../pure/errors";
 import { access } from "fs-extra";
 import { BaseLogger } from "../common";
 import { DisposableObject } from "../pure/disposable-object";
+import {
+  showAndLogExceptionWithTelemetry,
+  showAndLogWarningMessage,
+} from "../common/vscode/log";
 
 async function isFileAccessible(uri: Uri): Promise<boolean> {
   try {

--- a/extensions/ql-vscode/src/run-queries-shared.ts
+++ b/extensions/ql-vscode/src/run-queries-shared.ts
@@ -2,7 +2,7 @@ import * as messages from "./pure/messages-shared";
 import * as legacyMessages from "./pure/legacy-messages";
 import { DatabaseInfo, QueryMetadata } from "./pure/interface-types";
 import { join, parse, dirname, basename } from "path";
-import { createTimestampFile, showAndLogWarningMessage } from "./helpers";
+import { createTimestampFile } from "./helpers";
 import {
   ConfigurationTarget,
   Range,
@@ -30,6 +30,7 @@ import { DecodedBqrsChunk, EntityValue } from "./pure/bqrs-cli-types";
 import { BaseLogger, extLogger } from "./common";
 import { generateSummarySymbolsFile } from "./log-insights/summary-parser";
 import { getErrorMessage } from "./pure/helpers-pure";
+import { showAndLogWarningMessage } from "./common/vscode/log";
 
 /**
  * run-queries.ts

--- a/extensions/ql-vscode/src/variant-analysis/data-flow-paths-view.ts
+++ b/extensions/ql-vscode/src/variant-analysis/data-flow-paths-view.ts
@@ -10,8 +10,8 @@ import {
   ToDataFlowPathsMessage,
 } from "../pure/interface-types";
 import { DataFlowPaths } from "./shared/data-flow-paths";
-import { showAndLogExceptionWithTelemetry } from "../helpers";
 import { redactableError } from "../pure/errors";
+import { showAndLogExceptionWithTelemetry } from "../common/vscode/log";
 
 export class DataFlowPathsView extends AbstractWebview<
   ToDataFlowPathsMessage,

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-content-provider.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-content-provider.ts
@@ -1,8 +1,8 @@
 import { TextDocumentContentProvider, Uri } from "vscode";
 import { URLSearchParams } from "url";
-import { showAndLogWarningMessage } from "../helpers";
 import { SHOW_QUERY_TEXT_MSG } from "../query-history/query-history-manager";
 import { VariantAnalysisManager } from "./variant-analysis-manager";
+import { showAndLogWarningMessage } from "../common/vscode/log";
 
 export const createVariantAnalysisContentProvider = (
   variantAnalysisManager: VariantAnalysisManager,

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -43,12 +43,7 @@ import {
   processVariantAnalysisRepositoryTask,
 } from "./variant-analysis-processor";
 import PQueue from "p-queue";
-import {
-  createTimestampFile,
-  showAndLogExceptionWithTelemetry,
-  showAndLogInformationMessage,
-  showAndLogWarningMessage,
-} from "../helpers";
+import { createTimestampFile } from "../helpers";
 import { readFile, remove, pathExists } from "fs-extra";
 import { EOL } from "os";
 import { cancelVariantAnalysis } from "./gh-api/gh-actions-api-client";
@@ -77,6 +72,11 @@ import {
 import { GITHUB_AUTH_PROVIDER_ID } from "../common/vscode/authentication";
 import { FetchError } from "node-fetch";
 import { extLogger } from "../common";
+import {
+  showAndLogExceptionWithTelemetry,
+  showAndLogInformationMessage,
+  showAndLogWarningMessage,
+} from "../common/vscode/log";
 
 const maxRetryCount = 3;
 

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-monitor.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-monitor.ts
@@ -13,9 +13,9 @@ import { processUpdatedVariantAnalysis } from "./variant-analysis-processor";
 import { DisposableObject } from "../pure/disposable-object";
 import { sleep } from "../pure/time";
 import { getErrorMessage } from "../pure/helpers-pure";
-import { showAndLogWarningMessage } from "../helpers";
 import { App } from "../common/app";
 import { extLogger } from "../common";
+import { showAndLogWarningMessage } from "../common/vscode/log";
 
 export class VariantAnalysisMonitor extends DisposableObject {
   // With a sleep of 5 seconds, the maximum number of attempts takes

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-view.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-view.ts
@@ -18,10 +18,6 @@ import {
   VariantAnalysisViewInterface,
   VariantAnalysisViewManager,
 } from "./variant-analysis-view-manager";
-import {
-  showAndLogExceptionWithTelemetry,
-  showAndLogWarningMessage,
-} from "../helpers";
 import { telemetryListener } from "../telemetry";
 import { redactableError } from "../pure/errors";
 import { DataFlowPathsView } from "./data-flow-paths-view";
@@ -31,6 +27,10 @@ import {
   getVariantAnalysisDefaultResultsFilter,
   getVariantAnalysisDefaultResultsSort,
 } from "../config";
+import {
+  showAndLogExceptionWithTelemetry,
+  showAndLogWarningMessage,
+} from "../common/vscode/log";
 
 export class VariantAnalysisView
   extends AbstractWebview<ToVariantAnalysisMessage, FromVariantAnalysisMessage>

--- a/extensions/ql-vscode/test/vscode-tests/activated-extension/variant-analysis/variant-analysis-monitor.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/activated-extension/variant-analysis/variant-analysis-monitor.test.ts
@@ -23,7 +23,8 @@ import {
 import { createMockVariantAnalysis } from "../../../factories/variant-analysis/shared/variant-analysis";
 import { createMockApp } from "../../../__mocks__/appMock";
 import { createMockCommandManager } from "../../../__mocks__/commandsMock";
-import * as helpers from "../../../../src/helpers";
+import * as log from "../../../../src/common/vscode/log";
+import { showAndLogWarningMessage } from "../../../../src/common/vscode/log";
 
 jest.setTimeout(60_000);
 
@@ -200,14 +201,14 @@ describe("Variant Analysis Monitor", () => {
 
     describe("when some responses fail", () => {
       let showAndLogWarningMessageSpy: jest.SpiedFunction<
-        typeof helpers.showAndLogWarningMessage
+        typeof showAndLogWarningMessage
       >;
 
       let scannedRepos: ApiVariantAnalysisScannedRepository[];
 
       beforeEach(async () => {
         showAndLogWarningMessageSpy = jest
-          .spyOn(helpers, "showAndLogWarningMessage")
+          .spyOn(log, "showAndLogWarningMessage")
           .mockResolvedValue(undefined);
 
         scannedRepos = createMockScannedRepos([
@@ -301,12 +302,12 @@ describe("Variant Analysis Monitor", () => {
 
     describe("when a 404 is returned", () => {
       let showAndLogWarningMessageSpy: jest.SpiedFunction<
-        typeof helpers.showAndLogWarningMessage
+        typeof showAndLogWarningMessage
       >;
 
       beforeEach(async () => {
         showAndLogWarningMessageSpy = jest
-          .spyOn(helpers, "showAndLogWarningMessage")
+          .spyOn(log, "showAndLogWarningMessage")
           .mockResolvedValue(undefined);
 
         const scannedRepos = createMockScannedRepos([

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/packaging/packaging.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/packaging/packaging.test.ts
@@ -4,13 +4,17 @@ import { join } from "path";
 import { CodeQLCliServer } from "../../../../src/codeql-cli/cli";
 import { getErrorMessage } from "../../../../src/pure/helpers-pure";
 
-import * as helpers from "../../../../src/helpers";
+import * as log from "../../../../src/common/vscode/log";
 import {
   handleDownloadPacks,
   handleInstallPackDependencies,
 } from "../../../../src/packaging";
 import { mockedQuickPickItem } from "../../utils/mocking.helpers";
 import { getActivatedExtension } from "../../global.helper";
+import {
+  showAndLogExceptionWithTelemetry,
+  showAndLogInformationMessage,
+} from "../../../../src/common/vscode/log";
 
 describe("Packaging commands", () => {
   let cli: CodeQLCliServer;
@@ -18,10 +22,10 @@ describe("Packaging commands", () => {
   let quickPickSpy: jest.SpiedFunction<typeof window.showQuickPick>;
   let inputBoxSpy: jest.SpiedFunction<typeof window.showInputBox>;
   let showAndLogExceptionWithTelemetrySpy: jest.SpiedFunction<
-    typeof helpers.showAndLogExceptionWithTelemetry
+    typeof showAndLogExceptionWithTelemetry
   >;
   let showAndLogInformationMessageSpy: jest.SpiedFunction<
-    typeof helpers.showAndLogInformationMessage
+    typeof showAndLogInformationMessage
   >;
 
   beforeEach(async () => {
@@ -32,10 +36,10 @@ describe("Packaging commands", () => {
       .spyOn(window, "showInputBox")
       .mockResolvedValue(undefined);
     showAndLogExceptionWithTelemetrySpy = jest
-      .spyOn(helpers, "showAndLogExceptionWithTelemetry")
+      .spyOn(log, "showAndLogExceptionWithTelemetry")
       .mockResolvedValue(undefined);
     showAndLogInformationMessageSpy = jest
-      .spyOn(helpers, "showAndLogInformationMessage")
+      .spyOn(log, "showAndLogInformationMessage")
       .mockResolvedValue(undefined);
 
     const extension = await getActivatedExtension();

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/codeql-cli/distribution.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/codeql-cli/distribution.test.ts
@@ -1,20 +1,24 @@
 import * as fetch from "node-fetch";
 import { Range } from "semver";
 
-import * as helpers from "../../../../src/helpers";
+import * as log from "../../../../src/common/vscode/log";
 import { extLogger } from "../../../../src/common";
 import * as fs from "fs-extra";
 import * as path from "path";
 import * as os from "os";
 import * as tmp from "tmp-promise";
+import { DirectoryResult } from "tmp-promise";
 import {
+  DistributionManager,
+  getExecutableFromDirectory,
   GithubRelease,
   GithubReleaseAsset,
   ReleasesApiConsumer,
-  getExecutableFromDirectory,
-  DistributionManager,
 } from "../../../../src/codeql-cli/distribution";
-import { DirectoryResult } from "tmp-promise";
+import {
+  showAndLogErrorMessage,
+  showAndLogWarningMessage,
+} from "../../../../src/common/vscode/log";
 
 jest.mock("os", () => {
   const original = jest.requireActual("os");
@@ -204,8 +208,8 @@ describe("Releases API consumer", () => {
 });
 
 describe("Launcher path", () => {
-  let warnSpy: jest.SpiedFunction<typeof helpers.showAndLogWarningMessage>;
-  let errorSpy: jest.SpiedFunction<typeof helpers.showAndLogErrorMessage>;
+  let warnSpy: jest.SpiedFunction<typeof showAndLogWarningMessage>;
+  let errorSpy: jest.SpiedFunction<typeof showAndLogErrorMessage>;
   let logSpy: jest.SpiedFunction<typeof extLogger.log>;
 
   let directory: DirectoryResult;
@@ -215,10 +219,10 @@ describe("Launcher path", () => {
 
   beforeEach(async () => {
     warnSpy = jest
-      .spyOn(helpers, "showAndLogWarningMessage")
+      .spyOn(log, "showAndLogWarningMessage")
       .mockResolvedValue(undefined);
     errorSpy = jest
-      .spyOn(helpers, "showAndLogErrorMessage")
+      .spyOn(log, "showAndLogErrorMessage")
       .mockResolvedValue(undefined);
     logSpy = jest.spyOn(extLogger, "log").mockResolvedValue(undefined);
 

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/data-extensions-editor/extension-pack-picker.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/data-extensions-editor/extension-pack-picker.test.ts
@@ -7,10 +7,11 @@ import {
   QlpacksInfo,
   ResolveExtensionsResult,
 } from "../../../../src/codeql-cli/cli";
-import * as helpers from "../../../../src/helpers";
+import * as log from "../../../../src/common/vscode/log";
 
 import { pickExtensionPackModelFile } from "../../../../src/data-extensions-editor/extension-pack-picker";
 import { ExtensionPack } from "../../../../src/data-extensions-editor/shared/extension-pack";
+import { showAndLogErrorMessage } from "../../../../src/common/vscode/log";
 
 describe("pickExtensionPackModelFile", () => {
   let tmpDir: string;
@@ -33,7 +34,7 @@ describe("pickExtensionPackModelFile", () => {
   let showQuickPickSpy: jest.SpiedFunction<typeof window.showQuickPick>;
   let showInputBoxSpy: jest.SpiedFunction<typeof window.showInputBox>;
   let showAndLogErrorMessageSpy: jest.SpiedFunction<
-    typeof helpers.showAndLogErrorMessage
+    typeof showAndLogErrorMessage
   >;
 
   beforeEach(async () => {
@@ -79,7 +80,7 @@ describe("pickExtensionPackModelFile", () => {
       .spyOn(window, "showInputBox")
       .mockRejectedValue(new Error("Unexpected call to showInputBox"));
     showAndLogErrorMessageSpy = jest
-      .spyOn(helpers, "showAndLogErrorMessage")
+      .spyOn(log, "showAndLogErrorMessage")
       .mockImplementation((msg) => {
         throw new Error(`Unexpected call to showAndLogErrorMessage: ${msg}`);
       });

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/data-extensions-editor/external-api-usage-query.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/data-extensions-editor/external-api-usage-query.test.ts
@@ -11,8 +11,9 @@ import { readdir, readFile } from "fs-extra";
 import { load } from "js-yaml";
 import { dirname, join } from "path";
 import { fetchExternalApiQueries } from "../../../../src/data-extensions-editor/queries";
-import * as helpers from "../../../../src/helpers";
+import * as log from "../../../../src/common/vscode/log";
 import { RedactableError } from "../../../../src/pure/errors";
+import { showAndLogExceptionWithTelemetry } from "../../../../src/common/vscode/log";
 
 function createMockUri(path = "/a/b/c/foo"): Uri {
   return {
@@ -134,12 +135,12 @@ describe("readQueryResults", () => {
   };
 
   let showAndLogExceptionWithTelemetrySpy: jest.SpiedFunction<
-    typeof helpers.showAndLogExceptionWithTelemetry
+    typeof showAndLogExceptionWithTelemetry
   >;
 
   beforeEach(() => {
     showAndLogExceptionWithTelemetrySpy = jest.spyOn(
-      helpers,
+      log,
       "showAndLogExceptionWithTelemetry",
     );
   });

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/language-support/contextual/query-resolver.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/language-support/contextual/query-resolver.test.ts
@@ -3,7 +3,7 @@ import * as fs from "fs-extra";
 
 import { getErrorMessage } from "../../../../../src/pure/helpers-pure";
 
-import * as helpers from "../../../../../src/helpers";
+import * as log from "../../../../../src/common/vscode/log";
 import * as workspaceFolders from "../../../../../src/common/vscode/workspace-folders";
 import * as qlpack from "../../../../../src/databases/qlpack";
 import {
@@ -42,7 +42,7 @@ describe("queryResolver", () => {
     jest
       .spyOn(workspaceFolders, "getOnDiskWorkspaceFolders")
       .mockReturnValue([]);
-    jest.spyOn(helpers, "showAndLogErrorMessage").mockResolvedValue(undefined);
+    jest.spyOn(log, "showAndLogErrorMessage").mockResolvedValue(undefined);
   });
 
   describe("resolveQueries", () => {


### PR DESCRIPTION
This is the third part in a series that will split the `helpers.ts` file. This PR moves the show and log functions to a separate file. This decreases the number of things the `helpers.ts` file is doing.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
