### PR TITLE
Do not add source archive folder for "Model dependency"

### DIFF
--- a/extensions/ql-vscode/src/databases/database-fetcher.ts
+++ b/extensions/ql-vscode/src/databases/database-fetcher.ts
@@ -87,6 +87,7 @@ export async function promptImportInternetDatabase(
  * @param cli the CodeQL CLI server
  * @param language the language to download. If undefined, the user will be prompted to choose a language.
  * @param makeSelected make the new database selected in the databases panel (default: true)
+ * @param addSourceArchiveFolder whether to add a workspace folder containing the source archive to the workspace
  */
 export async function promptImportGithubDatabase(
   commandManager: AppCommandManager,
@@ -97,6 +98,7 @@ export async function promptImportGithubDatabase(
   cli?: CodeQLCliServer,
   language?: string,
   makeSelected = true,
+  addSourceArchiveFolder = true,
 ): Promise<DatabaseItem | undefined> {
   const githubRepo = await askForGitHubRepo(progress);
   if (!githubRepo) {
@@ -112,6 +114,7 @@ export async function promptImportGithubDatabase(
     cli,
     language,
     makeSelected,
+    addSourceArchiveFolder,
   );
 
   if (databaseItem) {
@@ -163,6 +166,7 @@ export async function askForGitHubRepo(
  * @param cli the CodeQL CLI server
  * @param language the language to download. If undefined, the user will be prompted to choose a language.
  * @param makeSelected make the new database selected in the databases panel (default: true)
+ * @param addSourceArchiveFolder whether to add a workspace folder containing the source archive to the workspace
  **/
 export async function downloadGitHubDatabase(
   githubRepo: string,
@@ -173,6 +177,7 @@ export async function downloadGitHubDatabase(
   cli?: CodeQLCliServer,
   language?: string,
   makeSelected = true,
+  addSourceArchiveFolder = true,
 ): Promise<DatabaseItem | undefined> {
   const nwo = getNwoFromGitHubUrl(githubRepo) || githubRepo;
   if (!isValidGitHubNwo(nwo)) {
@@ -218,6 +223,7 @@ export async function downloadGitHubDatabase(
     progress,
     cli,
     makeSelected,
+    addSourceArchiveFolder,
   );
 }
 
@@ -277,6 +283,7 @@ export async function importArchiveDatabase(
  * @param nameOverride a name for the database that overrides the default
  * @param progress callback to send progress messages to
  * @param makeSelected make the new database selected in the databases panel (default: true)
+ * @param addSourceArchiveFolder whether to add a workspace folder containing the source archive to the workspace
  */
 async function databaseArchiveFetcher(
   databaseUrl: string,
@@ -287,6 +294,7 @@ async function databaseArchiveFetcher(
   progress: ProgressCallback,
   cli?: CodeQLCliServer,
   makeSelected = true,
+  addSourceArchiveFolder = true,
 ): Promise<DatabaseItem> {
   progress({
     message: "Getting database",
@@ -329,6 +337,9 @@ async function databaseArchiveFetcher(
       Uri.file(dbPath),
       makeSelected,
       nameOverride,
+      {
+        addSourceArchiveFolder,
+      },
     );
     return item;
   } else {

--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -329,13 +329,14 @@ export class DatabaseUI extends DisposableObject {
             if (databaseItem === undefined) {
               const makeSelected = true;
               const nameOverride = "CodeQL Tutorial Database";
-              const isTutorialDatabase = true;
 
               await this.databaseManager.openDatabase(
                 uri,
                 makeSelected,
                 nameOverride,
-                isTutorialDatabase,
+                {
+                  isTutorialDatabase: true,
+                },
               );
             }
             await this.handleTourDependencies();

--- a/extensions/ql-vscode/src/databases/local-databases/database-manager.ts
+++ b/extensions/ql-vscode/src/databases/local-databases/database-manager.ts
@@ -71,6 +71,14 @@ function eventFired<T>(
   });
 }
 
+type OpenDatabaseOptions = {
+  isTutorialDatabase?: boolean;
+  /**
+   * Whether to add a workspace folder containing the source archive to the workspace. Default is true.
+   */
+  addSourceArchiveFolder?: boolean;
+};
+
 export class DatabaseManager extends DisposableObject {
   private readonly _onDidChangeDatabaseItem = this.push(
     new vscode.EventEmitter<DatabaseChangedEvent>(),
@@ -107,7 +115,10 @@ export class DatabaseManager extends DisposableObject {
     uri: vscode.Uri,
     makeSelected = true,
     displayName?: string,
-    isTutorialDatabase?: boolean,
+    {
+      isTutorialDatabase = false,
+      addSourceArchiveFolder = true,
+    }: OpenDatabaseOptions = {},
   ): Promise<DatabaseItem> {
     const databaseItem = await this.createDatabaseItem(uri, displayName);
 
@@ -115,6 +126,7 @@ export class DatabaseManager extends DisposableObject {
       databaseItem,
       makeSelected,
       isTutorialDatabase,
+      addSourceArchiveFolder,
     );
   }
 
@@ -128,6 +140,7 @@ export class DatabaseManager extends DisposableObject {
     databaseItem: DatabaseItemImpl,
     makeSelected: boolean,
     isTutorialDatabase?: boolean,
+    addSourceArchiveFolder = true,
   ): Promise<DatabaseItem> {
     const existingItem = this.findDatabaseItem(databaseItem.databaseUri);
     if (existingItem !== undefined) {
@@ -141,7 +154,9 @@ export class DatabaseManager extends DisposableObject {
     if (makeSelected) {
       await this.setCurrentDatabaseItem(databaseItem);
     }
-    await this.addDatabaseSourceArchiveFolder(databaseItem);
+    if (addSourceArchiveFolder) {
+      await this.addDatabaseSourceArchiveFolder(databaseItem);
+    }
 
     if (isCodespacesTemplate() && !isTutorialDatabase) {
       await this.createSkeletonPacks(databaseItem);

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -578,6 +578,7 @@ export class ModelEditorView extends AbstractWebview<
       this.cliServer,
       this.databaseItem.language,
       makeSelected,
+      false,
     );
     if (!addedDatabase) {
       void this.app.logger.log("No database chosen");

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-queries/local-databases.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-queries/local-databases.test.ts
@@ -742,7 +742,7 @@ describe("local databases", () => {
             mockDbItem.databaseUri,
             makeSelected,
             nameOverride,
-            isTutorialDatabase,
+            { isTutorialDatabase },
           );
 
           expect(createSkeletonPacksSpy).toBeCalledTimes(0);


### PR DESCRIPTION
When importing a database through "Model dependency" in the model editor, this will stop adding the source archive folder to the workspace. This will ensure that the window does not reload if the user is in a single-folder workspace.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
