### PR TITLE
Rename WebviewView to WebviewKind

### DIFF
--- a/extensions/ql-vscode/src/common/vscode/abstract-webview.ts
+++ b/extensions/ql-vscode/src/common/vscode/abstract-webview.ts
@@ -11,13 +11,13 @@ import { join } from "path";
 
 import { DisposableObject, DisposeHandler } from "../disposable-object";
 import { tmpDir } from "../../tmp-dir";
-import { getHtmlForWebview, WebviewMessage, WebviewView } from "./webview-html";
+import { getHtmlForWebview, WebviewMessage, WebviewKind } from "./webview-html";
 
 export type WebviewPanelConfig = {
   viewId: string;
   title: string;
   viewColumn: ViewColumn;
-  view: WebviewView;
+  view: WebviewKind;
   preserveFocus?: boolean;
   iconPath?: Uri | { dark: Uri; light: Uri };
   additionalOptions?: WebviewPanelOptions & WebviewOptions;

--- a/extensions/ql-vscode/src/common/vscode/webview-html.ts
+++ b/extensions/ql-vscode/src/common/vscode/webview-html.ts
@@ -2,7 +2,7 @@ import { ExtensionContext, Uri, Webview } from "vscode";
 import { randomBytes } from "crypto";
 import { EOL } from "os";
 
-export type WebviewView =
+export type WebviewKind =
   | "results"
   | "compare"
   | "variant-analysis"
@@ -20,7 +20,7 @@ export interface WebviewMessage {
 export function getHtmlForWebview(
   ctx: ExtensionContext,
   webview: Webview,
-  view: WebviewView,
+  view: WebviewKind,
   {
     allowInlineStyles,
     allowWasmEval,


### PR DESCRIPTION
The term WebviewView has a specific meaning in VS Code extensions (see [docs](https://code.visualstudio.com/api/references/vscode-api#WebviewView)), so this PR renames our own WebviewView to avoid confusion.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
