### PR TITLE
Refactor data extensions editor queries to reduce duplication

### DIFF
--- a/extensions/ql-vscode/src/data-extensions-editor/queries/csharp.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/queries/csharp.ts
@@ -9,17 +9,18 @@ export const fetchExternalApisQuery: Query = {
  * @id cs/telemetry/fetch-external-apis
  */
 
-import csharp
-import ExternalApi
+private import csharp
+private import AutomodelVsCode
+
+class ExternalApi extends CallableMethod {
+  ExternalApi() {
+    this.isUnboundDeclaration() and
+    this.fromLibrary() and
+    this.(Modifiable).isEffectivelyPublic()
+  }
+}
 
 private Call aUsage(ExternalApi api) { result.getTarget().getUnboundDeclaration() = api }
-
-private boolean isSupported(ExternalApi api) {
-  api.isSupported() and result = true
-  or
-  not api.isSupported() and
-  result = false
-}
 
 from ExternalApi api, string apiName, boolean supported, Call usage
 where
@@ -29,142 +30,30 @@ where
 select usage, apiName, supported.toString(), "supported", api.getFile().getBaseName(), "library"
 `,
   frameworkModeQuery: `/**
- * @name Usage of APIs coming from external libraries
- * @description A list of 3rd party APIs used in the codebase.
+ * @name Public methods
+ * @description A list of APIs callable by consumers. Excludes test and generated code.
  * @tags telemetry
  * @kind problem
- * @id cs/telemetry/fetch-external-apis
+ * @id cs/telemetry/fetch-public-methods
  */
 
 private import csharp
-private import cil
 private import dotnet
-private import semmle.code.csharp.dispatch.Dispatch
-private import semmle.code.csharp.dataflow.ExternalFlow
-private import semmle.code.csharp.dataflow.FlowSummary
-private import semmle.code.csharp.dataflow.internal.DataFlowImplCommon as DataFlowImplCommon
-private import semmle.code.csharp.dataflow.internal.DataFlowPrivate
-private import semmle.code.csharp.dataflow.internal.DataFlowDispatch as DataFlowDispatch
-private import semmle.code.csharp.dataflow.internal.FlowSummaryImpl as FlowSummaryImpl
-private import semmle.code.csharp.dataflow.internal.TaintTrackingPrivate
-private import semmle.code.csharp.security.dataflow.flowsources.Remote
+private import AutomodelVsCode
 
-pragma[nomagic]
-private predicate isTestNamespace(Namespace ns) {
-  ns.getFullName()
-      .matches([
-          "NUnit.Framework%", "Xunit%", "Microsoft.VisualStudio.TestTools.UnitTesting%", "Moq%"
-        ])
-}
-
-/**
- * A test library.
- */
-class TestLibrary extends RefType {
-  TestLibrary() { isTestNamespace(this.getNamespace()) }
-}
-
-/** Holds if the given callable is not worth supporting. */
-private predicate isUninteresting(DotNet::Callable c) {
-  c.getDeclaringType() instanceof TestLibrary or
-  c.(Constructor).isParameterless() or
-  c.getDeclaringType() instanceof AnonymousClass
-}
-
-class PublicMethod extends DotNet::Member {
-  PublicMethod() { this.isPublic() and not isUninteresting(this) }
-
-  /**
-   * Gets the unbound type, name and parameter types of this API.
-   */
-  bindingset[this]
-  private string getSignature() {
-    result =
-      this.getDeclaringType().getUnboundDeclaration() + "." + this.getName() + "(" +
-        parameterQualifiedTypeNamesToString(this) + ")"
-  }
-
-  /**
-   * Gets the namespace of this API.
-   */
-  bindingset[this]
-  string getNamespace() { this.getDeclaringType().hasQualifiedName(result, _) }
-
-  /**
-   * Gets the namespace and signature of this API.
-   */
-  bindingset[this]
-  string getApiName() { result = this.getNamespace() + "#" + this.getSignature() }
-
-  /** Gets a node that is an input to a call to this API. */
-  private ArgumentNode getAnInput() {
-    result
-        .getCall()
-        .(DataFlowDispatch::NonDelegateDataFlowCall)
-        .getATarget(_)
-        .getUnboundDeclaration() = this
-  }
-
-  /** Gets a node that is an output from a call to this API. */
-  private DataFlow::Node getAnOutput() {
-    exists(
-      Call c, DataFlowDispatch::NonDelegateDataFlowCall dc, DataFlowImplCommon::ReturnKindExt ret
-    |
-      dc.getDispatchCall().getCall() = c and
-      c.getTarget().getUnboundDeclaration() = this
-    |
-      result = ret.getAnOutNode(dc)
-    )
-  }
-
-  /** Holds if this API has a supported summary. */
-  pragma[nomagic]
-  predicate hasSummary() {
-    this instanceof SummarizedCallable
-    or
-    defaultAdditionalTaintStep(this.getAnInput(), _)
-  }
-
-  /** Holds if this API is a known source. */
-  pragma[nomagic]
-  predicate isSource() {
-    this.getAnOutput() instanceof RemoteFlowSource or sourceNode(this.getAnOutput(), _)
-  }
-
-  /** Holds if this API is a known sink. */
-  pragma[nomagic]
-  predicate isSink() { sinkNode(this.getAnInput(), _) }
-
-  /** Holds if this API is a known neutral. */
-  pragma[nomagic]
-  predicate isNeutral() { this instanceof FlowSummaryImpl::Public::NeutralCallable }
-
-  /**
-   * Holds if this API is supported by existing CodeQL libraries, that is, it is either a
-   * recognized source, sink or neutral or it has a flow summary.
-   */
-  predicate isSupported() {
-    this.hasSummary() or this.isSource() or this.isSink() or this.isNeutral()
-  }
-}
-
-private boolean isSupported(PublicMethod publicMethod) {
-  publicMethod.isSupported() and result = true
-  or
-  not publicMethod.isSupported() and
-  result = false
+class PublicMethod extends CallableMethod {
+  PublicMethod() { this.fromSource() }
 }
 
 from PublicMethod publicMethod, string apiName, boolean supported
 where
   apiName = publicMethod.getApiName() and
-  publicMethod.getDeclaringType().fromSource() and
   supported = isSupported(publicMethod)
 select publicMethod, apiName, supported.toString(), "supported",
   publicMethod.getFile().getBaseName(), "library"
 `,
   dependencies: {
-    "ExternalApi.qll": `/** Provides classes and predicates related to handling APIs from external libraries. */
+    "AutomodelVsCode.qll": `/** Provides classes and predicates related to handling APIs for the VS Code extension. */
 
 private import csharp
 private import dotnet
@@ -194,18 +83,17 @@ class TestLibrary extends RefType {
 }
 
 /** Holds if the given callable is not worth supporting. */
-private predicate isUninteresting(DotNet::Callable c) {
+private predicate isUninteresting(DotNet::Declaration c) {
   c.getDeclaringType() instanceof TestLibrary or
-  c.(Constructor).isParameterless()
+  c.(Constructor).isParameterless() or
+  c.getDeclaringType() instanceof AnonymousClass
 }
 
 /**
- * An external API from either the C# Standard Library or a 3rd party library.
+ * An callable method from either the C# Standard Library, a 3rd party library, or from the source.
  */
-class ExternalApi extends DotNet::Callable {
-  ExternalApi() {
-    this.isUnboundDeclaration() and
-    this.fromLibrary() and
+class CallableMethod extends DotNet::Declaration {
+  CallableMethod() {
     this.(Modifiable).isEffectivelyPublic() and
     not isUninteresting(this)
   }
@@ -284,47 +172,11 @@ class ExternalApi extends DotNet::Callable {
   }
 }
 
-/**
- * Gets the limit for the number of results produced by a telemetry query.
- */
-int resultLimit() { result = 1000 }
-
-/**
- * Holds if it is relevant to count usages of \`api\`.
- */
-signature predicate relevantApi(ExternalApi api);
-
-/**
- * Given a predicate to count relevant API usages, this module provides a predicate
- * for restricting the number or returned results based on a certain limit.
- */
-module Results<relevantApi/1 getRelevantUsages> {
-  private int getUsages(string apiName) {
-    result =
-      strictcount(Call c, ExternalApi api |
-        c.getTarget().getUnboundDeclaration() = api and
-        apiName = api.getApiName() and
-        getRelevantUsages(api)
-      )
-  }
-
-  private int getOrder(string apiName) {
-    apiName =
-      rank[result](string name, int usages |
-        usages = getUsages(name)
-      |
-        name order by usages desc, name
-      )
-  }
-
-  /**
-   * Holds if there exists an API with \`apiName\` that is being used \`usages\` times
-   * and if it is in the top results (guarded by resultLimit).
-   */
-  predicate restrict(string apiName, int usages) {
-    usages = getUsages(apiName) and
-    getOrder(apiName) <= resultLimit()
-  }
+boolean isSupported(CallableMethod callableMethod) {
+  callableMethod.isSupported() and result = true
+  or
+  not callableMethod.isSupported() and
+  result = false
 }
 `,
   },

--- a/extensions/ql-vscode/src/data-extensions-editor/queries/java.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/queries/java.ts
@@ -26,8 +26,7 @@ where
   apiName = externalApi.getApiName() and
   supported = isSupported(externalApi) and
   usage = aUsage(externalApi)
-select usage, apiName, supported.toString(), "supported",
-  externalApi.getCompilationUnit().getParentContainer().getBaseName(), "library"
+select usage, apiName, supported.toString(), "supported", externalApi.jarContainer(), "library"
 `,
   frameworkModeQuery: `/**
  * @name Public methods

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/data-extensions-editor/external-api-usage-query.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/data-extensions-editor/external-api-usage-query.test.ts
@@ -117,7 +117,11 @@ describe("runQuery", () => {
 
       const queryFiles = await readdir(queryDirectory);
       expect(queryFiles.sort()).toEqual(
-        ["codeql-pack.yml", "FetchExternalApis.ql", "ExternalApi.qll"].sort(),
+        [
+          "codeql-pack.yml",
+          "FetchExternalApis.ql",
+          "AutomodelVsCode.qll",
+        ].sort(),
       );
 
       const suiteFileContents = await readFile(


### PR DESCRIPTION
This refactors the data extensions editor queries to use a new `AutomodelVsCode` module. This module is based on the `ExternalApi` module, but is more general and can be used for retrieving public methods from the source as well. The actual conditions are now in the queries themselves.

This reduces the duplicated module in the framework mode query and will mean that when we update the `ExternalApi` module, we will just have to port it to the `AutomodelVsCode` module, and not to the `ExternalApi` and a separate framework mode query.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
