### PR TITLE
Set loading state when switching between modes

### DIFF
--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -277,7 +277,12 @@ export class ModelEditorView extends AbstractWebview<
         break;
       case "switchMode":
         this.mode = msg.mode;
+        this.methods = [];
         await Promise.all([
+          this.postMessage({
+            t: "setMethods",
+            methods: this.methods,
+          }),
           this.setViewState(),
           withProgress((progress) => this.loadExternalApiUsages(progress), {
             cancellable: false,

--- a/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
@@ -281,7 +281,6 @@ export function ModelEditor({
       t: "switchMode",
       mode: newMode,
     });
-    setMethods([]);
   }, [viewState?.mode]);
 
   const onHideModeledApis = useCallback(() => {

--- a/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
@@ -281,6 +281,7 @@ export function ModelEditor({
       t: "switchMode",
       mode: newMode,
     });
+    setMethods([]);
   }, [viewState?.mode]);
 
   const onHideModeledApis = useCallback(() => {


### PR DESCRIPTION
This sets the loading state when switching between application and framework mode. It does this by setting the `methods` to an empty array, which will show the loading state ([`methods.length === 0`](https://github.com/github/vscode-codeql/blob/b0eab8b9fed827a565abb1b4985d3a8a2db24df2/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx#L291)).

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
