### PR TITLE
Add in-progress UI state for modeling methods

### DIFF
--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -510,6 +510,11 @@ interface AddModeledMethodsMessage {
   modeledMethods: Record<string, ModeledMethod>;
 }
 
+interface SetInProgressMethodsMessage {
+  t: "setInProgressMethods";
+  inProgressMethods: string[];
+}
+
 interface SwitchModeMessage {
   t: "switchMode";
   mode: Mode;
@@ -556,7 +561,8 @@ export type ToDataExtensionsEditorMessage =
   | SetExtensionPackStateMessage
   | SetExternalApiUsagesMessage
   | LoadModeledMethodsMessage
-  | AddModeledMethodsMessage;
+  | AddModeledMethodsMessage
+  | SetInProgressMethodsMessage;
 
 export type FromDataExtensionsEditorMessage =
   | ViewLoadedMsg

--- a/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
@@ -91,6 +91,10 @@ export function DataExtensionsEditor({
     new Set(),
   );
 
+  const [inProgressSignatures, setInProgressSignatures] = useState<Set<string>>(
+    new Set(),
+  );
+
   const [hideModeledApis, setHideModeledApis] = useState(true);
 
   const [modeledMethods, setModeledMethods] = useState<
@@ -134,6 +138,9 @@ export function DataExtensionsEditor({
                   ...Object.keys(msg.modeledMethods),
                 ]),
             );
+            break;
+          case "setInProgressMethods":
+            setInProgressSignatures(new Set(msg.inProgressMethods));
             break;
           default:
             assertNever(msg);
@@ -330,6 +337,7 @@ export function DataExtensionsEditor({
           externalApiUsages={externalApiUsages}
           modeledMethods={modeledMethods}
           modifiedSignatures={modifiedSignatures}
+          inProgressSignatures={inProgressSignatures}
           viewState={viewState}
           hideModeledApis={hideModeledApis}
           onChange={onChange}

--- a/extensions/ql-vscode/src/view/data-extensions-editor/InProgressDropdown.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/InProgressDropdown.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+import { Dropdown } from "../common/Dropdown";
+
+export const InProgressDropdown = () => {
+  const options: Array<{ label: string; value: string }> = [
+    {
+      label: "Thinking...",
+      value: "Thinking...",
+    },
+  ];
+  const noop = () => {
+    // Do nothing
+  };
+
+  return (
+    <Dropdown
+      value="Thinking..."
+      options={options}
+      disabled={false}
+      onChange={noop}
+    />
+  );
+};

--- a/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
@@ -72,6 +72,7 @@ type Props = {
   externalApiUsages: ExternalApiUsage[];
   modeledMethods: Record<string, ModeledMethod>;
   modifiedSignatures: Set<string>;
+  inProgressSignatures: Set<string>;
   viewState: DataExtensionEditorViewState;
   hideModeledApis: boolean;
   onChange: (
@@ -97,6 +98,7 @@ export const LibraryRow = ({
   externalApiUsages,
   modeledMethods,
   modifiedSignatures,
+  inProgressSignatures,
   viewState,
   hideModeledApis,
   onChange,
@@ -209,6 +211,7 @@ export const LibraryRow = ({
             externalApiUsages={externalApiUsages}
             modeledMethods={modeledMethods}
             modifiedSignatures={modifiedSignatures}
+            inProgressSignatures={inProgressSignatures}
             mode={viewState.mode}
             hideModeledApis={hideModeledApis}
             onChange={onChangeWithModelName}

--- a/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/MethodRow.tsx
@@ -2,6 +2,7 @@ import {
   VSCodeDataGridCell,
   VSCodeDataGridRow,
   VSCodeLink,
+  VSCodeProgressRing,
 } from "@vscode/webview-ui-toolkit/react";
 import * as React from "react";
 import { ChangeEvent, useCallback, useMemo } from "react";
@@ -23,6 +24,7 @@ import {
   ModelingStatus,
   ModelingStatusIndicator,
 } from "./ModelingStatusIndicator";
+import { InProgressDropdown } from "./InProgressDropdown";
 
 const ApiOrMethodCell = styled(VSCodeDataGridCell)`
   display: flex;
@@ -43,6 +45,12 @@ const ViewLink = styled(VSCodeLink)`
   white-space: nowrap;
 `;
 
+const ProgressRing = styled(VSCodeProgressRing)`
+  width: 16px;
+  height: 16px;
+  margin-left: auto;
+`;
+
 const modelTypeOptions: Array<{ value: ModeledMethodType; label: string }> = [
   { value: "none", label: "Unmodeled" },
   { value: "source", label: "Source" },
@@ -55,6 +63,7 @@ type Props = {
   externalApiUsage: ExternalApiUsage;
   modeledMethod: ModeledMethod | undefined;
   methodIsUnsaved: boolean;
+  modelingInProgress: boolean;
   mode: Mode;
   hideModeledApis: boolean;
   onChange: (
@@ -216,38 +225,59 @@ function ModelableMethodRow(props: Props) {
           </UsagesButton>
         )}
         <ViewLink onClick={jumpToUsage}>View</ViewLink>
+        {props.modelingInProgress && <ProgressRing />}
       </ApiOrMethodCell>
-      <VSCodeDataGridCell gridColumn={2}>
-        <Dropdown
-          value={modeledMethod?.type ?? "none"}
-          options={modelTypeOptions}
-          onChange={handleTypeInput}
-        />
-      </VSCodeDataGridCell>
-      <VSCodeDataGridCell gridColumn={3}>
-        <Dropdown
-          value={modeledMethod?.input}
-          options={inputOptions}
-          disabled={!showInputCell}
-          onChange={handleInputInput}
-        />
-      </VSCodeDataGridCell>
-      <VSCodeDataGridCell gridColumn={4}>
-        <Dropdown
-          value={modeledMethod?.output}
-          options={outputOptions}
-          disabled={!showOutputCell}
-          onChange={handleOutputInput}
-        />
-      </VSCodeDataGridCell>
-      <VSCodeDataGridCell gridColumn={5}>
-        <KindInput
-          kinds={predicate?.supportedKinds || []}
-          value={modeledMethod?.kind}
-          disabled={!showKindCell}
-          onChange={handleKindChange}
-        />
-      </VSCodeDataGridCell>
+      {props.modelingInProgress && (
+        <>
+          <VSCodeDataGridCell gridColumn={2}>
+            <InProgressDropdown />
+          </VSCodeDataGridCell>
+          <VSCodeDataGridCell gridColumn={3}>
+            <InProgressDropdown />
+          </VSCodeDataGridCell>
+          <VSCodeDataGridCell gridColumn={4}>
+            <InProgressDropdown />
+          </VSCodeDataGridCell>
+          <VSCodeDataGridCell gridColumn={5}>
+            <InProgressDropdown />
+          </VSCodeDataGridCell>
+        </>
+      )}
+      {!props.modelingInProgress && (
+        <>
+          <VSCodeDataGridCell gridColumn={2}>
+            <Dropdown
+              value={modeledMethod?.type ?? "none"}
+              options={modelTypeOptions}
+              onChange={handleTypeInput}
+            />
+          </VSCodeDataGridCell>
+          <VSCodeDataGridCell gridColumn={3}>
+            <Dropdown
+              value={modeledMethod?.input}
+              options={inputOptions}
+              disabled={!showInputCell}
+              onChange={handleInputInput}
+            />
+          </VSCodeDataGridCell>
+          <VSCodeDataGridCell gridColumn={4}>
+            <Dropdown
+              value={modeledMethod?.output}
+              options={outputOptions}
+              disabled={!showOutputCell}
+              onChange={handleOutputInput}
+            />
+          </VSCodeDataGridCell>
+          <VSCodeDataGridCell gridColumn={5}>
+            <KindInput
+              kinds={predicate?.supportedKinds || []}
+              value={modeledMethod?.kind}
+              disabled={!showKindCell}
+              onChange={handleKindChange}
+            />
+          </VSCodeDataGridCell>
+        </>
+      )}
     </VSCodeDataGridRow>
   );
 }

--- a/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodDataGrid.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodDataGrid.tsx
@@ -15,6 +15,7 @@ type Props = {
   externalApiUsages: ExternalApiUsage[];
   modeledMethods: Record<string, ModeledMethod>;
   modifiedSignatures: Set<string>;
+  inProgressSignatures: Set<string>;
   mode: Mode;
   hideModeledApis: boolean;
   onChange: (
@@ -27,6 +28,7 @@ export const ModeledMethodDataGrid = ({
   externalApiUsages,
   modeledMethods,
   modifiedSignatures,
+  inProgressSignatures,
   mode,
   hideModeledApis,
   onChange,
@@ -37,7 +39,7 @@ export const ModeledMethodDataGrid = ({
   );
 
   return (
-    <VSCodeDataGrid gridTemplateColumns="0.5fr 0.125fr 0.125fr 0.125fr 0.125fr">
+    <VSCodeDataGrid gridTemplateColumns="0.5fr 0.125fr 0.125fr 0.125fr 0.125fr 0.125fr">
       <VSCodeDataGridRow rowType="header">
         <VSCodeDataGridCell cellType="columnheader" gridColumn={1}>
           API or method
@@ -61,6 +63,9 @@ export const ModeledMethodDataGrid = ({
           externalApiUsage={externalApiUsage}
           modeledMethod={modeledMethods[externalApiUsage.signature]}
           methodIsUnsaved={modifiedSignatures.has(externalApiUsage.signature)}
+          modelingInProgress={inProgressSignatures.has(
+            externalApiUsage.signature,
+          )}
           mode={mode}
           hideModeledApis={hideModeledApis}
           onChange={onChange}

--- a/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodsList.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodsList.tsx
@@ -14,6 +14,7 @@ type Props = {
   externalApiUsages: ExternalApiUsage[];
   modeledMethods: Record<string, ModeledMethod>;
   modifiedSignatures: Set<string>;
+  inProgressSignatures: Set<string>;
   viewState: DataExtensionEditorViewState;
   hideModeledApis: boolean;
   onChange: (
@@ -41,6 +42,7 @@ export const ModeledMethodsList = ({
   externalApiUsages,
   modeledMethods,
   modifiedSignatures,
+  inProgressSignatures,
   viewState,
   hideModeledApis,
   onChange,
@@ -84,6 +86,7 @@ export const ModeledMethodsList = ({
           externalApiUsages={grouped[libraryName]}
           modeledMethods={modeledMethods}
           modifiedSignatures={modifiedSignatures}
+          inProgressSignatures={inProgressSignatures}
           viewState={viewState}
           hideModeledApis={hideModeledApis}
           onChange={onChange}


### PR DESCRIPTION
Add the ability to mark methods as being "in progress" for modeling. This will be used for the AI modeling flows. The exact UX is still TBD, but some initial mock-ups show a progress ring and drop-downs being replaced with "Thinking...".

I followed the same approach as the one we use to track modified methods which unfortunately has a bit of prop drilling but I don't think it's too bad and we can improve that separately if we like.

Note that this new state and view message is not used yet - it'll be plugged in in a later PR. It can be seen in action using the storybook.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
