### PR TITLE
Exclude methods from anonymous classes in framework mode

### DIFF
--- a/extensions/ql-vscode/src/data-extensions-editor/queries/csharp.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/queries/csharp.ts
@@ -37,6 +37,7 @@ select usage, apiName, supported.toString(), "supported", api.getFile().getBaseN
  */
 
 private import csharp
+private import cil
 private import dotnet
 private import semmle.code.csharp.dispatch.Dispatch
 private import semmle.code.csharp.dataflow.ExternalFlow
@@ -66,11 +67,12 @@ class TestLibrary extends RefType {
 /** Holds if the given callable is not worth supporting. */
 private predicate isUninteresting(DotNet::Callable c) {
   c.getDeclaringType() instanceof TestLibrary or
-  c.(Constructor).isParameterless()
+  c.(Constructor).isParameterless() or
+  c.getDeclaringType() instanceof AnonymousClass
 }
 
 class PublicMethod extends DotNet::Member {
-  PublicMethod() { this.isPublic() and not isUninteresting(this) and exists(this.(DotNet::Member)) }
+  PublicMethod() { this.isPublic() and not isUninteresting(this) }
 
   /**
    * Gets the unbound type, name and parameter types of this API.

--- a/extensions/ql-vscode/src/data-extensions-editor/queries/java.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/queries/java.ts
@@ -50,10 +50,11 @@ private import semmle.code.java.dataflow.internal.ModelExclusions
 /** Holds if the given callable is not worth supporting. */
 private predicate isUninteresting(Callable c) {
   c.getDeclaringType() instanceof TestLibrary or
-  c.(Constructor).isParameterless()
+  c.(Constructor).isParameterless() or
+  c.getDeclaringType() instanceof AnonymousClass
 }
 
-class PublicMethod extends Callable {
+class PublicMethod extends Method {
   PublicMethod() { this.isPublic() and not isUninteresting(this) }
 
   /**


### PR DESCRIPTION
This will exclude methods from anonymous classes in framework mode to remove packages shown as `org.sql2o.data.new AbstractList<Map<String, Object>>(...) { ..`.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
