### PR TITLE
Split AlertTable into smaller components

### DIFF
--- a/extensions/ql-vscode/src/view/results/AlertTable.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTable.tsx
@@ -94,29 +94,26 @@ export class AlertTable extends React.Component<
       return <AlertTableNoResults {...this.props} />;
     }
 
-    const rows: JSX.Element[] =
-      resultSet.interpretation.data.runs[0].results.map(
-        (result, resultIndex) => (
-          <AlertTableResultRow
-            key={resultIndex}
-            result={result}
-            resultIndex={resultIndex}
-            expanded={this.state.expanded}
-            selectedItem={this.state.selectedItem}
-            databaseUri={databaseUri}
-            sourceLocationPrefix={sourceLocationPrefix}
-            updateSelectionCallback={updateSelectionCallback}
-            toggler={toggler}
-            scroller={this.scroller}
-          />
-        ),
-      );
-
     return (
       <table className={className}>
         <AlertTableHeader sortState={resultSet.interpretation.data.sortState} />
         <tbody>
-          {rows}
+          {resultSet.interpretation.data.runs[0].results.map(
+            (result, resultIndex) => (
+              <AlertTableResultRow
+                key={resultIndex}
+                result={result}
+                resultIndex={resultIndex}
+                expanded={this.state.expanded}
+                selectedItem={this.state.selectedItem}
+                databaseUri={databaseUri}
+                sourceLocationPrefix={sourceLocationPrefix}
+                updateSelectionCallback={updateSelectionCallback}
+                toggler={toggler}
+                scroller={this.scroller}
+              />
+            ),
+          )}
           <AlertTableTruncatedMessage
             numTruncatedResults={numTruncatedResults}
           />

--- a/extensions/ql-vscode/src/view/results/AlertTable.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTable.tsx
@@ -19,7 +19,6 @@ import { sendTelemetry } from "../common/telemetry";
 import { AlertTableHeader } from "./AlertTableHeader";
 import { AlertTableNoResults } from "./AlertTableNoResults";
 import { AlertTableTruncatedMessage } from "./AlertTableTruncatedMessage";
-import { AlertTablePathRow } from "./AlertTablePathRow";
 import { AlertTableResultRow } from "./AlertTableResultRow";
 
 type AlertTableProps = ResultTableProps & {
@@ -97,47 +96,20 @@ export class AlertTable extends React.Component<
 
     const rows: JSX.Element[] =
       resultSet.interpretation.data.runs[0].results.map(
-        (result, resultIndex) => {
-          const resultKey: Keys.Result = { resultIndex };
-          const currentResultExpanded = this.state.expanded.has(
-            Keys.keyToString(resultKey),
-          );
-
-          return (
-            <>
-              <AlertTableResultRow
-                result={result}
-                resultIndex={resultIndex}
-                currentResultExpanded={currentResultExpanded}
-                selectedItem={this.state.selectedItem}
-                databaseUri={databaseUri}
-                sourceLocationPrefix={sourceLocationPrefix}
-                updateSelectionCallback={updateSelectionCallback}
-                toggler={toggler}
-                scroller={this.scroller}
-              />
-              {currentResultExpanded &&
-                result.codeFlows &&
-                Keys.getAllPaths(result).map((path, pathIndex) => (
-                  <AlertTablePathRow
-                    key={`${resultIndex}-${pathIndex}`}
-                    path={path}
-                    pathIndex={pathIndex}
-                    resultIndex={resultIndex}
-                    currentPathExpanded={this.state.expanded.has(
-                      Keys.keyToString({ resultIndex, pathIndex }),
-                    )}
-                    selectedItem={this.state.selectedItem}
-                    databaseUri={databaseUri}
-                    sourceLocationPrefix={sourceLocationPrefix}
-                    updateSelectionCallback={updateSelectionCallback}
-                    toggler={toggler}
-                    scroller={this.scroller}
-                  />
-                ))}
-            </>
-          );
-        },
+        (result, resultIndex) => (
+          <AlertTableResultRow
+            key={resultIndex}
+            result={result}
+            resultIndex={resultIndex}
+            expanded={this.state.expanded}
+            selectedItem={this.state.selectedItem}
+            databaseUri={databaseUri}
+            sourceLocationPrefix={sourceLocationPrefix}
+            updateSelectionCallback={updateSelectionCallback}
+            toggler={toggler}
+            scroller={this.scroller}
+          />
+        ),
       );
 
     return (

--- a/extensions/ql-vscode/src/view/results/AlertTable.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTable.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import * as Sarif from "sarif";
 import * as Keys from "./result-keys";
-import { info, listUnordered } from "./octicons";
+import { info } from "./octicons";
 import {
   className,
   ResultTableProps,
@@ -21,10 +21,10 @@ import { sendTelemetry } from "../common/telemetry";
 import { AlertTableHeader } from "./AlertTableHeader";
 import { SarifMessageWithLocations } from "./locations/SarifMessageWithLocations";
 import { SarifLocation } from "./locations/SarifLocation";
-import { AlertTableDropdownIndicatorCell } from "./AlertTableDropdownIndicatorCell";
 import { AlertTableNoResults } from "./AlertTableNoResults";
 import { AlertTableTruncatedMessage } from "./AlertTableTruncatedMessage";
 import { AlertTablePathRow } from "./AlertTablePathRow";
+import { AlertTableResultRow } from "./AlertTableResultRow";
 
 type AlertTableProps = ResultTableProps & {
   resultSet: InterpretedResultSet<SarifInterpretationData>;
@@ -153,27 +153,17 @@ export class AlertTable extends React.Component<
           } else {
             const paths: Sarif.ThreadFlow[] = Keys.getAllPaths(result);
 
-            const indices =
-              paths.length === 1
-                ? [resultKey, { ...resultKey, pathIndex: 0 }]
-                : /* if there's exactly one path, auto-expand
-                   * the path when expanding the result */
-                  [resultKey];
-
             const resultRow = (
-              <tr
-                ref={this.scroller.ref(resultRowIsSelected)}
-                {...selectableZebraStripe(resultRowIsSelected, resultIndex)}
-                key={resultIndex}
-              >
-                <AlertTableDropdownIndicatorCell
-                  expanded={currentResultExpanded}
-                  onClick={toggler(indices)}
-                />
-                <td className="vscode-codeql__icon-cell">{listUnordered}</td>
-                <td colSpan={2}>{msg}</td>
-                {locationCells}
-              </tr>
+              <AlertTableResultRow
+                result={result}
+                resultIndex={resultIndex}
+                currentResultExpanded={currentResultExpanded}
+                selectedItem={selectedItem}
+                toggler={toggler}
+                scroller={this.scroller}
+                msg={msg}
+                locationCells={locationCells}
+              />
             );
 
             const pathRows =

--- a/extensions/ql-vscode/src/view/results/AlertTable.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTable.tsx
@@ -23,6 +23,7 @@ import { SarifMessageWithLocations } from "./locations/SarifMessageWithLocations
 import { SarifLocation } from "./locations/SarifLocation";
 import { AlertTableDropdownIndicatorCell } from "./AlertTableDropdownIndicatorCell";
 import { AlertTableNoResults } from "./AlertTableNoResults";
+import { AlertTableTruncatedMessage } from "./AlertTableTruncatedMessage";
 
 type AlertTableProps = ResultTableProps & {
   resultSet: InterpretedResultSet<SarifInterpretationData>;
@@ -295,21 +296,15 @@ export class AlertTable extends React.Component<
       },
     );
 
-    if (numTruncatedResults > 0) {
-      rows.push(
-        <tr key="truncatd-message">
-          <td colSpan={5} style={{ textAlign: "center", fontStyle: "italic" }}>
-            Too many results to show at once. {numTruncatedResults} result(s)
-            omitted.
-          </td>
-        </tr>,
-      );
-    }
-
     return (
       <table className={className}>
         <AlertTableHeader sortState={resultSet.interpretation.data.sortState} />
-        <tbody>{rows}</tbody>
+        <tbody>
+          {rows}
+          <AlertTableTruncatedMessage
+            numTruncatedResults={numTruncatedResults}
+          />
+        </tbody>
       </table>
     );
   }

--- a/extensions/ql-vscode/src/view/results/AlertTable.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTable.tsx
@@ -1,11 +1,9 @@
 import * as React from "react";
 import * as Sarif from "sarif";
 import * as Keys from "./result-keys";
-import { info } from "./octicons";
 import {
   className,
   ResultTableProps,
-  selectableZebraStripe,
   jumpToLocation,
 } from "./result-table-utils";
 import { onNavigation } from "./ResultsApp";
@@ -133,57 +131,39 @@ export class AlertTable extends React.Component<
             <td className="vscode-codeql__location-cell">{location}</td>
           );
 
-          const selectedItem = this.state.selectedItem;
-          const resultRowIsSelected =
-            selectedItem?.resultIndex === resultIndex &&
-            selectedItem.pathIndex === undefined;
-
-          if (result.codeFlows === undefined) {
-            return (
-              <tr
-                ref={this.scroller.ref(resultRowIsSelected)}
-                key={resultIndex}
-                {...selectableZebraStripe(resultRowIsSelected, resultIndex)}
-              >
-                <td className="vscode-codeql__icon-cell">{info}</td>
-                <td colSpan={3}>{msg}</td>
-                {locationCells}
-              </tr>
-            );
-          } else {
-            return (
-              <>
-                <AlertTableResultRow
-                  result={result}
-                  resultIndex={resultIndex}
-                  currentResultExpanded={currentResultExpanded}
-                  selectedItem={selectedItem}
-                  toggler={toggler}
-                  scroller={this.scroller}
-                  msg={msg}
-                  locationCells={locationCells}
-                />
-                {currentResultExpanded &&
-                  Keys.getAllPaths(result).map((path, pathIndex) => (
-                    <AlertTablePathRow
-                      key={`${resultIndex}-${pathIndex}`}
-                      path={path}
-                      pathIndex={pathIndex}
-                      resultIndex={resultIndex}
-                      currentPathExpanded={this.state.expanded.has(
-                        Keys.keyToString({ resultIndex, pathIndex }),
-                      )}
-                      selectedItem={selectedItem}
-                      databaseUri={databaseUri}
-                      sourceLocationPrefix={sourceLocationPrefix}
-                      updateSelectionCallback={updateSelectionCallback}
-                      toggler={toggler}
-                      scroller={this.scroller}
-                    />
-                  ))}
-              </>
-            );
-          }
+          return (
+            <>
+              <AlertTableResultRow
+                result={result}
+                resultIndex={resultIndex}
+                currentResultExpanded={currentResultExpanded}
+                selectedItem={this.state.selectedItem}
+                toggler={toggler}
+                scroller={this.scroller}
+                msg={msg}
+                locationCells={locationCells}
+              />
+              {currentResultExpanded &&
+                result.codeFlows &&
+                Keys.getAllPaths(result).map((path, pathIndex) => (
+                  <AlertTablePathRow
+                    key={`${resultIndex}-${pathIndex}`}
+                    path={path}
+                    pathIndex={pathIndex}
+                    resultIndex={resultIndex}
+                    currentPathExpanded={this.state.expanded.has(
+                      Keys.keyToString({ resultIndex, pathIndex }),
+                    )}
+                    selectedItem={this.state.selectedItem}
+                    databaseUri={databaseUri}
+                    sourceLocationPrefix={sourceLocationPrefix}
+                    updateSelectionCallback={updateSelectionCallback}
+                    toggler={toggler}
+                    scroller={this.scroller}
+                  />
+                ))}
+            </>
+          );
         },
       );
 

