### PR TITLE
Add call classification and supported kind to data extensions editor

### DIFF
--- a/extensions/ql-vscode/src/data-extensions-editor/bqrs.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/bqrs.ts
@@ -1,5 +1,10 @@
 import { DecodedBqrsChunk } from "../common/bqrs-cli-types";
-import { Call, ExternalApiUsage } from "./external-api-usage";
+import {
+  Call,
+  CallClassification,
+  ExternalApiUsage,
+} from "./external-api-usage";
+import { ModeledMethodType } from "./modeled-method";
 
 export function decodeBqrsToExternalApiUsages(
   chunk: DecodedBqrsChunk,
@@ -11,6 +16,8 @@ export function decodeBqrsToExternalApiUsages(
     const signature = tuple[1] as string;
     const supported = (tuple[2] as string) === "true";
     const library = tuple[4] as string;
+    const type = tuple[6] as ModeledMethodType;
+    const classification = tuple[8] as CallClassification;
 
     const [packageWithType, methodDeclaration] = signature.split("#");
 
@@ -39,12 +46,16 @@ export function decodeBqrsToExternalApiUsages(
         methodName,
         methodParameters,
         supported,
+        supportedType: type,
         usages: [],
       });
     }
 
     const method = methodsByApiName.get(signature)!;
-    method.usages.push(usage);
+    method.usages.push({
+      ...usage,
+      classification,
+    });
   });
 
   return Array.from(methodsByApiName.values());

--- a/extensions/ql-vscode/src/data-extensions-editor/external-api-usage.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/external-api-usage.ts
@@ -1,8 +1,20 @@
 import { ResolvableLocationValue } from "../common/bqrs-cli-types";
