### PR TITLE
Data extensions editor: Update styling of "unsaved" tag

### DIFF
--- a/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
@@ -71,6 +71,7 @@ const ButtonsContainer = styled.div`
   gap: 0.4em;
   justify-content: right;
   margin-bottom: 1rem;
+  margin-right: 1rem;
 `;
 
 type Props = {

--- a/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
@@ -8,7 +8,11 @@ import { calculateModeledPercentage } from "../../data-extensions-editor/shared/
 import { percentFormatter } from "./formatters";
 import { Codicon } from "../common";
 import { Mode } from "../../data-extensions-editor/shared/mode";
-import { VSCodeButton, VSCodeDivider } from "@vscode/webview-ui-toolkit/react";
+import {
+  VSCodeButton,
+  VSCodeDivider,
+  VSCodeTag,
+} from "@vscode/webview-ui-toolkit/react";
 
 const LibraryContainer = styled.div`
   background-color: var(--vscode-peekViewResult-background);
@@ -51,13 +55,6 @@ const DependencyName = styled.span`
 
 const ModeledPercentage = styled.span`
   color: var(--vscode-descriptionForeground);
-`;
-
-const UnsavedLabel = styled.span`
-  text-transform: uppercase;
-  background-color: var(--vscode-input-background);
-  padding: 0.2em 0.4em;
-  border-radius: 0.2em;
 `;
 
 const TitleButton = styled(VSCodeButton)`
@@ -142,7 +139,7 @@ export const LibraryRow = ({
           <ModeledPercentage>
             {percentFormatter.format(modeledPercentage / 100)} modeled
           </ModeledPercentage>
-          {hasUnsavedChanges ? <UnsavedLabel>UNSAVED</UnsavedLabel> : null}
+          {hasUnsavedChanges ? <VSCodeTag>UNSAVED</VSCodeTag> : null}
         </NameContainer>
         <TitleButton onClick={handleModelWithAI}>
           <Codicon name="lightbulb-autofix" label="Model with AI" />


### PR DESCRIPTION
Some minor adjustments to the saved/unsaved buttons: 
![screenshot of library row](https://github.com/github/vscode-codeql/assets/42641846/b0a81ff0-a8c3-4919-bdb6-89360a04e382)

- Uses the "VS Code Tag" from the UI toolkit for the "UNSAVED" label
- Moves the "Save" button further away from the border

## Checklist

N/A—internal only 🎃

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
