### PR TITLE
Relax 'resolve ram' test

### DIFF
--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/run-cli.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/run-cli.test.ts
@@ -50,7 +50,9 @@ describe("Use cli", () => {
 
   it("should resolve ram", async () => {
     const result = await (cli as any).resolveRam(8192);
-    expect(result).toEqual(["-J-Xmx4096M", "--off-heap-ram=4096"]);
+    expect(result.length).toEqual(2);
+    expect(result[0]).toMatch(/^-J-Xmx\d+M$/);
+    expect(result[1]).toMatch(/^--off-heap-ram=\d+$/);
   });
 
   describe("silent logging", () => {


### PR DESCRIPTION
The test currently assumes that the CLI will use an exact 50/50 split between heap and off-heap RAM, but this is not guaranteed. Relax the test so that it doesn't care about the specific numbers.