### PR TITLE
Hook up generating from source in the new collapsible section

### DIFF
--- a/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
@@ -179,7 +179,7 @@ export function DataExtensionsEditor({
     [],
   );
 
-  const onGenerateClick = useCallback(() => {
+  const onGenerateFromSourceClick = useCallback(() => {
     vscode.postMessage({
       t: "generateExternalApi",
     });
@@ -279,7 +279,7 @@ export function DataExtensionsEditor({
                   Refresh
                 </VSCodeButton>
               )}
-              <VSCodeButton onClick={onGenerateClick}>
+              <VSCodeButton onClick={onGenerateFromSourceClick}>
                 {viewState?.mode === Mode.Framework
                   ? "Generate"
                   : "Download and generate"}
@@ -301,6 +301,7 @@ export function DataExtensionsEditor({
               onChange={onChange}
               onSaveModelClick={onSaveModelClick}
               onGenerateFromLlmClick={onGenerateFromLlmClick}
+              onGenerateFromSourceClick={onGenerateFromSourceClick}
             />
           </EditorContainer>
         </>

--- a/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
@@ -87,6 +87,7 @@ type Props = {
     externalApiUsages: ExternalApiUsage[],
     modeledMethods: Record<string, ModeledMethod>,
   ) => void;
+  onGenerateFromSourceClick: () => void;
 };
 
 export const LibraryRow = ({
@@ -99,6 +100,7 @@ export const LibraryRow = ({
   onChange,
   onSaveModelClick,
   onGenerateFromLlmClick,
+  onGenerateFromSourceClick,
 }: Props) => {
   const modeledPercentage = useMemo(() => {
     return calculateModeledPercentage(externalApiUsages);
@@ -119,10 +121,14 @@ export const LibraryRow = ({
     [externalApiUsages, modeledMethods, onGenerateFromLlmClick],
   );
 
-  const handleModelFromSource = useCallback(async (e: React.MouseEvent) => {
-    e.stopPropagation();
-    e.preventDefault();
-  }, []);
+  const handleModelFromSource = useCallback(
+    async (e: React.MouseEvent) => {
+      onGenerateFromSourceClick();
+      e.stopPropagation();
+      e.preventDefault();
+    },
+    [onGenerateFromSourceClick],
+  );
 
   const handleModelDependency = useCallback(async (e: React.MouseEvent) => {
     e.stopPropagation();

--- a/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodsList.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodsList.tsx
@@ -30,6 +30,7 @@ type Props = {
     externalApiUsages: ExternalApiUsage[],
     modeledMethods: Record<string, ModeledMethod>,
   ) => void;
+  onGenerateFromSourceClick: () => void;
 };
 
 export const ModeledMethodsList = ({
@@ -41,6 +42,7 @@ export const ModeledMethodsList = ({
   onChange,
   onSaveModelClick,
   onGenerateFromLlmClick,
+  onGenerateFromSourceClick,
 }: Props) => {
   const grouped = useMemo(
     () => groupMethods(externalApiUsages, mode),
@@ -63,6 +65,7 @@ export const ModeledMethodsList = ({
           onChange={onChange}
           onSaveModelClick={onSaveModelClick}
           onGenerateFromLlmClick={onGenerateFromLlmClick}
+          onGenerateFromSourceClick={onGenerateFromSourceClick}
         />
       ))}
     </>


### PR DESCRIPTION
This hooks up the existing handler that sends a `generateExternalApi` message to the new collapsible sections. I believe that the behaviour for the button in the header and button in each section basically needs to be the same.

When used it will prompt the user for a github repository name, attempt to download the CodeQL database, and then generate some models. In the future we hope to not have to ask for the repository name and instead determine it from the dependency name, but right now we haven't implemented that. So for right now the button on each section is identical and it doesn't matter which one you click. It's my understanding that this is ok for now. If we want it'll be easy to hide the button on each section and only show a single button in the header, so this PR is pretty low risk.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
