### PR TITLE
Make the "Create query" location workspace-specific

### DIFF
--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -670,7 +670,7 @@ export function getQlPackLocation(): string | undefined {
 }
 
 export async function setQlPackLocation(folder: string | undefined) {
-  await QL_PACK_LOCATION.updateValue(folder, ConfigurationTarget.Global);
+  await QL_PACK_LOCATION.updateValue(folder, ConfigurationTarget.Workspace);
 }
 
 /**
@@ -690,7 +690,10 @@ export function getAutogenerateQlPacks(): AutogenerateQLPacks {
 }
 
 export async function setAutogenerateQlPacks(choice: AutogenerateQLPacks) {
-  await AUTOGENERATE_QL_PACKS.updateValue(choice, ConfigurationTarget.Global);
+  await AUTOGENERATE_QL_PACKS.updateValue(
+    choice,
+    ConfigurationTarget.Workspace,
+  );
 }
 
 /**

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/local-queries/skeleton-query-wizard.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/local-queries/skeleton-query-wizard.test.ts
@@ -399,7 +399,7 @@ describe("SkeletonQueryWizard", () => {
 
       await wizard.determineStoragePath();
 
-      expect(updateValueSpy).toHaveBeenCalledWith(storagePath, 1);
+      expect(updateValueSpy).toHaveBeenCalledWith(storagePath, 2);
     });
 
     describe("when the user is using the codespace template", () => {

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-queries/local-databases.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-queries/local-databases.test.ts
@@ -628,7 +628,7 @@ describe("local databases", () => {
         await (databaseManager as any).createSkeletonPacks(mockDbItem);
 
         expect(generateSpy).not.toBeCalled();
-        expect(updateValueSpy).toHaveBeenCalledWith("never", 1);
+        expect(updateValueSpy).toHaveBeenCalledWith("never", 2);
       });
 
       it("should create the skeleton QL pack for the user", async () => {


### PR DESCRIPTION
If a user picks a folder in which to create custom queries (`createQuery.qlPackLocation`), that should be saved in workspace settings, rather than global settings by default. See internal linked issue for details! 📦 

I've also changed `createQuery.autogenerateQlPacks` to get written to workspace settings, for consistency. There's no harm either way, but I think we should default to workspace settings, and only write to global settings for "higher-level" settings (such as enabling/disabling telemetry) ⚙

## Checklist

N/A—this is still feature-flagged 🎁

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
