### PR TITLE
Data extensions editor: Change "already modeled" message

### DIFF
--- a/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
@@ -270,7 +270,7 @@ function UnmodelableMethodRow(props: Props) {
         <MethodClassifications externalApiUsage={externalApiUsage} />
       </ApiOrMethodCell>
       <VSCodeDataGridCell gridColumn="span 4">
-        Method modeled by CodeQL or a different extension pack
+        Method already modeled
       </VSCodeDataGridCell>
     </VSCodeDataGridRow>
   );


### PR DESCRIPTION
Minor change to simplify the message when a method is already modeled: 
![image](https://github.com/github/vscode-codeql/assets/42641846/0060d185-cf91-4c97-b2e3-268e087d1553)

See internal linked issue! 

## Checklist

N/A: internal only 🦒 

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
