### PR TITLE
Starcke/automodel queries refactor

### DIFF
--- a/extensions/ql-vscode/src/data-extensions-editor/auto-model-codeml-queries.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/auto-model-codeml-queries.ts
@@ -55,7 +55,7 @@ export async function runAutoModelQueries({
   cancellationTokenSource,
 }: AutoModelQueriesOptions): Promise<AutoModelQueriesResult | undefined> {
   // First, resolve the query that we want to run.
-  const queryPath = await resolveAutomodelQueries(
+  const queryPath = await resolveAutomodelQuery(
     cliServer,
     databaseItem,
     "candidates",
@@ -121,7 +121,7 @@ export async function runAutoModelQueries({
   };
 }
 
-async function resolveAutomodelQueries(
+async function resolveAutomodelQuery(
   cliServer: CodeQLCliServer,
   databaseItem: DatabaseItem,
   queryTag: string,
@@ -223,8 +223,7 @@ async function interpretAutomodelResults(
     "results.sarif",
   );
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- We only need the actual SARIF data, not the extra fields added by SarifInterpretationData
-  const { t, sortState, ...sarif } = await interpretResultsSarif(
+  const { ...sarif } = await interpretResultsSarif(
     cliServer,
     metadata,
     {

--- a/extensions/ql-vscode/src/local-queries/run-query.ts
+++ b/extensions/ql-vscode/src/local-queries/run-query.ts
@@ -1,0 +1,78 @@
+import { CancellationToken } from "vscode";
+import { CodeQLCliServer } from "../codeql-cli/cli";
+import { ProgressCallback } from "../common/vscode/progress";
+import { DatabaseItem } from "../databases/local-databases";
+import { CoreCompletedQuery, QueryRunner } from "../query-server";
+import { createLockFileForStandardQuery } from "./standard-queries";
+import { TeeLogger, showAndLogExceptionWithTelemetry } from "../common/logging";
+import { QueryResultType } from "../query-server/new-messages";
+import { extLogger } from "../common/logging/vscode";
+import { telemetryListener } from "../common/vscode/telemetry";
+import { redactableError } from "../common/errors";
+import { basename } from "path";
+
+type RunQueriesOptions = {
+  cliServer: CodeQLCliServer;
+  queryRunner: QueryRunner;
+  databaseItem: DatabaseItem;
+  queryPath: string;
+  queryStorageDir: string;
+  additionalPacks: string[];
+  extensionPacks: string[] | undefined;
+  progress: ProgressCallback;
+  token: CancellationToken;
+};
+
+export async function runQuery({
+  cliServer,
+  queryRunner,
+  databaseItem,
+  queryPath,
+  queryStorageDir,
+  additionalPacks,
+  extensionPacks,
+  progress,
+  token,
+}: RunQueriesOptions): Promise<CoreCompletedQuery | undefined> {
+  // Create a lock file for the query. This is required to resolve dependencies and library path for the query.
+  const { cleanup: cleanupLockFile } = await createLockFileForStandardQuery(
+    cliServer,
+    queryPath,
+  );
+
+  // Create a query run to execute
+  const queryRun = queryRunner.createQueryRun(
+    databaseItem.databaseUri.fsPath,
+    {
+      queryPath,
+      quickEvalPosition: undefined,
+      quickEvalCountOnly: false,
+    },
+    false,
+    additionalPacks,
+    extensionPacks,
+    queryStorageDir,
+    undefined,
+    undefined,
+  );
+
+  const completedQuery = await queryRun.evaluate(
+    progress,
+    token,
+    new TeeLogger(queryRunner.logger, queryRun.outputDir.logPath),
+  );
+
+  await cleanupLockFile?.();
+
+  if (completedQuery.resultType !== QueryResultType.SUCCESS) {
+    void showAndLogExceptionWithTelemetry(
+      extLogger,
+      telemetryListener,
+      redactableError`Failed to run ${basename(queryPath)} query: ${
+        completedQuery.message ?? "No message"
+      }`,
+    );
+    return;
+  }
+  return completedQuery;
+}

--- a/extensions/ql-vscode/src/local-queries/run-query.ts
+++ b/extensions/ql-vscode/src/local-queries/run-query.ts
@@ -11,7 +11,7 @@ import { telemetryListener } from "../common/vscode/telemetry";
 import { redactableError } from "../common/errors";
 import { basename } from "path";
 
-type RunQueriesOptions = {
+type RunQueryOptions = {
   cliServer: CodeQLCliServer;
   queryRunner: QueryRunner;
   databaseItem: DatabaseItem;
@@ -33,7 +33,7 @@ export async function runQuery({
   extensionPacks,
   progress,
   token,
-}: RunQueriesOptions): Promise<CoreCompletedQuery | undefined> {
+}: RunQueryOptions): Promise<CoreCompletedQuery | undefined> {
   // Create a lock file for the query. This is required to resolve dependencies and library path for the query.
   const { cleanup: cleanupLockFile } = await createLockFileForStandardQuery(
     cliServer,

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/data-extensions-editor/auto-model-codeml-queries.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/data-extensions-editor/auto-model-codeml-queries.test.ts
@@ -20,6 +20,7 @@ import { join } from "path";
 import { exists, readFile } from "fs-extra";
 import { load as loadYaml } from "js-yaml";
 import { CancellationTokenSource } from "vscode-jsonrpc";
+import { QueryOutputDir } from "../../../../src/run-queries-shared";
 
 describe("runAutoModelQueries", () => {
   const qlpack = {
@@ -59,12 +60,8 @@ describe("runAutoModelQueries", () => {
   });
 
   it("should run the query and return the results", async () => {
-    const logPath = (await file()).path;
-    const bqrsPath = (await file()).path;
-    const outputDir = {
-      logPath,
-      bqrsPath,
-    };
+    const queryStorageDir = (await file()).path;
+    const outputDir = new QueryOutputDir(join(queryStorageDir, "1"));
 
     const options = {
       mode: Mode.Application,


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

This generalizes the automodel queries so that they rely on shared resolution and run methods.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
