### PR TITLE
Split codeQL.copyVariantAnalysisRepoList into two commands

### DIFF
--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -244,7 +244,11 @@ export type VariantAnalysisCommands = {
     scannedRepo: VariantAnalysisScannedRepository,
     variantAnalysisSummary: VariantAnalysis,
   ) => Promise<void>;
-  "codeQL.copyVariantAnalysisRepoList": (
+  "codeQL.copyVariantAnalysisRepoListQueryHistory": (
+    variantAnalysisId: number,
+    filterSort?: RepositoriesFilterSortStateWithIds,
+  ) => Promise<void>;
+  "codeQL.copyVariantAnalysisRepoListView": (
     variantAnalysisId: number,
     filterSort?: RepositoriesFilterSortStateWithIds,
   ) => Promise<void>;

--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -4,7 +4,6 @@ import type { AstItem } from "../language-support";
 import type { DbTreeViewItem } from "../databases/ui/db-tree-view-item";
 import type { DatabaseItem } from "../databases/local-databases";
 import type { QueryHistoryInfo } from "../query-history/query-history-info";
-import type { RepositoriesFilterSortStateWithIds } from "../variant-analysis/shared/variant-analysis-filter-sort";
 import type { TestTreeNode } from "../query-testing/test-tree-node";
 import type {
   VariantAnalysis,
@@ -243,10 +242,6 @@ export type VariantAnalysisCommands = {
   "codeQL.autoDownloadVariantAnalysisResult": (
     scannedRepo: VariantAnalysisScannedRepository,
     variantAnalysisSummary: VariantAnalysis,
-  ) => Promise<void>;
-  "codeQL.copyVariantAnalysisRepoListView": (
-    variantAnalysisId: number,
-    filterSort?: RepositoriesFilterSortStateWithIds,
   ) => Promise<void>;
   "codeQL.loadVariantAnalysisRepoResults": (
     variantAnalysisId: number,

--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -244,10 +244,6 @@ export type VariantAnalysisCommands = {
     scannedRepo: VariantAnalysisScannedRepository,
     variantAnalysisSummary: VariantAnalysis,
   ) => Promise<void>;
-  "codeQL.copyVariantAnalysisRepoListQueryHistory": (
-    variantAnalysisId: number,
-    filterSort?: RepositoriesFilterSortStateWithIds,
-  ) => Promise<void>;
   "codeQL.copyVariantAnalysisRepoListView": (
     variantAnalysisId: number,
     filterSort?: RepositoriesFilterSortStateWithIds,

--- a/extensions/ql-vscode/src/query-history/query-history-manager.ts
+++ b/extensions/ql-vscode/src/query-history/query-history-manager.ts
@@ -952,8 +952,7 @@ export class QueryHistoryManager extends DisposableObject {
       return;
     }
 
-    await this.app.commands.execute(
-      "codeQL.copyVariantAnalysisRepoListQueryHistory",
+    await this.variantAnalysisManager.copyRepoListToClipboard(
       item.variantAnalysis.id,
     );
   }

--- a/extensions/ql-vscode/src/query-history/query-history-manager.ts
+++ b/extensions/ql-vscode/src/query-history/query-history-manager.ts
@@ -953,7 +953,7 @@ export class QueryHistoryManager extends DisposableObject {
     }
 
     await this.app.commands.execute(
-      "codeQL.copyVariantAnalysisRepoList",
+      "codeQL.copyVariantAnalysisRepoListQueryHistory",
       item.variantAnalysis.id,
     );
   }

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -148,8 +148,6 @@ export class VariantAnalysisManager
     return {
       "codeQL.autoDownloadVariantAnalysisResult":
         this.enqueueDownload.bind(this),
-      "codeQL.copyVariantAnalysisRepoListView":
-        this.copyRepoListToClipboard.bind(this),
       "codeQL.loadVariantAnalysisRepoResults": this.loadResults.bind(this),
       "codeQL.monitorNewVariantAnalysis":
         this.monitorVariantAnalysis.bind(this),

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -148,8 +148,6 @@ export class VariantAnalysisManager
     return {
       "codeQL.autoDownloadVariantAnalysisResult":
         this.enqueueDownload.bind(this),
-      "codeQL.copyVariantAnalysisRepoListQueryHistory":
-        this.copyRepoListToClipboard.bind(this),
       "codeQL.copyVariantAnalysisRepoListView":
         this.copyRepoListToClipboard.bind(this),
       "codeQL.loadVariantAnalysisRepoResults": this.loadResults.bind(this),

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -148,7 +148,9 @@ export class VariantAnalysisManager
     return {
       "codeQL.autoDownloadVariantAnalysisResult":
         this.enqueueDownload.bind(this),
-      "codeQL.copyVariantAnalysisRepoList":
+      "codeQL.copyVariantAnalysisRepoListQueryHistory":
+        this.copyRepoListToClipboard.bind(this),
+      "codeQL.copyVariantAnalysisRepoListView":
         this.copyRepoListToClipboard.bind(this),
       "codeQL.loadVariantAnalysisRepoResults": this.loadResults.bind(this),
       "codeQL.monitorNewVariantAnalysis":

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-view-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-view-manager.ts
@@ -32,4 +32,8 @@ export interface VariantAnalysisViewManager<
     variantAnalysisId: number,
     filterSort?: RepositoriesFilterSortStateWithIds,
   ): Promise<void>;
+  copyRepoListToClipboard(
+    variantAnalysisId: number,
+    filterSort?: RepositoriesFilterSortStateWithIds,
+  ): Promise<void>;
 }

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-view.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-view.ts
@@ -139,8 +139,7 @@ export class VariantAnalysisView
         await this.manager.openQueryText(this.variantAnalysisId);
         break;
       case "copyRepositoryList":
-        void this.app.commands.execute(
-          "codeQL.copyVariantAnalysisRepoListView",
+        await this.manager.copyRepoListToClipboard(
           this.variantAnalysisId,
           msg.filterSort,
         );

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-view.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-view.ts
@@ -140,7 +140,7 @@ export class VariantAnalysisView
         break;
       case "copyRepositoryList":
         void this.app.commands.execute(
-          "codeQL.copyVariantAnalysisRepoList",
+          "codeQL.copyVariantAnalysisRepoListView",
           this.variantAnalysisId,
           msg.filterSort,
         );

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysis.tsx
@@ -131,6 +131,7 @@ export function VariantAnalysis({
         repositoryIds: selectedRepositoryIds,
       },
     });
+    sendTelemetry("variant-analysis-copy-repository-list");
   }, [filterSortState, selectedRepositoryIds]);
 
   const exportResults = useCallback(() => {

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-manager.test.ts
@@ -709,13 +709,13 @@ describe("QueryHistoryManager", () => {
     });
 
     it("should copy repo list for a single variant analysis", async () => {
+      variantAnalysisManagerStub.copyRepoListToClipboard = jest.fn();
       queryHistoryManager = await createMockQueryHistory(allHistory);
-      queryHistoryManager.handleCopyRepoList = jest.fn();
 
       const item = variantAnalysisHistory[1];
       await queryHistoryManager.handleCopyRepoList(item);
 
-      expect(queryHistoryManager.handleCopyRepoList).toBeCalledWith(
+      expect(variantAnalysisManagerStub.copyRepoListToClipboard).toBeCalledWith(
         item.variantAnalysis.id,
       );
     });

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-manager.test.ts
@@ -710,11 +710,12 @@ describe("QueryHistoryManager", () => {
 
     it("should copy repo list for a single variant analysis", async () => {
       queryHistoryManager = await createMockQueryHistory(allHistory);
+      queryHistoryManager.handleCopyRepoList = jest.fn();
 
       const item = variantAnalysisHistory[1];
       await queryHistoryManager.handleCopyRepoList(item);
-      expect(executeCommand).toBeCalledWith(
-        "codeQL.copyVariantAnalysisRepoListQueryHistory",
+
+      expect(queryHistoryManager.handleCopyRepoList).toBeCalledWith(
         item.variantAnalysis.id,
       );
     });

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-manager.test.ts
@@ -714,7 +714,7 @@ describe("QueryHistoryManager", () => {
       const item = variantAnalysisHistory[1];
       await queryHistoryManager.handleCopyRepoList(item);
       expect(executeCommand).toBeCalledWith(
-        "codeQL.copyVariantAnalysisRepoList",
+        "codeQL.copyVariantAnalysisRepoListQueryHistory",
         item.variantAnalysis.id,
       );
     });


### PR DESCRIPTION
Fixes https://github.com/github/vscode-codeql/security/code-scanning/461

`codeQL.copyVariantAnalysisRepoList` is used from two places, but they're both internal so it's trivial to split the command into two.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
