### PR TITLE
Make the showAndLog family of functions usable without the `vscode` module

### DIFF
--- a/extensions/ql-vscode/src/codeql-cli/distribution.ts
+++ b/extensions/ql-vscode/src/codeql-cli/distribution.ts
@@ -160,6 +160,7 @@ export class DistributionManager implements DistributionProvider {
     if (this.config.customCodeQlPath) {
       if (!(await pathExists(this.config.customCodeQlPath))) {
         void showAndLogErrorMessage(
+          extLogger,
           `The CodeQL executable path is specified as "${this.config.customCodeQlPath}" ` +
             "by a configuration setting, but a CodeQL executable could not be found at that path. Please check " +
             "that a CodeQL executable exists at the specified path or remove the setting.",
@@ -852,6 +853,7 @@ export async function getExecutableFromDirectory(
 
 function warnDeprecatedLauncher() {
   void showAndLogWarningMessage(
+    extLogger,
     `The "${deprecatedCodeQlLauncherName()!}" launcher has been deprecated and will be removed in a future version. ` +
       `Please use "${codeQlLauncherName()}" instead. It is recommended to update to the latest CodeQL binaries.`,
   );

--- a/extensions/ql-vscode/src/codeql-cli/distribution.ts
+++ b/extensions/ql-vscode/src/codeql-cli/distribution.ts
@@ -25,7 +25,7 @@ import {
 import {
   showAndLogErrorMessage,
   showAndLogWarningMessage,
-} from "../common/vscode/log";
+} from "../common/logging";
 
 /**
  * distribution.ts

--- a/extensions/ql-vscode/src/codeql-cli/query-language.ts
+++ b/extensions/ql-vscode/src/codeql-cli/query-language.ts
@@ -4,7 +4,7 @@ import { isQueryLanguage, QueryLanguage } from "../common/query-language";
 import { getOnDiskWorkspaceFolders } from "../common/vscode/workspace-folders";
 import { extLogger } from "../common";
 import { UserCancellationException } from "../common/vscode/progress";
-import { showAndLogErrorMessage } from "../common/vscode/log";
+import { showAndLogErrorMessage } from "../common/logging";
 
 /**
  * Finds the language that a query targets.

--- a/extensions/ql-vscode/src/codeql-cli/query-language.ts
+++ b/extensions/ql-vscode/src/codeql-cli/query-language.ts
@@ -59,6 +59,7 @@ export async function askForLanguage(
       throw new UserCancellationException("Cancelled.");
     } else {
       void showAndLogErrorMessage(
+        extLogger,
         "Language not found. Language must be specified manually.",
       );
     }
@@ -67,6 +68,7 @@ export async function askForLanguage(
 
   if (!isQueryLanguage(language)) {
     void showAndLogErrorMessage(
+      extLogger,
       `Language '${language}' is not supported. Only languages ${Object.values(
         QueryLanguage,
       ).join(", ")} are supported.`,

--- a/extensions/ql-vscode/src/common/app.ts
+++ b/extensions/ql-vscode/src/common/app.ts
@@ -1,14 +1,14 @@
 import { Credentials } from "./authentication";
 import { Disposable } from "../pure/disposable-object";
 import { AppEventEmitter } from "./events";
-import { Logger } from "./logging";
+import { NotificationLogger } from "./logging";
 import { Memento } from "./memento";
 import { AppCommandManager } from "./commands";
 
 export interface App {
   createEventEmitter<T>(): AppEventEmitter<T>;
   readonly mode: AppMode;
-  readonly logger: Logger;
+  readonly logger: NotificationLogger;
   readonly subscriptions: Disposable[];
   readonly extensionPath: string;
   readonly globalStoragePath: string;

--- a/extensions/ql-vscode/src/common/logging/index.ts
+++ b/extensions/ql-vscode/src/common/logging/index.ts
@@ -1,5 +1,6 @@
 export * from "./logger";
 export * from "./notification-logger";
+export * from "./notifications";
 export * from "./tee-logger";
 export * from "./vscode/loggers";
 export * from "./vscode/output-channel-logger";

--- a/extensions/ql-vscode/src/common/logging/index.ts
+++ b/extensions/ql-vscode/src/common/logging/index.ts
@@ -1,4 +1,5 @@
 export * from "./logger";
+export * from "./notification-logger";
 export * from "./tee-logger";
 export * from "./vscode/loggers";
 export * from "./vscode/output-channel-logger";

--- a/extensions/ql-vscode/src/common/logging/notification-logger.ts
+++ b/extensions/ql-vscode/src/common/logging/notification-logger.ts
@@ -1,0 +1,7 @@
+import { Logger } from "./logger";
+
+export interface NotificationLogger extends Logger {
+  showErrorMessage(message: string): Promise<void>;
+  showWarningMessage(message: string): Promise<void>;
+  showInformationMessage(message: string): Promise<void>;
+}

--- a/extensions/ql-vscode/src/common/logging/notifications.ts
+++ b/extensions/ql-vscode/src/common/logging/notifications.ts
@@ -1,36 +1,11 @@
-import { RedactableError } from "../../pure/errors";
-import { telemetryListener } from "../../telemetry";
-import { NotificationLogger } from "../logging";
+import { NotificationLogger } from "./notification-logger";
 
-interface ShowAndLogExceptionOptions extends ShowAndLogOptions {
-  /** Custom properties to include in the telemetry report. */
-  extraTelemetryProperties?: { [key: string]: string };
-}
-
-interface ShowAndLogOptions {
+export interface ShowAndLogOptions {
   /**
    * An alternate message that is added to the log, but not displayed in the popup.
    * This is useful for adding extra detail to the logs that would be too noisy for the popup.
    */
   fullMessage?: string;
-}
-
-/**
- * Show an error message, log it to the console, and emit redacted information as telemetry
- *
- * @param logger The logger that will receive the message.
- * @param error The error to show. Only redacted information will be included in the telemetry.
- * @param options See individual fields on `ShowAndLogExceptionOptions` type.
- *
- * @return A promise that resolves to the selected item or undefined when being dismissed.
- */
-export async function showAndLogExceptionWithTelemetry(
-  logger: NotificationLogger,
-  error: RedactableError,
-  options: ShowAndLogExceptionOptions = {},
-): Promise<void> {
-  telemetryListener?.sendError(error, options.extraTelemetryProperties);
-  return showAndLogErrorMessage(logger, error.fullMessage, options);
 }
 
 /**

--- a/extensions/ql-vscode/src/common/logging/vscode/output-channel-logger.ts
+++ b/extensions/ql-vscode/src/common/logging/vscode/output-channel-logger.ts
@@ -1,11 +1,15 @@
 import { window as Window, OutputChannel, Progress } from "vscode";
 import { Logger, LogOptions } from "../logger";
 import { DisposableObject } from "../../../pure/disposable-object";
+import { NotificationLogger } from "../notification-logger";
 
 /**
  * A logger that writes messages to an output channel in the VS Code Output tab.
  */
-export class OutputChannelLogger extends DisposableObject implements Logger {
+export class OutputChannelLogger
+  extends DisposableObject
+  implements Logger, NotificationLogger
+{
   public readonly outputChannel: OutputChannel;
   isCustomLogDirectory: boolean;
 
@@ -41,6 +45,30 @@ export class OutputChannelLogger extends DisposableObject implements Logger {
 
   show(preserveFocus?: boolean): void {
     this.outputChannel.show(preserveFocus);
+  }
+
+  async showErrorMessage(message: string): Promise<void> {
+    await this.showMessage(message, Window.showErrorMessage);
+  }
+
+  async showInformationMessage(message: string): Promise<void> {
+    await this.showMessage(message, Window.showInformationMessage);
+  }
+
+  async showWarningMessage(message: string): Promise<void> {
+    await this.showMessage(message, Window.showWarningMessage);
+  }
+
+  private async showMessage(
+    message: string,
+    show: (message: string, ...items: string[]) => Thenable<string | undefined>,
+  ): Promise<void> {
+    const label = "Show Log";
+    const result = await show(message, label);
+
+    if (result === label) {
+      this.show();
+    }
   }
 }
 

--- a/extensions/ql-vscode/src/common/vscode/commands.ts
+++ b/extensions/ql-vscode/src/common/vscode/commands.ts
@@ -1,6 +1,10 @@
 import { commands, Disposable } from "vscode";
 import { CommandFunction, CommandManager } from "../../packages/commands";
-import { extLogger, OutputChannelLogger } from "../logging";
+import {
+  extLogger,
+  OutputChannelLogger,
+  showAndLogWarningMessage,
+} from "../logging";
 import {
   asError,
   getErrorMessage,
@@ -9,10 +13,7 @@ import {
 import { redactableError } from "../../pure/errors";
 import { UserCancellationException } from "./progress";
 import { telemetryListener } from "../../telemetry";
-import {
-  showAndLogExceptionWithTelemetry,
-  showAndLogWarningMessage,
-} from "./log";
+import { showAndLogExceptionWithTelemetry } from "./logging";
 
 /**
  * Create a command manager for VSCode, wrapping registerCommandWithErrorHandling

--- a/extensions/ql-vscode/src/common/vscode/commands.ts
+++ b/extensions/ql-vscode/src/common/vscode/commands.ts
@@ -54,9 +54,7 @@ export function registerCommandWithErrorHandling(
         if (e.silent) {
           void outputLogger.log(errorMessage.fullMessage);
         } else {
-          void showAndLogWarningMessage(errorMessage.fullMessage, {
-            outputLogger,
-          });
+          void showAndLogWarningMessage(outputLogger, errorMessage.fullMessage);
         }
       } else {
         // Include the full stack in the error log only.
@@ -64,8 +62,7 @@ export function registerCommandWithErrorHandling(
         const fullMessage = errorStack
           ? `${errorMessage.fullMessage}\n${errorStack}`
           : errorMessage.fullMessage;
-        void showAndLogExceptionWithTelemetry(errorMessage, {
-          outputLogger,
+        void showAndLogExceptionWithTelemetry(outputLogger, errorMessage, {
           fullMessage,
           extraTelemetryProperties: {
             command: commandId,

--- a/extensions/ql-vscode/src/common/vscode/commands.ts
+++ b/extensions/ql-vscode/src/common/vscode/commands.ts
@@ -2,7 +2,7 @@ import { commands, Disposable } from "vscode";
 import { CommandFunction, CommandManager } from "../../packages/commands";
 import {
   extLogger,
-  OutputChannelLogger,
+  NotificationLogger,
   showAndLogWarningMessage,
 } from "../logging";
 import {
@@ -21,9 +21,9 @@ import { showAndLogExceptionWithTelemetry } from "./logging";
  */
 export function createVSCodeCommandManager<
   Commands extends Record<string, CommandFunction>,
->(outputLogger?: OutputChannelLogger): CommandManager<Commands> {
+>(logger?: NotificationLogger): CommandManager<Commands> {
   return new CommandManager((commandId, task) => {
-    return registerCommandWithErrorHandling(commandId, task, outputLogger);
+    return registerCommandWithErrorHandling(commandId, task, logger);
   }, wrapExecuteCommand);
 }
 
@@ -33,11 +33,12 @@ export function createVSCodeCommandManager<
  * @param commandId The ID of the command to register.
  * @param task The task to run. It is passed directly to `commands.registerCommand`. Any
  * arguments to the command handler are passed on to the task.
+ * @param logger The logger to use for error reporting.
  */
 export function registerCommandWithErrorHandling(
   commandId: string,
   task: (...args: any[]) => Promise<any>,
-  outputLogger = extLogger,
+  logger: NotificationLogger = extLogger,
 ): Disposable {
   return commands.registerCommand(commandId, async (...args: any[]) => {
     const startTime = Date.now();
@@ -53,9 +54,9 @@ export function registerCommandWithErrorHandling(
       if (e instanceof UserCancellationException) {
         // User has cancelled this action manually
         if (e.silent) {
-          void outputLogger.log(errorMessage.fullMessage);
+          void logger.log(errorMessage.fullMessage);
         } else {
-          void showAndLogWarningMessage(outputLogger, errorMessage.fullMessage);
+          void showAndLogWarningMessage(logger, errorMessage.fullMessage);
         }
       } else {
         // Include the full stack in the error log only.
@@ -63,7 +64,7 @@ export function registerCommandWithErrorHandling(
         const fullMessage = errorStack
           ? `${errorMessage.fullMessage}\n${errorStack}`
           : errorMessage.fullMessage;
-        void showAndLogExceptionWithTelemetry(outputLogger, errorMessage, {
+        void showAndLogExceptionWithTelemetry(logger, errorMessage, {
           fullMessage,
           extraTelemetryProperties: {
             command: commandId,

--- a/extensions/ql-vscode/src/common/vscode/external-files.ts
+++ b/extensions/ql-vscode/src/common/vscode/external-files.ts
@@ -8,6 +8,7 @@ import {
   getErrorStack,
 } from "../../pure/helpers-pure";
 import { showAndLogExceptionWithTelemetry } from "./log";
+import { extLogger } from "../logging";
 
 export async function tryOpenExternalFile(
   commandManager: AppCommandManager,
@@ -34,6 +35,7 @@ the file in the file explorer and dragging it into the workspace.`,
           await commandManager.execute("revealFileInOS", uri);
         } catch (e) {
           void showAndLogExceptionWithTelemetry(
+            extLogger,
             redactableError(
               asError(e),
             )`Failed to reveal file in OS: ${getErrorMessage(e)}`,
@@ -42,6 +44,7 @@ the file in the file explorer and dragging it into the workspace.`,
       }
     } else {
       void showAndLogExceptionWithTelemetry(
+        extLogger,
         redactableError(asError(e))`Could not open file ${fileLocation}`,
         {
           fullMessage: `${getErrorMessage(e)}\n${getErrorStack(e)}`,

--- a/extensions/ql-vscode/src/common/vscode/external-files.ts
+++ b/extensions/ql-vscode/src/common/vscode/external-files.ts
@@ -7,8 +7,8 @@ import {
   getErrorMessage,
   getErrorStack,
 } from "../../pure/helpers-pure";
-import { showAndLogExceptionWithTelemetry } from "./log";
 import { extLogger } from "../logging";
+import { showAndLogExceptionWithTelemetry } from "./logging";
 
 export async function tryOpenExternalFile(
   commandManager: AppCommandManager,

--- a/extensions/ql-vscode/src/common/vscode/logging.ts
+++ b/extensions/ql-vscode/src/common/vscode/logging.ts
@@ -1,0 +1,30 @@
+import {
+  NotificationLogger,
+  showAndLogErrorMessage,
+  ShowAndLogOptions,
+} from "../logging";
+import { RedactableError } from "../../pure/errors";
+import { telemetryListener } from "../../telemetry";
+
+interface ShowAndLogExceptionOptions extends ShowAndLogOptions {
+  /** Custom properties to include in the telemetry report. */
+  extraTelemetryProperties?: { [key: string]: string };
+}
+
+/**
+ * Show an error message, log it to the console, and emit redacted information as telemetry
+ *
+ * @param logger The logger that will receive the message.
+ * @param error The error to show. Only redacted information will be included in the telemetry.
+ * @param options See individual fields on `ShowAndLogExceptionOptions` type.
+ *
+ * @return A promise that resolves to the selected item or undefined when being dismissed.
+ */
+export async function showAndLogExceptionWithTelemetry(
+  logger: NotificationLogger,
+  error: RedactableError,
+  options: ShowAndLogExceptionOptions = {},
+): Promise<void> {
+  telemetryListener?.sendError(error, options.extraTelemetryProperties);
+  return showAndLogErrorMessage(logger, error.fullMessage, options);
+}

--- a/extensions/ql-vscode/src/common/vscode/selection-commands.ts
+++ b/extensions/ql-vscode/src/common/vscode/selection-commands.ts
@@ -3,8 +3,7 @@ import {
   TreeViewContextMultiSelectionCommandFunction,
   TreeViewContextSingleSelectionCommandFunction,
 } from "../commands";
-import { showAndLogErrorMessage } from "./log";
-import { extLogger } from "../logging";
+import { showAndLogErrorMessage, extLogger } from "../logging";
 
 // A hack to match types that are not an array, which is useful to help avoid
 // misusing createSingleSelectionCommand, e.g. where T accidentally gets instantiated

--- a/extensions/ql-vscode/src/common/vscode/selection-commands.ts
+++ b/extensions/ql-vscode/src/common/vscode/selection-commands.ts
@@ -3,7 +3,7 @@ import {
   TreeViewContextMultiSelectionCommandFunction,
   TreeViewContextSingleSelectionCommandFunction,
 } from "../commands";
-import { showAndLogErrorMessage, extLogger } from "../logging";
+import { showAndLogErrorMessage, NotificationLogger } from "../logging";
 
 // A hack to match types that are not an array, which is useful to help avoid
 // misusing createSingleSelectionCommand, e.g. where T accidentally gets instantiated
@@ -25,6 +25,7 @@ type SelectionCommand<T extends NotArray> = CreateSupertypeOf<
 >;
 
 export function createSingleSelectionCommand<T extends NotArray>(
+  logger: NotificationLogger,
   f: (argument: T) => Promise<void>,
   itemName: string,
 ): SelectionCommand<T> {
@@ -33,7 +34,7 @@ export function createSingleSelectionCommand<T extends NotArray>(
       return f(singleItem);
     } else {
       void showAndLogErrorMessage(
-        extLogger,
+        logger,
         `Please select a single ${itemName}.`,
       );
       return;

--- a/extensions/ql-vscode/src/common/vscode/selection-commands.ts
+++ b/extensions/ql-vscode/src/common/vscode/selection-commands.ts
@@ -4,6 +4,7 @@ import {
   TreeViewContextSingleSelectionCommandFunction,
 } from "../commands";
 import { showAndLogErrorMessage } from "./log";
+import { extLogger } from "../logging";
 
 // A hack to match types that are not an array, which is useful to help avoid
 // misusing createSingleSelectionCommand, e.g. where T accidentally gets instantiated
@@ -32,7 +33,10 @@ export function createSingleSelectionCommand<T extends NotArray>(
     if (multiSelect === undefined || multiSelect.length === 1) {
       return f(singleItem);
     } else {
-      void showAndLogErrorMessage(`Please select a single ${itemName}.`);
+      void showAndLogErrorMessage(
+        extLogger,
+        `Please select a single ${itemName}.`,
+      );
       return;
     }
   };

--- a/extensions/ql-vscode/src/common/vscode/vscode-app.ts
+++ b/extensions/ql-vscode/src/common/vscode/vscode-app.ts
@@ -3,7 +3,7 @@ import { VSCodeCredentials } from "./authentication";
 import { Disposable } from "../../pure/disposable-object";
 import { App, AppMode, EnvironmentContext } from "../app";
 import { AppEventEmitter } from "../events";
-import { extLogger, Logger, queryServerLogger } from "../logging";
+import { extLogger, NotificationLogger, queryServerLogger } from "../logging";
 import { Memento } from "../memento";
 import { VSCodeAppEventEmitter } from "./events";
 import { AppCommandManager, QueryServerCommandManager } from "../commands";
@@ -55,7 +55,7 @@ export class ExtensionApp implements App {
     }
   }
 
-  public get logger(): Logger {
+  public get logger(): NotificationLogger {
     return extLogger;
   }
 

--- a/extensions/ql-vscode/src/compare/compare-view.ts
+++ b/extensions/ql-vscode/src/compare/compare-view.ts
@@ -5,7 +5,7 @@ import {
   ToCompareViewMessage,
   QueryCompareResult,
 } from "../pure/interface-types";
-import { Logger } from "../common";
+import { extLogger, Logger } from "../common";
 import { CodeQLCliServer } from "../codeql-cli/cli";
 import { DatabaseManager } from "../databases/local-databases";
 import { jumpToLocation } from "../databases/local-databases/locations";
@@ -152,6 +152,7 @@ export class CompareView extends AbstractWebview<
 
       case "unhandledError":
         void showAndLogExceptionWithTelemetry(
+          extLogger,
           redactableError(
             msg.error,
           )`Unhandled error in result comparison view: ${msg.error.message}`,

--- a/extensions/ql-vscode/src/compare/compare-view.ts
+++ b/extensions/ql-vscode/src/compare/compare-view.ts
@@ -6,6 +6,7 @@ import {
   QueryCompareResult,
 } from "../pure/interface-types";
 import { extLogger, Logger } from "../common";
+import { showAndLogExceptionWithTelemetry } from "../common/vscode/logging";
 import { CodeQLCliServer } from "../codeql-cli/cli";
 import { DatabaseManager } from "../databases/local-databases";
 import { jumpToLocation } from "../databases/local-databases/locations";
@@ -24,8 +25,6 @@ import {
 } from "../common/vscode/abstract-webview";
 import { telemetryListener } from "../telemetry";
 import { redactableError } from "../pure/errors";
-
-import { showAndLogExceptionWithTelemetry } from "../common/vscode/log";
 
 interface ComparePair {
   from: CompletedLocalQueryInfo;

--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-module.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-module.ts
@@ -9,7 +9,7 @@ import { join } from "path";
 import { App } from "../common/app";
 import { withProgress } from "../common/vscode/progress";
 import { pickExtensionPackModelFile } from "./extension-pack-picker";
-import { showAndLogErrorMessage } from "../common/vscode/log";
+import { showAndLogErrorMessage } from "../common/logging";
 import { extLogger } from "../common";
 
 const SUPPORTED_LANGUAGES: string[] = ["java", "csharp"];

--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-module.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-module.ts
@@ -10,6 +10,7 @@ import { App } from "../common/app";
 import { withProgress } from "../common/vscode/progress";
 import { pickExtensionPackModelFile } from "./extension-pack-picker";
 import { showAndLogErrorMessage } from "../common/vscode/log";
+import { extLogger } from "../common";
 
 const SUPPORTED_LANGUAGES: string[] = ["java", "csharp"];
 
@@ -56,12 +57,13 @@ export class DataExtensionsEditorModule {
       "codeQL.openDataExtensionsEditor": async () => {
         const db = this.databaseManager.currentDatabaseItem;
         if (!db) {
-          void showAndLogErrorMessage("No database selected");
+          void showAndLogErrorMessage(extLogger, "No database selected");
           return;
         }
 
         if (!SUPPORTED_LANGUAGES.includes(db.language)) {
           void showAndLogErrorMessage(
+            extLogger,
             `The data extensions editor is not supported for ${db.language} databases.`,
           );
           return;
@@ -71,6 +73,7 @@ export class DataExtensionsEditorModule {
           async (progress, token) => {
             if (!(await this.cliServer.cliConstraints.supportsQlpacksKind())) {
               void showAndLogErrorMessage(
+                extLogger,
                 `This feature requires CodeQL CLI version ${CliVersionConstraint.CLI_VERSION_WITH_QLPACKS_KIND.format()} or later.`,
               );
               return;

--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-module.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-module.ts
@@ -10,7 +10,6 @@ import { App } from "../common/app";
 import { withProgress } from "../common/vscode/progress";
 import { pickExtensionPackModelFile } from "./extension-pack-picker";
 import { showAndLogErrorMessage } from "../common/logging";
-import { extLogger } from "../common";
 
 const SUPPORTED_LANGUAGES: string[] = ["java", "csharp"];
 
@@ -57,13 +56,13 @@ export class DataExtensionsEditorModule {
       "codeQL.openDataExtensionsEditor": async () => {
         const db = this.databaseManager.currentDatabaseItem;
         if (!db) {
-          void showAndLogErrorMessage(extLogger, "No database selected");
+          void showAndLogErrorMessage(this.app.logger, "No database selected");
           return;
         }
 
         if (!SUPPORTED_LANGUAGES.includes(db.language)) {
           void showAndLogErrorMessage(
-            extLogger,
+            this.app.logger,
             `The data extensions editor is not supported for ${db.language} databases.`,
           );
           return;
@@ -73,7 +72,7 @@ export class DataExtensionsEditorModule {
           async (progress, token) => {
             if (!(await this.cliServer.cliConstraints.supportsQlpacksKind())) {
               void showAndLogErrorMessage(
-                extLogger,
+                this.app.logger,
                 `This feature requires CodeQL CLI version ${CliVersionConstraint.CLI_VERSION_WITH_QLPACKS_KIND.format()} or later.`,
               );
               return;
@@ -82,6 +81,7 @@ export class DataExtensionsEditorModule {
             const modelFile = await pickExtensionPackModelFile(
               this.cliServer,
               db,
+              this.app.logger,
               progress,
               token,
             );

--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
@@ -208,6 +208,7 @@ export class DataExtensionsEditorView extends AbstractWebview<
 
       if (!existingModeledMethods) {
         void showAndLogErrorMessage(
+          extLogger,
           `Failed to parse data extension YAML ${this.modelFile.filename}.`,
         );
         return;
@@ -219,6 +220,7 @@ export class DataExtensionsEditorView extends AbstractWebview<
       });
     } catch (e: unknown) {
       void showAndLogErrorMessage(
+        extLogger,
         `Unable to read data extension YAML ${
           this.modelFile.filename
         }: ${getErrorMessage(e)}`,
@@ -276,6 +278,7 @@ export class DataExtensionsEditorView extends AbstractWebview<
       await this.clearProgress();
     } catch (err) {
       void showAndLogExceptionWithTelemetry(
+        extLogger,
         redactableError(
           asError(err),
         )`Failed to load external API usages: ${getErrorMessage(err)}`,
@@ -341,6 +344,7 @@ export class DataExtensionsEditorView extends AbstractWebview<
       });
     } catch (e: unknown) {
       void showAndLogExceptionWithTelemetry(
+        extLogger,
         redactableError(
           asError(e),
         )`Failed to generate flow model: ${getErrorMessage(e)}`,
@@ -474,6 +478,7 @@ export class DataExtensionsEditorView extends AbstractWebview<
 
       if (e instanceof RequestError && e.status === 429) {
         void showAndLogExceptionWithTelemetry(
+          extLogger,
           redactableError(e)`Rate limit hit, please try again soon.`,
         );
         return null;

--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
@@ -18,6 +18,7 @@ import {
 import { ProgressUpdate } from "../common/vscode/progress";
 import { QueryRunner } from "../query-server";
 import { extLogger } from "../common";
+import { showAndLogExceptionWithTelemetry } from "../common/vscode/logging";
 import { outputFile, pathExists, readFile } from "fs-extra";
 import { load as loadYaml } from "js-yaml";
 import { DatabaseItem, DatabaseManager } from "../databases/local-databases";
@@ -42,10 +43,7 @@ import {
 } from "./auto-model";
 import { showLlmGeneration } from "../config";
 import { getAutoModelUsages } from "./auto-model-usages-query";
-import {
-  showAndLogErrorMessage,
-  showAndLogExceptionWithTelemetry,
-} from "../common/vscode/log";
+import { showAndLogErrorMessage } from "../common/logging";
 
 export class DataExtensionsEditorView extends AbstractWebview<
   ToDataExtensionsEditorMessage,

--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
@@ -17,7 +17,6 @@ import {
 } from "../pure/interface-types";
 import { ProgressUpdate } from "../common/vscode/progress";
 import { QueryRunner } from "../query-server";
-import { extLogger } from "../common";
 import { showAndLogExceptionWithTelemetry } from "../common/vscode/logging";
 import { outputFile, pathExists, readFile } from "fs-extra";
 import { load as loadYaml } from "js-yaml";
@@ -165,10 +164,10 @@ export class DataExtensionsEditorView extends AbstractWebview<
             "Original file of this result is not in the database's source archive.",
           );
         } else {
-          void extLogger.log(`Unable to handleMsgFromView: ${e.message}`);
+          void this.app.logger.log(`Unable to handleMsgFromView: ${e.message}`);
         }
       } else {
-        void extLogger.log(`Unable to handleMsgFromView: ${e}`);
+        void this.app.logger.log(`Unable to handleMsgFromView: ${e}`);
       }
     }
   }
@@ -185,7 +184,7 @@ export class DataExtensionsEditorView extends AbstractWebview<
 
     await outputFile(this.modelFile.filename, yaml);
 
-    void extLogger.log(
+    void this.app.logger.log(
       `Saved data extension YAML to ${this.modelFile.filename}`,
     );
   }
@@ -206,7 +205,7 @@ export class DataExtensionsEditorView extends AbstractWebview<
 
       if (!existingModeledMethods) {
         void showAndLogErrorMessage(
-          extLogger,
+          this.app.logger,
           `Failed to parse data extension YAML ${this.modelFile.filename}.`,
         );
         return;
@@ -218,7 +217,7 @@ export class DataExtensionsEditorView extends AbstractWebview<
       });
     } catch (e: unknown) {
       void showAndLogErrorMessage(
-        extLogger,
+        this.app.logger,
         `Unable to read data extension YAML ${
           this.modelFile.filename
         }: ${getErrorMessage(e)}`,
@@ -276,7 +275,7 @@ export class DataExtensionsEditorView extends AbstractWebview<
       await this.clearProgress();
     } catch (err) {
       void showAndLogExceptionWithTelemetry(
-        extLogger,
+        this.app.logger,
         redactableError(
           asError(err),
         )`Failed to load external API usages: ${getErrorMessage(err)}`,
@@ -303,7 +302,7 @@ export class DataExtensionsEditorView extends AbstractWebview<
     );
     if (!database) {
       await this.clearProgress();
-      void extLogger.log("No database chosen");
+      void this.app.logger.log("No database chosen");
 
       return;
     }
@@ -342,7 +341,7 @@ export class DataExtensionsEditorView extends AbstractWebview<
       });
     } catch (e: unknown) {
       void showAndLogExceptionWithTelemetry(
-        extLogger,
+        this.app.logger,
         redactableError(
           asError(e),
         )`Failed to generate flow model: ${getErrorMessage(e)}`,
@@ -476,7 +475,7 @@ export class DataExtensionsEditorView extends AbstractWebview<
 
       if (e instanceof RequestError && e.status === 429) {
         void showAndLogExceptionWithTelemetry(
-          extLogger,
+          this.app.logger,
           redactableError(e)`Rate limit hit, please try again soon.`,
         );
         return null;

--- a/extensions/ql-vscode/src/data-extensions-editor/extension-pack-picker.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/extension-pack-picker.ts
@@ -15,6 +15,7 @@ import { getErrorMessage } from "../pure/helpers-pure";
 import { ExtensionPack, ExtensionPackModelFile } from "./shared/extension-pack";
 import { showAndLogErrorMessage } from "../common/vscode/log";
 import { containsPath } from "../pure/files";
+import { extLogger } from "../common";
 
 const maxStep = 3;
 
@@ -85,6 +86,7 @@ async function pickExtensionPack(
       Object.entries(extensionPacksInfo).map(async ([name, paths]) => {
         if (paths.length !== 1) {
           void showAndLogErrorMessage(
+            extLogger,
             `Extension pack ${name} resolves to multiple paths`,
             {
               fullMessage: `Extension pack ${name} resolves to multiple paths: ${paths.join(
@@ -102,11 +104,15 @@ async function pickExtensionPack(
         try {
           extensionPack = await readExtensionPack(path);
         } catch (e: unknown) {
-          void showAndLogErrorMessage(`Could not read extension pack ${name}`, {
-            fullMessage: `Could not read extension pack ${name} at ${path}: ${getErrorMessage(
-              e,
-            )}`,
-          });
+          void showAndLogErrorMessage(
+            extLogger,
+            `Could not read extension pack ${name}`,
+            {
+              fullMessage: `Could not read extension pack ${name} at ${path}: ${getErrorMessage(
+                e,
+              )}`,
+            },
+          );
 
           return undefined;
         }

--- a/extensions/ql-vscode/src/data-extensions-editor/extension-pack-picker.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/extension-pack-picker.ts
@@ -13,9 +13,8 @@ import { DatabaseItem } from "../databases/local-databases";
 import { getQlPackPath, QLPACK_FILENAMES } from "../pure/ql";
 import { getErrorMessage } from "../pure/helpers-pure";
 import { ExtensionPack, ExtensionPackModelFile } from "./shared/extension-pack";
-import { showAndLogErrorMessage } from "../common/vscode/log";
+import { showAndLogErrorMessage, extLogger } from "../common/logging";
 import { containsPath } from "../pure/files";
-import { extLogger } from "../common";
 
 const maxStep = 3;
 

--- a/extensions/ql-vscode/src/data-extensions-editor/extension-pack-picker.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/extension-pack-picker.ts
@@ -13,7 +13,7 @@ import { DatabaseItem } from "../databases/local-databases";
 import { getQlPackPath, QLPACK_FILENAMES } from "../pure/ql";
 import { getErrorMessage } from "../pure/helpers-pure";
 import { ExtensionPack, ExtensionPackModelFile } from "./shared/extension-pack";
-import { showAndLogErrorMessage, extLogger } from "../common/logging";
+import { NotificationLogger, showAndLogErrorMessage } from "../common/logging";
 import { containsPath } from "../pure/files";
 
 const maxStep = 3;
@@ -27,12 +27,14 @@ const packNameLength = 128;
 export async function pickExtensionPackModelFile(
   cliServer: Pick<CodeQLCliServer, "resolveQlpacks" | "resolveExtensions">,
   databaseItem: Pick<DatabaseItem, "name" | "language">,
+  logger: NotificationLogger,
   progress: ProgressCallback,
   token: CancellationToken,
 ): Promise<ExtensionPackModelFile | undefined> {
   const extensionPack = await pickExtensionPack(
     cliServer,
     databaseItem,
+    logger,
     progress,
     token,
   );
@@ -60,6 +62,7 @@ export async function pickExtensionPackModelFile(
 async function pickExtensionPack(
   cliServer: Pick<CodeQLCliServer, "resolveQlpacks">,
   databaseItem: Pick<DatabaseItem, "name" | "language">,
+  logger: NotificationLogger,
   progress: ProgressCallback,
   token: CancellationToken,
 ): Promise<ExtensionPack | undefined> {
@@ -85,7 +88,7 @@ async function pickExtensionPack(
       Object.entries(extensionPacksInfo).map(async ([name, paths]) => {
         if (paths.length !== 1) {
           void showAndLogErrorMessage(
-            extLogger,
+            logger,
             `Extension pack ${name} resolves to multiple paths`,
             {
               fullMessage: `Extension pack ${name} resolves to multiple paths: ${paths.join(
@@ -104,7 +107,7 @@ async function pickExtensionPack(
           extensionPack = await readExtensionPack(path);
         } catch (e: unknown) {
           void showAndLogErrorMessage(
-            extLogger,
+            logger,
             `Could not read extension pack ${name}`,
             {
               fullMessage: `Could not read extension pack ${name} at ${path}: ${getErrorMessage(

--- a/extensions/ql-vscode/src/data-extensions-editor/external-api-usage-query.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/external-api-usage-query.ts
@@ -3,7 +3,7 @@ import { dir } from "tmp-promise";
 import { writeFile } from "fs-extra";
 import { dump as dumpYaml } from "js-yaml";
 import { getOnDiskWorkspaceFolders } from "../common/vscode/workspace-folders";
-import { TeeLogger } from "../common";
+import { extLogger, TeeLogger } from "../common";
 import { isQueryLanguage } from "../common/query-language";
 import { CancellationToken } from "vscode";
 import { CodeQLCliServer } from "../codeql-cli/cli";
@@ -41,6 +41,7 @@ export async function runQuery({
 
   if (!isQueryLanguage(databaseItem.language)) {
     void showAndLogExceptionWithTelemetry(
+      extLogger,
       redactableError`Unsupported database language ${databaseItem.language}`,
     );
     return;
@@ -49,6 +50,7 @@ export async function runQuery({
   const query = fetchExternalApiQueries[databaseItem.language];
   if (!query) {
     void showAndLogExceptionWithTelemetry(
+      extLogger,
       redactableError`No external API usage query found for language ${databaseItem.language}`,
     );
     return;
@@ -104,6 +106,7 @@ export async function runQuery({
 
   if (completedQuery.resultType !== QueryResultType.SUCCESS) {
     void showAndLogExceptionWithTelemetry(
+      extLogger,
       redactableError`External API usage query failed: ${
         completedQuery.message ?? "No message"
       }`,
@@ -126,6 +129,7 @@ export async function readQueryResults({
   const bqrsInfo = await cliServer.bqrsInfo(bqrsPath);
   if (bqrsInfo["result-sets"].length !== 1) {
     void showAndLogExceptionWithTelemetry(
+      extLogger,
       redactableError`Expected exactly one result set, got ${bqrsInfo["result-sets"].length}`,
     );
     return undefined;

--- a/extensions/ql-vscode/src/data-extensions-editor/external-api-usage-query.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/external-api-usage-query.ts
@@ -4,6 +4,7 @@ import { writeFile } from "fs-extra";
 import { dump as dumpYaml } from "js-yaml";
 import { getOnDiskWorkspaceFolders } from "../common/vscode/workspace-folders";
 import { extLogger, TeeLogger } from "../common";
+import { showAndLogExceptionWithTelemetry } from "../common/vscode/logging";
 import { isQueryLanguage } from "../common/query-language";
 import { CancellationToken } from "vscode";
 import { CodeQLCliServer } from "../codeql-cli/cli";
@@ -13,7 +14,6 @@ import { fetchExternalApiQueries } from "./queries";
 import { QueryResultType } from "../pure/new-messages";
 import { join } from "path";
 import { redactableError } from "../pure/errors";
-import { showAndLogExceptionWithTelemetry } from "../common/vscode/log";
 
 export type RunQueryOptions = {
   cliServer: Pick<CodeQLCliServer, "resolveQlpacks">;

--- a/extensions/ql-vscode/src/data-extensions-editor/generate-flow-model.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/generate-flow-model.ts
@@ -3,7 +3,7 @@ import { DatabaseItem } from "../databases/local-databases";
 import { basename } from "path";
 import { QueryRunner } from "../query-server";
 import { CodeQLCliServer } from "../codeql-cli/cli";
-import { TeeLogger } from "../common";
+import { extLogger, TeeLogger } from "../common";
 import { extensiblePredicateDefinitions } from "./predicates";
 import { ProgressCallback } from "../common/vscode/progress";
 import { getOnDiskWorkspaceFolders } from "../common/vscode/workspace-folders";
@@ -81,6 +81,7 @@ async function getModeledMethodsFromFlow(
 ): Promise<ModeledMethodWithSignature[]> {
   if (queryPath === undefined) {
     void showAndLogExceptionWithTelemetry(
+      extLogger,
       redactableError`Failed to find ${type} query`,
     );
     return [];
@@ -115,6 +116,7 @@ async function getModeledMethodsFromFlow(
   );
   if (queryResult.resultType !== QueryResultType.SUCCESS) {
     void showAndLogExceptionWithTelemetry(
+      extLogger,
       redactableError`Failed to run ${basename(queryPath)} query: ${
         queryResult.message ?? "No message"
       }`,
@@ -127,6 +129,7 @@ async function getModeledMethodsFromFlow(
   const bqrsInfo = await cliServer.bqrsInfo(bqrsPath);
   if (bqrsInfo["result-sets"].length !== 1) {
     void showAndLogExceptionWithTelemetry(
+      extLogger,
       redactableError`Expected exactly one result set, got ${
         bqrsInfo["result-sets"].length
       } for ${basename(queryPath)}`,

--- a/extensions/ql-vscode/src/data-extensions-editor/generate-flow-model.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/generate-flow-model.ts
@@ -4,6 +4,7 @@ import { basename } from "path";
 import { QueryRunner } from "../query-server";
 import { CodeQLCliServer } from "../codeql-cli/cli";
 import { extLogger, TeeLogger } from "../common";
+import { showAndLogExceptionWithTelemetry } from "../common/vscode/logging";
 import { extensiblePredicateDefinitions } from "./predicates";
 import { ProgressCallback } from "../common/vscode/progress";
 import { getOnDiskWorkspaceFolders } from "../common/vscode/workspace-folders";
@@ -17,7 +18,6 @@ import { file } from "tmp-promise";
 import { writeFile } from "fs-extra";
 import { dump } from "js-yaml";
 import { qlpackOfDatabase } from "../language-support";
-import { showAndLogExceptionWithTelemetry } from "../common/vscode/log";
 
 type FlowModelOptions = {
   cliServer: CodeQLCliServer;

--- a/extensions/ql-vscode/src/databases/code-search-api.ts
+++ b/extensions/ql-vscode/src/databases/code-search-api.ts
@@ -4,6 +4,7 @@ import { Octokit } from "@octokit/rest";
 import { Progress, CancellationToken } from "vscode";
 import { Credentials } from "../common/authentication";
 import { showAndLogWarningMessage } from "../common/vscode/log";
+import { extLogger } from "../common";
 
 export async function getCodeSearchRepositories(
   query: string,
@@ -53,6 +54,7 @@ async function provideOctokitWithThrottling(
     throttle: {
       onRateLimit: (retryAfter: number, options: any): boolean => {
         void showAndLogWarningMessage(
+          extLogger,
           `Rate Limit detected for request ${options.method} ${options.url}. Retrying after ${retryAfter} seconds!`,
         );
 
@@ -60,6 +62,7 @@ async function provideOctokitWithThrottling(
       },
       onSecondaryRateLimit: (_retryAfter: number, options: any): void => {
         void showAndLogWarningMessage(
+          extLogger,
           `Secondary Rate Limit detected for request ${options.method} ${options.url}`,
         );
       },

--- a/extensions/ql-vscode/src/databases/code-search-api.ts
+++ b/extensions/ql-vscode/src/databases/code-search-api.ts
@@ -3,7 +3,7 @@ import { throttling } from "@octokit/plugin-throttling";
 import { Octokit } from "@octokit/rest";
 import { Progress, CancellationToken } from "vscode";
 import { Credentials } from "../common/authentication";
-import { showAndLogWarningMessage } from "../common/vscode/log";
+import { showAndLogWarningMessage } from "../common/logging";
 import { extLogger } from "../common";
 
 export async function getCodeSearchRepositories(

--- a/extensions/ql-vscode/src/databases/database-fetcher.ts
+++ b/extensions/ql-vscode/src/databases/database-fetcher.ts
@@ -31,7 +31,7 @@ import {
 import { Credentials } from "../common/authentication";
 import { AppCommandManager } from "../common/commands";
 import { ALLOW_HTTP_SETTING } from "../config";
-import { showAndLogInformationMessage } from "../common/vscode/log";
+import { showAndLogInformationMessage } from "../common/logging";
 
 /**
  * Prompts a user to fetch a database from a remote location. Database is assumed to be an archive file.

--- a/extensions/ql-vscode/src/databases/database-fetcher.ts
+++ b/extensions/ql-vscode/src/databases/database-fetcher.ts
@@ -70,6 +70,7 @@ export async function promptImportInternetDatabase(
   if (item) {
     await commandManager.execute("codeQLDatabases.focus");
     void showAndLogInformationMessage(
+      extLogger,
       "Database downloaded and imported successfully.",
     );
   }
@@ -115,6 +116,7 @@ export async function promptImportGithubDatabase(
   if (databaseItem) {
     await commandManager.execute("codeQLDatabases.focus");
     void showAndLogInformationMessage(
+      extLogger,
       "Database downloaded and imported successfully.",
     );
     return databaseItem;
@@ -246,6 +248,7 @@ export async function importArchiveDatabase(
     if (item) {
       await commandManager.execute("codeQLDatabases.focus");
       void showAndLogInformationMessage(
+        extLogger,
         "Database unzipped and imported successfully.",
       );
     }

--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -33,6 +33,7 @@ import {
   isLikelyDbLanguageFolder,
 } from "./local-databases/db-contents-heuristics";
 import { extLogger } from "../common";
+import { showAndLogExceptionWithTelemetry } from "../common/vscode/logging";
 import {
   importArchiveDatabase,
   promptImportGithubDatabase,
@@ -48,10 +49,7 @@ import {
   createMultiSelectionCommand,
   createSingleSelectionCommand,
 } from "../common/vscode/selection-commands";
-import {
-  showAndLogErrorMessage,
-  showAndLogExceptionWithTelemetry,
-} from "../common/vscode/log";
+import { showAndLogErrorMessage } from "../common/logging";
 
 enum SortOrder {
   NameAsc = "NameAsc",

--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -281,6 +281,7 @@ export class DatabaseUI extends DisposableObject {
       await this.chooseAndSetDatabase(true, { progress, token });
     } catch (e) {
       void showAndLogExceptionWithTelemetry(
+        extLogger,
         redactableError(
           asError(e),
         )`Failed to choose and set database: ${getErrorMessage(e)}`,
@@ -418,6 +419,7 @@ export class DatabaseUI extends DisposableObject {
           await remove(dbDir);
         } catch (e) {
           void showAndLogExceptionWithTelemetry(
+            extLogger,
             redactableError(
               asError(e),
             )`Failed to delete orphaned database: ${getErrorMessage(e)}`,
@@ -430,6 +432,7 @@ export class DatabaseUI extends DisposableObject {
     if (failures.length) {
       const dirname = path_dirname(failures[0]);
       void showAndLogErrorMessage(
+        extLogger,
         `Failed to delete unused databases (${failures.join(
           ", ",
         )}).\nTo delete unused databases, please remove them manually from the storage folder ${dirname}.`,
@@ -445,6 +448,7 @@ export class DatabaseUI extends DisposableObject {
       await this.chooseAndSetDatabase(false, { progress, token });
     } catch (e: unknown) {
       void showAndLogExceptionWithTelemetry(
+        extLogger,
         redactableError(
           asError(e),
         )`Failed to choose and set database: ${getErrorMessage(e)}`,

--- a/extensions/ql-vscode/src/databases/local-databases/database-manager.ts
+++ b/extensions/ql-vscode/src/databases/local-databases/database-manager.ts
@@ -412,6 +412,7 @@ export class DatabaseManager extends DisposableObject {
       } catch (e) {
         // database list had an unexpected type - nothing to be done?
         void showAndLogExceptionWithTelemetry(
+          extLogger,
           redactableError(
             asError(e),
           )`Database list loading failed: ${getErrorMessage(e)}`,

--- a/extensions/ql-vscode/src/databases/local-databases/database-manager.ts
+++ b/extensions/ql-vscode/src/databases/local-databases/database-manager.ts
@@ -1,5 +1,6 @@
 import vscode, { ExtensionContext } from "vscode";
 import { extLogger, Logger } from "../../common";
+import { showAndLogExceptionWithTelemetry } from "../../common/vscode/logging";
 import { DisposableObject } from "../../pure/disposable-object";
 import { App } from "../../common/app";
 import { QueryRunner } from "../../query-server";
@@ -28,7 +29,6 @@ import { remove } from "fs-extra";
 import { containsPath } from "../../pure/files";
 import { DatabaseChangedEvent, DatabaseEventKind } from "./database-events";
 import { DatabaseResolver } from "./database-resolver";
-import { showAndLogExceptionWithTelemetry } from "../../common/vscode/log";
 
 /**
  * The name of the key in the workspaceState dictionary in which we

--- a/extensions/ql-vscode/src/databases/local-databases/database-resolver.ts
+++ b/extensions/ql-vscode/src/databases/local-databases/database-resolver.ts
@@ -12,6 +12,7 @@ import {
   showAndLogInformationMessage,
   showAndLogWarningMessage,
 } from "../../common/vscode/log";
+import { extLogger } from "../../common";
 
 export class DatabaseResolver {
   public static async resolveDatabaseContents(
@@ -107,6 +108,7 @@ async function findDataset(parentDirectory: string): Promise<vscode.Uri> {
   const dbAbsolutePath = join(parentDirectory, dbRelativePaths[0]);
   if (dbRelativePaths.length > 1) {
     void showAndLogWarningMessage(
+      extLogger,
       `Found multiple dataset directories in database, using '${dbAbsolutePath}'.`,
     );
   }
@@ -138,6 +140,7 @@ export async function findSourceArchive(
   }
 
   void showAndLogInformationMessage(
+    extLogger,
     `Could not find source archive for database '${databasePath}'. Assuming paths are absolute.`,
   );
   return undefined;

--- a/extensions/ql-vscode/src/databases/local-databases/database-resolver.ts
+++ b/extensions/ql-vscode/src/databases/local-databases/database-resolver.ts
@@ -11,7 +11,7 @@ import { encodeArchiveBasePath } from "../../common/vscode/archive-filesystem-pr
 import {
   showAndLogInformationMessage,
   showAndLogWarningMessage,
-} from "../../common/vscode/log";
+} from "../../common/logging";
 import { extLogger } from "../../common";
 
 export class DatabaseResolver {

--- a/extensions/ql-vscode/src/databases/ui/db-panel.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-panel.ts
@@ -37,7 +37,7 @@ import { getCodeSearchRepositories } from "../code-search-api";
 import {
   showAndLogErrorMessage,
   showAndLogInformationMessage,
-} from "../../common/vscode/log";
+} from "../../common/logging";
 import { extLogger } from "../../common";
 
 export interface RemoteDatabaseQuickPickItem extends QuickPickItem {

--- a/extensions/ql-vscode/src/databases/ui/db-panel.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-panel.ts
@@ -38,6 +38,7 @@ import {
   showAndLogErrorMessage,
   showAndLogInformationMessage,
 } from "../../common/vscode/log";
+import { extLogger } from "../../common";
 
 export interface RemoteDatabaseQuickPickItem extends QuickPickItem {
   remoteDatabaseKind: string;
@@ -174,12 +175,18 @@ export class DbPanel extends DisposableObject {
 
     const nwo = getNwoFromGitHubUrl(repoName) || repoName;
     if (!isValidGitHubNwo(nwo)) {
-      void showAndLogErrorMessage(`Invalid GitHub repository: ${repoName}`);
+      void showAndLogErrorMessage(
+        extLogger,
+        `Invalid GitHub repository: ${repoName}`,
+      );
       return;
     }
 
     if (this.dbManager.doesRemoteRepoExist(nwo, parentList)) {
-      void showAndLogErrorMessage(`The repository '${nwo}' already exists`);
+      void showAndLogErrorMessage(
+        extLogger,
+        `The repository '${nwo}' already exists`,
+      );
       return;
     }
 
@@ -199,12 +206,18 @@ export class DbPanel extends DisposableObject {
 
     const owner = getOwnerFromGitHubUrl(ownerName) || ownerName;
     if (!isValidGitHubOwner(owner)) {
-      void showAndLogErrorMessage(`Invalid user or organization: ${owner}`);
+      void showAndLogErrorMessage(
+        extLogger,
+        `Invalid user or organization: ${owner}`,
+      );
       return;
     }
 
     if (this.dbManager.doesRemoteOwnerExist(owner)) {
-      void showAndLogErrorMessage(`The owner '${owner}' already exists`);
+      void showAndLogErrorMessage(
+        extLogger,
+        `The owner '${owner}' already exists`,
+      );
       return;
     }
 
@@ -223,7 +236,10 @@ export class DbPanel extends DisposableObject {
     }
 
     if (this.dbManager.doesListExist(listKind, listName)) {
-      void showAndLogErrorMessage(`The list '${listName}' already exists`);
+      void showAndLogErrorMessage(
+        extLogger,
+        `The list '${listName}' already exists`,
+      );
       return;
     }
 
@@ -287,7 +303,10 @@ export class DbPanel extends DisposableObject {
     }
 
     if (this.dbManager.doesListExist(DbListKind.Local, newName)) {
-      void showAndLogErrorMessage(`The list '${newName}' already exists`);
+      void showAndLogErrorMessage(
+        extLogger,
+        `The list '${newName}' already exists`,
+      );
       return;
     }
 
@@ -303,7 +322,10 @@ export class DbPanel extends DisposableObject {
     }
 
     if (this.dbManager.doesLocalDbExist(newName, dbItem.parentListName)) {
-      void showAndLogErrorMessage(`The database '${newName}' already exists`);
+      void showAndLogErrorMessage(
+        extLogger,
+        `The database '${newName}' already exists`,
+      );
       return;
     }
 
@@ -319,7 +341,10 @@ export class DbPanel extends DisposableObject {
     }
 
     if (this.dbManager.doesListExist(DbListKind.Remote, newName)) {
-      void showAndLogErrorMessage(`The list '${newName}' already exists`);
+      void showAndLogErrorMessage(
+        extLogger,
+        `The list '${newName}' already exists`,
+      );
       return;
     }
 
@@ -402,7 +427,7 @@ export class DbPanel extends DisposableObject {
         );
 
         token.onCancellationRequested(() => {
-          void showAndLogInformationMessage("Code search cancelled");
+          void showAndLogInformationMessage(extLogger, "Code search cancelled");
           return;
         });
 
@@ -471,6 +496,7 @@ export class DbPanel extends DisposableObject {
       }
 
       void showAndLogErrorMessage(
+        extLogger,
         `An error occurred while setting up the controller repository: ${getErrorMessage(
           e,
         )}`,

--- a/extensions/ql-vscode/src/databases/ui/db-panel.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-panel.ts
@@ -38,7 +38,6 @@ import {
   showAndLogErrorMessage,
   showAndLogInformationMessage,
 } from "../../common/logging";
-import { extLogger } from "../../common";
 
 export interface RemoteDatabaseQuickPickItem extends QuickPickItem {
   remoteDatabaseKind: string;
@@ -176,7 +175,7 @@ export class DbPanel extends DisposableObject {
     const nwo = getNwoFromGitHubUrl(repoName) || repoName;
     if (!isValidGitHubNwo(nwo)) {
       void showAndLogErrorMessage(
-        extLogger,
+        this.app.logger,
         `Invalid GitHub repository: ${repoName}`,
       );
       return;
@@ -184,7 +183,7 @@ export class DbPanel extends DisposableObject {
 
     if (this.dbManager.doesRemoteRepoExist(nwo, parentList)) {
       void showAndLogErrorMessage(
-        extLogger,
+        this.app.logger,
         `The repository '${nwo}' already exists`,
       );
       return;
@@ -207,7 +206,7 @@ export class DbPanel extends DisposableObject {
     const owner = getOwnerFromGitHubUrl(ownerName) || ownerName;
     if (!isValidGitHubOwner(owner)) {
       void showAndLogErrorMessage(
-        extLogger,
+        this.app.logger,
         `Invalid user or organization: ${owner}`,
       );
       return;
@@ -215,7 +214,7 @@ export class DbPanel extends DisposableObject {
 
     if (this.dbManager.doesRemoteOwnerExist(owner)) {
       void showAndLogErrorMessage(
-        extLogger,
+        this.app.logger,
         `The owner '${owner}' already exists`,
       );
       return;
@@ -237,7 +236,7 @@ export class DbPanel extends DisposableObject {
 
     if (this.dbManager.doesListExist(listKind, listName)) {
       void showAndLogErrorMessage(
-        extLogger,
+        this.app.logger,
         `The list '${listName}' already exists`,
       );
       return;
@@ -304,7 +303,7 @@ export class DbPanel extends DisposableObject {
 
     if (this.dbManager.doesListExist(DbListKind.Local, newName)) {
       void showAndLogErrorMessage(
-        extLogger,
+        this.app.logger,
         `The list '${newName}' already exists`,
       );
       return;
@@ -323,7 +322,7 @@ export class DbPanel extends DisposableObject {
 
     if (this.dbManager.doesLocalDbExist(newName, dbItem.parentListName)) {
       void showAndLogErrorMessage(
-        extLogger,
+        this.app.logger,
         `The database '${newName}' already exists`,
       );
       return;
@@ -342,7 +341,7 @@ export class DbPanel extends DisposableObject {
 
     if (this.dbManager.doesListExist(DbListKind.Remote, newName)) {
       void showAndLogErrorMessage(
-        extLogger,
+        this.app.logger,
         `The list '${newName}' already exists`,
       );
       return;
@@ -424,10 +423,14 @@ export class DbPanel extends DisposableObject {
           progress,
           token,
           this.app.credentials,
+          this.app.logger,
         );
 
         token.onCancellationRequested(() => {
-          void showAndLogInformationMessage(extLogger, "Code search cancelled");
+          void showAndLogInformationMessage(
+            this.app.logger,
+            "Code search cancelled",
+          );
           return;
         });
 
@@ -496,7 +499,7 @@ export class DbPanel extends DisposableObject {
       }
 
       void showAndLogErrorMessage(
-        extLogger,
+        this.app.logger,
         `An error occurred while setting up the controller repository: ${getErrorMessage(
           e,
         )}`,

--- a/extensions/ql-vscode/src/debugger/debug-configuration.ts
+++ b/extensions/ql-vscode/src/debugger/debug-configuration.ts
@@ -9,7 +9,7 @@ import { LocalQueries } from "../local-queries";
 import { getQuickEvalContext, validateQueryPath } from "../run-queries-shared";
 import * as CodeQLProtocol from "./debug-protocol";
 import { getErrorMessage } from "../pure/helpers-pure";
-import { showAndLogErrorMessage } from "../common/vscode/log";
+import { showAndLogErrorMessage } from "../common/logging";
 import { extLogger } from "../common";
 
 /**

--- a/extensions/ql-vscode/src/debugger/debug-configuration.ts
+++ b/extensions/ql-vscode/src/debugger/debug-configuration.ts
@@ -10,6 +10,7 @@ import { getQuickEvalContext, validateQueryPath } from "../run-queries-shared";
 import * as CodeQLProtocol from "./debug-protocol";
 import { getErrorMessage } from "../pure/helpers-pure";
 import { showAndLogErrorMessage } from "../common/vscode/log";
+import { extLogger } from "../common";
 
 /**
  * The CodeQL launch arguments, as specified in "launch.json".
@@ -126,7 +127,7 @@ export class QLDebugConfigurationProvider
       // Any unhandled exception will result in an OS-native error message box, which seems ugly.
       // We'll just show a real VS Code error message, then return null to prevent the debug session
       // from starting.
-      void showAndLogErrorMessage(getErrorMessage(e));
+      void showAndLogErrorMessage(extLogger, getErrorMessage(e));
       return null;
     }
   }

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -80,6 +80,7 @@ import {
   ProgressReporter,
   queryServerLogger,
 } from "./common";
+import { showAndLogExceptionWithTelemetry } from "./common/vscode/logging";
 import { QueryHistoryManager } from "./query-history/query-history-manager";
 import { CompletedLocalQueryInfo } from "./query-results";
 import {
@@ -127,10 +128,9 @@ import { NewQueryRunner, QueryRunner, QueryServerClient } from "./query-server";
 import { QueriesModule } from "./queries-panel/queries-module";
 import {
   showAndLogErrorMessage,
-  showAndLogExceptionWithTelemetry,
   showAndLogInformationMessage,
   showAndLogWarningMessage,
-} from "./common/vscode/log";
+} from "./common/logging";
 
 /**
  * extension.ts

--- a/extensions/ql-vscode/src/language-support/ast-viewer/ast-viewer.ts
+++ b/extensions/ql-vscode/src/language-support/ast-viewer/ast-viewer.ts
@@ -27,8 +27,8 @@ import { DisposableObject } from "../../pure/disposable-object";
 import { asError, getErrorMessage } from "../../pure/helpers-pure";
 import { redactableError } from "../../pure/errors";
 import { AstViewerCommands } from "../../common/commands";
-import { showAndLogExceptionWithTelemetry } from "../../common/vscode/log";
 import { extLogger } from "../../common";
+import { showAndLogExceptionWithTelemetry } from "../../common/vscode/logging";
 
 export interface AstItem {
   id: BqrsId;

--- a/extensions/ql-vscode/src/language-support/ast-viewer/ast-viewer.ts
+++ b/extensions/ql-vscode/src/language-support/ast-viewer/ast-viewer.ts
@@ -28,6 +28,7 @@ import { asError, getErrorMessage } from "../../pure/helpers-pure";
 import { redactableError } from "../../pure/errors";
 import { AstViewerCommands } from "../../common/commands";
 import { showAndLogExceptionWithTelemetry } from "../../common/vscode/log";
+import { extLogger } from "../../common";
 
 export interface AstItem {
   id: BqrsId;
@@ -145,6 +146,7 @@ export class AstViewer extends DisposableObject {
       },
       (error: unknown) =>
         showAndLogExceptionWithTelemetry(
+          extLogger,
           redactableError(
             asError(error),
           )`Failed to reveal AST: ${getErrorMessage(error)}`,
@@ -208,6 +210,7 @@ export class AstViewer extends DisposableObject {
           },
           (error: unknown) =>
             showAndLogExceptionWithTelemetry(
+              extLogger,
               redactableError(
                 asError(error),
               )`Failed to reveal AST: ${getErrorMessage(error)}`,

--- a/extensions/ql-vscode/src/language-support/contextual/query-resolver.ts
+++ b/extensions/ql-vscode/src/language-support/contextual/query-resolver.ts
@@ -102,7 +102,7 @@ current library path (tried searching the following packs: ${joinedPacksToSearch
 Try upgrading the CodeQL libraries. If that doesn't work, then ${keyTypeName} queries are not yet available \
 for this language.`;
 
-  void showAndLogExceptionWithTelemetry(error);
+  void showAndLogExceptionWithTelemetry(extLogger, error);
   throw error;
 }
 

--- a/extensions/ql-vscode/src/language-support/contextual/query-resolver.ts
+++ b/extensions/ql-vscode/src/language-support/contextual/query-resolver.ts
@@ -18,12 +18,12 @@ import {
 import { CodeQLCliServer } from "../../codeql-cli/cli";
 import { DatabaseItem } from "../../databases/local-databases";
 import { extLogger, TeeLogger } from "../../common";
+import { showAndLogExceptionWithTelemetry } from "../../common/vscode/logging";
 import { CancellationToken } from "vscode";
 import { ProgressCallback } from "../../common/vscode/progress";
 import { CoreCompletedQuery, QueryRunner } from "../../query-server";
 import { redactableError } from "../../pure/errors";
 import { QLPACK_FILENAMES } from "../../pure/ql";
-import { showAndLogExceptionWithTelemetry } from "../../common/vscode/log";
 
 export async function qlpackOfDatabase(
   cli: Pick<CodeQLCliServer, "resolveQlpacks">,

--- a/extensions/ql-vscode/src/language-support/query-editor.ts
+++ b/extensions/ql-vscode/src/language-support/query-editor.ts
@@ -6,6 +6,7 @@ import { getErrorMessage } from "../pure/helpers-pure";
 import { redactableError } from "../pure/errors";
 import { AppCommandManager, QueryEditorCommands } from "../common/commands";
 import { showAndLogExceptionWithTelemetry } from "../common/vscode/log";
+import { extLogger } from "../common";
 
 type QueryEditorOptions = {
   commandManager: AppCommandManager;
@@ -79,7 +80,7 @@ async function previewQueryHelp(
       )
         ? redactableError`Could not generate markdown from ${pathToQhelp}: Bad formatting in .qhelp file.`
         : redactableError`Could not open a preview of the generated file (${absolutePathToMd}).`;
-      void showAndLogExceptionWithTelemetry(errorMessage, {
+      void showAndLogExceptionWithTelemetry(extLogger, errorMessage, {
         fullMessage: `${errorMessage}\n${getErrorMessage(e)}`,
       });
     }

--- a/extensions/ql-vscode/src/language-support/query-editor.ts
+++ b/extensions/ql-vscode/src/language-support/query-editor.ts
@@ -5,8 +5,8 @@ import { basename, join } from "path";
 import { getErrorMessage } from "../pure/helpers-pure";
 import { redactableError } from "../pure/errors";
 import { AppCommandManager, QueryEditorCommands } from "../common/commands";
-import { showAndLogExceptionWithTelemetry } from "../common/vscode/log";
 import { extLogger } from "../common";
+import { showAndLogExceptionWithTelemetry } from "../common/vscode/logging";
 
 type QueryEditorOptions = {
   commandManager: AppCommandManager;

--- a/extensions/ql-vscode/src/local-queries/local-queries.ts
+++ b/extensions/ql-vscode/src/local-queries/local-queries.ts
@@ -323,6 +323,7 @@ export class LocalQueries extends DisposableObject {
 
     if (this.queryRunner.customLogDirectory) {
       void showAndLogWarningMessage(
+        extLogger,
         `Custom log directories are no longer supported. The "codeQL.runningQueries.customLogDirectory" setting is deprecated. Unset the setting to stop seeing this message. Query logs saved to ${outputDir.logPath}`,
       );
     }
@@ -469,6 +470,7 @@ export class LocalQueries extends DisposableObject {
     let filteredDBs = this.databaseManager.databaseItems;
     if (filteredDBs.length === 0) {
       void showAndLogErrorMessage(
+        extLogger,
         "No databases found. Please add a suitable database to your workspace.",
       );
       return;
@@ -481,6 +483,7 @@ export class LocalQueries extends DisposableObject {
       );
       if (filteredDBs.length === 0) {
         void showAndLogErrorMessage(
+          extLogger,
           `No databases found for language ${queryLanguage}. Please add a suitable database to your workspace.`,
         );
         return;
@@ -519,13 +522,14 @@ export class LocalQueries extends DisposableObject {
       if (skippedDatabases.length > 0) {
         void extLogger.log(`Errors:\n${errors.join("\n")}`);
         void showAndLogWarningMessage(
+          extLogger,
           `The following databases were skipped:\n${skippedDatabases.join(
             "\n",
           )}.\nFor details about the errors, see the logs.`,
         );
       }
     } else {
-      void showAndLogErrorMessage("No databases selected.");
+      void showAndLogErrorMessage(extLogger, "No databases selected.");
     }
   }
 

--- a/extensions/ql-vscode/src/local-queries/local-queries.ts
+++ b/extensions/ql-vscode/src/local-queries/local-queries.ts
@@ -12,7 +12,7 @@ import {
   window,
   workspace,
 } from "vscode";
-import { extLogger, TeeLogger } from "../common";
+import { TeeLogger } from "../common";
 import { isCanary, MAX_QUERIES } from "../config";
 import { gatherQlFiles } from "../pure/files";
 import { basename } from "path";
@@ -292,7 +292,7 @@ export class LocalQueries extends DisposableObject {
           this.cliServer,
           progress,
           credentials,
-          extLogger,
+          this.app.logger,
           this.databaseManager,
           token,
           contextStoragePath,
@@ -323,7 +323,7 @@ export class LocalQueries extends DisposableObject {
 
     if (this.queryRunner.customLogDirectory) {
       void showAndLogWarningMessage(
-        extLogger,
+        this.app.logger,
         `Custom log directories are no longer supported. The "codeQL.runningQueries.customLogDirectory" setting is deprecated. Unset the setting to stop seeing this message. Query logs saved to ${outputDir.logPath}`,
       );
     }
@@ -470,7 +470,7 @@ export class LocalQueries extends DisposableObject {
     let filteredDBs = this.databaseManager.databaseItems;
     if (filteredDBs.length === 0) {
       void showAndLogErrorMessage(
-        extLogger,
+        this.app.logger,
         "No databases found. Please add a suitable database to your workspace.",
       );
       return;
@@ -483,7 +483,7 @@ export class LocalQueries extends DisposableObject {
       );
       if (filteredDBs.length === 0) {
         void showAndLogErrorMessage(
-          extLogger,
+          this.app.logger,
           `No databases found for language ${queryLanguage}. Please add a suitable database to your workspace.`,
         );
         return;
@@ -520,16 +520,16 @@ export class LocalQueries extends DisposableObject {
         }
       }
       if (skippedDatabases.length > 0) {
-        void extLogger.log(`Errors:\n${errors.join("\n")}`);
+        void this.app.logger.log(`Errors:\n${errors.join("\n")}`);
         void showAndLogWarningMessage(
-          extLogger,
+          this.app.logger,
           `The following databases were skipped:\n${skippedDatabases.join(
             "\n",
           )}.\nFor details about the errors, see the logs.`,
         );
       }
     } else {
-      void showAndLogErrorMessage(extLogger, "No databases selected.");
+      void showAndLogErrorMessage(this.app.logger, "No databases selected.");
     }
   }
 

--- a/extensions/ql-vscode/src/local-queries/local-queries.ts
+++ b/extensions/ql-vscode/src/local-queries/local-queries.ts
@@ -46,7 +46,7 @@ import { createMultiSelectionCommand } from "../common/vscode/selection-commands
 import {
   showAndLogErrorMessage,
   showAndLogWarningMessage,
-} from "../common/vscode/log";
+} from "../common/logging";
 import { findLanguage } from "../codeql-cli/query-language";
 
 interface DatabaseQuickPickItem extends QuickPickItem {

--- a/extensions/ql-vscode/src/local-queries/local-query-run.ts
+++ b/extensions/ql-vscode/src/local-queries/local-query-run.ts
@@ -1,4 +1,4 @@
-import { BaseLogger, Logger } from "../common";
+import { BaseLogger, extLogger, Logger } from "../common";
 import { CoreQueryResults } from "../query-server";
 import { QueryHistoryManager } from "../query-history/query-history-manager";
 import { DatabaseItem } from "../databases/local-databases";
@@ -119,6 +119,7 @@ export class LocalQueryRun {
       // Raw evaluator log was not found. Notify the user, unless we know why it wasn't found.
       if (resultType === QueryResultType.SUCCESS) {
         void showAndLogWarningMessage(
+          extLogger,
           `Failed to write structured evaluator log to ${outputDir.evalLogPath}.`,
         );
       } else {
@@ -155,7 +156,7 @@ export class LocalQueryRun {
       const message = results.message
         ? redactableError`Failed to run query: ${results.message}`
         : redactableError`Failed to run query`;
-      void showAndLogExceptionWithTelemetry(message);
+      void showAndLogExceptionWithTelemetry(extLogger, message);
     }
     const message = formatResultMessage(results);
     const successful = results.resultType === QueryResultType.SUCCESS;

--- a/extensions/ql-vscode/src/local-queries/local-query-run.ts
+++ b/extensions/ql-vscode/src/local-queries/local-query-run.ts
@@ -1,4 +1,5 @@
 import { BaseLogger, extLogger, Logger } from "../common";
+import { showAndLogExceptionWithTelemetry } from "../common/vscode/logging";
 import { CoreQueryResults } from "../query-server";
 import { QueryHistoryManager } from "../query-history/query-history-manager";
 import { DatabaseItem } from "../databases/local-databases";
@@ -16,10 +17,7 @@ import { CodeQLCliServer } from "../codeql-cli/cli";
 import { QueryResultType } from "../pure/new-messages";
 import { redactableError } from "../pure/errors";
 import { LocalQueries } from "./local-queries";
-import {
-  showAndLogExceptionWithTelemetry,
-  showAndLogWarningMessage,
-} from "../common/vscode/log";
+import { showAndLogWarningMessage } from "../common/logging";
 import { tryGetQueryMetadata } from "../codeql-cli/query-metadata";
 
 function formatResultMessage(result: CoreQueryResults): string {

--- a/extensions/ql-vscode/src/local-queries/results-view.ts
+++ b/extensions/ql-vscode/src/local-queries/results-view.ts
@@ -41,6 +41,7 @@ import {
   ParsedResultSets,
 } from "../pure/interface-types";
 import { extLogger, Logger } from "../common";
+import { showAndLogExceptionWithTelemetry } from "../common/vscode/logging";
 import {
   CompletedQueryInfo,
   interpretResultsSarif,
@@ -73,7 +74,6 @@ import { HistoryItemLabelProvider } from "../query-history/history-item-label-pr
 import { telemetryListener } from "../telemetry";
 import { redactableError } from "../pure/errors";
 import { ResultsViewCommands } from "../common/commands";
-import { showAndLogExceptionWithTelemetry } from "../common/vscode/log";
 
 /**
  * results-view.ts

--- a/extensions/ql-vscode/src/local-queries/results-view.ts
+++ b/extensions/ql-vscode/src/local-queries/results-view.ts
@@ -40,7 +40,7 @@ import {
   getDefaultResultSetName,
   ParsedResultSets,
 } from "../pure/interface-types";
-import { Logger } from "../common";
+import { extLogger, Logger } from "../common";
 import {
   CompletedQueryInfo,
   interpretResultsSarif,
@@ -319,6 +319,7 @@ export class ResultsView extends AbstractWebview<
           break;
         case "unhandledError":
           void showAndLogExceptionWithTelemetry(
+            extLogger,
             redactableError(
               msg.error,
             )`Unhandled error in results view: ${msg.error.message}`,
@@ -329,6 +330,7 @@ export class ResultsView extends AbstractWebview<
       }
     } catch (e) {
       void showAndLogExceptionWithTelemetry(
+        extLogger,
         redactableError(
           asError(e),
         )`Error handling message from results view: ${getErrorMessage(e)}`,
@@ -378,6 +380,7 @@ export class ResultsView extends AbstractWebview<
   ): Promise<void> {
     if (this._displayedQuery === undefined) {
       void showAndLogExceptionWithTelemetry(
+        extLogger,
         redactableError`Failed to sort results since evaluation info was unknown.`,
       );
       return;
@@ -396,6 +399,7 @@ export class ResultsView extends AbstractWebview<
   ): Promise<void> {
     if (this._displayedQuery === undefined) {
       void showAndLogExceptionWithTelemetry(
+        extLogger,
         redactableError`Failed to sort results since evaluation info was unknown.`,
       );
       return;
@@ -806,6 +810,7 @@ export class ResultsView extends AbstractWebview<
         // If interpretation fails, accept the error and continue
         // trying to render uninterpreted results anyway.
         void showAndLogExceptionWithTelemetry(
+          extLogger,
           redactableError(
             asError(e),
           )`Showing raw results instead of interpreted ones due to an error. ${getErrorMessage(

--- a/extensions/ql-vscode/src/packaging/packaging.ts
+++ b/extensions/ql-vscode/src/packaging/packaging.ts
@@ -87,9 +87,13 @@ export async function handleDownloadPacks(
     });
     try {
       await cliServer.packDownload(packsToDownload);
-      void showAndLogInformationMessage("Finished downloading packs.");
+      void showAndLogInformationMessage(
+        extLogger,
+        "Finished downloading packs.",
+      );
     } catch (error) {
       void showAndLogExceptionWithTelemetry(
+        extLogger,
         redactableError(
           asError(error),
         )`Unable to download all packs. See log for more details.`,
@@ -165,6 +169,7 @@ export async function handleInstallPackDependencies(
       );
     } else {
       void showAndLogInformationMessage(
+        extLogger,
         "Finished installing pack dependencies.",
       );
     }

--- a/extensions/ql-vscode/src/packaging/packaging.ts
+++ b/extensions/ql-vscode/src/packaging/packaging.ts
@@ -7,14 +7,12 @@ import {
   withProgress,
 } from "../common/vscode/progress";
 import { extLogger } from "../common";
+import { showAndLogExceptionWithTelemetry } from "../common/vscode/logging";
 import { asError, getErrorStack } from "../pure/helpers-pure";
 import { redactableError } from "../pure/errors";
 import { PACKS_BY_QUERY_LANGUAGE } from "../common/query-language";
 import { PackagingCommands } from "../common/commands";
-import {
-  showAndLogExceptionWithTelemetry,
-  showAndLogInformationMessage,
-} from "../common/vscode/log";
+import { showAndLogInformationMessage } from "../common/logging";
 
 type PackagingOptions = {
   cliServer: CodeQLCliServer;

--- a/extensions/ql-vscode/src/query-evaluation-logging/eval-log-viewer.ts
+++ b/extensions/ql-vscode/src/query-evaluation-logging/eval-log-viewer.ts
@@ -13,6 +13,7 @@ import { asError, getErrorMessage } from "../pure/helpers-pure";
 import { redactableError } from "../pure/errors";
 import { EvalLogViewerCommands } from "../common/commands";
 import { showAndLogExceptionWithTelemetry } from "../common/vscode/log";
+import { extLogger } from "../common";
 
 export interface EvalLogTreeItem {
   label?: string;
@@ -109,6 +110,7 @@ export class EvalLogViewer extends DisposableObject {
       },
       (err: unknown) =>
         showAndLogExceptionWithTelemetry(
+          extLogger,
           redactableError(
             asError(err),
           )`Failed to reveal tree view: ${getErrorMessage(err)}`,

--- a/extensions/ql-vscode/src/query-evaluation-logging/eval-log-viewer.ts
+++ b/extensions/ql-vscode/src/query-evaluation-logging/eval-log-viewer.ts
@@ -12,8 +12,8 @@ import { DisposableObject } from "../pure/disposable-object";
 import { asError, getErrorMessage } from "../pure/helpers-pure";
 import { redactableError } from "../pure/errors";
 import { EvalLogViewerCommands } from "../common/commands";
-import { showAndLogExceptionWithTelemetry } from "../common/vscode/log";
 import { extLogger } from "../common";
+import { showAndLogExceptionWithTelemetry } from "../common/vscode/logging";
 
 export interface EvalLogTreeItem {
   label?: string;

--- a/extensions/ql-vscode/src/query-history/query-history-manager.ts
+++ b/extensions/ql-vscode/src/query-history/query-history-manager.ts
@@ -17,7 +17,6 @@ import {
   showBinaryChoiceDialog,
   showInformationMessageWithAction,
 } from "../common/vscode/dialog";
-import { extLogger } from "../common";
 import { URLSearchParams } from "url";
 import { DisposableObject } from "../pure/disposable-object";
 import { ONE_HOUR_IN_MS, TWO_HOURS_IN_MS } from "../pure/time";
@@ -238,6 +237,7 @@ export class QueryHistoryManager extends DisposableObject {
       "codeQLQueryHistory.sortByCount": this.handleSortByCount.bind(this),
 
       "codeQLQueryHistory.openQueryContextMenu": createSingleSelectionCommand(
+        this.app.logger,
         this.handleOpenQuery.bind(this),
         "query",
       ),
@@ -246,31 +246,38 @@ export class QueryHistoryManager extends DisposableObject {
       "codeQLQueryHistory.removeHistoryItemContextInline":
         createMultiSelectionCommand(this.handleRemoveHistoryItem.bind(this)),
       "codeQLQueryHistory.renameItem": createSingleSelectionCommand(
+        this.app.logger,
         this.handleRenameItem.bind(this),
         "query",
       ),
       "codeQLQueryHistory.compareWith": this.handleCompareWith.bind(this),
       "codeQLQueryHistory.showEvalLog": createSingleSelectionCommand(
+        this.app.logger,
         this.handleShowEvalLog.bind(this),
         "query",
       ),
       "codeQLQueryHistory.showEvalLogSummary": createSingleSelectionCommand(
+        this.app.logger,
         this.handleShowEvalLogSummary.bind(this),
         "query",
       ),
       "codeQLQueryHistory.showEvalLogViewer": createSingleSelectionCommand(
+        this.app.logger,
         this.handleShowEvalLogViewer.bind(this),
         "query",
       ),
       "codeQLQueryHistory.showQueryLog": createSingleSelectionCommand(
+        this.app.logger,
         this.handleShowQueryLog.bind(this),
         "query",
       ),
       "codeQLQueryHistory.showQueryText": createSingleSelectionCommand(
+        this.app.logger,
         this.handleShowQueryText.bind(this),
         "query",
       ),
       "codeQLQueryHistory.openQueryDirectory": createSingleSelectionCommand(
+        this.app.logger,
         this.handleOpenQueryDirectory.bind(this),
         "query",
       ),
@@ -278,34 +285,42 @@ export class QueryHistoryManager extends DisposableObject {
         this.handleCancel.bind(this),
       ),
       "codeQLQueryHistory.exportResults": createSingleSelectionCommand(
+        this.app.logger,
         this.handleExportResults.bind(this),
         "query",
       ),
       "codeQLQueryHistory.viewCsvResults": createSingleSelectionCommand(
+        this.app.logger,
         this.handleViewCsvResults.bind(this),
         "query",
       ),
       "codeQLQueryHistory.viewCsvAlerts": createSingleSelectionCommand(
+        this.app.logger,
         this.handleViewCsvAlerts.bind(this),
         "query",
       ),
       "codeQLQueryHistory.viewSarifAlerts": createSingleSelectionCommand(
+        this.app.logger,
         this.handleViewSarifAlerts.bind(this),
         "query",
       ),
       "codeQLQueryHistory.viewDil": createSingleSelectionCommand(
+        this.app.logger,
         this.handleViewDil.bind(this),
         "query",
       ),
       "codeQLQueryHistory.itemClicked": createSingleSelectionCommand(
+        this.app.logger,
         this.handleItemClicked.bind(this),
         "query",
       ),
       "codeQLQueryHistory.openOnGithub": createSingleSelectionCommand(
+        this.app.logger,
         this.handleOpenOnGithub.bind(this),
         "query",
       ),
       "codeQLQueryHistory.copyRepoList": createSingleSelectionCommand(
+        this.app.logger,
         this.handleCopyRepoList.bind(this),
         "query",
       ),
@@ -386,7 +401,7 @@ export class QueryHistoryManager extends DisposableObject {
             });
             await this.refreshTreeView();
           } else {
-            void extLogger.log(
+            void this.app.logger.log(
               "Variant analysis status update event received for unknown variant analysis",
             );
           }
@@ -417,7 +432,7 @@ export class QueryHistoryManager extends DisposableObject {
   }
 
   async readQueryHistory(): Promise<void> {
-    void extLogger.log(
+    void this.app.logger.log(
       `Reading cached query history from '${this.queryMetadataStorageLocation}'.`,
     );
     const history = await readQueryHistoryFromFile(
@@ -535,7 +550,7 @@ export class QueryHistoryManager extends DisposableObject {
     }
 
     this.treeDataProvider.remove(item);
-    void extLogger.log(`Deleted ${this.labelProvider.getLabel(item)}.`);
+    void this.app.logger.log(`Deleted ${this.labelProvider.getLabel(item)}.`);
 
     if (item.status === QueryStatus.InProgress) {
       await this.showToastWithWorkflowRunLink(item);
@@ -628,7 +643,7 @@ export class QueryHistoryManager extends DisposableObject {
       toItem = await this.findOtherQueryToCompare(fromItem, multiSelect);
     } catch (e) {
       void showAndLogErrorMessage(
-        extLogger,
+        this.app.logger,
         `Failed to compare queries: ${getErrorMessage(e)}`,
       );
     }
@@ -673,7 +688,7 @@ export class QueryHistoryManager extends DisposableObject {
         item.completedQuery.logFileLocation,
       );
     } else {
-      void showAndLogWarningMessage(extLogger, "No log file available");
+      void showAndLogWarningMessage(this.app.logger, "No log file available");
     }
   }
 
@@ -741,21 +756,21 @@ export class QueryHistoryManager extends DisposableObject {
 
   private warnNoEvalLogs() {
     void showAndLogWarningMessage(
-      extLogger,
+      this.app.logger,
       `Evaluator log, summary, and viewer are not available for this run. Perhaps it failed before evaluation, or you are running with a version of CodeQL before ' + ${CliVersionConstraint.CLI_VERSION_WITH_PER_QUERY_EVAL_LOG}?`,
     );
   }
 
   private warnInProgressEvalLogSummary() {
     void showAndLogWarningMessage(
-      extLogger,
+      this.app.logger,
       'The evaluator log summary is still being generated for this run. Please try again later. The summary generation process is tracked in the "CodeQL Extension Log" view.',
     );
   }
 
   private warnInProgressEvalLogViewer() {
     void showAndLogWarningMessage(
-      extLogger,
+      this.app.logger,
       "The viewer's data is still being generated for this run. Please try again or re-run the query.",
     );
   }
@@ -872,7 +887,7 @@ export class QueryHistoryManager extends DisposableObject {
     } else {
       const label = this.labelProvider.getLabel(item);
       void showAndLogInformationMessage(
-        extLogger,
+        this.app.logger,
         `Query ${label} has no interpreted results.`,
       );
     }

--- a/extensions/ql-vscode/src/query-history/query-history-manager.ts
+++ b/extensions/ql-vscode/src/query-history/query-history-manager.ts
@@ -60,7 +60,7 @@ import {
   showAndLogErrorMessage,
   showAndLogInformationMessage,
   showAndLogWarningMessage,
-} from "../common/vscode/log";
+} from "../common/logging";
 
 /**
  * query-history-manager.ts

--- a/extensions/ql-vscode/src/query-history/query-history-manager.ts
+++ b/extensions/ql-vscode/src/query-history/query-history-manager.ts
@@ -628,6 +628,7 @@ export class QueryHistoryManager extends DisposableObject {
       toItem = await this.findOtherQueryToCompare(fromItem, multiSelect);
     } catch (e) {
       void showAndLogErrorMessage(
+        extLogger,
         `Failed to compare queries: ${getErrorMessage(e)}`,
       );
     }
@@ -672,7 +673,7 @@ export class QueryHistoryManager extends DisposableObject {
         item.completedQuery.logFileLocation,
       );
     } else {
-      void showAndLogWarningMessage("No log file available");
+      void showAndLogWarningMessage(extLogger, "No log file available");
     }
   }
 
@@ -740,18 +741,21 @@ export class QueryHistoryManager extends DisposableObject {
 
   private warnNoEvalLogs() {
     void showAndLogWarningMessage(
+      extLogger,
       `Evaluator log, summary, and viewer are not available for this run. Perhaps it failed before evaluation, or you are running with a version of CodeQL before ' + ${CliVersionConstraint.CLI_VERSION_WITH_PER_QUERY_EVAL_LOG}?`,
     );
   }
 
   private warnInProgressEvalLogSummary() {
     void showAndLogWarningMessage(
+      extLogger,
       'The evaluator log summary is still being generated for this run. Please try again later. The summary generation process is tracked in the "CodeQL Extension Log" view.',
     );
   }
 
   private warnInProgressEvalLogViewer() {
     void showAndLogWarningMessage(
+      extLogger,
       "The viewer's data is still being generated for this run. Please try again or re-run the query.",
     );
   }
@@ -868,6 +872,7 @@ export class QueryHistoryManager extends DisposableObject {
     } else {
       const label = this.labelProvider.getLabel(item);
       void showAndLogInformationMessage(
+        extLogger,
         `Query ${label} has no interpreted results.`,
       );
     }

--- a/extensions/ql-vscode/src/query-history/store/query-history-store.ts
+++ b/extensions/ql-vscode/src/query-history/store/query-history-store.ts
@@ -13,6 +13,7 @@ import { QueryHistoryDto, QueryHistoryItemDto } from "./query-history-dto";
 import { mapQueryHistoryToDomainModel } from "./query-history-dto-mapper";
 import { mapQueryHistoryToDto } from "./query-history-domain-mapper";
 import { showAndLogExceptionWithTelemetry } from "../../common/vscode/log";
+import { extLogger } from "../../common";
 
 const ALLOWED_QUERY_HISTORY_VERSIONS = [1, 2];
 
@@ -30,6 +31,7 @@ export async function readQueryHistoryFromFile(
 
     if (!ALLOWED_QUERY_HISTORY_VERSIONS.includes(obj.version)) {
       void showAndLogExceptionWithTelemetry(
+        extLogger,
         redactableError`Can't parse query history. Unsupported query history format: v${obj.version}.`,
       );
       return [];
@@ -65,6 +67,7 @@ export async function readQueryHistoryFromFile(
     return filteredDomainModels;
   } catch (e) {
     void showAndLogExceptionWithTelemetry(
+      extLogger,
       redactableError(asError(e))`Error loading query history.`,
       {
         fullMessage: `Error loading query history.\n${getErrorStack(e)}`,

--- a/extensions/ql-vscode/src/query-history/store/query-history-store.ts
+++ b/extensions/ql-vscode/src/query-history/store/query-history-store.ts
@@ -12,8 +12,8 @@ import { redactableError } from "../../pure/errors";
 import { QueryHistoryDto, QueryHistoryItemDto } from "./query-history-dto";
 import { mapQueryHistoryToDomainModel } from "./query-history-dto-mapper";
 import { mapQueryHistoryToDto } from "./query-history-domain-mapper";
-import { showAndLogExceptionWithTelemetry } from "../../common/vscode/log";
 import { extLogger } from "../../common";
+import { showAndLogExceptionWithTelemetry } from "../../common/vscode/logging";
 
 const ALLOWED_QUERY_HISTORY_VERSIONS = [1, 2];
 

--- a/extensions/ql-vscode/src/query-server/legacy/run-queries.ts
+++ b/extensions/ql-vscode/src/query-server/legacy/run-queries.ts
@@ -13,6 +13,7 @@ import { tmpDir } from "../../tmp-dir";
 import { ProgressCallback } from "../../common/vscode/progress";
 import { QueryMetadata } from "../../pure/interface-types";
 import { extLogger, Logger } from "../../common";
+import { showAndLogExceptionWithTelemetry } from "../../common/vscode/logging";
 import * as messages from "../../pure/legacy-messages";
 import * as newMessages from "../../pure/new-messages";
 import * as qsClient from "./query-server-client";
@@ -22,10 +23,7 @@ import { QueryEvaluationInfo, QueryOutputDir } from "../../run-queries-shared";
 import { redactableError } from "../../pure/errors";
 import { CoreQueryResults, CoreQueryTarget } from "../query-runner";
 import { Position } from "../../pure/messages-shared";
-import {
-  showAndLogExceptionWithTelemetry,
-  showAndLogWarningMessage,
-} from "../../common/vscode/log";
+import { showAndLogWarningMessage } from "../../common/logging";
 import { ensureDirSync } from "fs-extra";
 
 const upgradesTmpDir = join(tmpDir.name, "upgrades");

--- a/extensions/ql-vscode/src/query-server/legacy/run-queries.ts
+++ b/extensions/ql-vscode/src/query-server/legacy/run-queries.ts
@@ -321,6 +321,7 @@ export async function compileAndRunQueryAgainstDatabaseCore(
 ): Promise<CoreQueryResults> {
   if (extensionPacks !== undefined && extensionPacks.length > 0) {
     void showAndLogWarningMessage(
+      extLogger,
       "Legacy query server does not support extension packs.",
     );
   }
@@ -386,6 +387,7 @@ export async function compileAndRunQueryAgainstDatabaseCore(
     }
   } catch (e) {
     void showAndLogExceptionWithTelemetry(
+      extLogger,
       redactableError(
         asError(e),
       )`Couldn't resolve available ML models for ${qlProgram.queryPath}. Running the query without any ML models: ${e}.`,
@@ -444,7 +446,7 @@ export async function compileAndRunQueryAgainstDatabaseCore(
           ? redactableError`${result.message}`
           : redactableError`Failed to run query`;
         void extLogger.log(error.fullMessage);
-        void showAndLogExceptionWithTelemetry(error);
+        void showAndLogExceptionWithTelemetry(extLogger, error);
       }
 
       return translateLegacyResult(result);

--- a/extensions/ql-vscode/src/query-server/legacy/upgrades.ts
+++ b/extensions/ql-vscode/src/query-server/legacy/upgrades.ts
@@ -6,6 +6,7 @@ import {
   UserCancellationException,
 } from "../../common/vscode/progress";
 import { extLogger } from "../../common";
+import { showAndLogExceptionWithTelemetry } from "../../common/vscode/logging";
 import * as messages from "../../pure/legacy-messages";
 import * as qsClient from "./query-server-client";
 import * as tmp from "tmp-promise";
@@ -13,7 +14,6 @@ import { dirname } from "path";
 import { DatabaseItem } from "../../databases/local-databases";
 import { asError, getErrorMessage } from "../../pure/helpers-pure";
 import { redactableError } from "../../pure/errors";
-import { showAndLogExceptionWithTelemetry } from "../../common/vscode/log";
 
 /**
  * Maximum number of lines to include from database upgrade message,

--- a/extensions/ql-vscode/src/query-server/legacy/upgrades.ts
+++ b/extensions/ql-vscode/src/query-server/legacy/upgrades.ts
@@ -206,6 +206,7 @@ export async function upgradeDatabaseExplicit(
       );
     } catch (e) {
       void showAndLogExceptionWithTelemetry(
+        extLogger,
         redactableError(
           asError(e),
         )`Compilation of database upgrades failed: ${getErrorMessage(e)}`,
@@ -220,6 +221,7 @@ export async function upgradeDatabaseExplicit(
         ? redactableError`${compileUpgradeResult.error}`
         : redactableError`[no error message available]`;
       void showAndLogExceptionWithTelemetry(
+        extLogger,
         redactableError`Compilation of database upgrades failed: ${error}`,
       );
       return;
@@ -253,6 +255,7 @@ export async function upgradeDatabaseExplicit(
       return result;
     } catch (e) {
       void showAndLogExceptionWithTelemetry(
+        extLogger,
         redactableError(asError(e))`Database upgrade failed: ${getErrorMessage(
           e,
         )}`,

--- a/extensions/ql-vscode/src/query-server/query-server-client.ts
+++ b/extensions/ql-vscode/src/query-server/query-server-client.ts
@@ -19,7 +19,7 @@ import {
 import { ServerProcess } from "./server-process";
 import { App } from "../common/app";
 
-import { showAndLogErrorMessage } from "../common/vscode/log";
+import { showAndLogErrorMessage } from "../common/logging";
 
 type ServerOpts = {
   logger: Logger;

--- a/extensions/ql-vscode/src/query-server/query-server-client.ts
+++ b/extensions/ql-vscode/src/query-server/query-server-client.ts
@@ -5,7 +5,7 @@ import { CancellationToken } from "vscode";
 import { createMessageConnection, RequestType } from "vscode-jsonrpc/node";
 import * as cli from "../codeql-cli/cli";
 import { QueryServerConfig } from "../config";
-import { Logger, ProgressReporter } from "../common";
+import { extLogger, Logger, ProgressReporter } from "../common";
 import {
   progress,
   ProgressMessage,
@@ -131,6 +131,7 @@ export class QueryServerClient extends DisposableObject {
       );
     } else {
       void showAndLogErrorMessage(
+        extLogger,
         "The CodeQL query server has unexpectedly terminated too many times. Please check the logs for errors. You can manually restart the query server using the command 'CodeQL: Restart query server'.",
       );
       // Make sure we dispose anyway to reject all pending requests.

--- a/extensions/ql-vscode/src/query-testing/test-runner.ts
+++ b/extensions/ql-vscode/src/query-testing/test-runner.ts
@@ -6,11 +6,9 @@ import { asError, getErrorMessage } from "../pure/helpers-pure";
 import { redactableError } from "../pure/errors";
 import { access } from "fs-extra";
 import { BaseLogger, extLogger } from "../common";
+import { showAndLogExceptionWithTelemetry } from "../common/vscode/logging";
 import { DisposableObject } from "../pure/disposable-object";
-import {
-  showAndLogExceptionWithTelemetry,
-  showAndLogWarningMessage,
-} from "../common/vscode/log";
+import { showAndLogWarningMessage } from "../common/logging";
 
 async function isFileAccessible(uri: Uri): Promise<boolean> {
   try {

--- a/extensions/ql-vscode/src/query-testing/test-runner.ts
+++ b/extensions/ql-vscode/src/query-testing/test-runner.ts
@@ -5,7 +5,7 @@ import { getOnDiskWorkspaceFolders } from "../common/vscode/workspace-folders";
 import { asError, getErrorMessage } from "../pure/helpers-pure";
 import { redactableError } from "../pure/errors";
 import { access } from "fs-extra";
-import { BaseLogger } from "../common";
+import { BaseLogger, extLogger } from "../common";
 import { DisposableObject } from "../pure/disposable-object";
 import {
   showAndLogExceptionWithTelemetry,
@@ -88,6 +88,7 @@ export class TestRunner extends DisposableObject {
         // Explorer UI swallows any thrown exception without reporting it to the user.
         // So we need to display the error message ourselves and then rethrow.
         void showAndLogExceptionWithTelemetry(
+          extLogger,
           redactableError(asError(e))`Cannot remove database ${
             database.name
           }: ${getErrorMessage(e)}`,
@@ -128,7 +129,10 @@ export class TestRunner extends DisposableObject {
           // This method is invoked from Test Explorer UI, and testing indicates that Test
           // Explorer UI swallows any thrown exception without reporting it to the user.
           // So we need to display the error message ourselves and then rethrow.
-          void showAndLogWarningMessage(`Cannot reopen database ${uri}: ${e}`);
+          void showAndLogWarningMessage(
+            extLogger,
+            `Cannot reopen database ${uri}: ${e}`,
+          );
           throw e;
         }
       }

--- a/extensions/ql-vscode/src/run-queries-shared.ts
+++ b/extensions/ql-vscode/src/run-queries-shared.ts
@@ -31,7 +31,7 @@ import { DecodedBqrsChunk, EntityValue } from "./pure/bqrs-cli-types";
 import { BaseLogger, extLogger } from "./common";
 import { generateSummarySymbolsFile } from "./log-insights/summary-parser";
 import { getErrorMessage } from "./pure/helpers-pure";
-import { showAndLogWarningMessage } from "./common/vscode/log";
+import { showAndLogWarningMessage } from "./common/logging";
 
 /**
  * run-queries.ts

--- a/extensions/ql-vscode/src/run-queries-shared.ts
+++ b/extensions/ql-vscode/src/run-queries-shared.ts
@@ -261,7 +261,7 @@ export class QueryEvaluationInfo extends QueryOutputDir {
   ): Promise<boolean> {
     const resultSet = await this.chooseResultSet(cliServer);
     if (!resultSet) {
-      void showAndLogWarningMessage("Query has no result set.");
+      void showAndLogWarningMessage(extLogger, "Query has no result set.");
       return false;
     }
     let stopDecoding = false;
@@ -659,6 +659,7 @@ async function generateHumanReadableLogSummary(
     return true;
   } catch (e) {
     void showAndLogWarningMessage(
+      extLogger,
       `Failed to generate human-readable structured evaluator log summary. Reason: ${getErrorMessage(
         e,
       )}`,
@@ -682,6 +683,7 @@ export async function logEndSummary(
     void logger.log(endSummaryContent);
   } catch (e) {
     void showAndLogWarningMessage(
+      extLogger,
       `Could not read structured evaluator log end of summary file at ${endSummary}.`,
     );
   }

--- a/extensions/ql-vscode/src/skeleton-query-wizard.ts
+++ b/extensions/ql-vscode/src/skeleton-query-wizard.ts
@@ -1,7 +1,7 @@
 import { join } from "path";
 import { CancellationToken, Uri, workspace, window as Window } from "vscode";
 import { CodeQLCliServer } from "./codeql-cli/cli";
-import { OutputChannelLogger } from "./common";
+import { BaseLogger } from "./common";
 import { Credentials } from "./common/authentication";
 import { QueryLanguage } from "./common/query-language";
 import {
@@ -49,7 +49,7 @@ export class SkeletonQueryWizard {
     private readonly cliServer: CodeQLCliServer,
     private readonly progress: ProgressCallback,
     private readonly credentials: Credentials | undefined,
-    private readonly extLogger: OutputChannelLogger,
+    private readonly logger: BaseLogger,
     private readonly databaseManager: DatabaseManager,
     private readonly token: CancellationToken,
     private readonly databaseStoragePath: string | undefined,
@@ -88,7 +88,7 @@ export class SkeletonQueryWizard {
     try {
       await this.openExampleFile();
     } catch (e: unknown) {
-      void this.extLogger.log(
+      void this.logger.log(
         `Could not open example query file: ${getErrorMessage(e)}`,
       );
     }
@@ -174,7 +174,7 @@ export class SkeletonQueryWizard {
 
       await qlPackGenerator.generate();
     } catch (e: unknown) {
-      void this.extLogger.log(
+      void this.logger.log(
         `Could not create skeleton QL pack: ${getErrorMessage(e)}`,
       );
     }
@@ -206,7 +206,7 @@ export class SkeletonQueryWizard {
       this.fileName = await this.determineNextFileName(this.folderName);
       await qlPackGenerator.createExampleQlFile(this.fileName);
     } catch (e: unknown) {
-      void this.extLogger.log(
+      void this.logger.log(
         `Could not create skeleton QL pack: ${getErrorMessage(e)}`,
       );
     }

--- a/extensions/ql-vscode/src/variant-analysis/data-flow-paths-view.ts
+++ b/extensions/ql-vscode/src/variant-analysis/data-flow-paths-view.ts
@@ -11,8 +11,8 @@ import {
 } from "../pure/interface-types";
 import { DataFlowPaths } from "./shared/data-flow-paths";
 import { redactableError } from "../pure/errors";
-import { showAndLogExceptionWithTelemetry } from "../common/vscode/log";
 import { extLogger } from "../common";
+import { showAndLogExceptionWithTelemetry } from "../common/vscode/logging";
 
 export class DataFlowPathsView extends AbstractWebview<
   ToDataFlowPathsMessage,

--- a/extensions/ql-vscode/src/variant-analysis/data-flow-paths-view.ts
+++ b/extensions/ql-vscode/src/variant-analysis/data-flow-paths-view.ts
@@ -12,6 +12,7 @@ import {
 import { DataFlowPaths } from "./shared/data-flow-paths";
 import { redactableError } from "../pure/errors";
 import { showAndLogExceptionWithTelemetry } from "../common/vscode/log";
+import { extLogger } from "../common";
 
 export class DataFlowPathsView extends AbstractWebview<
   ToDataFlowPathsMessage,
@@ -59,6 +60,7 @@ export class DataFlowPathsView extends AbstractWebview<
         break;
       case "unhandledError":
         void showAndLogExceptionWithTelemetry(
+          extLogger,
           redactableError(
             msg.error,
           )`Unhandled error in data flow paths view: ${msg.error.message}`,

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-content-provider.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-content-provider.ts
@@ -3,6 +3,7 @@ import { URLSearchParams } from "url";
 import { SHOW_QUERY_TEXT_MSG } from "../query-history/query-history-manager";
 import { VariantAnalysisManager } from "./variant-analysis-manager";
 import { showAndLogWarningMessage } from "../common/vscode/log";
+import { extLogger } from "../common";
 
 export const createVariantAnalysisContentProvider = (
   variantAnalysisManager: VariantAnalysisManager,
@@ -13,6 +14,7 @@ export const createVariantAnalysisContentProvider = (
     const variantAnalysisIdString = params.get("variantAnalysisId");
     if (!variantAnalysisIdString) {
       void showAndLogWarningMessage(
+        extLogger,
         "Unable to show query text. No variant analysis ID provided.",
       );
       return undefined;
@@ -24,6 +26,7 @@ export const createVariantAnalysisContentProvider = (
     );
     if (!variantAnalysis) {
       void showAndLogWarningMessage(
+        extLogger,
         "Unable to show query text. No variant analysis found.",
       );
       return undefined;

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-content-provider.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-content-provider.ts
@@ -2,7 +2,7 @@ import { TextDocumentContentProvider, Uri } from "vscode";
 import { URLSearchParams } from "url";
 import { SHOW_QUERY_TEXT_MSG } from "../query-history/query-history-manager";
 import { VariantAnalysisManager } from "./variant-analysis-manager";
-import { showAndLogWarningMessage } from "../common/vscode/log";
+import { showAndLogWarningMessage } from "../common/logging";
 import { extLogger } from "../common";
 
 export const createVariantAnalysisContentProvider = (

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -72,11 +72,11 @@ import {
 import { GITHUB_AUTH_PROVIDER_ID } from "../common/vscode/authentication";
 import { FetchError } from "node-fetch";
 import { extLogger } from "../common";
+import { showAndLogExceptionWithTelemetry } from "../common/vscode/logging";
 import {
-  showAndLogExceptionWithTelemetry,
   showAndLogInformationMessage,
   showAndLogWarningMessage,
-} from "../common/vscode/log";
+} from "../common/logging";
 
 const maxRetryCount = 3;
 

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -256,6 +256,7 @@ export class VariantAnalysisManager
     await this.onVariantAnalysisSubmitted(processedVariantAnalysis);
 
     void showAndLogInformationMessage(
+      extLogger,
       `Variant analysis ${processedVariantAnalysis.query.name} submitted for processing`,
     );
 
@@ -328,6 +329,7 @@ export class VariantAnalysisManager
   public async showView(variantAnalysisId: number): Promise<void> {
     if (!this.variantAnalyses.get(variantAnalysisId)) {
       void showAndLogExceptionWithTelemetry(
+        extLogger,
         redactableError`No variant analysis found with id: ${variantAnalysisId}.`,
       );
     }
@@ -347,6 +349,7 @@ export class VariantAnalysisManager
     const variantAnalysis = await this.getVariantAnalysis(variantAnalysisId);
     if (!variantAnalysis) {
       void showAndLogWarningMessage(
+        extLogger,
         "Could not open variant analysis query text. Variant analysis not found.",
       );
       return;
@@ -367,6 +370,7 @@ export class VariantAnalysisManager
       await Window.showTextDocument(doc, { preview: false });
     } catch (error) {
       void showAndLogWarningMessage(
+        extLogger,
         "Could not open variant analysis query text. Failed to open text document.",
       );
     }
@@ -377,6 +381,7 @@ export class VariantAnalysisManager
 
     if (!variantAnalysis) {
       void showAndLogWarningMessage(
+        extLogger,
         "Could not open variant analysis query file",
       );
       return;
@@ -389,6 +394,7 @@ export class VariantAnalysisManager
       await Window.showTextDocument(textDocument, ViewColumn.One);
     } catch (error) {
       void showAndLogWarningMessage(
+        extLogger,
         `Could not open file: ${variantAnalysis.query.filePath}`,
       );
     }
@@ -701,6 +707,7 @@ export class VariantAnalysisManager
     }
 
     void showAndLogInformationMessage(
+      extLogger,
       "Cancelling variant analysis. This may take a while.",
     );
     await cancelVariantAnalysis(this.app.credentials, variantAnalysis);

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -71,7 +71,6 @@ import {
 } from "./repo-states-store";
 import { GITHUB_AUTH_PROVIDER_ID } from "../common/vscode/authentication";
 import { FetchError } from "node-fetch";
-import { extLogger } from "../common";
 import { showAndLogExceptionWithTelemetry } from "../common/vscode/logging";
 import {
   showAndLogInformationMessage,
@@ -256,7 +255,7 @@ export class VariantAnalysisManager
     await this.onVariantAnalysisSubmitted(processedVariantAnalysis);
 
     void showAndLogInformationMessage(
-      extLogger,
+      this.app.logger,
       `Variant analysis ${processedVariantAnalysis.query.name} submitted for processing`,
     );
 
@@ -329,7 +328,7 @@ export class VariantAnalysisManager
   public async showView(variantAnalysisId: number): Promise<void> {
     if (!this.variantAnalyses.get(variantAnalysisId)) {
       void showAndLogExceptionWithTelemetry(
-        extLogger,
+        this.app.logger,
         redactableError`No variant analysis found with id: ${variantAnalysisId}.`,
       );
     }
@@ -349,7 +348,7 @@ export class VariantAnalysisManager
     const variantAnalysis = await this.getVariantAnalysis(variantAnalysisId);
     if (!variantAnalysis) {
       void showAndLogWarningMessage(
-        extLogger,
+        this.app.logger,
         "Could not open variant analysis query text. Variant analysis not found.",
       );
       return;
@@ -370,7 +369,7 @@ export class VariantAnalysisManager
       await Window.showTextDocument(doc, { preview: false });
     } catch (error) {
       void showAndLogWarningMessage(
-        extLogger,
+        this.app.logger,
         "Could not open variant analysis query text. Failed to open text document.",
       );
     }
@@ -381,7 +380,7 @@ export class VariantAnalysisManager
 
     if (!variantAnalysis) {
       void showAndLogWarningMessage(
-        extLogger,
+        this.app.logger,
         "Could not open variant analysis query file",
       );
       return;
@@ -394,7 +393,7 @@ export class VariantAnalysisManager
       await Window.showTextDocument(textDocument, ViewColumn.One);
     } catch (error) {
       void showAndLogWarningMessage(
-        extLogger,
+        this.app.logger,
         `Could not open file: ${variantAnalysis.query.filePath}`,
       );
     }
@@ -639,14 +638,14 @@ export class VariantAnalysisManager
               e instanceof FetchError &&
               (e.code === "ETIMEDOUT" || e.code === "ECONNRESET")
             ) {
-              void extLogger.log(
+              void this.app.logger.log(
                 `Timeout while trying to download variant analysis with id: ${
                   variantAnalysis.id
                 }. Error: ${getErrorMessage(e)}. Retrying...`,
               );
               continue;
             }
-            void extLogger.log(
+            void this.app.logger.log(
               `Failed to download variant analysis after ${retry} attempts.`,
             );
             throw e;
@@ -707,7 +706,7 @@ export class VariantAnalysisManager
     }
 
     void showAndLogInformationMessage(
-      extLogger,
+      this.app.logger,
       "Cancelling variant analysis. This may take a while.",
     );
     await cancelVariantAnalysis(this.app.credentials, variantAnalysis);

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-monitor.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-monitor.ts
@@ -15,7 +15,7 @@ import { sleep } from "../pure/time";
 import { getErrorMessage } from "../pure/helpers-pure";
 import { App } from "../common/app";
 import { extLogger } from "../common";
-import { showAndLogWarningMessage } from "../common/vscode/log";
+import { showAndLogWarningMessage } from "../common/logging";
 
 export class VariantAnalysisMonitor extends DisposableObject {
   // With a sleep of 5 seconds, the maximum number of attempts takes

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-monitor.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-monitor.ts
@@ -14,7 +14,6 @@ import { DisposableObject } from "../pure/disposable-object";
 import { sleep } from "../pure/time";
 import { getErrorMessage } from "../pure/helpers-pure";
 import { App } from "../common/app";
-import { extLogger } from "../common";
 import { showAndLogWarningMessage } from "../common/logging";
 
 export class VariantAnalysisMonitor extends DisposableObject {
@@ -47,7 +46,7 @@ export class VariantAnalysisMonitor extends DisposableObject {
     variantAnalysis: VariantAnalysis,
   ): Promise<void> {
     if (this.monitoringVariantAnalyses.has(variantAnalysis.id)) {
-      void extLogger.log(
+      void this.app.logger.log(
         `Already monitoring variant analysis ${variantAnalysis.id}`,
       );
       return;
@@ -96,9 +95,9 @@ export class VariantAnalysisMonitor extends DisposableObject {
 
         // If we have already shown this error to the user, don't show it again.
         if (lastErrorShown === errorMessage) {
-          void extLogger.log(message);
+          void this.app.logger.log(message);
         } else {
-          void showAndLogWarningMessage(extLogger, message);
+          void showAndLogWarningMessage(this.app.logger, message);
           lastErrorShown = errorMessage;
         }
 
@@ -107,7 +106,7 @@ export class VariantAnalysisMonitor extends DisposableObject {
           // keep polling for the variant analysis if it no longer exists.
           // Therefore, this block is down here rather than at the top of the
           // catch block.
-          void extLogger.log(
+          void this.app.logger.log(
             `Variant analysis ${variantAnalysisLabel} no longer exists or is no longer accessible, stopping monitoring.`,
           );
           // Cancel monitoring on 404, as this probably means the user does not have access to it anymore

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-monitor.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-monitor.ts
@@ -98,7 +98,7 @@ export class VariantAnalysisMonitor extends DisposableObject {
         if (lastErrorShown === errorMessage) {
           void extLogger.log(message);
         } else {
-          void showAndLogWarningMessage(message);
+          void showAndLogWarningMessage(extLogger, message);
           lastErrorShown = errorMessage;
         }
 

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-view.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-view.ts
@@ -166,6 +166,7 @@ export class VariantAnalysisView
         break;
       case "unhandledError":
         void showAndLogExceptionWithTelemetry(
+          extLogger,
           redactableError(
             msg.error,
           )`Unhandled error in variant analysis results view: ${msg.error.message}`,
@@ -186,7 +187,10 @@ export class VariantAnalysisView
     );
 
     if (!variantAnalysis) {
-      void showAndLogWarningMessage("Unable to load variant analysis");
+      void showAndLogWarningMessage(
+        extLogger,
+        "Unable to load variant analysis",
+      );
       return;
     }
 

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-view.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-view.ts
@@ -3,7 +3,6 @@ import {
   AbstractWebview,
   WebviewPanelConfig,
 } from "../common/vscode/abstract-webview";
-import { extLogger } from "../common";
 import { showAndLogExceptionWithTelemetry } from "../common/vscode/logging";
 import {
   FromVariantAnalysisMessage,
@@ -164,7 +163,7 @@ export class VariantAnalysisView
         break;
       case "unhandledError":
         void showAndLogExceptionWithTelemetry(
-          extLogger,
+          this.app.logger,
           redactableError(
             msg.error,
           )`Unhandled error in variant analysis results view: ${msg.error.message}`,
@@ -178,7 +177,7 @@ export class VariantAnalysisView
   protected async onWebViewLoaded() {
     super.onWebViewLoaded();
 
-    void extLogger.log("Variant analysis view loaded");
+    void this.app.logger.log("Variant analysis view loaded");
 
     const variantAnalysis = await this.manager.getVariantAnalysis(
       this.variantAnalysisId,
@@ -186,7 +185,7 @@ export class VariantAnalysisView
 
     if (!variantAnalysis) {
       void showAndLogWarningMessage(
-        extLogger,
+        this.app.logger,
         "Unable to load variant analysis",
       );
       return;

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-view.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-view.ts
@@ -4,6 +4,7 @@ import {
   WebviewPanelConfig,
 } from "../common/vscode/abstract-webview";
 import { extLogger } from "../common";
+import { showAndLogExceptionWithTelemetry } from "../common/vscode/logging";
 import {
   FromVariantAnalysisMessage,
   ToVariantAnalysisMessage,
@@ -27,10 +28,7 @@ import {
   getVariantAnalysisDefaultResultsFilter,
   getVariantAnalysisDefaultResultsSort,
 } from "../config";
-import {
-  showAndLogExceptionWithTelemetry,
-  showAndLogWarningMessage,
-} from "../common/vscode/log";
+import { showAndLogWarningMessage } from "../common/logging";
 
 export class VariantAnalysisView
   extends AbstractWebview<ToVariantAnalysisMessage, FromVariantAnalysisMessage>

--- a/extensions/ql-vscode/test/__mocks__/appMock.ts
+++ b/extensions/ql-vscode/test/__mocks__/appMock.ts
@@ -8,6 +8,7 @@ import { testCredentialsWithStub } from "../factories/authentication";
 import { Credentials } from "../../src/common/authentication";
 import { AppCommandManager } from "../../src/common/commands";
 import { createMockCommandManager } from "./commandsMock";
+import { NotificationLogger } from "../../src/common";
 
 export function createMockApp({
   extensionPath = "/mock/extension/path",
@@ -18,6 +19,7 @@ export function createMockApp({
   credentials = testCredentialsWithStub(),
   commands = createMockCommandManager(),
   environment = createMockEnvironmentContext(),
+  logger = createMockLogger(),
 }: {
   extensionPath?: string;
   workspaceStoragePath?: string;
@@ -27,10 +29,11 @@ export function createMockApp({
   credentials?: Credentials;
   commands?: AppCommandManager;
   environment?: EnvironmentContext;
+  logger?: NotificationLogger;
 }): App {
   return {
     mode: AppMode.Test,
-    logger: createMockLogger(),
+    logger,
     subscriptions: [],
     extensionPath,
     workspaceStoragePath,

--- a/extensions/ql-vscode/test/__mocks__/loggerMock.ts
+++ b/extensions/ql-vscode/test/__mocks__/loggerMock.ts
@@ -1,8 +1,11 @@
-import { Logger } from "../../src/common";
+import { NotificationLogger } from "../../src/common";
 
-export function createMockLogger(): Logger {
+export function createMockLogger(): NotificationLogger {
   return {
     log: jest.fn(() => Promise.resolve()),
     show: jest.fn(),
+    showErrorMessage: jest.fn(),
+    showWarningMessage: jest.fn(),
+    showInformationMessage: jest.fn(),
   };
 }

--- a/extensions/ql-vscode/test/vscode-tests/activated-extension/variant-analysis/variant-analysis-monitor.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/activated-extension/variant-analysis/variant-analysis-monitor.test.ts
@@ -23,8 +23,8 @@ import {
 import { createMockVariantAnalysis } from "../../../factories/variant-analysis/shared/variant-analysis";
 import { createMockApp } from "../../../__mocks__/appMock";
 import { createMockCommandManager } from "../../../__mocks__/commandsMock";
-import * as log from "../../../../src/common/vscode/log";
-import { showAndLogWarningMessage } from "../../../../src/common/vscode/log";
+import * as log from "../../../../src/common/logging";
+import { showAndLogWarningMessage } from "../../../../src/common/logging";
 
 jest.setTimeout(60_000);
 

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/packaging/packaging.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/packaging/packaging.test.ts
@@ -81,7 +81,7 @@ describe("Packaging commands", () => {
 
     expect(showAndLogExceptionWithTelemetrySpy).toHaveBeenCalled();
     expect(
-      showAndLogExceptionWithTelemetrySpy.mock.calls[0][0].fullMessage,
+      showAndLogExceptionWithTelemetrySpy.mock.calls[0][1].fullMessage,
     ).toEqual("Unable to download all packs. See log for more details.");
   });
 

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/packaging/packaging.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/packaging/packaging.test.ts
@@ -4,7 +4,7 @@ import { join } from "path";
 import { CodeQLCliServer } from "../../../../src/codeql-cli/cli";
 import { getErrorMessage } from "../../../../src/pure/helpers-pure";
 
-import * as log from "../../../../src/common/logging";
+import * as log from "../../../../src/common/logging/notifications";
 import * as vscodeLog from "../../../../src/common/vscode/logging";
 import {
   handleDownloadPacks,
@@ -53,6 +53,7 @@ describe("Packaging commands", () => {
     await handleDownloadPacks(cli, progress);
     expect(showAndLogExceptionWithTelemetrySpy).not.toHaveBeenCalled();
     expect(showAndLogInformationMessageSpy).toHaveBeenCalledWith(
+      expect.anything(),
       expect.stringContaining("Finished downloading packs."),
     );
   });
@@ -66,6 +67,7 @@ describe("Packaging commands", () => {
     await handleDownloadPacks(cli, progress);
     expect(showAndLogExceptionWithTelemetrySpy).not.toHaveBeenCalled();
     expect(showAndLogInformationMessageSpy).toHaveBeenCalledWith(
+      expect.anything(),
       expect.stringContaining("Finished downloading packs."),
     );
   });
@@ -97,6 +99,7 @@ describe("Packaging commands", () => {
 
     await handleInstallPackDependencies(cli, progress);
     expect(showAndLogInformationMessageSpy).toHaveBeenCalledWith(
+      expect.anything(),
       expect.stringContaining("Finished installing pack dependencies."),
     );
   });

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/packaging/packaging.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/packaging/packaging.test.ts
@@ -4,17 +4,16 @@ import { join } from "path";
 import { CodeQLCliServer } from "../../../../src/codeql-cli/cli";
 import { getErrorMessage } from "../../../../src/pure/helpers-pure";
 
-import * as log from "../../../../src/common/vscode/log";
+import * as log from "../../../../src/common/logging";
+import * as vscodeLog from "../../../../src/common/vscode/logging";
 import {
   handleDownloadPacks,
   handleInstallPackDependencies,
 } from "../../../../src/packaging";
 import { mockedQuickPickItem } from "../../utils/mocking.helpers";
 import { getActivatedExtension } from "../../global.helper";
-import {
-  showAndLogExceptionWithTelemetry,
-  showAndLogInformationMessage,
-} from "../../../../src/common/vscode/log";
+import { showAndLogInformationMessage } from "../../../../src/common/logging";
+import { showAndLogExceptionWithTelemetry } from "../../../../src/common/vscode/logging";
 
 describe("Packaging commands", () => {
   let cli: CodeQLCliServer;
@@ -36,7 +35,7 @@ describe("Packaging commands", () => {
       .spyOn(window, "showInputBox")
       .mockResolvedValue(undefined);
     showAndLogExceptionWithTelemetrySpy = jest
-      .spyOn(log, "showAndLogExceptionWithTelemetry")
+      .spyOn(vscodeLog, "showAndLogExceptionWithTelemetry")
       .mockResolvedValue(undefined);
     showAndLogInformationMessageSpy = jest
       .spyOn(log, "showAndLogInformationMessage")

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/codeql-cli/distribution.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/codeql-cli/distribution.test.ts
@@ -1,7 +1,7 @@
 import * as fetch from "node-fetch";
 import { Range } from "semver";
 
-import * as log from "../../../../src/common/logging";
+import * as log from "../../../../src/common/logging/notifications";
 import { extLogger } from "../../../../src/common";
 import * as fs from "fs-extra";
 import * as path from "path";

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/codeql-cli/distribution.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/codeql-cli/distribution.test.ts
@@ -1,7 +1,7 @@
 import * as fetch from "node-fetch";
 import { Range } from "semver";
 
-import * as log from "../../../../src/common/vscode/log";
+import * as log from "../../../../src/common/logging";
 import { extLogger } from "../../../../src/common";
 import * as fs from "fs-extra";
 import * as path from "path";
@@ -18,7 +18,7 @@ import {
 import {
   showAndLogErrorMessage,
   showAndLogWarningMessage,
-} from "../../../../src/common/vscode/log";
+} from "../../../../src/common/logging";
 
 jest.mock("os", () => {
   const original = jest.requireActual("os");

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/data-extensions-editor/extension-pack-picker.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/data-extensions-editor/extension-pack-picker.test.ts
@@ -12,6 +12,7 @@ import * as log from "../../../../src/common/logging";
 import { pickExtensionPackModelFile } from "../../../../src/data-extensions-editor/extension-pack-picker";
 import { ExtensionPack } from "../../../../src/data-extensions-editor/shared/extension-pack";
 import { showAndLogErrorMessage } from "../../../../src/common/logging";
+import { createMockLogger } from "../../../__mocks__/loggerMock";
 
 describe("pickExtensionPackModelFile", () => {
   let tmpDir: string;
@@ -36,6 +37,8 @@ describe("pickExtensionPackModelFile", () => {
   let showAndLogErrorMessageSpy: jest.SpiedFunction<
     typeof showAndLogErrorMessage
   >;
+
+  const logger = createMockLogger();
 
   beforeEach(async () => {
     tmpDir = (
@@ -104,6 +107,7 @@ describe("pickExtensionPackModelFile", () => {
       await pickExtensionPackModelFile(
         cliServer,
         databaseItem,
+        logger,
         progress,
         token,
       ),
@@ -178,6 +182,7 @@ describe("pickExtensionPackModelFile", () => {
       await pickExtensionPackModelFile(
         cliServer,
         databaseItem,
+        logger,
         progress,
         token,
       ),
@@ -212,6 +217,7 @@ describe("pickExtensionPackModelFile", () => {
       await pickExtensionPackModelFile(
         cliServer,
         databaseItem,
+        logger,
         progress,
         token,
       ),
@@ -240,6 +246,7 @@ describe("pickExtensionPackModelFile", () => {
       await pickExtensionPackModelFile(
         cliServer,
         databaseItem,
+        logger,
         progress,
         token,
       ),
@@ -314,6 +321,7 @@ describe("pickExtensionPackModelFile", () => {
           ...databaseItem,
           language: "csharp",
         },
+        logger,
         progress,
         token,
       ),
@@ -374,6 +382,7 @@ describe("pickExtensionPackModelFile", () => {
       await pickExtensionPackModelFile(
         cliServer,
         databaseItem,
+        logger,
         progress,
         token,
       ),
@@ -397,6 +406,7 @@ describe("pickExtensionPackModelFile", () => {
       await pickExtensionPackModelFile(
         cliServer,
         databaseItem,
+        logger,
         progress,
         token,
       ),
@@ -426,6 +436,7 @@ describe("pickExtensionPackModelFile", () => {
       await pickExtensionPackModelFile(
         cliServer,
         databaseItem,
+        logger,
         progress,
         token,
       ),
@@ -465,6 +476,7 @@ describe("pickExtensionPackModelFile", () => {
       await pickExtensionPackModelFile(
         cliServer,
         databaseItem,
+        logger,
         progress,
         token,
       ),
@@ -501,6 +513,7 @@ describe("pickExtensionPackModelFile", () => {
       await pickExtensionPackModelFile(
         cliServer,
         databaseItem,
+        logger,
         progress,
         token,
       ),
@@ -540,6 +553,7 @@ describe("pickExtensionPackModelFile", () => {
       await pickExtensionPackModelFile(
         cliServer,
         databaseItem,
+        logger,
         progress,
         token,
       ),
@@ -588,6 +602,7 @@ describe("pickExtensionPackModelFile", () => {
       await pickExtensionPackModelFile(
         cliServer,
         databaseItem,
+        logger,
         progress,
         token,
       ),
@@ -646,6 +661,7 @@ describe("pickExtensionPackModelFile", () => {
       await pickExtensionPackModelFile(
         cliServer,
         databaseItem,
+        logger,
         progress,
         token,
       ),
@@ -707,6 +723,7 @@ describe("pickExtensionPackModelFile", () => {
       await pickExtensionPackModelFile(
         cliServer,
         databaseItem,
+        logger,
         progress,
         token,
       ),
@@ -765,6 +782,7 @@ describe("pickExtensionPackModelFile", () => {
       await pickExtensionPackModelFile(
         cliServer,
         databaseItem,
+        logger,
         progress,
         token,
       ),
@@ -788,6 +806,7 @@ describe("pickExtensionPackModelFile", () => {
       await pickExtensionPackModelFile(
         cliServer,
         databaseItem,
+        logger,
         progress,
         token,
       ),
@@ -862,6 +881,7 @@ describe("pickExtensionPackModelFile", () => {
       await pickExtensionPackModelFile(
         cliServer,
         databaseItem,
+        logger,
         progress,
         token,
       ),
@@ -946,6 +966,7 @@ describe("pickExtensionPackModelFile", () => {
       await pickExtensionPackModelFile(
         cliServer,
         databaseItem,
+        logger,
         progress,
         token,
       ),
@@ -989,6 +1010,7 @@ describe("pickExtensionPackModelFile", () => {
           ...databaseItem,
           language: "csharp",
         },
+        logger,
         progress,
         token,
       ),

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/data-extensions-editor/extension-pack-picker.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/data-extensions-editor/extension-pack-picker.test.ts
@@ -7,11 +7,11 @@ import {
   QlpacksInfo,
   ResolveExtensionsResult,
 } from "../../../../src/codeql-cli/cli";
-import * as log from "../../../../src/common/vscode/log";
+import * as log from "../../../../src/common/logging";
 
 import { pickExtensionPackModelFile } from "../../../../src/data-extensions-editor/extension-pack-picker";
 import { ExtensionPack } from "../../../../src/data-extensions-editor/shared/extension-pack";
-import { showAndLogErrorMessage } from "../../../../src/common/vscode/log";
+import { showAndLogErrorMessage } from "../../../../src/common/logging";
 
 describe("pickExtensionPackModelFile", () => {
   let tmpDir: string;

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/data-extensions-editor/extension-pack-picker.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/data-extensions-editor/extension-pack-picker.test.ts
@@ -7,11 +7,9 @@ import {
   QlpacksInfo,
   ResolveExtensionsResult,
 } from "../../../../src/codeql-cli/cli";
-import * as log from "../../../../src/common/logging";
 
 import { pickExtensionPackModelFile } from "../../../../src/data-extensions-editor/extension-pack-picker";
 import { ExtensionPack } from "../../../../src/data-extensions-editor/shared/extension-pack";
-import { showAndLogErrorMessage } from "../../../../src/common/logging";
 import { createMockLogger } from "../../../__mocks__/loggerMock";
 
 describe("pickExtensionPackModelFile", () => {
@@ -34,9 +32,6 @@ describe("pickExtensionPackModelFile", () => {
   const progress = jest.fn();
   let showQuickPickSpy: jest.SpiedFunction<typeof window.showQuickPick>;
   let showInputBoxSpy: jest.SpiedFunction<typeof window.showInputBox>;
-  let showAndLogErrorMessageSpy: jest.SpiedFunction<
-    typeof showAndLogErrorMessage
-  >;
 
   const logger = createMockLogger();
 
@@ -82,11 +77,6 @@ describe("pickExtensionPackModelFile", () => {
     showInputBoxSpy = jest
       .spyOn(window, "showInputBox")
       .mockRejectedValue(new Error("Unexpected call to showInputBox"));
-    showAndLogErrorMessageSpy = jest
-      .spyOn(log, "showAndLogErrorMessage")
-      .mockImplementation((msg) => {
-        throw new Error(`Unexpected call to showAndLogErrorMessage: ${msg}`);
-      });
   });
 
   it("allows choosing an existing extension pack and model file", async () => {
@@ -418,8 +408,6 @@ describe("pickExtensionPackModelFile", () => {
   });
 
   it("shows an error when an extension pack resolves to more than 1 location", async () => {
-    showAndLogErrorMessageSpy.mockResolvedValue(undefined);
-
     const cliServer = mockCliServer(
       {
         "my-extension-pack": [
@@ -441,10 +429,9 @@ describe("pickExtensionPackModelFile", () => {
         token,
       ),
     ).toEqual(undefined);
-    expect(showAndLogErrorMessageSpy).toHaveBeenCalledTimes(1);
-    expect(showAndLogErrorMessageSpy).toHaveBeenCalledWith(
+    expect(logger.showErrorMessage).toHaveBeenCalledTimes(1);
+    expect(logger.showErrorMessage).toHaveBeenCalledWith(
       expect.stringMatching(/resolves to multiple paths/),
-      expect.anything(),
     );
     expect(showQuickPickSpy).toHaveBeenCalledTimes(1);
     expect(showQuickPickSpy).toHaveBeenCalledWith(
@@ -547,7 +534,6 @@ describe("pickExtensionPackModelFile", () => {
     );
 
     showQuickPickSpy.mockResolvedValueOnce(undefined);
-    showAndLogErrorMessageSpy.mockResolvedValue(undefined);
 
     expect(
       await pickExtensionPackModelFile(
@@ -572,10 +558,9 @@ describe("pickExtensionPackModelFile", () => {
       token,
     );
     expect(showInputBoxSpy).not.toHaveBeenCalled();
-    expect(showAndLogErrorMessageSpy).toHaveBeenCalledTimes(1);
-    expect(showAndLogErrorMessageSpy).toHaveBeenCalledWith(
+    expect(logger.showErrorMessage).toHaveBeenCalledTimes(1);
+    expect(logger.showErrorMessage).toHaveBeenCalledWith(
       expect.stringMatching(/my-extension-pack/),
-      expect.anything(),
     );
     expect(cliServer.resolveQlpacks).toHaveBeenCalled();
     expect(cliServer.resolveExtensions).not.toHaveBeenCalled();
@@ -596,7 +581,6 @@ describe("pickExtensionPackModelFile", () => {
     await outputFile(join(tmpDir.path, "codeql-pack.yml"), dumpYaml("java"));
 
     showQuickPickSpy.mockResolvedValueOnce(undefined);
-    showAndLogErrorMessageSpy.mockResolvedValue(undefined);
 
     expect(
       await pickExtensionPackModelFile(
@@ -621,10 +605,9 @@ describe("pickExtensionPackModelFile", () => {
       token,
     );
     expect(showInputBoxSpy).not.toHaveBeenCalled();
-    expect(showAndLogErrorMessageSpy).toHaveBeenCalledTimes(1);
-    expect(showAndLogErrorMessageSpy).toHaveBeenCalledWith(
+    expect(logger.showErrorMessage).toHaveBeenCalledTimes(1);
+    expect(logger.showErrorMessage).toHaveBeenCalledWith(
       expect.stringMatching(/my-extension-pack/),
-      expect.anything(),
     );
     expect(cliServer.resolveQlpacks).toHaveBeenCalled();
     expect(cliServer.resolveExtensions).not.toHaveBeenCalled();
@@ -655,7 +638,6 @@ describe("pickExtensionPackModelFile", () => {
     );
 
     showQuickPickSpy.mockResolvedValueOnce(undefined);
-    showAndLogErrorMessageSpy.mockResolvedValue(undefined);
 
     expect(
       await pickExtensionPackModelFile(
@@ -680,10 +662,9 @@ describe("pickExtensionPackModelFile", () => {
       token,
     );
     expect(showInputBoxSpy).not.toHaveBeenCalled();
-    expect(showAndLogErrorMessageSpy).toHaveBeenCalledTimes(1);
-    expect(showAndLogErrorMessageSpy).toHaveBeenCalledWith(
+    expect(logger.showErrorMessage).toHaveBeenCalledTimes(1);
+    expect(logger.showErrorMessage).toHaveBeenCalledWith(
       expect.stringMatching(/my-extension-pack/),
-      expect.anything(),
     );
     expect(cliServer.resolveQlpacks).toHaveBeenCalled();
     expect(cliServer.resolveExtensions).not.toHaveBeenCalled();
@@ -717,7 +698,6 @@ describe("pickExtensionPackModelFile", () => {
     );
 
     showQuickPickSpy.mockResolvedValueOnce(undefined);
-    showAndLogErrorMessageSpy.mockResolvedValue(undefined);
 
     expect(
       await pickExtensionPackModelFile(
@@ -742,10 +722,9 @@ describe("pickExtensionPackModelFile", () => {
       token,
     );
     expect(showInputBoxSpy).not.toHaveBeenCalled();
-    expect(showAndLogErrorMessageSpy).toHaveBeenCalledTimes(1);
-    expect(showAndLogErrorMessageSpy).toHaveBeenCalledWith(
+    expect(logger.showErrorMessage).toHaveBeenCalledTimes(1);
+    expect(logger.showErrorMessage).toHaveBeenCalledWith(
       expect.stringMatching(/my-extension-pack/),
-      expect.anything(),
     );
     expect(cliServer.resolveQlpacks).toHaveBeenCalled();
     expect(cliServer.resolveExtensions).not.toHaveBeenCalled();

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/data-extensions-editor/external-api-usage-query.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/data-extensions-editor/external-api-usage-query.test.ts
@@ -152,6 +152,7 @@ describe("readQueryResults", () => {
 
     expect(await readQueryResults(options)).toBeUndefined();
     expect(showAndLogExceptionWithTelemetrySpy).toHaveBeenCalledWith(
+      expect.anything(),
       expect.any(RedactableError),
     );
   });
@@ -184,6 +185,7 @@ describe("readQueryResults", () => {
 
     expect(await readQueryResults(options)).toBeUndefined();
     expect(showAndLogExceptionWithTelemetrySpy).toHaveBeenCalledWith(
+      expect.anything(),
       expect.any(RedactableError),
     );
   });

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/data-extensions-editor/external-api-usage-query.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/data-extensions-editor/external-api-usage-query.test.ts
@@ -11,9 +11,9 @@ import { readdir, readFile } from "fs-extra";
 import { load } from "js-yaml";
 import { dirname, join } from "path";
 import { fetchExternalApiQueries } from "../../../../src/data-extensions-editor/queries";
-import * as log from "../../../../src/common/vscode/log";
+import * as vscodeLog from "../../../../src/common/vscode/logging";
 import { RedactableError } from "../../../../src/pure/errors";
-import { showAndLogExceptionWithTelemetry } from "../../../../src/common/vscode/log";
+import { showAndLogExceptionWithTelemetry } from "../../../../src/common/vscode/logging";
 
 function createMockUri(path = "/a/b/c/foo"): Uri {
   return {
@@ -140,7 +140,7 @@ describe("readQueryResults", () => {
 
   beforeEach(() => {
     showAndLogExceptionWithTelemetrySpy = jest.spyOn(
-      log,
+      vscodeLog,
       "showAndLogExceptionWithTelemetry",
     );
   });

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/language-support/contextual/query-resolver.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/language-support/contextual/query-resolver.test.ts
@@ -3,7 +3,7 @@ import * as fs from "fs-extra";
 
 import { getErrorMessage } from "../../../../../src/pure/helpers-pure";
 
-import * as log from "../../../../../src/common/vscode/log";
+import * as log from "../../../../../src/common/logging";
 import * as workspaceFolders from "../../../../../src/common/vscode/workspace-folders";
 import * as qlpack from "../../../../../src/databases/qlpack";
 import {

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/language-support/contextual/query-resolver.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/language-support/contextual/query-resolver.test.ts
@@ -3,7 +3,7 @@ import * as fs from "fs-extra";
 
 import { getErrorMessage } from "../../../../../src/pure/helpers-pure";
 
-import * as log from "../../../../../src/common/logging";
+import * as log from "../../../../../src/common/logging/notifications";
 import * as workspaceFolders from "../../../../../src/common/vscode/workspace-folders";
 import * as qlpack from "../../../../../src/databases/qlpack";
 import {


### PR DESCRIPTION
This makes the following functions callable without a dependency on the `vscode` module:
- `showAndLogErrorMessage`
- `showAndLogWarningMessage`
- `showAndLogInformationMessage`

This PR does not yet fix the `showAndLogExceptionWithTelemetry` function since it has a dependency on the `telemetryListener`, which imports the `vscode` module. This will be fixed in a follow-up PR.

Unfortunately, most of the call sites are still using `extLogger` as argument rather than `app.logger`. I'm hoping that this will be fixed in the future as we move more to using the `App`.

Please review this PR commit-by-commit. Each commit is relatively self-contained and most changes in each commit are changing 1 file path or call signature.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
