### PR TITLE
Queries panel: Add new message when there are no queries

### DIFF
--- a/extensions/ql-vscode/src/queries-panel/queries-panel.ts
+++ b/extensions/ql-vscode/src/queries-panel/queries-panel.ts
@@ -12,6 +12,14 @@ export class QueriesPanel extends DisposableObject {
     const treeView = window.createTreeView("codeQLQueries", {
       treeDataProvider: dataProvider,
     });
+    dataProvider.onDidChangeTreeData(() => {
+      if (dataProvider.getChildren().length === 0) {
+        treeView.message =
+          "We didn't find any CodeQL queries in this workspace. Create one to get started.";
+      } else {
+        treeView.message = undefined;
+      }
+    });
     this.push(treeView);
   }
 }

--- a/extensions/ql-vscode/src/queries-panel/query-tree-data-provider.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-tree-data-provider.ts
@@ -3,7 +3,6 @@ import {
   QueryTreeViewItem,
   createQueryTreeFileItem,
   createQueryTreeFolderItem,
-  createQueryTreeTextItem,
 } from "./query-tree-view-item";
 import { DisposableObject } from "../common/disposable-object";
 import { FileTreeNode } from "../common/file-tree-nodes";
@@ -40,10 +39,8 @@ export class QueryTreeDataProvider
 
   private createTree(): QueryTreeViewItem[] {
     const queryTree = this.queryDiscoverer.buildQueryTree();
-    if (queryTree === undefined) {
+    if (queryTree === undefined || queryTree.length === 0) {
       return [];
-    } else if (queryTree.length === 0) {
-      return [this.noQueriesTreeViewItem()];
     } else {
       return queryTree.map(this.convertFileTreeNode.bind(this));
     }
@@ -65,12 +62,6 @@ export class QueryTreeDataProvider
         fileTreeDirectory.children.map(this.convertFileTreeNode.bind(this)),
       );
     }
-  }
-
-  private noQueriesTreeViewItem(): QueryTreeViewItem {
-    return createQueryTreeTextItem(
-      "This workspace doesn't contain any CodeQL queries at the moment.",
-    );
   }
 
   /**

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/queries-panel/query-tree-data-provider.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/queries-panel/query-tree-data-provider.test.ts
@@ -7,7 +7,6 @@ import { QueryTreeDataProvider } from "../../../../src/queries-panel/query-tree-
 import {
   createQueryTreeFileItem,
   createQueryTreeFolderItem,
-  createQueryTreeTextItem,
 } from "../../../../src/queries-panel/query-tree-view-item";
 
 describe("QueryTreeDataProvider", () => {
@@ -21,17 +20,13 @@ describe("QueryTreeDataProvider", () => {
       expect(dataProvider.getChildren()).toEqual([]);
     });
 
-    it("returns an explanatory message when there are no queries", async () => {
+    it("returns empty array when there are no queries", async () => {
       const dataProvider = new QueryTreeDataProvider({
         buildQueryTree: () => [],
         onDidChangeQueries: jest.fn(),
       });
 
-      expect(dataProvider.getChildren()).toEqual([
-        createQueryTreeTextItem(
-          "This workspace doesn't contain any CodeQL queries at the moment.",
-        ),
-      ]);
+      expect(dataProvider.getChildren()).toEqual([]);
     });
 
     it("converts FileTreeNode to QueryTreeViewItem", async () => {


### PR DESCRIPTION
Adds a new tree view message when the queries panel is empty:
![image](https://github.com/github/vscode-codeql/assets/42641846/28053154-d3af-4f41-b594-4c3ac31a933c)

See internal linked issue for details (and for an explanation about why we've had to deviate from the designs)! 🖼️ 

We used to do this as a "text tree view item", but it makes more sense to use the `TreeView.message` (since that's its intended use, and the formatting is slightly nicer) 🌳 

### Testing thoughts 🧪 

We can't test this in the existing `query-tree-data-provider.test.ts` file, so I briefly considered a new `queries-panel.test.ts`, to check that the `message` is as expected. Annoyingly, that would involve getting access to the underlying treeview and data provider and it seemed more hassle than it's worth 🙈 

## Checklist

N/A—nothing publicly visible yet 🦺


- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
