### PR TITLE
Add support for automodel requests in the mock API server

### DIFF
--- a/extensions/ql-vscode/src/variant-analysis/gh-api/mocks/gh-api-request.ts
+++ b/extensions/ql-vscode/src/variant-analysis/gh-api/mocks/gh-api-request.ts
@@ -11,6 +11,7 @@ export enum RequestKind {
   GetVariantAnalysisRepo = "getVariantAnalysisRepo",
   GetVariantAnalysisRepoResult = "getVariantAnalysisRepoResult",
   CodeSearch = "codeSearch",
+  AutoModel = "autoModel",
 }
 
 interface BasicErorResponse {
@@ -87,13 +88,27 @@ interface CodeSearchRequest {
   };
 }
 
+interface AutoModelRequest {
+  request: {
+    kind: RequestKind.AutoModel;
+  };
+  response: {
+    status: number;
+    body?: {
+      candidates: string;
+    };
+    message?: string;
+  };
+}
+
 export type GitHubApiRequest =
   | GetRepoRequest
   | SubmitVariantAnalysisRequest
   | GetVariantAnalysisRequest
   | GetVariantAnalysisRepoRequest
   | GetVariantAnalysisRepoResultRequest
-  | CodeSearchRequest;
+  | CodeSearchRequest
+  | AutoModelRequest;
 
 export const isGetRepoRequest = (
   request: GitHubApiRequest,
@@ -123,3 +138,8 @@ export const isCodeSearchRequest = (
   request: GitHubApiRequest,
 ): request is CodeSearchRequest =>
   request.request.kind === RequestKind.CodeSearch;
+
+export const isAutoModelRequest = (
+  request: GitHubApiRequest,
+): request is AutoModelRequest =>
+  request.request.kind === RequestKind.AutoModel;

--- a/extensions/ql-vscode/src/variant-analysis/gh-api/mocks/recorder.ts
+++ b/extensions/ql-vscode/src/variant-analysis/gh-api/mocks/recorder.ts
@@ -259,6 +259,21 @@ async function createGitHubApiRequest(
     };
   }
 
+  const autoModelMatch = url.match(
+    /\/repos\/github\/codeql\/code-scanning\/codeql\/auto-model/,
+  );
+  if (autoModelMatch) {
+    return {
+      request: {
+        kind: RequestKind.AutoModel,
+      },
+      response: {
+        status,
+        body: JSON.parse(body),
+      },
+    };
+  }
+
   return undefined;
 }
 


### PR DESCRIPTION
This follows the same approach as other API requests we mock out.

Appreciate that the mock API server currently lives inside /variant-analysis. I'll create an internal issue to move it out.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
