### PR TITLE
Modernize query packs

### DIFF
--- a/.github/codeql/queries/qlpack.yml
+++ b/.github/codeql/queries/qlpack.yml
@@ -1,3 +1,4 @@
 name: vscode-codeql-custom-queries-javascript
 version: 0.0.0
-libraryPathDependencies: codeql-javascript
+dependencies:
+  codeql/javascript-queries: "*"

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/data/qlpack.yml
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/data/qlpack.yml
@@ -1,3 +1,4 @@
 name: integration-test-queries-javascript
 version: 0.0.0
-libraryPathDependencies: codeql-javascript
+dependencies:
+  codeql/javascript-queries: "*"


### PR DESCRIPTION
Remove legacy `libraryPathDependencies`. We are making some changes internally that will cause legacy packs with lock files to throw an error.

## Checklist

- [n/a] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [n/a] Issues have been created for any UI or other user-facing changes made by this pull request.
- [n/a] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
