### PR TITLE
Use containsPath where possible

### DIFF
--- a/extensions/ql-vscode/src/data-extensions-editor/extension-pack-picker.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/extension-pack-picker.ts
@@ -14,6 +14,7 @@ import { DatabaseItem } from "../databases/local-databases";
 import { getQlPackPath, QLPACK_FILENAMES } from "../pure/ql";
 import { getErrorMessage } from "../pure/helpers-pure";
 import { ExtensionPack, ExtensionPackModelFile } from "./shared/extension-pack";
+import { containsPath } from "../pure/files";
 
 const maxStep = 3;
 
@@ -347,11 +348,7 @@ async function pickNewModelFile(
           return "File already exists";
         }
 
-        const notInExtensionPack = relative(
-          extensionPack.path,
-          path,
-        ).startsWith("..");
-        if (notInExtensionPack) {
+        if (!containsPath(extensionPack.path, path)) {
           return "File must be in the extension pack";
         }
 

--- a/extensions/ql-vscode/src/databases/local-databases/database-item-impl.ts
+++ b/extensions/ql-vscode/src/databases/local-databases/database-item-impl.ts
@@ -2,7 +2,7 @@
 import * as cli from "../../codeql-cli/cli";
 import vscode from "vscode";
 import { FullDatabaseOptions } from "./database-options";
-import { basename, dirname, extname, join, relative } from "path";
+import { basename, dirname, extname, join } from "path";
 import {
   decodeSourceArchiveUri,
   encodeArchiveBasePath,
@@ -12,7 +12,7 @@ import {
 import { DatabaseItem, PersistedDatabaseItem } from "./database-item";
 import { isLikelyDatabaseRoot } from "./db-contents-heuristics";
 import { stat } from "fs-extra";
-import { pathsEqual } from "../../pure/files";
+import { containsPath, pathsEqual } from "../../pure/files";
 import { DatabaseContents } from "./database-contents";
 
 export class DatabaseItemImpl implements DatabaseItem {
@@ -199,7 +199,7 @@ export class DatabaseItemImpl implements DatabaseItem {
     try {
       const stats = await stat(testPath);
       if (stats.isDirectory()) {
-        return !relative(testPath, databasePath).startsWith("..");
+        return containsPath(testPath, databasePath);
       } else {
         // database for /one/two/three/test.ql is at /one/two/three/three.testproj
         const testdir = dirname(testPath);


### PR DESCRIPTION
Following on from https://github.com/github/vscode-codeql/pull/2509, these are two places that were doing their own check of if a path contains another path. We can use `containsPath` instead and it shouldn't change any behaviour, or it might make it more correct.

I haven't looked too hard into how this code is used, but only at the low level code. It should be equivalent, but I can run some tests if needed.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
