### PR TITLE
Fix alert by replacing regex with path.basename

### DIFF
--- a/extensions/ql-vscode/src/view/results/result-tables.tsx
+++ b/extensions/ql-vscode/src/view/results/result-tables.tsx
@@ -27,8 +27,7 @@ import {
 } from "./result-table-utils";
 import { vscode } from "../vscode-api";
 import { sendTelemetry } from "../common/telemetry";
-
-const FILE_PATH_REGEX = /^(?:.+[\\/])*(.+)$/;
+import { basename } from "path";
 
 /**
  * Properties for the `ResultTables` component.
@@ -302,7 +301,7 @@ export class ResultTables extends React.Component<
       openFile(this.props.queryPath);
       sendTelemetry("local-results-open-query-file");
     };
-    const fileName = FILE_PATH_REGEX.exec(this.props.queryPath)?.[1] || "query";
+    const fileName = basename(this.props.queryPath);
 
     return (
       <span className="vscode-codeql__table-selection-pagination">

--- a/extensions/ql-vscode/src/view/results/result-tables.tsx
+++ b/extensions/ql-vscode/src/view/results/result-tables.tsx
@@ -27,7 +27,7 @@ import {
 } from "./result-table-utils";
 import { vscode } from "../vscode-api";
 import { sendTelemetry } from "../common/telemetry";
-import { basename } from "path";
+import { basename } from "../../common/path";
 
 /**
  * Properties for the `ResultTables` component.


### PR DESCRIPTION
This should hopefully fix https://github.com/github/vscode-codeql/security/code-scanning/547 by replacing the inefficient regex with `path.basename`. As far as I can tell, this is the job that the regex is performing.

Is there are a need for us to do anything more complicated than `path.basename`? I believe all of this is happening locally, so there's no need to do anything fancy like handle paths from other operating systems.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
