### PR TITLE
Data extensions editor: Allow users to pick an existing database from their workspace

### DIFF
--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
@@ -299,7 +299,9 @@ export class DataExtensionsEditorView extends AbstractWebview<
         // In application mode, we need the database of a specific library to generate
         // the modeled methods. In framework mode, we'll use the current database.
         if (this.mode === Mode.Application) {
-          addedDatabase = await this.promptImportDatabase(progress);
+          addedDatabase = await this.promptChooseNewOrExistingDatabase(
+            progress,
+          );
           if (!addedDatabase) {
             return;
           }
@@ -342,6 +344,7 @@ export class DataExtensionsEditorView extends AbstractWebview<
           );
         }
 
+        // To do: don't do this for local dbs!
         if (addedDatabase) {
           // After the flow model has been generated, we can remove the temporary database
           // which we used for generating the flow model.
@@ -431,7 +434,9 @@ export class DataExtensionsEditorView extends AbstractWebview<
 
   private async modelDependency(): Promise<void> {
     return withProgress(async (progress, token) => {
-      const addedDatabase = await this.promptImportDatabase(progress);
+      const addedDatabase = await this.promptChooseNewOrExistingDatabase(
+        progress,
+      );
       if (!addedDatabase || token.isCancellationRequested) {
         return;
       }
@@ -460,6 +465,51 @@ export class DataExtensionsEditorView extends AbstractWebview<
       );
       await view.openView();
     });
+  }
+
+  private async promptChooseNewOrExistingDatabase(
+    progress: ProgressCallback,
+  ): Promise<DatabaseItem | undefined> {
+    // To do: should we filter these by language?
+    const databases = this.databaseManager.databaseItems;
+    if (databases.length === 0) {
+      return await this.promptImportDatabase(progress);
+    } else {
+      const local = {
+        label: "$(database) Use existing database",
+        detail: "Use database from the workspace",
+      };
+      const github = {
+        label: "$(repo) Import database",
+        detail: "Choose database from GitHub",
+      };
+      const newOrExistingDatabase = await window.showQuickPick([local, github]);
+
+      if (!newOrExistingDatabase) {
+        void this.app.logger.log("No database chosen");
+        return;
+      }
+
+      if (newOrExistingDatabase === local) {
+        const pickedDatabase = await window.showQuickPick(
+          databases.map((database) => ({
+            label: database.name,
+            description: database.language,
+            database,
+          })),
+          {
+            placeHolder: "Pick a database",
+          },
+        );
+        if (!pickedDatabase) {
+          void this.app.logger.log("No database chosen");
+          return;
+        }
+        return pickedDatabase.database;
+      } else {
+        return await this.promptImportDatabase(progress);
+      }
+    }
   }
 
   private async promptImportDatabase(

--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
@@ -343,18 +343,6 @@ export class DataExtensionsEditorView extends AbstractWebview<
             )`Failed to generate flow model: ${getErrorMessage(e)}`,
           );
         }
-
-        // To do: don't do this for local dbs!
-        if (addedDatabase) {
-          // After the flow model has been generated, we can remove the temporary database
-          // which we used for generating the flow model.
-          progress({
-            step: 3900,
-            maxStep: 4000,
-            message: "Removing temporary database",
-          });
-          await this.databaseManager.removeDatabaseItem(addedDatabase);
-        }
       },
       { cancellable: false },
     );

--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
@@ -470,8 +470,10 @@ export class DataExtensionsEditorView extends AbstractWebview<
   private async promptChooseNewOrExistingDatabase(
     progress: ProgressCallback,
   ): Promise<DatabaseItem | undefined> {
-    // To do: should we filter these by language?
-    const databases = this.databaseManager.databaseItems;
+    const language = this.databaseItem.language;
+    const databases = this.databaseManager.databaseItems.filter(
+      (db) => db.language === language,
+    );
     if (databases.length === 0) {
       return await this.promptImportDatabase(progress);
     } else {


### PR DESCRIPTION
The "Model from source" and "Model dependency" buttons currently automatically prompt you to download a database, even if you already have a relevant DB in your workspace. This PR changes that behaviour, so that users can choose a local one if they want to:

![image](https://github.com/github/vscode-codeql/assets/42641846/b55dde11-53dd-434b-b307-0fc634605686)


## Checklist

N/A: Internal only 🦀

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
