### PR TITLE
Clear up how we pass around view state

### DIFF
--- a/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
@@ -304,7 +304,6 @@ export function DataExtensionsEditor({
               unsavedModels={unsavedModels}
               modeledMethods={modeledMethods}
               viewState={viewState}
-              mode={viewState.mode}
               onChange={onChange}
               onSaveModelClick={onSaveModelClick}
               onGenerateFromLlmClick={onGenerateFromLlmClick}

--- a/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
@@ -18,6 +18,13 @@ import { ModeledMethodsList } from "./ModeledMethodsList";
 import { percentFormatter } from "./formatters";
 import { Mode } from "../../data-extensions-editor/shared/mode";
 
+const LoadingContainer = styled.div`
+  text-align: center;
+  padding: 1em;
+  font-size: x-large;
+  font-weight: 600;
+`;
+
 const DataExtensionsEditorContainer = styled.div`
   margin-top: 1rem;
 `;
@@ -223,6 +230,10 @@ export function DataExtensionsEditor({
     });
   }, [viewState?.mode]);
 
+  if (viewState === undefined) {
+    return <LoadingContainer>Loading...</LoadingContainer>;
+  }
+
   return (
     <DataExtensionsEditorContainer>
       {progress.maxStep > 0 && (
@@ -236,25 +247,21 @@ export function DataExtensionsEditor({
         <>
           <ViewTitle>Data extensions editor</ViewTitle>
           <DetailsContainer>
-            {viewState?.extensionPack && (
-              <>
-                <LinkIconButton onClick={onOpenExtensionPackClick}>
-                  <span slot="start" className="codicon codicon-package"></span>
-                  {viewState.extensionPack.name}
-                </LinkIconButton>
-              </>
-            )}
+            <LinkIconButton onClick={onOpenExtensionPackClick}>
+              <span slot="start" className="codicon codicon-package"></span>
+              {viewState.extensionPack.name}
+            </LinkIconButton>
             <div>
               {percentFormatter.format(modeledPercentage / 100)} modeled
             </div>
             <div>
               {percentFormatter.format(unModeledPercentage / 100)} unmodeled
             </div>
-            {viewState?.enableFrameworkMode && (
+            {viewState.enableFrameworkMode && (
               <>
                 <div>
                   Mode:{" "}
-                  {viewState?.mode === Mode.Framework
+                  {viewState.mode === Mode.Framework
                     ? "Framework"
                     : "Application"}
                 </div>
@@ -274,17 +281,17 @@ export function DataExtensionsEditor({
           <EditorContainer>
             <ButtonsContainer>
               <VSCodeButton onClick={onSaveAllClick}>Apply</VSCodeButton>
-              {viewState?.enableFrameworkMode && (
+              {viewState.enableFrameworkMode && (
                 <VSCodeButton appearance="secondary" onClick={onRefreshClick}>
                   Refresh
                 </VSCodeButton>
               )}
               <VSCodeButton onClick={onGenerateFromSourceClick}>
-                {viewState?.mode === Mode.Framework
+                {viewState.mode === Mode.Framework
                   ? "Generate"
                   : "Download and generate"}
               </VSCodeButton>
-              {viewState?.showLlmButton && (
+              {viewState.showLlmButton && (
                 <>
                   <VSCodeButton onClick={onGenerateAllFromLlmClick}>
                     Generate using LLM
@@ -297,7 +304,7 @@ export function DataExtensionsEditor({
               unsavedModels={unsavedModels}
               modeledMethods={modeledMethods}
               viewState={viewState}
-              mode={viewState?.mode ?? Mode.Application}
+              mode={viewState.mode}
               onChange={onChange}
               onSaveModelClick={onSaveModelClick}
               onGenerateFromLlmClick={onGenerateFromLlmClick}

--- a/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
@@ -71,7 +71,6 @@ type Props = {
   externalApiUsages: ExternalApiUsage[];
   modeledMethods: Record<string, ModeledMethod>;
   viewState: DataExtensionEditorViewState;
-  mode: Mode;
   hasUnsavedChanges: boolean;
   onChange: (
     modelName: string,
@@ -95,7 +94,6 @@ export const LibraryRow = ({
   externalApiUsages,
   modeledMethods,
   viewState,
-  mode,
   hasUnsavedChanges,
   onChange,
   onSaveModelClick,
@@ -190,7 +188,7 @@ export const LibraryRow = ({
           <ModeledMethodDataGrid
             externalApiUsages={externalApiUsages}
             modeledMethods={modeledMethods}
-            mode={mode}
+            mode={viewState.mode}
             onChange={onChangeWithModelName}
           />
           <SectionDivider />

--- a/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
@@ -70,7 +70,7 @@ type Props = {
   title: string;
   externalApiUsages: ExternalApiUsage[];
   modeledMethods: Record<string, ModeledMethod>;
-  viewState: DataExtensionEditorViewState | undefined;
+  viewState: DataExtensionEditorViewState;
   mode: Mode;
   hasUnsavedChanges: boolean;
   onChange: (
@@ -166,7 +166,7 @@ export const LibraryRow = ({
           </ModeledPercentage>
           {hasUnsavedChanges ? <VSCodeTag>UNSAVED</VSCodeTag> : null}
         </NameContainer>
-        {viewState?.showLlmButton && (
+        {viewState.showLlmButton && (
           <VSCodeButton appearance="icon" onClick={handleModelWithAI}>
             <Codicon name="lightbulb-autofix" label="Model with AI" />
             &nbsp;Model with AI
@@ -176,8 +176,8 @@ export const LibraryRow = ({
           <Codicon name="code" label="Model from source" />
           &nbsp;Model from source
         </VSCodeButton>
-        {viewState?.enableFrameworkMode &&
-          viewState?.mode === Mode.Application && (
+        {viewState.enableFrameworkMode &&
+          viewState.mode === Mode.Application && (
             <VSCodeButton appearance="icon" onClick={handleModelDependency}>
               <Codicon name="references" label="Model dependency" />
               &nbsp;Model dependency

--- a/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodsList.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodsList.tsx
@@ -14,7 +14,7 @@ type Props = {
   externalApiUsages: ExternalApiUsage[];
   unsavedModels: Set<string>;
   modeledMethods: Record<string, ModeledMethod>;
-  viewState: DataExtensionEditorViewState | undefined;
+  viewState: DataExtensionEditorViewState;
   mode: Mode;
   onChange: (
     modelName: string,

--- a/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodsList.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodsList.tsx
@@ -3,7 +3,6 @@ import { useMemo } from "react";
 import { ExternalApiUsage } from "../../data-extensions-editor/external-api-usage";
 import { ModeledMethod } from "../../data-extensions-editor/modeled-method";
 import { LibraryRow } from "./LibraryRow";
-import { Mode } from "../../data-extensions-editor/shared/mode";
 import {
   groupMethods,
   sortGroupNames,
@@ -15,7 +14,6 @@ type Props = {
   unsavedModels: Set<string>;
   modeledMethods: Record<string, ModeledMethod>;
   viewState: DataExtensionEditorViewState;
-  mode: Mode;
   onChange: (
     modelName: string,
     externalApiUsage: ExternalApiUsage,
@@ -38,15 +36,14 @@ export const ModeledMethodsList = ({
   unsavedModels,
   modeledMethods,
   viewState,
-  mode,
   onChange,
   onSaveModelClick,
   onGenerateFromLlmClick,
   onGenerateFromSourceClick,
 }: Props) => {
   const grouped = useMemo(
-    () => groupMethods(externalApiUsages, mode),
-    [externalApiUsages, mode],
+    () => groupMethods(externalApiUsages, viewState.mode),
+    [externalApiUsages, viewState.mode],
   );
 
   const sortedGroupNames = useMemo(() => sortGroupNames(grouped), [grouped]);
@@ -61,7 +58,6 @@ export const ModeledMethodsList = ({
           hasUnsavedChanges={unsavedModels.has(libraryName)}
           modeledMethods={modeledMethods}
           viewState={viewState}
-          mode={mode}
           onChange={onChange}
           onSaveModelClick={onSaveModelClick}
           onGenerateFromLlmClick={onGenerateFromLlmClick}


### PR DESCRIPTION
I realised we were passing in both `ViewState` and `Mode` to some components. This is a mistake I made earlier and didn't realise the view state was already available.

I also take the opportunity to simplify the types and avoiding passing a possibly-undefined view state around as much as possible. This shouldn't ever be undefined in practice because the first thing we do once the view is loaded is to send a `setDataExtensionEditorViewState` message. The fact that we have to do this is a drawback of the webview model where we have to send initialisation data only after the view is loaded. I think we can treat the brief window where the view state is undefined as a "loading" phase and display a message. This way for the rest of the code we are sure that the variable is defined. In practice this loading message is invisible and I can't spot it when the view is opened.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
