### PR TITLE
Ensure the qhelp preview is refreshed after editing

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Remove "last updated" information and sorting from variant analysis results view. [#2637](https://github.com/github/vscode-codeql/pull/2637)
 - Links to code on GitHub now include column numbers as well as line numbers. [#2406](https://github.com/github/vscode-codeql/pull/2406)
 - No longer highlight trailing commas for jump to definition.  [#2615](https://github.com/github/vscode-codeql/pull/2615)
+- Fix a bug where the QHelp preview page was not being refreshed after changes to the underlying `.qhelp` file.
 
 ## 1.8.8 - 17 July 2023
 

--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Remove "last updated" information and sorting from variant analysis results view. [#2637](https://github.com/github/vscode-codeql/pull/2637)
 - Links to code on GitHub now include column numbers as well as line numbers. [#2406](https://github.com/github/vscode-codeql/pull/2406)
 - No longer highlight trailing commas for jump to definition.  [#2615](https://github.com/github/vscode-codeql/pull/2615)
-- Fix a bug where the QHelp preview page was not being refreshed after changes to the underlying `.qhelp` file.
+- Fix a bug where the QHelp preview page was not being refreshed after changes to the underlying `.qhelp` file. [#2660](https://github.com/github/vscode-codeql/pull/2660)
 
 ## 1.8.8 - 17 July 2023
 

--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -59,6 +59,7 @@ type BuiltInVsCodeCommands = {
   // The codeQLDatabases.focus command is provided by VS Code because we've registered the custom view
   "codeQLDatabases.focus": () => Promise<void>;
   "markdown.showPreviewToSide": (uri: Uri) => Promise<void>;
+  "workbench.action.closeActiveEditor": () => Promise<void>;
   revealFileInOS: (uri: Uri) => Promise<void>;
   setContext: (
     key: `${"codeql" | "codeQL"}${string}`,

--- a/extensions/ql-vscode/src/language-support/query-editor.ts
+++ b/extensions/ql-vscode/src/language-support/query-editor.ts
@@ -1,4 +1,4 @@
-import { Uri, window } from "vscode";
+import { Uri, ViewColumn, window, workspace } from "vscode";
 import { CodeQLCliServer } from "../codeql-cli/cli";
 import { QueryRunner } from "../query-server";
 import { basename, join } from "path";
@@ -74,7 +74,16 @@ async function previewQueryHelp(
     const uri = Uri.file(absolutePathToMd);
     try {
       await cliServer.generateQueryHelp(pathToQhelp, absolutePathToMd);
+      // Open the raw markdown file as well as the rendered file.
+      // This will force the rendered page to refresh if there has been a change to the markdown.
+      await window.showTextDocument(uri, {
+        viewColumn: ViewColumn.Active,
+      });
       await commandManager.execute("markdown.showPreviewToSide", uri);
+      // close the editor we just opened. Users will see a brief flicker of this editor
+      // being opened, but doing so will ensure that the preview is refreshed.
+      await window.showTextDocument(uri);
+      await commandManager.execute("workbench.action.closeActiveEditor");
     } catch (e) {
       const errorMessage = getErrorMessage(e).includes(
         "Generating qhelp in markdown",


### PR DESCRIPTION
This commit fixes a bug in the extension where the qhelp preview was not being refreshed after the first time the preview was rendered. The reason is that vscode will not refresh the markdown preview unless the original file with the markdown in it is already open in the editor.

This fix will briefly open the raw markdown, refresh the preview and close the raw markdown.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
