### PR TITLE
Populate details panel with external API usages

### DIFF
--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-module.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-module.ts
@@ -22,11 +22,13 @@ import { isQueryLanguage } from "../common/query-language";
 import { setUpPack } from "./external-api-usage-query";
 import { DisposableObject } from "../common/disposable-object";
 import { ModelDetailsPanel } from "./model-details/model-details-panel";
+import { Mode } from "./shared/mode";
 
 const SUPPORTED_LANGUAGES: string[] = ["java", "csharp"];
 
 export class DataExtensionsEditorModule extends DisposableObject {
   private readonly queryStorageDir: string;
+  private readonly modelDetailsPanel: ModelDetailsPanel;
 
   private constructor(
     private readonly ctx: ExtensionContext,
@@ -41,7 +43,7 @@ export class DataExtensionsEditorModule extends DisposableObject {
       baseQueryStorageDir,
       "data-extensions-editor-results",
     );
-    this.push(new ModelDetailsPanel());
+    this.modelDetailsPanel = this.push(new ModelDetailsPanel());
   }
 
   public static async initialize(
@@ -142,6 +144,8 @@ export class DataExtensionsEditorModule extends DisposableObject {
               queryDir,
               db,
               modelFile,
+              Mode.Application,
+              (usages) => this.modelDetailsPanel.setExternalApiUsages(usages),
             );
             await view.openView();
           },

--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-module.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-module.ts
@@ -20,10 +20,12 @@ import { redactableError } from "../common/errors";
 import { extLogger } from "../common/logging/vscode";
 import { isQueryLanguage } from "../common/query-language";
 import { setUpPack } from "./external-api-usage-query";
+import { DisposableObject } from "../common/disposable-object";
+import { ModelDetailsPanel } from "./model-details/model-details-panel";
 
 const SUPPORTED_LANGUAGES: string[] = ["java", "csharp"];
 
-export class DataExtensionsEditorModule {
+export class DataExtensionsEditorModule extends DisposableObject {
   private readonly queryStorageDir: string;
 
   private constructor(
@@ -34,10 +36,12 @@ export class DataExtensionsEditorModule {
     private readonly queryRunner: QueryRunner,
     baseQueryStorageDir: string,
   ) {
+    super();
     this.queryStorageDir = join(
       baseQueryStorageDir,
       "data-extensions-editor-results",
     );
+    this.push(new ModelDetailsPanel());
   }
 
   public static async initialize(

--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
@@ -76,7 +76,10 @@ export class DataExtensionsEditorView extends AbstractWebview<
     private readonly queryDir: string,
     private readonly databaseItem: DatabaseItem,
     private readonly extensionPack: ExtensionPack,
-    private mode: Mode = Mode.Application,
+    private mode: Mode,
+    private readonly onExternalApiUsagesChanged: (
+      externalApiUsages: ExternalApiUsage[],
+    ) => void,
   ) {
     super(ctx);
   }
@@ -307,6 +310,7 @@ export class DataExtensionsEditorView extends AbstractWebview<
             t: "setExternalApiUsages",
             externalApiUsages,
           });
+          this.onExternalApiUsagesChanged(externalApiUsages);
         } catch (err) {
           void showAndLogExceptionWithTelemetry(
             this.app.logger,
@@ -588,6 +592,7 @@ export class DataExtensionsEditorView extends AbstractWebview<
         addedDatabase,
         modelFile,
         Mode.Framework,
+        this.onExternalApiUsagesChanged,
       );
       await view.openView();
     });

--- a/extensions/ql-vscode/src/data-extensions-editor/external-api-usage.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/external-api-usage.ts
@@ -13,7 +13,7 @@ export enum CallClassification {
   Generated = "generated",
 }
 
