### PR TITLE
Remove unused NPM dependencies

### DIFF
--- a/extensions/ql-vscode/package-lock.json
+++ b/extensions/ql-vscode/package-lock.json
@@ -78,7 +78,6 @@
         "@types/fs-extra": "^11.0.1",
         "@types/gulp": "^4.0.9",
         "@types/gulp-replace": "^1.1.0",
-        "@types/gulp-sourcemaps": "0.0.32",
         "@types/jest": "^29.0.2",
         "@types/js-yaml": "^3.12.5",
         "@types/jszip": "^3.1.6",
@@ -11353,14 +11352,6 @@
       "dev": true,
       "dependencies": {
         "gulp-replace": "*"
-      }
-    },
-    "node_modules/@types/gulp-sourcemaps": {
-      "version": "0.0.32",
-      "integrity": "sha512-+7BAmptW2bxyJnJcCEuie7vLoop3FwWgCdBMzyv7MYXED/HeNMeQuX7uPCkp4vfU1TTu4CYFH0IckNPvo0VePA==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/hoist-non-react-statics": {
@@ -41116,14 +41107,6 @@
       "dev": true,
       "requires": {
         "gulp-replace": "*"
-      }
-    },
-    "@types/gulp-sourcemaps": {
-      "version": "0.0.32",
-      "integrity": "sha512-+7BAmptW2bxyJnJcCEuie7vLoop3FwWgCdBMzyv7MYXED/HeNMeQuX7uPCkp4vfU1TTu4CYFH0IckNPvo0VePA==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
       }
     },
     "@types/hoist-non-react-statics": {

--- a/extensions/ql-vscode/package-lock.json
+++ b/extensions/ql-vscode/package-lock.json
@@ -141,7 +141,6 @@
         "ts-json-schema-generator": "^1.1.2",
         "ts-loader": "^9.4.2",
         "ts-node": "^10.7.0",
-        "ts-protoc-gen": "^0.9.0",
         "ts-unused-exports": "^9.0.5",
         "typescript": "^5.0.2",
         "webpack": "^5.76.0",
@@ -31319,14 +31318,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/ts-protoc-gen": {
-      "version": "0.9.0",
-      "integrity": "sha512-cFEUTY9U9o6C4DPPfMHk2ZUdIAKL91hZN1fyx5Stz3g56BDVOC7hk+r5fEMCAGaaIgi2akkT1a2hrxu1wo2Phg==",
-      "dev": true,
-      "bin": {
-        "protoc-gen-ts": "bin/protoc-gen-ts"
-      }
-    },
     "node_modules/ts-unused-exports": {
       "version": "9.0.5",
       "integrity": "sha512-1XAXaH2i4Al/aZO06pWDn9MUgTN0KQi+fvWudiWfHUTHAav45gzrx7Xq6JAsu6+LoMlVoyGvNvZSPW3KTjDncA==",
@@ -55797,11 +55788,6 @@
           "dev": true
         }
       }
-    },
-    "ts-protoc-gen": {
-      "version": "0.9.0",
-      "integrity": "sha512-cFEUTY9U9o6C4DPPfMHk2ZUdIAKL91hZN1fyx5Stz3g56BDVOC7hk+r5fEMCAGaaIgi2akkT1a2hrxu1wo2Phg==",
-      "dev": true
     },
     "ts-unused-exports": {
       "version": "9.0.5",

--- a/extensions/ql-vscode/package-lock.json
+++ b/extensions/ql-vscode/package-lock.json
@@ -34,7 +34,6 @@
         "semver": "^7.5.2",
         "source-map": "^0.7.4",
         "source-map-support": "^0.5.21",
-        "stream": "^0.0.2",
         "stream-chain": "^2.2.4",
         "stream-json": "^1.7.3",
         "styled-components": "^6.0.2",
@@ -16872,10 +16871,6 @@
       "version": "1.4.463",
       "integrity": "sha512-fT3hvdUWLjDbaTGzyOjng/CQhQJSQP8ThO3XZAoaxHvHo2kUXiRQVMj9M235l8uDFiNPsPa6KHT1p3RaR6ugRw=="
     },
