### PR TITLE
Graph: Set fill color for all graph text

### DIFF
--- a/extensions/ql-vscode/src/view/results/graph.tsx
+++ b/extensions/ql-vscode/src/view/results/graph.tsx
@@ -52,9 +52,11 @@ export function Graph({ graphData, databaseUri }: GraphProps) {
             });
           }
         }
-
         if ("fill" in d.attributes) {
-          d.attributes.fill = d.tag === "text" ? color : backgroundColor;
+          d.attributes.fill = backgroundColor;
+        }
+        if (d.tag === "text") {
+          d.attributes.fill = color;
         }
         if ("stroke" in d.attributes) {
           // There is no proper way to identify the element containing the graph (which we


### PR DESCRIPTION
Grapviz no longer sets it when it is the default so we don't have anything to override.

This just overrides all text which seems to work.

This fixes the graph viewer with dark themes.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
