### PR TITLE
Make "create query" command available when queries panel is enabled

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1652,7 +1652,7 @@
         },
         {
           "command": "codeQL.createQuery",
-          "when": "config.codeQL.codespacesTemplate"
+          "when": "config.codeQL.codespacesTemplate || config.codeQL.canary && config.codeQL.queriesPanel"
         },
         {
           "command": "codeQLTests.acceptOutputContextTestItem",


### PR DESCRIPTION
We'll need access to the "create query" command from the queries panel. This PR updates the command's feature flags so that they also align with the queries panel's flags:

https://github.com/github/vscode-codeql/blob/a85e7c9707128ea6a9523b3136c2f41959087d10/extensions/ql-vscode/package.json#L1735-L1739

## Checklist

N/A: no visible impact yet, all of this is feature-flagged 🎏  See internal linked issue for more details. 

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
