### PR TITLE
Data extensions editor: Implement "Hide modeled APIs" checkbox and make it the default

### DIFF
--- a/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
@@ -91,6 +91,8 @@ export function DataExtensionsEditor({
     new Set(),
   );
 
+  const [hideModeledApis, setHideModeledApis] = useState(true);
+
   const [modeledMethods, setModeledMethods] = useState<
     Record<string, ModeledMethod>
   >(initialModeledMethods);
@@ -252,6 +254,10 @@ export function DataExtensionsEditor({
     });
   }, [viewState?.mode]);
 
+  const onHideModeledApis = useCallback(() => {
+    setHideModeledApis((oldHideModeledApis) => !oldHideModeledApis);
+  }, []);
+
   if (viewState === undefined || externalApiUsages.length === 0) {
     return <LoadingContainer>Loading...</LoadingContainer>;
   }
@@ -292,7 +298,12 @@ export function DataExtensionsEditor({
         </HeaderColumn>
         <HeaderSpacer />
         <HeaderColumn>
-          <VSCodeCheckbox>Hide modeled APIs</VSCodeCheckbox>
+          <VSCodeCheckbox
+            checked={hideModeledApis}
+            onChange={onHideModeledApis}
+          >
+            Hide modeled APIs
+          </VSCodeCheckbox>
         </HeaderColumn>
       </HeaderContainer>
 
@@ -320,6 +331,7 @@ export function DataExtensionsEditor({
           modeledMethods={modeledMethods}
           modifiedSignatures={modifiedSignatures}
           viewState={viewState}
+          hideModeledApis={hideModeledApis}
           onChange={onChange}
           onSaveModelClick={onSaveModelClick}
           onGenerateFromLlmClick={onGenerateFromLlmClick}

--- a/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
@@ -73,6 +73,7 @@ type Props = {
   modeledMethods: Record<string, ModeledMethod>;
   modifiedSignatures: Set<string>;
   viewState: DataExtensionEditorViewState;
+  hideModeledApis: boolean;
   onChange: (
     modelName: string,
     externalApiUsage: ExternalApiUsage,
@@ -97,6 +98,7 @@ export const LibraryRow = ({
   modeledMethods,
   modifiedSignatures,
   viewState,
+  hideModeledApis,
   onChange,
   onSaveModelClick,
   onGenerateFromLlmClick,
@@ -208,6 +210,7 @@ export const LibraryRow = ({
             modeledMethods={modeledMethods}
             modifiedSignatures={modifiedSignatures}
             mode={viewState.mode}
+            hideModeledApis={hideModeledApis}
             onChange={onChangeWithModelName}
           />
           <SectionDivider />

--- a/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
@@ -56,6 +56,7 @@ type Props = {
   modeledMethod: ModeledMethod | undefined;
   methodIsUnsaved: boolean;
   mode: Mode;
+  hideModeledApis: boolean;
   onChange: (
     externalApiUsage: ExternalApiUsage,
     modeledMethod: ModeledMethod,
@@ -63,7 +64,8 @@ type Props = {
 };
 
 export const MethodRow = (props: Props) => {
-  const { externalApiUsage, modeledMethod, methodIsUnsaved } = props;
+  const { externalApiUsage, modeledMethod, methodIsUnsaved, hideModeledApis } =
+    props;
 
   const methodCanBeModeled =
     !externalApiUsage.supported ||
@@ -72,6 +74,8 @@ export const MethodRow = (props: Props) => {
 
   if (methodCanBeModeled) {
     return <ModelableMethodRow {...props} />;
+  } else if (hideModeledApis) {
+    return null;
   } else {
     return <UnmodelableMethodRow {...props} />;
   }

--- a/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodDataGrid.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodDataGrid.tsx
@@ -16,6 +16,7 @@ type Props = {
   modeledMethods: Record<string, ModeledMethod>;
   modifiedSignatures: Set<string>;
   mode: Mode;
+  hideModeledApis: boolean;
   onChange: (
     externalApiUsage: ExternalApiUsage,
     modeledMethod: ModeledMethod,
@@ -27,6 +28,7 @@ export const ModeledMethodDataGrid = ({
   modeledMethods,
   modifiedSignatures,
   mode,
+  hideModeledApis,
   onChange,
 }: Props) => {
   const sortedExternalApiUsages = useMemo(
@@ -60,6 +62,7 @@ export const ModeledMethodDataGrid = ({
           modeledMethod={modeledMethods[externalApiUsage.signature]}
           methodIsUnsaved={modifiedSignatures.has(externalApiUsage.signature)}
           mode={mode}
+          hideModeledApis={hideModeledApis}
           onChange={onChange}
         />
       ))}

--- a/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodsList.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodsList.tsx
@@ -15,6 +15,7 @@ type Props = {
   modeledMethods: Record<string, ModeledMethod>;
   modifiedSignatures: Set<string>;
   viewState: DataExtensionEditorViewState;
+  hideModeledApis: boolean;
   onChange: (
     modelName: string,
     externalApiUsage: ExternalApiUsage,
@@ -41,6 +42,7 @@ export const ModeledMethodsList = ({
   modeledMethods,
   modifiedSignatures,
   viewState,
+  hideModeledApis,
   onChange,
   onSaveModelClick,
   onGenerateFromLlmClick,
@@ -83,6 +85,7 @@ export const ModeledMethodsList = ({
           modeledMethods={modeledMethods}
           modifiedSignatures={modifiedSignatures}
           viewState={viewState}
+          hideModeledApis={hideModeledApis}
           onChange={onChange}
           onSaveModelClick={onSaveModelClick}
           onGenerateFromLlmClick={onGenerateFromLlmClick}


### PR DESCRIPTION
Makes the "Hide modeled APIs" checkbox actually hide modeled APIs from the view! ✅ (With help from @robertbrignull 🙏🏽)
![image](https://github.com/github/vscode-codeql/assets/42641846/d0e2d6cc-0890-4dc1-941c-76b6d9c37053)

See internal issue for more details 🔍 

## Checklist

N/A: Internal only 🐄 

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
