### PR TITLE
Make methodModelingView match the naming of other flags

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1785,7 +1785,7 @@
           "type": "webview",
           "id": "codeQLMethodModeling",
           "name": "CodeQL Method Modeling",
-          "when": "config.codeQL.canary && config.codeQL.modelEditor.methodModelingView && codeql.modelEditorOpen"
+          "when": "config.codeQL.canary && config.codeQL.model.methodModelingView && codeql.modelEditorOpen"
         }
       ]
     },


### PR DESCRIPTION
Renames the `codeQL.modelEditor.methodModelingView` feature flag to `codeQL.model.methodModelingView` so that it matches the prefix of the other modeling feature flags.

I'm guessing what happened is we were trying to preempt the change in https://github.com/github/vscode-codeql/pull/2766, but then we changed our mind to use `codeQL.model` instead of `codeQL.modelEditor`, so the `codeQL.modelEditor.methodModelingView` doesn't match the other flags now.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
