### PR TITLE
Only update the details view when data has changed

### DIFF
--- a/extensions/ql-vscode/src/data-extensions-editor/model-details/model-details-data-provider.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/model-details/model-details-data-provider.ts
@@ -34,16 +34,27 @@ export class ModelDetailsDataProvider
     return this.onDidChangeTreeDataEmitter.event;
   }
 
+  /**
+   * Update the data displayed in the tree view.
+   *
+   * Will only trigger an update if the data has changed. This relies on
+   * object identity, so be sure to not mutate the data passed to this
+   * method and instead always pass new objects/arrays.
+   */
   public async setState(
     externalApiUsages: ExternalApiUsage[],
     databaseItem: DatabaseItem,
   ): Promise<void> {
-    this.externalApiUsages = externalApiUsages;
-    this.databaseItem = databaseItem;
-    this.sourceLocationPrefix = await this.databaseItem.getSourceLocationPrefix(
-      this.cliServer,
-    );
-    this.onDidChangeTreeDataEmitter.fire();
+    if (
+      this.externalApiUsages !== externalApiUsages ||
+      this.databaseItem !== databaseItem
+    ) {
+      this.externalApiUsages = externalApiUsages;
+      this.databaseItem = databaseItem;
+      this.sourceLocationPrefix =
+        await this.databaseItem.getSourceLocationPrefix(this.cliServer);
+      this.onDidChangeTreeDataEmitter.fire();
+    }
   }
 
   getTreeItem(item: ModelDetailsTreeViewItem): TreeItem {

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/data-extensions-editor/model-details/model-details-data-provider.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/data-extensions-editor/model-details/model-details-data-provider.test.ts
@@ -22,7 +22,7 @@ describe("ModelDetailsDataProvider", () => {
 
       await dataProvider.setState(externalApiUsages, dbItem);
 
-      expect(onDidChangeTreeDataListener).toHaveBeenCalledTimes(0);
+      expect(onDidChangeTreeDataListener).not.toHaveBeenCalled();
     });
 
     it("should emit onDidChangeTreeData event when externalApiUsages has changed", async () => {

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/data-extensions-editor/model-details/model-details-data-provider.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/data-extensions-editor/model-details/model-details-data-provider.test.ts
@@ -8,7 +8,7 @@ describe("ModelDetailsDataProvider", () => {
   const mockCliServer = mockedObject<CodeQLCliServer>({});
 
   describe("setState", () => {
-    it("should emit onDidChangeTreeData event when state has changed", async () => {
+    it("should not emit onDidChangeTreeData event when state has not changed", async () => {
       const externalApiUsages: ExternalApiUsage[] = [];
       const dbItem = mockedObject<DatabaseItem>({
         getSourceLocationPrefix: () => "test",

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/data-extensions-editor/model-details/model-details-data-provider.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/data-extensions-editor/model-details/model-details-data-provider.test.ts
@@ -1,0 +1,66 @@
+import { CodeQLCliServer } from "../../../../../src/codeql-cli/cli";
+import { ExternalApiUsage } from "../../../../../src/data-extensions-editor/external-api-usage";
+import { ModelDetailsDataProvider } from "../../../../../src/data-extensions-editor/model-details/model-details-data-provider";
+import { DatabaseItem } from "../../../../../src/databases/local-databases";
+import { mockedObject } from "../../../utils/mocking.helpers";
+
+describe("ModelDetailsDataProvider", () => {
+  const mockCliServer = mockedObject<CodeQLCliServer>({});
+
+  describe("setState", () => {
+    it("should emit onDidChangeTreeData event when state has changed", async () => {
+      const externalApiUsages: ExternalApiUsage[] = [];
+      const dbItem = mockedObject<DatabaseItem>({
+        getSourceLocationPrefix: () => "test",
+      });
+
+      const dataProvider = new ModelDetailsDataProvider(mockCliServer);
+      await dataProvider.setState(externalApiUsages, dbItem);
+
+      const onDidChangeTreeDataListener = jest.fn();
+      dataProvider.onDidChangeTreeData(onDidChangeTreeDataListener);
+
+      await dataProvider.setState(externalApiUsages, dbItem);
+
+      expect(onDidChangeTreeDataListener).toHaveBeenCalledTimes(0);
+    });
+
+    it("should emit onDidChangeTreeData event when externalApiUsages has changed", async () => {
+      const externalApiUsages1: ExternalApiUsage[] = [];
+      const externalApiUsages2: ExternalApiUsage[] = [];
+      const dbItem = mockedObject<DatabaseItem>({
+        getSourceLocationPrefix: () => "test",
+      });
+
+      const dataProvider = new ModelDetailsDataProvider(mockCliServer);
+      await dataProvider.setState(externalApiUsages1, dbItem);
+
+      const onDidChangeTreeDataListener = jest.fn();
+      dataProvider.onDidChangeTreeData(onDidChangeTreeDataListener);
+
+      await dataProvider.setState(externalApiUsages2, dbItem);
+
+      expect(onDidChangeTreeDataListener).toHaveBeenCalledTimes(1);
+    });
+
+    it("should emit onDidChangeTreeData event when dbItem has changed", async () => {
+      const externalApiUsages: ExternalApiUsage[] = [];
+      const dbItem1 = mockedObject<DatabaseItem>({
+        getSourceLocationPrefix: () => "test",
+      });
+      const dbItem2 = mockedObject<DatabaseItem>({
+        getSourceLocationPrefix: () => "test",
+      });
+
+      const dataProvider = new ModelDetailsDataProvider(mockCliServer);
+      await dataProvider.setState(externalApiUsages, dbItem1);
+
+      const onDidChangeTreeDataListener = jest.fn();
+      dataProvider.onDidChangeTreeData(onDidChangeTreeDataListener);
+
+      await dataProvider.setState(externalApiUsages, dbItem2);
+
+      expect(onDidChangeTreeDataListener).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
The idea here is to only emit the `onDidChangeTreeData` event when data has really changed.

This means we can call `setState` more liberally, such as on all webview visibility changes, without worrying about the performance impact of re-rendering the details with with the same content.

This relies on the contract that data won't be mutated while reusing the same object/array. So it's the same rules that React uses. I believe we currently abide by these rules and it's unlikely we'd want to break them, due to the way we generate external API usages we always end up with a new array object.

I've added some tests for the behaviour being changed in this PR. We could easily add more tests for the data provider, but to stop this PR from growing in scope I've opened an issue to cover adding more tests.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
