### PR TITLE
Try to fix flakes in query history scrubber tests

### DIFF
--- a/extensions/ql-vscode/src/query-history/query-history-scrubber.ts
+++ b/extensions/ql-vscode/src/query-history/query-history-scrubber.ts
@@ -10,10 +10,6 @@ import { getErrorMessage } from "../common/helpers-pure";
 
 const LAST_SCRUB_TIME_KEY = "lastScrubTime";
 
-type Counter = {
-  increment: () => void;
-};
-
 /**
  * Registers an interval timer that will periodically check for queries old enought
  * to be deleted.
@@ -37,8 +33,8 @@ export function registerQueryHistoryScrubber(
   qhm: QueryHistoryManager,
   ctx: ExtensionContext,
 
-  // optional counter to keep track of how many times the scrubber has run
-  counter?: Counter,
+  // optional callback to keep track of how many times the scrubber has run
+  onScrubberRun?: () => void,
 ): Disposable {
   const deregister = setInterval(
     scrubQueries,
@@ -48,7 +44,7 @@ export function registerQueryHistoryScrubber(
     queryHistoryDirs,
     qhm,
     ctx,
-    counter,
+    onScrubberRun,
   );
 
   return {
@@ -64,7 +60,7 @@ async function scrubQueries(
   queryHistoryDirs: QueryHistoryDirs,
   qhm: QueryHistoryManager,
   ctx: ExtensionContext,
-  counter?: Counter,
+  onScrubberRun?: () => void,
 ) {
   const lastScrubTime = ctx.globalState.get<number>(LAST_SCRUB_TIME_KEY);
   const now = Date.now();
@@ -76,7 +72,7 @@ async function scrubQueries(
 
     let scrubCount = 0; // total number of directories deleted
     try {
-      counter?.increment();
+      onScrubberRun?.();
       void extLogger.log(
         "Cleaning up query history directories. Removing old entries.",
       );

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-scrubber.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-scrubber.test.ts
@@ -13,6 +13,7 @@ import {
   TWO_HOURS_IN_MS,
 } from "../../../../src/common/time";
 import { mockedObject } from "../../utils/mocking.helpers";
+import { DirResult } from "tmp";
 
 const now = Date.now();
 // We don't want our times to align exactly with the hour,
@@ -21,12 +22,13 @@ const LESS_THAN_ONE_DAY = ONE_DAY_IN_MS - 1000;
 
 describe("query history scrubber", () => {
   let deregister: vscode.Disposable | undefined;
-
-  const tmpDir = dirSync({
-    unsafeCleanup: true,
-  });
+  let tmpDir: DirResult;
 
   beforeEach(() => {
+    tmpDir = dirSync({
+      unsafeCleanup: true,
+    });
+
     jest.spyOn(extLogger, "log").mockResolvedValue(undefined);
 
     jest.useFakeTimers({
@@ -40,6 +42,7 @@ describe("query history scrubber", () => {
       deregister.dispose();
       deregister = undefined;
     }
+    tmpDir.removeCallback();
   });
 
   it("should not throw an error when the query directory does not exist", async () => {

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-scrubber.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-scrubber.test.ts
@@ -14,16 +14,16 @@ import {
 } from "../../../../src/common/time";
 import { mockedObject } from "../../utils/mocking.helpers";
 
-describe("query history scrubber", () => {
-  const now = Date.now();
+const now = Date.now();
+// We don't want our times to align exactly with the hour,
+// so we can better mimic real life
+const LESS_THAN_ONE_DAY = ONE_DAY_IN_MS - 1000;
 
+describe("query history scrubber", () => {
   let deregister: vscode.Disposable | undefined;
   let mockCtx: vscode.ExtensionContext;
   let runCount = 0;
 
-  // We don't want our times to align exactly with the hour,
-  // so we can better mimic real life
-  const LESS_THAN_ONE_DAY = ONE_DAY_IN_MS - 1000;
   const tmpDir = dirSync({
     unsafeCleanup: true,
   });


### PR DESCRIPTION
I believe that these changes might help with the flakes in the query history scrubber tests.

Most of the test failures that I've seen look like:
```
FAIL query-history/query-history-scrubber.test.ts (5.957 s)
  ● query history scrubber › should not throw an error when the query directory does not exist

    expect(received).toBe(expected) // Object.is equality

    Expected: 0
    Received: 16

      69 |     await wait();
      70 |     // "Should not have called the scrubber"
    > 71 |     expect(runCount).toBe(0);
         |                      ^
      72 |
      73 |     jest.advanceTimersByTime(ONE_HOUR_IN_MS - 1);
      74 |     await wait();
```
So this means when the test started the `runCount` variable wasn't set to zero! 🤯 

I believe this is because individual test run is receiving a reference to the same `runCount` variable, because it's defined in the `describe` block, and the variable isn't reset between tests because the `= 0` only applies when the variable is first defined. The fix is to avoid reusing the variable, or to reset the variable between tests. In this PR I opt to use a different variable for each test, and also to use a `jest.fn()` so we can use `toHaveBeenCalledTimes`.

I also try to clean up the tests in other ways so it matches other tests and it's clear we won't get any other inter-test dependencies that'll cause other flakes. Each change is in a separate commit.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
