### PR TITLE
Pass dependency name around when automodeling

### DIFF
--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -549,6 +549,7 @@ interface GenerateExternalApiMessage {
 
 interface GenerateExternalApiFromLlmMessage {
   t: "generateExternalApiFromLlm";
+  dependencyName: string;
   externalApiUsages: ExternalApiUsage[];
   modeledMethods: Record<string, ModeledMethod>;
 }

--- a/extensions/ql-vscode/src/data-extensions-editor/auto-modeler.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/auto-modeler.ts
@@ -29,18 +29,26 @@ export class AutoModeler {
   ) {}
 
   public async startModeling(
+    dependency: string,
     externalApiUsages: ExternalApiUsage[],
     modeledMethods: Record<string, ModeledMethod>,
     mode: Mode,
   ): Promise<void> {
-    await this.modelDependency(externalApiUsages, modeledMethods, mode);
+    await this.modelDependency(
+      dependency,
+      externalApiUsages,
+      modeledMethods,
+      mode,
+    );
   }
 
   private async modelDependency(
+    dependency: string,
     externalApiUsages: ExternalApiUsage[],
     modeledMethods: Record<string, ModeledMethod>,
     mode: Mode,
   ): Promise<void> {
+    void extLogger.log(`Modeling dependency ${dependency}`);
     await withProgress(async (progress) => {
       const maxStep = 3000;
 

--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
@@ -170,6 +170,7 @@ export class DataExtensionsEditorView extends AbstractWebview<
       case "generateExternalApiFromLlm":
         if (useLlmGenerationV2()) {
           await this.generateModeledMethodsFromLlmV2(
+            msg.dependencyName,
             msg.externalApiUsages,
             msg.modeledMethods,
           );
@@ -459,10 +460,12 @@ export class DataExtensionsEditorView extends AbstractWebview<
   }
 
   private async generateModeledMethodsFromLlmV2(
+    dependency: string,
     externalApiUsages: ExternalApiUsage[],
     modeledMethods: Record<string, ModeledMethod>,
   ): Promise<void> {
     await this.autoModeler.startModeling(
+      dependency,
       externalApiUsages,
       modeledMethods,
       this.mode,

--- a/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
@@ -227,11 +227,13 @@ export function DataExtensionsEditor({
 
   const onGenerateFromLlmClick = useCallback(
     (
+      dependencyName: string,
       externalApiUsages: ExternalApiUsage[],
       modeledMethods: Record<string, ModeledMethod>,
     ) => {
       vscode.postMessage({
         t: "generateExternalApiFromLlm",
+        dependencyName,
         externalApiUsages,
         modeledMethods,
       });

--- a/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
@@ -85,6 +85,7 @@ type Props = {
     modeledMethods: Record<string, ModeledMethod>,
   ) => void;
   onGenerateFromLlmClick: (
+    dependencyName: string,
     externalApiUsages: ExternalApiUsage[],
     modeledMethods: Record<string, ModeledMethod>,
   ) => void;
@@ -119,11 +120,11 @@ export const LibraryRow = ({
 
   const handleModelWithAI = useCallback(
     async (e: React.MouseEvent) => {
-      onGenerateFromLlmClick(externalApiUsages, modeledMethods);
+      onGenerateFromLlmClick(title, externalApiUsages, modeledMethods);
       e.stopPropagation();
       e.preventDefault();
     },
-    [externalApiUsages, modeledMethods, onGenerateFromLlmClick],
+    [title, externalApiUsages, modeledMethods, onGenerateFromLlmClick],
   );
 
   const handleModelFromSource = useCallback(

--- a/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodsList.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodsList.tsx
@@ -27,6 +27,7 @@ type Props = {
     modeledMethods: Record<string, ModeledMethod>,
   ) => void;
   onGenerateFromLlmClick: (
+    dependencyName: string,
     externalApiUsages: ExternalApiUsage[],
     modeledMethods: Record<string, ModeledMethod>,
   ) => void;


### PR DESCRIPTION
We will need the dependency name in order to manage automodeling jobs so this is a quick PR to make sure it's available.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
