### PR TITLE
Make "databases" the top panel in the CodeQL sidebar

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1747,13 +1747,13 @@
     "views": {
       "ql-container": [
         {
+          "id": "codeQLDatabases",
+          "name": "Databases"
+        },
+        {
           "id": "codeQLQueries",
           "name": "Queries",
           "when": "config.codeQL.canary && config.codeQL.queriesPanel"
-        },
-        {
-          "id": "codeQLDatabases",
-          "name": "Databases"
         },
         {
           "id": "codeQLVariantAnalysisRepositories",


### PR DESCRIPTION
Moves the databases panel to the top (since it'll later control the language that's displayed across all panels). See internal issue.

## Checklist

N/A—this is only visible to people who also had the queries panel visible (feature-flagged)

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