-    "node_modules/emitter-component": {
-      "version": "1.1.1",
-      "integrity": "sha512-G+mpdiAySMuB7kesVRLuyvYRqDmshB7ReKEVuyBPkzQlmiDiLrt7hHHIy4Aff552bgknVN7B2/d3lzhGO5dvpQ=="
-    },
     "node_modules/emitter-listener": {
       "version": "1.1.2",
       "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
@@ -29826,13 +29821,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
-      }
-    },
-    "node_modules/stream": {
-      "version": "0.0.2",
-      "integrity": "sha512-gCq3NDI2P35B2n6t76YJuOp7d6cN/C7Rt0577l91wllh0sY9ZBuw9KaSGqH/b0hzn3CWWJbpbW0W0WvQ1H/Q7g==",
-      "dependencies": {
-        "emitter-component": "^1.1.1"
       }
     },
     "node_modules/stream-chain": {
@@ -45263,10 +45251,6 @@
       "version": "1.4.463",
       "integrity": "sha512-fT3hvdUWLjDbaTGzyOjng/CQhQJSQP8ThO3XZAoaxHvHo2kUXiRQVMj9M235l8uDFiNPsPa6KHT1p3RaR6ugRw=="
     },
-    "emitter-component": {
-      "version": "1.1.1",
-      "integrity": "sha512-G+mpdiAySMuB7kesVRLuyvYRqDmshB7ReKEVuyBPkzQlmiDiLrt7hHHIy4Aff552bgknVN7B2/d3lzhGO5dvpQ=="
-    },
     "emitter-listener": {
       "version": "1.1.2",
       "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
@@ -54774,13 +54758,6 @@
       "dev": true,
       "requires": {
         "@storybook/cli": "7.1.0"
-      }
-    },
-    "stream": {
-      "version": "0.0.2",
-      "integrity": "sha512-gCq3NDI2P35B2n6t76YJuOp7d6cN/C7Rt0577l91wllh0sY9ZBuw9KaSGqH/b0hzn3CWWJbpbW0W0WvQ1H/Q7g==",
-      "requires": {
-        "emitter-component": "^1.1.1"
       }
     },
     "stream-chain": {

--- a/extensions/ql-vscode/package-lock.json
+++ b/extensions/ql-vscode/package-lock.json
@@ -25,7 +25,6 @@
         "fs-extra": "^11.1.1",
         "immutable": "^4.0.0",
         "js-yaml": "^4.1.0",
-        "minimist": "^1.2.6",
         "msw": "^1.2.0",
         "nanoid": "^3.2.0",
         "node-fetch": "^2.6.7",

--- a/extensions/ql-vscode/package-lock.json
+++ b/extensions/ql-vscode/package-lock.json
@@ -87,7 +87,6 @@
         "@types/react-dom": "^18.0.11",
         "@types/sarif": "^2.1.2",
         "@types/semver": "^7.2.0",
-        "@types/stream-chain": "^2.0.1",
         "@types/stream-json": "^1.7.1",
         "@types/styled-components": "^5.1.11",
         "@types/tar-stream": "^2.2.2",

--- a/extensions/ql-vscode/package-lock.json
+++ b/extensions/ql-vscode/package-lock.json
@@ -25,7 +25,6 @@
         "fs-extra": "^11.1.1",
         "immutable": "^4.0.0",
         "js-yaml": "^4.1.0",
-        "minimatch": "^9.0.0",
         "minimist": "^1.2.6",
         "msw": "^1.2.0",
         "nanoid": "^3.2.0",
@@ -26044,6 +26043,7 @@
     "node_modules/minimatch": {
       "version": "9.0.0",
       "integrity": "sha512-0jJj8AvgKqWN05mrwuqi8QYKx1WmYSUoKSxu5Qhs9prezTz10sxAHGNZe9J9cqIJzta8DWsleh2KaVaLl6Ru2w==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -51927,6 +51927,7 @@
     "minimatch": {
       "version": "9.0.0",
       "integrity": "sha512-0jJj8AvgKqWN05mrwuqi8QYKx1WmYSUoKSxu5Qhs9prezTz10sxAHGNZe9J9cqIJzta8DWsleh2KaVaLl6Ru2w==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^2.0.1"
       }

--- a/extensions/ql-vscode/package-lock.json
+++ b/extensions/ql-vscode/package-lock.json
@@ -34,7 +34,6 @@
         "semver": "^7.5.2",
         "source-map": "^0.7.4",
         "source-map-support": "^0.5.21",
-        "stream-chain": "^2.2.4",
         "stream-json": "^1.7.3",
         "styled-components": "^6.0.2",
         "tmp": "^0.1.0",

--- a/extensions/ql-vscode/package-lock.json
+++ b/extensions/ql-vscode/package-lock.json
@@ -80,7 +80,6 @@
         "@types/gulp-replace": "^1.1.0",
         "@types/jest": "^29.0.2",
         "@types/js-yaml": "^3.12.5",
-        "@types/jszip": "^3.1.6",
         "@types/nanoid": "^3.0.0",
         "@types/node": "^16.11.25",
         "@types/node-fetch": "^2.5.2",
@@ -11487,14 +11486,6 @@
     "node_modules/@types/jsonfile": {
       "version": "6.1.1",
       "integrity": "sha512-GSgiRCVeapDN+3pqA35IkQwasaCh/0YFH5dEF6S88iDvEn901DjOeH3/QPY+XYP1DFzDZPvIvfeEgk+7br5png==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/jszip": {
-      "version": "3.1.7",
-      "integrity": "sha512-+XQKNI5zpxutK05hO67huUTw/2imXCuJWjnFdU63tRES/xXSX1yVR9cv/QAdO6Rii2y2tTHbzjQ4i2apLfuK0Q==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -41228,14 +41219,6 @@
     "@types/jsonfile": {
       "version": "6.1.1",
       "integrity": "sha512-GSgiRCVeapDN+3pqA35IkQwasaCh/0YFH5dEF6S88iDvEn901DjOeH3/QPY+XYP1DFzDZPvIvfeEgk+7br5png==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/jszip": {
-      "version": "3.1.7",
-      "integrity": "sha512-+XQKNI5zpxutK05hO67huUTw/2imXCuJWjnFdU63tRES/xXSX1yVR9cv/QAdO6Rii2y2tTHbzjQ4i2apLfuK0Q==",
       "dev": true,
       "requires": {
         "@types/node": "*"

--- a/extensions/ql-vscode/package-lock.json
+++ b/extensions/ql-vscode/package-lock.json
@@ -76,7 +76,6 @@
         "@types/d3-graphviz": "^2.6.6",
         "@types/del": "^4.0.0",
         "@types/fs-extra": "^11.0.1",
-        "@types/google-protobuf": "^3.2.7",
         "@types/gulp": "^4.0.9",
         "@types/gulp-replace": "^1.1.0",
         "@types/gulp-sourcemaps": "0.0.32",
@@ -11328,11 +11327,6 @@
         "@types/glob": "*",
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/google-protobuf": {
-      "version": "3.7.2",
-      "integrity": "sha512-ifFemzjNchFBCtHS6bZNhSZCBu7tbtOe0e8qY0z2J4HtFXmPJjm6fXSaQsTG7yhShBEZtt2oP/bkwu5k+emlkQ==",
-      "dev": true
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
@@ -41097,11 +41091,6 @@
         "@types/glob": "*",
         "@types/node": "*"
       }
-    },
-    "@types/google-protobuf": {
-      "version": "3.7.2",
-      "integrity": "sha512-ifFemzjNchFBCtHS6bZNhSZCBu7tbtOe0e8qY0z2J4HtFXmPJjm6fXSaQsTG7yhShBEZtt2oP/bkwu5k+emlkQ==",
-      "dev": true
     },
     "@types/graceful-fs": {
       "version": "4.1.5",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1809,7 +1809,6 @@
     "@types/fs-extra": "^11.0.1",
     "@types/gulp": "^4.0.9",
     "@types/gulp-replace": "^1.1.0",
-    "@types/gulp-sourcemaps": "0.0.32",
     "@types/jest": "^29.0.2",
     "@types/js-yaml": "^3.12.5",
     "@types/jszip": "^3.1.6",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1818,7 +1818,6 @@
     "@types/react-dom": "^18.0.11",
     "@types/sarif": "^2.1.2",
     "@types/semver": "^7.2.0",
-    "@types/stream-chain": "^2.0.1",
     "@types/stream-json": "^1.7.1",
     "@types/styled-components": "^5.1.11",
     "@types/tar-stream": "^2.2.2",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1807,7 +1807,6 @@
     "@types/d3-graphviz": "^2.6.6",
     "@types/del": "^4.0.0",
     "@types/fs-extra": "^11.0.1",
-    "@types/google-protobuf": "^3.2.7",
     "@types/gulp": "^4.0.9",
     "@types/gulp-replace": "^1.1.0",
     "@types/gulp-sourcemaps": "0.0.32",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1756,7 +1756,6 @@
     "fs-extra": "^11.1.1",
     "immutable": "^4.0.0",
     "js-yaml": "^4.1.0",
-    "minimist": "^1.2.6",
     "msw": "^1.2.0",
     "nanoid": "^3.2.0",
     "node-fetch": "^2.6.7",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1811,7 +1811,6 @@
     "@types/gulp-replace": "^1.1.0",
     "@types/jest": "^29.0.2",
     "@types/js-yaml": "^3.12.5",
-    "@types/jszip": "^3.1.6",
     "@types/nanoid": "^3.0.0",
     "@types/node": "^16.11.25",
     "@types/node-fetch": "^2.5.2",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1765,7 +1765,6 @@
     "semver": "^7.5.2",
     "source-map": "^0.7.4",
     "source-map-support": "^0.5.21",
-    "stream-chain": "^2.2.4",
     "stream-json": "^1.7.3",
     "styled-components": "^6.0.2",
     "tmp": "^0.1.0",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1756,7 +1756,6 @@
     "fs-extra": "^11.1.1",
     "immutable": "^4.0.0",
     "js-yaml": "^4.1.0",
-    "minimatch": "^9.0.0",
     "minimist": "^1.2.6",
     "msw": "^1.2.0",
     "nanoid": "^3.2.0",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1765,7 +1765,6 @@
     "semver": "^7.5.2",
     "source-map": "^0.7.4",
     "source-map-support": "^0.5.21",
-    "stream": "^0.0.2",
     "stream-chain": "^2.2.4",
     "stream-json": "^1.7.3",
     "styled-components": "^6.0.2",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1872,7 +1872,6 @@
     "ts-json-schema-generator": "^1.1.2",
     "ts-loader": "^9.4.2",
     "ts-node": "^10.7.0",
-    "ts-protoc-gen": "^0.9.0",
     "ts-unused-exports": "^9.0.5",
     "typescript": "^5.0.2",
     "webpack": "^5.76.0",


### PR DESCRIPTION
I ran [depcheck](https://www.npmjs.com/package/depcheck) and then manually went through the results looking at which ones were genuinely unused. As far as I can tell, all of these are unused and can be removed.

After removing each dependency I ran `npm install` and `npm run build && npm run check-types`. I've also tried building and running the extension in development mode and installing from a file.

Of these:
- I'm fairly confident that the `@types` packages are correct. If any of these were used then the `check-types` script would fail.
- It may appear that `stream` is used from `cli.ts` and other files, but that is actually the built-in node.js stream implementation. The `stream` package is for providing the same implementation inside the browser/webviews, and we aren't using it in this context.
- I can't find any references to `minimatch`, `minimist`, `stream-chain`, or `ts-protoc-gen`.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
