### PR TITLE
Add a row to the model editor tables showing how many methods have been hidden

### DIFF
--- a/extensions/ql-vscode/src/view/model-editor/HiddenMethodsRow.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/HiddenMethodsRow.tsx
@@ -1,0 +1,30 @@
+import {
+  VSCodeDataGridCell,
+  VSCodeDataGridRow,
+} from "@vscode/webview-ui-toolkit/react";
+import * as React from "react";
+import { styled } from "styled-components";
+
+const HiddenMethodsCell = styled(VSCodeDataGridCell)`
+  text-align: center;
+`;
+
+interface Props {
+  numHiddenMethods: number;
+  someMethodsAreVisible: boolean;
+}
+
+export function HiddenMethodsRow(props: Props) {
+  if (props.numHiddenMethods === 0) {
+    return null;
+  }
+
+  return (
+    <VSCodeDataGridRow>
+      <HiddenMethodsCell gridColumn="span 5">
+        {props.someMethodsAreVisible && "And "}
+        {props.numHiddenMethods} methods modeled in other CodeQL packs
+      </HiddenMethodsCell>
+    </VSCodeDataGridRow>
+  );
+}

--- a/extensions/ql-vscode/src/view/model-editor/HiddenMethodsRow.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/HiddenMethodsRow.tsx
@@ -14,16 +14,19 @@ interface Props {
   someMethodsAreVisible: boolean;
 }
 
