### PR TITLE
Remove path-browserify

### DIFF
--- a/extensions/ql-vscode/gulpfile.ts/webpack.config.ts
+++ b/extensions/ql-vscode/gulpfile.ts/webpack.config.ts
@@ -15,9 +15,6 @@ export const config: webpack.Configuration = {
   devtool: isDevBuild ? "inline-source-map" : "source-map",
   resolve: {
     extensions: [".js", ".ts", ".tsx", ".json"],
-    fallback: {
-      path: require.resolve("path-browserify"),
-    },
   },
   module: {
     rules: [

--- a/extensions/ql-vscode/package-lock.json
+++ b/extensions/ql-vscode/package-lock.json
@@ -31,7 +31,6 @@
         "nanoid": "^3.2.0",
         "node-fetch": "~2.6.7",
         "p-queue": "^6.0.0",
-        "path-browserify": "^1.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "semver": "~7.5.2",
@@ -30611,7 +30610,8 @@
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true
     },
     "node_modules/path-dirname": {
       "version": "1.0.2",
@@ -59306,7 +59306,8 @@
     "path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true
     },
     "path-dirname": {
       "version": "1.0.2",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1761,7 +1761,6 @@
     "nanoid": "^3.2.0",
     "node-fetch": "~2.6.7",
     "p-queue": "^6.0.0",
-    "path-browserify": "^1.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "semver": "~7.5.2",

--- a/extensions/ql-vscode/src/view/results/locations/SarifLocation.tsx
+++ b/extensions/ql-vscode/src/view/results/locations/SarifLocation.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import * as Sarif from "sarif";
 import { isLineColumnLoc, isWholeFileLoc } from "../../../common/bqrs-utils";
 import { parseSarifLocation } from "../../../common/sarif-utils";
-import { basename } from "path";
+import { basename } from "../../../common/path";
 import { useMemo } from "react";
 import { Location } from "./Location";
 


### PR DESCRIPTION
This will remove our dependency on `path-browserify` and replace one last instance of an import from `path` to using `src/common/path.ts`.

If you now try to import the `path` module, you'll get an error from Webpack:

![Screenshot 2023-07-26 at 11 11 54](https://github.com/github/vscode-codeql/assets/1112623/e3b78bdc-0049-4eb7-8d66-5a5b085dfef5)


## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
