### PR TITLE
Use mockedObject for TreeView

### DIFF
--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/methods-usage/methods-usage-panel.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/methods-usage/methods-usage-panel.test.ts
@@ -39,9 +39,9 @@ describe("MethodsUsagePanel", () => {
     const usage = createUsage();
 
     beforeEach(() => {
-      mockTreeView = {
+      mockTreeView = mockedObject<TreeView<unknown>>({
         reveal: jest.fn(),
-      } as unknown as TreeView<unknown>;
+      });
       jest.spyOn(window, "createTreeView").mockReturnValue(mockTreeView);
     });
 


### PR DESCRIPTION
This is one possible solution to the conversation from https://github.com/github/vscode-codeql/pull/2735/files#r1303916205.

Effectively this is still using `as unknown as X` but at least that's now contained within `mockedObject` which mocks all other fields and methods and throws a helpful error message when code tries to use them.

I think using `mockedObject` for the `TreeView` type makes sense. It's a hard type to provide a "real" instance of, because:
- It's not a type we own or control.
- It's quite a large type with lots of methods we often don't care about.
- It's an interface that "does stuff" rather than being a data type that just contains static data.

Also importantly, we don't ever do type checking on this type, so fields being mocked doesn't cause problems with this. In the linked PR I objected to using `mockedObject` for the `ExternalApiUsage` and `Usage` types because we have the `isExternalApiUsage` method and therefore the actual fields at runtime matter and not just appeasing the typescript type system.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
