### PR TITLE
Rename feature flags.

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1416,7 +1416,7 @@
         },
         {
           "command": "codeQL.openModelEditor",
-          "when": "config.codeQL.canary && config.codeQL.dataExtensions.editor"
+          "when": "config.codeQL.canary && config.codeQL.model.editor"
         },
         {
           "command": "codeQLQueries.runLocalQueryContextMenu",

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -702,16 +702,13 @@ export function showQueriesPanel(): boolean {
   return !!QUERIES_PANEL.getValue<boolean>();
 }
 
-const DATA_EXTENSIONS = new Setting("dataExtensions", ROOT_SETTING);
-const LLM_GENERATION = new Setting("llmGeneration", DATA_EXTENSIONS);
+const MODEL_SETTING = new Setting("model", ROOT_SETTING);
+const LLM_GENERATION = new Setting("llmGeneration", MODEL_SETTING);
 const DISABLE_AUTO_NAME_EXTENSION_PACK = new Setting(
   "disableAutoNameExtensionPack",
-  DATA_EXTENSIONS,
+  MODEL_SETTING,
 );
-const EXTENSIONS_DIRECTORY = new Setting(
-  "extensionsDirectory",
-  DATA_EXTENSIONS,
-);
+const EXTENSIONS_DIRECTORY = new Setting("extensionsDirectory", MODEL_SETTING);
 
 export function showLlmGeneration(): boolean {
   return !!LLM_GENERATION.getValue<boolean>();

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/extension-pack-picker.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/extension-pack-picker.test.ts
@@ -164,7 +164,7 @@ describe("pickExtensionPack", () => {
         section?: string,
         scope?: ConfigurationScope | null,
       ): VSCodeWorkspaceConfiguration => {
-        expect(section).toEqual("codeQL.dataExtensions");
+        expect(section).toEqual("codeQL.model");
         expect((scope as any)?.languageId).toEqual("java");
 
         return {
@@ -205,7 +205,7 @@ describe("pickExtensionPack", () => {
         section?: string,
         scope?: ConfigurationScope | null,
       ): VSCodeWorkspaceConfiguration => {
-        expect(section).toEqual("codeQL.dataExtensions");
+        expect(section).toEqual("codeQL.model");
         expect((scope as any)?.languageId).toEqual("java");
 
         return {
@@ -311,7 +311,7 @@ describe("pickExtensionPack", () => {
         section?: string,
         scope?: ConfigurationScope | null,
       ): VSCodeWorkspaceConfiguration => {
-        expect(section).toEqual("codeQL.dataExtensions");
+        expect(section).toEqual("codeQL.model");
         expect((scope as any)?.languageId).toEqual("java");
 
         return {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

This renames the feature flags from:
```
    "codeQL.dataExtensions.editor": true,
    "codeQL.dataExtensions.llmGeneration": true,
    "codeQL.dataExtensions.disableAutoNameExtensionPack": true,
    "codeQL.dataExtensions.extensionsDirectory": true,
```
to
```
    "codeQL.model.editor": true,
    "codeQL.model.llmGeneration": true,
    "codeQL.model.disableAutoNameExtensionPack": true,
    "codeQL.model.extensionsDirectory": true,
```

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
