### PR TITLE
Implementing jumping to location when clicking on a usage in the details panel

### DIFF
--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -12,6 +12,7 @@ import type {
 } from "../variant-analysis/shared/variant-analysis";
 import type { QLDebugConfiguration } from "../debugger/debug-configuration";
 import type { QueryTreeViewItem } from "../queries-panel/query-tree-view-item";
+import type { Usage } from "../data-extensions-editor/external-api-usage";
 
 // A command function matching the signature that VS Code calls when
 // a command is invoked from a context menu on a TreeView with
@@ -304,6 +305,10 @@ export type PackagingCommands = {
 
 export type DataExtensionsEditorCommands = {
   "codeQL.openDataExtensionsEditor": () => Promise<void>;
+  "codeQLDataExtensions.jumpToUsageLocation": (
+    usage: Usage,
+    databaseItem: DatabaseItem,
+  ) => Promise<void>;
 };
 
 export type EvalLogViewerCommands = {

--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -305,7 +305,7 @@ export type PackagingCommands = {
 
 export type DataExtensionsEditorCommands = {
   "codeQL.openDataExtensionsEditor": () => Promise<void>;
-  "codeQLDataExtensions.jumpToUsageLocation": (
+  "codeQLDataExtensionsEditor.jumpToUsageLocation": (
     usage: Usage,
     databaseItem: DatabaseItem,
   ) => Promise<void>;

--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-module.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-module.ts
@@ -147,7 +147,7 @@ export class DataExtensionsEditorModule extends DisposableObject {
               db,
               modelFile,
               Mode.Application,
-              (usages) => this.modelDetailsPanel.setExternalApiUsages(usages),
+              this.modelDetailsPanel.setState.bind(this.modelDetailsPanel),
             );
             await view.openView();
           },

--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-module.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-module.ts
@@ -156,7 +156,7 @@ export class DataExtensionsEditorModule extends DisposableObject {
           },
         );
       },
-      "codeQLDataExtensions.jumpToUsageLocation": async (
+      "codeQLDataExtensionsEditor.jumpToUsageLocation": async (
         usage: Usage,
         databaseItem: DatabaseItem,
       ) => {

--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-module.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-module.ts
@@ -3,7 +3,7 @@ import { DataExtensionsEditorView } from "./data-extensions-editor-view";
 import { DataExtensionsEditorCommands } from "../common/commands";
 import { CliVersionConstraint, CodeQLCliServer } from "../codeql-cli/cli";
 import { QueryRunner } from "../query-server";
-import { DatabaseManager } from "../databases/local-databases";
+import { DatabaseItem, DatabaseManager } from "../databases/local-databases";
 import { ensureDir } from "fs-extra";
 import { join } from "path";
 import { App } from "../common/app";
@@ -23,6 +23,8 @@ import { setUpPack } from "./external-api-usage-query";
 import { DisposableObject } from "../common/disposable-object";
 import { ModelDetailsPanel } from "./model-details/model-details-panel";
 import { Mode } from "./shared/mode";
+import { showResolvableLocation } from "../databases/local-databases/locations";
+import { Usage } from "./external-api-usage";
 
 const SUPPORTED_LANGUAGES: string[] = ["java", "csharp"];
 
@@ -153,6 +155,12 @@ export class DataExtensionsEditorModule extends DisposableObject {
             title: "Opening Data Extensions Editor",
           },
         );
+      },
+      "codeQLDataExtensions.jumpToUsageLocation": async (
+        usage: Usage,
+        databaseItem: DatabaseItem,
+      ) => {
+        await showResolvableLocation(usage.url, databaseItem, this.app.logger);
       },
     };
   }

--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
@@ -77,8 +77,9 @@ export class DataExtensionsEditorView extends AbstractWebview<
     private readonly databaseItem: DatabaseItem,
     private readonly extensionPack: ExtensionPack,
     private mode: Mode,
-    private readonly onExternalApiUsagesChanged: (
+    private readonly updateModelDetailsPanelState: (
       externalApiUsages: ExternalApiUsage[],
+      databaseItem: DatabaseItem,
     ) => void,
   ) {
     super(ctx);
@@ -296,7 +297,10 @@ export class DataExtensionsEditorView extends AbstractWebview<
             t: "setExternalApiUsages",
             externalApiUsages,
           });
