### PR TITLE
Delete autoClosingPairs from LanguageConfiguration to appease proposed API

### DIFF
--- a/extensions/ql-vscode/src/language-support/language-support.ts
+++ b/extensions/ql-vscode/src/language-support/language-support.ts
@@ -20,6 +20,7 @@ export function install() {
     decreaseIndentPattern: /^((?!.*?\/\*).*\*\/)?\s*[\}\]].*$/,
     increaseIndentPattern: /^((?!\/\/).)*(\{[^}"'`]*|\([^)"'`]*|\[[^\]"'`]*)$/,
   };
+  delete langConfig.autoClosingPairs;
 
   languages.setLanguageConfiguration("ql", langConfig);
   languages.setLanguageConfiguration("qll", langConfig);


### PR DESCRIPTION
This allow the extension to start when using VS Code Insiders version `1.81.0-insider`. We're running afoul of the new [proposed API](https://code.visualstudio.com/api/advanced-topics/using-proposed-api) for [autoClosingPairs](https://github.com/microsoft/vscode/blob/main/src/vscode-dts/vscode.proposed.languageConfigurationAutoClosingPairs.d.ts).

Once the proposed API has been merged and is supported by all VS Code versions we aim to support, we can remove this line and pass in `autoClosingPairs` in the `LanguageConfiguration` object.

I've tested it and we do still get `autoClosingPairs` behaviour because we're still passing it in [language-configuration.json](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/language-configuration.json). This seems to still work and it accepts the value and provides the desired behaviour.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
