### PR TITLE
Add jump to definition in framework mode

### DIFF
--- a/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
@@ -38,6 +38,25 @@ const SupportSpan = styled.span<SupportedUnsupportedSpanProps>`
   }};
 `;
 
+type SupportedUnsupportedLinkProps = {
+  supported: boolean;
+  modeled: ModeledMethod | undefined;
+};
+
+const SupportLink = styled.button<SupportedUnsupportedLinkProps>`
+  color: ${(props) => {
+    if (!props.supported && props.modeled && props.modeled?.type !== "none") {
+      return "orange";
+    } else {
+      return props.supported ? "green" : "red";
+    }
+  }};
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+`;
+
 const UsagesButton = styled.button`
   color: var(--vscode-editor-foreground);
   background-color: transparent;
@@ -140,6 +159,7 @@ export const MethodRow = ({
   const jumpToUsage = useCallback(() => {
     vscode.postMessage({
       t: "jumpToUsage",
+      // In framework mode, the first and only usage is the definition of the method
       location: externalApiUsage.usages[0].url,
     });
   }, [externalApiUsage]);
@@ -160,13 +180,25 @@ export const MethodRow = ({
         </SupportSpan>
       </VSCodeDataGridCell>
       <VSCodeDataGridCell gridColumn={2}>
-        <SupportSpan
-          supported={externalApiUsage.supported}
-          modeled={modeledMethod}
-        >
-          {externalApiUsage.methodName}
-          {externalApiUsage.methodParameters}
-        </SupportSpan>
+        {mode === Mode.Application && (
+          <SupportSpan
+            supported={externalApiUsage.supported}
+            modeled={modeledMethod}
+          >
+            {externalApiUsage.methodName}
+            {externalApiUsage.methodParameters}
+          </SupportSpan>
+        )}
+        {mode === Mode.Framework && (
+          <SupportLink
+            supported={externalApiUsage.supported}
+            modeled={modeledMethod}
+            onClick={jumpToUsage}
+          >
+            {externalApiUsage.methodName}
+            {externalApiUsage.methodParameters}
+          </SupportLink>
+        )}
       </VSCodeDataGridCell>
       {mode === Mode.Application && (
         <VSCodeDataGridCell gridColumn={3}>


### PR DESCRIPTION
This makes the method name and parameters in framework mode a link to the definition of the method. In framework mode, the `usages` contains 1 element, which is the location of the definition of the method. Therefore, we can simply use `jumpToUsage` to jump to the definition.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
