### PR TITLE
Add code lens for "Open referenced file"

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [UNRELEASED]
 
+- Add a code lens to make the `CodeQL: Open Referenced File` command more discoverable. Click the "Open referenced file" prompt in a `.qlref` file to jump to the referenced `.ql` file. [#2704](https://github.com/github/vscode-codeql/pull/2704)
+
 ## 1.8.9 - 3 August 2023
 
 - Remove "last updated" information and sorting from variant analysis results view. [#2637](https://github.com/github/vscode-codeql/pull/2637)

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -134,6 +134,7 @@ import { TestRunner } from "./query-testing/test-runner";
 import { TestManagerBase } from "./query-testing/test-manager-base";
 import { NewQueryRunner, QueryRunner, QueryServerClient } from "./query-server";
 import { QueriesModule } from "./queries-panel/queries-module";
+import { OpenReferencedFileCodeLensProvider } from "./local-queries/open-referenced-file-code-lens-provider";
 
 /**
  * extension.ts
@@ -332,10 +333,17 @@ export async function activate(
 
   const app = new ExtensionApp(ctx);
 
-  const codelensProvider = new QuickEvalCodeLensProvider();
+  const quickEvalCodeLensProvider = new QuickEvalCodeLensProvider();
   languages.registerCodeLensProvider(
     { scheme: "file", language: "ql" },
-    codelensProvider,
+    quickEvalCodeLensProvider,
+  );
+
+  const openReferencedFileCodeLensProvider =
+    new OpenReferencedFileCodeLensProvider();
+  languages.registerCodeLensProvider(
+    { scheme: "file", pattern: "**/*.qlref" },
+    openReferencedFileCodeLensProvider,
   );
 
   ctx.subscriptions.push(distributionConfigListener);

--- a/extensions/ql-vscode/src/local-queries/open-referenced-file-code-lens-provider.ts
+++ b/extensions/ql-vscode/src/local-queries/open-referenced-file-code-lens-provider.ts
@@ -1,0 +1,34 @@
+import {
+  CodeLensProvider,
+  TextDocument,
+  CodeLens,
+  Command,
+  Range,
+} from "vscode";
+
+export class OpenReferencedFileCodeLensProvider implements CodeLensProvider {
+  async provideCodeLenses(document: TextDocument): Promise<CodeLens[]> {
+    const codeLenses: CodeLens[] = [];
+
+    // A .qlref file is a file that contains a single line with a path to a .ql file.
+    if (document.fileName.endsWith(".qlref")) {
+      const textLine = document.lineAt(0);
+      const range: Range = new Range(
+        textLine.range.start.line,
+        textLine.range.start.character,
+        textLine.range.start.line,
+        textLine.range.end.character,
+      );
+
+      const command: Command = {
+        command: "codeQL.openReferencedFile",
+        title: `Open referenced file`,
+        arguments: [document.uri],
+      };
+      const codeLens = new CodeLens(range, command);
+      codeLenses.push(codeLens);
+    }
+
+    return codeLenses;
+  }
+}


### PR DESCRIPTION
Makes the "Open referenced file" command more discoverable by adding a code lens: 
![image](https://github.com/github/vscode-codeql/assets/42641846/fe0c29dc-66e3-46ed-ae7a-a0e96b6f243e)

Click that prompt to jump to the referenced QL file 😎 See internal issue for more details! 🔍 

### Notes:
- I put this in the `local-queries` folder, which seemed reasonable 😅 Happy to be pointed to a more suitable location!
- I couldn't think of a useful way to test this, since it just calls out to the existing `codeQL.openReferencedFile` command... 

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
