### PR TITLE
Add "create query" button to queries panel

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -598,6 +598,11 @@
         "title": "Run against variant analysis repositories"
       },
       {
+        "command": "codeQLQueries.createQuery",
+        "title": "Create query",
+        "icon": "$(new-file)"
+      },
+      {
         "command": "codeQLVariantAnalysisRepositories.openConfigFile",
         "title": "Open database configuration file",
         "icon": "$(json)"
@@ -1007,6 +1012,11 @@
           "group": "navigation"
         },
         {
+          "command": "codeQLQueries.createQuery",
+          "when": "view == codeQLQueries",
+          "group": "navigation"
+        },
+        {
           "command": "codeQLQueryHistory.sortByName",
           "when": "view == codeQLQueryHistory",
           "group": "1_queryHistory@0"
@@ -1288,6 +1298,10 @@
         },
         {
           "command": "codeQLQueries.runLocalQueriesFromPanel",
+          "when": "false"
+        },
+        {
+          "command": "codeQLQueries.createQuery",
           "when": "false"
         },
         {

--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -135,6 +135,7 @@ export type LocalQueryCommands = {
   "codeQLQueries.runLocalQueryContextMenu": TreeViewContextSingleSelectionCommandFunction<QueryTreeViewItem>;
   "codeQLQueries.runLocalQueriesContextMenu": TreeViewContextSingleSelectionCommandFunction<QueryTreeViewItem>;
   "codeQLQueries.runLocalQueriesFromPanel": TreeViewContextSingleSelectionCommandFunction<QueryTreeViewItem>;
+  "codeQLQueries.createQuery": () => Promise<void>;
   "codeQL.runLocalQueryFromFileTab": (uri: Uri) => Promise<void>;
   "codeQL.runQueries": ExplorerSelectionCommandFunction<Uri>;
   "codeQL.quickEval": (uri: Uri) => Promise<void>;

--- a/extensions/ql-vscode/src/local-queries/local-queries.ts
+++ b/extensions/ql-vscode/src/local-queries/local-queries.ts
@@ -90,6 +90,7 @@ export class LocalQueries extends DisposableObject {
         this.runQueriesFromQueriesPanel.bind(this),
       "codeQLQueries.runLocalQueriesFromPanel":
         this.runQueriesFromQueriesPanel.bind(this),
+      "codeQLQueries.createQuery": this.createSkeletonQuery.bind(this),
       "codeQL.runLocalQueryFromFileTab": this.runQuery.bind(this),
       "codeQL.runQueries": createMultiSelectionCommand(
         this.runQueries.bind(this),


### PR DESCRIPTION
Adds a button to the Queries panel that calls the `createQuery` command:

https://github.com/github/vscode-codeql/assets/42641846/398a9692-1e25-41d3-8330-aa45840fa86a

❓ Note: I've added this command as a `LocalQueryCommand`, since that's what we do for the other query panel commands (such as "Run Query"). I think this is fine for now, but I wonder whether we should create a new group of `QueriesPanelCommand`s instead 🤔 


## Checklist

N/A—no user impact, this is still feature-flagged 🐳 

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
