### PR TITLE
Emit telemetry for all messages sent from model editor

### DIFF
--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -39,6 +39,7 @@ import { pickExtensionPack } from "./extension-pack-picker";
 import { getLanguageDisplayName } from "../common/query-language";
 import { AutoModeler } from "./auto-modeler";
 import { INITIAL_HIDE_MODELED_APIS_VALUE } from "./shared/hide-modeled-apis";
+import { telemetryListener } from "../common/vscode/telemetry";
 
 export class ModelEditorView extends AbstractWebview<
   ToModelEditorMessage,
@@ -190,10 +191,14 @@ export class ModelEditorView extends AbstractWebview<
         break;
       case "refreshMethods":
         await this.loadExternalApiUsages();
+        void telemetryListener?.sendUIInteraction(
+          "model-editor-refresh-methods",
+        );
 
         break;
       case "jumpToUsage":
         await this.handleJumpToUsage(msg.method, msg.usage);
+        void telemetryListener?.sendUIInteraction("model-editor-jump-to-usage");
 
         break;
       case "saveModeledMethods":
@@ -208,10 +213,16 @@ export class ModelEditorView extends AbstractWebview<
           this.app.logger,
         );
         await Promise.all([this.setViewState(), this.loadExternalApiUsages()]);
+        void telemetryListener?.sendUIInteraction(
+          "model-editor-save-modeled-methods",
+        );
 
         break;
       case "generateMethod":
         await this.generateModeledMethods();
+        void telemetryListener?.sendUIInteraction(
+          "model-editor-generate-modeled-methods",
+        );
 
         break;
       case "generateMethodsFromLlm":
@@ -220,17 +231,26 @@ export class ModelEditorView extends AbstractWebview<
           msg.methods,
           msg.modeledMethods,
         );
+        void telemetryListener?.sendUIInteraction(
+          "model-editor-generate-methods-from-llm",
+        );
         break;
       case "stopGeneratingMethodsFromLlm":
         await this.autoModeler.stopModeling(msg.packageName);
+        void telemetryListener?.sendUIInteraction(
+          "model-editor-stop-generating-methods-from-llm",
+        );
         break;
       case "modelDependency":
         await this.modelDependency();
+        void telemetryListener?.sendUIInteraction(
+          "model-editor-model-dependency",
+        );
         break;
       case "switchMode":
         this.mode = msg.mode;
-
         await Promise.all([this.setViewState(), this.loadExternalApiUsages()]);
+        void telemetryListener?.sendUIInteraction("model-editor-switch-modes");
 
         break;
       case "hideModeledApis":
@@ -239,6 +259,9 @@ export class ModelEditorView extends AbstractWebview<
           this.methods,
           this.databaseItem,
           this.hideModeledApis,
+        );
+        void telemetryListener?.sendUIInteraction(
+          "model-editor-hide-modeled-apis",
         );
         break;
       default:


### PR DESCRIPTION
This PR should ensure that we have sufficient telemetry of actions users are taking in the model editor.

Some actions are already covered because we emit telemetry for all commands that get executed. This PR then covers all places where we send a message from the view to the extension host. Theoretically there could also be UI interactions that don't result in a message being sent to the host, but in the case of the model editor I don't believe there are any.

If in the future we do find we've missed something that we would like to have telemetry on, we can always add it.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
