### PR TITLE
Download `codeql/java-all` in tests

### DIFF
--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/data-extensions-editor/modeled-method-fs.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/data-extensions-editor/modeled-method-fs.test.ts
@@ -52,6 +52,14 @@ describe("modeled-method-fs", () => {
   let workspacePath: string;
   let cli: CodeQLCliServer;
 
+  beforeAll(async () => {
+    const extension = await getActivatedExtension();
+    cli = extension.cliServer;
+
+    // The java-all pack needs to be available for codeql resolve extensions to succeed.
+    await cli.packDownload(["codeql/java-all"]);
+  });
+
   beforeEach(async () => {
     // On windows, make sure to use a temp directory that isn't an alias and therefore won't be canonicalised by CodeQL.
     // See https://github.com/github/vscode-codeql/pull/2605 for more context.


### PR DESCRIPTION
An upcoming change in the CLI will require that the extensible predicates that are targeted by a data extension needs to be available in order for the `resolve extensions` command to succeed.

There are a handful of tests that are failing with this new CLI. This change will update the tests so that the `codeql/java-all` pack is available in the tests and ensures they pass.

## Checklist

- [n/a] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [n/a] Issues have been created for any UI or other user-facing changes made by this pull request.
- [n/a] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
