### PR TITLE
Automatically create different model files per library

### DIFF
--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -532,6 +532,7 @@ export interface OpenExtensionPackMessage {
 
 export interface OpenModelFileMessage {
   t: "openModelFile";
+  library: string;
 }
 
 export interface SaveModeledMethods {

--- a/extensions/ql-vscode/src/common/path.ts
+++ b/extensions/ql-vscode/src/common/path.ts
@@ -19,3 +19,11 @@ export const basename = (path: string): string => {
   const index = path.lastIndexOf("\\");
   return index === -1 ? path : path.slice(index + 1);
 };
+
+// Returns the extension of a path, including the leading dot.
+export const extname = (path: string): string => {
+  const name = basename(path);
+
+  const index = name.lastIndexOf(".");
+  return index === -1 ? "" : name.slice(index);
+};

--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-module.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-module.ts
@@ -8,7 +8,7 @@ import { ensureDir } from "fs-extra";
 import { join } from "path";
 import { App } from "../common/app";
 import { withProgress } from "../common/vscode/progress";
-import { pickExtensionPackModelFile } from "./extension-pack-picker";
+import { pickExtensionPack } from "./extension-pack-picker";
 import { showAndLogErrorMessage } from "../common/logging";
 
 const SUPPORTED_LANGUAGES: string[] = ["java", "csharp"];
@@ -78,7 +78,7 @@ export class DataExtensionsEditorModule {
               return;
             }
 
-            const modelFile = await pickExtensionPackModelFile(
+            const modelFile = await pickExtensionPack(
               this.cliServer,
               db,
               this.app.logger,

--- a/extensions/ql-vscode/src/data-extensions-editor/shared/extension-pack.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/shared/extension-pack.ts
@@ -8,8 +8,3 @@ export interface ExtensionPack {
   extensionTargets: Record<string, string>;
   dataExtensions: string[];
 }
-
-export interface ExtensionPackModelFile {
-  filename: string;
-  extensionPack: ExtensionPack;
-}

--- a/extensions/ql-vscode/src/data-extensions-editor/shared/view-state.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/shared/view-state.ts
@@ -1,7 +1,6 @@
-import { ExtensionPackModelFile } from "./extension-pack";
+import { ExtensionPack } from "./extension-pack";
 
 export interface DataExtensionEditorViewState {
-  extensionPackModelFile: ExtensionPackModelFile;
-  modelFileExists: boolean;
+  extensionPack: ExtensionPack;
   showLlmButton: boolean;
 }

--- a/extensions/ql-vscode/src/data-extensions-editor/yaml.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/yaml.ts
@@ -124,7 +124,11 @@ export function createDataExtensionYamlsPerLibrary(
 const semverRegex =
   /[v=\s]*([0-9]+)\.([0-9]+)\.([0-9]+)(?:-?((?:[0-9]+|\d*[a-zA-Z-][a-zA-Z0-9-]*)(?:\.(?:[0-9]+|\d*[a-zA-Z-][a-zA-Z0-9-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?/;
 
-export function createFilenameForLibrary(library: string, prefix = "models/") {
+export function createFilenameForLibrary(
+  library: string,
+  prefix = "models/",
+  suffix = ".model",
+) {
   let libraryName = basename(library);
   const extension = extname(libraryName);
   libraryName = libraryName.slice(0, -extension.length);
@@ -153,7 +157,7 @@ export function createFilenameForLibrary(library: string, prefix = "models/") {
   // Remove any duplicate dots
   libraryName = libraryName.replaceAll(/\.{2,}/g, ".");
 
-  return `${prefix}${libraryName}.yml`;
+  return `${prefix}${libraryName}${suffix}.yml`;
 }
 
 export function loadDataExtensionYaml(

--- a/extensions/ql-vscode/src/stories/data-extensions-editor/DataExtensionsEditor.stories.tsx
+++ b/extensions/ql-vscode/src/stories/data-extensions-editor/DataExtensionsEditor.stories.tsx
@@ -16,20 +16,15 @@ const Template: ComponentStory<typeof DataExtensionsEditorComponent> = (
 export const DataExtensionsEditor = Template.bind({});
 DataExtensionsEditor.args = {
   initialViewState: {
-    extensionPackModelFile: {
-      extensionPack: {
-        path: "/home/user/vscode-codeql-starter/codeql-custom-queries-java/sql2o",
-        yamlPath:
-          "/home/user/vscode-codeql-starter/codeql-custom-queries-java/sql2o/codeql-pack.yml",
-        name: "codeql/sql2o-models",
-        version: "0.0.0",
-        extensionTargets: {},
-        dataExtensions: [],
-      },
-      filename:
-        "/home/user/vscode-codeql-starter/codeql-custom-queries-java/sql2o/models/sql2o.yml",
+    extensionPack: {
+      path: "/home/user/vscode-codeql-starter/codeql-custom-queries-java/sql2o",
+      yamlPath:
+        "/home/user/vscode-codeql-starter/codeql-custom-queries-java/sql2o/codeql-pack.yml",
+      name: "codeql/sql2o-models",
+      version: "0.0.0",
+      extensionTargets: {},
+      dataExtensions: [],
     },
-    modelFileExists: true,
     showLlmButton: true,
   },
   initialExternalApiUsages: [

--- a/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
@@ -12,7 +12,6 @@ import { assertNever } from "../../common/helpers-pure";
 import { vscode } from "../vscode-api";
 import { calculateModeledPercentage } from "./modeled";
 import { LinkIconButton } from "../variant-analysis/LinkIconButton";
-import { basename } from "../common/path";
 import { ViewTitle } from "../common";
 import { DataExtensionEditorViewState } from "../../data-extensions-editor/shared/view-state";
 import { ModeledMethodsList } from "./ModeledMethodsList";
@@ -25,12 +24,6 @@ const DataExtensionsEditorContainer = styled.div`
 const DetailsContainer = styled.div`
   display: flex;
   gap: 1em;
-  align-items: center;
-`;
-
-const NonExistingModelFileContainer = styled.div`
-  display: flex;
-  gap: 0.2em;
   align-items: center;
 `;
 
@@ -173,12 +166,6 @@ export function DataExtensionsEditor({
     });
   }, []);
 
-  const onOpenModelFileClick = useCallback(() => {
-    vscode.postMessage({
-      t: "openModelFile",
-    });
-  }, []);
-
   return (
     <DataExtensionsEditorContainer>
       {progress.maxStep > 0 && (
@@ -192,26 +179,12 @@ export function DataExtensionsEditor({
         <>
           <ViewTitle>Data extensions editor</ViewTitle>
           <DetailsContainer>
-            {viewState?.extensionPackModelFile && (
+            {viewState?.extensionPack && (
               <>
                 <LinkIconButton onClick={onOpenExtensionPackClick}>
                   <span slot="start" className="codicon codicon-package"></span>
-                  {viewState.extensionPackModelFile.extensionPack.name}
+                  {viewState.extensionPack.name}
                 </LinkIconButton>
-                {viewState.modelFileExists ? (
-                  <LinkIconButton onClick={onOpenModelFileClick}>
-                    <span
-                      slot="start"
-                      className="codicon codicon-file-code"
-                    ></span>
-                    {basename(viewState.extensionPackModelFile.filename)}
-                  </LinkIconButton>
-                ) : (
-                  <NonExistingModelFileContainer>
-                    <span className="codicon codicon-file-code"></span>
-                    {basename(viewState.extensionPackModelFile.filename)}
-                  </NonExistingModelFileContainer>
-                )}
               </>
             )}
             <div>

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisHeader.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisHeader.tsx
@@ -14,7 +14,7 @@ import { QueryDetails } from "./QueryDetails";
 import { VariantAnalysisActions } from "./VariantAnalysisActions";
 import { VariantAnalysisStats } from "./VariantAnalysisStats";
 import { parseDate } from "../../common/date";
-import { basename } from "../common/path";
+import { basename } from "../../common/path";
 import {
   defaultFilterSortState,
   filterAndSortRepositoriesWithResults,

--- a/extensions/ql-vscode/test/unit-tests/common/path.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/common/path.test.ts
@@ -1,6 +1,6 @@
-import { basename } from "../path";
+import { basename, extname } from "../../../src/common/path";
 
-describe(basename.name, () => {
+describe("basename", () => {
   const testCases = [
     { path: "test.ql", expected: "test.ql" },
     { path: "PLACEHOLDER/q0.ql", expected: "q0.ql" },
@@ -38,6 +38,28 @@ describe(basename.name, () => {
     "basename of $path is $expected",
     ({ path, expected }) => {
       expect(basename(path)).toEqual(expected);
+    },
+  );
+});
+
+describe("extname", () => {
+  const testCases = [
+    { path: "test.ql", expected: ".ql" },
+    { path: "PLACEHOLDER/q0.ql", expected: ".ql" },
+    {
+      path: "/etc/hosts/",
+      expected: "",
+    },
+    {
+      path: "/etc/hosts",
+      expected: "",
+    },
+  ];
+
+  test.each(testCases)(
+    "extname of $path is $expected",
+    ({ path, expected }) => {
+      expect(extname(path)).toEqual(expected);
     },
   );
 });

--- a/extensions/ql-vscode/test/unit-tests/data-extensions-editor/yaml.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/data-extensions-editor/yaml.test.ts
@@ -1,11 +1,142 @@
 import {
   createDataExtensionYaml,
+  createDataExtensionYamlsPerLibrary,
+  createFilenameForLibrary,
   loadDataExtensionYaml,
 } from "../../../src/data-extensions-editor/yaml";
 
 describe("createDataExtensionYaml", () => {
   it("creates the correct YAML file", () => {
-    const yaml = createDataExtensionYaml(
+    const yaml = createDataExtensionYaml("java", [
+      {
+        externalApiUsage: {
+          library: "sql2o-1.6.0.jar",
+          signature: "org.sql2o.Connection#createQuery(String)",
+          packageName: "org.sql2o",
+          typeName: "Connection",
+          methodName: "createQuery",
+          methodParameters: "(String)",
+          supported: true,
+          usages: [
+            {
+              label: "createQuery(...)",
+              url: {
+                uri: "file:/home/runner/work/sql2o-example/sql2o-example/src/main/java/org/example/HelloController.java",
+                startLine: 15,
+                startColumn: 13,
+                endLine: 15,
+                endColumn: 56,
+              },
+            },
+            {
+              label: "createQuery(...)",
+              url: {
+                uri: "file:/home/runner/work/sql2o-example/sql2o-example/src/main/java/org/example/HelloController.java",
+                startLine: 26,
+                startColumn: 13,
+                endLine: 26,
+                endColumn: 39,
+              },
+            },
+          ],
+        },
+        modeledMethod: {
+          type: "sink",
+          input: "Argument[0]",
+          output: "",
+          kind: "sql",
+          provenance: "df-generated",
+        },
+      },
+      {
+        externalApiUsage: {
+          library: "sql2o-1.6.0.jar",
+          signature: "org.sql2o.Query#executeScalar(Class)",
+          packageName: "org.sql2o",
+          typeName: "Query",
+          methodName: "executeScalar",
+          methodParameters: "(Class)",
+          supported: true,
+          usages: [
+            {
+              label: "executeScalar(...)",
+              url: {
+                uri: "file:/home/runner/work/sql2o-example/sql2o-example/src/main/java/org/example/HelloController.java",
+                startLine: 15,
+                startColumn: 13,
+                endLine: 15,
+                endColumn: 85,
+              },
+            },
+            {
+              label: "executeScalar(...)",
+              url: {
+                uri: "file:/home/runner/work/sql2o-example/sql2o-example/src/main/java/org/example/HelloController.java",
+                startLine: 26,
+                startColumn: 13,
+                endLine: 26,
+                endColumn: 68,
+              },
+            },
+          ],
+        },
+      },
+    ]);
+
+    expect(yaml).toEqual(`extensions:
+  - addsTo:
+      pack: codeql/java-all
+      extensible: sourceModel
+    data: []
+
+  - addsTo:
+      pack: codeql/java-all
+      extensible: sinkModel
+    data:
+      - ["org.sql2o","Connection",true,"createQuery","(String)","","Argument[0]","sql","df-generated"]
+
+  - addsTo:
+      pack: codeql/java-all
+      extensible: summaryModel
+    data: []
+
+  - addsTo:
+      pack: codeql/java-all
+      extensible: neutralModel
+    data: []
+`);
+  });
+
+  it("includes the correct language", () => {
+    const yaml = createDataExtensionYaml("csharp", []);
+
+    expect(yaml).toEqual(`extensions:
+  - addsTo:
+      pack: codeql/csharp-all
+      extensible: sourceModel
+    data: []
+
+  - addsTo:
+      pack: codeql/csharp-all
+      extensible: sinkModel
+    data: []
+
+  - addsTo:
+      pack: codeql/csharp-all
+      extensible: summaryModel
+    data: []
+
+  - addsTo:
+      pack: codeql/csharp-all
+      extensible: neutralModel
+    data: []
+`);
+  });
+});
+
+describe("createDataExtensionYamlsPerLibrary", () => {
+  it("creates the correct YAML files", () => {
+    const yaml = createDataExtensionYamlsPerLibrary(
       "java",
       [
         {
@@ -70,6 +201,70 @@ describe("createDataExtensionYaml", () => {
             },
           ],
         },
+        {
+          library: "sql2o-2.5.0-alpha1.jar",
+          signature: "org.sql2o.Sql2o#Sql2o(String,String,String)",
+          packageName: "org.sql2o",
+          typeName: "Sql2o",
+          methodName: "Sql2o",
+          methodParameters: "(String,String,String)",
+          supported: false,
+          usages: [
+            {
+              label: "new Sql2o(...)",
+              url: {
+                uri: "file:/home/runner/work/sql2o-example/sql2o-example/src/main/java/org/example/HelloController.java",
+                startLine: 10,
+                startColumn: 33,
+                endLine: 10,
+                endColumn: 88,
+              },
+            },
+          ],
+        },
+        {
+          library: "spring-boot-3.0.2.jar",
+          signature:
+            "org.springframework.boot.SpringApplication#run(Class,String[])",
+          packageName: "org.springframework.boot",
+          typeName: "SpringApplication",
+          methodName: "run",
+          methodParameters: "(Class,String[])",
+          supported: false,
+          usages: [
+            {
+              label: "run(...)",
+              url: {
+                uri: "file:/home/runner/work/sql2o-example/sql2o-example/src/main/java/org/example/Sql2oExampleApplication.java",
+                startLine: 9,
+                startColumn: 9,
+                endLine: 9,
+                endColumn: 66,
+              },
+            },
+          ],
+        },
+        {
+          library: "rt.jar",
+          signature: "java.io.PrintStream#println(String)",
+          packageName: "java.io",
+          typeName: "PrintStream",
+          methodName: "println",
+          methodParameters: "(String)",
+          supported: true,
+          usages: [
+            {
+              label: "println(...)",
+              url: {
+                uri: "file:/home/runner/work/sql2o-example/sql2o-example/src/main/java/org/example/HelloController.java",
+                startLine: 29,
+                startColumn: 9,
+                endLine: 29,
+                endColumn: 49,
+              },
+            },
+          ],
+        },
       ],
       {
         "org.sql2o.Connection#createQuery(String)": {
@@ -79,10 +274,25 @@ describe("createDataExtensionYaml", () => {
           kind: "sql",
           provenance: "df-generated",
         },
+        "org.springframework.boot.SpringApplication#run(Class,String[])": {
+          type: "neutral",
+          input: "",
+          output: "",
+          kind: "summary",
+          provenance: "manual",
+        },
+        "org.sql2o.Sql2o#Sql2o(String,String,String)": {
+          type: "sink",
+          input: "Argument[0]",
+          output: "",
+          kind: "jndi",
+          provenance: "manual",
+        },
       },
     );
 
-    expect(yaml).toEqual(`extensions:
+    expect(yaml).toEqual({
+      "models/sql2o.yml": `extensions:
   - addsTo:
       pack: codeql/java-all
       extensible: sourceModel
@@ -93,6 +303,7 @@ describe("createDataExtensionYaml", () => {
       extensible: sinkModel
     data:
       - ["org.sql2o","Connection",true,"createQuery","(String)","","Argument[0]","sql","df-generated"]
+      - ["org.sql2o","Sql2o",true,"Sql2o","(String,String,String)","","Argument[0]","jndi","manual"]
 
   - addsTo:
       pack: codeql/java-all
@@ -103,33 +314,30 @@ describe("createDataExtensionYaml", () => {
       pack: codeql/java-all
       extensible: neutralModel
     data: []
-`);
-  });
-
-  it("includes the correct language", () => {
-    const yaml = createDataExtensionYaml("csharp", [], {});
-
-    expect(yaml).toEqual(`extensions:
+`,
+      "models/spring-boot.yml": `extensions:
   - addsTo:
-      pack: codeql/csharp-all
+      pack: codeql/java-all
       extensible: sourceModel
     data: []
 
   - addsTo:
-      pack: codeql/csharp-all
+      pack: codeql/java-all
       extensible: sinkModel
     data: []
 
   - addsTo:
-      pack: codeql/csharp-all
+      pack: codeql/java-all
       extensible: summaryModel
     data: []
 
   - addsTo:
-      pack: codeql/csharp-all
+      pack: codeql/java-all
       extensible: neutralModel
-    data: []
-`);
+    data:
+      - ["org.springframework.boot","SpringApplication","run","(Class,String[])","summary","manual"]
+`,
+    });
   });
 });
 
@@ -190,4 +398,49 @@ describe("loadDataExtensionYaml", () => {
 `),
     ).toThrow("Invalid data extension YAML:  must be object");
   });
+});
+
+describe("createFilenameForLibrary", () => {
+  const testCases = [
+    { library: "sql2o.jar", filename: "models/sql2o.yml" },
+    {
+      library: "sql2o-1.6.0.jar",
+      filename: "models/sql2o.yml",
+    },
+    {
+      library: "spring-boot-3.0.2.jar",
+      filename: "models/spring-boot.yml",
+    },
+    {
+      library: "spring-boot-v3.0.2.jar",
+      filename: "models/spring-boot.yml",
+    },
+    {
+      library: "spring-boot-3.0.2-alpha1.jar",
+      filename: "models/spring-boot.yml",
+    },
+    {
+      library: "spring-boot-3.0.2beta2.jar",
+      filename: "models/spring-boot.yml",
+    },
+    {
+      library: "rt.jar",
+      filename: "models/rt.yml",
+    },
+    {
+      library: "System.Runtime.dll",
+      filename: "models/system.runtime.yml",
+    },
+    {
+      library: "System.Runtime.1.5.0.dll",
+      filename: "models/system.runtime.yml",
+    },
+  ];
+
+  test.each(testCases)(
+    "returns $filename if library name is $library",
+    ({ library, filename }) => {
+      expect(createFilenameForLibrary(library)).toEqual(filename);
+    },
+  );
 });

--- a/extensions/ql-vscode/test/unit-tests/data-extensions-editor/yaml.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/data-extensions-editor/yaml.test.ts
@@ -292,7 +292,7 @@ describe("createDataExtensionYamlsPerLibrary", () => {
     );
 
     expect(yaml).toEqual({
-      "models/sql2o.yml": `extensions:
+      "models/sql2o.model.yml": `extensions:
   - addsTo:
       pack: codeql/java-all
       extensible: sourceModel
@@ -315,7 +315,7 @@ describe("createDataExtensionYamlsPerLibrary", () => {
       extensible: neutralModel
     data: []
 `,
-      "models/spring-boot.yml": `extensions:
+      "models/spring-boot.model.yml": `extensions:
   - addsTo:
       pack: codeql/java-all
       extensible: sourceModel
@@ -402,38 +402,38 @@ describe("loadDataExtensionYaml", () => {
 
 describe("createFilenameForLibrary", () => {
   const testCases = [
-    { library: "sql2o.jar", filename: "models/sql2o.yml" },
+    { library: "sql2o.jar", filename: "models/sql2o.model.yml" },
     {
       library: "sql2o-1.6.0.jar",
-      filename: "models/sql2o.yml",
+      filename: "models/sql2o.model.yml",
     },
     {
       library: "spring-boot-3.0.2.jar",
-      filename: "models/spring-boot.yml",
+      filename: "models/spring-boot.model.yml",
     },
     {
       library: "spring-boot-v3.0.2.jar",
-      filename: "models/spring-boot.yml",
+      filename: "models/spring-boot.model.yml",
     },
     {
       library: "spring-boot-3.0.2-alpha1.jar",
-      filename: "models/spring-boot.yml",
+      filename: "models/spring-boot.model.yml",
     },
     {
       library: "spring-boot-3.0.2beta2.jar",
-      filename: "models/spring-boot.yml",
+      filename: "models/spring-boot.model.yml",
     },
     {
       library: "rt.jar",
-      filename: "models/rt.yml",
+      filename: "models/rt.model.yml",
     },
     {
       library: "System.Runtime.dll",
-      filename: "models/system.runtime.yml",
+      filename: "models/system.runtime.model.yml",
     },
     {
       library: "System.Runtime.1.5.0.dll",
-      filename: "models/system.runtime.yml",
+      filename: "models/system.runtime.model.yml",
     },
   ];
 


### PR DESCRIPTION
This will remove the user input for a model file and will instead create 1 model file per library (JAR/DLL). The model filename will be based on the JAR/DLL name, but will remove the version number and the file extension. It will also normalize the name.

These files will be created automatically, and the editor now also reads in all files contained in an extension pack to read the modeled methods. This could result in duplicates if the user has created a different file to contain the same modeled methods, but this is an edge-case that we're explicitly not handling.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
