### PR TITLE
Fix containsPath for paths that share a prefix

### DIFF
--- a/extensions/ql-vscode/src/databases/local-databases/database-item-impl.ts
+++ b/extensions/ql-vscode/src/databases/local-databases/database-item-impl.ts
@@ -207,7 +207,6 @@ export class DatabaseItemImpl implements DatabaseItem {
         return pathsEqual(
           databasePath,
           join(testdir, `${testdirbase}.testproj`),
-          process.platform,
         );
       }
     } catch {

--- a/extensions/ql-vscode/src/databases/local-databases/database-manager.ts
+++ b/extensions/ql-vscode/src/databases/local-databases/database-manager.ts
@@ -652,7 +652,7 @@ export class DatabaseManager extends DisposableObject {
   private isExtensionControlledLocation(uri: vscode.Uri) {
     const storageUri = this.ctx.storageUri || this.ctx.globalStorageUri;
     if (storageUri) {
-      return containsPath(storageUri.fsPath, uri.fsPath, process.platform);
+      return containsPath(storageUri.fsPath, uri.fsPath);
     }
     return false;
   }

--- a/extensions/ql-vscode/src/pure/files.ts
+++ b/extensions/ql-vscode/src/pure/files.ts
@@ -1,5 +1,5 @@
 import { pathExists, stat, readdir } from "fs-extra";
-import { join, resolve } from "path";
+import { isAbsolute, join, relative, resolve } from "path";
 
 /**
  * Recursively finds all .ql files in this set of Uris.
@@ -71,7 +71,13 @@ export function pathsEqual(path1: string, path2: string): boolean {
  * Returns true if `parent` contains `child`, or if they are equal.
  */
 export function containsPath(parent: string, child: string): boolean {
-  return normalizePath(child).startsWith(normalizePath(parent));
+  const relativePath = relative(parent, child);
+  return (
+    !relativePath.startsWith("..") &&
+    // On windows, if the two paths are in different drives, then the
+    // relative path will be an absolute path to the other drive.
+    !(process.platform === "win32" && isAbsolute(relativePath))
+  );
 }
 
 export async function readDirFullPaths(path: string): Promise<string[]> {

--- a/extensions/ql-vscode/src/pure/files.ts
+++ b/extensions/ql-vscode/src/pure/files.ts
@@ -51,37 +51,27 @@ export async function getDirectoryNamesInsidePath(
   return dirNames;
 }
 
-function normalizePath(path: string, platform: NodeJS.Platform): string {
+function normalizePath(path: string): string {
   // On Windows, "C:/", "C:\", and "c:/" are all equivalent. We need
   // to normalize the paths to ensure they all get resolved to the
   // same format. On Windows, we also need to do the comparison
   // case-insensitively.
   path = resolve(path);
-  if (platform === "win32") {
+  if (process.platform === "win32") {
     path = path.toLowerCase();
   }
   return path;
 }
 
-export function pathsEqual(
-  path1: string,
-  path2: string,
-  platform: NodeJS.Platform,
-): boolean {
-  return normalizePath(path1, platform) === normalizePath(path2, platform);
+export function pathsEqual(path1: string, path2: string): boolean {
+  return normalizePath(path1) === normalizePath(path2);
 }
 
 /**
  * Returns true if `parent` contains `child`, or if they are equal.
  */
-export function containsPath(
-  parent: string,
-  child: string,
-  platform: NodeJS.Platform,
-): boolean {
-  return normalizePath(child, platform).startsWith(
-    normalizePath(parent, platform),
-  );
+export function containsPath(parent: string, child: string): boolean {
+  return normalizePath(child).startsWith(normalizePath(parent));
 }
 
 export async function readDirFullPaths(path: string): Promise<string[]> {

--- a/extensions/ql-vscode/src/pure/files.ts
+++ b/extensions/ql-vscode/src/pure/files.ts
@@ -72,15 +72,15 @@ export function pathsEqual(
 }
 
 /**
- * Returns true if path1 contains path2.
+ * Returns true if `parent` contains `child`.
  */
 export function containsPath(
-  path1: string,
-  path2: string,
+  parent: string,
+  child: string,
   platform: NodeJS.Platform,
 ): boolean {
-  return normalizePath(path2, platform).startsWith(
-    normalizePath(path1, platform),
+  return normalizePath(child, platform).startsWith(
+    normalizePath(parent, platform),
   );
 }
 

--- a/extensions/ql-vscode/src/pure/files.ts
+++ b/extensions/ql-vscode/src/pure/files.ts
@@ -76,7 +76,7 @@ export function containsPath(parent: string, child: string): boolean {
     !relativePath.startsWith("..") &&
     // On windows, if the two paths are in different drives, then the
     // relative path will be an absolute path to the other drive.
-    !(process.platform === "win32" && isAbsolute(relativePath))
+    !isAbsolute(relativePath)
   );
 }
 

--- a/extensions/ql-vscode/src/pure/files.ts
+++ b/extensions/ql-vscode/src/pure/files.ts
@@ -72,7 +72,7 @@ export function pathsEqual(
 }
 
 /**
- * Returns true if `parent` contains `child`.
+ * Returns true if `parent` contains `child`, or if they are equal.
  */
 export function containsPath(
   parent: string,

--- a/extensions/ql-vscode/test/matchers/toEqualPath.ts
+++ b/extensions/ql-vscode/test/matchers/toEqualPath.ts
@@ -10,7 +10,7 @@ const toEqualPath: MatcherFunction<[expectedPath: unknown]> = function (
     throw new Error("These must be of type string!");
   }
 
-  const pass = pathsEqual(actual, expectedPath, process.platform);
+  const pass = pathsEqual(actual, expectedPath);
   if (pass) {
     return {
       message: () =>

--- a/extensions/ql-vscode/test/unit-tests/pure/files.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/pure/files.test.ts
@@ -207,79 +207,79 @@ describe("pathsEqual", () => {
 
 describe("containsPath", () => {
   const testCases: Array<{
-    path1: string;
-    path2: string;
+    parent: string;
+    child: string;
     platform: NodeJS.Platform;
     expected: boolean;
   }> = [
     {
-      path1:
+      parent:
         "/home/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript",
-      path2:
+      child:
         "/home/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript/example.ql",
       platform: "linux",
       expected: true,
     },
     {
-      path1:
+      parent:
         "/HOME/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript",
-      path2:
+      child:
         "/home/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript/example.ql",
       platform: "linux",
       expected: false,
     },
     {
-      path1:
+      parent:
         "/home/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript/example.ql",
-      path2:
+      child:
         "/home/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript",
       platform: "linux",
       expected: false,
     },
     {
-      path1:
+      parent:
         "C:/Users/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript",
-      path2:
+      child:
         "C:/Users/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript/example.ql",
       platform: "win32",
       expected: true,
     },
     {
-      path1:
+      parent:
         "C:/Users/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript",
-      path2:
+      child:
         "c:/Users/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript/example.ql",
       platform: "win32",
       expected: true,
     },
     {
-      path1:
+      parent:
         "C:/Users/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript",
-      path2:
+      child:
         "D:/Users/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript/example.ql",
       platform: "win32",
       expected: false,
     },
     {
-      path1:
+      parent:
         "C:/Users/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript/example.ql",
-      path2:
+      child:
         "C:/Users/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript",
       platform: "win32",
       expected: false,
     },
     {
-      path1:
+      parent:
         "C:/Users/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript",
-      path2:
+      child:
         "C:\\Users\\github\\projects\\vscode-codeql-starter\\codeql-custom-queries-javascript\\example.ql",
       platform: "win32",
       expected: true,
     },
     {
-      path1:
+      parent:
         "C:/Users/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript",
-      path2:
+      child:
         "D:\\Users\\github\\projects\\vscode-codeql-starter\\codeql-custom-queries-javascript\\example.ql",
       platform: "win32",
       expected: false,
@@ -287,15 +287,15 @@ describe("containsPath", () => {
   ];
 
   test.each(testCases)(
-    "$path1 contains $path2 on $platform = $expected",
-    ({ path1, path2, platform, expected }) => {
+    "$parent contains $child on $platform = $expected",
+    ({ parent, child, platform, expected }) => {
       if (platform !== process.platform) {
         // We're using the platform-specific path.resolve, so we can't really run
         // these tests on all platforms.
         return;
       }
 
-      expect(containsPath(path1, path2, platform)).toEqual(expected);
+      expect(containsPath(parent, child, platform)).toEqual(expected);
     },
   );
 });

--- a/extensions/ql-vscode/test/unit-tests/pure/files.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/pure/files.test.ts
@@ -238,6 +238,22 @@ describe("containsPath", () => {
     },
     {
       parent:
+        "/home/github/projects/vscode-codeql-starter/codeql-custom-queries-java",
+      child:
+        "/home/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript",
+      platform: "linux",
+      expected: false,
+    },
+    {
+      parent:
+        "/home/github/projects/vscode-codeql-starter/codeql-custom-queries-java",
+      child:
+        "/home/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript/example.ql",
+      platform: "linux",
+      expected: false,
+    },
+    {
+      parent:
         "C:/Users/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript",
       child:
         "C:/Users/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript/example.ql",
@@ -281,6 +297,22 @@ describe("containsPath", () => {
         "C:/Users/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript",
       child:
         "D:\\Users\\github\\projects\\vscode-codeql-starter\\codeql-custom-queries-javascript\\example.ql",
+      platform: "win32",
+      expected: false,
+    },
+    {
+      parent:
+        "C:/Users/github/projects/vscode-codeql-starter/codeql-custom-queries-java",
+      child:
+        "C:/Users/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript",
+      platform: "win32",
+      expected: false,
+    },
+    {
+      parent:
+        "C:/Users/github/projects/vscode-codeql-starter/codeql-custom-queries-java",
+      child:
+        "C:/Users/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript/example.ql",
       platform: "win32",
       expected: false,
     },

--- a/extensions/ql-vscode/test/unit-tests/pure/files.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/pure/files.test.ts
@@ -272,6 +272,14 @@ describe("containsPath", () => {
       parent:
         "C:/Users/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript",
       child:
+        "C:/USERS/GITHUB/PROJECTS/VSCODE-CODEQL-STARTER/CODEQL-CUSTOM-QUERIES-JAVASCRIPT/EXAMPLE.QL",
+      platform: "win32",
+      expected: true,
+    },
+    {
+      parent:
+        "C:/Users/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript",
+      child:
         "D:/Users/github/projects/vscode-codeql-starter/codeql-custom-queries-javascript/example.ql",
       platform: "win32",
       expected: false,

--- a/extensions/ql-vscode/test/unit-tests/pure/files.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/pure/files.test.ts
@@ -200,7 +200,7 @@ describe("pathsEqual", () => {
         return;
       }
 
-      expect(pathsEqual(path1, path2, platform)).toEqual(expected);
+      expect(pathsEqual(path1, path2)).toEqual(expected);
     },
   );
 });
@@ -295,7 +295,7 @@ describe("containsPath", () => {
         return;
       }
 
-      expect(containsPath(parent, child, platform)).toEqual(expected);
+      expect(containsPath(parent, child)).toEqual(expected);
     },
   );
 });


### PR DESCRIPTION
For context, in https://github.com/github/vscode-codeql/pull/2490 I started added my own method to determine if one paths contains another, but then I realised that we already have `files.ts` and `containsPath`.

Unfortunately `containsPath` uses a `startsWith` implementation and this isn't correct for examples like `/foo` and `/foobar`. In this case neither path is a parent of the other, but they do share `/foo` as a prefix.

This PR changes the implementation to use `path.relative` to do the work of deciding if a path contains another. We can also now remove the call to `normalizePath` from this method, as `relative` performs the same normalization as the `resolve` method. The only catch is we have to handle different drives on windows. See https://github.com/dsp-testing/robertbrignull-path-test/actions/runs/5244140271/jobs/9469730588 for some testing of this behaviour on linux vs windows.

I also made the methods a little clearer in my opinion, with more descriptive parameter names, documenting behaviour more closely, and removing the `platform` argument. We never actually pass a `platform` argument that isn't `process.platform`, and from my understanding it would be incorrect to ever do so because the behaviour of functions from `path` changes. It looks like we do in the tests, but actually the tests are skipped on mismatching platforms.

Changes are split up into separate commits to tell the renames from the new code and behaviour changes.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
