### PR TITLE
Make it so that automodel queries works without submodule.

### DIFF
--- a/extensions/ql-vscode/src/data-extensions-editor/auto-modeler.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/auto-modeler.ts
@@ -35,6 +35,7 @@ export class AutoModeler {
     private readonly app: App,
     private readonly cliServer: CodeQLCliServer,
     private readonly queryRunner: QueryRunner,
+    private readonly queryDir: string,
     private readonly queryStorageDir: string,
     private readonly databaseItem: DatabaseItem,
     private readonly setInProgressMethods: (
@@ -174,6 +175,7 @@ export class AutoModeler {
       candidateMethods,
       cliServer: this.cliServer,
       queryRunner: this.queryRunner,
+      queryDir: this.queryDir,
       queryStorageDir: this.queryStorageDir,
       databaseItem: this.databaseItem,
       progress: (update) => progress({ ...update }),

--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
@@ -84,6 +84,7 @@ export class DataExtensionsEditorView extends AbstractWebview<
       app,
       cliServer,
       queryRunner,
+      queryDir,
       queryStorageDir,
       databaseItem,
       async (packageName, inProgressMethods) => {

--- a/extensions/ql-vscode/src/data-extensions-editor/external-api-usage-query.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/external-api-usage-query.ts
@@ -51,7 +51,7 @@ export async function setUpPack(
     name: "codeql/external-api-usage",
     version: "0.0.0",
     dependencies: {
-      [`codeql/${language}-all`]: "*",
+      [`codeql/${language}-all`]: "*", // TODO: update with autmodel pack
     },
   };
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

WIP. This makes it so that the autmodel queries work without a ql submodule. We want to clean it up and then check what kind of order we need for the automodel pack. 

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