--- a/extensions/ql-vscode/src/view/results/AlertTable.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTable.tsx
@@ -18,7 +18,6 @@ import { ScrollIntoViewHelper } from "./scroll-into-view-helper";
 import { sendTelemetry } from "../common/telemetry";
 import { AlertTableHeader } from "./AlertTableHeader";
 import { SarifMessageWithLocations } from "./locations/SarifMessageWithLocations";
-import { SarifLocation } from "./locations/SarifLocation";
 import { AlertTableNoResults } from "./AlertTableNoResults";
 import { AlertTableTruncatedMessage } from "./AlertTableTruncatedMessage";
 import { AlertTablePathRow } from "./AlertTablePathRow";
@@ -118,18 +117,6 @@ export class AlertTable extends React.Component<
           const currentResultExpanded = this.state.expanded.has(
             Keys.keyToString(resultKey),
           );
-          const location = result.locations !== undefined &&
-            result.locations.length > 0 && (
-              <SarifLocation
-                loc={result.locations[0]}
-                sourceLocationPrefix={sourceLocationPrefix}
-                databaseUri={databaseUri}
-                onClick={updateSelectionCallback(resultKey)}
-              />
-            );
-          const locationCells = (
-            <td className="vscode-codeql__location-cell">{location}</td>
-          );
 
           return (
             <>
@@ -138,10 +125,12 @@ export class AlertTable extends React.Component<
                 resultIndex={resultIndex}
                 currentResultExpanded={currentResultExpanded}
                 selectedItem={this.state.selectedItem}
+                databaseUri={databaseUri}
+                sourceLocationPrefix={sourceLocationPrefix}
+                updateSelectionCallback={updateSelectionCallback}
                 toggler={toggler}
                 scroller={this.scroller}
                 msg={msg}
-                locationCells={locationCells}
               />
               {currentResultExpanded &&
                 result.codeFlows &&

--- a/extensions/ql-vscode/src/view/results/AlertTable.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTable.tsx
@@ -24,6 +24,7 @@ import { SarifLocation } from "./locations/SarifLocation";
 import { AlertTableDropdownIndicatorCell } from "./AlertTableDropdownIndicatorCell";
 import { AlertTableNoResults } from "./AlertTableNoResults";
 import { AlertTableTruncatedMessage } from "./AlertTableTruncatedMessage";
+import { AlertTablePathNodeRow } from "./AlertTablePathNodeRow";
 
 type AlertTableProps = ResultTableProps & {
   resultSet: InterpretedResultSet<SarifInterpretationData>;
@@ -210,81 +211,20 @@ export class AlertTable extends React.Component<
 
                 const pathNodeRows =
                   currentPathExpanded &&
-                  path.locations.map((step, pathNodeIndex) => {
-                    const pathNodeKey: Keys.PathNode = {
-                      ...pathKey,
-                      pathNodeIndex,
-                    };
-                    const msg =
-                      step.location !== undefined &&
-                      step.location.message !== undefined ? (
-                        <SarifLocation
-                          text={step.location.message.text}
-                          loc={step.location}
-                          sourceLocationPrefix={sourceLocationPrefix}
-                          databaseUri={databaseUri}
-                          onClick={updateSelectionCallback(pathNodeKey)}
-                        />
-                      ) : (
-                        "[no location]"
-                      );
-                    const additionalMsg =
-                      step.location !== undefined ? (
-                        <SarifLocation
-                          loc={step.location}
-                          sourceLocationPrefix={sourceLocationPrefix}
-                          databaseUri={databaseUri}
-                          onClick={updateSelectionCallback(pathNodeKey)}
-                        />
-                      ) : (
-                        ""
-                      );
-                    const isSelected = Keys.equalsNotUndefined(
-                      this.state.selectedItem,
-                      pathNodeKey,
-                    );
-                    const stepIndex = pathNodeIndex + 1; // Convert to 1-based
-                    const zebraIndex = resultIndex + stepIndex;
-                    return (
-                      <tr
-                        ref={this.scroller.ref(isSelected)}
-                        className={
-                          isSelected
-                            ? "vscode-codeql__selected-path-node"
-                            : undefined
-                        }
-                        key={`${resultIndex}-${pathIndex}-${pathNodeIndex}`}
-                      >
-                        <td className="vscode-codeql__icon-cell">
-                          <span className="vscode-codeql__vertical-rule"></span>
-                        </td>
-                        <td className="vscode-codeql__icon-cell">
-                          <span className="vscode-codeql__vertical-rule"></span>
-                        </td>
-                        <td
-                          {...selectableZebraStripe(
-                            isSelected,
-                            zebraIndex,
-                            "vscode-codeql__path-index-cell",
-                          )}
-                        >
-                          {stepIndex}
-                        </td>
-                        <td {...selectableZebraStripe(isSelected, zebraIndex)}>
-                          {msg}{" "}
-                        </td>
-                        <td
-                          {...selectableZebraStripe(
-                            isSelected,
-                            zebraIndex,
-                            "vscode-codeql__location-cell",
-                          )}
-                        >
-                          {additionalMsg}
-                        </td>
-                      </tr>
-                    );
-                  });
+                  path.locations.map((step, pathNodeIndex) => (
+                    <AlertTablePathNodeRow
+                      key={`${resultIndex}-${pathIndex}-${pathNodeIndex}`}
+                      step={step}
+                      pathNodeIndex={pathNodeIndex}
+                      pathIndex={pathIndex}
+                      resultIndex={resultIndex}
+                      selectedItem={selectedItem}
+                      databaseUri={databaseUri}
+                      sourceLocationPrefix={sourceLocationPrefix}
+                      updateSelectionCallback={updateSelectionCallback}
+                      scroller={this.scroller}
+                    />
+                  ));
 
                 return (
                   <>

--- a/extensions/ql-vscode/src/view/results/AlertTable.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTable.tsx
@@ -17,7 +17,6 @@ import { parseSarifLocation, isNoLocation } from "../../common/sarif-utils";
 import { ScrollIntoViewHelper } from "./scroll-into-view-helper";
 import { sendTelemetry } from "../common/telemetry";
 import { AlertTableHeader } from "./AlertTableHeader";
-import { SarifMessageWithLocations } from "./locations/SarifMessageWithLocations";
 import { AlertTableNoResults } from "./AlertTableNoResults";
 import { AlertTableTruncatedMessage } from "./AlertTableTruncatedMessage";
 import { AlertTablePathRow } from "./AlertTablePathRow";
@@ -100,20 +99,6 @@ export class AlertTable extends React.Component<
       resultSet.interpretation.data.runs[0].results.map(
         (result, resultIndex) => {
           const resultKey: Keys.Result = { resultIndex };
-          const text = result.message.text || "[no text]";
-          const msg =
-            result.relatedLocations === undefined ? (
-              <span key="0">{text}</span>
-            ) : (
-              <SarifMessageWithLocations
-                msg={text}
-                relatedLocations={result.relatedLocations}
-                sourceLocationPrefix={sourceLocationPrefix}
-                databaseUri={databaseUri}
-                onClick={updateSelectionCallback(resultKey)}
-              />
-            );
-
           const currentResultExpanded = this.state.expanded.has(
             Keys.keyToString(resultKey),
           );
@@ -130,7 +115,6 @@ export class AlertTable extends React.Component<
                 updateSelectionCallback={updateSelectionCallback}
                 toggler={toggler}
                 scroller={this.scroller}
-                msg={msg}
               />
               {currentResultExpanded &&
                 result.codeFlows &&

--- a/extensions/ql-vscode/src/view/results/AlertTable.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTable.tsx
@@ -151,45 +151,36 @@ export class AlertTable extends React.Component<
               </tr>
             );
           } else {
-            const paths: Sarif.ThreadFlow[] = Keys.getAllPaths(result);
-
-            const resultRow = (
-              <AlertTableResultRow
-                result={result}
-                resultIndex={resultIndex}
-                currentResultExpanded={currentResultExpanded}
-                selectedItem={selectedItem}
-                toggler={toggler}
-                scroller={this.scroller}
-                msg={msg}
-                locationCells={locationCells}
-              />
-            );
-
-            const pathRows =
-              currentResultExpanded &&
-              paths.map((path, pathIndex) => (
-                <AlertTablePathRow
-                  key={`${resultIndex}-${pathIndex}`}
-                  path={path}
-                  pathIndex={pathIndex}
-                  resultIndex={resultIndex}
-                  currentPathExpanded={this.state.expanded.has(
-                    Keys.keyToString({ resultIndex, pathIndex }),
-                  )}
-                  selectedItem={selectedItem}
-                  databaseUri={databaseUri}
-                  sourceLocationPrefix={sourceLocationPrefix}
-                  updateSelectionCallback={updateSelectionCallback}
-                  toggler={toggler}
-                  scroller={this.scroller}
-                />
-              ));
-
             return (
               <>
-                {resultRow}
-                {pathRows}
+                <AlertTableResultRow
+                  result={result}
+                  resultIndex={resultIndex}
+                  currentResultExpanded={currentResultExpanded}
+                  selectedItem={selectedItem}
+                  toggler={toggler}
+                  scroller={this.scroller}
+                  msg={msg}
+                  locationCells={locationCells}
+                />
+                {currentResultExpanded &&
+                  Keys.getAllPaths(result).map((path, pathIndex) => (
+                    <AlertTablePathRow
+                      key={`${resultIndex}-${pathIndex}`}
+                      path={path}
+                      pathIndex={pathIndex}
+                      resultIndex={resultIndex}
+                      currentPathExpanded={this.state.expanded.has(
+                        Keys.keyToString({ resultIndex, pathIndex }),
+                      )}
+                      selectedItem={selectedItem}
+                      databaseUri={databaseUri}
+                      sourceLocationPrefix={sourceLocationPrefix}
+                      updateSelectionCallback={updateSelectionCallback}
+                      toggler={toggler}
+                      scroller={this.scroller}
+                    />
+                  ))}
               </>
             );
           }

--- a/extensions/ql-vscode/src/view/results/AlertTable.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTable.tsx
@@ -84,12 +84,6 @@ export class AlertTable extends React.Component<
       };
     };
 
-    const toggler: (keys: Keys.ResultKey[]) => (e: React.MouseEvent) => void = (
-      indices,
-    ) => {
-      return (e) => this.toggle(e, indices);
-    };
-
     if (!resultSet.interpretation.data.runs?.[0]?.results?.length) {
       return <AlertTableNoResults {...this.props} />;
     }
@@ -109,7 +103,7 @@ export class AlertTable extends React.Component<
                 databaseUri={databaseUri}
                 sourceLocationPrefix={sourceLocationPrefix}
                 updateSelectionCallback={updateSelectionCallback}
-                toggler={toggler}
+                toggleExpanded={this.toggle.bind(this)}
                 scroller={this.scroller}
               />
             ),

--- a/extensions/ql-vscode/src/view/results/AlertTable.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTable.tsx
@@ -24,7 +24,7 @@ import { SarifLocation } from "./locations/SarifLocation";
 import { AlertTableDropdownIndicatorCell } from "./AlertTableDropdownIndicatorCell";
 import { AlertTableNoResults } from "./AlertTableNoResults";
 import { AlertTableTruncatedMessage } from "./AlertTableTruncatedMessage";
-import { AlertTablePathNodeRow } from "./AlertTablePathNodeRow";
+import { AlertTablePathRow } from "./AlertTablePathRow";
 
 type AlertTableProps = ResultTableProps & {
   resultSet: InterpretedResultSet<SarifInterpretationData>;
@@ -178,61 +178,23 @@ export class AlertTable extends React.Component<
 
             const pathRows =
               currentResultExpanded &&
-              paths.map((path, pathIndex) => {
-                const pathKey = { resultIndex, pathIndex };
-                const currentPathExpanded = this.state.expanded.has(
-                  Keys.keyToString(pathKey),
-                );
-                const isPathSpecificallySelected = Keys.equalsNotUndefined(
-                  pathKey,
-                  selectedItem,
-                );
-                const pathRow = (
-                  <tr
-                    ref={this.scroller.ref(isPathSpecificallySelected)}
-                    {...selectableZebraStripe(
-                      isPathSpecificallySelected,
-                      resultIndex,
-                    )}
-                    key={`${resultIndex}-${pathIndex}`}
-                  >
-                    <td className="vscode-codeql__icon-cell">
-                      <span className="vscode-codeql__vertical-rule"></span>
-                    </td>
-                    <AlertTableDropdownIndicatorCell
-                      expanded={currentPathExpanded}
-                      onClick={toggler([pathKey])}
-                    />
-                    <td className="vscode-codeql__text-center" colSpan={3}>
-                      Path
-                    </td>
-                  </tr>
-                );
-
-                const pathNodeRows =
-                  currentPathExpanded &&
-                  path.locations.map((step, pathNodeIndex) => (
-                    <AlertTablePathNodeRow
-                      key={`${resultIndex}-${pathIndex}-${pathNodeIndex}`}
-                      step={step}
-                      pathNodeIndex={pathNodeIndex}
-                      pathIndex={pathIndex}
-                      resultIndex={resultIndex}
-                      selectedItem={selectedItem}
-                      databaseUri={databaseUri}
-                      sourceLocationPrefix={sourceLocationPrefix}
-                      updateSelectionCallback={updateSelectionCallback}
-                      scroller={this.scroller}
-                    />
-                  ));
-
-                return (
-                  <>
-                    {pathRow}
-                    {pathNodeRows}
-                  </>
-                );
-              });
+              paths.map((path, pathIndex) => (
+                <AlertTablePathRow
+                  key={`${resultIndex}-${pathIndex}`}
+                  path={path}
+                  pathIndex={pathIndex}
+                  resultIndex={resultIndex}
+                  currentPathExpanded={this.state.expanded.has(
+                    Keys.keyToString({ resultIndex, pathIndex }),
+                  )}
+                  selectedItem={selectedItem}
+                  databaseUri={databaseUri}
+                  sourceLocationPrefix={sourceLocationPrefix}
+                  updateSelectionCallback={updateSelectionCallback}
+                  toggler={toggler}
+                  scroller={this.scroller}
+                />
+              ));
 
             return (
               <>

--- a/extensions/ql-vscode/src/view/results/AlertTable.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTable.tsx
@@ -21,9 +21,8 @@ import { sendTelemetry } from "../common/telemetry";
 import { AlertTableHeader } from "./AlertTableHeader";
 import { SarifMessageWithLocations } from "./locations/SarifMessageWithLocations";
 import { SarifLocation } from "./locations/SarifLocation";
-import { EmptyQueryResultsMessage } from "./EmptyQueryResultsMessage";
-import TextButton from "../common/TextButton";
 import { AlertTableDropdownIndicatorCell } from "./AlertTableDropdownIndicatorCell";
+import { AlertTableNoResults } from "./AlertTableNoResults";
 
 type AlertTableProps = ResultTableProps & {
   resultSet: InterpretedResultSet<SarifInterpretationData>;
@@ -70,22 +69,6 @@ export class AlertTable extends React.Component<
     e.preventDefault();
   }
 
-  renderNoResults(): JSX.Element {
-    if (this.props.nonemptyRawResults) {
-      return (
-        <span>
-          No Alerts. See{" "}
-          <TextButton onClick={this.props.showRawResults}>
-            raw results
-          </TextButton>
-          .
-        </span>
-      );
-    } else {
-      return <EmptyQueryResultsMessage />;
-    }
-  }
-
   render(): JSX.Element {
     const { databaseUri, resultSet } = this.props;
 
@@ -112,7 +95,7 @@ export class AlertTable extends React.Component<
     };
 
     if (!resultSet.interpretation.data.runs?.[0]?.results?.length) {
-      return this.renderNoResults();
+      return <AlertTableNoResults {...this.props} />;
     }
 
     resultSet.interpretation.data.runs[0].results.forEach(

--- a/extensions/ql-vscode/src/view/results/AlertTable.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTable.tsx
@@ -75,13 +75,11 @@ export class AlertTable extends React.Component<
     const updateSelectionCallback = (
       resultKey: Keys.PathNode | Keys.Result | undefined,
     ) => {
-      return () => {
-        this.setState((previousState) => ({
-          ...previousState,
-          selectedItem: resultKey,
-        }));
-        sendTelemetry("local-results-alert-table-path-selected");
-      };
+      this.setState((previousState) => ({
+        ...previousState,
+        selectedItem: resultKey,
+      }));
+      sendTelemetry("local-results-alert-table-path-selected");
     };
 
     if (!resultSet.interpretation.data.runs?.[0]?.results?.length) {

--- a/extensions/ql-vscode/src/view/results/AlertTableNoResults.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTableNoResults.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+import { EmptyQueryResultsMessage } from "./EmptyQueryResultsMessage";
+import TextButton from "../common/TextButton";
+
+interface Props {
+  nonemptyRawResults: boolean;
+  showRawResults: () => void;
+}
+
+export function AlertTableNoResults(props: Props): JSX.Element {
+  if (props.nonemptyRawResults) {
+    return (
+      <span>
+        No Alerts. See{" "}
+        <TextButton onClick={props.showRawResults}>raw results</TextButton>.
+      </span>
+    );
+  } else {
+    return <EmptyQueryResultsMessage />;
+  }
+}

--- a/extensions/ql-vscode/src/view/results/AlertTablePathNodeRow.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTablePathNodeRow.tsx
@@ -4,7 +4,7 @@ import * as Keys from "./result-keys";
 import { SarifLocation } from "./locations/SarifLocation";
 import { selectableZebraStripe } from "./result-table-utils";
 import { ScrollIntoViewHelper } from "./scroll-into-view-helper";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 
 interface Props {
   step: Sarif.ThreadFlowLocation;
@@ -16,7 +16,7 @@ interface Props {
   sourceLocationPrefix: string;
   updateSelectionCallback: (
     resultKey: Keys.PathNode | Keys.Result | undefined,
-  ) => () => void;
+  ) => void;
   scroller: ScrollIntoViewHelper;
 }
 
@@ -41,7 +41,7 @@ export function AlertTablePathNodeRow(props: Props) {
     }),
     [pathIndex, pathNodeIndex, resultIndex],
   );
-  const handleSarifLocationClicked = useMemo(
+  const handleSarifLocationClicked = useCallback(
     () => updateSelectionCallback(pathNodeKey),
     [pathNodeKey, updateSelectionCallback],
   );

--- a/extensions/ql-vscode/src/view/results/AlertTablePathNodeRow.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTablePathNodeRow.tsx
@@ -1,0 +1,98 @@
+import * as React from "react";
+import * as Sarif from "sarif";
+import * as Keys from "./result-keys";
+import { SarifLocation } from "./locations/SarifLocation";
+import { selectableZebraStripe } from "./result-table-utils";
+import { ScrollIntoViewHelper } from "./scroll-into-view-helper";
+
+interface Props {
+  step: Sarif.ThreadFlowLocation;
+  pathNodeIndex: number;
+  pathIndex: number;
+  resultIndex: number;
+  selectedItem: undefined | Keys.ResultKey;
+  databaseUri: string;
+  sourceLocationPrefix: string;
+  updateSelectionCallback: (
+    resultKey: Keys.PathNode | Keys.Result | undefined,
+  ) => () => void;
+  scroller: ScrollIntoViewHelper;
+}
+
+export function AlertTablePathNodeRow(props: Props) {
+  const {
+    step,
+    pathNodeIndex,
+    pathIndex,
+    resultIndex,
+    selectedItem,
+    databaseUri,
+    sourceLocationPrefix,
+    updateSelectionCallback,
+    scroller,
+  } = props;
+
+  const pathNodeKey: Keys.PathNode = {
+    resultIndex,
+    pathIndex,
+    pathNodeIndex,
+  };
+  const msg =
+    step.location !== undefined && step.location.message !== undefined ? (
+      <SarifLocation
+        text={step.location.message.text}
+        loc={step.location}
+        sourceLocationPrefix={sourceLocationPrefix}
+        databaseUri={databaseUri}
+        onClick={updateSelectionCallback(pathNodeKey)}
+      />
+    ) : (
+      "[no location]"
+    );
+  const additionalMsg =
+    step.location !== undefined ? (
+      <SarifLocation
+        loc={step.location}
+        sourceLocationPrefix={sourceLocationPrefix}
+        databaseUri={databaseUri}
+        onClick={updateSelectionCallback(pathNodeKey)}
+      />
+    ) : (
+      ""
+    );
+  const isSelected = Keys.equalsNotUndefined(selectedItem, pathNodeKey);
+  const stepIndex = pathNodeIndex + 1; // Convert to 1-based
+  const zebraIndex = resultIndex + stepIndex;
+  return (
+    <tr
+      ref={scroller.ref(isSelected)}
+      className={isSelected ? "vscode-codeql__selected-path-node" : undefined}
+    >
+      <td className="vscode-codeql__icon-cell">
+        <span className="vscode-codeql__vertical-rule"></span>
+      </td>
+      <td className="vscode-codeql__icon-cell">
+        <span className="vscode-codeql__vertical-rule"></span>
+      </td>
+      <td
+        {...selectableZebraStripe(
+          isSelected,
+          zebraIndex,
+          "vscode-codeql__path-index-cell",
+        )}
+      >
+        {stepIndex}
+      </td>
+      <td {...selectableZebraStripe(isSelected, zebraIndex)}>{msg} </td>
+      <td
+        {...selectableZebraStripe(
+          isSelected,
+          zebraIndex,
+          "vscode-codeql__location-cell",
+        )}
+      >
+        {additionalMsg}
+      </td>
+    </tr>
+  );
+}

--- a/extensions/ql-vscode/src/view/results/AlertTablePathNodeRow.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTablePathNodeRow.tsx
@@ -4,6 +4,7 @@ import * as Keys from "./result-keys";
 import { SarifLocation } from "./locations/SarifLocation";
 import { selectableZebraStripe } from "./result-table-utils";
 import { ScrollIntoViewHelper } from "./scroll-into-view-helper";
+import { useMemo } from "react";
 
 interface Props {
   step: Sarif.ThreadFlowLocation;
@@ -32,11 +33,19 @@ export function AlertTablePathNodeRow(props: Props) {
     scroller,
   } = props;
 
-  const pathNodeKey: Keys.PathNode = {
-    resultIndex,
-    pathIndex,
-    pathNodeIndex,
-  };
+  const pathNodeKey: Keys.PathNode = useMemo(
+    () => ({
+      resultIndex,
+      pathIndex,
+      pathNodeIndex,
+    }),
+    [pathIndex, pathNodeIndex, resultIndex],
+  );
+  const handleSarifLocationClicked = useMemo(
+    () => updateSelectionCallback(pathNodeKey),
+    [pathNodeKey, updateSelectionCallback],
+  );
+
   const isSelected = Keys.equalsNotUndefined(selectedItem, pathNodeKey);
   const stepIndex = pathNodeIndex + 1; // Convert to 1-based
   const zebraIndex = resultIndex + stepIndex;
@@ -67,7 +76,7 @@ export function AlertTablePathNodeRow(props: Props) {
             loc={step.location}
             sourceLocationPrefix={sourceLocationPrefix}
             databaseUri={databaseUri}
-            onClick={updateSelectionCallback(pathNodeKey)}
+            onClick={handleSarifLocationClicked}
           />
         ) : (
           "[no location]"
@@ -85,7 +94,7 @@ export function AlertTablePathNodeRow(props: Props) {
             loc={step.location}
             sourceLocationPrefix={sourceLocationPrefix}
             databaseUri={databaseUri}
-            onClick={updateSelectionCallback(pathNodeKey)}
+            onClick={handleSarifLocationClicked}
           />
         )}
       </td>

--- a/extensions/ql-vscode/src/view/results/AlertTablePathNodeRow.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTablePathNodeRow.tsx
@@ -37,29 +37,6 @@ export function AlertTablePathNodeRow(props: Props) {
     pathIndex,
     pathNodeIndex,
   };
-  const msg =
-    step.location !== undefined && step.location.message !== undefined ? (
-      <SarifLocation
-        text={step.location.message.text}
-        loc={step.location}
-        sourceLocationPrefix={sourceLocationPrefix}
-        databaseUri={databaseUri}
-        onClick={updateSelectionCallback(pathNodeKey)}
-      />
-    ) : (
-      "[no location]"
-    );
-  const additionalMsg =
-    step.location !== undefined ? (
-      <SarifLocation
-        loc={step.location}
-        sourceLocationPrefix={sourceLocationPrefix}
-        databaseUri={databaseUri}
-        onClick={updateSelectionCallback(pathNodeKey)}
-      />
-    ) : (
-      ""
-    );
   const isSelected = Keys.equalsNotUndefined(selectedItem, pathNodeKey);
   const stepIndex = pathNodeIndex + 1; // Convert to 1-based
   const zebraIndex = resultIndex + stepIndex;
@@ -83,7 +60,19 @@ export function AlertTablePathNodeRow(props: Props) {
       >
         {stepIndex}
       </td>
-      <td {...selectableZebraStripe(isSelected, zebraIndex)}>{msg} </td>
+      <td {...selectableZebraStripe(isSelected, zebraIndex)}>
+        {step.location && step.location.message ? (
+          <SarifLocation
+            text={step.location.message.text}
+            loc={step.location}
+            sourceLocationPrefix={sourceLocationPrefix}
+            databaseUri={databaseUri}
+            onClick={updateSelectionCallback(pathNodeKey)}
+          />
+        ) : (
+          "[no location]"
+        )}
+      </td>
       <td
         {...selectableZebraStripe(
           isSelected,
@@ -91,7 +80,14 @@ export function AlertTablePathNodeRow(props: Props) {
           "vscode-codeql__location-cell",
         )}
       >
-        {additionalMsg}
+        {step.location && (
+          <SarifLocation
+            loc={step.location}
+            sourceLocationPrefix={sourceLocationPrefix}
+            databaseUri={databaseUri}
+            onClick={updateSelectionCallback(pathNodeKey)}
+          />
+        )}
       </td>
     </tr>
   );

--- a/extensions/ql-vscode/src/view/results/AlertTablePathRow.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTablePathRow.tsx
@@ -18,7 +18,7 @@ interface Props {
   updateSelectionCallback: (
     resultKey: Keys.PathNode | Keys.Result | undefined,
   ) => () => void;
-  toggler: (keys: Keys.ResultKey[]) => (e: React.MouseEvent) => void;
+  toggleExpanded: (e: React.MouseEvent, keys: Keys.ResultKey[]) => void;
   scroller: ScrollIntoViewHelper;
 }
 
@@ -32,7 +32,7 @@ export function AlertTablePathRow(props: Props) {
     databaseUri,
     sourceLocationPrefix,
     updateSelectionCallback,
-    toggler,
+    toggleExpanded,
     scroller,
   } = props;
 
@@ -41,8 +41,8 @@ export function AlertTablePathRow(props: Props) {
     [pathIndex, resultIndex],
   );
   const handleDropdownClick = useMemo(
-    () => toggler([pathKey]),
-    [pathKey, toggler],
+    () => (e: React.MouseEvent) => toggleExpanded(e, [pathKey]),
+    [pathKey, toggleExpanded],
   );
 
   const isPathSpecificallySelected = Keys.equalsNotUndefined(

--- a/extensions/ql-vscode/src/view/results/AlertTablePathRow.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTablePathRow.tsx
@@ -17,7 +17,7 @@ interface Props {
   sourceLocationPrefix: string;
   updateSelectionCallback: (
     resultKey: Keys.PathNode | Keys.Result | undefined,
-  ) => () => void;
+  ) => void;
   toggleExpanded: (e: React.MouseEvent, keys: Keys.ResultKey[]) => void;
   scroller: ScrollIntoViewHelper;
 }

--- a/extensions/ql-vscode/src/view/results/AlertTablePathRow.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTablePathRow.tsx
@@ -49,45 +49,39 @@ export function AlertTablePathRow(props: Props) {
     pathKey,
     selectedItem,
   );
-  const pathRow = (
-    <tr
-      ref={scroller.ref(isPathSpecificallySelected)}
-      {...selectableZebraStripe(isPathSpecificallySelected, resultIndex)}
-    >
-      <td className="vscode-codeql__icon-cell">
-        <span className="vscode-codeql__vertical-rule"></span>
-      </td>
-      <AlertTableDropdownIndicatorCell
-        expanded={currentPathExpanded}
-        onClick={handleDropdownClick}
-      />
-      <td className="vscode-codeql__text-center" colSpan={3}>
-        Path
-      </td>
-    </tr>
-  );
-
-  const pathNodeRows =
-    currentPathExpanded &&
-    path.locations.map((step, pathNodeIndex) => (
-      <AlertTablePathNodeRow
-        key={`${resultIndex}-${pathIndex}-${pathNodeIndex}`}
-        step={step}
-        pathNodeIndex={pathNodeIndex}
-        pathIndex={pathIndex}
-        resultIndex={resultIndex}
-        selectedItem={selectedItem}
-        databaseUri={databaseUri}
-        sourceLocationPrefix={sourceLocationPrefix}
-        updateSelectionCallback={updateSelectionCallback}
-        scroller={scroller}
-      />
-    ));
 
   return (
     <>
-      {pathRow}
-      {pathNodeRows}
+      <tr
+        ref={scroller.ref(isPathSpecificallySelected)}
+        {...selectableZebraStripe(isPathSpecificallySelected, resultIndex)}
+      >
+        <td className="vscode-codeql__icon-cell">
+          <span className="vscode-codeql__vertical-rule"></span>
+        </td>
+        <AlertTableDropdownIndicatorCell
+          expanded={currentPathExpanded}
+          onClick={handleDropdownClick}
+        />
+        <td className="vscode-codeql__text-center" colSpan={3}>
+          Path
+        </td>
+      </tr>
+      {currentPathExpanded &&
+        path.locations.map((step, pathNodeIndex) => (
+          <AlertTablePathNodeRow
+            key={`${resultIndex}-${pathIndex}-${pathNodeIndex}`}
+            step={step}
+            pathNodeIndex={pathNodeIndex}
+            pathIndex={pathIndex}
+            resultIndex={resultIndex}
+            selectedItem={selectedItem}
+            databaseUri={databaseUri}
+            sourceLocationPrefix={sourceLocationPrefix}
+            updateSelectionCallback={updateSelectionCallback}
+            scroller={scroller}
+          />
+        ))}
     </>
   );
 }

--- a/extensions/ql-vscode/src/view/results/AlertTablePathRow.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTablePathRow.tsx
@@ -5,6 +5,7 @@ import { selectableZebraStripe } from "./result-table-utils";
 import { ScrollIntoViewHelper } from "./scroll-into-view-helper";
 import { AlertTablePathNodeRow } from "./AlertTablePathNodeRow";
 import { AlertTableDropdownIndicatorCell } from "./AlertTableDropdownIndicatorCell";
+import { useMemo } from "react";
 
 interface Props {
   path: Sarif.ThreadFlow;
@@ -35,7 +36,14 @@ export function AlertTablePathRow(props: Props) {
     scroller,
   } = props;
 
-  const pathKey = { resultIndex, pathIndex };
+  const pathKey = useMemo(
+    () => ({ resultIndex, pathIndex }),
+    [pathIndex, resultIndex],
+  );
+  const handleDropdownClick = useMemo(
+    () => toggler([pathKey]),
+    [pathKey, toggler],
+  );
 
   const isPathSpecificallySelected = Keys.equalsNotUndefined(
     pathKey,
@@ -51,7 +59,7 @@ export function AlertTablePathRow(props: Props) {
       </td>
       <AlertTableDropdownIndicatorCell
         expanded={currentPathExpanded}
-        onClick={toggler([pathKey])}
+        onClick={handleDropdownClick}
       />
       <td className="vscode-codeql__text-center" colSpan={3}>
         Path

--- a/extensions/ql-vscode/src/view/results/AlertTablePathRow.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTablePathRow.tsx
@@ -1,0 +1,85 @@
+import * as React from "react";
+import * as Sarif from "sarif";
+import * as Keys from "./result-keys";
+import { selectableZebraStripe } from "./result-table-utils";
+import { ScrollIntoViewHelper } from "./scroll-into-view-helper";
+import { AlertTablePathNodeRow } from "./AlertTablePathNodeRow";
+import { AlertTableDropdownIndicatorCell } from "./AlertTableDropdownIndicatorCell";
+
+interface Props {
+  path: Sarif.ThreadFlow;
+  pathIndex: number;
+  resultIndex: number;
+  currentPathExpanded: boolean;
+  selectedItem: undefined | Keys.ResultKey;
+  databaseUri: string;
+  sourceLocationPrefix: string;
+  updateSelectionCallback: (
+    resultKey: Keys.PathNode | Keys.Result | undefined,
+  ) => () => void;
+  toggler: (keys: Keys.ResultKey[]) => (e: React.MouseEvent) => void;
+  scroller: ScrollIntoViewHelper;
+}
+
+export function AlertTablePathRow(props: Props) {
+  const {
+    path,
+    pathIndex,
+    resultIndex,
+    currentPathExpanded,
+    selectedItem,
+    databaseUri,
+    sourceLocationPrefix,
+    updateSelectionCallback,
+    toggler,
+    scroller,
+  } = props;
+
+  const pathKey = { resultIndex, pathIndex };
+
+  const isPathSpecificallySelected = Keys.equalsNotUndefined(
+    pathKey,
+    selectedItem,
+  );
+  const pathRow = (
+    <tr
+      ref={scroller.ref(isPathSpecificallySelected)}
+      {...selectableZebraStripe(isPathSpecificallySelected, resultIndex)}
+    >
+      <td className="vscode-codeql__icon-cell">
+        <span className="vscode-codeql__vertical-rule"></span>
+      </td>
+      <AlertTableDropdownIndicatorCell
+        expanded={currentPathExpanded}
+        onClick={toggler([pathKey])}
+      />
+      <td className="vscode-codeql__text-center" colSpan={3}>
+        Path
+      </td>
+    </tr>
+  );
+
+  const pathNodeRows =
+    currentPathExpanded &&
+    path.locations.map((step, pathNodeIndex) => (
+      <AlertTablePathNodeRow
+        key={`${resultIndex}-${pathIndex}-${pathNodeIndex}`}
+        step={step}
+        pathNodeIndex={pathNodeIndex}
+        pathIndex={pathIndex}
+        resultIndex={resultIndex}
+        selectedItem={selectedItem}
+        databaseUri={databaseUri}
+        sourceLocationPrefix={sourceLocationPrefix}
+        updateSelectionCallback={updateSelectionCallback}
+        scroller={scroller}
+      />
+    ));
+
+  return (
+    <>
+      {pathRow}
+      {pathNodeRows}
+    </>
+  );
+}

--- a/extensions/ql-vscode/src/view/results/AlertTablePathRow.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTablePathRow.tsx
@@ -29,9 +29,6 @@ export function AlertTablePathRow(props: Props) {
     resultIndex,
     currentPathExpanded,
     selectedItem,
-    databaseUri,
-    sourceLocationPrefix,
-    updateSelectionCallback,
     toggleExpanded,
     scroller,
   } = props;
@@ -71,15 +68,9 @@ export function AlertTablePathRow(props: Props) {
         path.locations.map((step, pathNodeIndex) => (
           <AlertTablePathNodeRow
             key={`${resultIndex}-${pathIndex}-${pathNodeIndex}`}
+            {...props}
             step={step}
             pathNodeIndex={pathNodeIndex}
-            pathIndex={pathIndex}
-            resultIndex={resultIndex}
-            selectedItem={selectedItem}
-            databaseUri={databaseUri}
-            sourceLocationPrefix={sourceLocationPrefix}
-            updateSelectionCallback={updateSelectionCallback}
-            scroller={scroller}
           />
         ))}
     </>

--- a/extensions/ql-vscode/src/view/results/AlertTablePathRow.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTablePathRow.tsx
@@ -5,7 +5,7 @@ import { selectableZebraStripe } from "./result-table-utils";
 import { ScrollIntoViewHelper } from "./scroll-into-view-helper";
 import { AlertTablePathNodeRow } from "./AlertTablePathNodeRow";
 import { AlertTableDropdownIndicatorCell } from "./AlertTableDropdownIndicatorCell";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 
 interface Props {
   path: Sarif.ThreadFlow;
@@ -37,8 +37,8 @@ export function AlertTablePathRow(props: Props) {
     () => ({ resultIndex, pathIndex }),
     [pathIndex, resultIndex],
   );
-  const handleDropdownClick = useMemo(
-    () => (e: React.MouseEvent) => toggleExpanded(e, [pathKey]),
+  const handleDropdownClick = useCallback(
+    (e: React.MouseEvent) => toggleExpanded(e, [pathKey]),
     [pathKey, toggleExpanded],
   );
 

--- a/extensions/ql-vscode/src/view/results/AlertTableResultRow.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTableResultRow.tsx
@@ -19,7 +19,7 @@ interface Props {
   sourceLocationPrefix: string;
   updateSelectionCallback: (
     resultKey: Keys.PathNode | Keys.Result | undefined,
-  ) => () => void;
+  ) => void;
   toggleExpanded: (e: React.MouseEvent, keys: Keys.ResultKey[]) => void;
   scroller: ScrollIntoViewHelper;
 }
@@ -42,7 +42,7 @@ export function AlertTableResultRow(props: Props) {
     [resultIndex],
   );
 
-  const handleSarifLocationClicked = useMemo(
+  const handleSarifLocationClicked = useCallback(
     () => updateSelectionCallback(resultKey),
     [resultKey, updateSelectionCallback],
   );

--- a/extensions/ql-vscode/src/view/results/AlertTableResultRow.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTableResultRow.tsx
@@ -112,18 +112,12 @@ export function AlertTableResultRow(props: Props) {
         Keys.getAllPaths(result).map((path, pathIndex) => (
           <AlertTablePathRow
             key={`${resultIndex}-${pathIndex}`}
+            {...props}
             path={path}
             pathIndex={pathIndex}
-            resultIndex={resultIndex}
             currentPathExpanded={expanded.has(
               Keys.keyToString({ resultIndex, pathIndex }),
             )}
-            selectedItem={selectedItem}
-            databaseUri={databaseUri}
-            sourceLocationPrefix={sourceLocationPrefix}
-            updateSelectionCallback={updateSelectionCallback}
-            toggleExpanded={toggleExpanded}
-            scroller={scroller}
           />
         ))}
     </>

--- a/extensions/ql-vscode/src/view/results/AlertTableResultRow.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTableResultRow.tsx
@@ -6,16 +6,21 @@ import { ScrollIntoViewHelper } from "./scroll-into-view-helper";
 import { selectableZebraStripe } from "./result-table-utils";
 import { AlertTableDropdownIndicatorCell } from "./AlertTableDropdownIndicatorCell";
 import { useMemo } from "react";
+import { SarifLocation } from "./locations/SarifLocation";
 
 interface Props {
   result: Sarif.Result;
   resultIndex: number;
   currentResultExpanded: boolean;
   selectedItem: undefined | Keys.ResultKey;
+  databaseUri: string;
+  sourceLocationPrefix: string;
+  updateSelectionCallback: (
+    resultKey: Keys.PathNode | Keys.Result | undefined,
+  ) => () => void;
   toggler: (keys: Keys.ResultKey[]) => (e: React.MouseEvent) => void;
   scroller: ScrollIntoViewHelper;
   msg: JSX.Element;
-  locationCells: JSX.Element;
 }
 
 export function AlertTableResultRow(props: Props) {
@@ -24,14 +29,20 @@ export function AlertTableResultRow(props: Props) {
     resultIndex,
     currentResultExpanded,
     selectedItem,
+    databaseUri,
+    sourceLocationPrefix,
+    updateSelectionCallback,
     toggler,
     scroller,
     msg,
-    locationCells,
   } = props;
 
+  const resultKey: Keys.Result = useMemo(
+    () => ({ resultIndex }),
+    [resultIndex],
+  );
+
   const handleDropdownClick = useMemo(() => {
-    const resultKey: Keys.Result = { resultIndex };
     const indices =
       Keys.getAllPaths(result).length === 1
         ? [resultKey, { ...resultKey, pathIndex: 0 }]
@@ -39,7 +50,7 @@ export function AlertTableResultRow(props: Props) {
            * the path when expanding the result */
           [resultKey];
     return toggler(indices);
-  }, [result, resultIndex, toggler]);
+  }, [result, resultKey, toggler]);
 
   const resultRowIsSelected =
     selectedItem?.resultIndex === resultIndex &&
@@ -66,7 +77,16 @@ export function AlertTableResultRow(props: Props) {
           <td colSpan={2}>{msg}</td>
         </>
       )}
-      {locationCells}
+      <td className="vscode-codeql__location-cell">
+        {result.locations && result.locations.length > 0 && (
+          <SarifLocation
+            loc={result.locations[0]}
+            sourceLocationPrefix={sourceLocationPrefix}
+            databaseUri={databaseUri}
+            onClick={updateSelectionCallback(resultKey)}
+          />
+        )}
+      </td>
     </tr>
   );
 }

--- a/extensions/ql-vscode/src/view/results/AlertTableResultRow.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTableResultRow.tsx
@@ -42,6 +42,10 @@ export function AlertTableResultRow(props: Props) {
     [resultIndex],
   );
 
+  const handleSarifLocationClicked = useMemo(
+    () => updateSelectionCallback(resultKey),
+    [resultKey, updateSelectionCallback],
+  );
   const handleDropdownClick = useMemo(() => {
     const indices =
       Keys.getAllPaths(result).length === 1
@@ -83,7 +87,7 @@ export function AlertTableResultRow(props: Props) {
             loc={result.locations[0]}
             sourceLocationPrefix={sourceLocationPrefix}
             databaseUri={databaseUri}
-            onClick={updateSelectionCallback(resultKey)}
+            onClick={handleSarifLocationClicked}
           />
         )}
       </td>

--- a/extensions/ql-vscode/src/view/results/AlertTableResultRow.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTableResultRow.tsx
@@ -7,6 +7,7 @@ import { selectableZebraStripe } from "./result-table-utils";
 import { AlertTableDropdownIndicatorCell } from "./AlertTableDropdownIndicatorCell";
 import { useMemo } from "react";
 import { SarifLocation } from "./locations/SarifLocation";
+import { SarifMessageWithLocations } from "./locations/SarifMessageWithLocations";
 
 interface Props {
   result: Sarif.Result;
@@ -20,7 +21,6 @@ interface Props {
   ) => () => void;
   toggler: (keys: Keys.ResultKey[]) => (e: React.MouseEvent) => void;
   scroller: ScrollIntoViewHelper;
-  msg: JSX.Element;
 }
 
 export function AlertTableResultRow(props: Props) {
@@ -34,7 +34,6 @@ export function AlertTableResultRow(props: Props) {
     updateSelectionCallback,
     toggler,
     scroller,
-    msg,
   } = props;
 
   const resultKey: Keys.Result = useMemo(
@@ -59,6 +58,20 @@ export function AlertTableResultRow(props: Props) {
   const resultRowIsSelected =
     selectedItem?.resultIndex === resultIndex &&
     selectedItem.pathIndex === undefined;
+
+  const text = result.message.text || "[no text]";
+  const msg =
+    result.relatedLocations === undefined ? (
+      <span key="0">{text}</span>
+    ) : (
+      <SarifMessageWithLocations
+        msg={text}
+        relatedLocations={result.relatedLocations}
+        sourceLocationPrefix={sourceLocationPrefix}
+        databaseUri={databaseUri}
+        onClick={handleSarifLocationClicked}
+      />
+    );
 
   return (
     <tr

--- a/extensions/ql-vscode/src/view/results/AlertTableResultRow.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTableResultRow.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import * as Sarif from "sarif";
 import * as Keys from "./result-keys";
-import { listUnordered } from "./octicons";
+import { info, listUnordered } from "./octicons";
 import { ScrollIntoViewHelper } from "./scroll-into-view-helper";
 import { selectableZebraStripe } from "./result-table-utils";
 import { AlertTableDropdownIndicatorCell } from "./AlertTableDropdownIndicatorCell";
@@ -51,12 +51,21 @@ export function AlertTableResultRow(props: Props) {
       {...selectableZebraStripe(resultRowIsSelected, resultIndex)}
       key={resultIndex}
     >
-      <AlertTableDropdownIndicatorCell
-        expanded={currentResultExpanded}
-        onClick={handleDropdownClick}
-      />
-      <td className="vscode-codeql__icon-cell">{listUnordered}</td>
-      <td colSpan={2}>{msg}</td>
+      {result.codeFlows === undefined ? (
+        <>
+          <td className="vscode-codeql__icon-cell">{info}</td>
+          <td colSpan={3}>{msg}</td>
+        </>
+      ) : (
+        <>
+          <AlertTableDropdownIndicatorCell
+            expanded={currentResultExpanded}
+            onClick={handleDropdownClick}
+          />
+          <td className="vscode-codeql__icon-cell">{listUnordered}</td>
+          <td colSpan={2}>{msg}</td>
+        </>
+      )}
       {locationCells}
     </tr>
   );

--- a/extensions/ql-vscode/src/view/results/AlertTableResultRow.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTableResultRow.tsx
@@ -5,6 +5,7 @@ import { listUnordered } from "./octicons";
 import { ScrollIntoViewHelper } from "./scroll-into-view-helper";
 import { selectableZebraStripe } from "./result-table-utils";
 import { AlertTableDropdownIndicatorCell } from "./AlertTableDropdownIndicatorCell";
+import { useMemo } from "react";
 
 interface Props {
   result: Sarif.Result;
@@ -29,15 +30,16 @@ export function AlertTableResultRow(props: Props) {
     locationCells,
   } = props;
 
-  const resultKey: Keys.Result = { resultIndex };
-
-  const paths: Sarif.ThreadFlow[] = Keys.getAllPaths(result);
-  const indices =
-    paths.length === 1
-      ? [resultKey, { ...resultKey, pathIndex: 0 }]
-      : /* if there's exactly one path, auto-expand
-         * the path when expanding the result */
-        [resultKey];
+  const handleDropdownClick = useMemo(() => {
+    const resultKey: Keys.Result = { resultIndex };
+    const indices =
+      Keys.getAllPaths(result).length === 1
+        ? [resultKey, { ...resultKey, pathIndex: 0 }]
+        : /* if there's exactly one path, auto-expand
+           * the path when expanding the result */
+          [resultKey];
+    return toggler(indices);
+  }, [result, resultIndex, toggler]);
 
   const resultRowIsSelected =
     selectedItem?.resultIndex === resultIndex &&
@@ -51,7 +53,7 @@ export function AlertTableResultRow(props: Props) {
     >
       <AlertTableDropdownIndicatorCell
         expanded={currentResultExpanded}
-        onClick={toggler(indices)}
+        onClick={handleDropdownClick}
       />
       <td className="vscode-codeql__icon-cell">{listUnordered}</td>
       <td colSpan={2}>{msg}</td>

--- a/extensions/ql-vscode/src/view/results/AlertTableResultRow.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTableResultRow.tsx
@@ -5,7 +5,7 @@ import { info, listUnordered } from "./octicons";
 import { ScrollIntoViewHelper } from "./scroll-into-view-helper";
 import { selectableZebraStripe } from "./result-table-utils";
 import { AlertTableDropdownIndicatorCell } from "./AlertTableDropdownIndicatorCell";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { SarifLocation } from "./locations/SarifLocation";
 import { SarifMessageWithLocations } from "./locations/SarifMessageWithLocations";
 import { AlertTablePathRow } from "./AlertTablePathRow";
@@ -46,15 +46,18 @@ export function AlertTableResultRow(props: Props) {
     () => updateSelectionCallback(resultKey),
     [resultKey, updateSelectionCallback],
   );
-  const handleDropdownClick = useMemo(() => {
-    const indices =
-      Keys.getAllPaths(result).length === 1
-        ? [resultKey, { ...resultKey, pathIndex: 0 }]
-        : /* if there's exactly one path, auto-expand
-           * the path when expanding the result */
-          [resultKey];
-    return (e: React.MouseEvent) => toggleExpanded(e, indices);
-  }, [result, resultKey, toggleExpanded]);
+  const handleDropdownClick = useCallback(
+    (e: React.MouseEvent) => {
+      const indices =
+        Keys.getAllPaths(result).length === 1
+          ? [resultKey, { ...resultKey, pathIndex: 0 }]
+          : /* if there's exactly one path, auto-expand
+             * the path when expanding the result */
+            [resultKey];
+      toggleExpanded(e, indices);
+    },
+    [result, resultKey, toggleExpanded],
+  );
 
   const resultRowIsSelected =
     selectedItem?.resultIndex === resultIndex &&

--- a/extensions/ql-vscode/src/view/results/AlertTableResultRow.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTableResultRow.tsx
@@ -1,0 +1,61 @@
+import * as React from "react";
+import * as Sarif from "sarif";
+import * as Keys from "./result-keys";
+import { listUnordered } from "./octicons";
+import { ScrollIntoViewHelper } from "./scroll-into-view-helper";
+import { selectableZebraStripe } from "./result-table-utils";
+import { AlertTableDropdownIndicatorCell } from "./AlertTableDropdownIndicatorCell";
+
+interface Props {
+  result: Sarif.Result;
+  resultIndex: number;
+  currentResultExpanded: boolean;
+  selectedItem: undefined | Keys.ResultKey;
+  toggler: (keys: Keys.ResultKey[]) => (e: React.MouseEvent) => void;
+  scroller: ScrollIntoViewHelper;
+  msg: JSX.Element;
+  locationCells: JSX.Element;
+}
+
+export function AlertTableResultRow(props: Props) {
+  const {
+    result,
+    resultIndex,
+    currentResultExpanded,
+    selectedItem,
+    toggler,
+    scroller,
+    msg,
+    locationCells,
+  } = props;
+
+  const resultKey: Keys.Result = { resultIndex };
+
+  const paths: Sarif.ThreadFlow[] = Keys.getAllPaths(result);
+  const indices =
+    paths.length === 1
+      ? [resultKey, { ...resultKey, pathIndex: 0 }]
+      : /* if there's exactly one path, auto-expand
+         * the path when expanding the result */
+        [resultKey];
+
+  const resultRowIsSelected =
+    selectedItem?.resultIndex === resultIndex &&
+    selectedItem.pathIndex === undefined;
+
+  return (
+    <tr
+      ref={scroller.ref(resultRowIsSelected)}
+      {...selectableZebraStripe(resultRowIsSelected, resultIndex)}
+      key={resultIndex}
+    >
+      <AlertTableDropdownIndicatorCell
+        expanded={currentResultExpanded}
+        onClick={toggler(indices)}
+      />
+      <td className="vscode-codeql__icon-cell">{listUnordered}</td>
+      <td colSpan={2}>{msg}</td>
+      {locationCells}
+    </tr>
+  );
+}

--- a/extensions/ql-vscode/src/view/results/AlertTableResultRow.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTableResultRow.tsx
@@ -20,7 +20,7 @@ interface Props {
   updateSelectionCallback: (
     resultKey: Keys.PathNode | Keys.Result | undefined,
   ) => () => void;
-  toggler: (keys: Keys.ResultKey[]) => (e: React.MouseEvent) => void;
+  toggleExpanded: (e: React.MouseEvent, keys: Keys.ResultKey[]) => void;
   scroller: ScrollIntoViewHelper;
 }
 
@@ -33,7 +33,7 @@ export function AlertTableResultRow(props: Props) {
     databaseUri,
     sourceLocationPrefix,
     updateSelectionCallback,
-    toggler,
+    toggleExpanded,
     scroller,
   } = props;
 
@@ -53,8 +53,8 @@ export function AlertTableResultRow(props: Props) {
         : /* if there's exactly one path, auto-expand
            * the path when expanding the result */
           [resultKey];
-    return toggler(indices);
-  }, [result, resultKey, toggler]);
+    return (e: React.MouseEvent) => toggleExpanded(e, indices);
+  }, [result, resultKey, toggleExpanded]);
 
   const resultRowIsSelected =
     selectedItem?.resultIndex === resultIndex &&
@@ -122,7 +122,7 @@ export function AlertTableResultRow(props: Props) {
             databaseUri={databaseUri}
             sourceLocationPrefix={sourceLocationPrefix}
             updateSelectionCallback={updateSelectionCallback}
-            toggler={toggler}
+            toggleExpanded={toggleExpanded}
             scroller={scroller}
           />
         ))}

--- a/extensions/ql-vscode/src/view/results/AlertTableTruncatedMessage.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTableTruncatedMessage.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+
+interface Props {
+  numTruncatedResults: number;
+}
+
+export function AlertTableTruncatedMessage(props: Props): JSX.Element | null {
+  if (props.numTruncatedResults === 0) {
+    return null;
+  }
+  return (
+    <tr key="truncatd-message">
+      <td colSpan={5} style={{ textAlign: "center", fontStyle: "italic" }}>
+        Too many results to show at once. {props.numTruncatedResults} result(s)
+        omitted.
+      </td>
+    </tr>
+  );
+}


### PR DESCRIPTION
Refactors the rendering in `AlertTable`. Previous it was multiple nested `foreach` loops adding components to a `rows` array from multiple places, including the rendering of zero results or truncated results. As of this PR it's a series of hierarchical components.

Each small change is done as a separate commit, so theoretically you should be able to follow along with them. Or it may be easier to review the end result on its own if that's what you prefer.

I've tried to test manually and as far as I can tell, everything looks and behaves exactly the same as before 🎉 

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
