### PR TITLE
Data extensions UI: Add divider between title and status containers

### DIFF
--- a/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
@@ -8,7 +8,7 @@ import { calculateModeledPercentage } from "../../data-extensions-editor/shared/
 import { percentFormatter } from "./formatters";
 import { Codicon } from "../common";
 import { Mode } from "../../data-extensions-editor/shared/mode";
-import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
+import { VSCodeButton, VSCodeDivider } from "@vscode/webview-ui-toolkit/react";
 
 const LibraryContainer = styled.div`
   margin-bottom: 1rem;
@@ -24,6 +24,11 @@ const TitleContainer = styled.button`
   background-color: transparent;
   border: none;
   cursor: pointer;
+`;
+
+const TitleDivider = styled(VSCodeDivider)`
+  padding-top: 0.3rem;
+  padding-bottom: 0.3rem;
 `;
 
 const NameContainer = styled.div`
@@ -124,12 +129,15 @@ export const LibraryRow = ({
         </TitleButton>
       </TitleContainer>
       {isExpanded && (
-        <ModeledMethodDataGrid
-          externalApiUsages={externalApiUsages}
-          modeledMethods={modeledMethods}
-          mode={mode}
-          onChange={onChange}
-        />
+        <>
+          <TitleDivider />
+          <ModeledMethodDataGrid
+            externalApiUsages={externalApiUsages}
+            modeledMethods={modeledMethods}
+            mode={mode}
+            onChange={onChange}
+          />
+        </>
       )}
     </LibraryContainer>
   );


### PR DESCRIPTION
Adds a dividing line after the title.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
