### PR TITLE
Add a dropdown for choosing MRVA result format

### DIFF
--- a/extensions/ql-vscode/src/stories/variant-analysis/RepositoriesResultFormat.stories.tsx
+++ b/extensions/ql-vscode/src/stories/variant-analysis/RepositoriesResultFormat.stories.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+import { useState } from "react";
+
+import { Meta } from "@storybook/react";
+
+import { RepositoriesResultFormat as RepositoriesResultFormatComponent } from "../../view/variant-analysis/RepositoriesResultFormat";
+import { ResultFormat } from "../../variant-analysis/shared/variant-analysis-result-format";
+
+export default {
+  title: "Variant Analysis/Repositories Result Format",
+  component: RepositoriesResultFormatComponent,
+  argTypes: {
+    value: {
+      control: {
+        disable: true,
+      },
+    },
+  },
+} as Meta<typeof RepositoriesResultFormatComponent>;
+
+export const RepositoriesResultFormat = () => {
+  const [value, setValue] = useState(ResultFormat.Alerts);
+
+  return (
+    <RepositoriesResultFormatComponent value={value} onChange={setValue} />
+  );
+};

--- a/extensions/ql-vscode/src/variant-analysis/shared/variant-analysis-result-format.ts
+++ b/extensions/ql-vscode/src/variant-analysis/shared/variant-analysis-result-format.ts
@@ -1,0 +1,4 @@
+export enum ResultFormat {
+  Alerts = "Alerts",
+  RawResults = "Raw results",
+}

--- a/extensions/ql-vscode/src/view/variant-analysis/RepositoriesResultFormat.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/RepositoriesResultFormat.tsx
@@ -1,0 +1,40 @@
+import * as React from "react";
+import { useCallback } from "react";
+import { styled } from "styled-components";
+import { VSCodeDropdown, VSCodeOption } from "@vscode/webview-ui-toolkit/react";
+import { Codicon } from "../common";
+import { ResultFormat } from "../../variant-analysis/shared/variant-analysis-result-format";
+
+const Dropdown = styled(VSCodeDropdown)`
+  width: 100%;
+`;
+
+type Props = {
+  value: ResultFormat;
+  onChange: (value: ResultFormat) => void;
+
+  className?: string;
+};
+
+export const RepositoriesResultFormat = ({
+  value,
+  onChange,
+  className,
+}: Props) => {
+  const handleInput = useCallback(
+    (e: InputEvent) => {
+      const target = e.target as HTMLSelectElement;
+
+      onChange(target.value as ResultFormat);
+    },
+    [onChange],
+  );
+
+  return (
+    <Dropdown value={value} onInput={handleInput} className={className}>
+      <Codicon name="table" label="Result format..." slot="indicator" />
+      <VSCodeOption value={ResultFormat.Alerts}>Alerts</VSCodeOption>
+      <VSCodeOption value={ResultFormat.RawResults}>Raw results</VSCodeOption>
+    </Dropdown>
+  );
+};

--- a/extensions/ql-vscode/src/view/variant-analysis/RepositoriesResultFormat.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/RepositoriesResultFormat.tsx
@@ -33,8 +33,12 @@ export const RepositoriesResultFormat = ({
   return (
     <Dropdown value={value} onInput={handleInput} className={className}>
       <Codicon name="table" label="Result format..." slot="indicator" />
-      <VSCodeOption value={ResultFormat.Alerts}>Alerts</VSCodeOption>
-      <VSCodeOption value={ResultFormat.RawResults}>Raw results</VSCodeOption>
+      <VSCodeOption value={ResultFormat.Alerts}>
+        {ResultFormat.Alerts}
+      </VSCodeOption>
+      <VSCodeOption value={ResultFormat.RawResults}>
+        {ResultFormat.RawResults}
+      </VSCodeOption>
     </Dropdown>
   );
 };


### PR DESCRIPTION
I've added a new component for picking the format for MRVA results:
![image](https://github.com/github/vscode-codeql/assets/42641846/ee697ade-e5dc-4f68-8bd9-58af41d3e811)

It follows the style of the existing [Sort and Filter dropdowns](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/src/view/variant-analysis/RepositoriesSort.tsx):
![image](https://github.com/github/vscode-codeql/assets/42641846/a5c2fd63-0f13-499a-b7c9-432013013487)

Note that I haven't hooked this new component up to the rest of the view yet, so it won't show up anywhere (except in Storybook). See internal linked issue for details!



## Checklist

N/A—no user impact yet 🐘

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
