### PR TITLE
Display "result format" dropdown in results view for (path-)problem queries

### DIFF
--- a/extensions/ql-vscode/src/stories/variant-analysis/RepositoriesSearchSortRow.stories.tsx
+++ b/extensions/ql-vscode/src/stories/variant-analysis/RepositoriesSearchSortRow.stories.tsx
@@ -28,12 +28,15 @@ export const RepositoriesSearchSortRow = () => {
     ResultFormat.Alerts,
   );
 
+  const variantAnalysisQueryKind = "problem";
+
   return (
     <RepositoriesSearchSortRowComponent
       filterSortValue={filterSortValue}
       resultFormatValue={resultFormatValue}
       onFilterSortChange={setFilterSortValue}
       onResultFormatChange={setResultFormatValue}
+      variantAnalysisQueryKind={variantAnalysisQueryKind}
     />
   );
 };

--- a/extensions/ql-vscode/src/stories/variant-analysis/RepositoriesSearchSortRow.stories.tsx
+++ b/extensions/ql-vscode/src/stories/variant-analysis/RepositoriesSearchSortRow.stories.tsx
@@ -5,6 +5,7 @@ import { Meta } from "@storybook/react";
 
 import { RepositoriesSearchSortRow as RepositoriesSearchSortRowComponent } from "../../view/variant-analysis/RepositoriesSearchSortRow";
 import { defaultFilterSortState } from "../../variant-analysis/shared/variant-analysis-filter-sort";
