### PR TITLE
Add feature flag for flow generation

### DIFF
--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -706,8 +706,13 @@ export function showQueriesPanel(): boolean {
 }
 
 const MODEL_SETTING = new Setting("model", ROOT_SETTING);
+const FLOW_GENERATION = new Setting("flowGeneration", MODEL_SETTING);
 const LLM_GENERATION = new Setting("llmGeneration", MODEL_SETTING);
 const EXTENSIONS_DIRECTORY = new Setting("extensionsDirectory", MODEL_SETTING);
+
+export function showFlowGeneration(): boolean {
+  return !!FLOW_GENERATION.getValue<boolean>();
+}
 
 export function showLlmGeneration(): boolean {
   return !!LLM_GENERATION.getValue<boolean>();

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -34,7 +34,7 @@ import {
 import { Method, Usage } from "./method";
 import { ModeledMethod } from "./modeled-method";
 import { ExtensionPack } from "./shared/extension-pack";
-import { showLlmGeneration } from "../config";
+import { showFlowGeneration, showLlmGeneration } from "../config";
 import { Mode } from "./shared/mode";
 import { loadModeledMethods, saveModeledMethods } from "./modeled-method-fs";
 import { join } from "path";
@@ -322,6 +322,7 @@ export class ModelEditorView extends AbstractWebview<
       t: "setModelEditorViewState",
       viewState: {
         extensionPack: this.extensionPack,
+        showFlowGeneration: showFlowGeneration(),
         showLlmButton,
         mode: this.mode,
       },

--- a/extensions/ql-vscode/src/model-editor/shared/view-state.ts
+++ b/extensions/ql-vscode/src/model-editor/shared/view-state.ts
@@ -3,6 +3,7 @@ import { Mode } from "./mode";
 
 export interface ModelEditorViewState {
   extensionPack: ExtensionPack;
+  showFlowGeneration: boolean;
   showLlmButton: boolean;
   mode: Mode;
 }

--- a/extensions/ql-vscode/src/stories/model-editor/ModelEditor.stories.tsx
+++ b/extensions/ql-vscode/src/stories/model-editor/ModelEditor.stories.tsx
@@ -28,6 +28,7 @@ ModelEditor.args = {
       extensionTargets: {},
       dataExtensions: [],
     },
+    showFlowGeneration: true,
     showLlmButton: true,
     mode: Mode.Application,
   },

--- a/extensions/ql-vscode/src/view/model-editor/LibraryRow.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/LibraryRow.tsx
@@ -213,12 +213,13 @@ export const LibraryRow = ({
             &nbsp;Stop
           </VSCodeButton>
         )}
-        {viewState.mode === Mode.Application && (
-          <VSCodeButton appearance="icon" onClick={handleModelFromSource}>
-            <Codicon name="code" label="Model from source" />
-            &nbsp;Model from source
-          </VSCodeButton>
-        )}
+        {viewState.showFlowGeneration &&
+          viewState.mode === Mode.Application && (
+            <VSCodeButton appearance="icon" onClick={handleModelFromSource}>
+              <Codicon name="code" label="Model from source" />
+              &nbsp;Model from source
+            </VSCodeButton>
+          )}
         {viewState.mode === Mode.Application && (
           <VSCodeButton appearance="icon" onClick={handleModelDependency}>
             <Codicon name="references" label="Model dependency" />

--- a/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
@@ -345,11 +345,12 @@ export function ModelEditor({
           <VSCodeButton appearance="secondary" onClick={onRefreshClick}>
             Refresh
           </VSCodeButton>
-          {viewState.mode === Mode.Framework && (
-            <VSCodeButton onClick={onGenerateFromSourceClick}>
-              Generate
-            </VSCodeButton>
-          )}
+          {viewState.showFlowGeneration &&
+            viewState.mode === Mode.Framework && (
+              <VSCodeButton onClick={onGenerateFromSourceClick}>
+                Generate
+              </VSCodeButton>
+            )}
         </ButtonsContainer>
         <ModeledMethodsList
           methods={methods}


### PR DESCRIPTION
This adds a new `codeQL.model.flowGeneration` feature flag for hiding the "Generate" and "Model from source" options from the model editor by default. It uses the same approach as the LLM generation.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
