### PR TITLE
Only show LLM / framework mode when the view state says to show the button

### DIFF
--- a/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
@@ -282,6 +282,7 @@ export function DataExtensionsEditor({
               externalApiUsages={externalApiUsages}
               unsavedModels={unsavedModels}
               modeledMethods={modeledMethods}
+              viewState={viewState}
               mode={viewState?.mode ?? Mode.Application}
               onChange={onChange}
               onSaveModelClick={onSaveModelClick}

--- a/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
@@ -156,6 +156,13 @@ export const LibraryRow = ({
           <Codicon name="code" label="Model from source" />
           &nbsp;Model from source
         </VSCodeButton>
+        {viewState?.enableFrameworkMode &&
+          viewState?.mode === Mode.Application && (
+            <VSCodeButton appearance="icon" onClick={handleModelFromSource}>
+              <Codicon name="references" label="Model dependency" />
+              &nbsp;Model dependency
+            </VSCodeButton>
+          )}
       </TitleContainer>
       {isExpanded && (
         <>

--- a/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
@@ -13,6 +13,7 @@ import {
   VSCodeDivider,
   VSCodeTag,
 } from "@vscode/webview-ui-toolkit/react";
+import { DataExtensionEditorViewState } from "../../data-extensions-editor/shared/view-state";
 
 const LibraryContainer = styled.div`
   background-color: var(--vscode-peekViewResult-background);
@@ -69,6 +70,7 @@ type Props = {
   title: string;
   externalApiUsages: ExternalApiUsage[];
   modeledMethods: Record<string, ModeledMethod>;
+  viewState: DataExtensionEditorViewState | undefined;
   mode: Mode;
   hasUnsavedChanges: boolean;
   onChange: (
@@ -87,6 +89,7 @@ export const LibraryRow = ({
   title,
   externalApiUsages,
   modeledMethods,
+  viewState,
   mode,
   hasUnsavedChanges,
   onChange,
@@ -143,10 +146,12 @@ export const LibraryRow = ({
           </ModeledPercentage>
           {hasUnsavedChanges ? <VSCodeTag>UNSAVED</VSCodeTag> : null}
         </NameContainer>
-        <VSCodeButton appearance="icon" onClick={handleModelWithAI}>
-          <Codicon name="lightbulb-autofix" label="Model with AI" />
-          &nbsp;Model with AI
-        </VSCodeButton>
+        {viewState?.showLlmButton && (
+          <VSCodeButton appearance="icon" onClick={handleModelWithAI}>
+            <Codicon name="lightbulb-autofix" label="Model with AI" />
+            &nbsp;Model with AI
+          </VSCodeButton>
+        )}
         <VSCodeButton appearance="icon" onClick={handleModelFromSource}>
           <Codicon name="code" label="Model from source" />
           &nbsp;Model from source

--- a/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
@@ -115,6 +115,11 @@ export const LibraryRow = ({
     e.preventDefault();
   }, []);
 
+  const handleModelDependency = useCallback(async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+  }, []);
+
   const handleSave = useCallback(
     async (e: React.MouseEvent) => {
       onSaveModelClick(title, externalApiUsages, modeledMethods);
@@ -158,7 +163,7 @@ export const LibraryRow = ({
         </VSCodeButton>
         {viewState?.enableFrameworkMode &&
           viewState?.mode === Mode.Application && (
-            <VSCodeButton appearance="icon" onClick={handleModelFromSource}>
+            <VSCodeButton appearance="icon" onClick={handleModelDependency}>
               <Codicon name="references" label="Model dependency" />
               &nbsp;Model dependency
             </VSCodeButton>

--- a/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodsList.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodsList.tsx
@@ -8,11 +8,13 @@ import {
   groupMethods,
   sortGroupNames,
 } from "../../data-extensions-editor/shared/sorting";
+import { DataExtensionEditorViewState } from "../../data-extensions-editor/shared/view-state";
 
 type Props = {
   externalApiUsages: ExternalApiUsage[];
   unsavedModels: Set<string>;
   modeledMethods: Record<string, ModeledMethod>;
+  viewState: DataExtensionEditorViewState | undefined;
   mode: Mode;
   onChange: (
     modelName: string,
@@ -30,6 +32,7 @@ export const ModeledMethodsList = ({
   externalApiUsages,
   unsavedModels,
   modeledMethods,
+  viewState,
   mode,
   onChange,
   onSaveModelClick,
@@ -50,6 +53,7 @@ export const ModeledMethodsList = ({
           externalApiUsages={grouped[libraryName]}
           hasUnsavedChanges={unsavedModels.has(libraryName)}
           modeledMethods={modeledMethods}
+          viewState={viewState}
           mode={mode}
           onChange={onChange}
           onSaveModelClick={onSaveModelClick}


### PR DESCRIPTION
Addresses two points that were previously forgotton:
- Only shows the "Model with AI" button when the view state says we should do.
- Adds the "Model dependency" (i.e. framework mode) button.

Screenshots with and without settings enabled:
<img width="1222" alt="Screenshot 2023-07-07 at 15 21 44" src="https://github.com/github/vscode-codeql/assets/3749000/ae0fcb78-4283-4daa-b8cc-e6c22847c249">
<img width="1222" alt="Screenshot 2023-07-07 at 15 21 58" src="https://github.com/github/vscode-codeql/assets/3749000/3a888b36-396d-4f25-8160-480f4f6045fb">


## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
