### PR TITLE
Use more varied data for the number of usages

### DIFF
--- a/extensions/ql-vscode/src/stories/data-extensions-editor/DataExtensionsEditor.stories.tsx
+++ b/extensions/ql-vscode/src/stories/data-extensions-editor/DataExtensionsEditor.stories.tsx
@@ -39,28 +39,16 @@ DataExtensionsEditor.args = {
       methodName: "createQuery",
       methodParameters: "(String)",
       supported: true,
-      usages: [
-        {
-          label: "createQuery(...)",
-          url: {
-            uri: "file:/home/runner/work/sql2o-example/sql2o-example/src/main/java/org/example/HelloController.java",
-            startLine: 15,
-            startColumn: 13,
-            endLine: 15,
-            endColumn: 56,
-          },
+      usages: Array(10).fill({
+        label: "createQuery(...)",
+        url: {
+          uri: "file:/home/runner/work/sql2o-example/sql2o-example/src/main/java/org/example/HelloController.java",
+          startLine: 15,
+          startColumn: 13,
+          endLine: 15,
+          endColumn: 56,
         },
-        {
-          label: "createQuery(...)",
-          url: {
-            uri: "file:/home/runner/work/sql2o-example/sql2o-example/src/main/java/org/example/HelloController.java",
-            startLine: 26,
-            startColumn: 13,
-            endLine: 26,
-            endColumn: 39,
-          },
-        },
-      ],
+      }),
     },
     {
       library: "sql2o-1.6.0.jar",
@@ -70,28 +58,16 @@ DataExtensionsEditor.args = {
       methodName: "executeScalar",
       methodParameters: "(Class)",
       supported: true,
-      usages: [
-        {
-          label: "executeScalar(...)",
-          url: {
-            uri: "file:/home/runner/work/sql2o-example/sql2o-example/src/main/java/org/example/HelloController.java",
-            startLine: 15,
-            startColumn: 13,
-            endLine: 15,
-            endColumn: 85,
-          },
+      usages: Array(2).fill({
+        label: "executeScalar(...)",
+        url: {
+          uri: "file:/home/runner/work/sql2o-example/sql2o-example/src/main/java/org/example/HelloController.java",
+          startLine: 15,
+          startColumn: 13,
+          endLine: 15,
+          endColumn: 85,
         },
-        {
-          label: "executeScalar(...)",
-          url: {
-            uri: "file:/home/runner/work/sql2o-example/sql2o-example/src/main/java/org/example/HelloController.java",
-            startLine: 26,
-            startColumn: 13,
-            endLine: 26,
-            endColumn: 68,
-          },
-        },
-      ],
+      }),
     },
     {
       library: "sql2o-1.6.0.jar",
@@ -101,28 +77,16 @@ DataExtensionsEditor.args = {
       methodName: "open",
       methodParameters: "()",
       supported: false,
-      usages: [
-        {
-          label: "open(...)",
-          url: {
-            uri: "file:/home/runner/work/sql2o-example/sql2o-example/src/main/java/org/example/HelloController.java",
-            startLine: 14,
-            startColumn: 24,
-            endLine: 14,
-            endColumn: 35,
-          },
+      usages: Array(28).fill({
+        label: "open(...)",
+        url: {
+          uri: "file:/home/runner/work/sql2o-example/sql2o-example/src/main/java/org/example/HelloController.java",
+          startLine: 14,
+          startColumn: 24,
+          endLine: 14,
+          endColumn: 35,
         },
-        {
-          label: "open(...)",
-          url: {
-            uri: "file:/home/runner/work/sql2o-example/sql2o-example/src/main/java/org/example/HelloController.java",
-            startLine: 25,
-            startColumn: 24,
-            endLine: 25,
-            endColumn: 35,
-          },
-        },
-      ],
+      }),
     },
     {
       library: "rt.jar",
@@ -154,18 +118,16 @@ DataExtensionsEditor.args = {
       methodName: "run",
       methodParameters: "(Class,String[])",
       supported: false,
-      usages: [
-        {
-          label: "run(...)",
-          url: {
-            uri: "file:/home/runner/work/sql2o-example/sql2o-example/src/main/java/org/example/Sql2oExampleApplication.java",
-            startLine: 9,
-            startColumn: 9,
-            endLine: 9,
-            endColumn: 66,
-          },
+      usages: Array(7).fill({
+        label: "run(...)",
+        url: {
+          uri: "file:/home/runner/work/sql2o-example/sql2o-example/src/main/java/org/example/Sql2oExampleApplication.java",
+          startLine: 9,
+          startColumn: 9,
+          endLine: 9,
+          endColumn: 66,
         },
-      ],
+      }),
     },
     {
       library: "sql2o-1.6.0.jar",
@@ -175,18 +137,16 @@ DataExtensionsEditor.args = {
       methodName: "Sql2o",
       methodParameters: "(String,String,String)",
       supported: false,
-      usages: [
-        {
-          label: "new Sql2o(...)",
-          url: {
-            uri: "file:/home/runner/work/sql2o-example/sql2o-example/src/main/java/org/example/HelloController.java",
-            startLine: 10,
-            startColumn: 33,
-            endLine: 10,
-            endColumn: 88,
-          },
+      usages: Array(106).fill({
+        label: "new Sql2o(...)",
+        url: {
+          uri: "file:/home/runner/work/sql2o-example/sql2o-example/src/main/java/org/example/HelloController.java",
+          startLine: 10,
+          startColumn: 33,
+          endLine: 10,
+          endColumn: 88,
         },
-      ],
+      }),
     },
     {
       library: "sql2o-1.6.0.jar",
@@ -196,18 +156,16 @@ DataExtensionsEditor.args = {
       methodName: "Sql2o",
       methodParameters: "(String)",
       supported: false,
-      usages: [
-        {
-          label: "new Sql2o(...)",
-          url: {
-            uri: "file:/home/runner/work/sql2o-example/sql2o-example/src/main/java/org/example/HelloController.java",
-            startLine: 23,
-            startColumn: 23,
-            endLine: 23,
-            endColumn: 36,
-          },
+      usages: Array(4).fill({
+        label: "new Sql2o(...)",
+        url: {
+          uri: "file:/home/runner/work/sql2o-example/sql2o-example/src/main/java/org/example/HelloController.java",
+          startLine: 23,
+          startColumn: 23,
+          endLine: 23,
+          endColumn: 36,
         },
-      ],
+      }),
     },
   ],
   initialModeledMethods: {


### PR DESCRIPTION
The main goal here is making the number of usages not all be single-digit numbers. This helps show up errors in the column alignment of the table much more easily.

Rather than writing out each array element, I'm using `Array(10).fill(...)` to create an array of arbitrary size. Each element of the array will be the same object, but I think that's fine for this story.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
