### PR TITLE
Group framework mode model files by package

### DIFF
--- a/extensions/ql-vscode/src/model-editor/extension-pack-name.ts
+++ b/extensions/ql-vscode/src/model-editor/extension-pack-name.ts
@@ -37,7 +37,7 @@ export function autoNameExtensionPack(
   };
 }
 
-export function sanitizeExtensionPackName(name: string) {
+function sanitizeExtensionPackName(name: string) {
   // Lowercase everything
   name = name.toLowerCase();
 

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -217,7 +217,6 @@ export class ModelEditorView extends AbstractWebview<
             });
             await saveModeledMethods(
               this.extensionPack,
-              this.databaseItem.name,
               this.databaseItem.language,
               msg.methods,
               msg.modeledMethods,

--- a/extensions/ql-vscode/src/model-editor/modeled-method-fs.ts
+++ b/extensions/ql-vscode/src/model-editor/modeled-method-fs.ts
@@ -13,7 +13,6 @@ import { pathsEqual } from "../common/files";
 
 export async function saveModeledMethods(
   extensionPack: ExtensionPack,
-  databaseName: string,
   language: string,
   methods: Method[],
   modeledMethods: Record<string, ModeledMethod>,
@@ -28,7 +27,6 @@ export async function saveModeledMethods(
   );
 
   const yamls = createDataExtensionYamls(
-    databaseName,
     language,
     methods,
     modeledMethods,

--- a/extensions/ql-vscode/test/unit-tests/model-editor/yaml.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/model-editor/yaml.test.ts
@@ -3,6 +3,7 @@ import {
   createDataExtensionYamlsForApplicationMode,
   createDataExtensionYamlsForFrameworkMode,
   createFilenameForLibrary,
+  createFilenameForPackage,
   loadDataExtensionYaml,
 } from "../../../src/model-editor/yaml";
 import { CallClassification } from "../../../src/model-editor/method";
@@ -598,7 +599,6 @@ describe("createDataExtensionYamlsForApplicationMode", () => {
 describe("createDataExtensionYamlsForFrameworkMode", () => {
   it("creates the correct YAML files when there are no existing modeled methods", () => {
     const yaml = createDataExtensionYamlsForFrameworkMode(
-      "github/sql2o",
       "java",
       [
         {
@@ -723,7 +723,7 @@ describe("createDataExtensionYamlsForFrameworkMode", () => {
     );
 
     expect(yaml).toEqual({
-      "models/sql2o.model.yml": `extensions:
+      "models/org.sql2o.model.yml": `extensions:
   - addsTo:
       pack: codeql/java-all
       extensible: sourceModel
@@ -751,7 +751,6 @@ describe("createDataExtensionYamlsForFrameworkMode", () => {
 
   it("creates the correct YAML files when there are existing modeled methods", () => {
     const yaml = createDataExtensionYamlsForFrameworkMode(
-      "github/sql2o",
       "java",
       [
         {
@@ -873,7 +872,7 @@ describe("createDataExtensionYamlsForFrameworkMode", () => {
         },
       },
       {
-        "models/sql2o.model.yml": {
+        "models/org.sql2o.model.yml": {
           "org.sql2o.Connection#createQuery(String)": {
             type: "neutral",
             input: "",
@@ -917,7 +916,7 @@ describe("createDataExtensionYamlsForFrameworkMode", () => {
     );
 
     expect(yaml).toEqual({
-      "models/sql2o.model.yml": `extensions:
+      "models/org.sql2o.model.yml": `extensions:
   - addsTo:
       pack: codeql/java-all
       extensible: sourceModel
@@ -1041,6 +1040,43 @@ describe("createFilenameForLibrary", () => {
     "returns $filename if library name is $library",
     ({ library, filename }) => {
       expect(createFilenameForLibrary(library)).toEqual(filename);
+    },
+  );
+});
+
+describe("createFilenameForPackage", () => {
+  const testCases = [
+    {
+      library: "System.Net.Http.Headers",
+      filename: "models/System.Net.Http.Headers.model.yml",
+    },
+    {
+      library: "System.Security.Cryptography.X509Certificates",
+      filename:
+        "models/System.Security.Cryptography.X509Certificates.model.yml",
+    },
+    {
+      library: "com.google.common.io",
+      filename: "models/com.google.common.io.model.yml",
+    },
+    {
+      library: "hudson.cli",
+      filename: "models/hudson.cli.model.yml",
+    },
+    {
+      library: "java.util",
+      filename: "models/java.util.model.yml",
+    },
+    {
+      library: "org.apache.commons.io",
+      filename: "models/org.apache.commons.io.model.yml",
+    },
+  ];
+
+  test.each(testCases)(
+    "returns $filename if package name is $library",
+    ({ library, filename }) => {
+      expect(createFilenameForPackage(library)).toEqual(filename);
     },
   );
 });


### PR DESCRIPTION
This groups the framework mode model files by the package name rather than creating a single file for the library. This re-uses the existing logic from application mode and creates a new method which takes in a method to group by.

The actual grouping follows the approach the files are structured in the CodeQL repo: following the package name exactly. For C#, this means that the file names contain capital letters, like their respective namespaces do.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