+import { ModeledMethodType } from "./modeled-method";
 
 export type Call = {
   label: string;
   url: ResolvableLocationValue;
+};
+
+export enum CallClassification {
+  Unknown = "unknown",
+  Source = "source",
+  Test = "test",
+  Generated = "generated",
+}
+
+export type Usage = Call & {
+  classification: CallClassification;
 };
 
 export type ExternalApiUsage = {
@@ -30,5 +42,6 @@ export type ExternalApiUsage = {
    * If so, there is no need for the user to model it themselves.
    */
   supported: boolean;
-  usages: Call[];
+  supportedType: ModeledMethodType;
+  usages: Usage[];
 };

--- a/extensions/ql-vscode/src/data-extensions-editor/queries/java.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/queries/java.ts
@@ -16,17 +16,19 @@ class ExternalApi extends CallableMethod {
   ExternalApi() { not this.fromSource() }
 }
 
-private Call aUsage(ExternalApi api) {
-  result.getCallee().getSourceDeclaration() = api and
-  not result.getFile() instanceof GeneratedFile
-}
+private Call aUsage(ExternalApi api) { result.getCallee().getSourceDeclaration() = api }
 
-from ExternalApi externalApi, string apiName, boolean supported, Call usage
+from
+  ExternalApi externalApi, string apiName, boolean supported, Call usage, string type,
+  string classification
 where
   apiName = externalApi.getApiName() and
   supported = isSupported(externalApi) and
-  usage = aUsage(externalApi)
-select usage, apiName, supported.toString(), "supported", externalApi.jarContainer(), "library"
+  usage = aUsage(externalApi) and
+  type = supportedType(externalApi) and
+  classification = methodClassification(usage)
+select usage, apiName, supported.toString(), "supported", externalApi.jarContainer(), "library",
+  type, "type", classification, "classification"
 `,
   frameworkModeQuery: `/**
  * @name Public methods
@@ -41,12 +43,14 @@ import AutomodelVsCode
 
 class PublicMethodFromSource extends CallableMethod, ModelApi { }
 
-from PublicMethodFromSource publicMethod, string apiName, boolean supported
+from PublicMethodFromSource publicMethod, string apiName, boolean supported, string type
 where
   apiName = publicMethod.getApiName() and
-  supported = isSupported(publicMethod)
+  supported = isSupported(publicMethod) and
+  type = supportedType(publicMethod)
 select publicMethod, apiName, supported.toString(), "supported",
-  publicMethod.getCompilationUnit().getParentContainer().getBaseName(), "library"
+  publicMethod.getCompilationUnit().getParentContainer().getBaseName(), "library", type, "type",
+  "unknown", "classification"
 `,
   dependencies: {
     "AutomodelVsCode.qll": `/** Provides classes and predicates related to handling APIs for the VS Code extension. */
@@ -145,6 +149,28 @@ boolean isSupported(CallableMethod method) {
   method.isSupported() and result = true
   or
   not method.isSupported() and result = false
+}
+
+string supportedType(CallableMethod method) {
+  method.isSink() and result = "sink"
+  or
+  method.isSource() and result = "source"
+  or
+  method.hasSummary() and result = "summary"
+  or
+  method.isNeutral() and result = "neutral"
+  or
+  not method.isSupported() and result = "none"
+}
+
+string methodClassification(Call method) {
+  isInTestFile(method.getLocation().getFile()) and result = "test"
+  or
+  method.getFile() instanceof GeneratedFile and result = "generated"
+  or
+  not isInTestFile(method.getLocation().getFile()) and
+  not method.getFile() instanceof GeneratedFile and
+  result = "source"
 }
 
 // The below is a copy of https://github.com/github/codeql/blob/249f9f863db1e94e3c46ca85b49fb0ec32f8ca92/java/ql/lib/semmle/code/java/dataflow/internal/ModelExclusions.qll

--- a/extensions/ql-vscode/src/data-extensions-editor/queries/query.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/queries/query.ts
@@ -9,6 +9,10 @@ export type Query = {
    * - "supported": a string literal. This is required to make the query a valid problem query.
    * - libraryName: the name of the library that contains the external API. This is a string and usually the basename of a file.
    * - "library": a string literal. This is required to make the query a valid problem query.
+   * - type: the modeled kind of the method, either "sink", "source", "summary", or "neutral"
+   * - "type": a string literal. This is required to make the query a valid problem query.
+   * - classification: the classification of the use of the method, either "source", "test", "generated", or "unknown"
+   * - "classification: a string literal. This is required to make the query a valid problem query.
    */
   applicationModeQuery: string;
   /**
@@ -22,6 +26,10 @@ export type Query = {
    * - "supported": a string literal. This is required to make the query a valid problem query.
    * - libraryName: an arbitrary string. This is required to make it match the structure of the application query.
    * - "library": a string literal. This is required to make the query a valid problem query.
+   * - type: the modeled kind of the method, either "sink", "source", "summary", or "neutral"
+   * - "type": a string literal. This is required to make the query a valid problem query.
+   * - "unknown": a string literal. This is required to make it match the structure of the application query.
+   * - "classification: a string literal. This is required to make the query a valid problem query.
    */
   frameworkModeQuery: string;
   dependencies?: {

--- a/extensions/ql-vscode/src/stories/data-extensions-editor/DataExtensionsEditor.stories.tsx
+++ b/extensions/ql-vscode/src/stories/data-extensions-editor/DataExtensionsEditor.stories.tsx
@@ -4,6 +4,7 @@ import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import { Mode } from "../../data-extensions-editor/shared/mode";
 import { DataExtensionsEditor as DataExtensionsEditorComponent } from "../../view/data-extensions-editor/DataExtensionsEditor";
+import { CallClassification } from "../../data-extensions-editor/external-api-usage";
 
 export default {
   title: "Data Extensions Editor/Data Extensions Editor",
@@ -39,6 +40,7 @@ DataExtensionsEditor.args = {
       methodName: "createQuery",
       methodParameters: "(String)",
       supported: true,
+      supportedType: "summary",
       usages: Array(10).fill({
         label: "createQuery(...)",
         url: {
@@ -48,6 +50,7 @@ DataExtensionsEditor.args = {
           endLine: 15,
           endColumn: 56,
         },
+        classification: CallClassification.Source,
       }),
     },
     {
@@ -58,6 +61,7 @@ DataExtensionsEditor.args = {
       methodName: "executeScalar",
       methodParameters: "(Class)",
       supported: true,
+      supportedType: "neutral",
       usages: Array(2).fill({
         label: "executeScalar(...)",
         url: {
@@ -67,6 +71,7 @@ DataExtensionsEditor.args = {
           endLine: 15,
           endColumn: 85,
         },
+        classification: CallClassification.Source,
       }),
     },
     {
@@ -77,6 +82,7 @@ DataExtensionsEditor.args = {
       methodName: "open",
       methodParameters: "()",
       supported: false,
+      supportedType: "none",
       usages: Array(28).fill({
         label: "open(...)",
         url: {
@@ -86,6 +92,7 @@ DataExtensionsEditor.args = {
           endLine: 14,
           endColumn: 35,
         },
+        classification: CallClassification.Source,
       }),
     },
     {
@@ -96,6 +103,7 @@ DataExtensionsEditor.args = {
       methodName: "println",
       methodParameters: "(String)",
       supported: true,
+      supportedType: "summary",
       usages: [
         {
           label: "println(...)",
@@ -106,6 +114,7 @@ DataExtensionsEditor.args = {
             endLine: 29,
             endColumn: 49,
           },
+          classification: CallClassification.Source,
         },
       ],
     },
@@ -118,6 +127,7 @@ DataExtensionsEditor.args = {
       methodName: "run",
       methodParameters: "(Class,String[])",
       supported: false,
+      supportedType: "none",
       usages: Array(7).fill({
         label: "run(...)",
         url: {
@@ -127,6 +137,7 @@ DataExtensionsEditor.args = {
           endLine: 9,
           endColumn: 66,
         },
+        classification: CallClassification.Source,
       }),
     },
     {
@@ -137,6 +148,7 @@ DataExtensionsEditor.args = {
       methodName: "Sql2o",
       methodParameters: "(String,String,String)",
       supported: false,
+      supportedType: "none",
       usages: Array(106).fill({
         label: "new Sql2o(...)",
         url: {
@@ -145,6 +157,7 @@ DataExtensionsEditor.args = {
           startColumn: 33,
           endLine: 10,
           endColumn: 88,
+          classification: CallClassification.Source,
         },
       }),
     },
@@ -156,6 +169,7 @@ DataExtensionsEditor.args = {
       methodName: "Sql2o",
       methodParameters: "(String)",
       supported: false,
+      supportedType: "none",
       usages: Array(4).fill({
         label: "new Sql2o(...)",
         url: {
@@ -165,6 +179,7 @@ DataExtensionsEditor.args = {
           endLine: 23,
           endColumn: 36,
         },
+        classification: CallClassification.Source,
       }),
     },
   ],

--- a/extensions/ql-vscode/src/stories/data-extensions-editor/DataExtensionsEditor.stories.tsx
+++ b/extensions/ql-vscode/src/stories/data-extensions-editor/DataExtensionsEditor.stories.tsx
@@ -157,7 +157,7 @@ DataExtensionsEditor.args = {
           startColumn: 33,
           endLine: 10,
           endColumn: 88,
-          classification: CallClassification.Source,
+          classification: CallClassification.Test,
         },
       }),
     },

--- a/extensions/ql-vscode/src/stories/data-extensions-editor/DataExtensionsEditor.stories.tsx
+++ b/extensions/ql-vscode/src/stories/data-extensions-editor/DataExtensionsEditor.stories.tsx
@@ -116,6 +116,17 @@ DataExtensionsEditor.args = {
           },
           classification: CallClassification.Source,
         },
+        {
+          label: "println(...)",
+          url: {
+            uri: "file:/home/runner/work/sql2o-example/sql2o-example/src/test/java/org/example/HelloControllerTest.java",
+            startLine: 29,
+            startColumn: 9,
+            endLine: 29,
+            endColumn: 49,
+          },
+          classification: CallClassification.Test,
+        },
       ],
     },
     {
@@ -170,17 +181,30 @@ DataExtensionsEditor.args = {
       methodParameters: "(String)",
       supported: false,
       supportedType: "none",
-      usages: Array(4).fill({
-        label: "new Sql2o(...)",
-        url: {
-          uri: "file:/home/runner/work/sql2o-example/sql2o-example/src/main/java/org/example/HelloController.java",
-          startLine: 23,
-          startColumn: 23,
-          endLine: 23,
-          endColumn: 36,
+      usages: [
+        ...Array(4).fill({
+          label: "new Sql2o(...)",
+          url: {
+            uri: "file:/home/runner/work/sql2o-example/sql2o-example/src/main/java/org/example/HelloController.java",
+            startLine: 23,
+            startColumn: 23,
+            endLine: 23,
+            endColumn: 36,
+          },
+          classification: CallClassification.Test,
+        }),
+        {
+          label: "new Sql2o(...)",
+          url: {
+            uri: "file:/home/runner/work/sql2o-example/sql2o-example/build/generated/java/org/example/HelloControllerGenerated.java",
+            startLine: 23,
+            startColumn: 23,
+            endLine: 23,
+            endColumn: 36,
+          },
+          classification: CallClassification.Generated,
         },
-        classification: CallClassification.Source,
-      }),
+      ],
     },
   ],
   initialModeledMethods: {

--- a/extensions/ql-vscode/src/stories/data-extensions-editor/MethodRow.stories.tsx
+++ b/extensions/ql-vscode/src/stories/data-extensions-editor/MethodRow.stories.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 
 import { MethodRow as MethodRowComponent } from "../../view/data-extensions-editor/MethodRow";
+import { CallClassification } from "../../data-extensions-editor/external-api-usage";
 
 export default {
   title: "Data Extensions Editor/Method Row",
@@ -23,6 +24,7 @@ MethodRow.args = {
     methodName: "open",
     methodParameters: "()",
     supported: true,
+    supportedType: "summary",
     usages: [
       {
         label: "open(...)",
@@ -33,6 +35,7 @@ MethodRow.args = {
           endLine: 14,
           endColumn: 35,
         },
+        classification: CallClassification.Source,
       },
       {
         label: "open(...)",
@@ -43,6 +46,7 @@ MethodRow.args = {
           endLine: 25,
           endColumn: 35,
         },
+        classification: CallClassification.Source,
       },
     ],
   },

--- a/extensions/ql-vscode/src/view/data-extensions-editor/MethodClassifications.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/MethodClassifications.tsx
@@ -13,6 +13,10 @@ const ClassificationsContainer = styled.div`
   gap: 0.5rem;
 `;
 
+const ClassificationTag = styled(VSCodeTag)`
+  font-size: 0.75em;
+`;
+
 type Props = {
   externalApiUsage: ExternalApiUsage;
 };
@@ -38,8 +42,8 @@ export const MethodClassifications = ({ externalApiUsage }: Props) => {
 
   return (
     <ClassificationsContainer>
-      {inTest && <VSCodeTag>Test</VSCodeTag>}
-      {inGenerated && <VSCodeTag>Generated</VSCodeTag>}
+      {inTest && <ClassificationTag>Test</ClassificationTag>}
+      {inGenerated && <ClassificationTag>Generated</ClassificationTag>}
     </ClassificationsContainer>
   );
 };

--- a/extensions/ql-vscode/src/view/data-extensions-editor/MethodClassifications.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/MethodClassifications.tsx
@@ -36,12 +36,25 @@ export const MethodClassifications = ({ externalApiUsage }: Props) => {
   const inTest = allUsageClassifications.has(CallClassification.Test);
   const inGenerated = allUsageClassifications.has(CallClassification.Generated);
 
+  const tooltip = useMemo(() => {
+    if (inTest && inGenerated) {
+      return "This method is only used from test and generated code";
+    }
+    if (inTest) {
+      return "This method is only used from test code";
+    }
+    if (inGenerated) {
+      return "This method is only used from generated code";
+    }
+    return "";
+  }, [inTest, inGenerated]);
+
   if (inSource) {
     return null;
   }
 
   return (
-    <ClassificationsContainer>
+    <ClassificationsContainer title={tooltip}>
       {inTest && <ClassificationTag>Test</ClassificationTag>}
       {inGenerated && <ClassificationTag>Generated</ClassificationTag>}
     </ClassificationsContainer>

--- a/extensions/ql-vscode/src/view/data-extensions-editor/MethodClassifications.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/MethodClassifications.tsx
@@ -1,0 +1,45 @@
+import * as React from "react";
+import { useMemo } from "react";
+import {
+  CallClassification,
+  ExternalApiUsage,
+} from "../../data-extensions-editor/external-api-usage";
+import { VSCodeTag } from "@vscode/webview-ui-toolkit/react";
+import styled from "styled-components";
+
+const ClassificationsContainer = styled.div`
+  display: inline-flex;
+  flex-direction: row;
+  gap: 0.5rem;
+`;
+
+type Props = {
+  externalApiUsage: ExternalApiUsage;
+};
+
+export const MethodClassifications = ({ externalApiUsage }: Props) => {
+  const allUsageClassifications = useMemo(
+    () =>
+      new Set(
+        externalApiUsage.usages.map((usage) => {
+          return usage.classification;
+        }),
+      ),
+    [externalApiUsage.usages],
+  );
+
+  const inSource = allUsageClassifications.has(CallClassification.Source);
+  const inTest = allUsageClassifications.has(CallClassification.Test);
+  const inGenerated = allUsageClassifications.has(CallClassification.Generated);
+
+  if (inSource) {
+    return null;
+  }
+
+  return (
+    <ClassificationsContainer>
+      {inTest && <VSCodeTag>Test</VSCodeTag>}
+      {inGenerated && <VSCodeTag>Generated</VSCodeTag>}
+    </ClassificationsContainer>
+  );
+};

--- a/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
@@ -39,13 +39,21 @@ const ViewLink = styled(VSCodeLink)`
   white-space: nowrap;
 `;
 
-const modelTypeOptions = [
+const modelTypeOptions: Array<{ value: ModeledMethodType; label: string }> = [
   { value: "none", label: "Unmodeled" },
   { value: "source", label: "Source" },
   { value: "sink", label: "Sink" },
   { value: "summary", label: "Flow summary" },
   { value: "neutral", label: "Neutral" },
 ];
+
+const typeNames = modelTypeOptions.reduce(
+  (acc, { value, label }) => {
+    acc[value] = label;
+    return acc;
+  },
+  {} as Record<ModeledMethodType, string>,
+);
 
 type Props = {
   externalApiUsage: ExternalApiUsage;
@@ -233,11 +241,8 @@ function ModelableMethodRow(props: Props) {
   );
 }
 
-function UnmodelableMethodRow(props: {
-  externalApiUsage: ExternalApiUsage;
-  mode: Mode;
-}) {
-  const { externalApiUsage, mode } = props;
+function UnmodelableMethodRow(props: Props) {
+  const { externalApiUsage, modeledMethod, mode } = props;
 
   const jumpToUsage = useCallback(
     () => sendJumpToUsageMessage(externalApiUsage),
@@ -256,8 +261,15 @@ function UnmodelableMethodRow(props: {
         )}
         <ViewLink onClick={jumpToUsage}>View</ViewLink>
       </ApiOrMethodCell>
-      <VSCodeDataGridCell gridColumn="span 4">
-        Method already modeled by CodeQL or a different extension pack
+      <VSCodeDataGridCell gridColumn={2}>
+        {externalApiUsage.supported &&
+          !modeledMethod &&
+          externalApiUsage.supportedType !== "none" && (
+            <>{typeNames[externalApiUsage.supportedType]}</>
+          )}
+      </VSCodeDataGridCell>
+      <VSCodeDataGridCell gridColumn="span 3">
+        Method modeled by CodeQL or a different extension pack
       </VSCodeDataGridCell>
     </VSCodeDataGridRow>
   );

--- a/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
@@ -3,17 +3,13 @@ import {
   VSCodeDataGridCell,
   VSCodeDataGridRow,
   VSCodeLink,
-  VSCodeTag,
 } from "@vscode/webview-ui-toolkit/react";
 import * as React from "react";
 import { ChangeEvent, useCallback, useMemo } from "react";
 import styled from "styled-components";
 import { vscode } from "../vscode-api";
 
-import {
-  CallClassification,
-  ExternalApiUsage,
-} from "../../data-extensions-editor/external-api-usage";
+import { ExternalApiUsage } from "../../data-extensions-editor/external-api-usage";
 import {
   ModeledMethod,
   ModeledMethodType,
@@ -23,6 +19,7 @@ import { KindInput } from "./KindInput";
 import { extensiblePredicateDefinitions } from "../../data-extensions-editor/predicates";
 import { Mode } from "../../data-extensions-editor/shared/mode";
 import { Dropdown } from "../common/Dropdown";
+import { MethodClassifications } from "./MethodClassifications";
 
 const ApiOrMethodCell = styled(VSCodeDataGridCell)`
   display: flex;
@@ -41,12 +38,6 @@ const UsagesButton = styled.button`
 
 const ViewLink = styled(VSCodeLink)`
   white-space: nowrap;
-`;
-
-const ClassificationsContainer = styled.div`
-  display: inline-flex;
-  flex-direction: row;
-  gap: 0.5rem;
 `;
 
 const modelTypeOptions: Array<{ value: ModeledMethodType; label: string }> = [
@@ -196,20 +187,6 @@ function ModelableMethodRow(props: Props) {
       : undefined;
   const showKindCell = predicate?.supportedKinds;
 
-  const allUsageClassifications = useMemo(
-    () =>
-      new Set(
-        externalApiUsage.usages.map((usage) => {
-          return usage.classification;
-        }),
-      ),
-    [externalApiUsage.usages],
-  );
-
-  const inSource = allUsageClassifications.has(CallClassification.Source);
-  const inTest = allUsageClassifications.has(CallClassification.Test);
-  const inGenerated = allUsageClassifications.has(CallClassification.Generated);
-
   return (
     <VSCodeDataGridRow>
       <ApiOrMethodCell gridColumn={1}>
@@ -221,12 +198,7 @@ function ModelableMethodRow(props: Props) {
           </UsagesButton>
         )}
         <ViewLink onClick={jumpToUsage}>View</ViewLink>
-        {!inSource && (
-          <ClassificationsContainer>
-            {inTest && <VSCodeTag>Test</VSCodeTag>}
-            {inGenerated && <VSCodeTag>Generated</VSCodeTag>}
-          </ClassificationsContainer>
-        )}
+        <MethodClassifications externalApiUsage={externalApiUsage} />
       </ApiOrMethodCell>
       <VSCodeDataGridCell gridColumn={2}>
         <Dropdown
@@ -282,6 +254,7 @@ function UnmodelableMethodRow(props: Props) {
           </UsagesButton>
         )}
         <ViewLink onClick={jumpToUsage}>View</ViewLink>
+        <MethodClassifications externalApiUsage={externalApiUsage} />
       </ApiOrMethodCell>
       <VSCodeDataGridCell gridColumn="span 4">
         Method modeled by CodeQL or a different extension pack

--- a/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
@@ -57,14 +57,6 @@ const modelTypeOptions: Array<{ value: ModeledMethodType; label: string }> = [
   { value: "neutral", label: "Neutral" },
 ];
 
-const typeNames = modelTypeOptions.reduce(
-  (acc, { value, label }) => {
-    acc[value] = label;
-    return acc;
-  },
-  {} as Record<ModeledMethodType, string>,
-);
-
 type Props = {
   externalApiUsage: ExternalApiUsage;
   modeledMethod: ModeledMethod | undefined;
@@ -272,7 +264,7 @@ function ModelableMethodRow(props: Props) {
 }
 
 function UnmodelableMethodRow(props: Props) {
-  const { externalApiUsage, modeledMethod, mode } = props;
+  const { externalApiUsage, mode } = props;
 
   const jumpToUsage = useCallback(
     () => sendJumpToUsageMessage(externalApiUsage),
@@ -291,14 +283,7 @@ function UnmodelableMethodRow(props: Props) {
         )}
         <ViewLink onClick={jumpToUsage}>View</ViewLink>
       </ApiOrMethodCell>
-      <VSCodeDataGridCell gridColumn={2}>
-        {externalApiUsage.supported &&
-          !modeledMethod &&
-          externalApiUsage.supportedType !== "none" && (
-            <>{typeNames[externalApiUsage.supportedType]}</>
-          )}
-      </VSCodeDataGridCell>
-      <VSCodeDataGridCell gridColumn="span 3">
+      <VSCodeDataGridCell gridColumn="span 4">
         Method modeled by CodeQL or a different extension pack
       </VSCodeDataGridCell>
     </VSCodeDataGridRow>

--- a/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
@@ -3,13 +3,17 @@ import {
   VSCodeDataGridCell,
   VSCodeDataGridRow,
   VSCodeLink,
+  VSCodeTag,
 } from "@vscode/webview-ui-toolkit/react";
 import * as React from "react";
 import { ChangeEvent, useCallback, useMemo } from "react";
 import styled from "styled-components";
 import { vscode } from "../vscode-api";
 
-import { ExternalApiUsage } from "../../data-extensions-editor/external-api-usage";
+import {
+  CallClassification,
+  ExternalApiUsage,
+} from "../../data-extensions-editor/external-api-usage";
 import {
   ModeledMethod,
   ModeledMethodType,
@@ -37,6 +41,12 @@ const UsagesButton = styled.button`
 
 const ViewLink = styled(VSCodeLink)`
   white-space: nowrap;
+`;
+
+const ClassificationsContainer = styled.div`
+  display: inline-flex;
+  flex-direction: row;
+  gap: 0.5rem;
 `;
 
 const modelTypeOptions: Array<{ value: ModeledMethodType; label: string }> = [
@@ -194,6 +204,20 @@ function ModelableMethodRow(props: Props) {
       : undefined;
   const showKindCell = predicate?.supportedKinds;
 
+  const allUsageClassifications = useMemo(
+    () =>
+      new Set(
+        externalApiUsage.usages.map((usage) => {
+          return usage.classification;
+        }),
+      ),
+    [externalApiUsage.usages],
+  );
+
+  const inSource = allUsageClassifications.has(CallClassification.Source);
+  const inTest = allUsageClassifications.has(CallClassification.Test);
+  const inGenerated = allUsageClassifications.has(CallClassification.Generated);
+
   return (
     <VSCodeDataGridRow>
       <ApiOrMethodCell gridColumn={1}>
@@ -205,6 +229,12 @@ function ModelableMethodRow(props: Props) {
           </UsagesButton>
         )}
         <ViewLink onClick={jumpToUsage}>View</ViewLink>
+        {!inSource && (
+          <ClassificationsContainer>
+            {inTest && <VSCodeTag>Test</VSCodeTag>}
+            {inGenerated && <VSCodeTag>Generated</VSCodeTag>}
+          </ClassificationsContainer>
+        )}
       </ApiOrMethodCell>
       <VSCodeDataGridCell gridColumn={2}>
         <Dropdown

--- a/extensions/ql-vscode/test/unit-tests/data-extensions-editor/auto-model.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/data-extensions-editor/auto-model.test.ts
@@ -3,7 +3,10 @@ import {
   createAutoModelRequest,
   parsePredictedClassifications,
 } from "../../../src/data-extensions-editor/auto-model";
-import { ExternalApiUsage } from "../../../src/data-extensions-editor/external-api-usage";
+import {
+  CallClassification,
+  ExternalApiUsage,
+} from "../../../src/data-extensions-editor/external-api-usage";
 import { ModeledMethod } from "../../../src/data-extensions-editor/modeled-method";
 import {
   ClassificationType,
@@ -22,6 +25,7 @@ describe("createAutoModelRequest", () => {
       methodName: "run",
       methodParameters: "(Class,String[])",
       supported: false,
+      supportedType: "none",
       usages: [
         {
           label: "run(...)",
@@ -32,6 +36,7 @@ describe("createAutoModelRequest", () => {
             endLine: 9,
             endColumn: 66,
           },
+          classification: CallClassification.Source,
         },
       ],
     },
@@ -43,6 +48,7 @@ describe("createAutoModelRequest", () => {
       methodName: "createQuery",
       methodParameters: "(String)",
       supported: false,
+      supportedType: "none",
       usages: [
         {
           label: "createQuery(...)",
@@ -53,6 +59,7 @@ describe("createAutoModelRequest", () => {
             endLine: 15,
             endColumn: 56,
           },
+          classification: CallClassification.Source,
         },
         {
           label: "createQuery(...)",
@@ -63,6 +70,7 @@ describe("createAutoModelRequest", () => {
             endLine: 26,
             endColumn: 39,
           },
+          classification: CallClassification.Source,
         },
       ],
     },
@@ -74,6 +82,7 @@ describe("createAutoModelRequest", () => {
       methodName: "executeScalar",
       methodParameters: "(Class)",
       supported: false,
+      supportedType: "none",
       usages: [
         {
           label: "executeScalar(...)",
@@ -84,6 +93,7 @@ describe("createAutoModelRequest", () => {
             endLine: 15,
             endColumn: 85,
           },
+          classification: CallClassification.Source,
         },
         {
           label: "executeScalar(...)",
@@ -94,6 +104,7 @@ describe("createAutoModelRequest", () => {
             endLine: 26,
             endColumn: 68,
           },
+          classification: CallClassification.Source,
         },
       ],
     },
@@ -105,6 +116,7 @@ describe("createAutoModelRequest", () => {
       methodName: "open",
       methodParameters: "()",
       supported: false,
+      supportedType: "none",
       usages: [
         {
           label: "open(...)",
@@ -115,6 +127,7 @@ describe("createAutoModelRequest", () => {
             endLine: 14,
             endColumn: 35,
           },
+          classification: CallClassification.Source,
         },
         {
           label: "open(...)",
@@ -125,6 +138,7 @@ describe("createAutoModelRequest", () => {
             endLine: 25,
             endColumn: 35,
           },
+          classification: CallClassification.Source,
         },
       ],
     },
@@ -136,6 +150,7 @@ describe("createAutoModelRequest", () => {
       methodName: "println",
       methodParameters: "(String)",
       supported: false,
+      supportedType: "none",
       usages: [
         {
           label: "println(...)",
@@ -146,6 +161,7 @@ describe("createAutoModelRequest", () => {
             endLine: 29,
             endColumn: 49,
           },
+          classification: CallClassification.Source,
         },
       ],
     },
@@ -157,6 +173,7 @@ describe("createAutoModelRequest", () => {
       methodName: "Sql2o",
       methodParameters: "(String,String,String)",
       supported: false,
+      supportedType: "none",
       usages: [
         {
           label: "new Sql2o(...)",
@@ -167,6 +184,7 @@ describe("createAutoModelRequest", () => {
             endLine: 10,
             endColumn: 88,
           },
+          classification: CallClassification.Source,
         },
       ],
     },
@@ -178,6 +196,7 @@ describe("createAutoModelRequest", () => {
       methodName: "Sql2o",
       methodParameters: "(String)",
       supported: false,
+      supportedType: "none",
       usages: [
         {
           label: "new Sql2o(...)",
@@ -188,6 +207,7 @@ describe("createAutoModelRequest", () => {
             endLine: 23,
             endColumn: 36,
           },
+          classification: CallClassification.Source,
         },
       ],
     },
@@ -199,6 +219,7 @@ describe("createAutoModelRequest", () => {
       methodName: "test",
       methodParameters: "()",
       supported: true,
+      supportedType: "neutral",
       usages: [
         {
           label: "abc.test(...)",
@@ -209,6 +230,7 @@ describe("createAutoModelRequest", () => {
             endLine: 23,
             endColumn: 36,
           },
+          classification: CallClassification.Source,
         },
       ],
     },

--- a/extensions/ql-vscode/test/unit-tests/data-extensions-editor/yaml.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/data-extensions-editor/yaml.test.ts
@@ -5,6 +5,7 @@ import {
   createFilenameForLibrary,
   loadDataExtensionYaml,
 } from "../../../src/data-extensions-editor/yaml";
+import { CallClassification } from "../../../src/data-extensions-editor/external-api-usage";
 
 describe("createDataExtensionYaml", () => {
   it("creates the correct YAML file", () => {
@@ -18,6 +19,7 @@ describe("createDataExtensionYaml", () => {
           methodName: "createQuery",
           methodParameters: "(String)",
           supported: true,
+          supportedType: "sink",
           usages: [
             {
               label: "createQuery(...)",
@@ -28,6 +30,7 @@ describe("createDataExtensionYaml", () => {
                 endLine: 15,
                 endColumn: 56,
               },
+              classification: CallClassification.Source,
             },
             {
               label: "createQuery(...)",
@@ -38,6 +41,7 @@ describe("createDataExtensionYaml", () => {
                 endLine: 26,
                 endColumn: 39,
               },
+              classification: CallClassification.Source,
             },
           ],
         },
@@ -58,6 +62,7 @@ describe("createDataExtensionYaml", () => {
           methodName: "executeScalar",
           methodParameters: "(Class)",
           supported: true,
+          supportedType: "neutral",
           usages: [
             {
               label: "executeScalar(...)",
@@ -68,6 +73,7 @@ describe("createDataExtensionYaml", () => {
                 endLine: 15,
                 endColumn: 85,
               },
+              classification: CallClassification.Source,
             },
             {
               label: "executeScalar(...)",
@@ -78,6 +84,7 @@ describe("createDataExtensionYaml", () => {
                 endLine: 26,
                 endColumn: 68,
               },
+              classification: CallClassification.Source,
             },
           ],
         },
@@ -148,6 +155,7 @@ describe("createDataExtensionYamlsForApplicationMode", () => {
           methodName: "createQuery",
           methodParameters: "(String)",
           supported: true,
+          supportedType: "sink",
           usages: [
             {
               label: "createQuery(...)",
@@ -158,6 +166,7 @@ describe("createDataExtensionYamlsForApplicationMode", () => {
                 endLine: 15,
                 endColumn: 56,
               },
+              classification: CallClassification.Source,
             },
             {
               label: "createQuery(...)",
@@ -168,6 +177,7 @@ describe("createDataExtensionYamlsForApplicationMode", () => {
                 endLine: 26,
                 endColumn: 39,
               },
+              classification: CallClassification.Source,
             },
           ],
         },
@@ -179,6 +189,7 @@ describe("createDataExtensionYamlsForApplicationMode", () => {
           methodName: "executeScalar",
           methodParameters: "(Class)",
           supported: true,
+          supportedType: "neutral",
           usages: [
             {
               label: "executeScalar(...)",
@@ -189,6 +200,7 @@ describe("createDataExtensionYamlsForApplicationMode", () => {
                 endLine: 15,
                 endColumn: 85,
               },
+              classification: CallClassification.Source,
             },
             {
               label: "executeScalar(...)",
@@ -199,6 +211,7 @@ describe("createDataExtensionYamlsForApplicationMode", () => {
                 endLine: 26,
                 endColumn: 68,
               },
+              classification: CallClassification.Source,
             },
           ],
         },
@@ -210,6 +223,7 @@ describe("createDataExtensionYamlsForApplicationMode", () => {
           methodName: "Sql2o",
           methodParameters: "(String,String,String)",
           supported: false,
+          supportedType: "none",
           usages: [
             {
               label: "new Sql2o(...)",
@@ -220,6 +234,7 @@ describe("createDataExtensionYamlsForApplicationMode", () => {
                 endLine: 10,
                 endColumn: 88,
               },
+              classification: CallClassification.Source,
             },
           ],
         },
@@ -232,6 +247,7 @@ describe("createDataExtensionYamlsForApplicationMode", () => {
           methodName: "run",
           methodParameters: "(Class,String[])",
           supported: false,
+          supportedType: "none",
           usages: [
             {
               label: "run(...)",
@@ -242,6 +258,7 @@ describe("createDataExtensionYamlsForApplicationMode", () => {
                 endLine: 9,
                 endColumn: 66,
               },
+              classification: CallClassification.Source,
             },
           ],
         },
@@ -253,6 +270,7 @@ describe("createDataExtensionYamlsForApplicationMode", () => {
           methodName: "println",
           methodParameters: "(String)",
           supported: true,
+          supportedType: "summary",
           usages: [
             {
               label: "println(...)",
@@ -263,6 +281,7 @@ describe("createDataExtensionYamlsForApplicationMode", () => {
                 endLine: 29,
                 endColumn: 49,
               },
+              classification: CallClassification.Source,
             },
           ],
         },
@@ -356,6 +375,7 @@ describe("createDataExtensionYamlsForFrameworkMode", () => {
           methodName: "createQuery",
           methodParameters: "(String)",
           supported: true,
+          supportedType: "sink",
           usages: [
             {
               label: "createQuery(...)",
@@ -366,6 +386,7 @@ describe("createDataExtensionYamlsForFrameworkMode", () => {
                 endLine: 15,
                 endColumn: 56,
               },
+              classification: CallClassification.Source,
             },
             {
               label: "createQuery(...)",
@@ -376,6 +397,7 @@ describe("createDataExtensionYamlsForFrameworkMode", () => {
                 endLine: 26,
                 endColumn: 39,
               },
+              classification: CallClassification.Source,
             },
           ],
         },
@@ -387,6 +409,7 @@ describe("createDataExtensionYamlsForFrameworkMode", () => {
           methodName: "executeScalar",
           methodParameters: "(Class)",
           supported: true,
+          supportedType: "neutral",
           usages: [
             {
               label: "executeScalar(...)",
@@ -397,6 +420,7 @@ describe("createDataExtensionYamlsForFrameworkMode", () => {
                 endLine: 15,
                 endColumn: 85,
               },
+              classification: CallClassification.Source,
             },
             {
               label: "executeScalar(...)",
@@ -407,6 +431,7 @@ describe("createDataExtensionYamlsForFrameworkMode", () => {
                 endLine: 26,
                 endColumn: 68,
               },
+              classification: CallClassification.Source,
             },
           ],
         },
@@ -418,6 +443,7 @@ describe("createDataExtensionYamlsForFrameworkMode", () => {
           methodName: "Sql2o",
           methodParameters: "(String,String,String)",
           supported: false,
+          supportedType: "none",
           usages: [
             {
               label: "new Sql2o(...)",
@@ -428,6 +454,7 @@ describe("createDataExtensionYamlsForFrameworkMode", () => {
                 endLine: 10,
                 endColumn: 88,
               },
+              classification: CallClassification.Source,
             },
           ],
         },


### PR DESCRIPTION
This will add a "Test" or "Generated" tag on the method if it's only used in tests or generated code and not in the actual application source code. It also adds retrieving the method "type" (e.g. source or sink) to the queries, but does not show these yet.

![Screenshot 2023-07-13 at 16 46 04](https://github.com/github/vscode-codeql/assets/1112623/29198e1f-55d9-4540-9e77-f660efcd2a54)


## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
