### PR TITLE
Adjust styling of disabled dropdowns to make their state clearer

### DIFF
--- a/extensions/ql-vscode/src/view/common/Dropdown.tsx
+++ b/extensions/ql-vscode/src/view/common/Dropdown.tsx
@@ -2,6 +2,8 @@ import * as React from "react";
 import { ChangeEvent } from "react";
 import { styled } from "styled-components";
 
+const DISABLED_VALUE = "-";
+
 const StyledDropdown = styled.select`
   width: 100%;
   height: calc(var(--input-height) * 1px);
@@ -31,18 +33,20 @@ type Props = {
 export function Dropdown({ value, options, disabled, onChange }: Props) {
   return (
     <StyledDropdown
-      value={disabled ? undefined : value}
+      value={disabled ? DISABLED_VALUE : value}
       disabled={disabled}
       onChange={onChange}
     >
-      {!disabled && (
-        <>
-          {options.map((option) => (
-            <option key={option.value} value={option.value}>
-              {option.label}
-            </option>
-          ))}
-        </>
+      {disabled ? (
+        <option key={DISABLED_VALUE} value={DISABLED_VALUE}>
+          {DISABLED_VALUE}
+        </option>
+      ) : (
+        options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))
       )}
     </StyledDropdown>
   );

--- a/extensions/ql-vscode/src/view/common/Dropdown.tsx
+++ b/extensions/ql-vscode/src/view/common/Dropdown.tsx
@@ -9,7 +9,7 @@ const StyledDropdown = styled.select<{ disabled?: boolean }>`
   height: calc(var(--input-height) * 1px);
   background: var(--vscode-dropdown-background);
   color: var(--vscode-foreground);
-  border: none;
+  border-width: 0 5px 0 0;
   padding: 2px 6px 2px 8px;
   opacity: ${(props) =>
     props.disabled ? "var(--disabled-opacity)" : "inherit"};

--- a/extensions/ql-vscode/src/view/common/Dropdown.tsx
+++ b/extensions/ql-vscode/src/view/common/Dropdown.tsx
@@ -4,13 +4,15 @@ import { styled } from "styled-components";
 
 const DISABLED_VALUE = "-";
 
-const StyledDropdown = styled.select`
+const StyledDropdown = styled.select<{ disabled?: boolean }>`
   width: 100%;
   height: calc(var(--input-height) * 1px);
   background: var(--vscode-dropdown-background);
   color: var(--vscode-foreground);
   border: none;
   padding: 2px 6px 2px 8px;
+  opacity: ${(props) =>
+    props.disabled ? "var(--disabled-opacity)" : "inherit"};
 `;
 
 type Props = {


### PR DESCRIPTION
This PR makes three changes to dropdowns:
- When disabled, shows a dash/hyphen instead of nothing
- When disabled, sets the opacity value lower (this matches how the `VSCodeDropdown` component behaves)
- Moves the arrow further away from the right-hand edge

Screenshot:
<img width="1686" alt="Screenshot 2023-09-04 at 15 21 16" src="https://github.com/github/vscode-codeql/assets/3749000/f5dbe915-99d0-4c13-97a3-f3bd1bfacdab">

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
