### PR TITLE
Adjust styling of disabled dropdowns when automodeling is in progress

### DIFF
--- a/extensions/ql-vscode/src/stories/model-editor/MethodRow.stories.tsx
+++ b/extensions/ql-vscode/src/stories/model-editor/MethodRow.stories.tsx
@@ -101,3 +101,10 @@ AlreadyModeled.args = {
   method: { ...method, supported: true },
   modeledMethod: undefined,
 };
+
+export const ModelingInProgress = Template.bind({});
+ModelingInProgress.args = {
+  method,
+  modeledMethod,
+  modelingInProgress: true,
+};

--- a/extensions/ql-vscode/src/view/common/Dropdown.tsx
+++ b/extensions/ql-vscode/src/view/common/Dropdown.tsx
@@ -20,7 +20,7 @@ type Props = {
   options: Array<{ value: string; label: string }>;
   disabled?: boolean;
   disabledPlaceholder?: string;
-  onChange: (event: ChangeEvent<HTMLSelectElement>) => void;
+  onChange?: (event: ChangeEvent<HTMLSelectElement>) => void;
 };
 
 /**

--- a/extensions/ql-vscode/src/view/common/Dropdown.tsx
+++ b/extensions/ql-vscode/src/view/common/Dropdown.tsx
@@ -19,6 +19,7 @@ type Props = {
   value: string | undefined;
   options: Array<{ value: string; label: string }>;
   disabled?: boolean;
+  disabledPlaceholder?: string;
   onChange: (event: ChangeEvent<HTMLSelectElement>) => void;
 };
 
@@ -32,16 +33,23 @@ type Props = {
  * See https://github.com/github/vscode-codeql/pull/2582#issuecomment-1622164429
  * for more info on the problem and other potential solutions.
  */
-export function Dropdown({ value, options, disabled, onChange }: Props) {
+export function Dropdown({
+  value,
+  options,
+  disabled,
+  disabledPlaceholder,
+  onChange,
+}: Props) {
+  const disabledValue = disabledPlaceholder ?? DISABLED_VALUE;
   return (
     <StyledDropdown
-      value={disabled ? DISABLED_VALUE : value}
+      value={disabled ? disabledValue : value}
       disabled={disabled}
       onChange={onChange}
     >
       {disabled ? (
-        <option key={DISABLED_VALUE} value={DISABLED_VALUE}>
-          {DISABLED_VALUE}
+        <option key={disabledValue} value={disabledValue}>
+          {disabledValue}
         </option>
       ) : (
         options.map((option) => (

--- a/extensions/ql-vscode/src/view/model-editor/InProgressDropdown.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/InProgressDropdown.tsx
@@ -2,17 +2,12 @@ import * as React from "react";
 import { Dropdown } from "../common/Dropdown";
 
 export const InProgressDropdown = () => {
-  const noop = () => {
-    // Do nothing
-  };
-
   return (
     <Dropdown
       value="Thinking..."
       options={[]}
       disabled={true}
       disabledPlaceholder="Thinking..."
-      onChange={noop}
     />
   );
 };

--- a/extensions/ql-vscode/src/view/model-editor/InProgressDropdown.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/InProgressDropdown.tsx
@@ -2,12 +2,6 @@ import * as React from "react";
 import { Dropdown } from "../common/Dropdown";
 
 export const InProgressDropdown = () => {
-  const options: Array<{ label: string; value: string }> = [
-    {
-      label: "Thinking...",
-      value: "Thinking...",
-    },
-  ];
   const noop = () => {
     // Do nothing
   };
@@ -15,8 +9,9 @@ export const InProgressDropdown = () => {
   return (
     <Dropdown
       value="Thinking..."
-      options={options}
-      disabled={false}
+      options={[]}
+      disabled={true}
+      disabledPlaceholder="Thinking..."
       onChange={noop}
     />
   );


### PR DESCRIPTION
This changes the dropdowns when the automodeling process is in progress. The `Dropdown` component now has new features that we can make use of.

Previously, we shows a usable dropdown, except that the only available option was "Thinking...". But the user could still click on the dropdown and it was a little odd.

Now, we show a disabled dropdown that the user cannot click on. The dropdown is still showing the "Thinking..." text.

I recommend checking out the storybook to see what it looks like.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
