### PR TITLE
Batch automodeling

### DIFF
--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -554,6 +554,11 @@ interface GenerateExternalApiFromLlmMessage {
   modeledMethods: Record<string, ModeledMethod>;
 }
 
+interface StopGeneratingExternalApiFromLlmMessage {
+  t: "stopGeneratingExternalApiFromLlm";
+  dependencyName: string;
+}
+
 interface ModelDependencyMessage {
   t: "modelDependency";
 }
@@ -575,4 +580,5 @@ export type FromDataExtensionsEditorMessage =
   | SaveModeledMethods
   | GenerateExternalApiMessage
   | GenerateExternalApiFromLlmMessage
+  | StopGeneratingExternalApiFromLlmMessage
   | ModelDependencyMessage;

--- a/extensions/ql-vscode/src/data-extensions-editor/auto-model-codeml-queries.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/auto-model-codeml-queries.ts
@@ -160,6 +160,7 @@ type AutoModelQueriesOptions = {
   queryStorageDir: string;
 
   progress: ProgressCallback;
+  cancellationTokenSource: CancellationTokenSource;
 };
 
 export type AutoModelQueriesResult = {
@@ -174,11 +175,10 @@ export async function runAutoModelQueries({
   databaseItem,
   queryStorageDir,
   progress,
+  cancellationTokenSource,
 }: AutoModelQueriesOptions): Promise<AutoModelQueriesResult | undefined> {
   // maxStep for this part is 1500
   const maxStep = 1500;
-
-  const cancellationTokenSource = new CancellationTokenSource();
 
   const qlpack = await qlpackOfDatabase(cliServer, databaseItem);
 

--- a/extensions/ql-vscode/src/data-extensions-editor/auto-model-v2.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/auto-model-v2.ts
@@ -8,9 +8,6 @@ import { ExternalApiUsage, MethodSignature } from "./external-api-usage";
 import { ModeledMethod } from "./modeled-method";
 import { groupMethods, sortGroupNames, sortMethods } from "./shared/sorting";
 
-// Soft limit on the number of candidates to send to the model.
-// Note that the model may return fewer than this number of candidates.
-const candidateLimit = 20;
 /**
  * Return the candidates that the model should be run on. This includes limiting the number of
  * candidates to the candidate limit and filtering out anything that is already modeled and respecting
@@ -40,11 +37,6 @@ export function getCandidates(
     ] ?? {
       type: "none",
     };
-
-    // If we have reached the max number of candidates then stop
-    if (candidates.length >= candidateLimit) {
-      break;
-    }
 
     // Anything that is modeled is not a candidate
     if (modeledMethod.type !== "none") {

--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
@@ -187,6 +187,9 @@ export class DataExtensionsEditorView extends AbstractWebview<
           );
         }
         break;
+      case "stopGeneratingExternalApiFromLlm":
+        await this.autoModeler.stopModeling(msg.dependencyName);
+        break;
       case "modelDependency":
         await this.modelDependency();
         break;

--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
@@ -82,6 +82,12 @@ export class DataExtensionsEditorView extends AbstractWebview<
       queryRunner,
       queryStorageDir,
       databaseItem,
+      async (inProgressMethods) => {
+        await this.postMessage({
+          t: "setInProgressMethods",
+          inProgressMethods,
+        });
+      },
       async (modeledMethods) => {
         await this.postMessage({ t: "addModeledMethods", modeledMethods });
       },

--- a/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
@@ -241,6 +241,13 @@ export function DataExtensionsEditor({
     [],
   );
 
+  const onStopGenerateFromLlmClick = useCallback((dependencyName: string) => {
+    vscode.postMessage({
+      t: "stopGeneratingExternalApiFromLlm",
+      dependencyName,
+    });
+  }, []);
+
   const onOpenDatabaseClick = useCallback(() => {
     vscode.postMessage({
       t: "openDatabase",
@@ -345,6 +352,7 @@ export function DataExtensionsEditor({
           onChange={onChange}
           onSaveModelClick={onSaveModelClick}
           onGenerateFromLlmClick={onGenerateFromLlmClick}
+          onStopGenerateFromLlmClick={onStopGenerateFromLlmClick}
           onGenerateFromSourceClick={onGenerateFromSourceClick}
           onModelDependencyClick={onModelDependencyClick}
         />

--- a/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/LibraryRow.tsx
@@ -89,6 +89,7 @@ type Props = {
     externalApiUsages: ExternalApiUsage[],
     modeledMethods: Record<string, ModeledMethod>,
   ) => void;
+  onStopGenerateFromLlmClick: (dependencyName: string) => void;
   onGenerateFromSourceClick: () => void;
   onModelDependencyClick: () => void;
 };
@@ -105,6 +106,7 @@ export const LibraryRow = ({
   onChange,
   onSaveModelClick,
   onGenerateFromLlmClick,
+  onStopGenerateFromLlmClick,
   onGenerateFromSourceClick,
   onModelDependencyClick,
 }: Props) => {
@@ -125,6 +127,15 @@ export const LibraryRow = ({
       e.preventDefault();
     },
     [title, externalApiUsages, modeledMethods, onGenerateFromLlmClick],
+  );
+
+  const handleStopModelWithAI = useCallback(
+    async (e: React.MouseEvent) => {
+      onStopGenerateFromLlmClick(title);
+      e.stopPropagation();
+      e.preventDefault();
+    },
+    [title, onStopGenerateFromLlmClick],
   );
 
   const handleModelFromSource = useCallback(
@@ -167,6 +178,12 @@ export const LibraryRow = ({
     );
   }, [externalApiUsages, modifiedSignatures]);
 
+  const canStopAutoModeling = useMemo(() => {
+    return externalApiUsages.some((externalApiUsage) =>
+      inProgressSignatures.has(externalApiUsage.signature),
+    );
+  }, [externalApiUsages, inProgressSignatures]);
+
   return (
     <LibraryContainer>
       <TitleContainer onClick={toggleExpanded} aria-expanded={isExpanded}>
@@ -185,10 +202,16 @@ export const LibraryRow = ({
           </ModeledPercentage>
           {hasUnsavedChanges ? <VSCodeTag>UNSAVED</VSCodeTag> : null}
         </NameContainer>
-        {viewState.showLlmButton && (
+        {viewState.showLlmButton && !canStopAutoModeling && (
           <VSCodeButton appearance="icon" onClick={handleModelWithAI}>
             <Codicon name="lightbulb-autofix" label="Model with AI" />
             &nbsp;Model with AI
+          </VSCodeButton>
+        )}
+        {viewState.showLlmButton && canStopAutoModeling && (
+          <VSCodeButton appearance="icon" onClick={handleStopModelWithAI}>
+            <Codicon name="debug-stop" label="Stop model with AI" />
+            &nbsp;Stop
           </VSCodeButton>
         )}
         {viewState.mode === Mode.Application && (

--- a/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodsList.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodsList.tsx
@@ -31,6 +31,7 @@ type Props = {
     externalApiUsages: ExternalApiUsage[],
     modeledMethods: Record<string, ModeledMethod>,
   ) => void;
+  onStopGenerateFromLlmClick: (dependencyName: string) => void;
   onGenerateFromSourceClick: () => void;
   onModelDependencyClick: () => void;
 };
@@ -49,6 +50,7 @@ export const ModeledMethodsList = ({
   onChange,
   onSaveModelClick,
   onGenerateFromLlmClick,
+  onStopGenerateFromLlmClick,
   onGenerateFromSourceClick,
   onModelDependencyClick,
 }: Props) => {
@@ -93,6 +95,7 @@ export const ModeledMethodsList = ({
           onChange={onChange}
           onSaveModelClick={onSaveModelClick}
           onGenerateFromLlmClick={onGenerateFromLlmClick}
+          onStopGenerateFromLlmClick={onStopGenerateFromLlmClick}
           onGenerateFromSourceClick={onGenerateFromSourceClick}
           onModelDependencyClick={onModelDependencyClick}
         />

--- a/extensions/ql-vscode/test/unit-tests/data-extensions-editor/auto-model-v2.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/data-extensions-editor/auto-model-v2.test.ts
@@ -165,28 +165,4 @@ describe("getCandidates", () => {
     );
     expect(candidates.length).toEqual(1);
   });
-
-  it("respects the limit", () => {
-    const externalApiUsages: ExternalApiUsage[] = [];
-    for (let i = 0; i < 30; i++) {
-      externalApiUsages.push({
-        library: "my.jar",
-        signature: `org.my.A#x${i}()`,
-        packageName: "org.my",
-        typeName: "A",
-        methodName: `x${i}`,
-        methodParameters: "()",
-        supported: false,
-        supportedType: "none",
-        usages: [],
-      });
-    }
-    const modeledMethods = {};
-    const candidates = getCandidates(
-      Mode.Application,
-      externalApiUsages,
-      modeledMethods,
-    );
-    expect(candidates.length).toEqual(20);
-  });
 });

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/data-extensions-editor/auto-model-codeml-queries.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/data-extensions-editor/auto-model-codeml-queries.test.ts
@@ -19,6 +19,7 @@ import { MethodSignature } from "../../../../src/data-extensions-editor/external
 import { join } from "path";
 import { exists, readFile } from "fs-extra";
 import { load as loadYaml } from "js-yaml";
+import { CancellationTokenSource } from "vscode-jsonrpc";
 
 describe("runAutoModelQueries", () => {
   const qlpack = {
@@ -142,6 +143,7 @@ describe("runAutoModelQueries", () => {
       }),
       queryStorageDir: "/tmp/queries",
       progress: jest.fn(),
+      cancellationTokenSource: new CancellationTokenSource(),
     };
 
     const result = await runAutoModelQueries(options);


### PR DESCRIPTION
Add batching of automodeling requests and also the ability to stop. See individual commits for the two steps.

Note that there is a bug around progress that I'd like to fix separately as it requires some refactoring of the in progress state. The bug shows up if a user starts modeling a dependency before the previous one has finished. 

The progress and stopping notifications can also do with a bit of improvement, but this is a good enough start in my opinion.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
