### PR TITLE
Update data extensions modelling table title bar

### DIFF
--- a/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
@@ -9,6 +9,7 @@ import { calculateModeledPercentage } from "../../data-extensions-editor/shared/
 import { decimalFormatter, percentFormatter } from "./formatters";
 import { Codicon } from "../common";
 import { Mode } from "../../data-extensions-editor/shared/mode";
+import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
 
 const LibraryContainer = styled.div`
   margin-bottom: 1rem;
@@ -19,13 +20,44 @@ const TitleContainer = styled.button`
   gap: 0.5em;
   align-items: center;
   width: 100%;
-  font-size: 1.2em;
-  font-weight: bold;
 
   color: var(--vscode-editor-foreground);
   background-color: transparent;
   border: none;
   cursor: pointer;
+`;
+
+const NameContainer = styled.div`
+  display: flex;
+  gap: 0.5em;
+  align-items: baseline;
+  flex-grow: 1;
+  text-align: left;
+`;
+
+const DependencyName = styled.span`
+  font-size: 1.2em;
+  font-weight: bold;
+`;
+
+const ModeledPercentage = styled.span`
+  color: var(--vscode-descriptionForeground);
+`;
+
+const UnsavedLabel = styled.span`
+  text-transform: uppercase;
+  background-color: var(--vscode-input-background);
+  padding: 0.2em 0.4em;
+  border-radius: 0.2em;
+`;
+
+const TitleButton = styled(VSCodeButton)`
+  background-color: transparent;
+
+  &:hover {
+    pointer: cursor;
+    background-color: var(--vscode-button-secondaryBackground);
+  }
 `;
 
 const StatusContainer = styled.div`
