### PR TITLE
Make query resolver more generic

### DIFF
--- a/extensions/ql-vscode/src/data-extensions-editor/generate-flow-model.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/generate-flow-model.ts
@@ -14,7 +14,7 @@ import { QueryResultType } from "../query-server/new-messages";
 import { file } from "tmp-promise";
 import { writeFile } from "fs-extra";
 import { dump } from "js-yaml";
-import { qlpackOfDatabase } from "../language-support";
+import { qlpackOfDatabase } from "../local-queries";
 import { telemetryListener } from "../common/vscode/telemetry";
 
 type FlowModelOptions = {

--- a/extensions/ql-vscode/src/language-support/contextual/location-finder.ts
+++ b/extensions/ql-vscode/src/language-support/contextual/location-finder.ts
@@ -12,16 +12,13 @@ import { CodeQLCliServer } from "../../codeql-cli/cli";
 import { DatabaseManager, DatabaseItem } from "../../databases/local-databases";
 import { ProgressCallback } from "../../common/vscode/progress";
 import { KeyType } from "./key-type";
-import {
-  qlpackOfDatabase,
-  resolveQueries,
-  runContextualQuery,
-} from "./query-resolver";
+import { resolveQueries, runContextualQuery } from "./query-resolver";
 import { CancellationToken, LocationLink, Uri } from "vscode";
 import { QueryOutputDir } from "../../run-queries-shared";
 import { QueryRunner } from "../../query-server";
 import { QueryResultType } from "../../query-server/new-messages";
 import { fileRangeFromURI } from "./file-range-from-uri";
+import { qlpackOfDatabase } from "../../local-queries";
 
 export const SELECT_QUERY_NAME = "#select";
 export const SELECTED_SOURCE_FILE = "selectedSourceFile";

--- a/extensions/ql-vscode/src/language-support/contextual/query-resolver.ts
+++ b/extensions/ql-vscode/src/language-support/contextual/query-resolver.ts
@@ -1,6 +1,3 @@
-import { promises } from "fs-extra";
-import { basename, dirname, resolve } from "path";
-
 import { getOnDiskWorkspaceFolders } from "../../common/vscode/workspace-folders";
 import { QlPacksForLanguage } from "../../databases/qlpack";
 import {
@@ -17,7 +14,7 @@ import { TeeLogger } from "../../common/logging";
 import { CancellationToken } from "vscode";
 import { ProgressCallback } from "../../common/vscode/progress";
 import { CoreCompletedQuery, QueryRunner } from "../../query-server";
-import { QLPACK_FILENAMES } from "../../common/ql";
+import { createLockFileForStandardQuery } from "../../local-queries/standard-queries";
 
 export async function resolveQueries(
   cli: CodeQLCliServer,
@@ -27,64 +24,6 @@ export async function resolveQueries(
   return resolveLocalQueries(cli, qlpacks, nameOfKeyType(keyType), {
     kind: kindOfKeyType(keyType),
     "tags contain": [tagOfKeyType(keyType)],
-  });
-}
-
-async function resolveContextualQuery(
-  cli: CodeQLCliServer,
-  query: string,
-): Promise<{ packPath: string; createdTempLockFile: boolean }> {
-  // Contextual queries now live within the standard library packs.
-  // This simplifies distribution (you don't need the standard query pack to use the AST viewer),
-  // but if the library pack doesn't have a lockfile, we won't be able to find
-  // other pack dependencies of the library pack.
-
-  // Work out the enclosing pack.
-  const packContents = await cli.packPacklist(query, false);
-  const packFilePath = packContents.find((p) =>
-    QLPACK_FILENAMES.includes(basename(p)),
-  );
-  if (packFilePath === undefined) {
-    // Should not happen; we already resolved this query.
-    throw new Error(
-      `Could not find a CodeQL pack file for the pack enclosing the contextual query ${query}`,
-    );
-  }
-  const packPath = dirname(packFilePath);
-  const lockFilePath = packContents.find((p) =>
-    ["codeql-pack.lock.yml", "qlpack.lock.yml"].includes(basename(p)),
-  );
-  let createdTempLockFile = false;
-  if (!lockFilePath) {
-    // No lock file, likely because this library pack is in the package cache.
-    // Create a lock file so that we can resolve dependencies and library path
-    // for the contextual query.
-    void extLogger.log(
-      `Library pack ${packPath} is missing a lock file; creating a temporary lock file`,
-    );
-    await cli.packResolveDependencies(packPath);
-    createdTempLockFile = true;
-    // Clear CLI server pack cache before installing dependencies,
-    // so that it picks up the new lock file, not the previously cached pack.
-    void extLogger.log("Clearing the CodeQL CLI server's pack cache");
-    await cli.clearCache();
-    // Install dependencies.
-    void extLogger.log(
-      `Installing package dependencies for library pack ${packPath}`,
-    );
-    await cli.packInstall(packPath);
-  }
-  return { packPath, createdTempLockFile };
-}
-
-async function removeTemporaryLockFile(packPath: string) {
-  const tempLockFilePath = resolve(packPath, "codeql-pack.lock.yml");
-  void extLogger.log(
-    `Deleting temporary package lock file at ${tempLockFilePath}`,
-  );
-  // It's fine if the file doesn't exist.
-  await promises.rm(resolve(packPath, "codeql-pack.lock.yml"), {
-    force: true,
   });
 }
 
@@ -98,10 +37,7 @@ export async function runContextualQuery(
   token: CancellationToken,
   templates: Record<string, string>,
 ): Promise<CoreCompletedQuery> {
-  const { packPath, createdTempLockFile } = await resolveContextualQuery(
-    cli,
-    query,
-  );
+  const { cleanup } = await createLockFileForStandardQuery(cli, query);
   const queryRun = qs.createQueryRun(
     db.databaseUri.fsPath,
     { queryPath: query, quickEvalPosition: undefined },
@@ -120,8 +56,6 @@ export async function runContextualQuery(
     token,
     new TeeLogger(qs.logger, queryRun.outputDir.logPath),
   );
-  if (createdTempLockFile) {
-    await removeTemporaryLockFile(packPath);
-  }
+  await cleanup?.();
   return results;
 }

--- a/extensions/ql-vscode/src/language-support/contextual/template-provider.ts
+++ b/extensions/ql-vscode/src/language-support/contextual/template-provider.ts
@@ -27,11 +27,7 @@ import {
   SELECTED_SOURCE_LINE,
   SELECTED_SOURCE_COLUMN,
 } from "./location-finder";
-import {
-  qlpackOfDatabase,
-  resolveQueries,
-  runContextualQuery,
-} from "./query-resolver";
+import { resolveQueries, runContextualQuery } from "./query-resolver";
 import {
   isCanary,
   NO_CACHE_AST_VIEWER,
@@ -39,6 +35,7 @@ import {
 } from "../../config";
 import { CoreCompletedQuery, QueryRunner } from "../../query-server";
 import { AstBuilder } from "../ast-viewer/ast-builder";
+import { qlpackOfDatabase } from "../../local-queries";
 
 /**
  * Runs templated CodeQL queries to find definitions in

--- a/extensions/ql-vscode/src/local-queries/index.ts
+++ b/extensions/ql-vscode/src/local-queries/index.ts
@@ -1,5 +1,6 @@
 export * from "./local-queries";
 export * from "./local-query-run";
+export * from "./query-resolver";
 export * from "./quick-eval-code-lens-provider";
 export * from "./quick-query";
 export * from "./results-view";

--- a/extensions/ql-vscode/src/local-queries/query-resolver.ts
+++ b/extensions/ql-vscode/src/local-queries/query-resolver.ts
@@ -1,0 +1,131 @@
+import { CodeQLCliServer } from "../codeql-cli/cli";
+import { DatabaseItem } from "../databases/local-databases";
+import {
+  getPrimaryDbscheme,
+  getQlPackForDbscheme,
+  QlPacksForLanguage,
+} from "../databases/qlpack";
+import { file } from "tmp-promise";
+import { writeFile } from "fs-extra";
+import { dump } from "js-yaml";
+import { getOnDiskWorkspaceFolders } from "../common/vscode/workspace-folders";
+import { redactableError } from "../common/errors";
+import { showAndLogExceptionWithTelemetry } from "../common/logging";
+import { extLogger } from "../common/logging/vscode";
+import { telemetryListener } from "../common/vscode/telemetry";
+
+export async function qlpackOfDatabase(
+  cli: Pick<CodeQLCliServer, "resolveQlpacks">,
+  db: Pick<DatabaseItem, "contents">,
+): Promise<QlPacksForLanguage> {
+  if (db.contents === undefined) {
+    throw new Error("Database is invalid and cannot infer QLPack.");
+  }
+  const datasetPath = db.contents.datasetUri.fsPath;
+  const dbscheme = await getPrimaryDbscheme(datasetPath);
+  return await getQlPackForDbscheme(cli, dbscheme);
+}
+
+export interface QueryConstraints {
+  kind?: string;
+  "tags contain"?: string[];
+  "tags contain all"?: string[];
+}
+
+/**
+ * Finds the queries with the specified kind and tags in a list of CodeQL packs.
+ *
+ * @param cli The CLI instance to use.
+ * @param qlpacks The list of packs to search.
+ * @param constraints Constraints on the queries to search for.
+ * @returns The found queries from the first pack in which any matching queries were found.
+ */
+async function resolveQueriesFromPacks(
+  cli: CodeQLCliServer,
+  qlpacks: string[],
+  constraints: QueryConstraints,
+): Promise<string[]> {
+  const suiteFile = (
+    await file({
+      postfix: ".qls",
+    })
+  ).path;
+  const suiteYaml = [];
+  for (const qlpack of qlpacks) {
+    suiteYaml.push({
+      from: qlpack,
+      queries: ".",
+      include: constraints,
+    });
+  }
+  await writeFile(
+    suiteFile,
+    dump(suiteYaml, {
+      noRefs: true, // CodeQL doesn't really support refs
+    }),
+    "utf8",
+  );
+
+  return await cli.resolveQueriesInSuite(
+    suiteFile,
+    getOnDiskWorkspaceFolders(),
+  );
+}
+
+/**
+ * Finds the queries with the specified kind and tags in a QLPack.
+ *
+ * @param cli The CLI instance to use.
+ * @param qlpacks The list of packs to search.
+ * @param name The name of the query to use in error messages.
+ * @param constraints Constraints on the queries to search for.
+ * @returns The found queries from the first pack in which any matching queries were found.
+ */
+export async function resolveQueries(
+  cli: CodeQLCliServer,
+  qlpacks: QlPacksForLanguage,
+  name: string,
+  constraints: QueryConstraints,
+): Promise<string[]> {
+  const packsToSearch: string[] = [];
+
+  // The CLI can handle both library packs and query packs, so search both packs in order.
+  packsToSearch.push(qlpacks.dbschemePack);
+  if (qlpacks.queryPack !== undefined) {
+    packsToSearch.push(qlpacks.queryPack);
+  }
+
+  const queries = await resolveQueriesFromPacks(
+    cli,
+    packsToSearch,
+    constraints,
+  );
+  if (queries.length > 0) {
+    return queries;
+  }
+
+  // No queries found. Determine the correct error message for the various scenarios.
+  const humanConstraints = [];
+  if (constraints.kind !== undefined) {
+    humanConstraints.push(`kind "${constraints.kind}"`);
+  }
+  if (constraints["tags contain"] !== undefined) {
+    humanConstraints.push(`tagged "${constraints["tags contain"].join(" ")}"`);
+  }
+  if (constraints["tags contain all"] !== undefined) {
+    humanConstraints.push(
+      `tagged all of "${constraints["tags contain all"].join(" ")}"`,
+    );
+  }
+
+  const joinedPacksToSearch = packsToSearch.join(", ");
+  const error = redactableError`No ${name} queries (${humanConstraints.join(
+    ", ",
+  )}) could be found in the \
+current library path (tried searching the following packs: ${joinedPacksToSearch}). \
+Try upgrading the CodeQL libraries. If that doesn't work, then ${name} queries are not yet available \
+for this language.`;
+
+  void showAndLogExceptionWithTelemetry(extLogger, telemetryListener, error);
+  throw error;
+}

--- a/extensions/ql-vscode/src/local-queries/standard-queries.ts
+++ b/extensions/ql-vscode/src/local-queries/standard-queries.ts
@@ -1,0 +1,77 @@
+import { CodeQLCliServer } from "../codeql-cli/cli";
+import { QLPACK_FILENAMES, QLPACK_LOCK_FILENAMES } from "../common/ql";
+import { basename, dirname, resolve } from "path";
+import { extLogger } from "../common/logging/vscode";
+import { promises } from "fs-extra";
+import { BaseLogger } from "../common/logging";
+
+export type LockFileForStandardQueryResult = {
+  cleanup?: () => Promise<void>;
+};
+
+/**
+ * Create a temporary query suite for a given query living within the standard library packs.
+ *
+ * This will create a lock file so the CLI can run the query without having the ql submodule.
+ */
+export async function createLockFileForStandardQuery(
+  cli: CodeQLCliServer,
+  queryPath: string,
+  logger: BaseLogger = extLogger,
+): Promise<LockFileForStandardQueryResult> {
+  // These queries live within the standard library packs.
+  // This simplifies distribution (you don't need the standard query pack to use the AST viewer),
+  // but if the library pack doesn't have a lockfile, we won't be able to find
+  // other pack dependencies of the library pack.
+
+  // Work out the enclosing pack.
+  const packContents = await cli.packPacklist(queryPath, false);
+  const packFilePath = packContents.find((p) =>
+    QLPACK_FILENAMES.includes(basename(p)),
+  );
+  if (packFilePath === undefined) {
+    // Should not happen; we already resolved this query.
+    throw new Error(
+      `Could not find a CodeQL pack file for the pack enclosing the contextual query ${queryPath}`,
+    );
+  }
+  const packPath = dirname(packFilePath);
+  const lockFilePath = packContents.find((p) =>
+    QLPACK_LOCK_FILENAMES.includes(basename(p)),
+  );
+
+  let cleanup: (() => Promise<void>) | undefined = undefined;
+
+  if (!lockFilePath) {
+    // No lock file, likely because this library pack is in the package cache.
+    // Create a lock file so that we can resolve dependencies and library path
+    // for the contextual query.
+    void logger.log(
+      `Library pack ${packPath} is missing a lock file; creating a temporary lock file`,
+    );
+    await cli.packResolveDependencies(packPath);
+
+    cleanup = async () => {
+      const tempLockFilePath = resolve(packPath, "codeql-pack.lock.yml");
+      void logger.log(
+        `Deleting temporary package lock file at ${tempLockFilePath}`,
+      );
+      // It's fine if the file doesn't exist.
+      await promises.rm(resolve(packPath, "codeql-pack.lock.yml"), {
+        force: true,
+      });
+    };
+
+    // Clear CLI server pack cache before installing dependencies,
+    // so that it picks up the new lock file, not the previously cached pack.
+    void logger.log("Clearing the CodeQL CLI server's pack cache");
+    await cli.clearCache();
+    // Install dependencies.
+    void logger.log(
+      `Installing package dependencies for library pack ${packPath}`,
+    );
+    await cli.packInstall(packPath);
+  }
+
+  return { cleanup };
+}

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/language-support/contextual/query-resolver.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/language-support/contextual/query-resolver.test.ts
@@ -5,23 +5,11 @@ import { getErrorMessage } from "../../../../../src/common/helpers-pure";
 
 import * as log from "../../../../../src/common/logging/notifications";
 import * as workspaceFolders from "../../../../../src/common/vscode/workspace-folders";
-import * as qlpack from "../../../../../src/databases/qlpack";
-import {
-  KeyType,
-  qlpackOfDatabase,
-  resolveQueries,
-} from "../../../../../src/language-support";
+import { KeyType, resolveQueries } from "../../../../../src/language-support";
 import { CodeQLCliServer } from "../../../../../src/codeql-cli/cli";
-import { mockDatabaseItem, mockedObject } from "../../../utils/mocking.helpers";
+import { mockedObject } from "../../../utils/mocking.helpers";
 
 describe("queryResolver", () => {
-  let getQlPackForDbschemeSpy: jest.SpiedFunction<
-    typeof qlpack.getQlPackForDbscheme
-  >;
-  let getPrimaryDbschemeSpy: jest.SpiedFunction<
-    typeof qlpack.getPrimaryDbscheme
-  >;
-
   const resolveQueriesInSuite = jest.fn();
 
   const mockCli = mockedObject<CodeQLCliServer>({
@@ -29,16 +17,6 @@ describe("queryResolver", () => {
   });
 
   beforeEach(() => {
-    getQlPackForDbschemeSpy = jest
-      .spyOn(qlpack, "getQlPackForDbscheme")
-      .mockResolvedValue({
-        dbschemePack: "dbschemePack",
-        dbschemePackIsLibraryPack: false,
-      });
-    getPrimaryDbschemeSpy = jest
-      .spyOn(qlpack, "getPrimaryDbscheme")
-      .mockResolvedValue("primaryDbscheme");
-
     jest
       .spyOn(workspaceFolders, "getOnDiskWorkspaceFolders")
       .mockReturnValue([]);
@@ -68,7 +46,7 @@ describe("queryResolver", () => {
           queries: ".",
           include: {
             kind: "definitions",
-            "tags contain": "ide-contextual-queries/local-definitions",
+            "tags contain": ["ide-contextual-queries/local-definitions"],
           },
         },
       ]);
@@ -87,31 +65,9 @@ describe("queryResolver", () => {
         expect(true).toBe(false);
       } catch (e) {
         expect(getErrorMessage(e)).toBe(
-          'No definitions queries (tagged "ide-contextual-queries/local-definitions") could be found in the current library path (tried searching the following packs: my-qlpack). Try upgrading the CodeQL libraries. If that doesn\'t work, then definitions queries are not yet available for this language.',
+          'No definitions queries (kind "definitions", tagged "ide-contextual-queries/local-definitions") could be found in the current library path (tried searching the following packs: my-qlpack). Try upgrading the CodeQL libraries. If that doesn\'t work, then definitions queries are not yet available for this language.',
         );
       }
-    });
-  });
-
-  describe("qlpackOfDatabase", () => {
-    it("should get the qlpack of a database", async () => {
-      getQlPackForDbschemeSpy.mockResolvedValue({
-        dbschemePack: "my-qlpack",
-        dbschemePackIsLibraryPack: false,
-      });
-      const db = mockDatabaseItem({
-        contents: {
-          datasetUri: {
-            fsPath: "/path/to/database",
-          },
-        },
-      });
-      const result = await qlpackOfDatabase(mockCli, db);
-      expect(result).toEqual({
-        dbschemePack: "my-qlpack",
-        dbschemePackIsLibraryPack: false,
-      });
-      expect(getPrimaryDbschemeSpy).toBeCalledWith("/path/to/database");
     });
   });
 });

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/local-queries/query-resolver.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/local-queries/query-resolver.test.ts
@@ -1,0 +1,119 @@
+import {
+  qlpackOfDatabase,
+  resolveQueries,
+} from "../../../../src/local-queries";
+import { mockDatabaseItem, mockedObject } from "../../utils/mocking.helpers";
+import { CodeQLCliServer } from "../../../../src/codeql-cli/cli";
+import * as qlpack from "../../../../src/databases/qlpack";
+import * as workspaceFolders from "../../../../src/common/vscode/workspace-folders";
+import * as log from "../../../../src/common/logging/notifications";
+import { load } from "js-yaml";
+import * as fs from "fs-extra";
+
+describe("qlpackOfDatabase", () => {
+  let getQlPackForDbschemeSpy: jest.SpiedFunction<
+    typeof qlpack.getQlPackForDbscheme
+  >;
+  let getPrimaryDbschemeSpy: jest.SpiedFunction<
+    typeof qlpack.getPrimaryDbscheme
+  >;
+
+  const mockCli = mockedObject<CodeQLCliServer>({});
+
+  beforeEach(() => {
+    getQlPackForDbschemeSpy = jest
+      .spyOn(qlpack, "getQlPackForDbscheme")
+      .mockResolvedValue({
+        dbschemePack: "dbschemePack",
+        dbschemePackIsLibraryPack: false,
+      });
+    getPrimaryDbschemeSpy = jest
+      .spyOn(qlpack, "getPrimaryDbscheme")
+      .mockResolvedValue("primaryDbscheme");
+  });
+
+  it("should get the qlpack of a database", async () => {
+    getQlPackForDbschemeSpy.mockResolvedValue({
+      dbschemePack: "my-qlpack",
+      dbschemePackIsLibraryPack: false,
+    });
+    const db = mockDatabaseItem({
+      contents: {
+        datasetUri: {
+          fsPath: "/path/to/database",
+        },
+      },
+    });
+    const result = await qlpackOfDatabase(mockCli, db);
+    expect(result).toEqual({
+      dbschemePack: "my-qlpack",
+      dbschemePackIsLibraryPack: false,
+    });
+    expect(getPrimaryDbschemeSpy).toBeCalledWith("/path/to/database");
+  });
+});
+
+describe("resolveQueries", () => {
+  const resolveQueriesInSuite = jest.fn();
+
+  const mockCli = mockedObject<CodeQLCliServer>({
+    resolveQueriesInSuite,
+  });
+
+  beforeEach(() => {
+    jest
+      .spyOn(workspaceFolders, "getOnDiskWorkspaceFolders")
+      .mockReturnValue([]);
+    jest.spyOn(log, "showAndLogErrorMessage").mockResolvedValue(undefined);
+  });
+
+  it("should resolve a query", async () => {
+    resolveQueriesInSuite.mockReturnValue(["a", "b"]);
+    const result = await resolveQueries(
+      mockCli,
+      { dbschemePack: "my-qlpack", dbschemePackIsLibraryPack: false },
+      "my query",
+      {
+        kind: "graph",
+        "tags contain": ["ide-contextual-queries/print-ast"],
+      },
+    );
+    expect(result).toEqual(["a", "b"]);
+
+    expect(resolveQueriesInSuite).toHaveBeenCalledWith(
+      expect.stringMatching(/\.qls$/),
+      [],
+    );
+
+    const fileName = resolveQueriesInSuite.mock.calls[0][0];
+
+    expect(load(await fs.readFile(fileName, "utf-8"))).toEqual([
+      {
+        from: "my-qlpack",
+        queries: ".",
+        include: {
+          kind: "graph",
+          "tags contain": ["ide-contextual-queries/print-ast"],
+        },
+      },
+    ]);
+  });
+
+  it("should throw an error when there are no queries found", async () => {
+    resolveQueriesInSuite.mockReturnValue([]);
+
+    await expect(
+      resolveQueries(
+        mockCli,
+        { dbschemePack: "my-qlpack", dbschemePackIsLibraryPack: false },
+        "my query",
+        {
+          kind: "graph",
+          "tags contain": ["ide-contextual-queries/print-ast"],
+        },
+      ),
+    ).rejects.toThrowError(
+      'No my query queries (kind "graph", tagged "ide-contextual-queries/print-ast") could be found in the current library path (tried searching the following packs: my-qlpack). Try upgrading the CodeQL libraries. If that doesn\'t work, then my query queries are not yet available for this language.',
+    );
+  });
+});

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/local-queries/standard-queries.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/local-queries/standard-queries.test.ts
@@ -1,0 +1,113 @@
+import { mockedObject } from "../../utils/mocking.helpers";
+import { CodeQLCliServer } from "../../../../src/codeql-cli/cli";
+import { dir, DirectoryResult } from "tmp-promise";
+import { join } from "path";
+import { createLockFileForStandardQuery } from "../../../../src/local-queries/standard-queries";
+import { outputFile, pathExists } from "fs-extra";
+
+describe("createLockFileForStandardQuery", () => {
+  let tmpDir: DirectoryResult;
+  let packPath: string;
+  let qlpackPath: string;
+  let queryPath: string;
+
+  const packPacklist = jest.fn();
+  const packResolveDependencies = jest.fn();
+  const clearCache = jest.fn();
+  const packInstall = jest.fn();
+
+  const mockCli = mockedObject<CodeQLCliServer>({
+    packPacklist,
+    packResolveDependencies,
+    clearCache,
+    packInstall,
+  });
+
+  beforeEach(async () => {
+    tmpDir = await dir({
+      unsafeCleanup: true,
+    });
+
+    packPath = join(tmpDir.path, "a", "b");
+    qlpackPath = join(packPath, "qlpack.yml");
+    queryPath = join(packPath, "d", "e", "query.ql");
+
+    packPacklist.mockResolvedValue([qlpackPath, queryPath]);
+  });
+
+  afterEach(async () => {
+    await tmpDir.cleanup();
+  });
+
+  describe("when the lock file exists", () => {
+    let lockfilePath: string;
+
+    beforeEach(async () => {
+      lockfilePath = join(packPath, "qlpack.lock.yml");
+
+      packPacklist.mockResolvedValue([qlpackPath, lockfilePath, queryPath]);
+    });
+
+    it("does not resolve or install dependencies", async () => {
+      expect(await createLockFileForStandardQuery(mockCli, queryPath)).toEqual({
+        cleanup: undefined,
+      });
+
+      expect(packResolveDependencies).not.toHaveBeenCalled();
+      expect(clearCache).not.toHaveBeenCalled();
+      expect(packInstall).not.toHaveBeenCalled();
+    });
+
+    it("does not resolve or install dependencies with a codeql-pack.lock.yml", async () => {
+      lockfilePath = join(packPath, "codeql-pack.lock.yml");
+
+      packPacklist.mockResolvedValue([qlpackPath, lockfilePath, queryPath]);
+
+      expect(await createLockFileForStandardQuery(mockCli, queryPath)).toEqual({
+        cleanup: undefined,
+      });
+
+      expect(packResolveDependencies).not.toHaveBeenCalled();
+      expect(clearCache).not.toHaveBeenCalled();
+      expect(packInstall).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the lock file does not exist", () => {
+    it("resolves and installs dependencies", async () => {
+      expect(await createLockFileForStandardQuery(mockCli, queryPath)).toEqual({
+        cleanup: expect.any(Function),
+      });
+
+      expect(packResolveDependencies).toHaveBeenCalledWith(packPath);
+      expect(clearCache).toHaveBeenCalledWith();
+      expect(packInstall).toHaveBeenCalledWith(packPath);
+    });
+
+    it("cleans up the lock file using the cleanup function", async () => {
+      const { cleanup } = await createLockFileForStandardQuery(
+        mockCli,
+        queryPath,
+      );
+      expect(cleanup).not.toBeUndefined();
+
+      const lockfilePath = join(packPath, "codeql-pack.lock.yml");
+
+      await outputFile(lockfilePath, "lock file contents");
+
+      await cleanup?.();
+
+      expect(await pathExists(lockfilePath)).toBe(false);
+    });
+
+    it("does not fail when cleaning up a non-existing lock file", async () => {
+      const { cleanup } = await createLockFileForStandardQuery(
+        mockCli,
+        queryPath,
+      );
+      expect(cleanup).not.toBeUndefined();
+
+      await cleanup?.();
+    });
+  });
+});


### PR DESCRIPTION
This will make the query resolving functionality currently used for contextual queries more generic and usable for resolving other types of queries as well (e.g. based on `tags` instead of on `id`). This is in preparation for https://github.com/github/vscode-codeql/pull/2633. There should be no changes in behavior, except for a single changed error message (which adds `kind "definitions",` to the error message, so shouldn't really have any influence).

It's easiest to review this commit-by-commit.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
