### PR TITLE
Add `nestedName` function for C#

### DIFF
--- a/extensions/ql-vscode/src/data-extensions-editor/queries/csharp.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/queries/csharp.ts
@@ -104,7 +104,7 @@ class CallableMethod extends DotNet::Declaration {
   bindingset[this]
   private string getSignature() {
     result =
-      this.getDeclaringType().getUnboundDeclaration() + "." + this.getName() + "(" +
+      nestedName(this.getDeclaringType().getUnboundDeclaration()) + "." + this.getName() + "(" +
         parameterQualifiedTypeNamesToString(this) + ")"
   }
 
@@ -177,6 +177,21 @@ boolean isSupported(CallableMethod callableMethod) {
   or
   not callableMethod.isSupported() and
   result = false
+}
+
+/**
+ * Gets the nested name of the declaration.
+ *
+ * If the declaration is not a nested type, the result is the same as \`getName()\`.
+ * Otherwise the name of the nested type is prefixed with a \`+\` and appended to
+ * the name of the enclosing type, which might be a nested type as well.
+ */
+private string nestedName(Declaration declaration) {
+  not exists(declaration.getDeclaringType().getUnboundDeclaration()) and
+  result = declaration.getName()
+  or
+  nestedName(declaration.getDeclaringType().getUnboundDeclaration()) + "+" + declaration.getName() =
+    result
 }
 `,
   },


### PR DESCRIPTION
Similar to https://github.com/github/vscode-codeql/pull/2553, this changes the C# query to correctly report the name of nested types. I couldn't find a `nestedName` method for C#, so this adds one in the `AutomodelVsCode` library.

C# seems to use `+` as a separator for nested types, as reported by `getQualifiedName()`:

```
GitHub.Nested.MyFirstClass+NestedClass
```

The `getApiName()` will now report:

```
GitHub.Nested#MyFirstClass+NestedClass.Test()
```

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
