### PR TITLE
Update data extensions modelling table to new designs

### DIFF
--- a/extensions/ql-vscode/src/view/common/Dropdown.tsx
+++ b/extensions/ql-vscode/src/view/common/Dropdown.tsx
@@ -1,0 +1,21 @@
+import styled from "styled-components";
+
+/**
+ * Styled to look like a `VSCodeDropdown`.
+ *
+ * The reason for doing this is that `VSCodeDropdown` doesn't handle fitting into
+ * available space and truncating content, and this leads to breaking the
+ * `VSCodeDataGrid` layout. This version using `select` directly will truncate the
+ * content as necessary and fit into whatever space is available.
+ * See https://github.com/github/vscode-codeql/pull/2582#issuecomment-1622164429
+ * for more info on the problem and other potential solutions.
+ */
+export const Dropdown = styled.select`
+  width: 100%;
+  height: calc(var(--input-height) * 1px);
+  background: var(--dropdown-background);
+  color: var(--foreground);
+  font-family: var(--font-family);
+  border: none;
+  padding: 2px 6px 2px 8px;
+`;

--- a/extensions/ql-vscode/src/view/common/Dropdown.tsx
+++ b/extensions/ql-vscode/src/view/common/Dropdown.tsx
@@ -1,16 +1,8 @@
+import * as React from "react";
+import { ChangeEvent } from "react";
 import styled from "styled-components";
 
-/**
- * Styled to look like a `VSCodeDropdown`.
- *
- * The reason for doing this is that `VSCodeDropdown` doesn't handle fitting into
- * available space and truncating content, and this leads to breaking the
- * `VSCodeDataGrid` layout. This version using `select` directly will truncate the
- * content as necessary and fit into whatever space is available.
- * See https://github.com/github/vscode-codeql/pull/2582#issuecomment-1622164429
- * for more info on the problem and other potential solutions.
- */
-export const Dropdown = styled.select`
+const StyledDropdown = styled.select`
   width: 100%;
   height: calc(var(--input-height) * 1px);
   background: var(--dropdown-background);
@@ -19,3 +11,40 @@ export const Dropdown = styled.select`
   border: none;
   padding: 2px 6px 2px 8px;
 `;
