### PR TITLE
Queries panel: Run all queries in folder (context menu)

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -525,6 +525,10 @@
         "title": "Run against local database"
       },
       {
+        "command": "codeQLQueries.runLocalQueriesContextMenu",
+        "title": "Run against local database"
+      },
+      {
         "command": "codeQLQueries.runVariantAnalysisContextMenu",
         "title": "Run against variant analysis repositories"
       },
@@ -1140,6 +1144,11 @@
           "when": "view == codeQLQueries && viewItem == queryFile && codeQL.currentDatabaseItem"
         },
         {
+          "command": "codeQLQueries.runLocalQueriesContextMenu",
+          "group": "queriesPanel@1",
+          "when": "view == codeQLQueries && viewItem == queryFolder && codeQL.currentDatabaseItem"
+        },
+        {
           "command": "codeQLQueries.runVariantAnalysisContextMenu",
           "group": "queriesPanel@1",
           "when": "view == codeQLQueries && viewItem == queryFile"
@@ -1346,6 +1355,10 @@
         },
         {
           "command": "codeQLQueries.runLocalQueryContextMenu",
+          "when": "false"
+        },
+        {
+          "command": "codeQLQueries.runLocalQueriesContextMenu",
           "when": "false"
         },
         {

--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -132,6 +132,7 @@ export type LocalQueryCommands = {
   ) => Promise<void>;
   "codeQLQueries.runLocalQueryFromQueriesPanel": TreeViewContextSingleSelectionCommandFunction<QueryTreeViewItem>;
   "codeQLQueries.runLocalQueryContextMenu": TreeViewContextSingleSelectionCommandFunction<QueryTreeViewItem>;
+  "codeQLQueries.runLocalQueriesContextMenu": TreeViewContextSingleSelectionCommandFunction<QueryTreeViewItem>;
   "codeQLQueries.runLocalQueriesFromPanel": TreeViewContextSingleSelectionCommandFunction<QueryTreeViewItem>;
   "codeQL.runLocalQueryFromFileTab": (uri: Uri) => Promise<void>;
   "codeQL.runQueries": ExplorerSelectionCommandFunction<Uri>;

--- a/extensions/ql-vscode/src/local-queries/local-queries.ts
+++ b/extensions/ql-vscode/src/local-queries/local-queries.ts
@@ -105,6 +105,8 @@ export class LocalQueries extends DisposableObject {
         this.runQueryFromQueriesPanel.bind(this),
       "codeQLQueries.runLocalQueryContextMenu":
         this.runQueryFromQueriesPanel.bind(this),
+      "codeQLQueries.runLocalQueriesContextMenu":
+        this.runQueriesFromQueriesPanel.bind(this),
       "codeQLQueries.runLocalQueriesFromPanel":
         this.runQueriesFromQueriesPanel.bind(this),
       "codeQL.runLocalQueryFromFileTab": this.runQuery.bind(this),


### PR DESCRIPTION
Adds a command to run all queries in a certain folder. This uses the existing `runQueries` command, which lets you run multiple queries against the selected local database.

![image](https://github.com/github/vscode-codeql/assets/42641846/bea901c6-2675-461f-b32e-399ba8867e90)


⚠️ We don't have a corresponding command for running multiple variant analysis queries, so I haven't implemented that. It's probably a separate product discussion of whether we want to allow users to start multiple variant analysis runs in one click? 🤔 




## Checklist

N/A (feature-flagged for internal use)

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
