### PR TITLE
Implement "model dependency" button in application mode

### DIFF
--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -553,6 +553,10 @@ export interface GenerateExternalApiFromLlmMessage {
   modeledMethods: Record<string, ModeledMethod>;
 }
 
+export interface ModelDependencyMessage {
+  t: "modelDependency";
+}
+
 export type ToDataExtensionsEditorMessage =
   | SetExtensionPackStateMessage
   | SetExternalApiUsagesMessage
@@ -568,4 +572,5 @@ export type FromDataExtensionsEditorMessage =
   | JumpToUsageMessage
   | SaveModeledMethods
   | GenerateExternalApiMessage
-  | GenerateExternalApiFromLlmMessage;
+  | GenerateExternalApiFromLlmMessage
+  | ModelDependencyMessage;

--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
@@ -139,6 +139,8 @@ export class DataExtensionsEditorView extends AbstractWebview<
         );
 
         break;
+      case "modelDependency":
+        break;
       case "switchMode":
         this.mode = msg.mode;
 

--- a/extensions/ql-vscode/src/databases/database-fetcher.ts
+++ b/extensions/ql-vscode/src/databases/database-fetcher.ts
@@ -85,6 +85,7 @@ export async function promptImportInternetDatabase(
  * @param credentials the credentials to use to authenticate with GitHub
  * @param progress the progress callback
  * @param cli the CodeQL CLI server
+ * @param language the language to download. If undefined, the user will be prompted to choose a language.
  */
 export async function promptImportGithubDatabase(
   commandManager: AppCommandManager,
@@ -93,6 +94,7 @@ export async function promptImportGithubDatabase(
   credentials: Credentials | undefined,
   progress: ProgressCallback,
   cli?: CodeQLCliServer,
+  language?: string,
 ): Promise<DatabaseItem | undefined> {
   const githubRepo = await askForGitHubRepo(progress);
   if (!githubRepo) {
@@ -106,6 +108,7 @@ export async function promptImportGithubDatabase(
     credentials,
     progress,
     cli,
+    language,
   );
 
   if (databaseItem) {

--- a/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
@@ -215,6 +215,12 @@ export function DataExtensionsEditor({
     });
   }, [externalApiUsages, modeledMethods]);
 
+  const onModelDependencyClick = useCallback(() => {
+    vscode.postMessage({
+      t: "modelDependency",
+    });
+  }, []);
+
   const onGenerateFromLlmClick = useCallback(
     (
       externalApiUsages: ExternalApiUsage[],
@@ -323,6 +329,7 @@ export function DataExtensionsEditor({
               onSaveModelClick={onSaveModelClick}
               onGenerateFromLlmClick={onGenerateFromLlmClick}
               onGenerateFromSourceClick={onGenerateFromSourceClick}
+              onModelDependencyClick={onModelDependencyClick}
             />
           </EditorContainer>
         </>

--- a/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
@@ -87,6 +87,7 @@ type Props = {
     modeledMethods: Record<string, ModeledMethod>,
   ) => void;
   onGenerateFromSourceClick: () => void;
+  onModelDependencyClick: () => void;
 };
 
 export const LibraryRow = ({
@@ -100,6 +101,7 @@ export const LibraryRow = ({
   onSaveModelClick,
   onGenerateFromLlmClick,
   onGenerateFromSourceClick,
+  onModelDependencyClick,
 }: Props) => {
   const modeledPercentage = useMemo(() => {
     return calculateModeledPercentage(externalApiUsages);
@@ -129,10 +131,14 @@ export const LibraryRow = ({
     [onGenerateFromSourceClick],
   );
 
-  const handleModelDependency = useCallback(async (e: React.MouseEvent) => {
-    e.stopPropagation();
-    e.preventDefault();
-  }, []);
+  const handleModelDependency = useCallback(
+    async (e: React.MouseEvent) => {
+      onModelDependencyClick();
+      e.stopPropagation();
+      e.preventDefault();
+    },
+    [onModelDependencyClick],
+  );
 
   const handleSave = useCallback(
     async (e: React.MouseEvent) => {

--- a/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodsList.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodsList.tsx
@@ -29,6 +29,7 @@ type Props = {
     modeledMethods: Record<string, ModeledMethod>,
   ) => void;
   onGenerateFromSourceClick: () => void;
+  onModelDependencyClick: () => void;
 };
 
 const libraryNameOverrides: Record<string, string> = {
@@ -44,6 +45,7 @@ export const ModeledMethodsList = ({
   onSaveModelClick,
   onGenerateFromLlmClick,
   onGenerateFromSourceClick,
+  onModelDependencyClick,
 }: Props) => {
   const grouped = useMemo(
     () => groupMethods(externalApiUsages, viewState.mode),
@@ -85,6 +87,7 @@ export const ModeledMethodsList = ({
           onSaveModelClick={onSaveModelClick}
           onGenerateFromLlmClick={onGenerateFromLlmClick}
           onGenerateFromSourceClick={onGenerateFromSourceClick}
+          onModelDependencyClick={onModelDependencyClick}
         />
       ))}
     </>


### PR DESCRIPTION
This PR adds the implementation for the "model dependency" button. This prompts the user for a repository name, then downloads that repository and opens a new data extensions window in framework mode.

This shares a bunch of implementation with the "model from source" button because they both prompt the user to download a new database. I think both of these will continue to share implementation, so any improvements we make will apply to both.

I have encountered problems when the new databases causes the workspace to transition from single-root to multi-root. I have some ideas for things we can do about this, and these might help with "model from source" as well if that shares the same issue. However I'm thinking about raising those changes as separate PRs.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
