### PR TITLE
Only show automodel button for Java

### DIFF
--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
@@ -190,12 +190,15 @@ export class DataExtensionsEditorView extends AbstractWebview<
   }
 
   private async setViewState(): Promise<void> {
+    const showLlmButton =
+      this.databaseItem.language === "java" && showLlmGeneration();
+
     await this.postMessage({
       t: "setDataExtensionEditorViewState",
       viewState: {
         extensionPack: this.extensionPack,
         enableFrameworkMode: enableFrameworkMode(),
-        showLlmButton: showLlmGeneration(),
+        showLlmButton,
         mode: this.mode,
       },
     });


### PR DESCRIPTION
We currently show the button for both Java and C# and the solution doesn't work for C#.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
