### PR TITLE
Run variant analysis from Queries Panel context menu

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -511,6 +511,10 @@
         "title": "Run against local database"
       },
       {
+        "command": "codeQLQueries.runVariantAnalysisContextMenu",
+        "title": "Run against variant analysis repositories"
+      },
+      {
         "command": "codeQLVariantAnalysisRepositories.openConfigFile",
         "title": "Open database configuration file",
         "icon": "$(json)"
@@ -1115,6 +1119,11 @@
           "when": "view == codeQLQueries && viewItem == queryFile && codeQL.currentDatabaseItem"
         },
         {
+          "command": "codeQLQueries.runVariantAnalysisContextMenu",
+          "group": "queriesPanel@1",
+          "when": "view == codeQLQueries && viewItem == queryFile"
+        },
+        {
           "command": "codeQLTests.showOutputDifferences",
           "group": "qltest@1",
           "when": "viewItem == testWithSource"
@@ -1299,6 +1308,10 @@
         },
         {
           "command": "codeQLQueries.runLocalQueryContextMenu",
+          "when": "false"
+        },
+        {
+          "command": "codeQLQueries.runVariantAnalysisContextMenu",
           "when": "false"
         },
         {

--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -265,6 +265,7 @@ export type VariantAnalysisCommands = {
   ) => Promise<void>;
   "codeQL.runVariantAnalysis": (uri?: Uri) => Promise<void>;
   "codeQL.runVariantAnalysisContextEditor": (uri?: Uri) => Promise<void>;
+  "codeQLQueries.runVariantAnalysisContextMenu": TreeViewContextSingleSelectionCommandFunction<QueryTreeViewItem>;
 };
 
 export type DatabasePanelCommands = {

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -76,6 +76,7 @@ import {
   showAndLogInformationMessage,
   showAndLogWarningMessage,
 } from "../common/logging";
+import type { QueryTreeViewItem } from "../queries-panel/query-tree-view-item";
 
 const maxRetryCount = 3;
 
@@ -163,6 +164,8 @@ export class VariantAnalysisManager
       // Since we are tracking extension usage through commands, this command mirrors the "codeQL.runVariantAnalysis" command
       "codeQL.runVariantAnalysisContextEditor":
         this.runVariantAnalysisFromCommand.bind(this),
+      "codeQLQueries.runVariantAnalysisContextMenu":
+        this.runVariantAnalysisFromQueriesPanel.bind(this),
     };
   }
 
@@ -183,6 +186,12 @@ export class VariantAnalysisManager
         cancellable: true,
       },
     );
+  }
+
+  private async runVariantAnalysisFromQueriesPanel(
+    queryTreeViewItem: QueryTreeViewItem,
+  ): Promise<void> {
+    await this.runVariantAnalysisFromCommand(Uri.file(queryTreeViewItem.path));
   }
 
   public async runVariantAnalysis(


### PR DESCRIPTION
Based on https://github.com/github/vscode-codeql/pull/2546. Adds an extra command to run a local query from the right-click context menu of the queries panel (only for an individual `.ql` file, not for folders of queries):

![queries panel with two context-menu commands](https://github.com/github/vscode-codeql/assets/42641846/6be4b3ba-3016-46d7-939f-ba08ec308926)




## Checklist

N/A—still feature-flagged 🏳

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
