### PR TITLE
fix syntax highlighting after imports with instantiation arguments

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Increase the required version of VS Code to 1.82.0. [#2877](https://github.com/github/vscode-codeql/pull/2877)
 - Fix a bug where the query server was restarted twice after configuration changes. [#2884](https://github.com/github/vscode-codeql/pull/2884).
 - Add support for the `telemetry.telemetryLevel` setting. For more information, see the [telemetry documentation](https://codeql.github.com/docs/codeql-for-visual-studio-code/about-telemetry-in-codeql-for-visual-studio-code). [#2824](https://github.com/github/vscode-codeql/pull/2824).
-- Fixed syntax highlighting directly after import statements with instantiation arguments.
+- Fix syntax highlighting directly after import statements with instantiation arguments. [#2792](https://github.com/github/vscode-codeql/pull/2792)
 
 ## 1.9.1 - 29 September 2023
 

--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Increase the required version of VS Code to 1.82.0. [#2877](https://github.com/github/vscode-codeql/pull/2877)
 - Fix a bug where the query server was restarted twice after configuration changes. [#2884](https://github.com/github/vscode-codeql/pull/2884).
 - Add support for the `telemetry.telemetryLevel` setting. For more information, see the [telemetry documentation](https://codeql.github.com/docs/codeql-for-visual-studio-code/about-telemetry-in-codeql-for-visual-studio-code). [#2824](https://github.com/github/vscode-codeql/pull/2824).
+- Fixed syntax highlighting directly after import statements with instantiation arguments.
 
 ## 1.9.1 - 29 September 2023
 

--- a/extensions/ql-vscode/syntaxes/ql.tmLanguage.yml
+++ b/extensions/ql-vscode/syntaxes/ql.tmLanguage.yml
@@ -170,6 +170,14 @@ repository:
     match: '\]'
     name: punctuation.squarebracket.close.ql
 
+  open-angle:
+    match: '<'
+    name: punctuation.anglebracket.open.ql
+
+  close-angle:
+    match: '>'
+    name: punctuation.anglebracket.close.ql
+
   operator-or-punctuation:
     patterns:
     - include: '#relational-operator'
@@ -186,6 +194,8 @@ repository:
     - include: '#close-brace'
     - include: '#open-bracket'
     - include: '#close-bracket'
+    - include: '#open-angle'
+    - include: '#close-angle'
 
 # Keywords
   dont-care:
@@ -651,6 +661,15 @@ repository:
     - include: '#non-context-sensitive'
     - include: '#annotation'
 
+  instantiation-arguments:
+    beginPattern: '#open-angle'
+    end: '#close-angle'
+    patterns:
+    - include: '#potential-instantiation'
+
+  potential-instantiation:
+    matches: '(?#simple-id) (?#instantiation-arguments)?'
+
   # An `import` directive. Note that we parse the optional `as` clause as a separate top-level
   # directive, because otherwise it's too hard to figure out where the `import` directive ends.
   import-directive:
@@ -664,7 +683,7 @@ repository:
     name: meta.block.import-directive.ql
     patterns:
     - include: '#non-context-sensitive'
-    - match: '(?#simple-id)'
+    - match: '(?#potential-instantiation)'
       name: entity.name.type.namespace.ql
 
   # The end pattern for an `as` clause, whether on an `import` directive, in an aggregate, or on a
@@ -702,7 +721,6 @@ repository:
     - include: '#non-context-sensitive'
     - match: '(?#simple-id)|(?#at-lower-id)'
       name: entity.name.type.ql
-
 
   # A `module` declaration, whether a module definition or an alias declaration.
   module-declaration:

--- a/extensions/ql-vscode/syntaxes/ql.tmLanguage.yml
+++ b/extensions/ql-vscode/syntaxes/ql.tmLanguage.yml
@@ -661,29 +661,38 @@ repository:
     - include: '#non-context-sensitive'
     - include: '#annotation'
 
-  instantiation-arguments:
+  # The argument list of an instantiation, enclosed in angle brackets.
+  instantiation-args:
     beginPattern: '#open-angle'
-    end: '#close-angle'
+    endPattern: '#close-angle'
+    name: meta.type.parameters.ql
     patterns:
-    - include: '#potential-instantiation'
-
-  potential-instantiation:
-    matches: '(?#simple-id) (?#instantiation-arguments)?'
+    # Include `#instantiation-args` first so that `#open-angle` and `#close-angle` take precedence
+    # over `#relational-operator`.
+    - include: '#instantiation-args'
+    - include: '#non-context-sensitive'
+    - match: '(?#simple-id)'
+      name: entity.name.type.namespace.ql
 
   # An `import` directive. Note that we parse the optional `as` clause as a separate top-level
   # directive, because otherwise it's too hard to figure out where the `import` directive ends.
   import-directive:
     beginPattern: '#import'
-    # Ends with a simple-id that is not followed by a `.` or a `::`. This does not handle comments or
-    # line breaks between the simple-id and the `.` or `::`. 
-    end: '(?#simple-id) (?!\s*(\.|\:\:))'
-    endCaptures:
-      '0':
-        name: entity.name.type.namespace.ql
+    # TextMate makes it tricky to tell whether an identifier that we encounter is part of the
+    # `import` directive or whether it's the first token of the next module-level declaration.
+    # To find the end of the import directive, we'll look for a zero-width match where the previous
+    # token is either an identifier (other than `import`) or a `>`, and the next token is not a `.`,
+    # `<`, `,`, or `::`. This works for nearly all real-world `import` directives, but it will end the
+    # `import` directive too early if there is a comment or line break between two components of the
+    # module expression.
+    end: '(?<!\bimport)(?<=(?:\>)|[A-Za-z0-9_]) (?!\s*(\.|\:\:|\,|(?#open-angle)))'
     name: meta.block.import-directive.ql
     patterns:
+    # Include `#instantiation-args` first so that `#open-angle` and `#close-angle` take precedence
+    # over `#relational-operator`.
+    - include: '#instantiation-args'
     - include: '#non-context-sensitive'
-    - match: '(?#potential-instantiation)'
+    - match: '(?#simple-id)'
       name: entity.name.type.namespace.ql
 
   # The end pattern for an `as` clause, whether on an `import` directive, in an aggregate, or on a

--- a/syntaxes/ql.tmLanguage.json
+++ b/syntaxes/ql.tmLanguage.json
@@ -108,6 +108,14 @@
       "match": "(?x)\\]",
       "name": "punctuation.squarebracket.close.ql"
     },
+    "open-angle": {
+      "match": "(?x)<",
+      "name": "punctuation.anglebracket.open.ql"
+    },
+    "close-angle": {
+      "match": "(?x)>",
+      "name": "punctuation.anglebracket.close.ql"
+    },
     "operator-or-punctuation": {
       "patterns": [
         {
@@ -151,6 +159,12 @@
         },
         {
           "include": "#close-bracket"
+        },
+        {
+          "include": "#open-angle"
+        },
+        {
+          "include": "#close-angle"
         }
       ]
     },
@@ -661,9 +675,9 @@
               "begin": "(?x)(?<=/\\*\\*)([^*]|\\*(?!/))*$",
               "while": "(?x)(^|\\G)\\s*([^*]|\\*(?!/))(?=([^*]|[*](?!/))*$)",
               "patterns": [
-                
-                
-                
+
+
+
                 {
                   "match": "(?x)\\G\\s* (@\\S+)",
                   "name": "keyword.tag.ql"
@@ -723,15 +737,48 @@
         }
       ]
     },
-    "import-directive": {
-      "end": "(?x)(?:\\b [A-Za-z][0-9A-Za-z_]* (?:(?!(?:[0-9A-Za-z_])))) (?!\\s*(\\.|\\:\\:))",
-      "endCaptures": {
-        "0": {
+    "instantiation-args": {
+      "name": "meta.type.parameters.ql",
+      "patterns": [
+        {
+          "include": "#instantiation-args"
+        },
+        {
+          "include": "#non-context-sensitive"
+        },
+        {
+          "match": "(?x)(?:\\b [A-Za-z][0-9A-Za-z_]* (?:(?!(?:[0-9A-Za-z_]))))",
           "name": "entity.name.type.namespace.ql"
         }
+      ],
+      "begin": "(?x)((?:<))",
+      "beginCaptures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#open-angle"
+            }
+          ]
+        }
       },
+      "end": "(?x)((?:>))",
+      "endCaptures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#close-angle"
+            }
+          ]
+        }
+      }
+    },
+    "import-directive": {
+      "end": "(?x)(?<!\\bimport)(?<=(?:\\>)|[A-Za-z0-9_]) (?!\\s*(\\.|\\:\\:|\\,|(?:<)))",
       "name": "meta.block.import-directive.ql",
       "patterns": [
+        {
+          "include": "#instantiation-args"
+        },
         {
           "include": "#non-context-sensitive"
         },


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Fixes https://github.com/github/codeql-core/issues/3697

This PR updates the TextMate grammar to allow instantiation arguments in import statements. This will improve syntax highlighting. Specifically, It is meant to fix the highlighting of `pragma` in the example below.

![image](https://github.com/github/vscode-codeql/assets/12936686/5ff1a7ee-1cc1-4a54-a934-cce6ede5d356)

Note that I don't know the TextMate grammar world very well, so am not really sure whether what I did here makes any sense.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
