### PR TITLE
Group modeled methods by library in the data extensions editor

### DIFF
--- a/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
@@ -4,16 +4,10 @@ import {
   ShowProgressMessage,
   ToDataExtensionsEditorMessage,
 } from "../../pure/interface-types";
-import {
-  VSCodeButton,
-  VSCodeDataGrid,
-  VSCodeDataGridCell,
-  VSCodeDataGridRow,
-} from "@vscode/webview-ui-toolkit/react";
+import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
 import styled from "styled-components";
 import { ExternalApiUsage } from "../../data-extensions-editor/external-api-usage";
 import { ModeledMethod } from "../../data-extensions-editor/modeled-method";
-import { MethodRow } from "./MethodRow";
 import { assertNever } from "../../pure/helpers-pure";
 import { vscode } from "../vscode-api";
 import { calculateModeledPercentage } from "./modeled";
@@ -21,6 +15,7 @@ import { LinkIconButton } from "../variant-analysis/LinkIconButton";
 import { basename } from "../common/path";
 import { ViewTitle } from "../common";
 import { DataExtensionEditorViewState } from "../../data-extensions-editor/shared/view-state";
+import { ModeledMethodDataGrid } from "./ModeledMethodDataGrid";
 
 const DataExtensionsEditorContainer = styled.div`
   margin-top: 1rem;
@@ -40,6 +35,12 @@ const NonExistingModelFileContainer = styled.div`
 
 const EditorContainer = styled.div`
   margin-top: 1rem;
+`;
+
+const ButtonsContainer = styled.div`
+  display: flex;
+  gap: 0.4em;
+  margin-bottom: 1rem;
 `;
 
 type ProgressBarProps = {
@@ -217,57 +218,24 @@ export function DataExtensionsEditor({
           </DetailsContainer>
 
           <EditorContainer>
-            <VSCodeButton onClick={onApplyClick}>Apply</VSCodeButton>
-            &nbsp;
-            <VSCodeButton onClick={onGenerateClick}>
-              Download and generate
-            </VSCodeButton>
-            {viewState?.showLlmButton && (
-              <>
-                &nbsp;
-                <VSCodeButton onClick={onGenerateFromLlmClick}>
-                  Generate using LLM
-                </VSCodeButton>
-              </>
-            )}
-            <br />
-            <br />
-            <VSCodeDataGrid>
-              <VSCodeDataGridRow rowType="header">
-                <VSCodeDataGridCell cellType="columnheader" gridColumn={1}>
-                  Library
-                </VSCodeDataGridCell>
-                <VSCodeDataGridCell cellType="columnheader" gridColumn={2}>
-                  Type
-                </VSCodeDataGridCell>
-                <VSCodeDataGridCell cellType="columnheader" gridColumn={3}>
-                  Method
-                </VSCodeDataGridCell>
-                <VSCodeDataGridCell cellType="columnheader" gridColumn={4}>
-                  Usages
-                </VSCodeDataGridCell>
-                <VSCodeDataGridCell cellType="columnheader" gridColumn={5}>
-                  Model type
-                </VSCodeDataGridCell>
-                <VSCodeDataGridCell cellType="columnheader" gridColumn={6}>
-                  Input
-                </VSCodeDataGridCell>
-                <VSCodeDataGridCell cellType="columnheader" gridColumn={7}>
-                  Output
-                </VSCodeDataGridCell>
-                <VSCodeDataGridCell cellType="columnheader" gridColumn={8}>
-                  Kind
-                </VSCodeDataGridCell>
-              </VSCodeDataGridRow>
-              {externalApiUsages.map((externalApiUsage) => (
-                <MethodRow
-                  key={externalApiUsage.signature}
-                  externalApiUsage={externalApiUsage}
-                  modeledMethod={modeledMethods[externalApiUsage.signature]}
-                  onChange={onChange}
-                />
-              ))}
-            </VSCodeDataGrid>
+            <ButtonsContainer>
+              <VSCodeButton onClick={onApplyClick}>Apply</VSCodeButton>
+              <VSCodeButton onClick={onGenerateClick}>
+                Download and generate
+              </VSCodeButton>
+              {viewState?.showLlmButton && (
+                <>
+                  <VSCodeButton onClick={onGenerateFromLlmClick}>
+                    Generate using LLM
+                  </VSCodeButton>
+                </>
+              )}
+            </ButtonsContainer>
+            <ModeledMethodDataGrid
+              externalApiUsages={externalApiUsages}
+              modeledMethods={modeledMethods}
+              onChange={onChange}
+            />
           </EditorContainer>
         </>
       )}

--- a/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
@@ -15,7 +15,7 @@ import { LinkIconButton } from "../variant-analysis/LinkIconButton";
 import { basename } from "../common/path";
 import { ViewTitle } from "../common";
 import { DataExtensionEditorViewState } from "../../data-extensions-editor/shared/view-state";
-import { ModeledMethodDataGrid } from "./ModeledMethodDataGrid";
+import { ModeledMethodsList } from "./ModeledMethodsList";
 
 const DataExtensionsEditorContainer = styled.div`
   margin-top: 1rem;
@@ -231,7 +231,7 @@ export function DataExtensionsEditor({
                 </>
               )}
             </ButtonsContainer>
-            <ModeledMethodDataGrid
+            <ModeledMethodsList
               externalApiUsages={externalApiUsages}
               modeledMethods={modeledMethods}
               onChange={onChange}

--- a/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
@@ -149,9 +149,6 @@ export const MethodRow = ({
   return (
     <VSCodeDataGridRow>
       <VSCodeDataGridCell gridColumn={1}>
-        {externalApiUsage.library}
-      </VSCodeDataGridCell>
-      <VSCodeDataGridCell gridColumn={2}>
         <SupportSpan
           supported={externalApiUsage.supported}
           modeled={modeledMethod}
@@ -159,7 +156,7 @@ export const MethodRow = ({
           {externalApiUsage.packageName}.{externalApiUsage.typeName}
         </SupportSpan>
       </VSCodeDataGridCell>
-      <VSCodeDataGridCell gridColumn={3}>
+      <VSCodeDataGridCell gridColumn={2}>
         <SupportSpan
           supported={externalApiUsage.supported}
           modeled={modeledMethod}
@@ -168,12 +165,12 @@ export const MethodRow = ({
           {externalApiUsage.methodParameters}
         </SupportSpan>
       </VSCodeDataGridCell>
-      <VSCodeDataGridCell gridColumn={4}>
+      <VSCodeDataGridCell gridColumn={3}>
         <UsagesButton onClick={jumpToUsage}>
           {externalApiUsage.usages.length}
         </UsagesButton>
       </VSCodeDataGridCell>
-      <VSCodeDataGridCell gridColumn={5}>
+      <VSCodeDataGridCell gridColumn={4}>
         {(!externalApiUsage.supported ||
           (modeledMethod && modeledMethod?.type !== "none")) && (
           <Dropdown
@@ -188,7 +185,7 @@ export const MethodRow = ({
           </Dropdown>
         )}
       </VSCodeDataGridCell>
-      <VSCodeDataGridCell gridColumn={6}>
+      <VSCodeDataGridCell gridColumn={5}>
         {modeledMethod?.type &&
           ["sink", "summary"].includes(modeledMethod?.type) && (
             <Dropdown value={modeledMethod?.input} onInput={handleInputInput}>
@@ -201,7 +198,7 @@ export const MethodRow = ({
             </Dropdown>
           )}
       </VSCodeDataGridCell>
-      <VSCodeDataGridCell gridColumn={7}>
+      <VSCodeDataGridCell gridColumn={6}>
         {modeledMethod?.type &&
           ["source", "summary"].includes(modeledMethod?.type) && (
             <Dropdown value={modeledMethod?.output} onInput={handleOutputInput}>
@@ -215,7 +212,7 @@ export const MethodRow = ({
             </Dropdown>
           )}
       </VSCodeDataGridCell>
-      <VSCodeDataGridCell gridColumn={8}>
+      <VSCodeDataGridCell gridColumn={7}>
         {predicate?.supportedKinds && (
           <KindInput
             kinds={predicate.supportedKinds}

--- a/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodDataGrid.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodDataGrid.tsx
@@ -26,27 +26,24 @@ export const ModeledMethodDataGrid = ({
     <VSCodeDataGrid>
       <VSCodeDataGridRow rowType="header">
         <VSCodeDataGridCell cellType="columnheader" gridColumn={1}>
-          Library
-        </VSCodeDataGridCell>
-        <VSCodeDataGridCell cellType="columnheader" gridColumn={2}>
           Type
         </VSCodeDataGridCell>
-        <VSCodeDataGridCell cellType="columnheader" gridColumn={3}>
+        <VSCodeDataGridCell cellType="columnheader" gridColumn={2}>
           Method
         </VSCodeDataGridCell>
-        <VSCodeDataGridCell cellType="columnheader" gridColumn={4}>
+        <VSCodeDataGridCell cellType="columnheader" gridColumn={3}>
           Usages
         </VSCodeDataGridCell>
-        <VSCodeDataGridCell cellType="columnheader" gridColumn={5}>
+        <VSCodeDataGridCell cellType="columnheader" gridColumn={4}>
           Model type
         </VSCodeDataGridCell>
-        <VSCodeDataGridCell cellType="columnheader" gridColumn={6}>
+        <VSCodeDataGridCell cellType="columnheader" gridColumn={5}>
           Input
         </VSCodeDataGridCell>
-        <VSCodeDataGridCell cellType="columnheader" gridColumn={7}>
+        <VSCodeDataGridCell cellType="columnheader" gridColumn={6}>
           Output
         </VSCodeDataGridCell>
-        <VSCodeDataGridCell cellType="columnheader" gridColumn={8}>
+        <VSCodeDataGridCell cellType="columnheader" gridColumn={7}>
           Kind
         </VSCodeDataGridCell>
       </VSCodeDataGridRow>

--- a/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodDataGrid.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodDataGrid.tsx
@@ -1,0 +1,63 @@
+import * as React from "react";
+import {
+  VSCodeDataGrid,
+  VSCodeDataGridCell,
+  VSCodeDataGridRow,
+} from "@vscode/webview-ui-toolkit/react";
+import { MethodRow } from "./MethodRow";
+import { ExternalApiUsage } from "../../data-extensions-editor/external-api-usage";
+import { ModeledMethod } from "../../data-extensions-editor/modeled-method";
+
+type Props = {
+  externalApiUsages: ExternalApiUsage[];
+  modeledMethods: Record<string, ModeledMethod>;
+  onChange: (
+    externalApiUsage: ExternalApiUsage,
+    modeledMethod: ModeledMethod,
+  ) => void;
+};
+
+export const ModeledMethodDataGrid = ({
+  externalApiUsages,
+  modeledMethods,
+  onChange,
+}: Props) => {
+  return (
+    <VSCodeDataGrid>
+      <VSCodeDataGridRow rowType="header">
+        <VSCodeDataGridCell cellType="columnheader" gridColumn={1}>
+          Library
+        </VSCodeDataGridCell>
+        <VSCodeDataGridCell cellType="columnheader" gridColumn={2}>
+          Type
+        </VSCodeDataGridCell>
+        <VSCodeDataGridCell cellType="columnheader" gridColumn={3}>
+          Method
+        </VSCodeDataGridCell>
+        <VSCodeDataGridCell cellType="columnheader" gridColumn={4}>
+          Usages
+        </VSCodeDataGridCell>
+        <VSCodeDataGridCell cellType="columnheader" gridColumn={5}>
+          Model type
+        </VSCodeDataGridCell>
+        <VSCodeDataGridCell cellType="columnheader" gridColumn={6}>
+          Input
+        </VSCodeDataGridCell>
+        <VSCodeDataGridCell cellType="columnheader" gridColumn={7}>
+          Output
+        </VSCodeDataGridCell>
+        <VSCodeDataGridCell cellType="columnheader" gridColumn={8}>
+          Kind
+        </VSCodeDataGridCell>
+      </VSCodeDataGridRow>
+      {externalApiUsages.map((externalApiUsage) => (
+        <MethodRow
+          key={externalApiUsage.signature}
+          externalApiUsage={externalApiUsage}
+          modeledMethod={modeledMethods[externalApiUsage.signature]}
+          onChange={onChange}
+        />
+      ))}
+    </VSCodeDataGrid>
+  );
+};

--- a/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodsList.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodsList.tsx
@@ -1,0 +1,55 @@
+import * as React from "react";
+import { useMemo } from "react";
+import styled from "styled-components";
+import { ExternalApiUsage } from "../../data-extensions-editor/external-api-usage";
+import { ModeledMethod } from "../../data-extensions-editor/modeled-method";
+import { ModeledMethodDataGrid } from "./ModeledMethodDataGrid";
+
+const LibraryContainer = styled.div`
+  margin-bottom: 1rem;
+`;
+
+type Props = {
+  externalApiUsages: ExternalApiUsage[];
+  modeledMethods: Record<string, ModeledMethod>;
+  onChange: (
+    externalApiUsage: ExternalApiUsage,
+    modeledMethod: ModeledMethod,
+  ) => void;
+};
+
+export const ModeledMethodsList = ({
+  externalApiUsages,
+  modeledMethods,
+  onChange,
+}: Props) => {
+  const groupedByLibrary = useMemo(() => {
+    const groupedByLibrary: Record<string, ExternalApiUsage[]> = {};
+
+    for (const externalApiUsage of externalApiUsages) {
+      groupedByLibrary[externalApiUsage.library] ??= [];
+      groupedByLibrary[externalApiUsage.library].push(externalApiUsage);
+    }
+
+    return groupedByLibrary;
+  }, [externalApiUsages]);
+
+  const sortedLibraryNames = useMemo(() => {
+    return Object.keys(groupedByLibrary).sort();
+  }, [groupedByLibrary]);
+
+  return (
+    <>
+      {sortedLibraryNames.map((libraryName) => (
+        <LibraryContainer key={libraryName}>
+          <h3>{libraryName}</h3>
+          <ModeledMethodDataGrid
+            externalApiUsages={groupedByLibrary[libraryName]}
+            modeledMethods={modeledMethods}
+            onChange={onChange}
+          />
+        </LibraryContainer>
+      ))}
+    </>
+  );
+};


### PR DESCRIPTION
This groups the modeled methods in the data extensions editor by library:

![Screenshot 2023-06-19 at 12 11 11](https://github.com/github/vscode-codeql/assets/1112623/9025139b-705e-4972-8250-04ea06206e9c)

For now, it's sorted by name. Follow-up PRs will change this to be based on other factors, such as usages and the modeled percentage.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