-          this.onExternalApiUsagesChanged(externalApiUsages);
+          this.updateModelDetailsPanelState(
+            externalApiUsages,
+            this.databaseItem,
+          );
         } catch (err) {
           void showAndLogExceptionWithTelemetry(
             this.app.logger,
@@ -578,7 +582,7 @@ export class DataExtensionsEditorView extends AbstractWebview<
         addedDatabase,
         modelFile,
         Mode.Framework,
-        this.onExternalApiUsagesChanged,
+        this.updateModelDetailsPanelState,
       );
       await view.openView();
     });

--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
@@ -230,21 +230,7 @@ export class DataExtensionsEditorView extends AbstractWebview<
   protected async jumpToUsage(
     location: ResolvableLocationValue,
   ): Promise<void> {
-    try {
-      await showResolvableLocation(location, this.databaseItem);
-    } catch (e) {
-      if (e instanceof Error) {
-        if (e.message.match(/File not found/)) {
-          void window.showErrorMessage(
-            "Original file of this result is not in the database's source archive.",
-          );
-        } else {
-          void this.app.logger.log(`Unable to handleMsgFromView: ${e.message}`);
-        }
-      } else {
-        void this.app.logger.log(`Unable to handleMsgFromView: ${e}`);
-      }
-    }
+    await showResolvableLocation(location, this.databaseItem, this.app.logger);
   }
 
   protected async loadExistingModeledMethods(): Promise<void> {

--- a/extensions/ql-vscode/src/data-extensions-editor/model-details/model-details-data-provider.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/model-details/model-details-data-provider.ts
@@ -7,12 +7,14 @@ import {
 } from "vscode";
 import { DisposableObject } from "../../common/disposable-object";
 import { ExternalApiUsage, Usage } from "../external-api-usage";
+import { DatabaseItem } from "../../databases/local-databases";
 
 export class ModelDetailsDataProvider
   extends DisposableObject
   implements TreeDataProvider<ModelDetailsTreeViewItem>
 {
   private externalApiUsages: ExternalApiUsage[] = [];
+  private databaseItem: DatabaseItem | undefined = undefined;
 
   private readonly onDidChangeTreeDataEmitter = this.push(
     new EventEmitter<void>(),
@@ -22,8 +24,12 @@ export class ModelDetailsDataProvider
     return this.onDidChangeTreeDataEmitter.event;
   }
 
-  public setExternalApiUsages(externalApiUsages: ExternalApiUsage[]): void {
+  public setState(
+    externalApiUsages: ExternalApiUsage[],
+    databaseItem: DatabaseItem,
+  ): void {
     this.externalApiUsages = externalApiUsages;
+    this.databaseItem = databaseItem;
     this.onDidChangeTreeDataEmitter.fire();
   }
 

--- a/extensions/ql-vscode/src/data-extensions-editor/model-details/model-details-data-provider.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/model-details/model-details-data-provider.ts
@@ -43,6 +43,11 @@ export class ModelDetailsDataProvider
       return {
         label: item.label,
         collapsibleState: TreeItemCollapsibleState.None,
+        command: {
+          title: "Show usage",
+          command: "codeQLDataExtensions.jumpToUsageLocation",
+          arguments: [item, this.databaseItem],
+        },
       };
     }
   }

--- a/extensions/ql-vscode/src/data-extensions-editor/model-details/model-details-data-provider.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/model-details/model-details-data-provider.ts
@@ -45,7 +45,7 @@ export class ModelDetailsDataProvider
         collapsibleState: TreeItemCollapsibleState.None,
         command: {
           title: "Show usage",
-          command: "codeQLDataExtensions.jumpToUsageLocation",
+          command: "codeQLDataExtensionsEditor.jumpToUsageLocation",
           arguments: [item, this.databaseItem],
         },
       };

--- a/extensions/ql-vscode/src/data-extensions-editor/model-details/model-details-panel.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/model-details/model-details-panel.ts
@@ -2,6 +2,7 @@ import { window } from "vscode";
 import { DisposableObject } from "../../common/disposable-object";
 import { ModelDetailsDataProvider } from "./model-details-data-provider";
 import { ExternalApiUsage } from "../external-api-usage";
