### PR TITLE
Install `java-all` and transitive dependencies

### DIFF
--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/data-extensions-editor/modeled-method-fs.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/data-extensions-editor/modeled-method-fs.test.ts
@@ -56,8 +56,14 @@ describe("modeled-method-fs", () => {
     const extension = await getActivatedExtension();
     cli = extension.cliServer;
 
-    // The java-all pack needs to be available for codeql resolve extensions to succeed.
-    await cli.packDownload(["codeql/java-all"]);
+    // All transitive dependencies must be available for resolve extensions to succeed.
+    const packUsingExtensionsPath = join(
+      __dirname,
+      "../../..",
+      "data-extensions",
+      "pack-using-extensions",
+    );
+    await cli.packInstall(packUsingExtensionsPath);
   });
 
   beforeEach(async () => {


### PR DESCRIPTION
#2655 was not sufficient in fixing the integration test. I forgot that we
need to install all transitive dependencies of `java-all` as well. This will do it.