### PR TITLE
Make InProgressMethods immutable so it's safer to use as react state

### DIFF
--- a/extensions/ql-vscode/src/data-extensions-editor/shared/in-progress-methods.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/shared/in-progress-methods.ts
@@ -19,10 +19,7 @@ export class InProgressMethods {
     packageName: string,
     methods: Set<string>,
   ): InProgressMethods {
-    const newMethodMap = new Map<string, Set<string>>();
-    this.methodMap.forEach((value, key) => {
-      newMethodMap.set(key, new Set<string>(value));
-    });
+    const newMethodMap = new Map<string, Set<string>>(this.methodMap);
     newMethodMap.set(packageName, methods);
     return new InProgressMethods(newMethodMap);
   }

--- a/extensions/ql-vscode/src/data-extensions-editor/shared/in-progress-methods.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/shared/in-progress-methods.ts
@@ -1,16 +1,30 @@
 /**
  * A class that keeps track of which methods are in progress for each package.
+ *
+ * This class is immutable and therefore is safe to be used in a react useState hook.
  */
 export class InProgressMethods {
   // A map of in-progress method signatures for each package.
-  private readonly methodMap: Map<string, Set<string>>;
+  private readonly methodMap: ReadonlyMap<string, Set<string>>;
 
-  constructor() {
-    this.methodMap = new Map<string, Set<string>>();
+  constructor(methodMap?: ReadonlyMap<string, Set<string>>) {
+    this.methodMap = methodMap ?? new Map<string, Set<string>>();
   }
 
-  public setPackageMethods(packageName: string, methods: Set<string>): void {
-    this.methodMap.set(packageName, methods);
+  /**
+   * Sets the in-progress methods for the given package.
+   * Returns a new InProgressMethods instance.
+   */
+  public setPackageMethods(
+    packageName: string,
+    methods: Set<string>,
+  ): InProgressMethods {
+    const newMethodMap = new Map<string, Set<string>>();
+    this.methodMap.forEach((value, key) => {
+      newMethodMap.set(key, new Set<string>(value));
+    });
+    newMethodMap.set(packageName, methods);
+    return new InProgressMethods(newMethodMap);
   }
 
   public hasMethod(packageName: string, method: string): boolean {
@@ -19,13 +33,5 @@ export class InProgressMethods {
       return methods.has(method);
     }
     return false;
-  }
-
-  public static fromExisting(methods: InProgressMethods): InProgressMethods {
-    const newInProgressMethods = new InProgressMethods();
-    methods.methodMap.forEach((value, key) => {
-      newInProgressMethods.methodMap.set(key, new Set<string>(value));
-    });
-    return newInProgressMethods;
   }
 }

--- a/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
+++ b/extensions/ql-vscode/src/view/data-extensions-editor/DataExtensionsEditor.tsx
@@ -141,15 +141,12 @@ export function DataExtensionsEditor({
             );
             break;
           case "setInProgressMethods":
-            setInProgressMethods((oldInProgressMethods) => {
-              const methods =
-                InProgressMethods.fromExisting(oldInProgressMethods);
-              methods.setPackageMethods(
+            setInProgressMethods((oldInProgressMethods) =>
+              oldInProgressMethods.setPackageMethods(
                 msg.packageName,
                 new Set(msg.inProgressMethods),
-              );
-              return methods;
-            });
+              ),
+            );
             break;
           default:
             assertNever(msg);


### PR DESCRIPTION
A small modification that makes `setPackagedMethods` return a new object instead of mutating the existing object. The current code is correct, but I worry the chance of the class accidentally being used incorrectly is a bit too high.

The danger of having `InProgressMethods` be mutable is that we use it as react state, and react tracks state changes only by object identity. This means if a developer do something like:
```typescript
setInProgressMethods((oldInProgressMethods) => {
    oldInProgressMethods.setPackagedMethods(packageName, methods);
    return oldInProgressMethods;
);
```
then react would not see that the object was modified and would not trigger a re-render of the component. When the next render happened for whatever other reason, the change in state would be rendered. This leads to bugs and unpredictable visual behaviour.

By making `InProgressMethods` immutable it means you don't need to know that you must call `fromExisting` first to create a new object, and it'll be harder to accidentally mutate an object being used as react state.

It's worth nothing we do also have this problem with other objects and also with arrays. This one stuck out to me because it's a custom object with an interface, so the mutation of lack of it is hidden from the developer. We may also want to look at ways of reducing the chance of this bug in other places. Maybe a CodeQL query?

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
