### PR TITLE
Display different message when queries are loading vs no queries found

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1686,7 +1686,7 @@
       },
       {
         "view": "codeQLQueries",
-        "contents": "This workspace doesn't contain any CodeQL queries at the moment."
+        "contents": "Looking for queries..."
       },
       {
         "view": "codeQLDatabases",

--- a/extensions/ql-vscode/src/common/vscode/file-path-discovery.ts
+++ b/extensions/ql-vscode/src/common/vscode/file-path-discovery.ts
@@ -34,6 +34,12 @@ interface PathData {
  * relevant, and what extra data to compute for each file.
  */
 export abstract class FilePathDiscovery<T extends PathData> extends Discovery {
+  /**
+   * Has `discover` been called. This allows distinguishing between
+   * "no paths found" and not having scanned yet.
+   */
+  private discoverHasCompletedOnce = false;
+
   /** The set of known paths and associated data that we are tracking */
   private pathData: T[] = [];
 
@@ -73,7 +79,10 @@ export abstract class FilePathDiscovery<T extends PathData> extends Discovery {
     this.push(this.watcher.onDidChange(this.fileChanged.bind(this)));
   }
 
-  protected getPathData(): ReadonlyArray<Readonly<T>> {
+  protected getPathData(): ReadonlyArray<Readonly<T>> | undefined {
+    if (!this.discoverHasCompletedOnce) {
+      return undefined;
+    }
     return this.pathData;
   }
 
@@ -171,6 +180,7 @@ export abstract class FilePathDiscovery<T extends PathData> extends Discovery {
       }
     }
 
+    this.discoverHasCompletedOnce = true;
     if (pathsUpdated) {
       this.onDidChangePathDataEmitter.fire();
     }

--- a/extensions/ql-vscode/src/common/vscode/file-path-discovery.ts
+++ b/extensions/ql-vscode/src/common/vscode/file-path-discovery.ts
@@ -127,7 +127,8 @@ export abstract class FilePathDiscovery<T extends PathData> extends Discovery {
     });
 
     this.updateWatchers();
-    return this.refresh();
+    await this.refresh();
+    this.onDidChangePathDataEmitter.fire();
   }
 
   private workspaceFoldersChanged(event: WorkspaceFoldersChangeEvent) {

--- a/extensions/ql-vscode/src/local-queries/local-queries.ts
+++ b/extensions/ql-vscode/src/local-queries/local-queries.ts
@@ -48,10 +48,7 @@ import { SkeletonQueryWizard } from "../skeleton-query-wizard";
 import { LocalQueryRun } from "./local-query-run";
 import { createMultiSelectionCommand } from "../common/vscode/selection-commands";
 import { findLanguage } from "../codeql-cli/query-language";
-import {
-  QueryTreeQueryItem,
-  QueryTreeViewItem,
-} from "../queries-panel/query-tree-view-item";
+import { QueryTreeViewItem } from "../queries-panel/query-tree-view-item";
 
 interface DatabaseQuickPickItem extends QuickPickItem {
   databaseItem: DatabaseItem;
@@ -133,7 +130,7 @@ export class LocalQueries extends DisposableObject {
   private async runQueryFromQueriesPanel(
     queryTreeViewItem: QueryTreeViewItem,
   ): Promise<void> {
-    if (queryTreeViewItem instanceof QueryTreeQueryItem) {
+    if (queryTreeViewItem.path !== undefined) {
       await this.runQuery(Uri.file(queryTreeViewItem.path));
     }
   }
@@ -141,12 +138,13 @@ export class LocalQueries extends DisposableObject {
   private async runQueriesFromQueriesPanel(
     queryTreeViewItem: QueryTreeViewItem,
   ): Promise<void> {
-    if (queryTreeViewItem instanceof QueryTreeQueryItem) {
-      const uris = queryTreeViewItem.children.map((child) =>
-        Uri.file(child.path),
-      );
-      await this.runQueries(uris);
+    const uris = [];
+    for (const child of queryTreeViewItem.children) {
+      if (child.path !== undefined) {
+        uris.push(Uri.file(child.path));
+      }
     }
+    await this.runQueries(uris);
   }
 
   private async runQuery(uri: Uri | undefined): Promise<void> {

--- a/extensions/ql-vscode/src/local-queries/local-queries.ts
+++ b/extensions/ql-vscode/src/local-queries/local-queries.ts
@@ -48,7 +48,10 @@ import { SkeletonQueryWizard } from "../skeleton-query-wizard";
 import { LocalQueryRun } from "./local-query-run";
 import { createMultiSelectionCommand } from "../common/vscode/selection-commands";
 import { findLanguage } from "../codeql-cli/query-language";
-import type { QueryTreeViewItem } from "../queries-panel/query-tree-view-item";
+import {
+  QueryTreeQueryItem,
+  QueryTreeViewItem,
+} from "../queries-panel/query-tree-view-item";
 
 interface DatabaseQuickPickItem extends QuickPickItem {
   databaseItem: DatabaseItem;
@@ -130,16 +133,20 @@ export class LocalQueries extends DisposableObject {
   private async runQueryFromQueriesPanel(
     queryTreeViewItem: QueryTreeViewItem,
   ): Promise<void> {
-    await this.runQuery(Uri.file(queryTreeViewItem.path));
+    if (queryTreeViewItem instanceof QueryTreeQueryItem) {
+      await this.runQuery(Uri.file(queryTreeViewItem.path));
+    }
   }
 
   private async runQueriesFromQueriesPanel(
     queryTreeViewItem: QueryTreeViewItem,
   ): Promise<void> {
-    const uris = queryTreeViewItem.children.map((child) =>
-      Uri.file(child.path),
-    );
-    await this.runQueries(uris);
+    if (queryTreeViewItem instanceof QueryTreeQueryItem) {
+      const uris = queryTreeViewItem.children.map((child) =>
+        Uri.file(child.path),
+      );
+      await this.runQueries(uris);
+    }
   }
 
   private async runQuery(uri: Uri | undefined): Promise<void> {

--- a/extensions/ql-vscode/src/local-queries/local-queries.ts
+++ b/extensions/ql-vscode/src/local-queries/local-queries.ts
@@ -48,7 +48,7 @@ import { SkeletonQueryWizard } from "../skeleton-query-wizard";
 import { LocalQueryRun } from "./local-query-run";
 import { createMultiSelectionCommand } from "../common/vscode/selection-commands";
 import { findLanguage } from "../codeql-cli/query-language";
-import { QueryTreeViewItem } from "../queries-panel/query-tree-view-item";
+import type { QueryTreeViewItem } from "../queries-panel/query-tree-view-item";
 
 interface DatabaseQuickPickItem extends QuickPickItem {
   databaseItem: DatabaseItem;

--- a/extensions/ql-vscode/src/queries-panel/query-discovery.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-discovery.ts
@@ -56,10 +56,15 @@ export class QueryDiscovery
    *
    * Trivial directories where there is only one child will be collapsed into a single node.
    */
-  public buildQueryTree(): Array<FileTreeNode<string>> {
+  public buildQueryTree(): Array<FileTreeNode<string>> | undefined {
+    const pathData = this.getPathData();
+    if (pathData === undefined) {
+      return undefined;
+    }
+
     const roots = [];
     for (const workspaceFolder of getOnDiskWorkspaceFoldersObjects()) {
-      const queriesInRoot = this.getPathData().filter((query) =>
+      const queriesInRoot = pathData.filter((query) =>
         containsPath(workspaceFolder.uri.fsPath, query.path),
       );
       if (queriesInRoot.length === 0) {

--- a/extensions/ql-vscode/src/queries-panel/query-pack-discovery.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-pack-discovery.ts
@@ -36,8 +36,13 @@ export class QueryPackDiscovery extends FilePathDiscovery<QueryPack> {
    * or the pack's language is unknown.
    */
   public getLanguageForQueryFile(queryPath: string): QueryLanguage | undefined {
+    const pathData = this.getPathData();
+    if (pathData === undefined) {
+      return undefined;
+    }
+
     // Find all packs in a higher directory than the query
-    const packs = (this.getPathData() || []).filter((queryPack) =>
+    const packs = pathData.filter((queryPack) =>
       containsPath(dirname(queryPack.path), queryPath),
     );
 

--- a/extensions/ql-vscode/src/queries-panel/query-pack-discovery.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-pack-discovery.ts
@@ -37,7 +37,7 @@ export class QueryPackDiscovery extends FilePathDiscovery<QueryPack> {
    */
   public getLanguageForQueryFile(queryPath: string): QueryLanguage | undefined {
     // Find all packs in a higher directory than the query
-    const packs = this.getPathData().filter((queryPack) =>
+    const packs = (this.getPathData() || []).filter((queryPack) =>
       containsPath(dirname(queryPack.path), queryPath),
     );
 

--- a/extensions/ql-vscode/src/queries-panel/query-tree-data-provider.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-tree-data-provider.ts
@@ -1,8 +1,9 @@
 import { Event, EventEmitter, TreeDataProvider, TreeItem } from "vscode";
 import {
-  QueryTreeQueryItem,
-  QueryTreeTextItem,
   QueryTreeViewItem,
+  createQueryTreeLeafItem,
+  createQueryTreeNodeItem,
+  createQueryTreeTextItem,
 } from "./query-tree-view-item";
 import { DisposableObject } from "../common/disposable-object";
 import { FileTreeNode } from "../common/file-tree-nodes";
@@ -50,17 +51,24 @@ export class QueryTreeDataProvider
 
   private convertFileTreeNode(
     fileTreeDirectory: FileTreeNode<string>,
-  ): QueryTreeQueryItem {
-    return new QueryTreeQueryItem(
-      fileTreeDirectory.name,
-      fileTreeDirectory.path,
-      fileTreeDirectory.data,
-      fileTreeDirectory.children.map(this.convertFileTreeNode.bind(this)),
-    );
+  ): QueryTreeViewItem {
+    if (fileTreeDirectory.children.length === 0) {
+      return createQueryTreeLeafItem(
+        fileTreeDirectory.name,
+        fileTreeDirectory.path,
+        fileTreeDirectory.data,
+      );
+    } else {
+      return createQueryTreeNodeItem(
+        fileTreeDirectory.name,
+        fileTreeDirectory.path,
+        fileTreeDirectory.children.map(this.convertFileTreeNode.bind(this)),
+      );
+    }
   }
 
   private noQueriesTreeViewItem(): QueryTreeViewItem {
-    return new QueryTreeTextItem(
+    return createQueryTreeTextItem(
       "This workspace doesn't contain any CodeQL queries at the moment.",
     );
   }
@@ -83,10 +91,8 @@ export class QueryTreeDataProvider
     if (!item) {
       // We're at the root.
       return this.queryTreeItems;
-    } else if (item instanceof QueryTreeQueryItem) {
-      return item.children;
     } else {
-      return [];
+      return item.children;
     }
   }
 }

--- a/extensions/ql-vscode/src/queries-panel/query-tree-data-provider.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-tree-data-provider.ts
@@ -1,8 +1,8 @@
 import { Event, EventEmitter, TreeDataProvider, TreeItem } from "vscode";
 import {
   QueryTreeViewItem,
-  createQueryTreeLeafItem,
-  createQueryTreeNodeItem,
+  createQueryTreeFileItem,
+  createQueryTreeFolderItem,
   createQueryTreeTextItem,
 } from "./query-tree-view-item";
 import { DisposableObject } from "../common/disposable-object";
@@ -53,13 +53,13 @@ export class QueryTreeDataProvider
     fileTreeDirectory: FileTreeNode<string>,
   ): QueryTreeViewItem {
     if (fileTreeDirectory.children.length === 0) {
-      return createQueryTreeLeafItem(
+      return createQueryTreeFileItem(
         fileTreeDirectory.name,
         fileTreeDirectory.path,
         fileTreeDirectory.data,
       );
     } else {
-      return createQueryTreeNodeItem(
+      return createQueryTreeFolderItem(
         fileTreeDirectory.name,
         fileTreeDirectory.path,
         fileTreeDirectory.children.map(this.convertFileTreeNode.bind(this)),

--- a/extensions/ql-vscode/src/queries-panel/query-tree-data-provider.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-tree-data-provider.ts
@@ -4,7 +4,7 @@ import { DisposableObject } from "../common/disposable-object";
 import { FileTreeNode } from "../common/file-tree-nodes";
 
 export interface QueryDiscoverer {
-  readonly buildQueryTree: () => Array<FileTreeNode<string>>;
+  readonly buildQueryTree: () => Array<FileTreeNode<string>> | undefined;
   readonly onDidChangeQueries: Event<void>;
 }
 
@@ -34,9 +34,11 @@ export class QueryTreeDataProvider
   }
 
   private createTree(): QueryTreeViewItem[] {
-    return this.queryDiscoverer
-      .buildQueryTree()
-      .map(this.convertFileTreeNode.bind(this));
+    const queryTree = this.queryDiscoverer.buildQueryTree();
+    if (queryTree === undefined) {
+      return [];
+    }
+    return queryTree.map(this.convertFileTreeNode.bind(this));
   }
 
   private convertFileTreeNode(

--- a/extensions/ql-vscode/src/queries-panel/query-tree-view-item.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-tree-view-item.ts
@@ -1,38 +1,45 @@
 import * as vscode from "vscode";
 
-export abstract class QueryTreeViewItem extends vscode.TreeItem {
-  protected constructor(name: string) {
-    super(name);
-  }
-}
-
-export class QueryTreeQueryItem extends QueryTreeViewItem {
+export class QueryTreeViewItem extends vscode.TreeItem {
   constructor(
     name: string,
-    public readonly path: string,
-    language: string | undefined,
-    public readonly children: QueryTreeQueryItem[],
+    public readonly path: string | undefined,
+    public readonly children: QueryTreeViewItem[],
   ) {
     super(name);
-    this.tooltip = path;
-    if (this.children.length === 0) {
-      this.description = language;
-      this.collapsibleState = vscode.TreeItemCollapsibleState.None;
-      this.contextValue = "queryFile";
-      this.command = {
-        title: "Open",
-        command: "vscode.open",
-        arguments: [vscode.Uri.file(path)],
-      };
-    } else {
-      this.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
-      this.contextValue = "queryFolder";
-    }
   }
 }
 
-export class QueryTreeTextItem extends QueryTreeViewItem {
-  constructor(text: string) {
-    super(text);
-  }
+export function createQueryTreeNodeItem(
+  name: string,
+  path: string,
+  children: QueryTreeViewItem[],
+): QueryTreeViewItem {
+  const item = new QueryTreeViewItem(name, path, children);
+  item.tooltip = path;
+  item.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
+  item.contextValue = "queryFolder";
+  return item;
+}
+
+export function createQueryTreeLeafItem(
+  name: string,
+  path: string,
+  language: string | undefined,
+): QueryTreeViewItem {
+  const item = new QueryTreeViewItem(name, path, []);
+  item.tooltip = path;
+  item.description = language;
+  item.collapsibleState = vscode.TreeItemCollapsibleState.None;
+  item.contextValue = "queryFile";
+  item.command = {
+    title: "Open",
+    command: "vscode.open",
+    arguments: [vscode.Uri.file(path)],
+  };
+  return item;
+}
+
+export function createQueryTreeTextItem(text: string): QueryTreeViewItem {
+  return new QueryTreeViewItem(text, undefined, []);
 }

--- a/extensions/ql-vscode/src/queries-panel/query-tree-view-item.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-tree-view-item.ts
@@ -10,7 +10,7 @@ export class QueryTreeViewItem extends vscode.TreeItem {
   }
 }
 
-export function createQueryTreeNodeItem(
+export function createQueryTreeFolderItem(
   name: string,
   path: string,
   children: QueryTreeViewItem[],
@@ -22,7 +22,7 @@ export function createQueryTreeNodeItem(
   return item;
 }
 
-export function createQueryTreeLeafItem(
+export function createQueryTreeFileItem(
   name: string,
   path: string,
   language: string | undefined,

--- a/extensions/ql-vscode/src/queries-panel/query-tree-view-item.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-tree-view-item.ts
@@ -1,11 +1,17 @@
 import * as vscode from "vscode";
 
-export class QueryTreeViewItem extends vscode.TreeItem {
+export abstract class QueryTreeViewItem extends vscode.TreeItem {
+  protected constructor(name: string) {
+    super(name);
+  }
+}
+
+export class QueryTreeQueryItem extends QueryTreeViewItem {
   constructor(
     name: string,
     public readonly path: string,
     language: string | undefined,
-    public readonly children: QueryTreeViewItem[],
+    public readonly children: QueryTreeQueryItem[],
   ) {
     super(name);
     this.tooltip = path;
@@ -22,5 +28,11 @@ export class QueryTreeViewItem extends vscode.TreeItem {
       this.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
       this.contextValue = "queryFolder";
     }
+  }
+}
+
+export class QueryTreeTextItem extends QueryTreeViewItem {
+  constructor(text: string) {
+    super(text);
   }
 }

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -76,7 +76,10 @@ import {
   showAndLogInformationMessage,
   showAndLogWarningMessage,
 } from "../common/logging";
-import type { QueryTreeViewItem } from "../queries-panel/query-tree-view-item";
+import {
+  QueryTreeQueryItem,
+  QueryTreeViewItem,
+} from "../queries-panel/query-tree-view-item";
 
 const maxRetryCount = 3;
 
@@ -191,7 +194,11 @@ export class VariantAnalysisManager
   private async runVariantAnalysisFromQueriesPanel(
     queryTreeViewItem: QueryTreeViewItem,
   ): Promise<void> {
-    await this.runVariantAnalysisFromCommand(Uri.file(queryTreeViewItem.path));
+    if (queryTreeViewItem instanceof QueryTreeQueryItem) {
+      await this.runVariantAnalysisFromCommand(
+        Uri.file(queryTreeViewItem.path),
+      );
+    }
   }
 
   public async runVariantAnalysis(

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -76,10 +76,7 @@ import {
   showAndLogInformationMessage,
   showAndLogWarningMessage,
 } from "../common/logging";
-import {
-  QueryTreeQueryItem,
-  QueryTreeViewItem,
-} from "../queries-panel/query-tree-view-item";
+import { QueryTreeViewItem } from "../queries-panel/query-tree-view-item";
 
 const maxRetryCount = 3;
 
@@ -194,7 +191,7 @@ export class VariantAnalysisManager
   private async runVariantAnalysisFromQueriesPanel(
     queryTreeViewItem: QueryTreeViewItem,
   ): Promise<void> {
-    if (queryTreeViewItem instanceof QueryTreeQueryItem) {
+    if (queryTreeViewItem.path !== undefined) {
       await this.runVariantAnalysisFromCommand(
         Uri.file(queryTreeViewItem.path),
       );

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/common/vscode/file-path-discovery.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/common/vscode/file-path-discovery.test.ts
@@ -159,6 +159,26 @@ describe("FilePathDiscovery", () => {
         new Set([{ path: join(workspacePath, "1.test"), contents: "1" }]),
       );
     });
+
+    it("should trigger listener when paths are found", async () => {
+      makeTestFile(join(workspacePath, "123.test"));
+
+      const didChangePathsListener = jest.fn();
+      discovery.onDidChangePaths(didChangePathsListener);
+
+      await discovery.initialRefresh();
+
+      expect(didChangePathsListener).toHaveBeenCalled();
+    });
+
+    it("should trigger listener when no paths are found", async () => {
+      const didChangePathsListener = jest.fn();
+      discovery.onDidChangePaths(didChangePathsListener);
+
+      await discovery.initialRefresh();
+
+      expect(didChangePathsListener).toHaveBeenCalled();
+    });
   });
 
   describe("file added", () => {

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/common/vscode/file-path-discovery.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/common/vscode/file-path-discovery.test.ts
@@ -34,7 +34,7 @@ class TestFilePathDiscovery extends FilePathDiscovery<TestData> {
     return this.onDidChangePathData;
   }
 
-  public getPathData(): readonly TestData[] {
+  public getPathData(): readonly TestData[] | undefined {
     return super.getPathData();
   }
 
@@ -123,6 +123,10 @@ describe("FilePathDiscovery", () => {
   });
 
   describe("initialRefresh", () => {
+    it("should return undefined until initialRefresh is called", async () => {
+      expect(discovery.getPathData()).toEqual(undefined);
+    });
+
     it("should handle no files being present", async () => {
       await discovery.initialRefresh();
       expect(discovery.getPathData()).toEqual([]);

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/queries-panel/query-discovery.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/queries-panel/query-discovery.test.ts
@@ -54,6 +54,10 @@ describe("Query pack discovery", () => {
   });
 
   describe("buildQueryTree", () => {
+    it("returns undefined before initial refresh has been done", async () => {
+      expect(discovery.buildQueryTree()).toEqual(undefined);
+    });
+
     it("returns an empty tree when there are no query files", async () => {
       await discovery.initialRefresh();
 

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/queries-panel/query-tree-data-provider.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/queries-panel/query-tree-data-provider.test.ts
@@ -5,8 +5,8 @@ import {
 } from "../../../../src/common/file-tree-nodes";
 import { QueryTreeDataProvider } from "../../../../src/queries-panel/query-tree-data-provider";
 import {
-  createQueryTreeLeafItem,
-  createQueryTreeNodeItem,
+  createQueryTreeFileItem,
+  createQueryTreeFolderItem,
   createQueryTreeTextItem,
 } from "../../../../src/queries-panel/query-tree-view-item";
 
@@ -59,14 +59,14 @@ describe("QueryTreeDataProvider", () => {
       });
 
       expect(dataProvider.getChildren()).toEqual([
-        createQueryTreeNodeItem("dir1", "dir1", [
-          createQueryTreeNodeItem("dir2", "dir1/dir2", [
-            createQueryTreeLeafItem("file1", "dir1/dir2/file1", "javascript"),
-            createQueryTreeLeafItem("file2", "dir1/dir2/file2", "javascript"),
+        createQueryTreeFolderItem("dir1", "dir1", [
+          createQueryTreeFolderItem("dir2", "dir1/dir2", [
+            createQueryTreeFileItem("file1", "dir1/dir2/file1", "javascript"),
+            createQueryTreeFileItem("file2", "dir1/dir2/file2", "javascript"),
           ]),
         ]),
-        createQueryTreeNodeItem("dir3", "dir3", [
-          createQueryTreeLeafItem("file3", "dir3/file3", "javascript"),
+        createQueryTreeFolderItem("dir3", "dir3", [
+          createQueryTreeFileItem("file3", "dir3/file3", "javascript"),
         ]),
       ]);
     });

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/queries-panel/query-tree-data-provider.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/queries-panel/query-tree-data-provider.test.ts
@@ -4,16 +4,33 @@ import {
   FileTreeLeaf,
 } from "../../../../src/common/file-tree-nodes";
 import { QueryTreeDataProvider } from "../../../../src/queries-panel/query-tree-data-provider";
+import {
+  QueryTreeQueryItem,
+  QueryTreeTextItem,
+} from "../../../../src/queries-panel/query-tree-view-item";
 
 describe("QueryTreeDataProvider", () => {
   describe("getChildren", () => {
-    it("returns no children when there are no queries", async () => {
+    it("returns empty array when discovery has not yet happened", async () => {
+      const dataProvider = new QueryTreeDataProvider({
+        buildQueryTree: () => undefined,
+        onDidChangeQueries: jest.fn(),
+      });
+
+      expect(dataProvider.getChildren()).toEqual([]);
+    });
+
+    it("returns a explanatory message when there are no queries", async () => {
       const dataProvider = new QueryTreeDataProvider({
         buildQueryTree: () => [],
         onDidChangeQueries: jest.fn(),
       });
 
-      expect(dataProvider.getChildren()).toEqual([]);
+      expect(dataProvider.getChildren()).toEqual([
+        new QueryTreeTextItem(
+          "This workspace doesn't contain any CodeQL queries at the moment.",
+        ),
+      ]);
     });
 
     it("converts FileTreeNode to QueryTreeViewItem", async () => {
@@ -27,7 +44,7 @@ describe("QueryTreeDataProvider", () => {
                 "javascript",
               ),
               new FileTreeLeaf<string>(
-                "dir1/dir2/file1",
+                "dir1/dir2/file2",
                 "file2",
                 "javascript",
               ),
@@ -40,24 +57,27 @@ describe("QueryTreeDataProvider", () => {
         onDidChangeQueries: jest.fn(),
       });
 
-      expect(dataProvider.getChildren().length).toEqual(2);
-
-      expect(dataProvider.getChildren()[0].label).toEqual("dir1");
-      expect(dataProvider.getChildren()[0].children.length).toEqual(1);
-      expect(dataProvider.getChildren()[0].children[0].label).toEqual("dir2");
-      expect(dataProvider.getChildren()[0].children[0].children.length).toEqual(
-        2,
-      );
-      expect(
-        dataProvider.getChildren()[0].children[0].children[0].label,
-      ).toEqual("file1");
-      expect(
-        dataProvider.getChildren()[0].children[0].children[1].label,
-      ).toEqual("file2");
-
-      expect(dataProvider.getChildren()[1].label).toEqual("dir3");
-      expect(dataProvider.getChildren()[1].children.length).toEqual(1);
-      expect(dataProvider.getChildren()[1].children[0].label).toEqual("file3");
+      expect(dataProvider.getChildren()).toEqual([
+        new QueryTreeQueryItem("dir1", "dir1", undefined, [
+          new QueryTreeQueryItem("dir2", "dir1/dir2", undefined, [
+            new QueryTreeQueryItem(
+              "file1",
+              "dir1/dir2/file1",
+              "javascript",
+              [],
+            ),
+            new QueryTreeQueryItem(
+              "file2",
+              "dir1/dir2/file2",
+              "javascript",
+              [],
+            ),
+          ]),
+        ]),
+        new QueryTreeQueryItem("dir3", "dir3", undefined, [
+          new QueryTreeQueryItem("file3", "dir3/file3", "javascript", []),
+        ]),
+      ]);
     });
   });
 

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/queries-panel/query-tree-data-provider.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/queries-panel/query-tree-data-provider.test.ts
@@ -20,7 +20,7 @@ describe("QueryTreeDataProvider", () => {
       expect(dataProvider.getChildren()).toEqual([]);
     });
 
-    it("returns a explanatory message when there are no queries", async () => {
+    it("returns an explanatory message when there are no queries", async () => {
       const dataProvider = new QueryTreeDataProvider({
         buildQueryTree: () => [],
         onDidChangeQueries: jest.fn(),

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/queries-panel/query-tree-data-provider.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/queries-panel/query-tree-data-provider.test.ts
@@ -5,8 +5,9 @@ import {
 } from "../../../../src/common/file-tree-nodes";
 import { QueryTreeDataProvider } from "../../../../src/queries-panel/query-tree-data-provider";
 import {
-  QueryTreeQueryItem,
-  QueryTreeTextItem,
+  createQueryTreeLeafItem,
+  createQueryTreeNodeItem,
+  createQueryTreeTextItem,
 } from "../../../../src/queries-panel/query-tree-view-item";
 
 describe("QueryTreeDataProvider", () => {
@@ -27,7 +28,7 @@ describe("QueryTreeDataProvider", () => {
       });
 
       expect(dataProvider.getChildren()).toEqual([
-        new QueryTreeTextItem(
+        createQueryTreeTextItem(
           "This workspace doesn't contain any CodeQL queries at the moment.",
         ),
       ]);
@@ -58,24 +59,14 @@ describe("QueryTreeDataProvider", () => {
       });
 
       expect(dataProvider.getChildren()).toEqual([
-        new QueryTreeQueryItem("dir1", "dir1", undefined, [
-          new QueryTreeQueryItem("dir2", "dir1/dir2", undefined, [
-            new QueryTreeQueryItem(
-              "file1",
-              "dir1/dir2/file1",
-              "javascript",
-              [],
-            ),
-            new QueryTreeQueryItem(
-              "file2",
-              "dir1/dir2/file2",
-              "javascript",
-              [],
-            ),
+        createQueryTreeNodeItem("dir1", "dir1", [
+          createQueryTreeNodeItem("dir2", "dir1/dir2", [
+            createQueryTreeLeafItem("file1", "dir1/dir2/file1", "javascript"),
+            createQueryTreeLeafItem("file2", "dir1/dir2/file2", "javascript"),
           ]),
         ]),
-        new QueryTreeQueryItem("dir3", "dir3", undefined, [
-          new QueryTreeQueryItem("file3", "dir3/file3", "javascript", []),
+        createQueryTreeNodeItem("dir3", "dir3", [
+          createQueryTreeLeafItem("file3", "dir3/file3", "javascript"),
         ]),
       ]);
     });


### PR DESCRIPTION
Displays a "loading" message while query discovery has not yet finished, and a separate message when no queries have been found. This should help avoid confusing users by saying there are no queries when really the discovery is just in progress.

The approach I've taken is to make the welcome message the "loading" message, and display a custom text node for the "no queries" case. This helps avoid the effect seen in https://github.com/github/vscode-codeql/pull/2523#issuecomment-1597245642 where it flips between the two options before the extension has started initialising.

For the datatypes I opt to create subclasses for `QueryTreeQueryItem` and `QueryTreeTextItem`, where `QueryTreeQueryItem` is identical to the old `QueryTreeViewItem`. We could maybe split this up further into "node" and "leaf" classes, but I haven't done this here.

I also fix a bug where it wouldn't update the tree view in the case that the initial refresh found no queries. This bug just wasn't visible before because it would display the welcome message anyway.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
