### PR TITLE
Improve responsiveness of model editor

### DIFF
--- a/extensions/ql-vscode/src/model-editor/auto-model-codeml-queries.ts
+++ b/extensions/ql-vscode/src/model-editor/auto-model-codeml-queries.ts
@@ -75,7 +75,6 @@ export async function runAutoModelQueries({
 
   // Run the actual query
   const completedQuery = await runQuery({
-    cliServer,
     queryRunner,
     databaseItem,
     queryPath,
@@ -84,7 +83,6 @@ export async function runAutoModelQueries({
     extensionPacks,
     progress,
     token: cancellationTokenSource.token,
-    createLockFile: false,
   });
 
   if (!completedQuery) {

--- a/extensions/ql-vscode/src/model-editor/extension-pack-picker.ts
+++ b/extensions/ql-vscode/src/model-editor/extension-pack-picker.ts
@@ -18,13 +18,12 @@ import {
 } from "./extension-pack-name";
 import { autoPickExtensionsDirectory } from "./extensions-workspace-folder";
 
-const maxStep = 3;
-
 export async function pickExtensionPack(
   cliServer: Pick<CodeQLCliServer, "resolveQlpacks">,
   databaseItem: Pick<DatabaseItem, "name" | "language">,
   logger: NotificationLogger,
   progress: ProgressCallback,
+  maxStep: number,
 ): Promise<ExtensionPack | undefined> {
   progress({
     message: "Resolving extension packs...",

--- a/extensions/ql-vscode/src/model-editor/external-api-usage-queries.ts
+++ b/extensions/ql-vscode/src/model-editor/external-api-usage-queries.ts
@@ -106,8 +106,7 @@ export async function runExternalApiQueries(
         message: update.message,
       }),
     token,
-    // We need to create a lock file, because the query is inside our own pack
-    createLockFile: true,
+    createLockFile: false,
   });
 
   if (!completedQuery) {

--- a/extensions/ql-vscode/src/model-editor/external-api-usage-queries.ts
+++ b/extensions/ql-vscode/src/model-editor/external-api-usage-queries.ts
@@ -92,7 +92,6 @@ export async function runExternalApiQueries(
 
   // Run the actual query
   const completedQuery = await runQuery({
-    cliServer,
     queryRunner,
     databaseItem,
     queryPath,
@@ -106,7 +105,6 @@ export async function runExternalApiQueries(
         message: update.message,
       }),
     token,
-    createLockFile: false,
   });
 
   if (!completedQuery) {

--- a/extensions/ql-vscode/src/model-editor/flow-model-queries.ts
+++ b/extensions/ql-vscode/src/model-editor/flow-model-queries.ts
@@ -120,7 +120,6 @@ async function runSingleFlowQuery(
 
   // Run the query
   const completedQuery = await runQuery({
-    cliServer,
     queryRunner,
     databaseItem,
     queryPath,
@@ -134,7 +133,6 @@ async function runSingleFlowQuery(
         maxStep: 4000,
       }),
     token,
-    createLockFile: false,
   });
 
   if (!completedQuery) {

--- a/extensions/ql-vscode/src/model-editor/model-editor-module.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-module.ts
@@ -102,6 +102,8 @@ export class ModelEditorModule extends DisposableObject {
 
         return withProgress(
           async (progress) => {
+            const maxStep = 4;
+
             if (!(await this.cliServer.cliConstraints.supportsQlpacksKind())) {
               void showAndLogErrorMessage(
                 this.app.logger,
@@ -125,10 +127,17 @@ export class ModelEditorModule extends DisposableObject {
               db,
               this.app.logger,
               progress,
+              maxStep,
             );
             if (!modelFile) {
               return;
             }
+
+            progress({
+              message: "Installing dependencies...",
+              step: 3,
+              maxStep,
+            });
 
             // Create new temporary directory for query files and pack dependencies
             const queryDir = (await dir({ unsafeCleanup: true })).path;
@@ -136,6 +145,12 @@ export class ModelEditorModule extends DisposableObject {
             if (!success) {
               return;
             }
+
+            progress({
+              message: "Opening editor...",
+              step: 4,
+              maxStep,
+            });
 
             const view = new ModelEditorView(
               this.ctx,

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -483,6 +483,7 @@ export class ModelEditorView extends AbstractWebview<
         addedDatabase,
         this.app.logger,
         progress,
+        3,
       );
       if (!modelFile) {
         return;

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/extension-pack-picker.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/extension-pack-picker.test.ts
@@ -34,6 +34,7 @@ describe("pickExtensionPack", () => {
   let workspaceFolder: WorkspaceFolder;
 
   const logger = createMockLogger();
+  const maxStep = 4;
 
   beforeEach(async () => {
     tmpDir = (
@@ -98,7 +99,13 @@ describe("pickExtensionPack", () => {
     const cliServer = mockCliServer(qlPacks);
 
     expect(
-      await pickExtensionPack(cliServer, databaseItem, logger, progress),
+      await pickExtensionPack(
+        cliServer,
+        databaseItem,
+        logger,
+        progress,
+        maxStep,
+      ),
     ).toEqual(autoExtensionPack);
     expect(cliServer.resolveQlpacks).toHaveBeenCalledTimes(1);
     expect(cliServer.resolveQlpacks).toHaveBeenCalledWith(
@@ -173,7 +180,13 @@ describe("pickExtensionPack", () => {
     const cliServer = mockCliServer({});
 
     expect(
-      await pickExtensionPack(cliServer, databaseItem, logger, progress),
+      await pickExtensionPack(
+        cliServer,
+        databaseItem,
+        logger,
+        progress,
+        maxStep,
+      ),
     ).toEqual({
       path: newPackDir,
       yamlPath: join(newPackDir, "codeql-pack.yml"),
@@ -241,7 +254,13 @@ describe("pickExtensionPack", () => {
     const cliServer = mockCliServer({});
 
     expect(
-      await pickExtensionPack(cliServer, databaseItem, logger, progress),
+      await pickExtensionPack(
+        cliServer,
+        databaseItem,
+        logger,
+        progress,
+        maxStep,
+      ),
     ).toEqual({
       path: newPackDir,
       yamlPath: join(newPackDir, "codeql-pack.yml"),
@@ -277,7 +296,13 @@ describe("pickExtensionPack", () => {
     });
 
     expect(
-      await pickExtensionPack(cliServer, databaseItem, logger, progress),
+      await pickExtensionPack(
+        cliServer,
+        databaseItem,
+        logger,
+        progress,
+        maxStep,
+      ),
     ).toEqual(undefined);
     expect(logger.showErrorMessage).toHaveBeenCalledTimes(1);
     expect(logger.showErrorMessage).toHaveBeenCalledWith(
@@ -296,7 +321,13 @@ describe("pickExtensionPack", () => {
     });
 
     expect(
-      await pickExtensionPack(cliServer, databaseItem, logger, progress),
+      await pickExtensionPack(
+        cliServer,
+        databaseItem,
+        logger,
+        progress,
+        maxStep,
+      ),
     ).toEqual(undefined);
     expect(logger.showErrorMessage).toHaveBeenCalledTimes(1);
     expect(logger.showErrorMessage).toHaveBeenCalledWith(
@@ -317,7 +348,13 @@ describe("pickExtensionPack", () => {
     await outputFile(join(tmpDir.path, "codeql-pack.yml"), dumpYaml("java"));
 
     expect(
-      await pickExtensionPack(cliServer, databaseItem, logger, progress),
+      await pickExtensionPack(
+        cliServer,
+        databaseItem,
+        logger,
+        progress,
+        maxStep,
+      ),
     ).toEqual(undefined);
     expect(logger.showErrorMessage).toHaveBeenCalledTimes(1);
     expect(logger.showErrorMessage).toHaveBeenCalledWith(
@@ -348,7 +385,13 @@ describe("pickExtensionPack", () => {
     );
 
     expect(
-      await pickExtensionPack(cliServer, databaseItem, logger, progress),
+      await pickExtensionPack(
+        cliServer,
+        databaseItem,
+        logger,
+        progress,
+        maxStep,
+      ),
     ).toEqual(undefined);
     expect(logger.showErrorMessage).toHaveBeenCalledTimes(1);
     expect(logger.showErrorMessage).toHaveBeenCalledWith(
@@ -382,7 +425,13 @@ describe("pickExtensionPack", () => {
     );
 
     expect(
-      await pickExtensionPack(cliServer, databaseItem, logger, progress),
+      await pickExtensionPack(
+        cliServer,
+        databaseItem,
+        logger,
+        progress,
+        maxStep,
+      ),
     ).toEqual(undefined);
     expect(logger.showErrorMessage).toHaveBeenCalledTimes(1);
     expect(logger.showErrorMessage).toHaveBeenCalledWith(
@@ -433,7 +482,13 @@ describe("pickExtensionPack", () => {
     };
 
     expect(
-      await pickExtensionPack(cliServer, databaseItem, logger, progress),
+      await pickExtensionPack(
+        cliServer,
+        databaseItem,
+        logger,
+        progress,
+        maxStep,
+      ),
     ).toEqual(extensionPack);
   });
 });


### PR DESCRIPTION
This improves the responsiveness of the model editor. It is not necessary to create a lock file when running the external API usage queries because the pack has already installed the dependencies in `setUpPack`. By skipping this step, refreshing becomes almost instant with no changes rather than requiring a 5 second wait to re-install pack dependencies.

This also improves the progress notifications so it feels more responsive and is more accurate as to what the editor is doing.

I tested this both in a the `vscode-codeql-starter` and in an empty workspace, so I believe this should still work even when you do not have the `ql` submodule.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
