### PR TITLE
Only show the details view when a data extensions editor is open

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1697,7 +1697,7 @@
         {
           "id": "codeQLModelDetails",
           "name": "CodeQL Model Details",
-          "when": "config.codeQL.canary && config.codeQL.dataExtensions.modelDetailsView"
+          "when": "config.codeQL.canary && config.codeQL.dataExtensions.modelDetailsView && codeql.dataExtensionsEditorOpen"
         }
       ]
     },


### PR DESCRIPTION
Implements only showing the details view when at least one data extensions editor is open. When a new editor is opened we set the `codeql.dataExtensionsEditorOpen` context key to true, and when an editor is closed we check to see if there are any others remaining and set the context value accordingly.

In my local testing it's working pretty well.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
