### PR TITLE
Show whether changes to a method are saved or not

### DIFF
--- a/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
@@ -71,15 +71,14 @@ type Props = {
   libraryVersion?: string;
   externalApiUsages: ExternalApiUsage[];
   modeledMethods: Record<string, ModeledMethod>;
+  modifiedSignatures: Set<string>;
   viewState: DataExtensionEditorViewState;
-  hasUnsavedChanges: boolean;
   onChange: (
     modelName: string,
     externalApiUsage: ExternalApiUsage,
     modeledMethod: ModeledMethod,
   ) => void;
   onSaveModelClick: (
-    modelName: string,
     externalApiUsages: ExternalApiUsage[],
     modeledMethods: Record<string, ModeledMethod>,
   ) => void;
@@ -95,8 +94,8 @@ export const LibraryRow = ({
   libraryVersion,
   externalApiUsages,
   modeledMethods,
+  modifiedSignatures,
   viewState,
-  hasUnsavedChanges,
   onChange,
   onSaveModelClick,
   onGenerateFromLlmClick,
@@ -137,11 +136,11 @@ export const LibraryRow = ({
 
   const handleSave = useCallback(
     async (e: React.MouseEvent) => {
-      onSaveModelClick(title, externalApiUsages, modeledMethods);
+      onSaveModelClick(externalApiUsages, modeledMethods);
       e.stopPropagation();
       e.preventDefault();
     },
-    [title, externalApiUsages, modeledMethods, onSaveModelClick],
+    [externalApiUsages, modeledMethods, onSaveModelClick],
   );
 
   const onChangeWithModelName = useCallback(
@@ -150,6 +149,12 @@ export const LibraryRow = ({
     },
     [onChange, title],
   );
+
+  const hasUnsavedChanges = useMemo(() => {
+    return externalApiUsages.some((externalApiUsage) =>
+      modifiedSignatures.has(externalApiUsage.signature),
+    );
+  }, [externalApiUsages, modifiedSignatures]);
 
   return (
     <LibraryContainer>

--- a/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
@@ -200,6 +200,7 @@ export const LibraryRow = ({
           <ModeledMethodDataGrid
             externalApiUsages={externalApiUsages}
             modeledMethods={modeledMethods}
+            modifiedSignatures={modifiedSignatures}
             mode={viewState.mode}
             onChange={onChangeWithModelName}
           />

--- a/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodDataGrid.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodDataGrid.tsx
@@ -14,6 +14,7 @@ import { sortMethods } from "../../data-extensions-editor/shared/sorting";
 type Props = {
   externalApiUsages: ExternalApiUsage[];
   modeledMethods: Record<string, ModeledMethod>;
+  modifiedSignatures: Set<string>;
   mode: Mode;
   onChange: (
     externalApiUsage: ExternalApiUsage,
@@ -24,6 +25,7 @@ type Props = {
 export const ModeledMethodDataGrid = ({
   externalApiUsages,
   modeledMethods,
+  modifiedSignatures,
   mode,
   onChange,
 }: Props) => {
@@ -56,6 +58,7 @@ export const ModeledMethodDataGrid = ({
           key={externalApiUsage.signature}
           externalApiUsage={externalApiUsage}
           modeledMethod={modeledMethods[externalApiUsage.signature]}
+          modifiedSignatures={modifiedSignatures}
           mode={mode}
           onChange={onChange}
         />

--- a/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodsList.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodsList.tsx
@@ -12,8 +12,8 @@ import { DataExtensionEditorViewState } from "../../data-extensions-editor/share
 
 type Props = {
   externalApiUsages: ExternalApiUsage[];
-  unsavedModels: Set<string>;
   modeledMethods: Record<string, ModeledMethod>;
+  modifiedSignatures: Set<string>;
   viewState: DataExtensionEditorViewState;
   onChange: (
     modelName: string,
@@ -21,7 +21,6 @@ type Props = {
     modeledMethod: ModeledMethod,
   ) => void;
   onSaveModelClick: (
-    modelName: string,
     externalApiUsages: ExternalApiUsage[],
     modeledMethods: Record<string, ModeledMethod>,
   ) => void;
@@ -38,8 +37,8 @@ const libraryNameOverrides: Record<string, string> = {
 
 export const ModeledMethodsList = ({
   externalApiUsages,
-  unsavedModels,
   modeledMethods,
+  modifiedSignatures,
   viewState,
   onChange,
   onSaveModelClick,
@@ -79,8 +78,8 @@ export const ModeledMethodsList = ({
           title={libraryNameOverrides[libraryName] ?? libraryName}
           libraryVersion={libraryVersions[libraryName]}
           externalApiUsages={grouped[libraryName]}
-          hasUnsavedChanges={unsavedModels.has(libraryName)}
           modeledMethods={modeledMethods}
+          modifiedSignatures={modifiedSignatures}
           viewState={viewState}
           onChange={onChange}
           onSaveModelClick={onSaveModelClick}


### PR DESCRIPTION
This PR replaces the checkbox on each method row with an icon that shows whether that method is modelled, whether there have been any changes to that row, and whether those changes are saved or not.

Screenshot:
<img width="2449" alt="Screenshot 2023-07-14 at 16 18 07" src="https://github.com/github/vscode-codeql/assets/3749000/39b768f1-37c5-4612-b232-20b8d9c312d2">

Implementing this involved changing how we track changes, to track individual methods instead of entire models. Thankfully this was fairly easy to implement and I think actually made things a little clearer overall. I haven't tried to remember what the original state was, so if you make a change and then revert it then the method will still show as changed and unsaved, but I think this behaviour is acceptable here.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
