### PR TITLE
Fix alert by rewriting query history scrubbed to do fewer file operations

### DIFF
--- a/extensions/ql-vscode/src/query-history/query-history-scrubber.ts
+++ b/extensions/ql-vscode/src/query-history/query-history-scrubber.ts
@@ -6,6 +6,7 @@ import { extLogger } from "../common/logging/vscode";
 import { readDirFullPaths } from "../common/files";
 import { QueryHistoryDirs } from "./query-history-dirs";
 import { QueryHistoryManager } from "./query-history-manager";
+import { getErrorMessage } from "../common/helpers-pure";
 
 const LAST_SCRUB_TIME_KEY = "lastScrubTime";
 
@@ -141,7 +142,7 @@ async function scrubDirectory(
     }
   } catch (err) {
     return {
-      errorMsg: `  Could not delete '${dir}': ${err}`,
+      errorMsg: `  Could not delete '${dir}': ${getErrorMessage(err)}`,
       deleted: false,
     };
   }
@@ -177,7 +178,9 @@ async function getTimestamp(
     return parseInt(timestampText, 10);
   } catch (err) {
     void extLogger.log(
-      `  Could not read timestamp file '${timestampFile}': ${err}`,
+      `  Could not read timestamp file '${timestampFile}': ${getErrorMessage(
+        err,
+      )}`,
     );
     return undefined;
   }

--- a/extensions/ql-vscode/src/query-history/query-history-scrubber.ts
+++ b/extensions/ql-vscode/src/query-history/query-history-scrubber.ts
@@ -1,4 +1,4 @@
-import { pathExists, stat, remove, readFile } from "fs-extra";
+import { pathExists, remove, readFile } from "fs-extra";
 import { EOL } from "os";
 import { join } from "path";
 import { Disposable, ExtensionContext } from "vscode";
@@ -132,46 +132,53 @@ async function scrubDirectory(
   errorMsg?: string;
   deleted: boolean;
 }> {
-  const timestampFile = join(dir, "timestamp");
   try {
-    let deleted = true;
-    if (!(await stat(dir)).isDirectory()) {
-      void extLogger.log(`  ${dir} is not a directory. Deleting.`);
+    if (await shouldScrubDirectory(dir, now, maxQueryTime)) {
       await remove(dir);
-    } else if (!(await pathExists(timestampFile))) {
-      void extLogger.log(`  ${dir} has no timestamp file. Deleting.`);
-      await remove(dir);
-    } else if (!(await stat(timestampFile)).isFile()) {
-      void extLogger.log(`  ${timestampFile} is not a file. Deleting.`);
-      await remove(dir);
+      return { deleted: true };
     } else {
-      const timestampText = await readFile(timestampFile, "utf8");
-      const timestamp = parseInt(timestampText, 10);
-
-      if (Number.isNaN(timestamp)) {
-        void extLogger.log(
-          `  ${dir} has invalid timestamp '${timestampText}'. Deleting.`,
-        );
-        await remove(dir);
-      } else if (now - timestamp > maxQueryTime) {
-        void extLogger.log(
-          `  ${dir} is older than ${maxQueryTime / 1000} seconds. Deleting.`,
-        );
-        await remove(dir);
-      } else {
-        void extLogger.log(
-          `  ${dir} is not older than ${maxQueryTime / 1000} seconds. Keeping.`,
-        );
-        deleted = false;
-      }
+      return { deleted: false };
     }
-    return {
-      deleted,
-    };
   } catch (err) {
     return {
       errorMsg: `  Could not delete '${dir}': ${err}`,
       deleted: false,
     };
+  }
+}
+
+async function shouldScrubDirectory(
+  dir: string,
+  now: number,
+  maxQueryTime: number,
+): Promise<boolean> {
+  const timestamp = await getTimestamp(join(dir, "timestamp"));
+  if (timestamp === undefined || Number.isNaN(timestamp)) {
+    void extLogger.log(`  ${dir} timestamp is missing or invalid. Deleting.`);
+    return true;
+  } else if (now - timestamp > maxQueryTime) {
+    void extLogger.log(
+      `  ${dir} is older than ${maxQueryTime / 1000} seconds. Deleting.`,
+    );
+    return true;
+  } else {
+    void extLogger.log(
+      `  ${dir} is not older than ${maxQueryTime / 1000} seconds. Keeping.`,
+    );
+    return false;
+  }
+}
+
+async function getTimestamp(
+  timestampFile: string,
+): Promise<number | undefined> {
+  try {
+    const timestampText = await readFile(timestampFile, "utf8");
+    return parseInt(timestampText, 10);
+  } catch (err) {
+    void extLogger.log(
+      `  Could not read timestamp file '${timestampFile}': ${err}`,
+    );
+    return undefined;
   }
 }


### PR DESCRIPTION
This PR aims to fix https://github.com/github/vscode-codeql/security/code-scanning/384

We could maybe also get away with just closing the alert as "wont fix". It's not the most important of use-after-check errors. But I think we can make things a little bit better.

I'm not sure there's a way to rewrite the check to use file descriptors as the alert suggests. Although we could pass a file descriptor to `readFile`, I don't think `pathExists` or `stat` support them.

I think a better solution may be to rewrite the function to only make a single access to the file. All we need to do is to attempt to read its contents and then we can determine a lot of the rest from whether that succeeds or fails. We do lose some information so we can't keep 100% of the different error messages, but it's unclear to me if this detailed level of logging is strictly necessary. The tests we have don't explicitly check the error message 🤷🏼

I've also rewritten the code to be three smaller functions instead of one big function. Hopefully that makes the logic a little clearer.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
