### PR TITLE
Make "result format" dropdown determine result display

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [UNRELEASED]
 
+- Update how variant analysis results are displayed. For queries with ["path-problem" or "problem" `@kind`](https://codeql.github.com/docs/writing-codeql-queries/metadata-for-codeql-queries/#metadata-properties), you can choose to display the results as rendered alerts or as a table of raw results. For queries with any other `@kind`, the results are displayed as a table. [#2745](https://github.com/github/vscode-codeql/pull/2745) & [#2749](https://github.com/github/vscode-codeql/pull/2749)
 - When running variant analyses, don't download artifacts for repositories with no results. [#2736](https://github.com/github/vscode-codeql/pull/2736)
 - Group the extension settings, so that they're easier to find in the Settings UI. [#2706](https://github.com/github/vscode-codeql/pull/2706)
 

--- a/extensions/ql-vscode/src/view/variant-analysis/AnalyzedRepoItemContent.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/AnalyzedRepoItemContent.tsx
@@ -11,6 +11,7 @@ import {
   VariantAnalysisScannedRepositoryDownloadStatus,
 } from "../../variant-analysis/shared/variant-analysis";
 import { Alert } from "../common";
+import { ResultFormat } from "../../variant-analysis/shared/variant-analysis-result-format";
 
 const ContentContainer = styled.div`
   display: flex;
@@ -37,12 +38,28 @@ const RawResultsContainer = styled.div`
   margin-top: 0.5em;
 `;
 
+function chooseResultFormat(
+  interpretedResults: AnalysisAlert[] | undefined,
+  rawResults: AnalysisRawResults | undefined,
+  resultFormat: ResultFormat,
+): ResultFormat | undefined {
+  if (interpretedResults && resultFormat === ResultFormat.Alerts) {
+    return ResultFormat.Alerts;
+  } else if (rawResults) {
+    return ResultFormat.RawResults;
+  } else {
+    return undefined;
+  }
+}
+
 export type AnalyzedRepoItemContentProps = {
   status?: VariantAnalysisRepoStatus;
   downloadStatus?: VariantAnalysisScannedRepositoryDownloadStatus;
 
   interpretedResults?: AnalysisAlert[];
   rawResults?: AnalysisRawResults;
+
+  resultFormat: ResultFormat;
 };
 
 export const AnalyzedRepoItemContent = ({
@@ -50,7 +67,13 @@ export const AnalyzedRepoItemContent = ({
   downloadStatus,
   interpretedResults,
   rawResults,
+  resultFormat,
 }: AnalyzedRepoItemContentProps) => {
+  const chosenResultFormat = chooseResultFormat(
+    interpretedResults,
+    rawResults,
+    resultFormat,
+  );
   return (
     <ContentContainer>
       {status === VariantAnalysisRepoStatus.Failed && (
@@ -90,7 +113,7 @@ export const AnalyzedRepoItemContent = ({
           />
         </AlertContainer>
       )}
-      {interpretedResults && (
+      {interpretedResults && chosenResultFormat === ResultFormat.Alerts && (
         <InterpretedResultsContainer>
           {interpretedResults.map((r, i) => (
             <InterpretedResultItem key={i}>
@@ -99,7 +122,7 @@ export const AnalyzedRepoItemContent = ({
           ))}
         </InterpretedResultsContainer>
       )}
-      {rawResults && (
+      {rawResults && chosenResultFormat === ResultFormat.RawResults && (
         <RawResultsContainer>
           <RawResultsTable
             schema={rawResults.schema}

--- a/extensions/ql-vscode/src/view/variant-analysis/RepoRow.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/RepoRow.tsx
@@ -26,6 +26,7 @@ import { AnalyzedRepoItemContent } from "./AnalyzedRepoItemContent";
 import StarCount from "../common/StarCount";
 import { useTelemetryOnChange } from "../common/telemetry";
 import { DeterminateProgressRing } from "../common/DeterminateProgressRing";
+import { ResultFormat } from "../../variant-analysis/shared/variant-analysis-result-format";
 
 // This will ensure that these icons have a className which we can use in the TitleContainer
 const ExpandCollapseCodicon = styled(Codicon)``;
@@ -98,6 +99,8 @@ export type RepoRowProps = {
   interpretedResults?: AnalysisAlert[];
   rawResults?: AnalysisRawResults;
 
+  resultFormat?: ResultFormat;
+
   selected?: boolean;
   onSelectedChange?: (repositoryId: number, selected: boolean) => void;
 };
@@ -168,6 +171,7 @@ export const RepoRow = ({
   resultCount,
   interpretedResults,
   rawResults,
+  resultFormat = ResultFormat.Alerts,
   selected,
   onSelectedChange,
 }: RepoRowProps) => {
@@ -304,6 +308,7 @@ export const RepoRow = ({
           downloadStatus={downloadState?.downloadStatus}
           interpretedResults={interpretedResults}
           rawResults={rawResults}
+          resultFormat={resultFormat}
         />
       )}
     </div>

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisAnalyzedRepos.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisAnalyzedRepos.tsx
@@ -11,6 +11,7 @@ import {
   filterAndSortRepositoriesWithResultsByName,
   RepositoriesFilterSortState,
 } from "../../variant-analysis/shared/variant-analysis-filter-sort";
+import { ResultFormat } from "../../variant-analysis/shared/variant-analysis-result-format";
 
 const Container = styled.div`
   display: flex;
@@ -26,6 +27,8 @@ export type VariantAnalysisAnalyzedReposProps = {
 
   filterSortState?: RepositoriesFilterSortState;
 
+  resultFormat: ResultFormat;
+
   selectedRepositoryIds?: number[];
   setSelectedRepositoryIds?: Dispatch<SetStateAction<number[]>>;
 };
@@ -35,6 +38,7 @@ export const VariantAnalysisAnalyzedRepos = ({
   repositoryStates,
   repositoryResults,
   filterSortState,
+  resultFormat,
   selectedRepositoryIds,
   setSelectedRepositoryIds,
 }: VariantAnalysisAnalyzedReposProps) => {
@@ -93,6 +97,7 @@ export const VariantAnalysisAnalyzedRepos = ({
             resultCount={repository.resultCount}
             interpretedResults={results?.interpretedResults}
             rawResults={results?.rawResults}
+            resultFormat={resultFormat}
             selected={selectedRepositoryIds?.includes(repository.repository.id)}
             onSelectedChange={onSelectedChange}
           />

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisOutcomePanels.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisOutcomePanels.tsx
@@ -136,6 +136,7 @@ export const VariantAnalysisOutcomePanels = ({
           repositoryStates={repositoryStates}
           repositoryResults={repositoryResults}
           filterSortState={filterSortState}
+          resultFormat={resultFormat}
           selectedRepositoryIds={selectedRepositoryIds}
           setSelectedRepositoryIds={setSelectedRepositoryIds}
         />
@@ -185,6 +186,7 @@ export const VariantAnalysisOutcomePanels = ({
               repositoryStates={repositoryStates}
               repositoryResults={repositoryResults}
               filterSortState={filterSortState}
+              resultFormat={resultFormat}
               selectedRepositoryIds={selectedRepositoryIds}
               setSelectedRepositoryIds={setSelectedRepositoryIds}
             />

--- a/extensions/ql-vscode/src/view/variant-analysis/__tests__/AnalyzedRepoItemContent.spec.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/__tests__/AnalyzedRepoItemContent.spec.tsx
@@ -8,12 +8,14 @@ import {
   AnalyzedRepoItemContent,
   AnalyzedRepoItemContentProps,
 } from "../AnalyzedRepoItemContent";
+import { ResultFormat } from "../../../variant-analysis/shared/variant-analysis-result-format";
 
 describe(AnalyzedRepoItemContent.name, () => {
   const render = (props: Partial<AnalyzedRepoItemContentProps> = {}) => {
     return reactRender(
       <AnalyzedRepoItemContent
         status={VariantAnalysisRepoStatus.Succeeded}
+        resultFormat={ResultFormat.Alerts}
         {...props}
       />,
     );

--- a/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisAnalyzedRepos.spec.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisAnalyzedRepos.spec.tsx
@@ -15,6 +15,7 @@ import { createMockRepositoryWithMetadata } from "../../../../test/factories/var
 import { createMockScannedRepo } from "../../../../test/factories/variant-analysis/shared/scanned-repositories";
 import { SortKey } from "../../../variant-analysis/shared/variant-analysis-filter-sort";
 import { permissiveFilterSortState } from "../../../../test/unit-tests/variant-analysis-filter-sort.test";
+import { ResultFormat } from "../../../variant-analysis/shared/variant-analysis-result-format";
 
 describe(VariantAnalysisAnalyzedRepos.name, () => {
   const defaultVariantAnalysis = createMockVariantAnalysis({
@@ -99,6 +100,7 @@ describe(VariantAnalysisAnalyzedRepos.name, () => {
     return reactRender(
       <VariantAnalysisAnalyzedRepos
         variantAnalysis={defaultVariantAnalysis}
+        resultFormat={ResultFormat.Alerts}
         {...props}
       />,
     );


### PR DESCRIPTION
Follow-up to https://github.com/github/vscode-codeql/pull/2745. Display variant analysis results as rendered alerts or a raw table, depending on the user's selection in the dropdown: 

https://github.com/github/vscode-codeql/assets/42641846/e9e8124c-37f0-4f49-b379-2411f2f8d2f5

For queries that have alerts available (`path-problem` or `problem` queries), we display as alerts by default, with the option to swap to raw results. For other queries, we can only show a raw results table, so we don't show the dropdown at all.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
     - https://github.com/github/codeql/pull/14051 
