### PR TITLE
Remove config.codeQL.dataExtensions.modelDetailsView feature flag

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1763,7 +1763,7 @@
         {
           "id": "codeQLModelDetails",
           "name": "CodeQL Model Details",
-          "when": "config.codeQL.canary && config.codeQL.dataExtensions.modelDetailsView && codeql.dataExtensionsEditorOpen"
+          "when": "config.codeQL.canary && codeql.dataExtensionsEditorOpen"
         }
       ]
     },

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -713,11 +713,6 @@ const EXTENSIONS_DIRECTORY = new Setting(
   "extensionsDirectory",
   DATA_EXTENSIONS,
 );
-const MODEL_DETAILS_VIEW = new Setting("modelDetailsView", DATA_EXTENSIONS);
-
-export function showModelDetailsView(): boolean {
-  return !!MODEL_DETAILS_VIEW.getValue<boolean>();
-}
 
 export function showLlmGeneration(): boolean {
   return !!LLM_GENERATION.getValue<boolean>();

--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
@@ -32,11 +32,7 @@ import { readQueryResults, runQuery } from "./external-api-usage-query";
 import { ExternalApiUsage, Usage } from "./external-api-usage";
 import { ModeledMethod } from "./modeled-method";
 import { ExtensionPack } from "./shared/extension-pack";
-import {
-  enableFrameworkMode,
-  showLlmGeneration,
-  showModelDetailsView,
-} from "../config";
+import { enableFrameworkMode, showLlmGeneration } from "../config";
 import { Mode } from "./shared/mode";
 import { loadModeledMethods, saveModeledMethods } from "./modeled-method-fs";
 import { join } from "path";
@@ -280,9 +276,7 @@ export class DataExtensionsEditorView extends AbstractWebview<
   }
 
   protected async handleJumpToUsage(usage: Usage) {
-    if (showModelDetailsView()) {
-      await this.revealItemInDetailsPanel(usage);
-    }
+    await this.revealItemInDetailsPanel(usage);
     await showResolvableLocation(usage.url, this.databaseItem, this.app.logger);
   }
 


### PR DESCRIPTION
This effectively ships the data extensions model details view, though it is still hidden behind the main feature flag for the data extensions editor.

I've opened this PR but it doesn't have to be merged until we're happy with the state of the new panel.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
