### PR TITLE
Show more clearly when a method is already modeled

### DIFF
--- a/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
@@ -60,28 +60,19 @@ type Props = {
 export const MethodRow = (props: Props) => {
   const { externalApiUsage, modeledMethod } = props;
 
-  const jumpToUsage = useCallback(() => {
-    vscode.postMessage({
-      t: "jumpToUsage",
-      // In framework mode, the first and only usage is the definition of the method
-      location: externalApiUsage.usages[0].url,
-    });
-  }, [externalApiUsage]);
-
   const methodCanBeModeled =
     !externalApiUsage.supported ||
     (modeledMethod && modeledMethod?.type !== "none");
 
   if (methodCanBeModeled) {
-    return <ModelableMethodRow {...props} jumpToUsage={jumpToUsage} />;
+    return <ModelableMethodRow {...props} />;
   } else {
-    return <UmmodelableMethodRow {...props} jumpToUsage={jumpToUsage} />;
+    return <UmmodelableMethodRow {...props} />;
   }
 };
 
-function ModelableMethodRow(props: Props & { jumpToUsage: () => void }) {
-  const { externalApiUsage, modeledMethod, mode, onChange, jumpToUsage } =
-    props;
+function ModelableMethodRow(props: Props) {
+  const { externalApiUsage, modeledMethod, mode, onChange } = props;
 
   const argumentsList = useMemo(() => {
     if (externalApiUsage.methodParameters === "()") {
@@ -155,6 +146,11 @@ function ModelableMethodRow(props: Props & { jumpToUsage: () => void }) {
       });
     },
     [onChange, externalApiUsage, modeledMethod],
+  );
+
+  const jumpToUsage = useCallback(
+    () => sendJumpToUsageMessage(externalApiUsage),
+    [externalApiUsage],
   );
 
   const inputOptions = useMemo(
@@ -240,9 +236,14 @@ function ModelableMethodRow(props: Props & { jumpToUsage: () => void }) {
 function UmmodelableMethodRow(props: {
   externalApiUsage: ExternalApiUsage;
   mode: Mode;
-  jumpToUsage: () => void;
 }) {
-  const { externalApiUsage, mode, jumpToUsage } = props;
+  const { externalApiUsage, mode } = props;
+
+  const jumpToUsage = useCallback(
+    () => sendJumpToUsageMessage(externalApiUsage),
+    [externalApiUsage],
+  );
+
   return (
     <VSCodeDataGridRow>
       <ApiOrMethodCell gridColumn={1}>
@@ -271,4 +272,12 @@ function ExternalApiUsageName(props: { externalApiUsage: ExternalApiUsage }) {
       {props.externalApiUsage.methodParameters}
     </span>
   );
+}
+
+function sendJumpToUsageMessage(externalApiUsage: ExternalApiUsage) {
+  vscode.postMessage({
+    t: "jumpToUsage",
+    // In framework mode, the first and only usage is the definition of the method
+    location: externalApiUsage.usages[0].url,
+  });
 }

--- a/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
@@ -256,10 +256,9 @@ function UmmodelableMethodRow(props: {
         )}
         <ViewLink onClick={jumpToUsage}>View</ViewLink>
       </ApiOrMethodCell>
-      <VSCodeDataGridCell gridColumn={2} />
-      <VSCodeDataGridCell gridColumn={3} />
-      <VSCodeDataGridCell gridColumn={4} />
-      <VSCodeDataGridCell gridColumn={5} />
+      <VSCodeDataGridCell gridColumn="span 4">
+        Method modeled by CodeQL or another extension pack
+      </VSCodeDataGridCell>
     </VSCodeDataGridRow>
   );
 }

--- a/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
@@ -137,11 +137,6 @@ export const MethodRow = ({
     });
   }, [externalApiUsage]);
 
-  const predicate =
-    modeledMethod?.type && modeledMethod.type !== "none"
-      ? extensiblePredicateDefinitions[modeledMethod.type]
-      : undefined;
-
   const showModelTypeCell =
     !externalApiUsage.supported ||
     (modeledMethod && modeledMethod?.type !== "none");
@@ -183,6 +178,10 @@ export const MethodRow = ({
     [argumentsList],
   );
 
+  const predicate =
+    modeledMethod?.type && modeledMethod.type !== "none"
+      ? extensiblePredicateDefinitions[modeledMethod.type]
+      : undefined;
   const showKindCell = predicate?.supportedKinds;
 
   return (

--- a/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
@@ -137,9 +137,6 @@ export const MethodRow = ({
     });
   }, [externalApiUsage]);
 
-  const methodCanBeModeled =
-    !externalApiUsage.supported ||
-    (modeledMethod && modeledMethod?.type !== "none");
   const modelTypeOptions = useMemo(
     () => [
       { value: "none", label: "Unmodeled" },
@@ -151,8 +148,6 @@ export const MethodRow = ({
     [],
   );
 
-  const showInputCell =
-    modeledMethod?.type && ["sink", "summary"].includes(modeledMethod?.type);
   const inputOptions = useMemo(
     () => [
       { value: "Argument[this]", label: "Argument[this]" },
@@ -164,8 +159,6 @@ export const MethodRow = ({
     [argumentsList],
   );
 
-  const showOutputCell =
-    modeledMethod?.type && ["source", "summary"].includes(modeledMethod?.type);
   const outputOptions = useMemo(
     () => [
       { value: "ReturnValue", label: "ReturnValue" },
@@ -178,6 +171,13 @@ export const MethodRow = ({
     [argumentsList],
   );
 
+  const methodCanBeModeled =
+    !externalApiUsage.supported ||
+    (modeledMethod && modeledMethod?.type !== "none");
+  const showInputCell =
+    modeledMethod?.type && ["sink", "summary"].includes(modeledMethod?.type);
+  const showOutputCell =
+    modeledMethod?.type && ["source", "summary"].includes(modeledMethod?.type);
   const predicate =
     modeledMethod?.type && modeledMethod.type !== "none"
       ? extensiblePredicateDefinitions[modeledMethod.type]

--- a/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
@@ -257,7 +257,7 @@ function UnmodelableMethodRow(props: {
         <ViewLink onClick={jumpToUsage}>View</ViewLink>
       </ApiOrMethodCell>
       <VSCodeDataGridCell gridColumn="span 4">
-        Method modeled by CodeQL or another extension pack
+        Method already modeled by CodeQL or a different extension pack
       </VSCodeDataGridCell>
     </VSCodeDataGridRow>
   );

--- a/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
@@ -57,12 +57,9 @@ type Props = {
   ) => void;
 };
 
-export const MethodRow = ({
-  externalApiUsage,
-  modeledMethod,
-  mode,
-  onChange,
-}: Props) => {
+export const MethodRow = (props: Props) => {
+  const { externalApiUsage, modeledMethod, mode, onChange } = props;
+
   const argumentsList = useMemo(() => {
     if (externalApiUsage.methodParameters === "()") {
       return [];
@@ -172,33 +169,8 @@ export const MethodRow = ({
     !externalApiUsage.supported ||
     (modeledMethod && modeledMethod?.type !== "none");
 
-  const externalApiUsageName = (
-    <span>
-      {externalApiUsage.packageName}.{externalApiUsage.typeName}.
-      {externalApiUsage.methodName}
-      {externalApiUsage.methodParameters}
-    </span>
-  );
-
   if (!methodCanBeModeled) {
-    return (
-      <VSCodeDataGridRow>
-        <ApiOrMethodCell gridColumn={1}>
-          <VSCodeCheckbox />
-          {externalApiUsageName}
-          {mode === Mode.Application && (
-            <UsagesButton onClick={jumpToUsage}>
-              {externalApiUsage.usages.length}
-            </UsagesButton>
-          )}
-          <ViewLink onClick={jumpToUsage}>View</ViewLink>
-        </ApiOrMethodCell>
-        <VSCodeDataGridCell gridColumn={2} />
-        <VSCodeDataGridCell gridColumn={3} />
-        <VSCodeDataGridCell gridColumn={4} />
-        <VSCodeDataGridCell gridColumn={5} />
-      </VSCodeDataGridRow>
-    );
+    return <UmmodelableMethodRow {...props} jumpToUsage={jumpToUsage} />;
   }
 
   const showInputCell =
@@ -215,7 +187,7 @@ export const MethodRow = ({
     <VSCodeDataGridRow>
       <ApiOrMethodCell gridColumn={1}>
         <VSCodeCheckbox />
-        {externalApiUsageName}
+        <ExternalApiUsageName {...props} />
         {mode === Mode.Application && (
           <UsagesButton onClick={jumpToUsage}>
             {externalApiUsage.usages.length}
@@ -257,3 +229,39 @@ export const MethodRow = ({
     </VSCodeDataGridRow>
   );
 };
+
+function UmmodelableMethodRow(props: {
+  externalApiUsage: ExternalApiUsage;
+  mode: Mode;
+  jumpToUsage: () => void;
+}) {
+  const { externalApiUsage, mode, jumpToUsage } = props;
+  return (
+    <VSCodeDataGridRow>
+      <ApiOrMethodCell gridColumn={1}>
+        <VSCodeCheckbox />
+        <ExternalApiUsageName {...props} />
+        {mode === Mode.Application && (
+          <UsagesButton onClick={jumpToUsage}>
+            {externalApiUsage.usages.length}
+          </UsagesButton>
+        )}
+        <ViewLink onClick={jumpToUsage}>View</ViewLink>
+      </ApiOrMethodCell>
+      <VSCodeDataGridCell gridColumn={2} />
+      <VSCodeDataGridCell gridColumn={3} />
+      <VSCodeDataGridCell gridColumn={4} />
+      <VSCodeDataGridCell gridColumn={5} />
+    </VSCodeDataGridRow>
+  );
+}
+
+function ExternalApiUsageName(props: { externalApiUsage: ExternalApiUsage }) {
+  return (
+    <span>
+      {props.externalApiUsage.packageName}.{props.externalApiUsage.typeName}.
+      {props.externalApiUsage.methodName}
+      {props.externalApiUsage.methodParameters}
+    </span>
+  );
+}

--- a/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
@@ -67,7 +67,7 @@ export const MethodRow = (props: Props) => {
   if (methodCanBeModeled) {
     return <ModelableMethodRow {...props} />;
   } else {
-    return <UmmodelableMethodRow {...props} />;
+    return <UnmodelableMethodRow {...props} />;
   }
 };
 
@@ -233,7 +233,7 @@ function ModelableMethodRow(props: Props) {
   );
 }
 
-function UmmodelableMethodRow(props: {
+function UnmodelableMethodRow(props: {
   externalApiUsage: ExternalApiUsage;
   mode: Mode;
 }) {

--- a/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
@@ -39,6 +39,14 @@ const ViewLink = styled(VSCodeLink)`
   white-space: nowrap;
 `;
 
+const modelTypeOptions = [
+  { value: "none", label: "Unmodeled" },
+  { value: "source", label: "Source" },
+  { value: "sink", label: "Sink" },
+  { value: "summary", label: "Flow summary" },
+  { value: "neutral", label: "Neutral" },
+];
+
 type Props = {
   externalApiUsage: ExternalApiUsage;
   modeledMethod: ModeledMethod | undefined;
@@ -136,17 +144,6 @@ export const MethodRow = ({
       location: externalApiUsage.usages[0].url,
     });
   }, [externalApiUsage]);
-
-  const modelTypeOptions = useMemo(
-    () => [
-      { value: "none", label: "Unmodeled" },
-      { value: "source", label: "Source" },
-      { value: "sink", label: "Sink" },
-      { value: "summary", label: "Flow summary" },
-      { value: "neutral", label: "Neutral" },
-    ],
-    [],
-  );
 
   const inputOptions = useMemo(
     () => [

--- a/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
@@ -137,7 +137,7 @@ export const MethodRow = ({
     });
   }, [externalApiUsage]);
 
-  const showModelTypeCell =
+  const methodCanBeModeled =
     !externalApiUsage.supported ||
     (modeledMethod && modeledMethod?.type !== "none");
   const modelTypeOptions = useMemo(
@@ -204,7 +204,7 @@ export const MethodRow = ({
         <Dropdown
           value={modeledMethod?.type ?? "none"}
           options={modelTypeOptions}
-          disabled={!showModelTypeCell}
+          disabled={!methodCanBeModeled}
           onChange={handleTypeInput}
         />
       </VSCodeDataGridCell>

--- a/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
@@ -174,6 +174,36 @@ export const MethodRow = ({
   const methodCanBeModeled =
     !externalApiUsage.supported ||
     (modeledMethod && modeledMethod?.type !== "none");
+
+  const externalApiUsageName = (
+    <span>
+      {externalApiUsage.packageName}.{externalApiUsage.typeName}.
+      {externalApiUsage.methodName}
+      {externalApiUsage.methodParameters}
+    </span>
+  );
+
+  if (!methodCanBeModeled) {
+    return (
+      <VSCodeDataGridRow>
+        <ApiOrMethodCell gridColumn={1}>
+          <VSCodeCheckbox />
+          {externalApiUsageName}
+          {mode === Mode.Application && (
+            <UsagesButton onClick={jumpToUsage}>
+              {externalApiUsage.usages.length}
+            </UsagesButton>
+          )}
+          <ViewLink onClick={jumpToUsage}>View</ViewLink>
+        </ApiOrMethodCell>
+        <VSCodeDataGridCell gridColumn={2} />
+        <VSCodeDataGridCell gridColumn={3} />
+        <VSCodeDataGridCell gridColumn={4} />
+        <VSCodeDataGridCell gridColumn={5} />
+      </VSCodeDataGridRow>
+    );
+  }
+
   const showInputCell =
     modeledMethod?.type && ["sink", "summary"].includes(modeledMethod?.type);
   const showOutputCell =
@@ -188,11 +218,7 @@ export const MethodRow = ({
     <VSCodeDataGridRow>
       <ApiOrMethodCell gridColumn={1}>
         <VSCodeCheckbox />
-        <span>
-          {externalApiUsage.packageName}.{externalApiUsage.typeName}.
-          {externalApiUsage.methodName}
-          {externalApiUsage.methodParameters}
-        </span>
+        {externalApiUsageName}
         {mode === Mode.Application && (
           <UsagesButton onClick={jumpToUsage}>
             {externalApiUsage.usages.length}
@@ -204,7 +230,6 @@ export const MethodRow = ({
         <Dropdown
           value={modeledMethod?.type ?? "none"}
           options={modelTypeOptions}
-          disabled={!methodCanBeModeled}
           onChange={handleTypeInput}
         />
       </VSCodeDataGridCell>


### PR DESCRIPTION
This PR does some refactoring of the `MethodRow` component to split it into two cases:
- When the method can be modeled, which is most of the implementation.
- When the method cannot be modeled, because it is already modeled by another source such CodeQL or another extension pack than the one we're currently editing.

We then finally add a simple message saying that a method is already modeled and cannot be edited.

<img width="2414" alt="Screenshot 2023-07-12 at 14 59 04" src="https://github.com/github/vscode-codeql/assets/3749000/a3364338-4d62-4a85-abf5-8929b9ad83c3">

The refactoring is not strictly necessary, and I can remove it or pull it out to two separate PRs if that would be easier. What I like about the refactoring and splitting into two components is that we don't have to define all the various handlers and other computation for the unmodelable case where we don't use any of them.

Note that right now I don't think we can tell between a method modeled by CodeQL or another extension pack. I'd like to make that more clear but I think it would be better as a separate PR. Therefore the message right now has to cover both cases. Suggestions on the wording of the message are very welcome.

Also note, I've made a separate issue for making the checkboxes work and match the designs. So ignore those for now.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
