### PR TITLE
Queries Panel: run-all queries of a folders

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -511,6 +511,11 @@
         "icon": "$(run)"
       },
       {
+        "command": "codeQLQueries.runLocalQueriesFromPanel",
+        "title": "Run local queries",
+        "icon": "$(run-all)"
+      },
+      {
         "command": "codeQL.runLocalQueryFromFileTab",
         "title": "CodeQL: Run local query",
         "icon": "$(run)"
@@ -1140,6 +1145,11 @@
           "when": "view == codeQLQueries && viewItem == queryFile"
         },
         {
+          "command": "codeQLQueries.runLocalQueriesFromPanel",
+          "group": "inline",
+          "when": "view == codeQLQueries && viewItem == queryFolder && codeQL.currentDatabaseItem"
+        },
+        {
           "command": "codeQLTests.showOutputDifferences",
           "group": "qltest@1",
           "when": "viewItem == testWithSource"
@@ -1200,6 +1210,10 @@
         },
         {
           "command": "codeQLQueries.runLocalQueryFromQueriesPanel",
+          "when": "false"
+        },
+        {
+          "command": "codeQLQueries.runLocalQueriesFromPanel",
           "when": "false"
         },
         {

--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -132,6 +132,7 @@ export type LocalQueryCommands = {
   ) => Promise<void>;
   "codeQLQueries.runLocalQueryFromQueriesPanel": TreeViewContextSingleSelectionCommandFunction<QueryTreeViewItem>;
   "codeQLQueries.runLocalQueryContextMenu": TreeViewContextSingleSelectionCommandFunction<QueryTreeViewItem>;
+  "codeQLQueries.runLocalQueriesFromPanel": TreeViewContextSingleSelectionCommandFunction<QueryTreeViewItem>;
   "codeQL.runLocalQueryFromFileTab": (uri: Uri) => Promise<void>;
   "codeQL.runQueries": ExplorerSelectionCommandFunction<Uri>;
   "codeQL.quickEval": (uri: Uri) => Promise<void>;

--- a/extensions/ql-vscode/src/local-queries/local-queries.ts
+++ b/extensions/ql-vscode/src/local-queries/local-queries.ts
@@ -105,6 +105,8 @@ export class LocalQueries extends DisposableObject {
         this.runQueryFromQueriesPanel.bind(this),
       "codeQLQueries.runLocalQueryContextMenu":
         this.runQueryFromQueriesPanel.bind(this),
+      "codeQLQueries.runLocalQueriesFromPanel":
+        this.runQueriesFromQueriesPanel.bind(this),
       "codeQL.runLocalQueryFromFileTab": this.runQuery.bind(this),
       "codeQL.runQueries": createMultiSelectionCommand(
         this.runQueries.bind(this),
@@ -129,6 +131,15 @@ export class LocalQueries extends DisposableObject {
     queryTreeViewItem: QueryTreeViewItem,
   ): Promise<void> {
     await this.runQuery(Uri.file(queryTreeViewItem.path));
+  }
+
+  private async runQueriesFromQueriesPanel(
+    queryTreeViewItem: QueryTreeViewItem,
+  ): Promise<void> {
+    const uris = queryTreeViewItem.children.map((child) =>
+      Uri.file(child.path),
+    );
+    await this.runQueries(uris);
   }
 
   private async runQuery(uri: Uri | undefined): Promise<void> {

--- a/extensions/ql-vscode/src/queries-panel/query-tree-view-item.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-tree-view-item.ts
@@ -20,6 +20,7 @@ export class QueryTreeViewItem extends vscode.TreeItem {
       };
     } else {
       this.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
+      this.contextValue = "queryFolder";
     }
   }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Adds a run-all icon to folder elements in the new panel to run local queries.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
