### PR TITLE
Add library versions to data extensions editor

### DIFF
--- a/extensions/ql-vscode/src/data-extensions-editor/bqrs.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/bqrs.ts
@@ -5,6 +5,7 @@ import {
   ExternalApiUsage,
 } from "./external-api-usage";
 import { ModeledMethodType } from "./modeled-method";
+import { parseLibraryFilename } from "./library";
 
 export function decodeBqrsToExternalApiUsages(
   chunk: DecodedBqrsChunk,
@@ -15,7 +16,8 @@ export function decodeBqrsToExternalApiUsages(
     const usage = tuple[0] as Call;
     const signature = tuple[1] as string;
     const supported = (tuple[2] as string) === "true";
-    const library = tuple[4] as string;
+    let library = tuple[4] as string;
+    let libraryVersion: string | undefined = tuple[5] as string;
     const type = tuple[6] as ModeledMethodType;
     const classification = tuple[8] as CallClassification;
 
@@ -37,9 +39,25 @@ export function decodeBqrsToExternalApiUsages(
       methodDeclaration.indexOf("("),
     );
 
+    // For Java, we'll always get back a .jar file, and the library version may be bad because not all library authors
+    // properly specify the version. Therefore, we'll always try to parse the name and version from the library filename
+    // for Java.
+    if (library.endsWith(".jar") || libraryVersion === "") {
+      const { name, version } = parseLibraryFilename(library);
+      library = name;
+      if (version) {
+        libraryVersion = version;
+      }
+    }
+
+    if (libraryVersion === "") {
+      libraryVersion = undefined;
+    }
+
     if (!methodsByApiName.has(signature)) {
       methodsByApiName.set(signature, {
         library,
+        libraryVersion,
         signature,
         packageName,
         typeName,

--- a/extensions/ql-vscode/src/data-extensions-editor/external-api-usage.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/external-api-usage.ts
@@ -23,6 +23,10 @@ export type ExternalApiUsage = {
    */
   library: string;
   /**
+   * Contains the version of the library if it can be determined by CodeQL, e.g. `4.2.2.2`
+   */
+  libraryVersion?: string;
+  /**
    * A unique signature that can be used to identify this external API usage.
    *
    * The signature contains the package name, type name, method name, and method parameters

--- a/extensions/ql-vscode/src/data-extensions-editor/library.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/library.ts
@@ -1,0 +1,55 @@
+import { basename, extname } from "../common/path";
+
+// From the semver package using
+// const { re, t } = require("semver/internal/re");
+// console.log(re[t.LOOSE]);
+// Modifications:
+// - Added version named group which does not capture the v prefix
+// - Removed the ^ and $ anchors
+// - Made the minor and patch versions optional
+// This will match any semver string at the end of a larger string
+const semverRegex =
+  /[v=\s]*(?<version>([0-9]+)(\.([0-9]+)(?:\.([0-9]+)(?:-?((?:[0-9]+|\d*[a-zA-Z-][a-zA-Z0-9-]*)(?:\.(?:[0-9]+|\d*[a-zA-Z-][a-zA-Z0-9-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?)?)?)/g;
+
+export interface Library {
+  name: string;
+  version?: string;
+}
+
+export function parseLibraryFilename(filename: string): Library {
+  let libraryName = basename(filename);
+  const extension = extname(libraryName);
+  libraryName = libraryName.slice(0, -extension.length);
+
+  let libraryVersion: string | undefined;
+
+  let match: RegExpMatchArray | null = null;
+
+  // Reset the regex
+  semverRegex.lastIndex = 0;
+
+  // Find the last occurence of the regex within the library name
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const currentMatch = semverRegex.exec(libraryName);
+    if (currentMatch === null) {
+      break;
+    }
+
+    match = currentMatch;
+  }
+
+  if (match?.groups) {
+    libraryVersion = match.groups?.version;
+    // Remove everything after the start of the match
+    libraryName = libraryName.slice(0, match.index);
+  }
+
+  // Remove any leading or trailing hyphens or dots
+  libraryName = libraryName.replaceAll(/^[.-]+|[.-]+$/g, "");
+
+  return {
+    name: libraryName,
+    version: libraryVersion,
+  };
+}

--- a/extensions/ql-vscode/src/data-extensions-editor/library.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/library.ts
@@ -7,9 +7,12 @@ import { basename, extname } from "../common/path";
 // - Added version named group which does not capture the v prefix
 // - Removed the ^ and $ anchors
 // - Made the minor and patch versions optional
+// - Added a hyphen to the start of the version
+// - Added a dot as a valid separator between the version and the label
+// - Made the patch version optional even if a label is given
 // This will match any semver string at the end of a larger string
 const semverRegex =
-  /[v=\s]*(?<version>([0-9]+)(\.([0-9]+)(?:\.([0-9]+)(?:-?((?:[0-9]+|\d*[a-zA-Z-][a-zA-Z0-9-]*)(?:\.(?:[0-9]+|\d*[a-zA-Z-][a-zA-Z0-9-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?)?)?)/g;
+  /-[v=\s]*(?<version>([0-9]+)(\.([0-9]+)(?:(\.([0-9]+))?(?:[-.]?((?:[0-9]+|\d*[a-zA-Z-][a-zA-Z0-9-]*)(?:\.(?:[0-9]+|\d*[a-zA-Z-][a-zA-Z0-9-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?)?)?)/g;
 
 export interface Library {
   name: string;

--- a/extensions/ql-vscode/src/data-extensions-editor/queries/query.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/queries/query.ts
@@ -8,7 +8,7 @@ export type Query = {
    * - supported: whether the external API is modeled. This should be a string representation of a boolean to satify the result pattern for a problem query.
    * - "supported": a string literal. This is required to make the query a valid problem query.
    * - libraryName: the name of the library that contains the external API. This is a string and usually the basename of a file.
-   * - "library": a string literal. This is required to make the query a valid problem query.
+   * - libraryVersion: the version of the library that contains the external API. This is a string and can be empty if the version cannot be determined.
    * - type: the modeled kind of the method, either "sink", "source", "summary", or "neutral"
    * - "type": a string literal. This is required to make the query a valid problem query.
    * - classification: the classification of the use of the method, either "source", "test", "generated", or "unknown"
@@ -25,7 +25,7 @@ export type Query = {
    * - supported: whether this method is modeled. This should be a string representation of a boolean to satify the result pattern for a problem query.
    * - "supported": a string literal. This is required to make the query a valid problem query.
    * - libraryName: an arbitrary string. This is required to make it match the structure of the application query.
-   * - "library": a string literal. This is required to make the query a valid problem query.
+   * - libraryVersion: an arbitrary string. This is required to make it match the structure of the application query.
    * - type: the modeled kind of the method, either "sink", "source", "summary", or "neutral"
    * - "type": a string literal. This is required to make the query a valid problem query.
    * - "unknown": a string literal. This is required to make it match the structure of the application query.

--- a/extensions/ql-vscode/src/data-extensions-editor/yaml.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/yaml.ts
@@ -1,6 +1,5 @@
 import Ajv from "ajv";
 
-import { basename, extname } from "../common/path";
 import { ExternalApiUsage } from "./external-api-usage";
 import { ModeledMethod, ModeledMethodType } from "./modeled-method";
 import {
@@ -144,29 +143,12 @@ export function createDataExtensionYamlsForFrameworkMode(
   };
 }
 
-// From the semver package using
-// const { re, t } = require("semver/internal/re");
-// console.log(re[t.LOOSE]);
-// Modified to remove the ^ and $ anchors
-// This will match any semver string at the end of a larger string
-const semverRegex =
-  /[v=\s]*([0-9]+)\.([0-9]+)\.([0-9]+)(?:-?((?:[0-9]+|\d*[a-zA-Z-][a-zA-Z0-9-]*)(?:\.(?:[0-9]+|\d*[a-zA-Z-][a-zA-Z0-9-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?/;
-
 export function createFilenameForLibrary(
   library: string,
   prefix = "models/",
   suffix = ".model",
 ) {
-  let libraryName = basename(library);
-  const extension = extname(libraryName);
-  libraryName = libraryName.slice(0, -extension.length);
-
-  const match = semverRegex.exec(libraryName);
-
-  if (match !== null) {
-    // Remove everything after the start of the match
-    libraryName = libraryName.slice(0, match.index);
-  }
+  let libraryName = library;
 
   // Lowercase everything
   libraryName = libraryName.toLowerCase();

--- a/extensions/ql-vscode/src/stories/data-extensions-editor/DataExtensionsEditor.stories.tsx
+++ b/extensions/ql-vscode/src/stories/data-extensions-editor/DataExtensionsEditor.stories.tsx
@@ -33,7 +33,8 @@ DataExtensionsEditor.args = {
   },
   initialExternalApiUsages: [
     {
-      library: "sql2o-1.6.0.jar",
+      library: "sql2o",
+      libraryVersion: "1.6.0",
       signature: "org.sql2o.Connection#createQuery(String)",
       packageName: "org.sql2o",
       typeName: "Connection",
@@ -54,7 +55,8 @@ DataExtensionsEditor.args = {
       }),
     },
     {
-      library: "sql2o-1.6.0.jar",
+      library: "sql2o",
+      libraryVersion: "1.6.0",
       signature: "org.sql2o.Query#executeScalar(Class)",
       packageName: "org.sql2o",
       typeName: "Query",
@@ -75,7 +77,8 @@ DataExtensionsEditor.args = {
       }),
     },
     {
-      library: "sql2o-1.6.0.jar",
+      library: "sql2o",
+      libraryVersion: "1.6.0",
       signature: "org.sql2o.Sql2o#open()",
       packageName: "org.sql2o",
       typeName: "Sql2o",
@@ -96,7 +99,7 @@ DataExtensionsEditor.args = {
       }),
     },
     {
-      library: "rt.jar",
+      library: "rt",
       signature: "java.io.PrintStream#println(String)",
       packageName: "java.io",
       typeName: "PrintStream",
@@ -130,7 +133,8 @@ DataExtensionsEditor.args = {
       ],
     },
     {
-      library: "spring-boot-3.0.2.jar",
+      library: "spring-boot",
+      libraryVersion: "3.0.2",
       signature:
         "org.springframework.boot.SpringApplication#run(Class,String[])",
       packageName: "org.springframework.boot",
@@ -152,7 +156,8 @@ DataExtensionsEditor.args = {
       }),
     },
     {
-      library: "sql2o-1.6.0.jar",
+      library: "sql2o",
+      libraryVersion: "1.6.0",
       signature: "org.sql2o.Sql2o#Sql2o(String,String,String)",
       packageName: "org.sql2o",
       typeName: "Sql2o",
@@ -173,7 +178,8 @@ DataExtensionsEditor.args = {
       }),
     },
     {
-      library: "sql2o-1.6.0.jar",
+      library: "sql2o",
+      libraryVersion: "1.6.0",
       signature: "org.sql2o.Sql2o#Sql2o(String)",
       packageName: "org.sql2o",
       typeName: "Sql2o",

--- a/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
@@ -68,6 +68,7 @@ const ButtonsContainer = styled.div`
 
 type Props = {
   title: string;
+  libraryVersion?: string;
   externalApiUsages: ExternalApiUsage[];
   modeledMethods: Record<string, ModeledMethod>;
   viewState: DataExtensionEditorViewState;
@@ -91,6 +92,7 @@ type Props = {
 
 export const LibraryRow = ({
   title,
+  libraryVersion,
   externalApiUsages,
   modeledMethods,
   viewState,
@@ -158,7 +160,10 @@ export const LibraryRow = ({
           <Codicon name="chevron-right" label="Expand" />
         )}
         <NameContainer>
-          <DependencyName>{title}</DependencyName>
+          <DependencyName>
+            {title}
+            {libraryVersion && <>@{libraryVersion}</>}
+          </DependencyName>
           <ModeledPercentage>
             {percentFormatter.format(modeledPercentage / 100)} modeled
           </ModeledPercentage>

--- a/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
@@ -266,8 +266,10 @@ function UnmodelableMethodRow(props: Props) {
 function ExternalApiUsageName(props: { externalApiUsage: ExternalApiUsage }) {
   return (
     <span>
-      {props.externalApiUsage.packageName}.{props.externalApiUsage.typeName}.
-      {props.externalApiUsage.methodName}
+      {props.externalApiUsage.packageName && (
+        <>{props.externalApiUsage.packageName}.</>
+      )}
+      {props.externalApiUsage.typeName}.{props.externalApiUsage.methodName}
       {props.externalApiUsage.methodParameters}
     </span>
   );

--- a/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodsList.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodsList.tsx
@@ -3,6 +3,7 @@ import { useMemo } from "react";
 import { ExternalApiUsage } from "../../data-extensions-editor/external-api-usage";
 import { ModeledMethod } from "../../data-extensions-editor/modeled-method";
 import { LibraryRow } from "./LibraryRow";
+import { Mode } from "../../data-extensions-editor/shared/mode";
 import {
   groupMethods,
   sortGroupNames,
@@ -31,6 +32,10 @@ type Props = {
   onGenerateFromSourceClick: () => void;
 };
 
+const libraryNameOverrides: Record<string, string> = {
+  rt: "Java Runtime",
+};
+
 export const ModeledMethodsList = ({
   externalApiUsages,
   unsavedModels,
@@ -46,6 +51,24 @@ export const ModeledMethodsList = ({
     [externalApiUsages, viewState.mode],
   );
 
+  const libraryVersions = useMemo(() => {
+    if (viewState.mode !== Mode.Application) {
+      return {};
+    }
+
+    const libraryVersions: Record<string, string> = {};
+
+    for (const externalApiUsage of externalApiUsages) {
+      const { library, libraryVersion } = externalApiUsage;
+
+      if (library && libraryVersion) {
+        libraryVersions[library] = libraryVersion;
+      }
+    }
+
+    return libraryVersions;
+  }, [externalApiUsages, viewState.mode]);
+
   const sortedGroupNames = useMemo(() => sortGroupNames(grouped), [grouped]);
 
   return (
@@ -53,7 +76,8 @@ export const ModeledMethodsList = ({
       {sortedGroupNames.map((libraryName) => (
         <LibraryRow
           key={libraryName}
-          title={libraryName}
+          title={libraryNameOverrides[libraryName] ?? libraryName}
+          libraryVersion={libraryVersions[libraryName]}
           externalApiUsages={grouped[libraryName]}
           hasUnsavedChanges={unsavedModels.has(libraryName)}
           modeledMethods={modeledMethods}

--- a/extensions/ql-vscode/test/unit-tests/data-extensions-editor/bqrs.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/data-extensions-editor/bqrs.test.ts
@@ -1,5 +1,6 @@
 import { decodeBqrsToExternalApiUsages } from "../../../src/data-extensions-editor/bqrs";
 import { DecodedBqrsChunk } from "../../../src/common/bqrs-cli-types";
+import { CallClassification } from "../../../src/data-extensions-editor/external-api-usage";
 
 describe("decodeBqrsToExternalApiUsages", () => {
   const chunk: DecodedBqrsChunk = {
@@ -7,6 +8,12 @@ describe("decodeBqrsToExternalApiUsages", () => {
       { name: "usage", kind: "Entity" },
       { name: "apiName", kind: "String" },
       { kind: "String" },
+      { kind: "String" },
+      { kind: "String" },
+      { kind: "String" },
+      { name: "type", kind: "String" },
+      { kind: "String" },
+      { name: "classification", kind: "String" },
       { kind: "String" },
     ],
     tuples: [
@@ -24,6 +31,12 @@ describe("decodeBqrsToExternalApiUsages", () => {
         "java.io.PrintStream#println(String)",
         "true",
         "supported",
+        "rt.jar",
+        "",
+        "sink",
+        "type",
+        "source",
+        "classification",
       ],
       [
         {
@@ -39,6 +52,12 @@ describe("decodeBqrsToExternalApiUsages", () => {
         "org.springframework.boot.SpringApplication#run(Class,String[])",
         "false",
         "supported",
+        "spring-boot-3.0.2.jar",
+        "",
+        "none",
+        "type",
+        "source",
+        "classification",
       ],
       [
         {
@@ -54,6 +73,12 @@ describe("decodeBqrsToExternalApiUsages", () => {
         "org.sql2o.Connection#createQuery(String)",
         "true",
         "supported",
+        "sql2o-1.6.0.jar",
+        "",
+        "sink",
+        "type",
+        "source",
+        "classification",
       ],
       [
         {
@@ -69,6 +94,12 @@ describe("decodeBqrsToExternalApiUsages", () => {
         "org.sql2o.Connection#createQuery(String)",
         "true",
         "supported",
+        "sql2o-1.6.0.jar",
+        "",
+        "sink",
+        "type",
+        "source",
+        "classification",
       ],
       [
         {
@@ -84,6 +115,12 @@ describe("decodeBqrsToExternalApiUsages", () => {
         "org.sql2o.Query#executeScalar(Class)",
         "true",
         "supported",
+        "sql2o-1.6.0.jar",
+        "",
+        "sink",
+        "type",
+        "source",
+        "classification",
       ],
       [
         {
@@ -99,6 +136,12 @@ describe("decodeBqrsToExternalApiUsages", () => {
         "org.sql2o.Query#executeScalar(Class)",
         "true",
         "supported",
+        "sql2o-1.6.0.jar",
+        "",
+        "sink",
+        "type",
+        "source",
+        "classification",
       ],
       [
         {
@@ -114,6 +157,12 @@ describe("decodeBqrsToExternalApiUsages", () => {
         "org.sql2o.Sql2o#open()",
         "true",
         "supported",
+        "sql2o-1.6.0.jar",
+        "",
+        "sink",
+        "type",
+        "source",
+        "classification",
       ],
       [
         {
@@ -129,6 +178,12 @@ describe("decodeBqrsToExternalApiUsages", () => {
         "org.sql2o.Sql2o#open()",
         "true",
         "supported",
+        "sql2o-1.6.0.jar",
+        "",
+        "sink",
+        "type",
+        "source",
+        "classification",
       ],
       [
         {
@@ -144,6 +199,12 @@ describe("decodeBqrsToExternalApiUsages", () => {
         "org.sql2o.Sql2o#Sql2o(String,String,String)",
         "true",
         "supported",
+        "sql2o-1.6.0.jar",
+        "",
+        "sink",
+        "type",
+        "source",
+        "classification",
       ],
       [
         {
@@ -159,6 +220,12 @@ describe("decodeBqrsToExternalApiUsages", () => {
         "org.sql2o.Sql2o#Sql2o(String)",
         "true",
         "supported",
+        "sql2o-1.6.0.jar",
+        "",
+        "sink",
+        "type",
+        "source",
+        "classification",
       ],
     ],
   };
@@ -169,12 +236,15 @@ describe("decodeBqrsToExternalApiUsages", () => {
     // - Sorting the array of usages is guaranteed to be a stable sort
     expect(decodeBqrsToExternalApiUsages(chunk)).toEqual([
       {
+        library: "rt",
+        libraryVersion: undefined,
         signature: "java.io.PrintStream#println(String)",
         packageName: "java.io",
         typeName: "PrintStream",
         methodName: "println",
         methodParameters: "(String)",
         supported: true,
+        supportedType: "sink",
         usages: [
           {
             label: "println(...)",
@@ -185,10 +255,13 @@ describe("decodeBqrsToExternalApiUsages", () => {
               endLine: 29,
               endColumn: 49,
             },
+            classification: CallClassification.Source,
           },
         ],
       },
       {
+        library: "spring-boot",
+        libraryVersion: "3.0.2",
         signature:
           "org.springframework.boot.SpringApplication#run(Class,String[])",
         packageName: "org.springframework.boot",
@@ -196,6 +269,7 @@ describe("decodeBqrsToExternalApiUsages", () => {
         methodName: "run",
         methodParameters: "(Class,String[])",
         supported: false,
+        supportedType: "none",
         usages: [
           {
             label: "run(...)",
@@ -206,16 +280,20 @@ describe("decodeBqrsToExternalApiUsages", () => {
               endLine: 9,
               endColumn: 66,
             },
+            classification: CallClassification.Source,
           },
         ],
       },
       {
+        library: "sql2o",
+        libraryVersion: "1.6.0",
         signature: "org.sql2o.Connection#createQuery(String)",
         packageName: "org.sql2o",
         typeName: "Connection",
         methodName: "createQuery",
         methodParameters: "(String)",
         supported: true,
+        supportedType: "sink",
         usages: [
           {
             label: "createQuery(...)",
@@ -226,6 +304,7 @@ describe("decodeBqrsToExternalApiUsages", () => {
               endLine: 15,
               endColumn: 56,
             },
+            classification: CallClassification.Source,
           },
           {
             label: "createQuery(...)",
@@ -236,16 +315,20 @@ describe("decodeBqrsToExternalApiUsages", () => {
               endLine: 26,
               endColumn: 39,
             },
+            classification: CallClassification.Source,
           },
         ],
       },
       {
+        library: "sql2o",
+        libraryVersion: "1.6.0",
         signature: "org.sql2o.Query#executeScalar(Class)",
         packageName: "org.sql2o",
         typeName: "Query",
         methodName: "executeScalar",
         methodParameters: "(Class)",
         supported: true,
+        supportedType: "sink",
         usages: [
           {
             label: "executeScalar(...)",
@@ -256,6 +339,7 @@ describe("decodeBqrsToExternalApiUsages", () => {
               endLine: 15,
               endColumn: 85,
             },
+            classification: CallClassification.Source,
           },
           {
             label: "executeScalar(...)",
@@ -266,16 +350,20 @@ describe("decodeBqrsToExternalApiUsages", () => {
               endLine: 26,
               endColumn: 68,
             },
+            classification: CallClassification.Source,
           },
         ],
       },
       {
+        library: "sql2o",
+        libraryVersion: "1.6.0",
         signature: "org.sql2o.Sql2o#open()",
         packageName: "org.sql2o",
         typeName: "Sql2o",
         methodName: "open",
         methodParameters: "()",
         supported: true,
+        supportedType: "sink",
         usages: [
           {
             label: "open(...)",
@@ -286,6 +374,7 @@ describe("decodeBqrsToExternalApiUsages", () => {
               endLine: 14,
               endColumn: 35,
             },
+            classification: CallClassification.Source,
           },
           {
             label: "open(...)",
@@ -296,16 +385,20 @@ describe("decodeBqrsToExternalApiUsages", () => {
               endLine: 25,
               endColumn: 35,
             },
+            classification: CallClassification.Source,
           },
         ],
       },
       {
+        library: "sql2o",
+        libraryVersion: "1.6.0",
         signature: "org.sql2o.Sql2o#Sql2o(String,String,String)",
         packageName: "org.sql2o",
         typeName: "Sql2o",
         methodName: "Sql2o",
         methodParameters: "(String,String,String)",
         supported: true,
+        supportedType: "sink",
         usages: [
           {
             label: "new Sql2o(...)",
@@ -316,16 +409,20 @@ describe("decodeBqrsToExternalApiUsages", () => {
               endLine: 10,
               endColumn: 88,
             },
+            classification: CallClassification.Source,
           },
         ],
       },
       {
+        library: "sql2o",
+        libraryVersion: "1.6.0",
         signature: "org.sql2o.Sql2o#Sql2o(String)",
         packageName: "org.sql2o",
         typeName: "Sql2o",
         methodName: "Sql2o",
         methodParameters: "(String)",
         supported: true,
+        supportedType: "sink",
         usages: [
           {
             label: "new Sql2o(...)",
@@ -336,6 +433,7 @@ describe("decodeBqrsToExternalApiUsages", () => {
               endLine: 23,
               endColumn: 36,
             },
+            classification: CallClassification.Source,
           },
         ],
       },

--- a/extensions/ql-vscode/test/unit-tests/data-extensions-editor/library.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/data-extensions-editor/library.test.ts
@@ -1,0 +1,59 @@
+import { parseLibraryFilename } from "../../../src/data-extensions-editor/library";
+
+describe("parseLibraryFilename", () => {
+  const testCases = [
+    { filename: "sql2o-1.6.0.jar", name: "sql2o", version: "1.6.0" },
+    {
+      filename: "spring-boot-3.0.2.jar",
+      name: "spring-boot",
+      version: "3.0.2",
+    },
+    { filename: "rt.jar", name: "rt", version: undefined },
+    { filename: "guava-15.0.jar", name: "guava", version: "15.0" },
+    {
+      filename: "embedded-db-junit-1.0.0.jar",
+      name: "embedded-db-junit",
+      version: "1.0.0",
+    },
+    {
+      filename: "h2-1.3.160.jar",
+      name: "h2",
+      version: "1.3.160",
+    },
+    {
+      filename: "joda-time-2.0.jar",
+      name: "joda-time",
+      version: "2.0",
+    },
+    {
+      filename: "System.Runtime.dll",
+      name: "System.Runtime",
+      version: undefined,
+    },
+    {
+      filename: "System.Linq.Expressions.dll",
+      name: "System.Linq.Expressions",
+      version: undefined,
+    },
+    {
+      filename: "System.Diagnostics.Debug.dll",
+      name: "System.Diagnostics.Debug",
+      version: undefined,
+    },
+    {
+      filename: "spring-boot-3.1.0-rc2.jar",
+      name: "spring-boot",
+      version: "3.1.0-rc2",
+    },
+  ];
+
+  test.each(testCases)(
+    "$filename is $name@$version",
+    ({ filename, name, version }) => {
+      expect(parseLibraryFilename(filename)).toEqual({
+        name,
+        version,
+      });
+    },
+  );
+});

--- a/extensions/ql-vscode/test/unit-tests/data-extensions-editor/library.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/data-extensions-editor/library.test.ts
@@ -45,6 +45,46 @@ describe("parseLibraryFilename", () => {
       name: "spring-boot",
       version: "3.1.0-rc2",
     },
+    {
+      filename: "org.eclipse.sisu.plexus-0.9.0.M2.jar",
+      name: "org.eclipse.sisu.plexus",
+      version: "0.9.0.M2",
+    },
+    {
+      filename: "org.eclipse.sisu.inject-0.9.0.M2.jar",
+      name: "org.eclipse.sisu.inject",
+      version: "0.9.0.M2",
+    },
+    {
+      filename: "slf4j-api-1.7.36.jar",
+      name: "slf4j-api",
+      version: "1.7.36",
+    },
+    {
+      filename: "guava-30.1.1-jre.jar",
+      name: "guava",
+      version: "30.1.1-jre",
+    },
+    {
+      filename: "caliper-1.0-beta-3.jar",
+      name: "caliper",
+      version: "1.0-beta-3",
+    },
+    {
+      filename: "protobuf-java-4.0.0-rc-2.jar",
+      name: "protobuf-java",
+      version: "4.0.0-rc-2",
+    },
+    {
+      filename: "jetty-util-9.4.51.v20230217.jar",
+      name: "jetty-util",
+      version: "9.4.51.v20230217",
+    },
+    {
+      filename: "jetty-servlet-9.4.51.v20230217.jar",
+      name: "jetty-servlet",
+      version: "9.4.51.v20230217",
+    },
   ];
 
   test.each(testCases)(

--- a/extensions/ql-vscode/test/unit-tests/data-extensions-editor/yaml.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/data-extensions-editor/yaml.test.ts
@@ -148,7 +148,8 @@ describe("createDataExtensionYamlsForApplicationMode", () => {
       "java",
       [
         {
-          library: "sql2o-1.6.0.jar",
+          library: "sql2o",
+          libraryVersion: "1.6.0",
           signature: "org.sql2o.Connection#createQuery(String)",
           packageName: "org.sql2o",
           typeName: "Connection",
@@ -182,7 +183,8 @@ describe("createDataExtensionYamlsForApplicationMode", () => {
           ],
         },
         {
-          library: "sql2o-1.6.0.jar",
+          library: "sql2o",
+          libraryVersion: "1.6.0",
           signature: "org.sql2o.Query#executeScalar(Class)",
           packageName: "org.sql2o",
           typeName: "Query",
@@ -216,7 +218,8 @@ describe("createDataExtensionYamlsForApplicationMode", () => {
           ],
         },
         {
-          library: "sql2o-2.5.0-alpha1.jar",
+          library: "sql2o",
+          libraryVersion: "2.5.0-alpha1",
           signature: "org.sql2o.Sql2o#Sql2o(String,String,String)",
           packageName: "org.sql2o",
           typeName: "Sql2o",
@@ -239,7 +242,8 @@ describe("createDataExtensionYamlsForApplicationMode", () => {
           ],
         },
         {
-          library: "spring-boot-3.0.2.jar",
+          library: "spring-boot",
+          libraryVersion: "3.0.2",
           signature:
             "org.springframework.boot.SpringApplication#run(Class,String[])",
           packageName: "org.springframework.boot",
@@ -263,7 +267,7 @@ describe("createDataExtensionYamlsForApplicationMode", () => {
           ],
         },
         {
-          library: "rt.jar",
+          library: "rt",
           signature: "java.io.PrintStream#println(String)",
           packageName: "java.io",
           typeName: "PrintStream",
@@ -566,37 +570,28 @@ describe("loadDataExtensionYaml", () => {
 
 describe("createFilenameForLibrary", () => {
   const testCases = [
-    { library: "sql2o.jar", filename: "models/sql2o.model.yml" },
     {
-      library: "sql2o-1.6.0.jar",
+      library: "sql2o",
       filename: "models/sql2o.model.yml",
     },
     {
-      library: "spring-boot-3.0.2.jar",
+      library: "spring-boot",
       filename: "models/spring-boot.model.yml",
     },
     {
-      library: "spring-boot-v3.0.2.jar",
+      library: "spring--boot",
       filename: "models/spring-boot.model.yml",
     },
     {
-      library: "spring-boot-3.0.2-alpha1.jar",
-      filename: "models/spring-boot.model.yml",
-    },
-    {
-      library: "spring-boot-3.0.2beta2.jar",
-      filename: "models/spring-boot.model.yml",
-    },
-    {
-      library: "rt.jar",
+      library: "rt",
       filename: "models/rt.model.yml",
     },
     {
-      library: "System.Runtime.dll",
+      library: "System.Runtime",
       filename: "models/system.runtime.model.yml",
     },
     {
-      library: "System.Runtime.1.5.0.dll",
+      library: "System..Runtime",
       filename: "models/system.runtime.model.yml",
     },
   ];


### PR DESCRIPTION
This adds the versions of libraries to the data extensions editor and hides the filename for Java libraries.

![Screenshot 2023-07-14 at 12 03 47](https://github.com/github/vscode-codeql/assets/1112623/c2cedf33-ef01-4b2e-b47e-a8172ae4ced3)

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
