### PR TITLE
Change the java query to work for multiple java versions.

### DIFF
--- a/extensions/ql-vscode/src/data-extensions-editor/queries/java.ts
+++ b/extensions/ql-vscode/src/data-extensions-editor/queries/java.ts
@@ -147,7 +147,12 @@ class CallableMethod extends Callable {
 
   /** Holds if this API is a known neutral. */
   pragma[nomagic]
-  predicate isNeutral() { this instanceof FlowSummaryImpl::Public::NeutralCallable }
+  predicate isNeutral() {
+    exists(string namespace, string type, string name, string signature, string kind, string provenance |
+      neutralModel(namespace, type, name, signature, kind, provenance) and
+      this = interpretElement(namespace, type, false, name, signature, "")
+    )
+  }
 
   /**
    * Holds if this API is supported by existing CodeQL libraries, that is, it is either a


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

This is a follow up to https://github.com/github/vscode-codeql/pull/2755. By fixing the query against main in the submodule we broke it against the released package :/

This _hopefully_ tweaks the predicate to work in both versions, but we should get started on moving the query out I think.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