-type Usage = Call & {
+export type Usage = Call & {
   classification: CallClassification;
 };
 

--- a/extensions/ql-vscode/src/data-extensions-editor/model-details/model-details-data-provider.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/model-details/model-details-data-provider.ts
@@ -1,0 +1,17 @@
+import { TreeDataProvider, TreeItem } from "vscode";
+import { DisposableObject } from "../../common/disposable-object";
+
+export class ModelDetailsDataProvider
+  extends DisposableObject
+  implements TreeDataProvider<ModelDetailsTreeViewItem>
+{
+  getTreeItem(): TreeItem {
+    throw new Error("Method not implemented.");
+  }
+
+  getChildren(): ModelDetailsTreeViewItem[] {
+    return [];
+  }
+}
+
+interface ModelDetailsTreeViewItem {}

--- a/extensions/ql-vscode/src/data-extensions-editor/model-details/model-details-data-provider.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/model-details/model-details-data-provider.ts
@@ -1,17 +1,61 @@
-import { TreeDataProvider, TreeItem } from "vscode";
+import {
+  Event,
+  EventEmitter,
+  TreeDataProvider,
+  TreeItem,
+  TreeItemCollapsibleState,
+} from "vscode";
 import { DisposableObject } from "../../common/disposable-object";
+import { ExternalApiUsage, Usage } from "../external-api-usage";
 
 export class ModelDetailsDataProvider
   extends DisposableObject
   implements TreeDataProvider<ModelDetailsTreeViewItem>
 {
-  getTreeItem(): TreeItem {
-    throw new Error("Method not implemented.");
+  private externalApiUsages: ExternalApiUsage[] = [];
+
+  private readonly onDidChangeTreeDataEmitter = this.push(
+    new EventEmitter<void>(),
+  );
+
+  public get onDidChangeTreeData(): Event<void> {
+    return this.onDidChangeTreeDataEmitter.event;
   }
 
-  getChildren(): ModelDetailsTreeViewItem[] {
-    return [];
+  public setExternalApiUsages(externalApiUsages: ExternalApiUsage[]): void {
+    this.externalApiUsages = externalApiUsages;
+    this.onDidChangeTreeDataEmitter.fire();
+  }
+
+  getTreeItem(item: ModelDetailsTreeViewItem): TreeItem {
+    if (isExternalApiUsage(item)) {
+      return {
+        label: item.signature,
+        collapsibleState: TreeItemCollapsibleState.Collapsed,
+      };
+    } else {
+      return {
+        label: item.label,
+        collapsibleState: TreeItemCollapsibleState.None,
+      };
+    }
+  }
+
+  getChildren(item?: ModelDetailsTreeViewItem): ModelDetailsTreeViewItem[] {
+    if (item === undefined) {
+      return this.externalApiUsages;
+    } else if (isExternalApiUsage(item)) {
+      return item.usages;
+    } else {
+      return [];
+    }
   }
 }
 
-interface ModelDetailsTreeViewItem {}
+type ModelDetailsTreeViewItem = ExternalApiUsage | Usage;
+
+function isExternalApiUsage(
+  item: ModelDetailsTreeViewItem,
+): item is ExternalApiUsage {
+  return (item as any).usages !== undefined;
+}

--- a/extensions/ql-vscode/src/data-extensions-editor/model-details/model-details-panel.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/model-details/model-details-panel.ts
@@ -1,0 +1,16 @@
+import { window } from "vscode";
+import { DisposableObject } from "../../common/disposable-object";
+import { ModelDetailsDataProvider } from "./model-details-data-provider";
+
+export class ModelDetailsPanel extends DisposableObject {
+  public constructor() {
+    super();
+
+    const dataProvider = new ModelDetailsDataProvider();
+
+    const treeView = window.createTreeView("codeQLModelDetails", {
+      treeDataProvider: dataProvider,
+    });
+    this.push(treeView);
+  }
+}

--- a/extensions/ql-vscode/src/data-extensions-editor/model-details/model-details-panel.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/model-details/model-details-panel.ts
@@ -1,16 +1,23 @@
 import { window } from "vscode";
 import { DisposableObject } from "../../common/disposable-object";
 import { ModelDetailsDataProvider } from "./model-details-data-provider";
+import { ExternalApiUsage } from "../external-api-usage";
 
 export class ModelDetailsPanel extends DisposableObject {
+  private readonly dataProvider: ModelDetailsDataProvider;
+
   public constructor() {
     super();
 
-    const dataProvider = new ModelDetailsDataProvider();
+    this.dataProvider = new ModelDetailsDataProvider();
 
     const treeView = window.createTreeView("codeQLModelDetails", {
-      treeDataProvider: dataProvider,
+      treeDataProvider: this.dataProvider,
     });
     this.push(treeView);
+  }
+
+  public setExternalApiUsages(externalApiUsages: ExternalApiUsage[]): void {
+    this.dataProvider.setExternalApiUsages(externalApiUsages);
   }
 }


### PR DESCRIPTION
This PR adds `ModelDetailsPanel` and `ModelDetailsDataProvider`, and populates the tree view with data whenever new external API usages are calculated.

<img width="1360" alt="Screenshot 2023-08-08 at 10 56 00" src="https://github.com/github/vscode-codeql/assets/3749000/3e89e619-a428-42a7-b9bd-211a9afdbdbf">

This isn't perfect, but everything is hidden behind a feature flag so I think this is a suitable step in the right direction. There are still lots of changes to make, which we'll do in future PRs. For example:
- Handling when there are multiple data extensions editor windows open at once.
- Making sure data is always updated when new external API usages are calculated.
- Styling of the details panel, with icons and better labels.
- Jumping to definition when clicking an item.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
