### PR TITLE
Update title in Data extensions editor tab

### DIFF
--- a/extensions/ql-vscode/src/common/query-language.ts
+++ b/extensions/ql-vscode/src/common/query-language.ts
@@ -9,6 +9,29 @@ export enum QueryLanguage {
   Swift = "swift",
 }
 
+export function getLanguageDisplayName(language: string): string {
+  switch (language) {
+    case QueryLanguage.CSharp:
+      return "C#";
+    case QueryLanguage.Cpp:
+      return "C / C++";
+    case QueryLanguage.Go:
+      return "Go";
+    case QueryLanguage.Java:
+      return "Java";
+    case QueryLanguage.Javascript:
+      return "JavaScript";
+    case QueryLanguage.Python:
+      return "Python";
+    case QueryLanguage.Ruby:
+      return "Ruby";
+    case QueryLanguage.Swift:
+      return "Swift";
+    default:
+      return language;
+  }
+}
+
 export const PACKS_BY_QUERY_LANGUAGE = {
   [QueryLanguage.Cpp]: ["codeql/cpp-queries"],
   [QueryLanguage.CSharp]: [

--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
@@ -49,6 +49,7 @@ import { Mode } from "./shared/mode";
 import { loadModeledMethods, saveModeledMethods } from "./modeled-method-fs";
 import { join } from "path";
 import { pickExtensionPack } from "./extension-pack-picker";
+import { getLanguageDisplayName } from "../common/query-language";
 
 export class DataExtensionsEditorView extends AbstractWebview<
   ToDataExtensionsEditorMessage,
@@ -78,8 +79,9 @@ export class DataExtensionsEditorView extends AbstractWebview<
   protected async getPanelConfig(): Promise<WebviewPanelConfig> {
     return {
       viewId: "data-extensions-editor",
-      title: `Modeling ${this.extensionPack.language} (${this.extensionPack.name})`,
-      // Still TODO: fix capitalization of language name
+      title: `Modeling ${getLanguageDisplayName(
+        this.extensionPack.language,
+      )} (${this.extensionPack.name})`,
       viewColumn: ViewColumn.Active,
       preserveFocus: true,
       view: "data-extensions-editor",

--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
@@ -78,7 +78,8 @@ export class DataExtensionsEditorView extends AbstractWebview<
   protected async getPanelConfig(): Promise<WebviewPanelConfig> {
     return {
       viewId: "data-extensions-editor",
-      title: "Data Extensions Editor",
+      title: `Modeling ${this.extensionPack.language} (${this.extensionPack.name})`,
+      // Still TODO: fix capitalization of language name
       viewColumn: ViewColumn.Active,
       preserveFocus: true,
       view: "data-extensions-editor",

--- a/extensions/ql-vscode/src/data-extensions-editor/extension-pack-picker.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/extension-pack-picker.ts
@@ -88,7 +88,7 @@ export async function pickExtensionPack(
 
         let extensionPack: ExtensionPack;
         try {
-          extensionPack = await readExtensionPack(path);
+          extensionPack = await readExtensionPack(path, databaseItem.language);
         } catch (e: unknown) {
           void showAndLogErrorMessage(
             logger,
@@ -253,7 +253,10 @@ async function autoCreateExtensionPack(
   if (existingExtensionPackPaths?.length === 1) {
     let extensionPack: ExtensionPack;
     try {
-      extensionPack = await readExtensionPack(existingExtensionPackPaths[0]);
+      extensionPack = await readExtensionPack(
+        existingExtensionPackPaths[0],
+        language,
+      );
     } catch (e: unknown) {
       void showAndLogErrorMessage(
         logger,
@@ -317,6 +320,7 @@ async function writeExtensionPack(
     yamlPath: packYamlPath,
     name: formatPackName(packName),
     version: "0.0.0",
+    language,
     extensionTargets: {
       [`codeql/${language}-all`]: "*",
     },
@@ -337,7 +341,10 @@ async function writeExtensionPack(
   return extensionPack;
 }
 
-async function readExtensionPack(path: string): Promise<ExtensionPack> {
+async function readExtensionPack(
+  path: string,
+  language: string,
+): Promise<ExtensionPack> {
   const qlpackPath = await getQlPackPath(path);
   if (!qlpackPath) {
     throw new Error(
@@ -374,6 +381,7 @@ async function readExtensionPack(path: string): Promise<ExtensionPack> {
     yamlPath: qlpackPath,
     name: qlpack.name,
     version: qlpack.version,
+    language,
     extensionTargets: qlpack.extensionTargets,
     dataExtensions,
   };

--- a/extensions/ql-vscode/src/data-extensions-editor/shared/extension-pack.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/shared/extension-pack.ts
@@ -4,6 +4,7 @@ export interface ExtensionPack {
 
   name: string;
   version: string;
+  language: string;
 
   extensionTargets: Record<string, string>;
   dataExtensions: string[];

--- a/extensions/ql-vscode/src/stories/data-extensions-editor/DataExtensionsEditor.stories.tsx
+++ b/extensions/ql-vscode/src/stories/data-extensions-editor/DataExtensionsEditor.stories.tsx
@@ -24,6 +24,7 @@ DataExtensionsEditor.args = {
         "/home/user/vscode-codeql-starter/codeql-custom-queries-java/sql2o/codeql-pack.yml",
       name: "codeql/sql2o-models",
       version: "0.0.0",
+      language: "java",
       extensionTargets: {},
       dataExtensions: [],
     },

--- a/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
@@ -17,6 +17,7 @@ import { DataExtensionEditorViewState } from "../../data-extensions-editor/share
 import { ModeledMethodsList } from "./ModeledMethodsList";
 import { percentFormatter } from "./formatters";
 import { Mode } from "../../data-extensions-editor/shared/mode";
+import { getLanguageDisplayName } from "../../common/query-language";
 
 const LoadingContainer = styled.div`
   text-align: center;
@@ -266,7 +267,9 @@ export function DataExtensionsEditor({
 
       {externalApiUsages.length > 0 && (
         <>
-          <ViewTitle>{viewState.extensionPack.language}</ViewTitle>
+          <ViewTitle>
+            {getLanguageDisplayName(viewState.extensionPack.language)}
+          </ViewTitle>
           <DetailsContainer>
             <LinkIconButton onClick={onOpenExtensionPackClick}>
               <span slot="start" className="codicon codicon-package"></span>

--- a/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
@@ -266,7 +266,7 @@ export function DataExtensionsEditor({
 
       {externalApiUsages.length > 0 && (
         <>
-          <ViewTitle>Data extensions editor</ViewTitle>
+          <ViewTitle>{viewState.extensionPack.language}</ViewTitle>
           <DetailsContainer>
             <LinkIconButton onClick={onOpenExtensionPackClick}>
               <span slot="start" className="codicon codicon-package"></span>

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/data-extensions-editor/modeled-method-fs.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/data-extensions-editor/modeled-method-fs.test.ts
@@ -112,6 +112,7 @@ describe("modeled-method-fs", () => {
       yamlPath: path,
       name: "dummy/pack",
       version: "0.0.1",
+      language: "java",
       extensionTargets: {},
       dataExtensions: [],
     };

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/data-extensions-editor/extension-pack-picker.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/data-extensions-editor/extension-pack-picker.test.ts
@@ -268,6 +268,7 @@ describe("pickExtensionPack", () => {
       yamlPath: join(newPackDir, "codeql-pack.yml"),
       name: "github/vscode-codeql-java",
       version: "0.0.0",
+      language: "java",
       extensionTargets: {
         "codeql/java-all": "*",
       },
@@ -339,6 +340,7 @@ describe("pickExtensionPack", () => {
       yamlPath: join(newPackDir, "codeql-pack.yml"),
       name: "github/vscode-codeql-java",
       version: "0.0.0",
+      language: "java",
       extensionTargets: {
         "codeql/java-all": "*",
       },
@@ -399,6 +401,7 @@ describe("pickExtensionPack", () => {
       yamlPath: join(newPackDir, "codeql-pack.yml"),
       name: "pack/new-extension-pack",
       version: "0.0.0",
+      language: "java",
       extensionTargets: {
         "codeql/java-all": "*",
       },
@@ -466,6 +469,7 @@ describe("pickExtensionPack", () => {
       yamlPath: join(newPackDir, "codeql-pack.yml"),
       name: "pack/new-extension-pack",
       version: "0.0.0",
+      language: "csharp",
       extensionTargets: {
         "codeql/csharp-all": "*",
       },
@@ -815,6 +819,7 @@ describe("pickExtensionPack", () => {
       yamlPath: qlpackPath,
       name: "new-extension-pack",
       version: "0.0.0",
+      language: "java",
       extensionTargets: {
         "codeql/java-all": "*",
       },
@@ -838,6 +843,7 @@ describe("pickExtensionPack", () => {
       "csharp-extension-pack",
       {
         version: "0.5.3",
+        language: "csharp",
         extensionTargets: {
           "codeql/csharp-all": "*",
         },
@@ -906,6 +912,7 @@ async function createMockExtensionPack(
     yamlPath: join(path, "codeql-pack.yml"),
     name,
     version: "0.0.0",
+    language: "java",
     extensionTargets: {
       "codeql/java-all": "*",
     },


### PR DESCRIPTION
Changes the title from this:

![title "Data extensions editor"](https://github.com/github/vscode-codeql/assets/42641846/c207dd24-df89-48e5-89be-a20d495e31ea)

to this:

![title showing language and repo](https://github.com/github/vscode-codeql/assets/42641846/99f96373-f2a1-4ac3-bf84-d17cb989b492)

See internal issue for the linked designs! 

## Checklist

N/A: this is still internal and feature-flagged 🏴 

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
