### PR TITLE
Unexport LockFileForStandardQueryResult

### DIFF
--- a/extensions/ql-vscode/src/local-queries/standard-queries.ts
+++ b/extensions/ql-vscode/src/local-queries/standard-queries.ts
@@ -5,7 +5,7 @@ import { extLogger } from "../common/logging/vscode";
 import { promises } from "fs-extra";
 import { BaseLogger } from "../common/logging";
 
-export type LockFileForStandardQueryResult = {
+type LockFileForStandardQueryResult = {
   cleanup?: () => Promise<void>;
 };
 


### PR DESCRIPTION
Fixes a semantic merge-conflict between https://github.com/github/vscode-codeql/pull/2634 and https://github.com/github/vscode-codeql/pull/2631.

Hopefully we won't see this again. It should only affect PRs that were open before https://github.com/github/vscode-codeql/pull/2631 was merged and don't re-run their `Lint` CI check.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
