### PR TITLE
Data extensions UI: Add save button

### DIFF
--- a/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
@@ -26,7 +26,7 @@ const TitleContainer = styled.button`
   cursor: pointer;
 `;
 
-const TitleDivider = styled(VSCodeDivider)`
+const SectionDivider = styled(VSCodeDivider)`
   padding-top: 0.3rem;
   padding-bottom: 0.3rem;
 `;
@@ -62,6 +62,13 @@ const TitleButton = styled(VSCodeButton)`
     pointer: cursor;
     background-color: var(--vscode-button-secondaryBackground);
   }
+`;
+
+const ButtonsContainer = styled.div`
+  display: flex;
+  gap: 0.4em;
+  justify-content: right;
+  margin-bottom: 1rem;
 `;
 
 type Props = {
@@ -104,6 +111,11 @@ export const LibraryRow = ({
     e.preventDefault();
   }, []);
 
+  const handleSave = useCallback(async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+  }, []);
+
   return (
     <LibraryContainer>
       <TitleContainer onClick={toggleExpanded} aria-expanded={isExpanded}>
@@ -130,13 +142,17 @@ export const LibraryRow = ({
       </TitleContainer>
       {isExpanded && (
         <>
-          <TitleDivider />
+          <SectionDivider />
           <ModeledMethodDataGrid
             externalApiUsages={externalApiUsages}
             modeledMethods={modeledMethods}
             mode={mode}
             onChange={onChange}
           />
+          <SectionDivider />
+          <ButtonsContainer>
+            <VSCodeButton onClick={handleSave}>Save</VSCodeButton>
+          </ButtonsContainer>
         </>
       )}
     </LibraryContainer>


### PR DESCRIPTION
Add save button to the "bottom bar" of each individual library model:

![image](https://github.com/github/vscode-codeql/assets/42641846/d8e6717c-9093-44a3-8791-754eca6e6bc4)

(The button doesn't do anything yet, but stay tuned!)

## Checklist

N/A - internal only for now

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
