### PR TITLE
Delete untoggleProblemsView as it is unused

### DIFF
--- a/extensions/ql-vscode/src/view/results/result-tables.tsx
+++ b/extensions/ql-vscode/src/view/results/result-tables.tsx
@@ -176,12 +176,6 @@ export class ResultTables extends React.Component<
     }
   }
 
-  untoggleProblemsView() {
-    this.setState({
-      problemsViewSelected: false,
-    });
-  }
-
   private onTableSelectionChange = (
     event: React.ChangeEvent<HTMLSelectElement>,
   ): void => {


### PR DESCRIPTION
It was introduced in https://github.com/github/vscode-codeql/pull/602 and as far as I can tell it's always been unused. It seems just to be an error in that PR and the actual setting of state is done in `handleCheckboxChanged`.

Our deadcode detection seems to not be working for public methods on components like this.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
