### PR TITLE
Allow queries panel to be visible in non-dev mode

### DIFF
--- a/extensions/ql-vscode/src/queries-panel/queries-module.ts
+++ b/extensions/ql-vscode/src/queries-panel/queries-module.ts
@@ -1,6 +1,6 @@
 import { CodeQLCliServer } from "../codeql-cli/cli";
 import { extLogger } from "../common";
-import { App, AppMode } from "../common/app";
+import { App } from "../common/app";
 import { isCanary, showQueriesPanel } from "../config";
 import { DisposableObject } from "../pure/disposable-object";
 import { QueriesPanel } from "./queries-panel";
@@ -13,9 +13,9 @@ export class QueriesModule extends DisposableObject {
   }
 
   private initialize(app: App, cliServer: CodeQLCliServer): void {
-    if (app.mode === AppMode.Production || !isCanary() || !showQueriesPanel()) {
-      // Currently, we only want to expose the new panel when we are in development and canary mode
-      // and the developer has enabled the "Show queries panel" flag.
+    if (!isCanary() || !showQueriesPanel()) {
+      // Currently, we only want to expose the new panel when we are in canary mode
+      // and the user has enabled the "Show queries panel" flag.
       return;
     }
     void extLogger.log("Initializing queries panel.");


### PR DESCRIPTION
It's still hidden behind two feature flags, so won't disrupt general users. But at least this will allow non-developers more easy access to the panel. (For testing/feedback)

## Checklist

N/A—internal only 🐸 

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
