### PR TITLE
Store link to method on usage in the data provider

### DIFF
--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -523,6 +523,7 @@ interface SwitchModeMessage {
 
 interface JumpToUsageMessage {
   t: "jumpToUsage";
+  method: ExternalApiUsage;
   usage: Usage;
 }
 

--- a/extensions/ql-vscode/src/model-editor/methods-usage/methods-usage-data-provider.ts
+++ b/extensions/ql-vscode/src/model-editor/methods-usage/methods-usage-data-provider.ts
@@ -71,6 +71,7 @@ export class MethodsUsageDataProvider
         iconPath: new ThemeIcon("symbol-method"),
       };
     } else {
+      const method = this.getParent(item);
       return {
         label: item.label,
         description: `${this.relativePathWithinDatabase(item.url.uri)} [${
@@ -80,7 +81,7 @@ export class MethodsUsageDataProvider
         command: {
           title: "Show usage",
           command: "codeQLModelEditor.jumpToUsageLocation",
-          arguments: [item, this.databaseItem],
+          arguments: [method, item, this.databaseItem],
         },
         iconPath: new ThemeIcon("error", new ThemeColor("errorForeground")),
       };

--- a/extensions/ql-vscode/src/model-editor/methods-usage/methods-usage-data-provider.ts
+++ b/extensions/ql-vscode/src/model-editor/methods-usage/methods-usage-data-provider.ts
@@ -71,7 +71,6 @@ export class MethodsUsageDataProvider
         iconPath: new ThemeIcon("symbol-method"),
       };
     } else {
-      const method = this.getParent(item);
       return {
         label: item.label,
         description: `${this.relativePathWithinDatabase(item.url.uri)} [${
@@ -81,7 +80,7 @@ export class MethodsUsageDataProvider
         command: {
           title: "Show usage",
           command: "codeQLModelEditor.jumpToUsageLocation",
-          arguments: [method, item, this.databaseItem],
+          arguments: [item.method, item, this.databaseItem],
         },
         iconPath: new ThemeIcon("error", new ThemeColor("errorForeground")),
       };
@@ -105,7 +104,7 @@ export class MethodsUsageDataProvider
         return this.externalApiUsages;
       }
     } else if (isExternalApiUsage(item)) {
-      return item.usages;
+      return item.usages.map((u) => ({ ...u, method: item }));
     } else {
       return [];
     }
@@ -117,15 +116,15 @@ export class MethodsUsageDataProvider
     if (isExternalApiUsage(item)) {
       return undefined;
     } else {
-      return this.externalApiUsages.find((e) => e.usages.includes(item));
+      return item.method;
     }
   }
 
-  public resolveCanonicalUsage(usage: Usage): Usage | undefined {
+  public resolveCanonicalUsage(usage: Usage): UsageWithMethod | undefined {
     for (const externalApiUsage of this.externalApiUsages) {
       for (const u of externalApiUsage.usages) {
         if (usagesAreEqual(u, usage)) {
-          return u;
+          return { ...u, method: externalApiUsage };
         }
       }
     }
@@ -133,7 +132,8 @@ export class MethodsUsageDataProvider
   }
 }
 
-export type MethodsUsageTreeViewItem = ExternalApiUsage | Usage;
+type UsageWithMethod = Usage & { method: ExternalApiUsage };
+export type MethodsUsageTreeViewItem = ExternalApiUsage | UsageWithMethod;
 
 function isExternalApiUsage(
   item: MethodsUsageTreeViewItem,

--- a/extensions/ql-vscode/src/model-editor/model-editor-module.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-module.ts
@@ -175,23 +175,11 @@ export class ModelEditorModule extends DisposableObject {
     await ensureDir(this.queryStorageDir);
   }
 
-  private async showMethod(usage: Usage): Promise<void> {
+  private async showMethod(
+    method: ExternalApiUsage,
+    usage: Usage,
+  ): Promise<void> {
     await this.methodsUsagePanel.revealItem(usage);
-
-    // For now, just construct a dummy method and show it in the method modeling panel
-    // because the method isn't easily accessible yet.
-    const method: ExternalApiUsage = {
-      library: "sql2o",
-      libraryVersion: "1.6.0",
-      signature: "org.sql2o.Connection#createQuery(String)",
-      packageName: "org.sql2o",
-      typeName: "Connection",
-      methodName: "createQuery",
-      methodParameters: "(String)",
-      supported: true,
-      supportedType: "summary",
-      usages: [],
-    };
     await this.methodModelingPanel.setMethod(method);
   }
 }

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -65,7 +65,10 @@ export class ModelEditorView extends AbstractWebview<
       databaseItem: DatabaseItem,
       hideModeledApis: boolean,
     ) => Promise<void>,
-    private readonly showMethod: (usage: Usage) => Promise<void>,
+    private readonly showMethod: (
+      method: ExternalApiUsage,
+      usage: Usage,
+    ) => Promise<void>,
     private readonly handleViewBecameActive: (view: ModelEditorView) => void,
     private readonly handleViewWasDisposed: (view: ModelEditorView) => void,
     private readonly isMostRecentlyActiveView: (
@@ -190,7 +193,7 @@ export class ModelEditorView extends AbstractWebview<
 
         break;
       case "jumpToUsage":
-        await this.handleJumpToUsage(msg.usage);
+        await this.handleJumpToUsage(msg.method, msg.usage);
 
         break;
       case "saveModeledMethods":
@@ -267,8 +270,8 @@ export class ModelEditorView extends AbstractWebview<
     });
   }
 
-  protected async handleJumpToUsage(usage: Usage) {
-    await this.showMethod(usage);
+  protected async handleJumpToUsage(method: ExternalApiUsage, usage: Usage) {
+    await this.showMethod(method, usage);
     await showResolvableLocation(usage.url, this.databaseItem, this.app.logger);
   }
 

--- a/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
@@ -314,6 +314,7 @@ function UnmodelableMethodRow(props: Props) {
 function sendJumpToUsageMessage(externalApiUsage: ExternalApiUsage) {
   vscode.postMessage({
     t: "jumpToUsage",
+    method: externalApiUsage,
     // In framework mode, the first and only usage is the definition of the method
     usage: externalApiUsage.usages[0],
   });


### PR DESCRIPTION
The idea here is to make it easier to go from the usage back to the external API method. We need to do this in `getParent` and also when jumping to location. Currently this involves iterating through all external API usages, but we can make it instant by storing a reference.

Adding a new field to the actual `Usage` type isn't really possible, but we can define our own type local to `MethodsUsageDataProvider`. We can play around with exactly how we define `UsageWithMethod` and what we call it, but I think this general idea works out quite nicely.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
