### PR TITLE
Update assert-pure.ql now that the /pure directory has been removed

### DIFF
--- a/.github/codeql/queries/assert-no-vscode-dependency.ql
+++ b/.github/codeql/queries/assert-no-vscode-dependency.ql
@@ -2,9 +2,8 @@
  * @name Unwanted dependency on vscode API
  * @kind path-problem
  * @problem.severity error
- * @id vscode-codeql/assert-pure
- * @description The modules stored under `pure` and tested in the `pure-tests`
- * are intended to be "pure".
+ * @id vscode-codeql/assert-no-vscode-dependency
+ * @description The modules stored under `common` should not have dependencies on the VS Code API
  */
 
 import javascript
@@ -13,12 +12,9 @@ class VSCodeImport extends ImportDeclaration {
   VSCodeImport() { this.getImportedPath().getValue() = "vscode" }
 }
 
-class PureFile extends File {
-  PureFile() {
-    (
-      this.getRelativePath().regexpMatch(".*/src/pure/.*") or
-      this.getRelativePath().regexpMatch(".*/src/common/.*")
-    ) and
+class CommonFile extends File {
+  CommonFile() {
+    this.getRelativePath().regexpMatch(".*/src/common/.*") and
     not this.getRelativePath().regexpMatch(".*/vscode/.*")
   }
 }
@@ -34,7 +30,8 @@ query predicate edges(AstNode a, AstNode b) {
 
 from Module m, VSCodeImport v
 where
-  m.getFile() instanceof PureFile and
+  m.getFile() instanceof CommonFile and
   edges+(m, v)
 select m, m, v,
-  "This module is not pure: it has a transitive dependency on the vscode API imported $@", v, "here"
+  "This module is in the 'common' directory but has a transitive dependency on the vscode API imported $@",
+  v, "here"


### PR DESCRIPTION
(Should be merged once all PRs for moving files out of the `/pure` directory have been merged)

Once the `/pure` directory has been removed by moving files elsewhere, we should also update `update-pure.ql`. It now only needs to check for files in `/common`, and we should rename it to not mention the word "pure" anywhere if at all possible.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
