### PR TITLE
Handle when an alert message contains links to files outside of the repository source 

### DIFF
--- a/extensions/ql-vscode/src/common/sarif-utils.ts
+++ b/extensions/ql-vscode/src/common/sarif-utils.ts
@@ -2,7 +2,7 @@ import * as Sarif from "sarif";
 import type { HighlightedRegion } from "../variant-analysis/shared/analysis-result";
 import { ResolvableLocationValue } from "../common/bqrs-cli-types";
 
-interface SarifLink {
+export interface SarifLink {
   dest: number;
   text: string;
 }

--- a/extensions/ql-vscode/src/variant-analysis/shared/analysis-result.ts
+++ b/extensions/ql-vscode/src/variant-analysis/shared/analysis-result.ts
@@ -63,10 +63,12 @@ interface AnalysisMessageTextToken {
 export interface AnalysisMessageLocationToken {
   t: "location";
   text: string;
-  location: {
-    fileLink: FileLink;
-    highlightedRegion?: HighlightedRegion;
-  };
+  location: AnalysisMessageLocationTokenLocation;
+}
+
+export interface AnalysisMessageLocationTokenLocation {
+  fileLink: FileLink;
+  highlightedRegion?: HighlightedRegion;
 }
 
 export type ResultSeverity = "Recommendation" | "Warning" | "Error";

--- a/extensions/ql-vscode/test/unit-tests/sarif-processing.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/sarif-processing.test.ts
@@ -720,6 +720,33 @@ describe("SARIF processing", () => {
       expectNoParsingError(result);
       expect(actualCodeSnippet).not.toBeUndefined();
     });
+
+    it("should be able to handle when a location has no uri", () => {
+      const sarif = buildValidSarifLog();
+      sarif.runs![0].results![0].message.text = "message [String](1)";
+      sarif.runs![0].results![0].relatedLocations = [
+        {
+          id: 1,
+          physicalLocation: {
+            artifactLocation: {
+              uri: "file:/modules/java.base/java/lang/String.class",
+              index: 1,
+            },
+          },
+          message: {
+            text: "String",
+          },
+        },
+      ];
+
+      const result = extractAnalysisAlerts(sarif, fakefileLinkPrefix);
+
+      const actualCodeSnippet = result.alerts[0].codeSnippet;
+
+      expect(result).toBeTruthy();
+      expectNoParsingError(result);
+      expect(actualCodeSnippet).not.toBeUndefined();
+    });
   });
 
   function expectResultParsingError(msg: string) {


### PR DESCRIPTION
Closes https://github.com/github/vscode-codeql/issues/2622

Fixes support for MRVA using queries where a placeholder link goes to outside of the source archive. In this case we have a location without a `region` and this was causing a crash because we were naughtily assuming fields to be defined.

Rendering of alerts now works and the message placeholder is rendered as a regular string instead of a link:
<img width="1437" alt="Screenshot 2023-08-04 at 12 28 42" src="https://github.com/github/vscode-codeql/assets/3749000/939e0b3e-c78f-4b77-a1e3-ac968d04b88e">

Use the following query to reproduce the bug and observe that it now works:
```ql
/**
 * @kind problem
 */

import java

// Pick arbitrary element which is part of source; chose EnumType here because projects
// likely don't have that many enum types
// TypeString comes from the JDK and is not part of the source of the project
from EnumType t, TypeString notPartOfSource
where t.fromSource()
select t, "message $@", notPartOfSource, notPartOfSource.getName()
```

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
