### PR TITLE
Convert ResultTables to a function component

### DIFF
--- a/extensions/ql-vscode/src/view/results/ProblemsViewCheckbox.tsx
+++ b/extensions/ql-vscode/src/view/results/ProblemsViewCheckbox.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+import { ALERTS_TABLE_NAME } from "../../common/interface-types";
+import {
+  alertExtrasClassName,
+  toggleDiagnosticsClassName,
+} from "./result-table-utils";
+
+interface Props {
+  selectedTable: string;
+  problemsViewSelected: boolean;
+  handleCheckboxChanged: (event: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+export function ProblemsViewCheckbox(props: Props): JSX.Element | null {
+  const { selectedTable, problemsViewSelected, handleCheckboxChanged } = props;
+
+  if (selectedTable !== ALERTS_TABLE_NAME) {
+    return null;
+  }
+  return (
+    <div className={alertExtrasClassName}>
+      <div className={toggleDiagnosticsClassName}>
+        <input
+          type="checkbox"
+          id="toggle-diagnostics"
+          name="toggle-diagnostics"
+          onChange={handleCheckboxChanged}
+          checked={problemsViewSelected}
+        />
+        <label htmlFor="toggle-diagnostics">
+          Show results in Problems view
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/extensions/ql-vscode/src/view/results/ResultCount.tsx
+++ b/extensions/ql-vscode/src/view/results/ResultCount.tsx
@@ -1,0 +1,29 @@
+import * as React from "react";
+import { ResultSet } from "../../common/interface-types";
+import { tableHeaderItemClassName } from "./result-table-utils";
+
+interface Props {
+  resultSet?: ResultSet;
+}
+
+function getResultCount(resultSet: ResultSet): number {
+  switch (resultSet.t) {
+    case "RawResultSet":
+      return resultSet.schema.rows;
+    case "InterpretedResultSet":
+      return resultSet.interpretation.numTotalResults;
+  }
+}
+
+export function ResultCount(props: Props): JSX.Element | null {
+  if (!props.resultSet) {
+    return null;
+  }
+
+  const resultCount = getResultCount(props.resultSet);
+  return (
+    <span className={tableHeaderItemClassName}>
+      {resultCount} {resultCount === 1 ? "result" : "results"}
+    </span>
+  );
+}

--- a/extensions/ql-vscode/src/view/results/ResultTables.tsx
+++ b/extensions/ql-vscode/src/view/results/ResultTables.tsx
@@ -219,6 +219,9 @@ export function ResultTables(props: ResultTablesProps) {
   );
 
   const alertTableExtras = (): JSX.Element | undefined => {
+    if (selectedTable !== ALERTS_TABLE_NAME) {
+      return undefined;
+    }
     return (
       <div className={alertExtrasClassName}>
         <div className={toggleDiagnosticsClassName}>
@@ -266,7 +269,7 @@ export function ResultTables(props: ResultTablesProps) {
           {resultSetOptions}
         </select>
         {numberOfResults}
-        {selectedTable === ALERTS_TABLE_NAME ? alertTableExtras() : undefined}
+        {alertTableExtras()}
         {isLoadingNewResults ? (
           <span className={UPDATING_RESULTS_TEXT_CLASS_NAME}>
             Updating results…

--- a/extensions/ql-vscode/src/view/results/ResultTables.tsx
+++ b/extensions/ql-vscode/src/view/results/ResultTables.tsx
@@ -24,6 +24,7 @@ import { vscode } from "../vscode-api";
 import { sendTelemetry } from "../common/telemetry";
 import { ResultTable } from "./ResultTable";
 import { ResultTablesHeader } from "./ResultTablesHeader";
+import { useEffect } from "react";
 
 /**
  * Properties for the `ResultTables` component.
@@ -41,14 +42,6 @@ interface ResultTablesProps {
   isLoadingNewResults: boolean;
   queryName: string;
   queryPath: string;
-}
-
-/**
- * State for the `ResultTables` component.
- */
-interface ResultTablesState {
-  selectedTable: string; // name of selected result set
-  problemsViewSelected: boolean;
 }
 
 const UPDATING_RESULTS_TEXT_CLASS_NAME =
@@ -122,85 +115,71 @@ function getResultSets(
  * Displays multiple `ResultTable` tables, where the table to be displayed is selected by a
  * dropdown.
  */
-export class ResultTables extends React.Component<
-  ResultTablesProps,
-  ResultTablesState
-> {
-  constructor(props: ResultTablesProps) {
-    super(props);
-    const selectedTable =
-      props.parsedResultSets.selectedTable ||
-      getDefaultResultSet(
-        getResultSets(props.rawResultSets, props.interpretation),
-      );
-    this.state = {
-      selectedTable,
-      problemsViewSelected: false,
-    };
-  }
+export function ResultTables(props: ResultTablesProps) {
+  const {
+    parsedResultSets,
+    rawResultSets,
+    interpretation,
+    database,
+    resultsPath,
+    metadata,
+    origResultsPaths,
+    isLoadingNewResults,
+    sortStates,
+  } = props;
 
-  handleMessage(msg: IntoResultsViewMsg): void {
+  const [selectedTable, setSelectedTable] = React.useState(
+    parsedResultSets.selectedTable ||
+      getDefaultResultSet(getResultSets(rawResultSets, interpretation)),
+  );
+  const [problemsViewSelected, setProblemsViewSelected] = React.useState(false);
+
+  const handleMessage = (msg: IntoResultsViewMsg): void => {
     switch (msg.t) {
       case "untoggleShowProblems":
-        this.setState({
-          problemsViewSelected: false,
-        });
+        setProblemsViewSelected(false);
         break;
 
       default:
       // noop
     }
-  }
+  };
 
-  private vscodeMessageHandler(evt: MessageEvent) {
+  const vscodeMessageHandler = (evt: MessageEvent): void => {
     // sanitize origin
     const origin = evt.origin.replace(/\n|\r/g, "");
     evt.origin === window.origin
-      ? this.handleMessage(evt.data as IntoResultsViewMsg)
+      ? handleMessage(evt.data as IntoResultsViewMsg)
       : console.error(`Invalid event origin ${origin}`);
-  }
+  };
 
   // TODO: Duplicated from results.tsx consider a way to
   // avoid this duplication
-  componentDidMount(): void {
-    this.vscodeMessageHandler = this.vscodeMessageHandler.bind(this);
-    window.addEventListener("message", this.vscodeMessageHandler);
-  }
+  useEffect(() => {
+    window.addEventListener("message", vscodeMessageHandler);
 
-  componentWillUnmount(): void {
-    if (this.vscodeMessageHandler) {
-      window.removeEventListener("message", this.vscodeMessageHandler);
-    }
-  }
+    return () => {
+      window.removeEventListener("message", vscodeMessageHandler);
+    };
+  }, []);
 
-  componentDidUpdate(
-    prevProps: Readonly<ResultTablesProps>,
-    prevState: Readonly<ResultTablesState>,
-    snapshot?: any,
-  ) {
+  useEffect(() => {
     const resultSetExists =
-      this.props.parsedResultSets.resultSetNames.some(
-        (v) => this.state.selectedTable === v,
-      ) ||
-      getResultSets(this.props.rawResultSets, this.props.interpretation).some(
-        (v) => this.state.selectedTable === v.schema.name,
+      parsedResultSets.resultSetNames.some((v) => selectedTable === v) ||
+      getResultSets(rawResultSets, interpretation).some(
+        (v) => selectedTable === v.schema.name,
       );
 
     // If the selected result set does not exist, select the default result set.
     if (!resultSetExists) {
-      this.setState((state, props) => {
-        const selectedTable =
-          props.parsedResultSets.selectedTable ||
-          getDefaultResultSet(
-            getResultSets(props.rawResultSets, props.interpretation),
-          );
-
-        return { selectedTable };
-      });
+      setSelectedTable(
+        parsedResultSets.selectedTable ||
+          getDefaultResultSet(getResultSets(rawResultSets, interpretation)),
+      );
     }
-  }
+  });
 
-  private onTableSelectionChange = (
+  const onTableSelectionChange = (
     event: React.ChangeEvent<HTMLSelectElement>,
   ): void => {
     const selectedTable = event.target.value;
@@ -212,16 +191,13 @@ export class ResultTables extends React.Component<
     sendTelemetry("local-results-table-selection");
   };
 
-  private alertTableExtras(): JSX.Element | undefined {
-    const { database, resultsPath, metadata, origResultsPaths } = this.props;
+  const alertTableExtras = (): JSX.Element | undefined => {
     const handleCheckboxChanged = (e: React.ChangeEvent<HTMLInputElement>) => {
-      if (e.target.checked === this.state.problemsViewSelected) {
+      if (e.target.checked === problemsViewSelected) {
         // no change
         return;
       }
-      this.setState({
-        problemsViewSelected: e.target.checked,
-      });
+      setProblemsViewSelected(e.target.checked);
       if (e.target.checked) {
         sendTelemetry("local-results-show-results-in-problems-view");
       }
@@ -244,7 +220,7 @@ export class ResultTables extends React.Component<
             id="toggle-diagnostics"
             name="toggle-diagnostics"
             onChange={handleCheckboxChanged}
-            checked={this.state.problemsViewSelected}
+            checked={problemsViewSelected}
           />
           <label htmlFor="toggle-diagnostics">
             Show results in Problems view
@@ -252,77 +228,61 @@ export class ResultTables extends React.Component<
         </div>
       </div>
     );
-  }
+  };
 
-  getOffset(): number {
-    const { parsedResultSets } = this.props;
+  const getOffset = (): number => {
     return parsedResultSets.pageNumber * parsedResultSets.pageSize;
-  }
+  };
 
-  render(): React.ReactNode {
-    const { selectedTable } = this.state;
-    const resultSets = getResultSets(
-      this.props.rawResultSets,
-      this.props.interpretation,
-    );
-    const resultSetNames = getResultSetNames(
-      this.props.interpretation,
-      this.props.parsedResultSets,
-    );
+  const resultSets = getResultSets(rawResultSets, interpretation);
+  const resultSetNames = getResultSetNames(interpretation, parsedResultSets);
 
-    const resultSet = resultSets.find(
-      (resultSet) => resultSet.schema.name === selectedTable,
-    );
-    const nonemptyRawResults = resultSets.some(
-      (resultSet) =>
-        resultSet.t === "RawResultSet" && resultSet.rows.length > 0,
-    );
-    const numberOfResults = resultSet && renderResultCountString(resultSet);
+  const resultSet = resultSets.find(
+    (resultSet) => resultSet.schema.name === selectedTable,
+  );
+  const nonemptyRawResults = resultSets.some(
+    (resultSet) => resultSet.t === "RawResultSet" && resultSet.rows.length > 0,
+  );
+  const numberOfResults = resultSet && renderResultCountString(resultSet);
 
-    const resultSetOptions = resultSetNames.map((name) => (
-      <option key={name} value={name}>
-        {name}
-      </option>
-    ));
-    return (
-      <div>
-        <ResultTablesHeader
-          {...this.props}
-          selectedTable={this.state.selectedTable}
-        />
-        <div className={tableHeaderClassName}></div>
-        <div className={tableHeaderClassName}>
-          <select value={selectedTable} onChange={this.onTableSelectionChange}>
-            {resultSetOptions}
-          </select>
-          {numberOfResults}
-          {selectedTable === ALERTS_TABLE_NAME
-            ? this.alertTableExtras()
-            : undefined}
-          {this.props.isLoadingNewResults ? (
-            <span className={UPDATING_RESULTS_TEXT_CLASS_NAME}>
-              Updating results…
-            </span>
-          ) : null}
-        </div>
-        {resultSet && (
-          <ResultTable
-            key={resultSet.schema.name}
-            resultSet={resultSet}
-            databaseUri={this.props.database.databaseUri}
-            resultsPath={this.props.resultsPath}
-            sortState={this.props.sortStates.get(resultSet.schema.name)}
-            nonemptyRawResults={nonemptyRawResults}
-            showRawResults={() => {
-              this.setState({ selectedTable: SELECT_TABLE_NAME });
-              sendTelemetry("local-results-show-raw-results");
-            }}
-            offset={this.getOffset()}
-          />
-        )}
+  const resultSetOptions = resultSetNames.map((name) => (
+    <option key={name} value={name}>
+      {name}
+    </option>
+  ));
+  return (
+    <div>
+      <ResultTablesHeader {...props} selectedTable={selectedTable} />
+      <div className={tableHeaderClassName}></div>
+      <div className={tableHeaderClassName}>
+        <select value={selectedTable} onChange={onTableSelectionChange}>
+          {resultSetOptions}
+        </select>
+        {numberOfResults}
+        {selectedTable === ALERTS_TABLE_NAME ? alertTableExtras() : undefined}
+        {isLoadingNewResults ? (
+          <span className={UPDATING_RESULTS_TEXT_CLASS_NAME}>
+            Updating results…
+          </span>
+        ) : null}
       </div>
-    );
-  }
+      {resultSet && (
+        <ResultTable
+          key={resultSet.schema.name}
+          resultSet={resultSet}
+          databaseUri={database.databaseUri}
+          resultsPath={resultsPath}
+          sortState={sortStates.get(resultSet.schema.name)}
+          nonemptyRawResults={nonemptyRawResults}
+          showRawResults={() => {
+            setSelectedTable(SELECT_TABLE_NAME);
+            sendTelemetry("local-results-show-raw-results");
+          }}
+          offset={getOffset()}
+        />
+      )}
+    </div>
+  );
 }
 
 function getDefaultResultSet(resultSets: readonly ResultSet[]): string {

--- a/extensions/ql-vscode/src/view/results/ResultTables.tsx
+++ b/extensions/ql-vscode/src/view/results/ResultTables.tsx
@@ -14,17 +14,14 @@ import {
   ParsedResultSets,
   IntoResultsViewMsg,
 } from "../../common/interface-types";
-import {
-  tableHeaderClassName,
-  toggleDiagnosticsClassName,
-  alertExtrasClassName,
-} from "./result-table-utils";
+import { tableHeaderClassName } from "./result-table-utils";
 import { vscode } from "../vscode-api";
 import { sendTelemetry } from "../common/telemetry";
 import { ResultTable } from "./ResultTable";
 import { ResultTablesHeader } from "./ResultTablesHeader";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { ResultCount } from "./ResultCount";
+import { ProblemsViewCheckbox } from "./ProblemsViewCheckbox";
 
 /**
  * Properties for the `ResultTables` component.
@@ -200,28 +197,6 @@ export function ResultTables(props: ResultTablesProps) {
     [database, metadata, origResultsPaths, problemsViewSelected, resultsPath],
   );
 
-  const alertTableExtras = useMemo((): JSX.Element | undefined => {
-    if (selectedTable !== ALERTS_TABLE_NAME) {
-      return undefined;
-    }
-    return (
-      <div className={alertExtrasClassName}>
-        <div className={toggleDiagnosticsClassName}>
-          <input
-            type="checkbox"
-            id="toggle-diagnostics"
-            name="toggle-diagnostics"
-            onChange={handleCheckboxChanged}
-            checked={problemsViewSelected}
-          />
-          <label htmlFor="toggle-diagnostics">
-            Show results in Problems view
-          </label>
-        </div>
-      </div>
-    );
-  }, [handleCheckboxChanged, problemsViewSelected, selectedTable]);
-
   const offset = parsedResultSets.pageNumber * parsedResultSets.pageSize;
 
   const resultSets = useMemo(
@@ -253,7 +228,11 @@ export function ResultTables(props: ResultTablesProps) {
           {resultSetOptions}
         </select>
         <ResultCount resultSet={resultSet} />
-        {alertTableExtras}
+        <ProblemsViewCheckbox
+          selectedTable={selectedTable}
+          problemsViewSelected={problemsViewSelected}
+          handleCheckboxChanged={handleCheckboxChanged}
+        />
         {isLoadingNewResults ? (
           <span className={UPDATING_RESULTS_TEXT_CLASS_NAME}>
             Updating results…

--- a/extensions/ql-vscode/src/view/results/ResultTables.tsx
+++ b/extensions/ql-vscode/src/view/results/ResultTables.tsx
@@ -164,7 +164,7 @@ export function ResultTables(props: ResultTablesProps) {
     return () => {
       window.removeEventListener("message", vscodeMessageHandler);
     };
-  }, []);
+  }, [vscodeMessageHandler]);
 
   useEffect(() => {
     const resultSetExists =
@@ -180,7 +180,7 @@ export function ResultTables(props: ResultTablesProps) {
           getDefaultResultSet(getResultSets(rawResultSets, interpretation)),
       );
     }
-  });
+  }, [parsedResultSets, interpretation, rawResultSets, selectedTable]);
 
   const onTableSelectionChange = (
     event: React.ChangeEvent<HTMLSelectElement>,

--- a/extensions/ql-vscode/src/view/results/ResultTables.tsx
+++ b/extensions/ql-vscode/src/view/results/ResultTables.tsx
@@ -24,7 +24,7 @@ import { vscode } from "../vscode-api";
 import { sendTelemetry } from "../common/telemetry";
 import { ResultTable } from "./ResultTable";
 import { ResultTablesHeader } from "./ResultTablesHeader";
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 
 /**
  * Properties for the `ResultTables` component.
@@ -218,7 +218,7 @@ export function ResultTables(props: ResultTablesProps) {
     [database, metadata, origResultsPaths, problemsViewSelected, resultsPath],
   );
 
-  const alertTableExtras = (): JSX.Element | undefined => {
+  const alertTableExtras = useMemo((): JSX.Element | undefined => {
     if (selectedTable !== ALERTS_TABLE_NAME) {
       return undefined;
     }
@@ -238,7 +238,7 @@ export function ResultTables(props: ResultTablesProps) {
         </div>
       </div>
     );
-  };
+  }, [handleCheckboxChanged, problemsViewSelected, selectedTable]);
 
   const getOffset = (): number => {
     return parsedResultSets.pageNumber * parsedResultSets.pageSize;
@@ -269,7 +269,7 @@ export function ResultTables(props: ResultTablesProps) {
           {resultSetOptions}
         </select>
         {numberOfResults}
-        {alertTableExtras()}
+        {alertTableExtras}
         {isLoadingNewResults ? (
           <span className={UPDATING_RESULTS_TEXT_CLASS_NAME}>
             Updating results…

--- a/extensions/ql-vscode/src/view/results/ResultTables.tsx
+++ b/extensions/ql-vscode/src/view/results/ResultTables.tsx
@@ -240,9 +240,7 @@ export function ResultTables(props: ResultTablesProps) {
     );
   }, [handleCheckboxChanged, problemsViewSelected, selectedTable]);
 
-  const getOffset = (): number => {
-    return parsedResultSets.pageNumber * parsedResultSets.pageSize;
-  };
+  const offset = parsedResultSets.pageNumber * parsedResultSets.pageSize;
 
   const resultSets = getResultSets(rawResultSets, interpretation);
   const resultSetNames = getResultSetNames(interpretation, parsedResultSets);
@@ -288,7 +286,7 @@ export function ResultTables(props: ResultTablesProps) {
             setSelectedTable(SELECT_TABLE_NAME);
             sendTelemetry("local-results-show-raw-results");
           }}
-          offset={getOffset()}
+          offset={offset}
         />
       )}
     </div>

--- a/extensions/ql-vscode/src/view/results/ResultTables.tsx
+++ b/extensions/ql-vscode/src/view/results/ResultTables.tsx
@@ -195,27 +195,27 @@ export function ResultTables(props: ResultTablesProps) {
     [],
   );
 
-  const alertTableExtras = (): JSX.Element | undefined => {
-    const handleCheckboxChanged = (e: React.ChangeEvent<HTMLInputElement>) => {
-      if (e.target.checked === problemsViewSelected) {
-        // no change
-        return;
-      }
-      setProblemsViewSelected(e.target.checked);
-      if (e.target.checked) {
-        sendTelemetry("local-results-show-results-in-problems-view");
-      }
-      if (resultsPath !== undefined) {
-        vscode.postMessage({
-          t: "toggleDiagnostics",
-          origResultsPaths,
-          databaseUri: database.databaseUri,
-          visible: e.target.checked,
-          metadata,
-        });
-      }
-    };
+  const handleCheckboxChanged = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.checked === problemsViewSelected) {
+      // no change
+      return;
+    }
+    setProblemsViewSelected(e.target.checked);
+    if (e.target.checked) {
+      sendTelemetry("local-results-show-results-in-problems-view");
+    }
+    if (resultsPath !== undefined) {
+      vscode.postMessage({
+        t: "toggleDiagnostics",
+        origResultsPaths,
+        databaseUri: database.databaseUri,
+        visible: e.target.checked,
+        metadata,
+      });
+    }
+  };
 
+  const alertTableExtras = (): JSX.Element | undefined => {
     return (
       <div className={alertExtrasClassName}>
         <div className={toggleDiagnosticsClassName}>

--- a/extensions/ql-vscode/src/view/results/ResultTables.tsx
+++ b/extensions/ql-vscode/src/view/results/ResultTables.tsx
@@ -145,13 +145,16 @@ export function ResultTables(props: ResultTablesProps) {
     }
   }, []);
 
-  const vscodeMessageHandler = (evt: MessageEvent): void => {
-    // sanitize origin
-    const origin = evt.origin.replace(/\n|\r/g, "");
-    evt.origin === window.origin
-      ? handleMessage(evt.data as IntoResultsViewMsg)
-      : console.error(`Invalid event origin ${origin}`);
-  };
+  const vscodeMessageHandler = useCallback(
+    (evt: MessageEvent): void => {
+      // sanitize origin
+      const origin = evt.origin.replace(/\n|\r/g, "");
+      evt.origin === window.origin
+        ? handleMessage(evt.data as IntoResultsViewMsg)
+        : console.error(`Invalid event origin ${origin}`);
+    },
+    [handleMessage],
+  );
 
   // TODO: Duplicated from results.tsx consider a way to
   // avoid this duplication

--- a/extensions/ql-vscode/src/view/results/ResultTables.tsx
+++ b/extensions/ql-vscode/src/view/results/ResultTables.tsx
@@ -139,6 +139,40 @@ export class ResultTables extends React.Component<
     };
   }
 
+  handleMessage(msg: IntoResultsViewMsg): void {
+    switch (msg.t) {
+      case "untoggleShowProblems":
+        this.setState({
+          problemsViewSelected: false,
+        });
+        break;
+
+      default:
+      // noop
+    }
+  }
+
+  private vscodeMessageHandler(evt: MessageEvent) {
+    // sanitize origin
+    const origin = evt.origin.replace(/\n|\r/g, "");
+    evt.origin === window.origin
+      ? this.handleMessage(evt.data as IntoResultsViewMsg)
+      : console.error(`Invalid event origin ${origin}`);
+  }
+
+  // TODO: Duplicated from results.tsx consider a way to
+  // avoid this duplication
+  componentDidMount(): void {
+    this.vscodeMessageHandler = this.vscodeMessageHandler.bind(this);
+    window.addEventListener("message", this.vscodeMessageHandler);
+  }
+
+  componentWillUnmount(): void {
+    if (this.vscodeMessageHandler) {
+      window.removeEventListener("message", this.vscodeMessageHandler);
+    }
+  }
+
   componentDidUpdate(
     prevProps: Readonly<ResultTablesProps>,
     prevState: Readonly<ResultTablesState>,
@@ -292,40 +326,6 @@ export class ResultTables extends React.Component<
         )}
       </div>
     );
-  }
-
-  handleMessage(msg: IntoResultsViewMsg): void {
-    switch (msg.t) {
-      case "untoggleShowProblems":
-        this.setState({
-          problemsViewSelected: false,
-        });
-        break;
-
-      default:
-      // noop
-    }
-  }
-
-  private vscodeMessageHandler(evt: MessageEvent) {
-    // sanitize origin
-    const origin = evt.origin.replace(/\n|\r/g, "");
-    evt.origin === window.origin
-      ? this.handleMessage(evt.data as IntoResultsViewMsg)
-      : console.error(`Invalid event origin ${origin}`);
-  }
-
-  // TODO: Duplicated from results.tsx consider a way to
-  // avoid this duplication
-  componentDidMount(): void {
-    this.vscodeMessageHandler = this.vscodeMessageHandler.bind(this);
-    window.addEventListener("message", this.vscodeMessageHandler);
-  }
-
-  componentWillUnmount(): void {
-    if (this.vscodeMessageHandler) {
-      window.removeEventListener("message", this.vscodeMessageHandler);
-    }
   }
 }
 

--- a/extensions/ql-vscode/src/view/results/ResultTables.tsx
+++ b/extensions/ql-vscode/src/view/results/ResultTables.tsx
@@ -307,6 +307,14 @@ export class ResultTables extends React.Component<
     }
   }
 
+  private vscodeMessageHandler(evt: MessageEvent) {
+    // sanitize origin
+    const origin = evt.origin.replace(/\n|\r/g, "");
+    evt.origin === window.origin
+      ? this.handleMessage(evt.data as IntoResultsViewMsg)
+      : console.error(`Invalid event origin ${origin}`);
+  }
+
   // TODO: Duplicated from results.tsx consider a way to
   // avoid this duplication
   componentDidMount(): void {
@@ -318,14 +326,6 @@ export class ResultTables extends React.Component<
     if (this.vscodeMessageHandler) {
       window.removeEventListener("message", this.vscodeMessageHandler);
     }
-  }
-
-  private vscodeMessageHandler(evt: MessageEvent) {
-    // sanitize origin
-    const origin = evt.origin.replace(/\n|\r/g, "");
-    evt.origin === window.origin
-      ? this.handleMessage(evt.data as IntoResultsViewMsg)
-      : console.error(`Invalid event origin ${origin}`);
   }
 }
 

--- a/extensions/ql-vscode/src/view/results/ResultTables.tsx
+++ b/extensions/ql-vscode/src/view/results/ResultTables.tsx
@@ -242,7 +242,10 @@ export function ResultTables(props: ResultTablesProps) {
 
   const offset = parsedResultSets.pageNumber * parsedResultSets.pageSize;
 
-  const resultSets = getResultSets(rawResultSets, interpretation);
+  const resultSets = useMemo(
+    () => getResultSets(rawResultSets, interpretation),
+    [interpretation, rawResultSets],
+  );
   const resultSetNames = getResultSetNames(interpretation, parsedResultSets);
 
   const resultSet = resultSets.find(

--- a/extensions/ql-vscode/src/view/results/ResultTables.tsx
+++ b/extensions/ql-vscode/src/view/results/ResultTables.tsx
@@ -259,10 +259,6 @@ export class ResultTables extends React.Component<
     return parsedResultSets.pageNumber * parsedResultSets.pageSize;
   }
 
-  sendResultsPageChangedTelemetry() {
-    sendTelemetry("local-results-alert-table-page-changed");
-  }
-
   render(): React.ReactNode {
     const { selectedTable } = this.state;
     const resultSets = getResultSets(

--- a/extensions/ql-vscode/src/view/results/ResultTables.tsx
+++ b/extensions/ql-vscode/src/view/results/ResultTables.tsx
@@ -248,8 +248,10 @@ export function ResultTables(props: ResultTablesProps) {
   );
   const resultSetNames = getResultSetNames(interpretation, parsedResultSets);
 
-  const resultSet = resultSets.find(
-    (resultSet) => resultSet.schema.name === selectedTable,
+  const resultSet = useMemo(
+    () =>
+      resultSets.find((resultSet) => resultSet.schema.name === selectedTable),
+    [resultSets, selectedTable],
   );
   const nonemptyRawResults = resultSets.some(
     (resultSet) => resultSet.t === "RawResultSet" && resultSet.rows.length > 0,

--- a/extensions/ql-vscode/src/view/results/ResultTables.tsx
+++ b/extensions/ql-vscode/src/view/results/ResultTables.tsx
@@ -24,7 +24,7 @@ import { vscode } from "../vscode-api";
 import { sendTelemetry } from "../common/telemetry";
 import { ResultTable } from "./ResultTable";
 import { ResultTablesHeader } from "./ResultTablesHeader";
-import { useEffect } from "react";
+import { useCallback, useEffect } from "react";
 
 /**
  * Properties for the `ResultTables` component.
@@ -134,7 +134,7 @@ export function ResultTables(props: ResultTablesProps) {
   );
   const [problemsViewSelected, setProblemsViewSelected] = React.useState(false);
 
-  const handleMessage = (msg: IntoResultsViewMsg): void => {
+  const handleMessage = useCallback((msg: IntoResultsViewMsg): void => {
     switch (msg.t) {
       case "untoggleShowProblems":
         setProblemsViewSelected(false);
@@ -143,7 +143,7 @@ export function ResultTables(props: ResultTablesProps) {
       default:
       // noop
     }
-  };
+  }, []);
 
   const vscodeMessageHandler = (evt: MessageEvent): void => {
     // sanitize origin

--- a/extensions/ql-vscode/src/view/results/ResultTables.tsx
+++ b/extensions/ql-vscode/src/view/results/ResultTables.tsx
@@ -24,7 +24,7 @@ import { vscode } from "../vscode-api";
 import { sendTelemetry } from "../common/telemetry";
 import { ResultTable } from "./ResultTable";
 import { ResultTablesHeader } from "./ResultTablesHeader";
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 /**
  * Properties for the `ResultTables` component.
@@ -128,11 +128,11 @@ export function ResultTables(props: ResultTablesProps) {
     sortStates,
   } = props;
 
-  const [selectedTable, setSelectedTable] = React.useState(
+  const [selectedTable, setSelectedTable] = useState(
     parsedResultSets.selectedTable ||
       getDefaultResultSet(getResultSets(rawResultSets, interpretation)),
   );
-  const [problemsViewSelected, setProblemsViewSelected] = React.useState(false);
+  const [problemsViewSelected, setProblemsViewSelected] = useState(false);
 
   const handleMessage = useCallback((msg: IntoResultsViewMsg): void => {
     switch (msg.t) {

--- a/extensions/ql-vscode/src/view/results/ResultTables.tsx
+++ b/extensions/ql-vscode/src/view/results/ResultTables.tsx
@@ -195,25 +195,28 @@ export function ResultTables(props: ResultTablesProps) {
     [],
   );
 
-  const handleCheckboxChanged = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target.checked === problemsViewSelected) {
-      // no change
-      return;
-    }
-    setProblemsViewSelected(e.target.checked);
-    if (e.target.checked) {
-      sendTelemetry("local-results-show-results-in-problems-view");
-    }
-    if (resultsPath !== undefined) {
-      vscode.postMessage({
-        t: "toggleDiagnostics",
-        origResultsPaths,
-        databaseUri: database.databaseUri,
-        visible: e.target.checked,
-        metadata,
-      });
-    }
-  };
+  const handleCheckboxChanged = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      if (e.target.checked === problemsViewSelected) {
+        // no change
+        return;
+      }
+      setProblemsViewSelected(e.target.checked);
+      if (e.target.checked) {
+        sendTelemetry("local-results-show-results-in-problems-view");
+      }
+      if (resultsPath !== undefined) {
+        vscode.postMessage({
+          t: "toggleDiagnostics",
+          origResultsPaths,
+          databaseUri: database.databaseUri,
+          visible: e.target.checked,
+          metadata,
+        });
+      }
+    },
+    [database, metadata, origResultsPaths, problemsViewSelected, resultsPath],
+  );
 
   const alertTableExtras = (): JSX.Element | undefined => {
     return (

--- a/extensions/ql-vscode/src/view/results/ResultTables.tsx
+++ b/extensions/ql-vscode/src/view/results/ResultTables.tsx
@@ -182,17 +182,18 @@ export function ResultTables(props: ResultTablesProps) {
     }
   }, [parsedResultSets, interpretation, rawResultSets, selectedTable]);
 
-  const onTableSelectionChange = (
-    event: React.ChangeEvent<HTMLSelectElement>,
-  ): void => {
-    const selectedTable = event.target.value;
-    vscode.postMessage({
-      t: "changePage",
-      pageNumber: 0,
-      selectedTable,
-    });
-    sendTelemetry("local-results-table-selection");
-  };
+  const onTableSelectionChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>): void => {
+      const selectedTable = event.target.value;
+      vscode.postMessage({
+        t: "changePage",
+        pageNumber: 0,
+        selectedTable,
+      });
+      sendTelemetry("local-results-table-selection");
+    },
+    [],
+  );
 
   const alertTableExtras = (): JSX.Element | undefined => {
     const handleCheckboxChanged = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/extensions/ql-vscode/src/view/results/ResultTables.tsx
+++ b/extensions/ql-vscode/src/view/results/ResultTables.tsx
@@ -16,7 +16,6 @@ import {
 } from "../../common/interface-types";
 import {
   tableHeaderClassName,
-  tableHeaderItemClassName,
   toggleDiagnosticsClassName,
   alertExtrasClassName,
 } from "./result-table-utils";
@@ -25,6 +24,7 @@ import { sendTelemetry } from "../common/telemetry";
 import { ResultTable } from "./ResultTable";
 import { ResultTablesHeader } from "./ResultTablesHeader";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { ResultCount } from "./ResultCount";
 
 /**
  * Properties for the `ResultTables` component.
@@ -46,24 +46,6 @@ interface ResultTablesProps {
 
 const UPDATING_RESULTS_TEXT_CLASS_NAME =
   "vscode-codeql__result-tables-updating-text";
-
-function getResultCount(resultSet: ResultSet): number {
-  switch (resultSet.t) {
-    case "RawResultSet":
-      return resultSet.schema.rows;
-    case "InterpretedResultSet":
-      return resultSet.interpretation.numTotalResults;
-  }
-}
-
-function renderResultCountString(resultSet: ResultSet): JSX.Element {
-  const resultCount = getResultCount(resultSet);
-  return (
-    <span className={tableHeaderItemClassName}>
-      {resultCount} {resultCount === 1 ? "result" : "results"}
-    </span>
-  );
-}
 
 function getInterpretedTableName(interpretation: Interpretation): string {
   return interpretation.data.t === "GraphInterpretationData"
@@ -256,7 +238,6 @@ export function ResultTables(props: ResultTablesProps) {
   const nonemptyRawResults = resultSets.some(
     (resultSet) => resultSet.t === "RawResultSet" && resultSet.rows.length > 0,
   );
-  const numberOfResults = resultSet && renderResultCountString(resultSet);
 
   const resultSetOptions = resultSetNames.map((name) => (
     <option key={name} value={name}>
@@ -271,7 +252,7 @@ export function ResultTables(props: ResultTablesProps) {
         <select value={selectedTable} onChange={onTableSelectionChange}>
           {resultSetOptions}
         </select>
-        {numberOfResults}
+        <ResultCount resultSet={resultSet} />
         {alertTableExtras}
         {isLoadingNewResults ? (
           <span className={UPDATING_RESULTS_TEXT_CLASS_NAME}>


### PR DESCRIPTION
Converts `ResultTables` from a class-based component to a function component. Then goes through and updates a few aspects to be cleaner. Every change is a separate commit, so feel free to review by commit or do the whole thing at once.

Tested locally and appears to work exactly as it did before.

There are some values that I haven't converted to `useMemo` because I don't believe it would help. The places where `useMemo` is helpful are for non-primitive values passed as props to other components, or for computationally expensive calculations. In cases where the calculation is cheap and the value is rendered directly instead of passed as a prop, my understanding is that `useMemo` is not helpful.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
