### PR TITLE
Rename ModelDetail to MethodsUsage in types and functions

### DIFF
--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-module.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-module.ts
@@ -14,7 +14,7 @@ import { dir } from "tmp-promise";
 
 import { isQueryLanguage } from "../common/query-language";
 import { DisposableObject } from "../common/disposable-object";
-import { ModelDetailsPanel } from "./methods-usage/methods-usage-panel";
+import { MethodsUsagePanel } from "./methods-usage/methods-usage-panel";
 import { Mode } from "./shared/mode";
 import { showResolvableLocation } from "../databases/local-databases/locations";
 import { Usage } from "./external-api-usage";
@@ -24,7 +24,7 @@ const SUPPORTED_LANGUAGES: string[] = ["java", "csharp"];
 
 export class DataExtensionsEditorModule extends DisposableObject {
   private readonly queryStorageDir: string;
-  private readonly modelDetailsPanel: ModelDetailsPanel;
+  private readonly methodsUsagePanel: MethodsUsagePanel;
 
   private mostRecentlyActiveView: DataExtensionsEditorView | undefined =
     undefined;
@@ -42,7 +42,7 @@ export class DataExtensionsEditorModule extends DisposableObject {
       baseQueryStorageDir,
       "data-extensions-editor-results",
     );
-    this.modelDetailsPanel = this.push(new ModelDetailsPanel(cliServer));
+    this.methodsUsagePanel = this.push(new MethodsUsagePanel(cliServer));
   }
 
   private handleViewBecameActive(view: DataExtensionsEditorView): void {
@@ -151,8 +151,8 @@ export class DataExtensionsEditorModule extends DisposableObject {
               db,
               modelFile,
               Mode.Application,
-              this.modelDetailsPanel.setState.bind(this.modelDetailsPanel),
-              this.modelDetailsPanel.revealItem.bind(this.modelDetailsPanel),
+              this.methodsUsagePanel.setState.bind(this.methodsUsagePanel),
+              this.methodsUsagePanel.revealItem.bind(this.methodsUsagePanel),
               this.handleViewBecameActive.bind(this),
               this.handleViewWasDisposed.bind(this),
               this.isMostRecentlyActiveView.bind(this),

--- a/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/data-extensions-editor-view.ts
@@ -61,12 +61,12 @@ export class DataExtensionsEditorView extends AbstractWebview<
     private readonly databaseItem: DatabaseItem,
     private readonly extensionPack: ExtensionPack,
     private mode: Mode,
-    private readonly updateModelDetailsPanelState: (
+    private readonly updateMethodsUsagePanelState: (
       externalApiUsages: ExternalApiUsage[],
       databaseItem: DatabaseItem,
       hideModeledApis: boolean,
     ) => Promise<void>,
-    private readonly revealItemInDetailsPanel: (usage: Usage) => Promise<void>,
+    private readonly revealItemInUsagePanel: (usage: Usage) => Promise<void>,
     private readonly handleViewBecameActive: (
       view: DataExtensionsEditorView,
     ) => void,
@@ -107,7 +107,7 @@ export class DataExtensionsEditorView extends AbstractWebview<
     panel.onDidChangeViewState(async () => {
       if (panel.active) {
         this.handleViewBecameActive(this);
-        await this.updateModelDetailsPanelState(
+        await this.updateMethodsUsagePanelState(
           this.externalApiUsages,
           this.databaseItem,
           this.hideModeledApis,
@@ -239,7 +239,7 @@ export class DataExtensionsEditorView extends AbstractWebview<
         break;
       case "hideModeledApis":
         this.hideModeledApis = msg.hideModeledApis;
-        await this.updateModelDetailsPanelState(
+        await this.updateMethodsUsagePanelState(
           this.externalApiUsages,
           this.databaseItem,
           this.hideModeledApis,
@@ -276,7 +276,7 @@ export class DataExtensionsEditorView extends AbstractWebview<
   }
 
   protected async handleJumpToUsage(usage: Usage) {
-    await this.revealItemInDetailsPanel(usage);
+    await this.revealItemInUsagePanel(usage);
     await showResolvableLocation(usage.url, this.databaseItem, this.app.logger);
   }
 
@@ -344,7 +344,7 @@ export class DataExtensionsEditorView extends AbstractWebview<
             externalApiUsages: this.externalApiUsages,
           });
           if (this.isMostRecentlyActiveView(this)) {
-            await this.updateModelDetailsPanelState(
+            await this.updateMethodsUsagePanelState(
               this.externalApiUsages,
               this.databaseItem,
               this.hideModeledApis,
@@ -467,8 +467,8 @@ export class DataExtensionsEditorView extends AbstractWebview<
         addedDatabase,
         modelFile,
         Mode.Framework,
-        this.updateModelDetailsPanelState,
-        this.revealItemInDetailsPanel,
+        this.updateMethodsUsagePanelState,
+        this.revealItemInUsagePanel,
         this.handleViewBecameActive,
         this.handleViewWasDisposed,
         this.isMostRecentlyActiveView,

--- a/extensions/ql-vscode/src/data-extensions-editor/methods-usage/methods-usage-data-provider.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/methods-usage/methods-usage-data-provider.ts
@@ -15,9 +15,9 @@ import { relative } from "path";
 import { CodeQLCliServer } from "../../codeql-cli/cli";
 import { INITIAL_HIDE_MODELED_APIS_VALUE } from "../shared/hide-modeled-apis";
 
-export class ModelDetailsDataProvider
+export class MethodsUsageDataProvider
   extends DisposableObject
-  implements TreeDataProvider<ModelDetailsTreeViewItem>
+  implements TreeDataProvider<MethodsUsageTreeViewItem>
 {
   private externalApiUsages: ExternalApiUsage[] = [];
   private databaseItem: DatabaseItem | undefined = undefined;
@@ -63,7 +63,7 @@ export class ModelDetailsDataProvider
     }
   }
 
-  getTreeItem(item: ModelDetailsTreeViewItem): TreeItem {
+  getTreeItem(item: MethodsUsageTreeViewItem): TreeItem {
     if (isExternalApiUsage(item)) {
       return {
         label: `${item.packageName}.${item.typeName}.${item.methodName}${item.methodParameters}`,
@@ -96,7 +96,7 @@ export class ModelDetailsDataProvider
     }
   }
 
-  getChildren(item?: ModelDetailsTreeViewItem): ModelDetailsTreeViewItem[] {
+  getChildren(item?: MethodsUsageTreeViewItem): MethodsUsageTreeViewItem[] {
     if (item === undefined) {
       if (this.hideModeledApis) {
         return this.externalApiUsages.filter((api) => !api.supported);
@@ -111,8 +111,8 @@ export class ModelDetailsDataProvider
   }
 
   getParent(
-    item: ModelDetailsTreeViewItem,
-  ): ModelDetailsTreeViewItem | undefined {
+    item: MethodsUsageTreeViewItem,
+  ): MethodsUsageTreeViewItem | undefined {
     if (isExternalApiUsage(item)) {
       return undefined;
     } else {
@@ -132,10 +132,10 @@ export class ModelDetailsDataProvider
   }
 }
 
-export type ModelDetailsTreeViewItem = ExternalApiUsage | Usage;
+export type MethodsUsageTreeViewItem = ExternalApiUsage | Usage;
 
 function isExternalApiUsage(
-  item: ModelDetailsTreeViewItem,
+  item: MethodsUsageTreeViewItem,
 ): item is ExternalApiUsage {
   return (item as any).usages !== undefined;
 }

--- a/extensions/ql-vscode/src/data-extensions-editor/methods-usage/methods-usage-panel.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/methods-usage/methods-usage-panel.ts
@@ -1,21 +1,21 @@
 import { TreeView, window } from "vscode";
 import { DisposableObject } from "../../common/disposable-object";
 import {
-  ModelDetailsDataProvider,
-  ModelDetailsTreeViewItem,
+  MethodsUsageDataProvider,
+  MethodsUsageTreeViewItem,
 } from "./methods-usage-data-provider";
 import { ExternalApiUsage, Usage } from "../external-api-usage";
 import { DatabaseItem } from "../../databases/local-databases";
 import { CodeQLCliServer } from "../../codeql-cli/cli";
 
-export class ModelDetailsPanel extends DisposableObject {
-  private readonly dataProvider: ModelDetailsDataProvider;
-  private readonly treeView: TreeView<ModelDetailsTreeViewItem>;
+export class MethodsUsagePanel extends DisposableObject {
+  private readonly dataProvider: MethodsUsageDataProvider;
+  private readonly treeView: TreeView<MethodsUsageTreeViewItem>;
 
   public constructor(cliServer: CodeQLCliServer) {
     super();
 
-    this.dataProvider = new ModelDetailsDataProvider(cliServer);
+    this.dataProvider = new MethodsUsageDataProvider(cliServer);
 
     this.treeView = window.createTreeView("codeQLMethodsUsage", {
       treeDataProvider: this.dataProvider,

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/data-extensions-editor/methods-usage/methods-usage-data-provider.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/data-extensions-editor/methods-usage/methods-usage-data-provider.test.ts
@@ -1,6 +1,6 @@
 import { CodeQLCliServer } from "../../../../../src/codeql-cli/cli";
 import { ExternalApiUsage } from "../../../../../src/data-extensions-editor/external-api-usage";
-import { ModelDetailsDataProvider } from "../../../../../src/data-extensions-editor/methods-usage/methods-usage-data-provider";
+import { MethodsUsageDataProvider } from "../../../../../src/data-extensions-editor/methods-usage/methods-usage-data-provider";
 import { DatabaseItem } from "../../../../../src/databases/local-databases";
 import {
   createExternalApiUsage,
@@ -8,12 +8,12 @@ import {
 } from "../../../../factories/data-extension/external-api-factories";
 import { mockedObject } from "../../../utils/mocking.helpers";
 
-describe("ModelDetailsDataProvider", () => {
+describe("MethodsUsageDataProvider", () => {
   const mockCliServer = mockedObject<CodeQLCliServer>({});
-  let dataProvider: ModelDetailsDataProvider;
+  let dataProvider: MethodsUsageDataProvider;
 
   beforeEach(() => {
-    dataProvider = new ModelDetailsDataProvider(mockCliServer);
+    dataProvider = new MethodsUsageDataProvider(mockCliServer);
   });
 
   describe("setState", () => {

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/data-extensions-editor/methods-usage/methods-usage-panel.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/data-extensions-editor/methods-usage/methods-usage-panel.test.ts
@@ -1,7 +1,7 @@
 import { window, TreeView } from "vscode";
 import { CodeQLCliServer } from "../../../../../src/codeql-cli/cli";
 import { ExternalApiUsage } from "../../../../../src/data-extensions-editor/external-api-usage";
-import { ModelDetailsPanel } from "../../../../../src/data-extensions-editor/methods-usage/methods-usage-panel";
+import { MethodsUsagePanel } from "../../../../../src/data-extensions-editor/methods-usage/methods-usage-panel";
 import { DatabaseItem } from "../../../../../src/databases/local-databases";
 import { mockedObject } from "../../../utils/mocking.helpers";
 import {
@@ -9,7 +9,7 @@ import {
   createUsage,
 } from "../../../../factories/data-extension/external-api-factories";
 
-describe("ModelDetailsPanel", () => {
+describe("MethodsUsagePanel", () => {
   const mockCliServer = mockedObject<CodeQLCliServer>({});
   const dbItem = mockedObject<DatabaseItem>({
     getSourceLocationPrefix: () => "test",
@@ -25,7 +25,7 @@ describe("ModelDetailsPanel", () => {
       } as TreeView<unknown>;
       jest.spyOn(window, "createTreeView").mockReturnValue(mockTreeView);
 
-      const panel = new ModelDetailsPanel(mockCliServer);
+      const panel = new MethodsUsagePanel(mockCliServer);
       await panel.setState(externalApiUsages, dbItem, hideModeledApis);
 
       expect(mockTreeView.badge?.value).toBe(1);
@@ -52,7 +52,7 @@ describe("ModelDetailsPanel", () => {
         }),
       ];
 
-      const panel = new ModelDetailsPanel(mockCliServer);
+      const panel = new MethodsUsagePanel(mockCliServer);
       await panel.setState(externalApiUsages, dbItem, hideModeledApis);
 
       await panel.revealItem(usage);
@@ -62,7 +62,7 @@ describe("ModelDetailsPanel", () => {
 
     it("should do nothing if usage cannot be found", async () => {
       const externalApiUsages = [createExternalApiUsage({})];
-      const panel = new ModelDetailsPanel(mockCliServer);
+      const panel = new MethodsUsagePanel(mockCliServer);
       await panel.setState(externalApiUsages, dbItem, hideModeledApis);
 
       await panel.revealItem(usage);


### PR DESCRIPTION
This is the final rename of the CodeQL Model Details view code to Methods Usage.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
