### PR TITLE
 legacy-query.test.ts: skip if CLI supports new query server

### DIFF
--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/new-query.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/new-query.test.ts
@@ -114,6 +114,9 @@ describeWithCodeQL()("using the new query server", () => {
 
     cliServer.quiet = true;
     if (!(await cliServer.cliConstraints.supportsNewQueryServerForTests())) {
+      console.log(
+        "Skipping new-query tests: the CLI supports only the legacy query server",
+      );
       supportNewQueryServer = false;
     }
     qs = new QueryServerClient(


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

This PR modifies `legacy-query.test.ts`, which tests integration with the legacy query server in the CodeQL CLI (i.e., `codeql execute query-server`), to run only for CLI versions that are too old to support the new query server (i.e., `codeql execute query-server2`).  The vscode extension automatically selects the new query server whenever possible, so it should be sufficient to test legacy query server integration only with old CLI versions.

See back-linked internal issue for additional context.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
