### PR TITLE
Add library to data extensions editor

### DIFF
--- a/extensions/ql-vscode/src/data-extensions-editor/bqrs.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/bqrs.ts
@@ -10,6 +10,7 @@ export function decodeBqrsToExternalApiUsages(
     const usage = tuple[0] as Call;
     const signature = tuple[1] as string;
     const supported = (tuple[2] as string) === "true";
+    const library = tuple[4] as string;
 
     const [packageWithType, methodDeclaration] = signature.split("#");
 
@@ -31,6 +32,7 @@ export function decodeBqrsToExternalApiUsages(
 
     if (!methodsByApiName.has(signature)) {
       methodsByApiName.set(signature, {
+        library,
         signature,
         packageName,
         typeName,

--- a/extensions/ql-vscode/src/data-extensions-editor/external-api-usage.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/external-api-usage.ts
@@ -7,6 +7,10 @@ export type Call = {
 
 export type ExternalApiUsage = {
   /**
+   * Contains the name of the library containing the method declaration, e.g. `sql2o-1.6.0.jar` or `System.Runtime.dll`
+   */
+  library: string;
+  /**
    * Contains the full method signature, e.g. `org.sql2o.Connection#createQuery(String)`
    */
   signature: string;

--- a/extensions/ql-vscode/src/data-extensions-editor/queries/csharp.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/queries/csharp.ts
@@ -26,7 +26,7 @@ where
   apiName = api.getApiName() and
   supported = isSupported(api) and
   usage = aUsage(api)
-select usage, apiName, supported.toString(), "supported"
+select usage, apiName, supported.toString(), "supported", api.getFile().getBaseName(), "library"
 `,
   dependencies: {
     "ExternalApi.qll": `/** Provides classes and predicates related to handling APIs from external libraries. */

--- a/extensions/ql-vscode/src/data-extensions-editor/queries/java.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/queries/java.ts
@@ -28,7 +28,7 @@ where
   apiName = api.getApiName() and
   supported = isSupported(api) and
   usage = aUsage(api)
-select usage, apiName, supported.toString(), "supported"
+select usage, apiName, supported.toString(), "supported", api.jarContainer(), "jar"
 `,
   dependencies: {
     "ExternalApi.qll": `/** Provides classes and predicates related to handling APIs from external libraries. */

--- a/extensions/ql-vscode/src/data-extensions-editor/queries/java.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/queries/java.ts
@@ -28,7 +28,7 @@ where
   apiName = api.getApiName() and
   supported = isSupported(api) and
   usage = aUsage(api)
-select usage, apiName, supported.toString(), "supported", api.jarContainer(), "jar"
+select usage, apiName, supported.toString(), "supported", api.jarContainer(), "library"
 `,
   dependencies: {
     "ExternalApi.qll": `/** Provides classes and predicates related to handling APIs from external libraries. */

--- a/extensions/ql-vscode/src/data-extensions-editor/queries/query.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/queries/query.ts
@@ -7,6 +7,8 @@ export type Query = {
    * - apiName: the name of the external API. This is a string.
    * - supported: whether the external API is supported by the extension. This should be a string representation of a boolean to satify the result pattern for a problem query.
    * - "supported": a string literal. This is required to make the query a valid problem query.
+   * - libraryName: the name of the library that contains the external API. This is a string and usually the basename of a file.
+   * - "library": a string literal. This is required to make the query a valid problem query.
    */
   mainQuery: string;
   dependencies?: {

--- a/extensions/ql-vscode/src/stories/data-extensions-editor/DataExtensionsEditor.stories.tsx
+++ b/extensions/ql-vscode/src/stories/data-extensions-editor/DataExtensionsEditor.stories.tsx
@@ -34,6 +34,7 @@ DataExtensionsEditor.args = {
   },
   initialExternalApiUsages: [
     {
+      library: "sql2o-1.6.0.jar",
       signature: "org.sql2o.Connection#createQuery(String)",
       packageName: "org.sql2o",
       typeName: "Connection",
@@ -64,6 +65,7 @@ DataExtensionsEditor.args = {
       ],
     },
     {
+      library: "sql2o-1.6.0.jar",
       signature: "org.sql2o.Query#executeScalar(Class)",
       packageName: "org.sql2o",
       typeName: "Query",
@@ -94,6 +96,7 @@ DataExtensionsEditor.args = {
       ],
     },
     {
+      library: "sql2o-1.6.0.jar",
       signature: "org.sql2o.Sql2o#open()",
       packageName: "org.sql2o",
       typeName: "Sql2o",
@@ -124,6 +127,7 @@ DataExtensionsEditor.args = {
       ],
     },
     {
+      library: "rt.jar",
       signature: "java.io.PrintStream#println(String)",
       packageName: "java.io",
       typeName: "PrintStream",
@@ -144,6 +148,7 @@ DataExtensionsEditor.args = {
       ],
     },
     {
+      library: "spring-boot-3.0.2.jar",
       signature:
         "org.springframework.boot.SpringApplication#run(Class,String[])",
       packageName: "org.springframework.boot",
@@ -165,6 +170,7 @@ DataExtensionsEditor.args = {
       ],
     },
     {
+      library: "sql2o-1.6.0.jar",
       signature: "org.sql2o.Sql2o#Sql2o(String,String,String)",
       packageName: "org.sql2o",
       typeName: "Sql2o",
@@ -185,6 +191,7 @@ DataExtensionsEditor.args = {
       ],
     },
     {
+      library: "sql2o-1.6.0.jar",
       signature: "org.sql2o.Sql2o#Sql2o(String)",
       packageName: "org.sql2o",
       typeName: "Sql2o",

--- a/extensions/ql-vscode/src/stories/data-extensions-editor/MethodRow.stories.tsx
+++ b/extensions/ql-vscode/src/stories/data-extensions-editor/MethodRow.stories.tsx
@@ -16,6 +16,7 @@ const Template: ComponentStory<typeof MethodRowComponent> = (args) => (
 export const MethodRow = Template.bind({});
 MethodRow.args = {
   externalApiUsage: {
+    library: "sql2o-1.6.0.jar",
     signature: "org.sql2o.Sql2o#open()",
     packageName: "org.sql2o",
     typeName: "Sql2o",

--- a/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
@@ -235,24 +235,27 @@ export function DataExtensionsEditor({
             <VSCodeDataGrid>
               <VSCodeDataGridRow rowType="header">
                 <VSCodeDataGridCell cellType="columnheader" gridColumn={1}>
-                  Type
+                  Library
                 </VSCodeDataGridCell>
                 <VSCodeDataGridCell cellType="columnheader" gridColumn={2}>
-                  Method
+                  Type
                 </VSCodeDataGridCell>
                 <VSCodeDataGridCell cellType="columnheader" gridColumn={3}>
-                  Usages
+                  Method
                 </VSCodeDataGridCell>
                 <VSCodeDataGridCell cellType="columnheader" gridColumn={4}>
-                  Model type
+                  Usages
                 </VSCodeDataGridCell>
                 <VSCodeDataGridCell cellType="columnheader" gridColumn={5}>
-                  Input
+                  Model type
                 </VSCodeDataGridCell>
                 <VSCodeDataGridCell cellType="columnheader" gridColumn={6}>
-                  Output
+                  Input
                 </VSCodeDataGridCell>
                 <VSCodeDataGridCell cellType="columnheader" gridColumn={7}>
+                  Output
+                </VSCodeDataGridCell>
+                <VSCodeDataGridCell cellType="columnheader" gridColumn={8}>
                   Kind
                 </VSCodeDataGridCell>
               </VSCodeDataGridRow>

--- a/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
@@ -149,6 +149,9 @@ export const MethodRow = ({
   return (
     <VSCodeDataGridRow>
       <VSCodeDataGridCell gridColumn={1}>
+        {externalApiUsage.library}
+      </VSCodeDataGridCell>
+      <VSCodeDataGridCell gridColumn={2}>
         <SupportSpan
           supported={externalApiUsage.supported}
           modeled={modeledMethod}
@@ -156,7 +159,7 @@ export const MethodRow = ({
           {externalApiUsage.packageName}.{externalApiUsage.typeName}
         </SupportSpan>
       </VSCodeDataGridCell>
-      <VSCodeDataGridCell gridColumn={2}>
+      <VSCodeDataGridCell gridColumn={3}>
         <SupportSpan
           supported={externalApiUsage.supported}
           modeled={modeledMethod}
@@ -165,12 +168,12 @@ export const MethodRow = ({
           {externalApiUsage.methodParameters}
         </SupportSpan>
       </VSCodeDataGridCell>
-      <VSCodeDataGridCell gridColumn={3}>
+      <VSCodeDataGridCell gridColumn={4}>
         <UsagesButton onClick={jumpToUsage}>
           {externalApiUsage.usages.length}
         </UsagesButton>
       </VSCodeDataGridCell>
-      <VSCodeDataGridCell gridColumn={4}>
+      <VSCodeDataGridCell gridColumn={5}>
         {(!externalApiUsage.supported ||
           (modeledMethod && modeledMethod?.type !== "none")) && (
           <Dropdown
@@ -185,7 +188,7 @@ export const MethodRow = ({
           </Dropdown>
         )}
       </VSCodeDataGridCell>
-      <VSCodeDataGridCell gridColumn={5}>
+      <VSCodeDataGridCell gridColumn={6}>
         {modeledMethod?.type &&
           ["sink", "summary"].includes(modeledMethod?.type) && (
             <Dropdown value={modeledMethod?.input} onInput={handleInputInput}>
@@ -198,7 +201,7 @@ export const MethodRow = ({
             </Dropdown>
           )}
       </VSCodeDataGridCell>
-      <VSCodeDataGridCell gridColumn={6}>
+      <VSCodeDataGridCell gridColumn={7}>
         {modeledMethod?.type &&
           ["source", "summary"].includes(modeledMethod?.type) && (
             <Dropdown value={modeledMethod?.output} onInput={handleOutputInput}>
@@ -212,7 +215,7 @@ export const MethodRow = ({
             </Dropdown>
           )}
       </VSCodeDataGridCell>
-      <VSCodeDataGridCell gridColumn={7}>
+      <VSCodeDataGridCell gridColumn={8}>
         {predicate?.supportedKinds && (
           <KindInput
             kinds={predicate.supportedKinds}

--- a/extensions/ql-vscode/test/unit-tests/data-extensions-editor/auto-model.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/data-extensions-editor/auto-model.test.ts
@@ -13,6 +13,7 @@ import {
 describe("createAutoModelRequest", () => {
   const externalApiUsages: ExternalApiUsage[] = [
     {
+      library: "spring-boot-3.0.2.jar",
       signature:
         "org.springframework.boot.SpringApplication#run(Class,String[])",
       packageName: "org.springframework.boot",
@@ -34,6 +35,7 @@ describe("createAutoModelRequest", () => {
       ],
     },
     {
+      library: "sql2o-1.6.0.jar",
       signature: "org.sql2o.Connection#createQuery(String)",
       packageName: "org.sql2o",
       typeName: "Connection",
@@ -64,6 +66,7 @@ describe("createAutoModelRequest", () => {
       ],
     },
     {
+      library: "sql2o-1.6.0.jar",
       signature: "org.sql2o.Query#executeScalar(Class)",
       packageName: "org.sql2o",
       typeName: "Query",
@@ -94,6 +97,7 @@ describe("createAutoModelRequest", () => {
       ],
     },
     {
+      library: "sql2o-1.6.0.jar",
       signature: "org.sql2o.Sql2o#open()",
       packageName: "org.sql2o",
       typeName: "Sql2o",
@@ -124,6 +128,7 @@ describe("createAutoModelRequest", () => {
       ],
     },
     {
+      library: "rt.jar",
       signature: "java.io.PrintStream#println(String)",
       packageName: "java.io",
       typeName: "PrintStream",
@@ -144,6 +149,7 @@ describe("createAutoModelRequest", () => {
       ],
     },
     {
+      library: "sql2o-1.6.0.jar",
       signature: "org.sql2o.Sql2o#Sql2o(String,String,String)",
       packageName: "org.sql2o",
       typeName: "Sql2o",
@@ -164,6 +170,7 @@ describe("createAutoModelRequest", () => {
       ],
     },
     {
+      library: "sql2o-1.6.0.jar",
       signature: "org.sql2o.Sql2o#Sql2o(String)",
       packageName: "org.sql2o",
       typeName: "Sql2o",
@@ -184,6 +191,7 @@ describe("createAutoModelRequest", () => {
       ],
     },
     {
+      library: "test.jar",
       signature: "org.test.MyClass#test()",
       packageName: "org.test",
       typeName: "MyClass",

--- a/extensions/ql-vscode/test/unit-tests/data-extensions-editor/yaml.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/data-extensions-editor/yaml.test.ts
@@ -9,6 +9,7 @@ describe("createDataExtensionYaml", () => {
       "java",
       [
         {
+          library: "sql2o-1.6.0.jar",
           signature: "org.sql2o.Connection#createQuery(String)",
           packageName: "org.sql2o",
           typeName: "Connection",
@@ -39,6 +40,7 @@ describe("createDataExtensionYaml", () => {
           ],
         },
         {
+          library: "sql2o-1.6.0.jar",
           signature: "org.sql2o.Query#executeScalar(Class)",
           packageName: "org.sql2o",
           typeName: "Query",


### PR DESCRIPTION
This adds a new library column to the data extensions editor containing the JAR or DLL file the method is defined in. This will be used to group methods by library in the future. For now, it just shows in a column.

![Screenshot 2023-06-16 at 12 02 23](https://github.com/github/vscode-codeql/assets/1112623/87ff1cd4-e785-45ac-9ae1-828085cb2640)


## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
