### PR TITLE
Instead of resetting the database after importing, pass through makeSelected = false

### DIFF
--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
@@ -293,7 +293,7 @@ export class DataExtensionsEditorView extends AbstractWebview<
     // In application mode, we need the database of a specific library to generate
     // the modeled methods. In framework mode, we'll use the current database.
     if (this.mode === Mode.Application) {
-      addedDatabase = await this.promptImportAndResetDatabase((update) =>
+      addedDatabase = await this.promptImportDatabase((update) =>
         this.showProgress(update),
       );
       if (!addedDatabase) {
@@ -423,7 +423,7 @@ export class DataExtensionsEditorView extends AbstractWebview<
 
   private async modelDependency(): Promise<void> {
     return withProgress(async (progress, token) => {
-      const addedDatabase = await this.promptImportAndResetDatabase(progress);
+      const addedDatabase = await this.promptImportDatabase(progress);
       if (!addedDatabase || token.isCancellationRequested) {
         return;
       }
@@ -454,14 +454,13 @@ export class DataExtensionsEditorView extends AbstractWebview<
     });
   }
 
-  private async promptImportAndResetDatabase(
+  private async promptImportDatabase(
     progress: ProgressCallback,
   ): Promise<DatabaseItem | undefined> {
-    const selectedDatabase = this.databaseManager.currentDatabaseItem;
-
     // The external API methods are in the library source code, so we need to ask
     // the user to import the library database. We need to have the database
     // imported to the query server, so we need to register it to our workspace.
+    const makeSelected = false;
     const addedDatabase = await promptImportGithubDatabase(
       this.app.commands,
       this.databaseManager,
@@ -470,15 +469,12 @@ export class DataExtensionsEditorView extends AbstractWebview<
       progress,
       this.cliServer,
       this.databaseItem.language,
+      makeSelected,
     );
     if (!addedDatabase) {
       void this.app.logger.log("No database chosen");
-      return undefined;
+      return;
     }
-
-    // The library database was set as the current database by importing it,
-    // but we need to set it back to the originally selected database.
-    await this.databaseManager.setCurrentDatabaseItem(selectedDatabase);
 
     return addedDatabase;
   }

--- a/extensions/ql-vscode/src/databases/database-fetcher.ts
+++ b/extensions/ql-vscode/src/databases/database-fetcher.ts
@@ -86,6 +86,7 @@ export async function promptImportInternetDatabase(
  * @param progress the progress callback
  * @param cli the CodeQL CLI server
  * @param language the language to download. If undefined, the user will be prompted to choose a language.
+ * @param makeSelected make the new database selected in the databases panel (default: true)
  */
 export async function promptImportGithubDatabase(
   commandManager: AppCommandManager,
@@ -95,6 +96,7 @@ export async function promptImportGithubDatabase(
   progress: ProgressCallback,
   cli?: CodeQLCliServer,
   language?: string,
+  makeSelected = true,
 ): Promise<DatabaseItem | undefined> {
   const githubRepo = await askForGitHubRepo(progress);
   if (!githubRepo) {
@@ -109,10 +111,13 @@ export async function promptImportGithubDatabase(
     progress,
     cli,
     language,
+    makeSelected,
   );
 
   if (databaseItem) {
-    await commandManager.execute("codeQLDatabases.focus");
+    if (makeSelected) {
+      await commandManager.execute("codeQLDatabases.focus");
+    }
     void showAndLogInformationMessage(
       extLogger,
       "Database downloaded and imported successfully.",
@@ -157,6 +162,7 @@ export async function askForGitHubRepo(
  * @param progress the progress callback
  * @param cli the CodeQL CLI server
  * @param language the language to download. If undefined, the user will be prompted to choose a language.
+ * @param makeSelected make the new database selected in the databases panel (default: true)
  **/
 export async function downloadGitHubDatabase(
   githubRepo: string,
@@ -166,6 +172,7 @@ export async function downloadGitHubDatabase(
   progress: ProgressCallback,
   cli?: CodeQLCliServer,
   language?: string,
+  makeSelected = true,
 ): Promise<DatabaseItem | undefined> {
   const nwo = getNwoFromGitHubUrl(githubRepo) || githubRepo;
   if (!isValidGitHubNwo(nwo)) {
@@ -210,6 +217,7 @@ export async function downloadGitHubDatabase(
     `${owner}/${name}`,
     progress,
     cli,
+    makeSelected,
   );
 }
 
@@ -268,6 +276,7 @@ export async function importArchiveDatabase(
  * @param storagePath where to store the unzipped database.
  * @param nameOverride a name for the database that overrides the default
  * @param progress callback to send progress messages to
+ * @param makeSelected make the new database selected in the databases panel (default: true)
  */
 async function databaseArchiveFetcher(
   databaseUrl: string,
@@ -277,6 +286,7 @@ async function databaseArchiveFetcher(
   nameOverride: string | undefined,
   progress: ProgressCallback,
   cli?: CodeQLCliServer,
+  makeSelected = true,
 ): Promise<DatabaseItem> {
   progress({
     message: "Getting database",
@@ -314,8 +324,6 @@ async function databaseArchiveFetcher(
       maxStep: 4,
     });
     await ensureZippedSourceLocation(dbPath);
-
-    const makeSelected = true;
 
     const item = await databaseManager.openDatabase(
       Uri.file(dbPath),


### PR DESCRIPTION
For "model from source" and "model dependency" we were importing the new database, setting it as the current database, and then resetting the current database back to what it was before. Instead we can pass through `makeSelected = false` all the way to `openDatabase` and therefore not have to remember and reset the current database.

Needs some testing for edge cases, but it seems to work for me.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
