### PR TITLE
Change calculateModeledPercentage to accept Method instead of using Pick

### DIFF
--- a/extensions/ql-vscode/src/model-editor/shared/modeled-percentage.ts
+++ b/extensions/ql-vscode/src/model-editor/shared/modeled-percentage.ts
@@ -1,12 +1,9 @@
 import { Method } from "../method";
 
-export function calculateModeledPercentage(
-  methods: Array<Pick<Method, "supported">>,
-): number {
+export function calculateModeledPercentage(methods: Method[]): number {
   if (methods.length === 0) {
     return 0;
   }
-
   const modeledMethods = methods.filter((m) => m.supported);
 
   const modeledRatio = modeledMethods.length / methods.length;

--- a/extensions/ql-vscode/test/unit-tests/model-editor/shared/modeled-percentage.spec.ts
+++ b/extensions/ql-vscode/test/unit-tests/model-editor/shared/modeled-percentage.spec.ts
@@ -1,4 +1,5 @@
 import { calculateModeledPercentage } from "../../../../src/model-editor/shared/modeled-percentage";
+import { createMethod } from "../../../factories/data-extension/method-factories";
 
 describe("calculateModeledPercentage", () => {
   it("when there are no external API usages", () => {
@@ -8,44 +9,28 @@ describe("calculateModeledPercentage", () => {
   it("when there are is 1 modeled external API usage", () => {
     expect(
       calculateModeledPercentage([
-        {
+        createMethod({
           supported: true,
-        },
+        }),
       ]),
     ).toBe(100);
   });
 
   it("when there are is 1 unmodeled external API usage", () => {
     expect(
-      calculateModeledPercentage([
-        {
-          supported: false,
-        },
-      ]),
+      calculateModeledPercentage([createMethod({ supported: false })]),
     ).toBe(0);
   });
 
   it("when there are multiple modeled and unmodeled external API usage", () => {
     expect(
       calculateModeledPercentage([
-        {
-          supported: false,
-        },
-        {
-          supported: true,
-        },
-        {
-          supported: false,
-        },
-        {
-          supported: false,
-        },
-        {
-          supported: true,
-        },
-        {
-          supported: false,
-        },
+        createMethod({ supported: false }),
+        createMethod({ supported: true }),
+        createMethod({ supported: false }),
+        createMethod({ supported: false }),
+        createMethod({ supported: true }),
+        createMethod({ supported: false }),
       ]),
     ).toBeCloseTo(33.33);
   });


### PR DESCRIPTION
I believe this method is accepting `Pick<Method, "supported">` in order to make the testing easier, but we now have better ways around that so it isn't necessary. Also this was making it difficult for me when I wanted to use another field from the `method` object.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
