### PR TITLE
Remove conditionals and version constraints for unsupported CLI versions

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1077,17 +1077,17 @@
         {
           "command": "codeQLQueryHistory.showEvalLog",
           "group": "4_queryHistory@1",
-          "when": "codeql.supportsEvalLog && viewItem == rawResultsItem || codeql.supportsEvalLog && viewItem == interpretedResultsItem || codeql.supportsEvalLog && viewItem == cancelledResultsItem"
+          "when": "viewItem == rawResultsItem || viewItem == interpretedResultsItem || viewItem == cancelledResultsItem"
         },
         {
           "command": "codeQLQueryHistory.showEvalLogSummary",
           "group": "4_queryHistory@2",
-          "when": "codeql.supportsEvalLog && viewItem == rawResultsItem || codeql.supportsEvalLog && viewItem == interpretedResultsItem || codeql.supportsEvalLog && viewItem == cancelledResultsItem"
+          "when": "viewItem == rawResultsItem || viewItem == interpretedResultsItem || viewItem == cancelledResultsItem"
         },
         {
           "command": "codeQLQueryHistory.showEvalLogViewer",
           "group": "4_queryHistory@3",
-          "when": "config.codeQL.canary && codeql.supportsEvalLog && viewItem == rawResultsItem || config.codeQL.canary && codeql.supportsEvalLog && viewItem == interpretedResultsItem || config.codeQL.canary && codeql.supportsEvalLog && viewItem == cancelledResultsItem"
+          "when": "config.codeQL.canary && viewItem == rawResultsItem || config.codeQL.canary && viewItem == interpretedResultsItem || config.codeQL.canary && viewItem == cancelledResultsItem"
         },
         {
           "command": "codeQLQueryHistory.showQueryText",

--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -1804,12 +1804,6 @@ export class CliVersionConstraint {
   public static CLI_VERSION_WITH_RESOLVE_EXTENSIONS = new SemVer("2.10.2");
 
   /**
-   * CLI version where the `--evaluator-log` and related options to the query server were introduced,
-   * on a per-query server basis.
-   */
-  public static CLI_VERSION_WITH_STRUCTURED_EVAL_LOG = new SemVer("2.8.2");
-
-  /**
    * CLI version that supports rotating structured logs to produce one per query.
    *
    * Note that 2.8.4 supports generating the evaluation logs and summaries,
@@ -1882,12 +1876,6 @@ export class CliVersionConstraint {
   async supportsResolveExtensions() {
     return this.isVersionAtLeast(
       CliVersionConstraint.CLI_VERSION_WITH_RESOLVE_EXTENSIONS,
-    );
-  }
-
-  async supportsStructuredEvalLog() {
-    return this.isVersionAtLeast(
-      CliVersionConstraint.CLI_VERSION_WITH_STRUCTURED_EVAL_LOG,
     );
   }
 

--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -1428,21 +1428,13 @@ export class CodeQLCliServer implements Disposable {
 
   async packPacklist(dir: string, includeQueries: boolean): Promise<string[]> {
     const args = includeQueries ? [dir] : ["--no-include-queries", dir];
-    // since 2.7.1, packlist returns an object with a "paths" property that is a list of packs.
-    // previous versions return a list of packs.
-    const results: { paths: string[] } | string[] =
-      await this.runJsonCodeQlCliCommand(
-        ["pack", "packlist"],
-        args,
-        "Generating the pack list",
-      );
+    const results: { paths: string[] } = await this.runJsonCodeQlCliCommand(
+      ["pack", "packlist"],
+      args,
+      "Generating the pack list",
+    );
 
-    // Once we no longer need to support 2.7.0 or earlier, we can remove this and assume all versions return an object.
-    if ("paths" in results) {
-      return results.paths;
-    } else {
-      return results;
-    }
+    return results.paths;
   }
 
   async packResolveDependencies(

--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -1470,13 +1470,6 @@ export class CodeQLCliServer implements Disposable {
         // this._version is only undefined upon config change, so we reset CLI-based context key only when necessary.
         await this.app.commands.execute(
           "setContext",
-          "codeql.supportsEvalLog",
-          newVersion.compare(
-            CliVersionConstraint.CLI_VERSION_WITH_PER_QUERY_EVAL_LOG,
-          ) >= 0,
-        );
-        await this.app.commands.execute(
-          "setContext",
           "codeql.supportsQuickEvalCount",
           newVersion.compare(
             CliVersionConstraint.CLI_VERSION_WITH_QUICK_EVAL_COUNT,
@@ -1804,17 +1797,6 @@ export class CliVersionConstraint {
   public static CLI_VERSION_WITH_RESOLVE_EXTENSIONS = new SemVer("2.10.2");
 
   /**
-   * CLI version that supports rotating structured logs to produce one per query.
-   *
-   * Note that 2.8.4 supports generating the evaluation logs and summaries,
-   * but 2.9.0 includes a new option to produce the end-of-query summary logs to
-   * the query server console. For simplicity we gate all features behind 2.9.0,
-   * but if a user is tied to the 2.8 release, we can enable evaluator logs
-   * and summaries for them.
-   */
-  public static CLI_VERSION_WITH_PER_QUERY_EVAL_LOG = new SemVer("2.9.0");
-
-  /**
    * CLI version that supports the `--sourcemap` option for log generation.
    */
   public static CLI_VERSION_WITH_SOURCEMAP = new SemVer("2.10.3");
@@ -1876,12 +1858,6 @@ export class CliVersionConstraint {
   async supportsResolveExtensions() {
     return this.isVersionAtLeast(
       CliVersionConstraint.CLI_VERSION_WITH_RESOLVE_EXTENSIONS,
-    );
-  }
-
-  async supportsPerQueryEvalLog() {
-    return this.isVersionAtLeast(
-      CliVersionConstraint.CLI_VERSION_WITH_PER_QUERY_EVAL_LOG,
     );
   }
 

--- a/extensions/ql-vscode/src/query-history/query-history-manager.ts
+++ b/extensions/ql-vscode/src/query-history/query-history-manager.ts
@@ -36,7 +36,6 @@ import {
 } from "./query-status";
 import { readQueryHistoryFromFile, writeQueryHistoryToFile } from "./store";
 import { pathExists } from "fs-extra";
-import { CliVersionConstraint } from "../codeql-cli/cli";
 import { HistoryItemLabelProvider } from "./history-item-label-provider";
 import { ResultsView, WebviewReveal } from "../local-queries";
 import { EvalLogTreeBuilder, EvalLogViewer } from "../query-evaluation-logging";
@@ -760,7 +759,7 @@ export class QueryHistoryManager extends DisposableObject {
   private warnNoEvalLogs() {
     void showAndLogWarningMessage(
       this.app.logger,
-      `Evaluator log, summary, and viewer are not available for this run. Perhaps it failed before evaluation, or you are running with a version of CodeQL before ' + ${CliVersionConstraint.CLI_VERSION_WITH_PER_QUERY_EVAL_LOG}?`,
+      `Evaluator log, summary, and viewer are not available for this run. Perhaps it failed before evaluation?`,
     );
   }
 

--- a/extensions/ql-vscode/src/query-server/legacy/query-server-client.ts
+++ b/extensions/ql-vscode/src/query-server/legacy/query-server-client.ts
@@ -146,10 +146,6 @@ export class QueryServerClient extends DisposableObject {
 
     args.push("--require-db-registration");
 
-    if (!(await this.cliServer.cliConstraints.supportsPerQueryEvalLog())) {
-      args.push("--old-eval-stats");
-    }
-
     const structuredLogFile = `${this.opts.contextStoragePath}/structured-evaluator-log.json`;
     await ensureFile(structuredLogFile);
 

--- a/extensions/ql-vscode/src/query-server/legacy/query-server-client.ts
+++ b/extensions/ql-vscode/src/query-server/legacy/query-server-client.ts
@@ -150,13 +150,11 @@ export class QueryServerClient extends DisposableObject {
       args.push("--old-eval-stats");
     }
 
-    if (await this.cliServer.cliConstraints.supportsStructuredEvalLog()) {
-      const structuredLogFile = `${this.opts.contextStoragePath}/structured-evaluator-log.json`;
-      await ensureFile(structuredLogFile);
+    const structuredLogFile = `${this.opts.contextStoragePath}/structured-evaluator-log.json`;
+    await ensureFile(structuredLogFile);
 
-      args.push("--evaluator-log");
-      args.push(structuredLogFile);
-    }
+    args.push("--evaluator-log");
+    args.push(structuredLogFile);
 
     if (this.config.debug) {
       args.push("--debug", "--tuple-counting");

--- a/extensions/ql-vscode/src/query-server/legacy/query-server-client.ts
+++ b/extensions/ql-vscode/src/query-server/legacy/query-server-client.ts
@@ -156,11 +156,6 @@ export class QueryServerClient extends DisposableObject {
 
       args.push("--evaluator-log");
       args.push(structuredLogFile);
-
-      // We hard-code the verbosity level to 5 and minify to false.
-      // This will be the behavior of the per-query structured logging in the CLI after 2.8.3.
-      args.push("--evaluator-log-level");
-      args.push("5");
     }
 
     if (this.config.debug) {

--- a/extensions/ql-vscode/src/query-server/legacy/run-queries.ts
+++ b/extensions/ql-vscode/src/query-server/legacy/run-queries.ts
@@ -129,10 +129,7 @@ async function runQuery(
     dbDir: dbContents.datasetUri.fsPath,
     workingSet: "default",
   };
-  if (
-    generateEvalLog &&
-    (await qs.cliServer.cliConstraints.supportsPerQueryEvalLog())
-  ) {
+  if (generateEvalLog) {
     await qs.sendRequest(messages.startLog, {
       db: dataset,
       logPath: outputDir.evalLogPath,
@@ -149,10 +146,7 @@ async function runQuery(
     await qs.sendRequest(messages.runQueries, params, token, progress);
   } finally {
     qs.unRegisterCallback(callbackId);
-    if (
-      generateEvalLog &&
-      (await qs.cliServer.cliConstraints.supportsPerQueryEvalLog())
-    ) {
+    if (generateEvalLog) {
       await qs.sendRequest(messages.endLog, {
         db: dataset,
         logPath: outputDir.evalLogPath,

--- a/extensions/ql-vscode/src/query-server/query-server-client.ts
+++ b/extensions/ql-vscode/src/query-server/query-server-client.ts
@@ -194,11 +194,6 @@ export class QueryServerClient extends DisposableObject {
     args.push("--evaluator-log");
     args.push(structuredLogFile);
 
-    // We hard-code the verbosity level to 5 and minify to false.
-    // This will be the behavior of the per-query structured logging in the CLI after 2.8.3.
-    args.push("--evaluator-log-level");
-    args.push("5");
-
     if (this.config.debug) {
       args.push("--debug", "--tuple-counting");
     }


### PR DESCRIPTION
We dropped support for CLI versions older than 2.9.4 in https://github.com/github/vscode-codeql/pull/2610.

This PR removes conditionals and version constraints for unsupported CLI versions.

See individual commits for more details.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
