### PR TITLE
Allow the details view to handle multiple open data extensions editors

### DIFF
--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-module.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-module.ts
@@ -32,6 +32,9 @@ export class DataExtensionsEditorModule extends DisposableObject {
   private readonly queryStorageDir: string;
   private readonly modelDetailsPanel: ModelDetailsPanel;
 
+  private mostRecentlyActiveView: DataExtensionsEditorView | undefined =
+    undefined;
+
   private constructor(
     private readonly ctx: ExtensionContext,
     private readonly app: App,
@@ -46,6 +49,20 @@ export class DataExtensionsEditorModule extends DisposableObject {
       "data-extensions-editor-results",
     );
     this.modelDetailsPanel = this.push(new ModelDetailsPanel(cliServer));
+  }
+
+  private handleViewBecameActive(view: DataExtensionsEditorView): void {
+    this.mostRecentlyActiveView = view;
+  }
+
+  private handleViewWasDisposed(view: DataExtensionsEditorView): void {
+    if (this.mostRecentlyActiveView === view) {
+      this.mostRecentlyActiveView = undefined;
+    }
+  }
+
+  private isMostRecentlyActiveView(view: DataExtensionsEditorView): boolean {
+    return this.mostRecentlyActiveView === view;
   }
 
   public static async initialize(
@@ -149,6 +166,9 @@ export class DataExtensionsEditorModule extends DisposableObject {
               Mode.Application,
               this.modelDetailsPanel.setState.bind(this.modelDetailsPanel),
               this.modelDetailsPanel.revealItem.bind(this.modelDetailsPanel),
+              this.handleViewBecameActive.bind(this),
+              this.handleViewWasDisposed.bind(this),
+              this.isMostRecentlyActiveView.bind(this),
             );
             await view.openView();
           },

--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
@@ -50,6 +50,8 @@ export class DataExtensionsEditorView extends AbstractWebview<
 > {
   private readonly autoModeler: AutoModeler;
 
+  private externalApiUsages: ExternalApiUsage[];
+
   public constructor(
     ctx: ExtensionContext,
     private readonly app: App,
@@ -86,6 +88,7 @@ export class DataExtensionsEditorView extends AbstractWebview<
         await this.postMessage({ t: "addModeledMethods", modeledMethods });
       },
     );
+    this.externalApiUsages = [];
   }
 
   public async openView() {
@@ -280,14 +283,14 @@ export class DataExtensionsEditorView extends AbstractWebview<
             maxStep: 1500,
           });
 
-          const externalApiUsages = decodeBqrsToExternalApiUsages(bqrsChunk);
+          this.externalApiUsages = decodeBqrsToExternalApiUsages(bqrsChunk);
 
           await this.postMessage({
             t: "setExternalApiUsages",
-            externalApiUsages,
+            externalApiUsages: this.externalApiUsages,
           });
           await this.updateModelDetailsPanelState(
-            externalApiUsages,
+            this.externalApiUsages,
             this.databaseItem,
           );
         } catch (err) {

--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
@@ -108,12 +108,23 @@ export class DataExtensionsEditorView extends AbstractWebview<
       }
     });
 
+    panel.onDidDispose(async () => {
+      await this.onPanelWasDisposed();
+    });
+
     await this.waitForPanelLoaded();
   }
 
   private async onPanelBecameActive(): Promise<void> {
     const panel = await this.getPanel();
     DataExtensionsEditorView.mostRecentlyActivePanel = panel;
+  }
+
+  private async onPanelWasDisposed(): Promise<void> {
+    const panel = await this.getPanel();
+    if (panel === DataExtensionsEditorView.mostRecentlyActivePanel) {
+      DataExtensionsEditorView.mostRecentlyActivePanel = undefined;
+    }
   }
 
   private async isTheMostRecentlyActivePanel(): Promise<boolean> {

--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
@@ -99,7 +99,8 @@ export class DataExtensionsEditorView extends AbstractWebview<
     panel.reveal(undefined, true);
 
     panel.onDidChangeViewState(async () => {
-      if (await this.isTheMostRecentlyActivePanel()) {
+      if (panel.active) {
+        await this.onPanelBecameActive();
         await this.updateModelDetailsPanelState(
           this.externalApiUsages,
           this.databaseItem,
@@ -110,15 +111,14 @@ export class DataExtensionsEditorView extends AbstractWebview<
     await this.waitForPanelLoaded();
   }
 
+  private async onPanelBecameActive(): Promise<void> {
+    const panel = await this.getPanel();
+    DataExtensionsEditorView.mostRecentlyActivePanel = panel;
+  }
+
   private async isTheMostRecentlyActivePanel(): Promise<boolean> {
     const panel = await this.getPanel();
-
-    if (panel.active) {
-      DataExtensionsEditorView.mostRecentlyActivePanel = panel;
-      return true;
-    } else {
-      return panel === DataExtensionsEditorView.mostRecentlyActivePanel;
-    }
+    return panel === DataExtensionsEditorView.mostRecentlyActivePanel;
   }
 
   protected async getPanelConfig(): Promise<WebviewPanelConfig> {


### PR DESCRIPTION
When there are multiple data extensions editors open, have the details view track whichever one was active (i.e. focussed by the user) the most recently. I believe this is the behaviour the user would expect when they have multiple editors open.

Note that while there can be at most one active data extensions editor at a time, there also could easily be zero active. If the user clicks over to a different tab, such as when viewing usages of a method, we want the details view to still be correct.

This PR introduces a couple of big changes to the `DataExtensionsEditorView` class:
- Adds a static variable tracking the `WebviewPanel` that has most recently been active.
  - If there's another better way to implement this behaviour I'm very open to it.
- Stores most recent `ExternalApiUsage[]` value, so it can be used to update the details view outside of the `loadExternalApiUsages` method.
  - We don't want to wait to re-run the queries whenever the user changes between tabs.

I've tried manually testing this in all of the configurations of tabs I could think of, and it seems to be working perfectly.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
