### PR TITLE
Throw error instead of using fail method

### DIFF
--- a/extensions/ql-vscode/test/unit-tests/command-lint.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/command-lint.test.ts
@@ -49,7 +49,7 @@ describe("commands declared in package.json", () => {
       expect(title).toBeDefined();
       commandTitles[command] = title!;
     } else {
-      fail(`Unexpected command name ${command}`);
+      throw new Error(`Unexpected command name ${command}`);
     }
   });
 

--- a/extensions/ql-vscode/test/unit-tests/pure/helpers-pure.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/pure/helpers-pure.test.ts
@@ -13,7 +13,7 @@ describe("helpers-pure", () => {
 
     try {
       await asyncFilter([1, 2, 3], rejects);
-      fail("Should have thrown");
+      throw new Error("Should have thrown");
     } catch (e) {
       expect(getErrorMessage(e)).toBe("opps");
     }

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/debugger/debug-controller.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/debugger/debug-controller.ts
@@ -310,11 +310,7 @@ export class DebugController
    */
   private async nextEvent(): Promise<AnyDebugEvent> {
     if (this.resolver !== undefined) {
-      const error = new Error(
-        "Attempt to wait for multiple debugger events at once.",
-      );
-      fail(error);
-      throw error;
+      throw new Error("Attempt to wait for multiple debugger events at once.");
     } else {
       if (this.nextEventIndex < this.eventQueue.length) {
         // No need to wait.


### PR DESCRIPTION
Should we be using the `fail` method? We seem to be using it in a few tests to catch incorrect setup, so if everything is correct then this code path doesn't run. But when it does run it appears the `fail` method isn't defined. See the following error:
<img width="689" alt="Screenshot 2023-06-21 at 16 03 33" src="https://github.com/github/vscode-codeql/assets/3749000/4861eb86-19c2-4c0d-a19b-9026269ba43b">

I haven't looked deeply into this yet, so I'm not sure if there's something else causing the above failure and maybe we do still want to use `fail`. But I wonder is there any downside to throwing an exception in any of these cases instead?

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
