### PR TITLE
Update jump to usage to include the method

### DIFF
--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -523,6 +523,7 @@ interface SwitchModeMessage {
 
 interface JumpToUsageMessage {
   t: "jumpToUsage";
+  method: ExternalApiUsage;
   usage: Usage;
 }
 

--- a/extensions/ql-vscode/src/model-editor/methods-usage/methods-usage-data-provider.ts
+++ b/extensions/ql-vscode/src/model-editor/methods-usage/methods-usage-data-provider.ts
@@ -71,6 +71,7 @@ export class MethodsUsageDataProvider
         iconPath: new ThemeIcon("symbol-method"),
       };
     } else {
+      const method = this.getParent(item);
       return {
         label: item.label,
         description: `${this.relativePathWithinDatabase(item.url.uri)} [${
@@ -80,7 +81,7 @@ export class MethodsUsageDataProvider
         command: {
           title: "Show usage",
           command: "codeQLModelEditor.jumpToUsageLocation",
-          arguments: [item, this.databaseItem],
+          arguments: [method, item, this.databaseItem],
         },
         iconPath: new ThemeIcon("error", new ThemeColor("errorForeground")),
       };

--- a/extensions/ql-vscode/src/model-editor/model-editor-module.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-module.ts
@@ -175,23 +175,11 @@ export class ModelEditorModule extends DisposableObject {
     await ensureDir(this.queryStorageDir);
   }
 
-  private async showMethod(usage: Usage): Promise<void> {
+  private async showMethod(
+    method: ExternalApiUsage,
+    usage: Usage,
+  ): Promise<void> {
     await this.methodsUsagePanel.revealItem(usage);
-
-    // For now, just construct a dummy method and show it in the method modeling panel
-    // because the method isn't easily accessible yet.
-    const method: ExternalApiUsage = {
-      library: "sql2o",
-      libraryVersion: "1.6.0",
-      signature: "org.sql2o.Connection#createQuery(String)",
-      packageName: "org.sql2o",
-      typeName: "Connection",
-      methodName: "createQuery",
-      methodParameters: "(String)",
-      supported: true,
-      supportedType: "summary",
-      usages: [],
-    };
     await this.methodModelingPanel.setMethod(method);
   }
 }

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -65,7 +65,10 @@ export class ModelEditorView extends AbstractWebview<
       databaseItem: DatabaseItem,
       hideModeledApis: boolean,
     ) => Promise<void>,
-    private readonly showMethod: (usage: Usage) => Promise<void>,
+    private readonly showMethod: (
+      method: ExternalApiUsage,
+      usage: Usage,
+    ) => Promise<void>,
     private readonly handleViewBecameActive: (view: ModelEditorView) => void,
     private readonly handleViewWasDisposed: (view: ModelEditorView) => void,
     private readonly isMostRecentlyActiveView: (
@@ -190,7 +193,7 @@ export class ModelEditorView extends AbstractWebview<
 
         break;
       case "jumpToUsage":
-        await this.handleJumpToUsage(msg.usage);
+        await this.handleJumpToUsage(msg.method, msg.usage);
 
         break;
       case "saveModeledMethods":
@@ -267,8 +270,8 @@ export class ModelEditorView extends AbstractWebview<
     });
   }
 
-  protected async handleJumpToUsage(usage: Usage) {
-    await this.showMethod(usage);
+  protected async handleJumpToUsage(method: ExternalApiUsage, usage: Usage) {
+    await this.showMethod(method, usage);
     await showResolvableLocation(usage.url, this.databaseItem, this.app.logger);
   }
 

--- a/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
@@ -314,6 +314,7 @@ function UnmodelableMethodRow(props: Props) {
 function sendJumpToUsageMessage(externalApiUsage: ExternalApiUsage) {
   vscode.postMessage({
     t: "jumpToUsage",
+    method: externalApiUsage,
     // In framework mode, the first and only usage is the definition of the method
     usage: externalApiUsage.usages[0],
   });


### PR DESCRIPTION
Updates the jump to usage message and related functions to include the method. This allows us to surface method information in the method modeling panel when "View" is clicked.

Note that I've not renamed the message - let me know if you think it should be renamed.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
