### PR TITLE
Use `nestedName` for getting the name of an API

### DIFF
--- a/extensions/ql-vscode/src/data-extensions-editor/queries/java.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/queries/java.ts
@@ -81,7 +81,7 @@ class CallableMethod extends Method {
    */
   string getApiName() {
     result =
-      this.getDeclaringType().getPackage() + "." + this.getDeclaringType().getSourceDeclaration() +
+      this.getDeclaringType().getPackage() + "." + this.getDeclaringType().nestedName() +
         "#" + this.getName() + paramsString(this)
   }
 


### PR DESCRIPTION
This changes the Java `CallableMethod.getApiName()` to use `nestedName` instead of `getSourceDeclaration`. `getSourceDeclaration` would return a `RefType`, on which the `toString()` method returns its `getName`(). However, for nested types this wouldn't work and wouldn't include the enclosing type. This fixes it by using `nestedName` which matches the method that is also used for determining whether a type matches an extensible predicate.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
