### PR TITLE
Rename 'dependency' to 'package' in auto-modeling code

### DIFF
--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -549,14 +549,14 @@ interface GenerateExternalApiMessage {
 
 interface GenerateExternalApiFromLlmMessage {
   t: "generateExternalApiFromLlm";
-  dependencyName: string;
+  packageName: string;
   externalApiUsages: ExternalApiUsage[];
   modeledMethods: Record<string, ModeledMethod>;
 }
 
 interface StopGeneratingExternalApiFromLlmMessage {
   t: "stopGeneratingExternalApiFromLlm";
-  dependencyName: string;
+  packageName: string;
 }
 
 interface ModelDependencyMessage {

--- a/extensions/ql-vscode/src/data-extensions-editor/auto-modeler.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/auto-modeler.ts
@@ -42,34 +42,34 @@ export class AutoModeler {
   }
 
   public async startModeling(
-    dependency: string,
+    packageName: string,
     externalApiUsages: ExternalApiUsage[],
     modeledMethods: Record<string, ModeledMethod>,
     mode: Mode,
   ): Promise<void> {
-    if (this.jobs.has(dependency)) {
+    if (this.jobs.has(packageName)) {
       return;
     }
 
     const cancellationTokenSource = new CancellationTokenSource();
-    this.jobs.set(dependency, cancellationTokenSource);
+    this.jobs.set(packageName, cancellationTokenSource);
 
     try {
-      await this.modelDependency(
-        dependency,
+      await this.modelPackage(
+        packageName,
         externalApiUsages,
         modeledMethods,
         mode,
         cancellationTokenSource,
       );
     } finally {
-      this.jobs.delete(dependency);
+      this.jobs.delete(packageName);
     }
   }
 
-  public async stopModeling(dependency: string): Promise<void> {
-    void extLogger.log(`Stopping modeling for dependency ${dependency}`);
-    const cancellationTokenSource = this.jobs.get(dependency);
+  public async stopModeling(packageName: string): Promise<void> {
+    void extLogger.log(`Stopping modeling for package ${packageName}`);
+    const cancellationTokenSource = this.jobs.get(packageName);
     if (cancellationTokenSource) {
       cancellationTokenSource.cancel();
     }
@@ -81,14 +81,14 @@ export class AutoModeler {
     }
   }
 
-  private async modelDependency(
-    dependency: string,
+  private async modelPackage(
+    packageName: string,
     externalApiUsages: ExternalApiUsage[],
     modeledMethods: Record<string, ModeledMethod>,
     mode: Mode,
     cancellationTokenSource: CancellationTokenSource,
   ): Promise<void> {
-    void extLogger.log(`Modeling dependency ${dependency}`);
+    void extLogger.log(`Modeling package ${packageName}`);
     await withProgress(async (progress) => {
       const maxStep = 3000;
 

--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
@@ -177,7 +177,7 @@ export class DataExtensionsEditorView extends AbstractWebview<
       case "generateExternalApiFromLlm":
         if (useLlmGenerationV2()) {
           await this.generateModeledMethodsFromLlmV2(
-            msg.dependencyName,
+            msg.packageName,
             msg.externalApiUsages,
             msg.modeledMethods,
           );
@@ -189,7 +189,7 @@ export class DataExtensionsEditorView extends AbstractWebview<
         }
         break;
       case "stopGeneratingExternalApiFromLlm":
-        await this.autoModeler.stopModeling(msg.dependencyName);
+        await this.autoModeler.stopModeling(msg.packageName);
         break;
       case "modelDependency":
         await this.modelDependency();
@@ -459,12 +459,12 @@ export class DataExtensionsEditorView extends AbstractWebview<
   }
 
   private async generateModeledMethodsFromLlmV2(
-    dependency: string,
+    packageName: string,
     externalApiUsages: ExternalApiUsage[],
     modeledMethods: Record<string, ModeledMethod>,
   ): Promise<void> {
     await this.autoModeler.startModeling(
-      dependency,
+      packageName,
       externalApiUsages,
       modeledMethods,
       this.mode,

--- a/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
@@ -227,13 +227,13 @@ export function DataExtensionsEditor({
 
   const onGenerateFromLlmClick = useCallback(
     (
-      dependencyName: string,
+      packageName: string,
       externalApiUsages: ExternalApiUsage[],
       modeledMethods: Record<string, ModeledMethod>,
     ) => {
       vscode.postMessage({
         t: "generateExternalApiFromLlm",
-        dependencyName,
+        packageName,
         externalApiUsages,
         modeledMethods,
       });
@@ -241,10 +241,10 @@ export function DataExtensionsEditor({
     [],
   );
 
-  const onStopGenerateFromLlmClick = useCallback((dependencyName: string) => {
+  const onStopGenerateFromLlmClick = useCallback((packageName: string) => {
     vscode.postMessage({
       t: "stopGeneratingExternalApiFromLlm",
-      dependencyName,
+      packageName,
     });
   }, []);
 

--- a/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodsList.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/ModeledMethodsList.tsx
@@ -27,11 +27,11 @@ type Props = {
     modeledMethods: Record<string, ModeledMethod>,
   ) => void;
   onGenerateFromLlmClick: (
-    dependencyName: string,
+    packageName: string,
     externalApiUsages: ExternalApiUsage[],
     modeledMethods: Record<string, ModeledMethod>,
   ) => void;
-  onStopGenerateFromLlmClick: (dependencyName: string) => void;
+  onStopGenerateFromLlmClick: (packageName: string) => void;
   onGenerateFromSourceClick: () => void;
   onModelDependencyClick: () => void;
 };


### PR DESCRIPTION
The term 'package' makes more sense for framework more so we're standardising on that, at least for this specific area of the codebase.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
