### PR TITLE
Queries Panel: Create query from welcome view

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1804,7 +1804,8 @@
       },
       {
         "view": "codeQLQueries",
-        "contents": "Looking for queries..."
+        "contents": "We didn't find any CodeQL queries in this workspace. [Create one to get started](command:codeQLQueries.createQuery).",
+        "when": "codeQL.noQueries"
       },
       {
         "view": "codeQLDatabases",

--- a/extensions/ql-vscode/src/queries-panel/queries-module.ts
+++ b/extensions/ql-vscode/src/queries-panel/queries-module.ts
@@ -44,7 +44,7 @@ export class QueriesModule extends DisposableObject {
     this.push(queryDiscovery);
     void queryDiscovery.initialRefresh();
 
-    this.queriesPanel = new QueriesPanel(queryDiscovery);
+    this.queriesPanel = new QueriesPanel(queryDiscovery, app);
     this.push(this.queriesPanel);
   }
 }

--- a/extensions/ql-vscode/src/queries-panel/queries-panel.ts
+++ b/extensions/ql-vscode/src/queries-panel/queries-panel.ts
@@ -2,12 +2,16 @@ import { DisposableObject } from "../common/disposable-object";
 import { QueryTreeDataProvider } from "./query-tree-data-provider";
 import { QueryDiscovery } from "./query-discovery";
 import { window } from "vscode";
+import { App } from "../common/app";
 
 export class QueriesPanel extends DisposableObject {
-  public constructor(queryDiscovery: QueryDiscovery) {
+  public constructor(
+    queryDiscovery: QueryDiscovery,
+    readonly app: App,
+  ) {
     super();
 
-    const dataProvider = new QueryTreeDataProvider(queryDiscovery);
+    const dataProvider = new QueryTreeDataProvider(queryDiscovery, app);
 
     const treeView = window.createTreeView("codeQLQueries", {
       treeDataProvider: dataProvider,

--- a/extensions/ql-vscode/src/queries-panel/query-tree-view-item.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-tree-view-item.ts
@@ -39,7 +39,3 @@ export function createQueryTreeFileItem(
   };
   return item;
 }
-
-export function createQueryTreeTextItem(text: string): QueryTreeViewItem {
-  return new QueryTreeViewItem(text, undefined, []);
-}


### PR DESCRIPTION
Removes the "Looking for queries..." loading message and replaces it with a welcome view that prompts users to create a query if their panel is empty. 

![image](https://github.com/github/vscode-codeql/assets/42641846/2f100033-204e-4f11-9059-570a45d48d22)

See internal linked issue for details and design discussions 🖼️

## Checklist

N/A—nothing publicly visible yet 🦺

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