@@ -43,6 +75,7 @@ type Props = {
   externalApiUsages: ExternalApiUsage[];
   modeledMethods: Record<string, ModeledMethod>;
   mode: Mode;
+  hasUnsavedChanges: boolean;
   onChange: (
     externalApiUsage: ExternalApiUsage,
     modeledMethod: ModeledMethod,
@@ -54,6 +87,7 @@ export const LibraryRow = ({
   externalApiUsages,
   modeledMethods,
   mode,
+  hasUnsavedChanges,
   onChange,
 }: Props) => {
   const modeledPercentage = useMemo(() => {
@@ -70,6 +104,16 @@ export const LibraryRow = ({
     return externalApiUsages.reduce((acc, curr) => acc + curr.usages.length, 0);
   }, [externalApiUsages]);
 
+  const handleModelWithAI = useCallback(async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+  }, []);
+
+  const handleModelFromSource = useCallback(async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+  }, []);
+
   return (
     <LibraryContainer>
       <TitleContainer onClick={toggleExpanded} aria-expanded={isExpanded}>
@@ -78,20 +122,21 @@ export const LibraryRow = ({
         ) : (
           <Codicon name="chevron-right" label="Expand" />
         )}
-        {title}
-        {isExpanded ? null : (
-          <>
-            {" "}
-            (
-            {pluralize(
-              externalApiUsages.length,
-              "method",
-              "methods",
-              decimalFormatter.format.bind(decimalFormatter),
-            )}
-            , {percentFormatter.format(modeledPercentage / 100)} modeled)
-          </>
-        )}
+        <NameContainer>
+          <DependencyName>{title}</DependencyName>
+          <ModeledPercentage>
+            {percentFormatter.format(modeledPercentage / 100)} modeled
+          </ModeledPercentage>
+          {hasUnsavedChanges ? <UnsavedLabel>UNSAVED</UnsavedLabel> : null}
+        </NameContainer>
+        <TitleButton onClick={handleModelWithAI}>
+          <Codicon name="lightbulb-autofix" label="Model with AI" />
+          &nbsp;Model with AI
+        </TitleButton>
+        <TitleButton onClick={handleModelFromSource}>
+          <Codicon name="code" label="Model from source" />
+          &nbsp;Model from source
+        </TitleButton>
       </TitleContainer>
       {isExpanded && (
         <>

--- a/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
@@ -3,10 +3,9 @@ import { useCallback, useMemo, useState } from "react";
 import styled from "styled-components";
 import { ExternalApiUsage } from "../../data-extensions-editor/external-api-usage";
 import { ModeledMethod } from "../../data-extensions-editor/modeled-method";
-import { pluralize } from "../../common/word";
 import { ModeledMethodDataGrid } from "./ModeledMethodDataGrid";
 import { calculateModeledPercentage } from "../../data-extensions-editor/shared/modeled-percentage";
-import { decimalFormatter, percentFormatter } from "./formatters";
+import { percentFormatter } from "./formatters";
 import { Codicon } from "../common";
 import { Mode } from "../../data-extensions-editor/shared/mode";
 import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
@@ -60,16 +59,6 @@ const TitleButton = styled(VSCodeButton)`
   }
 `;
 
-const StatusContainer = styled.div`
-  display: flex;
-  gap: 1em;
-  align-items: center;
-
-  margin-top: 0.5em;
-  margin-bottom: 0.5em;
-  margin-left: 1em;
-`;
-
 type Props = {
   title: string;
   externalApiUsages: ExternalApiUsage[];
@@ -99,10 +88,6 @@ export const LibraryRow = ({
   const toggleExpanded = useCallback(async () => {
     setExpanded((oldIsExpanded) => !oldIsExpanded);
   }, []);
-
-  const usagesCount = useMemo(() => {
-    return externalApiUsages.reduce((acc, curr) => acc + curr.usages.length, 0);
-  }, [externalApiUsages]);
 
   const handleModelWithAI = useCallback(async (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -139,35 +124,12 @@ export const LibraryRow = ({
         </TitleButton>
       </TitleContainer>
       {isExpanded && (
-        <>
-          <StatusContainer>
-            <div>
-              {pluralize(
-                externalApiUsages.length,
-                "method",
-                "methods",
-                decimalFormatter.format.bind(decimalFormatter),
-              )}
-            </div>
-            <div>
-              {pluralize(
-                usagesCount,
-                "usage",
-                "usages",
-                decimalFormatter.format.bind(decimalFormatter),
-              )}
-            </div>
-            <div>
-              {percentFormatter.format(modeledPercentage / 100)} modeled
-            </div>
-          </StatusContainer>
-          <ModeledMethodDataGrid
-            externalApiUsages={externalApiUsages}
-            modeledMethods={modeledMethods}
-            mode={mode}
-            onChange={onChange}
-          />
-        </>
+        <ModeledMethodDataGrid
+          externalApiUsages={externalApiUsages}
+          modeledMethods={modeledMethods}
+          mode={mode}
+          onChange={onChange}
+        />
       )}
     </LibraryContainer>
   );

--- a/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodsList.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodsList.tsx
@@ -41,6 +41,7 @@ export const ModeledMethodsList = ({
           externalApiUsages={grouped[libraryName]}
           modeledMethods={modeledMethods}
           mode={mode}
+          hasUnsavedChanges={false}
           onChange={onChange}
         />
       ))}


### PR DESCRIPTION
Updates the title bar of the modelling tables to match the new designs:
<img width="1662" alt="Screenshot 2023-07-03 at 15 57 09" src="https://github.com/github/vscode-codeql/assets/3749000/5aee45c6-ccac-4505-9e6f-b31e42545659">

I removed the old status info, since that is not present in the new designs.

A lot of manual styling was needed to get these new elements looking like the designs. Hopefully that's ok, but if it's too complicated or it's straying a bit too far from VS Code design principles then we can look at that.

The "Model with AI" / "Model from source" buttons and the "UNSAVED" label aren't hooked up to anything yet, but we'll get to those in a later PR. I gave them all no-op handlers for now. Since the data extensions view is not released yet we're not too worried about how the view looks while this work is in progress.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
