### PR TITLE
Variant analysis: Always read BQRS results file if it's available

### DIFF
--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-results-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-results-manager.ts
@@ -199,34 +199,35 @@ export class VariantAnalysisResultsManager extends DisposableObject {
     );
     const sarifPath = join(resultsDirectory, "results.sarif");
     const bqrsPath = join(resultsDirectory, "results.bqrs");
+
+    let interpretedResults: AnalysisAlert[] | undefined;
+    let rawResults: AnalysisRawResults | undefined;
+
     if (await pathExists(sarifPath)) {
-      const interpretedResults = await this.readSarifResults(
+      interpretedResults = await this.readSarifResults(
         sarifPath,
         fileLinkPrefix,
       );
-
-      return {
-        variantAnalysisId,
-        repositoryId: repoTask.repository.id,
-        interpretedResults,
-      };
     }
 
     if (await pathExists(bqrsPath)) {
-      const rawResults = await this.readBqrsResults(
+      rawResults = await this.readBqrsResults(
         bqrsPath,
         fileLinkPrefix,
         repoTask.sourceLocationPrefix,
       );
-
-      return {
-        variantAnalysisId,
-        repositoryId: repoTask.repository.id,
-        rawResults,
-      };
     }
 
-    throw new Error("Missing results file");
+    if (!interpretedResults && !rawResults) {
+      throw new Error("Missing results file");
+    }
+
+    return {
+      variantAnalysisId,
+      repositoryId: repoTask.repository.id,
+      interpretedResults,
+      rawResults,
+    };
   }
 
   public async isVariantAnalysisRepoDownloaded(


### PR DESCRIPTION
Once https://github.com/github/codeql-variant-analysis-action/pull/854 is merged, a succesful variant analysis run will always have the `result.bqrs` file available. 

Instead of choosing to read interpreted results _or_ raw results, we should support having both. (This is so that users will be able to toggle between raw and interpreted results in the results view.)

## Checklist

N/A—no user impact yet 🦁 

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
