### PR TITLE
Include in addModeledMethods whether the methods are unsaved or not

### DIFF
--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -509,21 +509,14 @@ export interface ShowProgressMessage {
   message: string;
 }
 
+export interface LoadModeledMethodsMessage {
+  t: "loadModeledMethods";
+  modeledMethods: Record<string, ModeledMethod>;
+}
+
 export interface AddModeledMethodsMessage {
   t: "addModeledMethods";
   modeledMethods: Record<string, ModeledMethod>;
-  /**
-   * Are these modeled methods newly generated in some way and not yet
-   * saved in any model file, or are they loaded from an existing model file.
-   */
-  unsaved: boolean;
-  /**
-   * If true, then any existing modeled methods set to "none" will be
-   * overwritten by the new modeled methods. Otherwise, the "none" modeled
-   * methods will not be overwritten, even if the new modeled methods
-   * contain a better model.
-   */
-  overrideNone?: boolean;
 }
 
 export interface SwitchModeMessage {
@@ -564,6 +557,7 @@ export type ToDataExtensionsEditorMessage =
   | SetExtensionPackStateMessage
   | SetExternalApiUsagesMessage
   | ShowProgressMessage
+  | LoadModeledMethodsMessage
   | AddModeledMethodsMessage;
 
 export type FromDataExtensionsEditorMessage =

--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -512,7 +512,11 @@ export interface ShowProgressMessage {
 export interface AddModeledMethodsMessage {
   t: "addModeledMethods";
   modeledMethods: Record<string, ModeledMethod>;
-
+  /**
+   * Are these modeled methods newly generated in some way and not yet
+   * saved in any model file, or are they loaded from an existing model file.
+   */
+  unsaved: boolean;
   /**
    * If true, then any existing modeled methods set to "none" will be
    * overwritten by the new modeled methods. Otherwise, the "none" modeled

--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
@@ -259,6 +259,7 @@ export class DataExtensionsEditorView extends AbstractWebview<
       await this.postMessage({
         t: "addModeledMethods",
         modeledMethods: existingModeledMethods,
+        unsaved: false,
       });
     } catch (e: unknown) {
       void showAndLogErrorMessage(
@@ -387,6 +388,7 @@ export class DataExtensionsEditorView extends AbstractWebview<
           await this.postMessage({
             t: "addModeledMethods",
             modeledMethods: modeledMethodsByName,
+            unsaved: true,
             overrideNone: true,
           });
         },
@@ -481,6 +483,7 @@ export class DataExtensionsEditorView extends AbstractWebview<
     await this.postMessage({
       t: "addModeledMethods",
       modeledMethods: predictedModeledMethods,
+      unsaved: true,
       overrideNone: true,
     });
 

--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
@@ -257,9 +257,8 @@ export class DataExtensionsEditorView extends AbstractWebview<
       }
 
       await this.postMessage({
-        t: "addModeledMethods",
+        t: "loadModeledMethods",
         modeledMethods: existingModeledMethods,
-        unsaved: false,
       });
     } catch (e: unknown) {
       void showAndLogErrorMessage(
@@ -388,8 +387,6 @@ export class DataExtensionsEditorView extends AbstractWebview<
           await this.postMessage({
             t: "addModeledMethods",
             modeledMethods: modeledMethodsByName,
-            unsaved: true,
-            overrideNone: true,
           });
         },
         progress: (update) => this.showProgress(update),
@@ -483,8 +480,6 @@ export class DataExtensionsEditorView extends AbstractWebview<
     await this.postMessage({
       t: "addModeledMethods",
       modeledMethods: predictedModeledMethods,
-      unsaved: true,
-      overrideNone: true,
     });
 
     await this.clearProgress();


### PR DESCRIPTION
This is an attempt to fix the behaviour around showing the "unsaved" label and enabling the save button. Previously it wasn't correctly showing a model as unsaved when generating from the LLM or modelling from source.

The approach in this PR works, but it feels a bit inelegant and brute-forcey. I also don't love that the listener has gained dependencies on a couple of different bits of state, but maybe it's ok as those bits of state don't actually change too often.

Any other suggestions for how to implement this? I tried a few variations of putting names of the affected models in `AddModeledMethodsMessage`, or putting the library/packageName on `ModeledMethod`, but both turned out to be pretty hard to do as we just don't have the info available when generating the modelled methods.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
