### PR TITLE
Use better colours for title buttons

### DIFF
--- a/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
@@ -60,15 +60,6 @@ const UnsavedLabel = styled.span`
   border-radius: 0.2em;
 `;
 
-const TitleButton = styled(VSCodeButton)`
-  background-color: transparent;
-
-  &:hover {
-    pointer: cursor;
-    background-color: var(--vscode-button-secondaryBackground);
-  }
-`;
-
 const ButtonsContainer = styled.div`
   display: flex;
   gap: 0.4em;
@@ -144,14 +135,14 @@ export const LibraryRow = ({
           </ModeledPercentage>
           {hasUnsavedChanges ? <UnsavedLabel>UNSAVED</UnsavedLabel> : null}
         </NameContainer>
-        <TitleButton onClick={handleModelWithAI}>
+        <VSCodeButton appearance="icon" onClick={handleModelWithAI}>
           <Codicon name="lightbulb-autofix" label="Model with AI" />
           &nbsp;Model with AI
-        </TitleButton>
-        <TitleButton onClick={handleModelFromSource}>
+        </VSCodeButton>
+        <VSCodeButton appearance="icon" onClick={handleModelFromSource}>
           <Codicon name="code" label="Model from source" />
           &nbsp;Model from source
-        </TitleButton>
+        </VSCodeButton>
       </TitleContainer>
       {isExpanded && (
         <>


### PR DESCRIPTION
Changes these buttons to use `appearance='icon'` instead of custom styling.

Light mode (showing hovering and non-hovering):
<img width="481" alt="Screenshot 2023-07-06 at 17 00 41" src="https://github.com/github/vscode-codeql/assets/3749000/f3145742-0e69-4db7-b381-593c574ebf8c">


Dark mode (showing hovering and non-hovering):
<img width="481" alt="Screenshot 2023-07-06 at 17 00 54" src="https://github.com/github/vscode-codeql/assets/3749000/e97026e4-c508-4635-9922-37cbd33283e7">

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
