### PR TITLE
Pull out AlertTableHeader to a separate component/file

### DIFF
--- a/extensions/ql-vscode/src/view/results/alert-table-header.tsx
+++ b/extensions/ql-vscode/src/view/results/alert-table-header.tsx
@@ -42,11 +42,6 @@ export function AlertTableHeader({
     });
   }, [getNextSortState]);
 
-  const clickCallback = useCallback(
-    () => toggleSortStateForColumn(),
-    [toggleSortStateForColumn],
-  );
-
   return (
     <thead>
       <tr>
@@ -54,7 +49,7 @@ export function AlertTableHeader({
         <th
           className={`${sortClass()} vscode-codeql__alert-message-cell`}
           colSpan={3}
-          onClick={clickCallback}
+          onClick={toggleSortStateForColumn}
         >
           Message
         </th>

--- a/extensions/ql-vscode/src/view/results/alert-table-header.tsx
+++ b/extensions/ql-vscode/src/view/results/alert-table-header.tsx
@@ -1,0 +1,76 @@
+import * as React from "react";
+import { useCallback } from "react";
+import { vscode } from "../vscode-api";
+import {
+  InterpretedResultsSortColumn,
+  InterpretedResultsSortState,
+  SortDirection,
+} from "../../common/interface-types";
+import { nextSortDirection } from "./result-table-utils";
+
+export function AlertTableHeader({
+  sortState,
+}: {
+  sortState?: InterpretedResultsSortState;
+}) {
+  const sortClass = useCallback(
+    (column: InterpretedResultsSortColumn): string => {
+      if (sortState !== undefined && sortState.sortBy === column) {
+        return sortState.sortDirection === SortDirection.asc
+          ? "sort-asc"
+          : "sort-desc";
+      } else {
+        return "sort-none";
+      }
+    },
+    [sortState],
+  );
+
+  const getNextSortState = useCallback(
+    (
+      column: InterpretedResultsSortColumn,
+    ): InterpretedResultsSortState | undefined => {
+      const prevDirection =
+        sortState && sortState.sortBy === column
+          ? sortState.sortDirection
+          : undefined;
+      const nextDirection = nextSortDirection(prevDirection, true);
+      return nextDirection === undefined
+        ? undefined
+        : { sortBy: column, sortDirection: nextDirection };
+    },
+    [sortState],
+  );
+
+  const toggleSortStateForColumn = useCallback(
+    (column: InterpretedResultsSortColumn): void => {
+      vscode.postMessage({
+        t: "changeInterpretedSort",
+        sortState: getNextSortState(column),
+      });
+    },
+    [getNextSortState],
+  );
+
+  const clickCallback = useCallback(
+    () => toggleSortStateForColumn("alert-message"),
+    [toggleSortStateForColumn],
+  );
+
+  return (
+    <thead>
+      <tr>
+        <th colSpan={2}></th>
+        <th
+          className={`${sortClass(
+            "alert-message",
+          )} vscode-codeql__alert-message-cell`}
+          colSpan={3}
+          onClick={clickCallback}
+        >
+          Message
+        </th>
+      </tr>
+    </thead>
+  );
+}

--- a/extensions/ql-vscode/src/view/results/alert-table-header.tsx
+++ b/extensions/ql-vscode/src/view/results/alert-table-header.tsx
@@ -13,7 +13,7 @@ export function AlertTableHeader({
   sortState?: InterpretedResultsSortState;
 }) {
   const sortClass = useCallback((): string => {
-    if (sortState !== undefined && sortState.sortBy === "alert-message") {
+    if (sortState?.sortBy === "alert-message") {
       return sortState.sortDirection === SortDirection.asc
         ? "sort-asc"
         : "sort-desc";
@@ -26,7 +26,7 @@ export function AlertTableHeader({
     | InterpretedResultsSortState
     | undefined => {
     const prevDirection =
-      sortState && sortState.sortBy === "alert-message"
+      sortState?.sortBy === "alert-message"
         ? sortState.sortDirection
         : undefined;
     const nextDirection = nextSortDirection(prevDirection, true);

--- a/extensions/ql-vscode/src/view/results/alert-table-header.tsx
+++ b/extensions/ql-vscode/src/view/results/alert-table-header.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import { useCallback } from "react";
 import { vscode } from "../vscode-api";
 import {
-  InterpretedResultsSortColumn,
   InterpretedResultsSortState,
   SortDirection,
 } from "../../common/interface-types";
@@ -13,47 +12,38 @@ export function AlertTableHeader({
 }: {
   sortState?: InterpretedResultsSortState;
 }) {
-  const sortClass = useCallback(
-    (column: InterpretedResultsSortColumn): string => {
-      if (sortState !== undefined && sortState.sortBy === column) {
-        return sortState.sortDirection === SortDirection.asc
-          ? "sort-asc"
-          : "sort-desc";
-      } else {
-        return "sort-none";
-      }
-    },
-    [sortState],
-  );
+  const sortClass = useCallback((): string => {
+    if (sortState !== undefined && sortState.sortBy === "alert-message") {
+      return sortState.sortDirection === SortDirection.asc
+        ? "sort-asc"
+        : "sort-desc";
+    } else {
+      return "sort-none";
+    }
+  }, [sortState]);
 
-  const getNextSortState = useCallback(
-    (
-      column: InterpretedResultsSortColumn,
-    ): InterpretedResultsSortState | undefined => {
-      const prevDirection =
-        sortState && sortState.sortBy === column
-          ? sortState.sortDirection
-          : undefined;
-      const nextDirection = nextSortDirection(prevDirection, true);
-      return nextDirection === undefined
-        ? undefined
-        : { sortBy: column, sortDirection: nextDirection };
-    },
-    [sortState],
-  );
+  const getNextSortState = useCallback(():
+    | InterpretedResultsSortState
+    | undefined => {
+    const prevDirection =
+      sortState && sortState.sortBy === "alert-message"
+        ? sortState.sortDirection
+        : undefined;
+    const nextDirection = nextSortDirection(prevDirection, true);
+    return nextDirection === undefined
+      ? undefined
+      : { sortBy: "alert-message", sortDirection: nextDirection };
+  }, [sortState]);
 
-  const toggleSortStateForColumn = useCallback(
-    (column: InterpretedResultsSortColumn): void => {
-      vscode.postMessage({
-        t: "changeInterpretedSort",
-        sortState: getNextSortState(column),
-      });
-    },
-    [getNextSortState],
-  );
+  const toggleSortStateForColumn = useCallback((): void => {
+    vscode.postMessage({
+      t: "changeInterpretedSort",
+      sortState: getNextSortState(),
+    });
+  }, [getNextSortState]);
 
   const clickCallback = useCallback(
-    () => toggleSortStateForColumn("alert-message"),
+    () => toggleSortStateForColumn(),
     [toggleSortStateForColumn],
   );
 
@@ -62,9 +52,7 @@ export function AlertTableHeader({
       <tr>
         <th colSpan={2}></th>
         <th
-          className={`${sortClass(
-            "alert-message",
-          )} vscode-codeql__alert-message-cell`}
+          className={`${sortClass()} vscode-codeql__alert-message-cell`}
           colSpan={3}
           onClick={clickCallback}
         >


### PR DESCRIPTION
This PR tries to pull out the table header to a separate file to make the `PathTable` component and file a bit smaller. This is a stepping stone to converting `PathTable` to a function component.

I think this is worth it because the props for the header are surprisingly small, and there are quite a few supporting functions that we can also move. So overall I think it removes a moderate amount of complexity from `PathTable`. It's unlikely that the `AlertTableHeader` component could be reused, but reuse wasn't really a driving factor and the main focus is on reducing the size of `alert-table.tsx`.

The new class is named `AlertTableHeader` rather than `PathTableHeader` because I'm assuming that https://github.com/github/vscode-codeql/pull/2570 will also be merged.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
