### PR TITLE
Fix running tests twice when test paths are passed

### DIFF
--- a/extensions/ql-vscode/patches/jest-runner-vscode+3.0.1.patch
+++ b/extensions/ql-vscode/patches/jest-runner-vscode+3.0.1.patch
@@ -25,7 +25,7 @@ index 1ac28d5..f91f216 100644
          await super.setup();
          await (0, load_pnp_1.default)();
 diff --git a/node_modules/jest-runner-vscode/dist/child/runner.js b/node_modules/jest-runner-vscode/dist/child/runner.js
-index 0663c5c..4991663 100644
+index 0663c5c..bdf4a8b 100644
 --- a/node_modules/jest-runner-vscode/dist/child/runner.js
 +++ b/node_modules/jest-runner-vscode/dist/child/runner.js
 @@ -18,10 +18,13 @@ async function run() {
@@ -43,6 +43,16 @@ index 0663c5c..4991663 100644
          const options = JSON.parse(PARENT_JEST_OPTIONS);
          const jestOptions = [
              ...options.args,
+@@ -39,6 +42,9 @@ async function run() {
+             ...(argv.projects?.map(project => path_1.default.resolve(project)) || []),
+             options.workspacePath,
+         ]);
++        const testPaths = new Set(argv._.map(testPath => path_1.default.resolve(testPath)));
++        argv._ = [...testPaths];
++
+         await (0, core_1.runCLI)(argv, [...projects]);
+     }
+     catch (error) {
 diff --git a/node_modules/jest-runner-vscode/dist/public-types.d.ts b/node_modules/jest-runner-vscode/dist/public-types.d.ts
 index 57716e5..d8614af 100644
 --- a/node_modules/jest-runner-vscode/dist/public-types.d.ts


### PR DESCRIPTION
When running tests using `--runTestsByPath <some-path>`, the tests were being run twice because jest-runner-vscode
[resolves test paths](https://github.com/adalinesimonian/jest-runner-vscode/blob/0c98dc12adac536a200e836b77e186b8c2ba8326/packages/jest-runner-vscode/src/runner.ts#L57-L66), while the original arguments were also still passed to Jest. So, the arguments Jest would receive would look something like `test/vscode-tests/no-workspace/databases/local-databases/locations.test.ts /Users/koesie10/github/vscode-codeql/extensions/ql-vscode/test/vscode-tests/no-workspace/databases/local-databases/locations.test.ts` which would cause Jest to run the tests twice. This fixes this by resolving the paths to their absolute paths, and then removing any duplicates.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