+import { ResultFormat } from "../../variant-analysis/shared/variant-analysis-result-format";
 
 export default {
   title: "Variant Analysis/Repositories Search and Sort Row",
@@ -19,9 +20,20 @@ export default {
 } as Meta<typeof RepositoriesSearchSortRowComponent>;
 
 export const RepositoriesSearchSortRow = () => {
-  const [value, setValue] = useState(defaultFilterSortState);
+  const [filterSortValue, setFilterSortValue] = useState(
+    defaultFilterSortState,
+  );
+
+  const [resultFormatValue, setResultFormatValue] = useState(
+    ResultFormat.Alerts,
+  );
 
   return (
-    <RepositoriesSearchSortRowComponent value={value} onChange={setValue} />
+    <RepositoriesSearchSortRowComponent
+      filterSortValue={filterSortValue}
+      resultFormatValue={resultFormatValue}
+      onFilterSortChange={setFilterSortValue}
+      onResultFormatChange={setResultFormatValue}
+    />
   );
 };

--- a/extensions/ql-vscode/src/view/variant-analysis/RepositoriesSearchSortRow.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/RepositoriesSearchSortRow.tsx
@@ -17,6 +17,7 @@ type Props = {
   resultFormatValue: ResultFormat;
   onFilterSortChange: Dispatch<SetStateAction<RepositoriesFilterSortState>>;
   onResultFormatChange: Dispatch<SetStateAction<ResultFormat>>;
+  variantAnalysisQueryKind: string | undefined;
 };
 
 const Container = styled.div`
@@ -43,11 +44,21 @@ const RepositoriesResultFormatColumn = styled(RepositoriesResultFormat)`
   flex: 1;
 `;
 
+function showResultFormatColumn(
+  variantAnalysisQueryKind: string | undefined,
+): boolean {
+  return (
+    variantAnalysisQueryKind === "problem" ||
+    variantAnalysisQueryKind === "path-problem"
+  );
+}
+
 export const RepositoriesSearchSortRow = ({
   filterSortValue,
   resultFormatValue,
   onFilterSortChange,
   onResultFormatChange,
+  variantAnalysisQueryKind,
 }: Props) => {
   const handleSearchValueChange = useCallback(
     (searchValue: string) => {
@@ -100,10 +111,12 @@ export const RepositoriesSearchSortRow = ({
         value={filterSortValue.sortKey}
         onChange={handleSortKeyChange}
       />
-      <RepositoriesResultFormatColumn
-        value={resultFormatValue}
-        onChange={handleResultFormatChange}
-      />
+      {showResultFormatColumn(variantAnalysisQueryKind) && (
+        <RepositoriesResultFormatColumn
+          value={resultFormatValue}
+          onChange={handleResultFormatChange}
+        />
+      )}
     </Container>
   );
 };

--- a/extensions/ql-vscode/src/view/variant-analysis/RepositoriesSearchSortRow.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/RepositoriesSearchSortRow.tsx
@@ -9,10 +9,14 @@ import {
 import { RepositoriesSearch } from "./RepositoriesSearch";
 import { RepositoriesSort } from "./RepositoriesSort";
 import { RepositoriesFilter } from "./RepositoriesFilter";
+import { RepositoriesResultFormat } from "./RepositoriesResultFormat";
+import { ResultFormat } from "../../variant-analysis/shared/variant-analysis-result-format";
 
 type Props = {
-  value: RepositoriesFilterSortState;
-  onChange: Dispatch<SetStateAction<RepositoriesFilterSortState>>;
+  filterSortValue: RepositoriesFilterSortState;
+  resultFormatValue: ResultFormat;
+  onFilterSortChange: Dispatch<SetStateAction<RepositoriesFilterSortState>>;
+  onResultFormatChange: Dispatch<SetStateAction<ResultFormat>>;
 };
 
 const Container = styled.div`
@@ -35,50 +39,70 @@ const RepositoriesSortColumn = styled(RepositoriesSort)`
   flex: 1;
 `;
 
-export const RepositoriesSearchSortRow = ({ value, onChange }: Props) => {
+const RepositoriesResultFormatColumn = styled(RepositoriesResultFormat)`
+  flex: 1;
+`;
+
+export const RepositoriesSearchSortRow = ({
+  filterSortValue,
+  resultFormatValue,
+  onFilterSortChange,
+  onResultFormatChange,
+}: Props) => {
   const handleSearchValueChange = useCallback(
     (searchValue: string) => {
-      onChange((oldValue) => ({
+      onFilterSortChange((oldValue) => ({
         ...oldValue,
         searchValue,
       }));
     },
-    [onChange],
+    [onFilterSortChange],
   );
 
   const handleFilterKeyChange = useCallback(
     (filterKey: FilterKey) => {
-      onChange((oldValue) => ({
+      onFilterSortChange((oldValue) => ({
         ...oldValue,
         filterKey,
       }));
     },
-    [onChange],
+    [onFilterSortChange],
   );
 
   const handleSortKeyChange = useCallback(
     (sortKey: SortKey) => {
-      onChange((oldValue) => ({
+      onFilterSortChange((oldValue) => ({
         ...oldValue,
         sortKey,
       }));
     },
-    [onChange],
+    [onFilterSortChange],
+  );
+
+  const handleResultFormatChange = useCallback(
+    (resultFormat: ResultFormat) => {
+      onResultFormatChange(resultFormat);
+    },
+    [onResultFormatChange],
   );
 
   return (
     <Container>
       <RepositoriesSearchColumn
-        value={value.searchValue}
+        value={filterSortValue.searchValue}
         onChange={handleSearchValueChange}
       />
       <RepositoriesFilterColumn
-        value={value.filterKey}
+        value={filterSortValue.filterKey}
         onChange={handleFilterKeyChange}
       />
       <RepositoriesSortColumn
-        value={value.sortKey}
+        value={filterSortValue.sortKey}
         onChange={handleSortKeyChange}
+      />
+      <RepositoriesResultFormatColumn
+        value={resultFormatValue}
+        onChange={handleResultFormatChange}
       />
     </Container>
   );

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisOutcomePanels.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisOutcomePanels.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Dispatch, SetStateAction } from "react";
+import { Dispatch, SetStateAction, useState } from "react";
 import { styled } from "styled-components";
 import {
   VSCodeBadge,
@@ -20,6 +20,7 @@ import { VariantAnalysisSkippedRepositoriesTab } from "./VariantAnalysisSkippedR
 import { RepositoriesFilterSortState } from "../../variant-analysis/shared/variant-analysis-filter-sort";
 import { RepositoriesSearchSortRow } from "./RepositoriesSearchSortRow";
 import { FailureReasonAlert } from "./FailureReasonAlert";
+import { ResultFormat } from "../../variant-analysis/shared/variant-analysis-result-format";
 
 export type VariantAnalysisOutcomePanelProps = {
   variantAnalysis: VariantAnalysis;
@@ -70,6 +71,7 @@ export const VariantAnalysisOutcomePanels = ({
   const accessMismatchRepositoryCount =
     variantAnalysis.skippedRepos?.accessMismatchRepos?.repositoryCount ?? 0;
 
+  const [resultFormat, setResultFormat] = useState(ResultFormat.Alerts);
   const warnings = (
     <WarningsContainer>
       {variantAnalysis.status === VariantAnalysisStatus.Canceled && (
@@ -123,8 +125,10 @@ export const VariantAnalysisOutcomePanels = ({
       <>
         {warnings}
         <RepositoriesSearchSortRow
-          value={filterSortState}
-          onChange={setFilterSortState}
+          filterSortValue={filterSortState}
+          resultFormatValue={resultFormat}
+          onFilterSortChange={setFilterSortState}
+          onResultFormatChange={setResultFormat}
         />
         <VariantAnalysisAnalyzedRepos
           variantAnalysis={variantAnalysis}
@@ -142,8 +146,10 @@ export const VariantAnalysisOutcomePanels = ({
     <>
       {warnings}
       <RepositoriesSearchSortRow
-        value={filterSortState}
-        onChange={setFilterSortState}
+        filterSortValue={filterSortState}
+        resultFormatValue={resultFormat}
+        onFilterSortChange={setFilterSortState}
+        onResultFormatChange={setResultFormat}
       />
       <VSCodePanels>
         {scannedReposCount > 0 && (

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisOutcomePanels.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisOutcomePanels.tsx
@@ -129,6 +129,7 @@ export const VariantAnalysisOutcomePanels = ({
           resultFormatValue={resultFormat}
           onFilterSortChange={setFilterSortState}
           onResultFormatChange={setResultFormat}
+          variantAnalysisQueryKind={variantAnalysis.query.kind}
         />
         <VariantAnalysisAnalyzedRepos
           variantAnalysis={variantAnalysis}
@@ -150,6 +151,7 @@ export const VariantAnalysisOutcomePanels = ({
         resultFormatValue={resultFormat}
         onFilterSortChange={setFilterSortState}
         onResultFormatChange={setResultFormat}
+        variantAnalysisQueryKind={variantAnalysis.query.kind}
       />
       <VSCodePanels>
         {scannedReposCount > 0 && (


### PR DESCRIPTION
For variant analyses with interpreted results (i.e. problem queries or path-problem queries), users should have the option to display raw results (see internal linked issue for details).

![image](https://github.com/github/vscode-codeql/assets/42641846/19c97425-ee61-46df-97c0-876cdab9e846)


This PR adds the new dropdown from https://github.com/github/vscode-codeql/pull/2743 to the MRVA results view, but only for queries that have a `path-problem` or `problem` kind. (Otherwise there's only one display format anyway)

Note: The dropdown currently has no effect 🙃 For the final piece of the puzzle, I'll open a PR that actually uses the result format to control the result display! (It's in progress, stay tuned 😎)


## Checklist

N/A (I'll update the changelog in the final PR that strings things together)

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