-export function HiddenMethodsRow(props: Props) {
-  if (props.numHiddenMethods === 0) {
+export function HiddenMethodsRow({
+  numHiddenMethods,
+  someMethodsAreVisible,
+}: Props) {
+  if (numHiddenMethods === 0) {
     return null;
   }
 
   return (
     <VSCodeDataGridRow>
       <HiddenMethodsCell gridColumn="span 5">
-        {props.someMethodsAreVisible && "And "}
-        {props.numHiddenMethods} methods modeled in other CodeQL packs
+        {someMethodsAreVisible && "And "}
+        {numHiddenMethods} methods modeled in other CodeQL packs
       </HiddenMethodsCell>
     </VSCodeDataGridRow>
   );

--- a/extensions/ql-vscode/src/view/model-editor/HiddenMethodsRow.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/HiddenMethodsRow.tsx
@@ -4,6 +4,7 @@ import {
 } from "@vscode/webview-ui-toolkit/react";
 import * as React from "react";
 import { styled } from "styled-components";
+import { pluralize } from "../../common/word";
 
 const HiddenMethodsCell = styled(VSCodeDataGridCell)`
   text-align: center;
@@ -26,7 +27,8 @@ export function HiddenMethodsRow({
     <VSCodeDataGridRow>
       <HiddenMethodsCell gridColumn="span 5">
         {someMethodsAreVisible && "And "}
-        {numHiddenMethods} methods modeled in other CodeQL packs
+        {pluralize(numHiddenMethods, "method", "methods")} modeled in other
+        CodeQL packs
       </HiddenMethodsCell>
     </VSCodeDataGridRow>
   );

--- a/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
@@ -62,26 +62,17 @@ const modelTypeOptions: Array<{ value: ModeledMethodType; label: string }> = [
 
 type Props = {
   method: Method;
+  methodCanBeModeled: boolean;
   modeledMethod: ModeledMethod | undefined;
   methodIsUnsaved: boolean;
   modelingInProgress: boolean;
   mode: Mode;
-  hideModeledApis: boolean;
   onChange: (method: Method, modeledMethod: ModeledMethod) => void;
 };
 
 export const MethodRow = (props: Props) => {
-  const { method, modeledMethod, methodIsUnsaved, hideModeledApis } = props;
-
-  const methodCanBeModeled =
-    !method.supported ||
-    (modeledMethod && modeledMethod?.type !== "none") ||
-    methodIsUnsaved;
-
-  if (methodCanBeModeled) {
+  if (props.methodCanBeModeled) {
     return <ModelableMethodRow {...props} />;
-  } else if (hideModeledApis) {
-    return null;
   } else {
     return <UnmodelableMethodRow {...props} />;
   }

--- a/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
@@ -71,7 +71,9 @@ type Props = {
 };
 
 export const MethodRow = (props: Props) => {
-  if (props.methodCanBeModeled) {
+  const { methodCanBeModeled } = props;
+
+  if (methodCanBeModeled) {
     return <ModelableMethodRow {...props} />;
   } else {
     return <UnmodelableMethodRow {...props} />;

--- a/extensions/ql-vscode/src/view/model-editor/ModeledMethodDataGrid.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModeledMethodDataGrid.tsx
@@ -55,40 +55,46 @@ export const ModeledMethodDataGrid = ({
     return methodsWithModelability;
   }, [hideModeledApis, methods, modeledMethods, modifiedSignatures]);
 
+  const someMethodsAreVisible = methodsWithModelability.length > 0;
+
   return (
     <VSCodeDataGrid gridTemplateColumns={GRID_TEMPLATE_COLUMNS}>
-      <VSCodeDataGridRow rowType="header">
-        <VSCodeDataGridCell cellType="columnheader" gridColumn={1}>
-          API or method
-        </VSCodeDataGridCell>
-        <VSCodeDataGridCell cellType="columnheader" gridColumn={2}>
-          Model type
-        </VSCodeDataGridCell>
-        <VSCodeDataGridCell cellType="columnheader" gridColumn={3}>
-          Input
-        </VSCodeDataGridCell>
-        <VSCodeDataGridCell cellType="columnheader" gridColumn={4}>
-          Output
-        </VSCodeDataGridCell>
-        <VSCodeDataGridCell cellType="columnheader" gridColumn={5}>
-          Kind
-        </VSCodeDataGridCell>
-      </VSCodeDataGridRow>
-      {methodsWithModelability.map(({ method, methodCanBeModeled }) => (
-        <MethodRow
-          key={method.signature}
-          method={method}
-          methodCanBeModeled={methodCanBeModeled}
-          modeledMethod={modeledMethods[method.signature]}
-          methodIsUnsaved={modifiedSignatures.has(method.signature)}
-          modelingInProgress={inProgressMethods.hasMethod(
-            packageName,
-            method.signature,
-          )}
-          mode={mode}
-          onChange={onChange}
-        />
-      ))}
+      {someMethodsAreVisible && (
+        <>
+          <VSCodeDataGridRow rowType="header">
+            <VSCodeDataGridCell cellType="columnheader" gridColumn={1}>
+              API or method
+            </VSCodeDataGridCell>
+            <VSCodeDataGridCell cellType="columnheader" gridColumn={2}>
+              Model type
+            </VSCodeDataGridCell>
+            <VSCodeDataGridCell cellType="columnheader" gridColumn={3}>
+              Input
+            </VSCodeDataGridCell>
+            <VSCodeDataGridCell cellType="columnheader" gridColumn={4}>
+              Output
+            </VSCodeDataGridCell>
+            <VSCodeDataGridCell cellType="columnheader" gridColumn={5}>
+              Kind
+            </VSCodeDataGridCell>
+          </VSCodeDataGridRow>
+          {methodsWithModelability.map(({ method, methodCanBeModeled }) => (
+            <MethodRow
+              key={method.signature}
+              method={method}
+              methodCanBeModeled={methodCanBeModeled}
+              modeledMethod={modeledMethods[method.signature]}
+              methodIsUnsaved={modifiedSignatures.has(method.signature)}
+              modelingInProgress={inProgressMethods.hasMethod(
+                packageName,
+                method.signature,
+              )}
+              mode={mode}
+              onChange={onChange}
+            />
+          ))}
+        </>
+      )}
     </VSCodeDataGrid>
   );
 };

--- a/extensions/ql-vscode/src/view/model-editor/ModeledMethodDataGrid.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModeledMethodDataGrid.tsx
@@ -11,6 +11,7 @@ import { useMemo } from "react";
 import { Mode } from "../../model-editor/shared/mode";
 import { sortMethods } from "../../model-editor/shared/sorting";
 import { InProgressMethods } from "../../model-editor/shared/in-progress-methods";
+import { HiddenMethodsRow } from "./HiddenMethodsRow";
 
 export const GRID_TEMPLATE_COLUMNS = "0.5fr 0.125fr 0.125fr 0.125fr 0.125fr";
 
@@ -35,11 +36,12 @@ export const ModeledMethodDataGrid = ({
   hideModeledApis,
   onChange,
 }: Props) => {
-  const methodsWithModelability: Array<{
-    method: Method;
-    methodCanBeModeled: boolean;
-  }> = useMemo(() => {
+  const [methodsWithModelability, numHiddenMethods]: [
+    Array<{ method: Method; methodCanBeModeled: boolean }>,
+    number,
+  ] = useMemo(() => {
     const methodsWithModelability = [];
+    let numHiddenMethods = 0;
     for (const method of sortMethods(methods)) {
       const modeledMethod = modeledMethods[method.signature];
       const methodIsUnsaved = modifiedSignatures.has(method.signature);
@@ -50,9 +52,11 @@ export const ModeledMethodDataGrid = ({
 
       if (methodCanBeModeled || !hideModeledApis) {
         methodsWithModelability.push({ method, methodCanBeModeled });
+      } else {
+        numHiddenMethods += 1;
       }
     }
-    return methodsWithModelability;
+    return [methodsWithModelability, numHiddenMethods];
   }, [hideModeledApis, methods, modeledMethods, modifiedSignatures]);
 
   const someMethodsAreVisible = methodsWithModelability.length > 0;
@@ -95,6 +99,10 @@ export const ModeledMethodDataGrid = ({
           ))}
         </>
       )}
+      <HiddenMethodsRow
+        numHiddenMethods={numHiddenMethods}
+        someMethodsAreVisible={someMethodsAreVisible}
+      />
     </VSCodeDataGrid>
   );
 };


### PR DESCRIPTION
The aim of this is help users understand the effect of the "Hide modeled APIs" option. So if methods are hidden then we'll show how many there were. This PR also improves the experience when the table all methods are hidden by not showing the table header when there is no table content.

Screenshot showing a non-empty and empty table:
![Screenshot 2023-09-11 at 11 47 29](https://github.com/github/vscode-codeql/assets/3749000/94579527-b738-46ac-a4c8-e469ccd0223e)

Suggestions about styling very welcome.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
