### PR TITLE
Implement saving only one model at a time

### DIFF
--- a/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
@@ -88,7 +88,6 @@ export function DataExtensionsEditor({
             break;
           case "setExternalApiUsages":
             setExternalApiUsages(msg.externalApiUsages);
-            setUnsavedModels(new Set());
             break;
           case "showProgress":
             setProgress(msg);
@@ -151,13 +150,34 @@ export function DataExtensionsEditor({
     });
   }, []);
 
-  const onApplyClick = useCallback(() => {
+  const onSaveAllClick = useCallback(() => {
     vscode.postMessage({
       t: "saveModeledMethods",
       externalApiUsages,
       modeledMethods,
     });
+    setUnsavedModels(new Set());
   }, [externalApiUsages, modeledMethods]);
+
+  const onSaveModelClick = useCallback(
+    (
+      modelName: string,
+      externalApiUsages: ExternalApiUsage[],
+      modeledMethods: Record<string, ModeledMethod>,
+    ) => {
+      vscode.postMessage({
+        t: "saveModeledMethods",
+        externalApiUsages,
+        modeledMethods,
+      });
+      setUnsavedModels((oldUnsavedModels) => {
+        const newUnsavedModels = new Set(oldUnsavedModels);
+        newUnsavedModels.delete(modelName);
+        return newUnsavedModels;
+      });
+    },
+    [],
+  );
 
   const onGenerateClick = useCallback(() => {
     vscode.postMessage({
@@ -239,7 +259,7 @@ export function DataExtensionsEditor({
 
           <EditorContainer>
             <ButtonsContainer>
-              <VSCodeButton onClick={onApplyClick}>Apply</VSCodeButton>
+              <VSCodeButton onClick={onSaveAllClick}>Apply</VSCodeButton>
               {viewState?.enableFrameworkMode && (
                 <VSCodeButton appearance="secondary" onClick={onRefreshClick}>
                   Refresh
@@ -264,6 +284,7 @@ export function DataExtensionsEditor({
               modeledMethods={modeledMethods}
               mode={viewState?.mode ?? Mode.Application}
               onChange={onChange}
+              onSaveModelClick={onSaveModelClick}
             />
           </EditorContainer>
         </>

--- a/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
@@ -87,6 +87,11 @@ type Props = {
     externalApiUsage: ExternalApiUsage,
     modeledMethod: ModeledMethod,
   ) => void;
+  onSaveModelClick: (
+    modelName: string,
+    externalApiUsages: ExternalApiUsage[],
+    modeledMethods: Record<string, ModeledMethod>,
+  ) => void;
 };
 
 export const LibraryRow = ({
@@ -96,6 +101,7 @@ export const LibraryRow = ({
   mode,
   hasUnsavedChanges,
   onChange,
+  onSaveModelClick,
 }: Props) => {
   const modeledPercentage = useMemo(() => {
     return calculateModeledPercentage(externalApiUsages);
@@ -117,10 +123,14 @@ export const LibraryRow = ({
     e.preventDefault();
   }, []);
 
-  const handleSave = useCallback(async (e: React.MouseEvent) => {
-    e.stopPropagation();
-    e.preventDefault();
-  }, []);
+  const handleSave = useCallback(
+    async (e: React.MouseEvent) => {
+      onSaveModelClick(title, externalApiUsages, modeledMethods);
+      e.stopPropagation();
+      e.preventDefault();
+    },
+    [title, externalApiUsages, modeledMethods, onSaveModelClick],
+  );
 
   const onChangeWithModelName = useCallback(
     (externalApiUsage: ExternalApiUsage, modeledMethod: ModeledMethod) => {

--- a/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodsList.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodsList.tsx
@@ -19,6 +19,11 @@ type Props = {
     externalApiUsage: ExternalApiUsage,
     modeledMethod: ModeledMethod,
   ) => void;
+  onSaveModelClick: (
+    modelName: string,
+    externalApiUsages: ExternalApiUsage[],
+    modeledMethods: Record<string, ModeledMethod>,
+  ) => void;
 };
 
 export const ModeledMethodsList = ({
@@ -27,6 +32,7 @@ export const ModeledMethodsList = ({
   modeledMethods,
   mode,
   onChange,
+  onSaveModelClick,
 }: Props) => {
   const grouped = useMemo(
     () => groupMethods(externalApiUsages, mode),
@@ -46,6 +52,7 @@ export const ModeledMethodsList = ({
           modeledMethods={modeledMethods}
           mode={mode}
           onChange={onChange}
+          onSaveModelClick={onSaveModelClick}
         />
       ))}
     </>


### PR DESCRIPTION
Paired with @shati-patel on this.

Hooks up the "Save" button in each collapsible section to save only the changes made to that model. Thankfully this turned out not to be too hard since the implementation of `saveModeledMethods` already (perhaps unintentionally) handles being gives only the methods from one model, because it splits the methods it's given into models and then saves only those files. Therefore it won't overwrite or delete other models that aren't being saved.

We also had to change how `setUnsavedModels` is called. I think what we were doing before was not quite fully correct but we were getting away with it. Now that we can save just one model at a time we need to be more granular.

We've tested this manually but checking that each model is saved individually and none of the other files are edited. Is there any more testing we can do of this?

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
