### PR TITLE
Rename PathTable => AlertTable

### DIFF
--- a/extensions/ql-vscode/src/view/results/alert-table.tsx
+++ b/extensions/ql-vscode/src/view/results/alert-table.tsx
@@ -32,18 +32,21 @@ import { isWholeFileLoc, isLineColumnLoc } from "../../common/bqrs-utils";
 import { ScrollIntoViewHelper } from "./scroll-into-view-helper";
 import { sendTelemetry } from "../common/telemetry";
 
-export type PathTableProps = ResultTableProps & {
+export type AlertTableProps = ResultTableProps & {
   resultSet: InterpretedResultSet<SarifInterpretationData>;
 };
-export interface PathTableState {
+export interface AlertTableState {
   expanded: Set<string>;
   selectedItem: undefined | Keys.ResultKey;
 }
 
-export class PathTable extends React.Component<PathTableProps, PathTableState> {
+export class AlertTable extends React.Component<
+  AlertTableProps,
+  AlertTableState
+> {
   private scroller = new ScrollIntoViewHelper();
 
-  constructor(props: PathTableProps) {
+  constructor(props: AlertTableProps) {
     super(props);
     this.state = { expanded: new Set<string>(), selectedItem: undefined };
     this.handleNavigationEvent = this.handleNavigationEvent.bind(this);

--- a/extensions/ql-vscode/src/view/results/result-tables.tsx
+++ b/extensions/ql-vscode/src/view/results/result-tables.tsx
@@ -14,7 +14,7 @@ import {
   ParsedResultSets,
   IntoResultsViewMsg,
 } from "../../common/interface-types";
-import { PathTable } from "./alert-table";
+import { AlertTable } from "./alert-table";
 import { Graph } from "./graph";
 import { RawTable } from "./raw-results-table";
 import {
@@ -461,7 +461,7 @@ class ResultTable extends React.Component<
               ...resultSet,
               interpretation: { ...resultSet.interpretation, data },
             };
-            return <PathTable {...this.props} resultSet={sarifResultSet} />;
+            return <AlertTable {...this.props} resultSet={sarifResultSet} />;
           }
           case "GraphInterpretationData": {
             const grapResultSet = {


### PR DESCRIPTION
In preparation for converting `PathTable` to a function component, rename it to a clearer name.

The file is called `alert-table.tsx` and I think that `AlertTable` is a more understandable name than `PathTable`. This table is used whenever there are "SarifInterpretationData", which includes `problem` and `path-problem` queries.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