+import { DatabaseItem } from "../../databases/local-databases";
 
 export class ModelDetailsPanel extends DisposableObject {
   private readonly dataProvider: ModelDetailsDataProvider;
@@ -17,7 +18,10 @@ export class ModelDetailsPanel extends DisposableObject {
     this.push(treeView);
   }
 
-  public setExternalApiUsages(externalApiUsages: ExternalApiUsage[]): void {
-    this.dataProvider.setExternalApiUsages(externalApiUsages);
+  public setState(
+    externalApiUsages: ExternalApiUsage[],
+    databaseItem: DatabaseItem,
+  ): void {
+    this.dataProvider.setState(externalApiUsages, databaseItem);
   }
 }

--- a/extensions/ql-vscode/src/databases/local-databases/locations.ts
+++ b/extensions/ql-vscode/src/databases/local-databases/locations.ts
@@ -97,8 +97,19 @@ export function tryResolveLocation(
 export async function showResolvableLocation(
   loc: ResolvableLocationValue,
   databaseItem: DatabaseItem,
+  logger: Logger,
 ): Promise<void> {
-  await showLocation(tryResolveLocation(loc, databaseItem));
+  try {
+    await showLocation(tryResolveLocation(loc, databaseItem));
+  } catch (e) {
+    if (e instanceof Error && e.message.match(/File not found/)) {
+      void Window.showErrorMessage(
+        "Original file of this result is not in the database's source archive.",
+      );
+    } else {
+      void logger.log(`Unable to jump to location: ${getErrorMessage(e)}`);
+    }
+  }
 }
 
 export async function showLocation(location?: Location) {
@@ -146,16 +157,6 @@ export async function jumpToLocation(
 ) {
   const databaseItem = databaseManager.findDatabaseItem(Uri.parse(databaseUri));
   if (databaseItem !== undefined) {
-    try {
-      await showResolvableLocation(loc, databaseItem);
-    } catch (e) {
-      if (e instanceof Error && e.message.match(/File not found/)) {
-        void Window.showErrorMessage(
-          "Original file of this result is not in the database's source archive.",
-        );
-      } else {
-        void logger.log(`Unable to jump to location: ${getErrorMessage(e)}`);
-      }
-    }
+    await showResolvableLocation(loc, databaseItem, logger);
   }
 }

--- a/extensions/ql-vscode/test/unit-tests/command-lint.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/command-lint.test.ts
@@ -45,7 +45,7 @@ describe("commands declared in package.json", () => {
       command.match(/^codeQLAstViewer\./) ||
       command.match(/^codeQLEvalLogViewer\./) ||
       command.match(/^codeQLTests\./) ||
-      command.match(/^codeQLDataExtensions\./)
+      command.match(/^codeQLDataExtensionsEditor\./)
     ) {
       scopedCmds.add(command);
       expect(title).toBeDefined();

--- a/extensions/ql-vscode/test/unit-tests/command-lint.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/command-lint.test.ts
@@ -44,7 +44,8 @@ describe("commands declared in package.json", () => {
       command.match(/^codeQLQueryHistory\./) ||
       command.match(/^codeQLAstViewer\./) ||
       command.match(/^codeQLEvalLogViewer\./) ||
-      command.match(/^codeQLTests\./)
+      command.match(/^codeQLTests\./) ||
+      command.match(/^codeQLDataExtensions\./)
     ) {
       scopedCmds.add(command);
       expect(title).toBeDefined();


### PR DESCRIPTION
The feature being implemented here is that you can click on an entry in the CodeQL model details panel and it'll open that code location in the main editor. This doesn't implement selecting the correct usage when clicking on the "view" button and that will be a different PR.

I've implemented this using a new `codeQLDataExtensions.jumpToUsageLocation` command. I did first try out using `vscode.open` and passing it a URI, but sadly I don't believe we can use that. Instead we can call the existing `showResolvableLocation` method, but making that work involves a few steps:
- We'd like some error handling, and we currently already perform this same error handling in two places. I move the error handling to be inside `showResolvableLocation` so we avoid duplication.
- We need the `DatabaseItem` to be able to resolve the code location to a file that can be displayed in the editor. This means that we need to pass the database item to the `ModelDetailsDataProvider` class along with the `ExternalApiUsage[]` array. I think it makes sense to set these together because you need both to be in sync in order to resolve locations correctly.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