+
+type Props = {
+  value: string | undefined;
+  options: Array<{ value: string; label: string }>;
+  disabled?: boolean;
+  onChange: (event: ChangeEvent<HTMLSelectElement>) => void;
+};
+
+/**
+ * A dropdown implementation styled to look like `VSCodeDropdown`.
+ *
+ * The reason for doing this is that `VSCodeDropdown` doesn't handle fitting into
+ * available space and truncating content, and this leads to breaking the
+ * `VSCodeDataGrid` layout. This version using `select` directly will truncate the
+ * content as necessary and fit into whatever space is available.
+ * See https://github.com/github/vscode-codeql/pull/2582#issuecomment-1622164429
+ * for more info on the problem and other potential solutions.
+ */
+export function Dropdown({ value, options, disabled, onChange }: Props) {
+  return (
+    <StyledDropdown
+      value={disabled ? undefined : value}
+      disabled={disabled}
+      onChange={onChange}
+    >
+      {!disabled && (
+        <>
+          {options.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </>
+      )}
+    </StyledDropdown>
+  );
+}

--- a/extensions/ql-vscode/src/view/common/Dropdown.tsx
+++ b/extensions/ql-vscode/src/view/common/Dropdown.tsx
@@ -5,9 +5,8 @@ import styled from "styled-components";
 const StyledDropdown = styled.select`
   width: 100%;
   height: calc(var(--input-height) * 1px);
-  background: var(--dropdown-background);
-  color: var(--foreground);
-  font-family: var(--font-family);
+  background: var(--vscode-dropdown-background);
+  color: var(--vscode-foreground);
   border: none;
   padding: 2px 6px 2px 8px;
 `;

--- a/extensions/ql-vscode/src/view/data-extensions-editor/KindInput.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/KindInput.tsx
@@ -13,10 +13,11 @@ type Props = {
   kinds: Array<ModeledMethod["kind"]>;
 
   value: ModeledMethod["kind"] | undefined;
+  disabled?: boolean;
   onChange: (value: ModeledMethod["kind"]) => void;
 };
 
-export const KindInput = ({ kinds, value, onChange }: Props) => {
+export const KindInput = ({ kinds, value, disabled, onChange }: Props) => {
   const handleInput = useCallback(
     (e: InputEvent) => {
       const target = e.target as HTMLSelectElement;
@@ -37,7 +38,7 @@ export const KindInput = ({ kinds, value, onChange }: Props) => {
   }, [value, kinds, onChange]);
 
   return (
-    <Dropdown value={value} onInput={handleInput}>
+    <Dropdown value={value} disabled={disabled} onInput={handleInput}>
       {kinds.map((kind) => (
         <VSCodeOption key={kind} value={kind}>
           {kind}

--- a/extensions/ql-vscode/src/view/data-extensions-editor/KindInput.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/KindInput.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { ChangeEvent, useCallback, useEffect } from "react";
+import { ChangeEvent, useCallback, useEffect, useMemo } from "react";
 
 import type { ModeledMethod } from "../../data-extensions-editor/modeled-method";
 import { Dropdown } from "../common/Dropdown";
@@ -13,6 +13,11 @@ type Props = {
 };
 
 export const KindInput = ({ kinds, value, disabled, onChange }: Props) => {
+  const options = useMemo(
+    () => kinds.map((kind) => ({ value: kind, label: kind })),
+    [kinds],
+  );
+
   const handleInput = useCallback(
     (e: ChangeEvent<HTMLSelectElement>) => {
       const target = e.target as HTMLSelectElement;
@@ -33,16 +38,11 @@ export const KindInput = ({ kinds, value, disabled, onChange }: Props) => {
   }, [value, kinds, onChange]);
 
   return (
-    <Dropdown value={value} disabled={disabled} onChange={handleInput}>
-      {!disabled && (
-        <>
-          {kinds.map((kind) => (
-            <option key={kind} value={kind}>
-              {kind}
-            </option>
-          ))}
-        </>
-      )}
-    </Dropdown>
+    <Dropdown
+      value={value}
+      options={options}
+      disabled={disabled}
+      onChange={handleInput}
+    />
   );
 };

--- a/extensions/ql-vscode/src/view/data-extensions-editor/KindInput.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/KindInput.tsx
@@ -1,13 +1,8 @@
 import * as React from "react";
-import { useCallback, useEffect } from "react";
-import styled from "styled-components";
-import { VSCodeDropdown, VSCodeOption } from "@vscode/webview-ui-toolkit/react";
+import { ChangeEvent, useCallback, useEffect } from "react";
 
 import type { ModeledMethod } from "../../data-extensions-editor/modeled-method";
-
-const Dropdown = styled(VSCodeDropdown)`
-  width: 100%;
-`;
+import { Dropdown } from "../common/Dropdown";
 
 type Props = {
   kinds: Array<ModeledMethod["kind"]>;
@@ -19,7 +14,7 @@ type Props = {
 
 export const KindInput = ({ kinds, value, disabled, onChange }: Props) => {
   const handleInput = useCallback(
-    (e: InputEvent) => {
+    (e: ChangeEvent<HTMLSelectElement>) => {
       const target = e.target as HTMLSelectElement;
 
       onChange(target.value as ModeledMethod["kind"]);
@@ -38,12 +33,16 @@ export const KindInput = ({ kinds, value, disabled, onChange }: Props) => {
   }, [value, kinds, onChange]);
 
   return (
-    <Dropdown value={value} disabled={disabled} onInput={handleInput}>
-      {kinds.map((kind) => (
-        <VSCodeOption key={kind} value={kind}>
-          {kind}
-        </VSCodeOption>
-      ))}
+    <Dropdown value={value} disabled={disabled} onChange={handleInput}>
+      {!disabled && (
+        <>
+          {kinds.map((kind) => (
+            <option key={kind} value={kind}>
+              {kind}
+            </option>
+          ))}
+        </>
+      )}
     </Dropdown>
   );
 };

--- a/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
@@ -35,6 +35,10 @@ const UsagesButton = styled.button`
   cursor: pointer;
 `;
 
+const ViewLink = styled(VSCodeLink)`
+  white-space: nowrap;
+`;
+
 type Props = {
   externalApiUsage: ExternalApiUsage;
   modeledMethod: ModeledMethod | undefined;
@@ -195,7 +199,7 @@ export const MethodRow = ({
             {externalApiUsage.usages.length}
           </UsagesButton>
         )}
-        <VSCodeLink onClick={jumpToUsage}>View</VSCodeLink>
+        <ViewLink onClick={jumpToUsage}>View</ViewLink>
       </ApiOrMethodCell>
       <VSCodeDataGridCell gridColumn={2}>
         <Dropdown

--- a/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
@@ -171,52 +171,54 @@ export const MethodRow = ({
         <VSCodeLink onClick={jumpToUsage}>View</VSCodeLink>
       </ApiOrMethodCell>
       <VSCodeDataGridCell gridColumn={2}>
-        {showModelTypeCell && (
-          <Dropdown
-            value={modeledMethod?.type ?? "none"}
-            onInput={handleTypeInput}
-          >
-            <VSCodeOption value="none">Unmodeled</VSCodeOption>
-            <VSCodeOption value="source">Source</VSCodeOption>
-            <VSCodeOption value="sink">Sink</VSCodeOption>
-            <VSCodeOption value="summary">Flow summary</VSCodeOption>
-            <VSCodeOption value="neutral">Neutral</VSCodeOption>
-          </Dropdown>
-        )}
+        <Dropdown
+          value={showModelTypeCell && (modeledMethod?.type ?? "none")}
+          disabled={!showModelTypeCell}
+          onInput={handleTypeInput}
+        >
+          <VSCodeOption value="none">Unmodeled</VSCodeOption>
+          <VSCodeOption value="source">Source</VSCodeOption>
+          <VSCodeOption value="sink">Sink</VSCodeOption>
+          <VSCodeOption value="summary">Flow summary</VSCodeOption>
+          <VSCodeOption value="neutral">Neutral</VSCodeOption>
+        </Dropdown>
       </VSCodeDataGridCell>
       <VSCodeDataGridCell gridColumn={3}>
-        {showInputCell && (
-          <Dropdown value={modeledMethod?.input} onInput={handleInputInput}>
-            <VSCodeOption value="Argument[this]">Argument[this]</VSCodeOption>
-            {argumentsList.map((argument, index) => (
-              <VSCodeOption key={argument} value={`Argument[${index}]`}>
-                Argument[{index}]: {argument}
-              </VSCodeOption>
-            ))}
-          </Dropdown>
-        )}
+        <Dropdown
+          value={showInputCell && modeledMethod?.input}
+          disabled={!showInputCell}
+          onInput={handleInputInput}
+        >
+          <VSCodeOption value="Argument[this]">Argument[this]</VSCodeOption>
+          {argumentsList.map((argument, index) => (
+            <VSCodeOption key={argument} value={`Argument[${index}]`}>
+              Argument[{index}]: {argument}
+            </VSCodeOption>
+          ))}
+        </Dropdown>
       </VSCodeDataGridCell>
       <VSCodeDataGridCell gridColumn={4}>
-        {showOutputCell && (
-          <Dropdown value={modeledMethod?.output} onInput={handleOutputInput}>
-            <VSCodeOption value="ReturnValue">ReturnValue</VSCodeOption>
-            <VSCodeOption value="Argument[this]">Argument[this]</VSCodeOption>
-            {argumentsList.map((argument, index) => (
-              <VSCodeOption key={argument} value={`Argument[${index}]`}>
-                Argument[{index}]: {argument}
-              </VSCodeOption>
-            ))}
-          </Dropdown>
-        )}
+        <Dropdown
+          value={showOutputCell && modeledMethod?.output}
+          disabled={!showOutputCell}
+          onInput={handleOutputInput}
+        >
+          <VSCodeOption value="ReturnValue">ReturnValue</VSCodeOption>
+          <VSCodeOption value="Argument[this]">Argument[this]</VSCodeOption>
+          {argumentsList.map((argument, index) => (
+            <VSCodeOption key={argument} value={`Argument[${index}]`}>
+              Argument[{index}]: {argument}
+            </VSCodeOption>
+          ))}
+        </Dropdown>
       </VSCodeDataGridCell>
       <VSCodeDataGridCell gridColumn={5}>
-        {showKindCell && (
-          <KindInput
-            kinds={predicate?.supportedKinds || []}
-            value={modeledMethod?.kind}
-            onChange={handleKindChange}
-          />
-        )}
+        <KindInput
+          kinds={predicate?.supportedKinds || []}
+          value={showKindCell && modeledMethod?.kind}
+          disabled={!showKindCell}
+          onChange={handleKindChange}
+        />
       </VSCodeDataGridCell>
     </VSCodeDataGridRow>
   );

--- a/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
@@ -25,21 +25,6 @@ const Dropdown = styled(VSCodeDropdown)`
   width: 100%;
 `;
 
-type SupportedUnsupportedSpanProps = {
-  supported: boolean;
-  modeled: ModeledMethod | undefined;
-};
-
-const SupportSpan = styled.span<SupportedUnsupportedSpanProps>`
-  color: ${(props) => {
-    if (!props.supported && props.modeled && props.modeled?.type !== "none") {
-      return "orange";
-    } else {
-      return props.supported ? "green" : "red";
-    }
-  }};
-`;
-
 const ApiOrMethodCell = styled(VSCodeDataGridCell)`
   display: flex;
   flex-direction: row;
@@ -164,14 +149,11 @@ export const MethodRow = ({
     <VSCodeDataGridRow>
       <ApiOrMethodCell gridColumn={1}>
         <VSCodeCheckbox />
-        <SupportSpan
-          supported={externalApiUsage.supported}
-          modeled={modeledMethod}
-        >
+        <span>
           {externalApiUsage.packageName}.{externalApiUsage.typeName}.
           {externalApiUsage.methodName}
           {externalApiUsage.methodParameters}
-        </SupportSpan>
+        </span>
         {mode === Mode.Application && (
           <UsagesButton onClick={jumpToUsage}>
             {externalApiUsage.usages.length}

--- a/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
@@ -145,6 +145,15 @@ export const MethodRow = ({
       ? extensiblePredicateDefinitions[modeledMethod.type]
       : undefined;
 
+  const showModelTypeCell =
+    !externalApiUsage.supported ||
+    (modeledMethod && modeledMethod?.type !== "none");
+  const showInputCell =
+    modeledMethod?.type && ["sink", "summary"].includes(modeledMethod?.type);
+  const showOutputCell =
+    modeledMethod?.type && ["source", "summary"].includes(modeledMethod?.type);
+  const showKindCell = predicate?.supportedKinds;
+
   return (
     <VSCodeDataGridRow>
       <ApiOrMethodCell gridColumn={1}>
@@ -162,8 +171,7 @@ export const MethodRow = ({
         <VSCodeLink onClick={jumpToUsage}>View</VSCodeLink>
       </ApiOrMethodCell>
       <VSCodeDataGridCell gridColumn={2}>
-        {(!externalApiUsage.supported ||
-          (modeledMethod && modeledMethod?.type !== "none")) && (
+        {showModelTypeCell && (
           <Dropdown
             value={modeledMethod?.type ?? "none"}
             onInput={handleTypeInput}
@@ -177,36 +185,34 @@ export const MethodRow = ({
         )}
       </VSCodeDataGridCell>
       <VSCodeDataGridCell gridColumn={3}>
-        {modeledMethod?.type &&
-          ["sink", "summary"].includes(modeledMethod?.type) && (
-            <Dropdown value={modeledMethod?.input} onInput={handleInputInput}>
-              <VSCodeOption value="Argument[this]">Argument[this]</VSCodeOption>
-              {argumentsList.map((argument, index) => (
-                <VSCodeOption key={argument} value={`Argument[${index}]`}>
-                  Argument[{index}]: {argument}
-                </VSCodeOption>
-              ))}
-            </Dropdown>
-          )}
+        {showInputCell && (
+          <Dropdown value={modeledMethod?.input} onInput={handleInputInput}>
+            <VSCodeOption value="Argument[this]">Argument[this]</VSCodeOption>
+            {argumentsList.map((argument, index) => (
+              <VSCodeOption key={argument} value={`Argument[${index}]`}>
+                Argument[{index}]: {argument}
+              </VSCodeOption>
+            ))}
+          </Dropdown>
+        )}
       </VSCodeDataGridCell>
       <VSCodeDataGridCell gridColumn={4}>
-        {modeledMethod?.type &&
-          ["source", "summary"].includes(modeledMethod?.type) && (
-            <Dropdown value={modeledMethod?.output} onInput={handleOutputInput}>
-              <VSCodeOption value="ReturnValue">ReturnValue</VSCodeOption>
-              <VSCodeOption value="Argument[this]">Argument[this]</VSCodeOption>
-              {argumentsList.map((argument, index) => (
-                <VSCodeOption key={argument} value={`Argument[${index}]`}>
-                  Argument[{index}]: {argument}
-                </VSCodeOption>
-              ))}
-            </Dropdown>
-          )}
+        {showOutputCell && (
+          <Dropdown value={modeledMethod?.output} onInput={handleOutputInput}>
+            <VSCodeOption value="ReturnValue">ReturnValue</VSCodeOption>
+            <VSCodeOption value="Argument[this]">Argument[this]</VSCodeOption>
+            {argumentsList.map((argument, index) => (
+              <VSCodeOption key={argument} value={`Argument[${index}]`}>
+                Argument[{index}]: {argument}
+              </VSCodeOption>
+            ))}
+          </Dropdown>
+        )}
       </VSCodeDataGridCell>
       <VSCodeDataGridCell gridColumn={5}>
-        {predicate?.supportedKinds && (
+        {showKindCell && (
           <KindInput
-            kinds={predicate.supportedKinds}
+            kinds={predicate?.supportedKinds || []}
             value={modeledMethod?.kind}
             onChange={handleKindChange}
           />

--- a/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
@@ -1,7 +1,9 @@
 import {
+  VSCodeCheckbox,
   VSCodeDataGridCell,
   VSCodeDataGridRow,
   VSCodeDropdown,
+  VSCodeLink,
   VSCodeOption,
 } from "@vscode/webview-ui-toolkit/react";
 import * as React from "react";
@@ -38,29 +40,18 @@ const SupportSpan = styled.span<SupportedUnsupportedSpanProps>`
   }};
 `;
 
-type SupportedUnsupportedLinkProps = {
-  supported: boolean;
-  modeled: ModeledMethod | undefined;
-};
-
-const SupportLink = styled.button<SupportedUnsupportedLinkProps>`
-  color: ${(props) => {
-    if (!props.supported && props.modeled && props.modeled?.type !== "none") {
-      return "orange";
-    } else {
-      return props.supported ? "green" : "red";
-    }
-  }};
-  background-color: transparent;
-  border: none;
-  cursor: pointer;
-  padding: 0;
+const ApiOrMethodCell = styled(VSCodeDataGridCell)`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5em;
 `;
 
 const UsagesButton = styled.button`
   color: var(--vscode-editor-foreground);
-  background-color: transparent;
+  background-color: var(--vscode-input-background);
   border: none;
+  border-radius: 40%;
   cursor: pointer;
 `;
 
@@ -171,43 +162,24 @@ export const MethodRow = ({
 
   return (
     <VSCodeDataGridRow>
-      <VSCodeDataGridCell gridColumn={1}>
+      <ApiOrMethodCell gridColumn={1}>
+        <VSCodeCheckbox />
         <SupportSpan
           supported={externalApiUsage.supported}
           modeled={modeledMethod}
         >
-          {externalApiUsage.packageName}.{externalApiUsage.typeName}
+          {externalApiUsage.packageName}.{externalApiUsage.typeName}.
+          {externalApiUsage.methodName}
+          {externalApiUsage.methodParameters}
         </SupportSpan>
-      </VSCodeDataGridCell>
-      <VSCodeDataGridCell gridColumn={2}>
         {mode === Mode.Application && (
-          <SupportSpan
-            supported={externalApiUsage.supported}
-            modeled={modeledMethod}
-          >
-            {externalApiUsage.methodName}
-            {externalApiUsage.methodParameters}
-          </SupportSpan>
-        )}
-        {mode === Mode.Framework && (
-          <SupportLink
-            supported={externalApiUsage.supported}
-            modeled={modeledMethod}
-            onClick={jumpToUsage}
-          >
-            {externalApiUsage.methodName}
-            {externalApiUsage.methodParameters}
-          </SupportLink>
-        )}
-      </VSCodeDataGridCell>
-      {mode === Mode.Application && (
-        <VSCodeDataGridCell gridColumn={3}>
           <UsagesButton onClick={jumpToUsage}>
             {externalApiUsage.usages.length}
           </UsagesButton>
-        </VSCodeDataGridCell>
-      )}
-      <VSCodeDataGridCell gridColumn={4}>
+        )}
+        <VSCodeLink onClick={jumpToUsage}>View</VSCodeLink>
+      </ApiOrMethodCell>
+      <VSCodeDataGridCell gridColumn={2}>
         {(!externalApiUsage.supported ||
           (modeledMethod && modeledMethod?.type !== "none")) && (
           <Dropdown
@@ -222,7 +194,7 @@ export const MethodRow = ({
           </Dropdown>
         )}
       </VSCodeDataGridCell>
-      <VSCodeDataGridCell gridColumn={5}>
+      <VSCodeDataGridCell gridColumn={3}>
         {modeledMethod?.type &&
           ["sink", "summary"].includes(modeledMethod?.type) && (
             <Dropdown value={modeledMethod?.input} onInput={handleInputInput}>
@@ -235,7 +207,7 @@ export const MethodRow = ({
             </Dropdown>
           )}
       </VSCodeDataGridCell>
-      <VSCodeDataGridCell gridColumn={6}>
+      <VSCodeDataGridCell gridColumn={4}>
         {modeledMethod?.type &&
           ["source", "summary"].includes(modeledMethod?.type) && (
             <Dropdown value={modeledMethod?.output} onInput={handleOutputInput}>
@@ -249,7 +221,7 @@ export const MethodRow = ({
             </Dropdown>
           )}
       </VSCodeDataGridCell>
-      <VSCodeDataGridCell gridColumn={7}>
+      <VSCodeDataGridCell gridColumn={5}>
         {predicate?.supportedKinds && (
           <KindInput
             kinds={predicate.supportedKinds}

--- a/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
@@ -141,10 +141,44 @@ export const MethodRow = ({
   const showModelTypeCell =
     !externalApiUsage.supported ||
     (modeledMethod && modeledMethod?.type !== "none");
+  const modelTypeOptions = useMemo(
+    () => [
+      { value: "none", label: "Unmodeled" },
+      { value: "source", label: "Source" },
+      { value: "sink", label: "Sink" },
+      { value: "summary", label: "Flow summary" },
+      { value: "neutral", label: "Neutral" },
+    ],
+    [],
+  );
+
   const showInputCell =
     modeledMethod?.type && ["sink", "summary"].includes(modeledMethod?.type);
+  const inputOptions = useMemo(
+    () => [
+      { value: "Argument[this]", label: "Argument[this]" },
+      ...argumentsList.map((argument, index) => ({
+        value: `Argument[${index}]`,
+        label: `Argument[${index}]: ${argument}`,
+      })),
+    ],
+    [argumentsList],
+  );
+
   const showOutputCell =
     modeledMethod?.type && ["source", "summary"].includes(modeledMethod?.type);
+  const outputOptions = useMemo(
+    () => [
+      { value: "ReturnValue", label: "ReturnValue" },
+      { value: "Argument[this]", label: "Argument[this]" },
+      ...argumentsList.map((argument, index) => ({
+        value: `Argument[${index}]`,
+        label: `Argument[${index}]: ${argument}`,
+      })),
+    ],
+    [argumentsList],
+  );
+
   const showKindCell = predicate?.supportedKinds;
 
   return (
@@ -165,62 +199,32 @@ export const MethodRow = ({
       </ApiOrMethodCell>
       <VSCodeDataGridCell gridColumn={2}>
         <Dropdown
-          value={showModelTypeCell ? modeledMethod?.type ?? "none" : undefined}
+          value={modeledMethod?.type ?? "none"}
+          options={modelTypeOptions}
           disabled={!showModelTypeCell}
           onChange={handleTypeInput}
-        >
-          {showModelTypeCell && (
-            <>
-              <option value="none">Unmodeled</option>
-              <option value="source">Source</option>
-              <option value="sink">Sink</option>
-              <option value="summary">Flow summary</option>
-              <option value="neutral">Neutral</option>
-            </>
-          )}
-        </Dropdown>
+        />
       </VSCodeDataGridCell>
       <VSCodeDataGridCell gridColumn={3}>
         <Dropdown
-          value={showInputCell ? modeledMethod?.input : undefined}
+          value={modeledMethod?.input}
+          options={inputOptions}
           disabled={!showInputCell}
           onChange={handleInputInput}
-        >
-          {showInputCell && (
-            <>
-              <option value="Argument[this]">Argument[this]</option>
-              {argumentsList.map((argument, index) => (
-                <option key={argument} value={`Argument[${index}]`}>
-                  Argument[{index}]: {argument}
-                </option>
-              ))}
-            </>
-          )}
-        </Dropdown>
+        />
       </VSCodeDataGridCell>
       <VSCodeDataGridCell gridColumn={4}>
         <Dropdown
-          value={showOutputCell ? modeledMethod?.output : undefined}
+          value={modeledMethod?.output}
+          options={outputOptions}
           disabled={!showOutputCell}
           onChange={handleOutputInput}
-        >
-          {showOutputCell && (
-            <>
-              <option value="ReturnValue">ReturnValue</option>
-              <option value="Argument[this]">Argument[this]</option>
-              {argumentsList.map((argument, index) => (
-                <option key={argument} value={`Argument[${index}]`}>
-                  Argument[{index}]: {argument}
-                </option>
-              ))}
-            </>
-          )}
-        </Dropdown>
+        />
       </VSCodeDataGridCell>
       <VSCodeDataGridCell gridColumn={5}>
         <KindInput
           kinds={predicate?.supportedKinds || []}
-          value={showKindCell && modeledMethod?.kind}
+          value={modeledMethod?.kind}
           disabled={!showKindCell}
           onChange={handleKindChange}
         />

--- a/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
@@ -2,12 +2,10 @@ import {
   VSCodeCheckbox,
   VSCodeDataGridCell,
   VSCodeDataGridRow,
-  VSCodeDropdown,
   VSCodeLink,
-  VSCodeOption,
 } from "@vscode/webview-ui-toolkit/react";
 import * as React from "react";
-import { useCallback, useMemo } from "react";
+import { ChangeEvent, useCallback, useMemo } from "react";
 import styled from "styled-components";
 import { vscode } from "../vscode-api";
 
@@ -20,10 +18,7 @@ import {
 import { KindInput } from "./KindInput";
 import { extensiblePredicateDefinitions } from "../../data-extensions-editor/predicates";
 import { Mode } from "../../data-extensions-editor/shared/mode";
-
-const Dropdown = styled(VSCodeDropdown)`
-  width: 100%;
-`;
+import { Dropdown } from "../common/Dropdown";
 
 const ApiOrMethodCell = styled(VSCodeDataGridCell)`
   display: flex;
@@ -66,9 +61,7 @@ export const MethodRow = ({
   }, [externalApiUsage.methodParameters]);
 
   const handleTypeInput = useCallback(
-    (e: InputEvent) => {
-      const target = e.target as HTMLSelectElement;
-
+    (e: ChangeEvent<HTMLSelectElement>) => {
       let newProvenance: Provenance = "manual";
       if (modeledMethod?.provenance === "df-generated") {
         newProvenance = "df-manual";
@@ -82,14 +75,14 @@ export const MethodRow = ({
         output: "ReturnType",
         kind: "value",
         ...modeledMethod,
-        type: target.value as ModeledMethodType,
+        type: e.target.value as ModeledMethodType,
         provenance: newProvenance,
       });
     },
     [onChange, externalApiUsage, modeledMethod, argumentsList],
   );
   const handleInputInput = useCallback(
-    (e: InputEvent) => {
+    (e: ChangeEvent<HTMLSelectElement>) => {
       if (!modeledMethod) {
         return;
       }
@@ -104,7 +97,7 @@ export const MethodRow = ({
     [onChange, externalApiUsage, modeledMethod],
   );
   const handleOutputInput = useCallback(
-    (e: InputEvent) => {
+    (e: ChangeEvent<HTMLSelectElement>) => {
       if (!modeledMethod) {
         return;
       }
@@ -172,44 +165,56 @@ export const MethodRow = ({
       </ApiOrMethodCell>
       <VSCodeDataGridCell gridColumn={2}>
         <Dropdown
-          value={showModelTypeCell && (modeledMethod?.type ?? "none")}
+          value={showModelTypeCell ? modeledMethod?.type ?? "none" : undefined}
           disabled={!showModelTypeCell}
-          onInput={handleTypeInput}
+          onChange={handleTypeInput}
         >
-          <VSCodeOption value="none">Unmodeled</VSCodeOption>
-          <VSCodeOption value="source">Source</VSCodeOption>
-          <VSCodeOption value="sink">Sink</VSCodeOption>
-          <VSCodeOption value="summary">Flow summary</VSCodeOption>
-          <VSCodeOption value="neutral">Neutral</VSCodeOption>
+          {showModelTypeCell && (
+            <>
+              <option value="none">Unmodeled</option>
+              <option value="source">Source</option>
+              <option value="sink">Sink</option>
+              <option value="summary">Flow summary</option>
+              <option value="neutral">Neutral</option>
+            </>
+          )}
         </Dropdown>
       </VSCodeDataGridCell>
       <VSCodeDataGridCell gridColumn={3}>
         <Dropdown
-          value={showInputCell && modeledMethod?.input}
+          value={showInputCell ? modeledMethod?.input : undefined}
           disabled={!showInputCell}
-          onInput={handleInputInput}
+          onChange={handleInputInput}
         >
-          <VSCodeOption value="Argument[this]">Argument[this]</VSCodeOption>
-          {argumentsList.map((argument, index) => (
-            <VSCodeOption key={argument} value={`Argument[${index}]`}>
-              Argument[{index}]: {argument}
-            </VSCodeOption>
-          ))}
+          {showInputCell && (
+            <>
+              <option value="Argument[this]">Argument[this]</option>
+              {argumentsList.map((argument, index) => (
+                <option key={argument} value={`Argument[${index}]`}>
+                  Argument[{index}]: {argument}
+                </option>
+              ))}
+            </>
+          )}
         </Dropdown>
       </VSCodeDataGridCell>
       <VSCodeDataGridCell gridColumn={4}>
         <Dropdown
-          value={showOutputCell && modeledMethod?.output}
+          value={showOutputCell ? modeledMethod?.output : undefined}
           disabled={!showOutputCell}
-          onInput={handleOutputInput}
+          onChange={handleOutputInput}
         >
-          <VSCodeOption value="ReturnValue">ReturnValue</VSCodeOption>
-          <VSCodeOption value="Argument[this]">Argument[this]</VSCodeOption>
-          {argumentsList.map((argument, index) => (
-            <VSCodeOption key={argument} value={`Argument[${index}]`}>
-              Argument[{index}]: {argument}
-            </VSCodeOption>
-          ))}
+          {showOutputCell && (
+            <>
+              <option value="ReturnValue">ReturnValue</option>
+              <option value="Argument[this]">Argument[this]</option>
+              {argumentsList.map((argument, index) => (
+                <option key={argument} value={`Argument[${index}]`}>
+                  Argument[{index}]: {argument}
+                </option>
+              ))}
+            </>
+          )}
         </Dropdown>
       </VSCodeDataGridCell>
       <VSCodeDataGridCell gridColumn={5}>

--- a/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodDataGrid.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodDataGrid.tsx
@@ -33,29 +33,21 @@ export const ModeledMethodDataGrid = ({
   );
 
   return (
-    <VSCodeDataGrid>
+    <VSCodeDataGrid gridTemplateColumns="0.4fr 0.15fr 0.15fr 0.15fr 0.15fr">
       <VSCodeDataGridRow rowType="header">
         <VSCodeDataGridCell cellType="columnheader" gridColumn={1}>
-          Type
+          API or method
         </VSCodeDataGridCell>
         <VSCodeDataGridCell cellType="columnheader" gridColumn={2}>
-          Method
-        </VSCodeDataGridCell>
-        {mode === Mode.Application && (
-          <VSCodeDataGridCell cellType="columnheader" gridColumn={3}>
-            Usages
-          </VSCodeDataGridCell>
-        )}
-        <VSCodeDataGridCell cellType="columnheader" gridColumn={4}>
           Model type
         </VSCodeDataGridCell>
-        <VSCodeDataGridCell cellType="columnheader" gridColumn={5}>
+        <VSCodeDataGridCell cellType="columnheader" gridColumn={3}>
           Input
         </VSCodeDataGridCell>
-        <VSCodeDataGridCell cellType="columnheader" gridColumn={6}>
+        <VSCodeDataGridCell cellType="columnheader" gridColumn={4}>
           Output
         </VSCodeDataGridCell>
-        <VSCodeDataGridCell cellType="columnheader" gridColumn={7}>
+        <VSCodeDataGridCell cellType="columnheader" gridColumn={5}>
           Kind
         </VSCodeDataGridCell>
       </VSCodeDataGridRow>


### PR DESCRIPTION
Converts the data extensions table to match the new designs:
<img width="1673" alt="Screenshot 2023-07-04 at 17 22 35" src="https://github.com/github/vscode-codeql/assets/3749000/e99a340f-c73c-4c9d-b6f6-accec9355795">


The changes are:
- Merge data into the "API or method" column, which now includes:
  - the package, class, method name, and parameter
  - a checkbox (which later on will show modelling status)
  - the usage count
  - an explicit link to view usages (though clicking the usage count number does still work)
- The inputs in the table are disabled but still visible, instead of being completely hidden
  - The value in the cell is still hidden, otherwise I think it's odd seeing content in the disabled inputs
- The red/green colouring is removed
  - It's my understanding this isn't mean to be a part of the new design. If that's not the case I can easily add it back in.

The bit I'm most unsure of is whether the whole "API or method" bit should be all one column or as separate columns. It depends on if we want the items to bunch together (like in the screenshot above), or if we want similar items to all align between rows. It's a little hard to tell from the designs since all of the dummy text is the same so stuff lines up regardless. @asiermartinez, what are your thoughts on whether items should align horizontally more or if the above screenshot looks good?

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
