### PR TITLE
Renames remaining references to "external API usage" in the code

### DIFF
--- a/extensions/ql-vscode/src/model-editor/bqrs.ts
+++ b/extensions/ql-vscode/src/model-editor/bqrs.ts
@@ -3,9 +3,7 @@ import { Call, CallClassification, Method } from "./method";
 import { ModeledMethodType } from "./modeled-method";
 import { parseLibraryFilename } from "./library";
 
-export function decodeBqrsToExternalApiUsages(
-  chunk: DecodedBqrsChunk,
-): Method[] {
+export function decodeBqrsToMethods(chunk: DecodedBqrsChunk): Method[] {
   const methodsByApiName = new Map<string, Method>();
 
   chunk?.tuples.forEach((tuple) => {

--- a/extensions/ql-vscode/src/model-editor/external-api-usage-queries.ts
+++ b/extensions/ql-vscode/src/model-editor/external-api-usage-queries.ts
@@ -15,7 +15,7 @@ import { QueryLanguage } from "../common/query-language";
 import { fetchExternalApiQueries } from "./queries";
 import { Method } from "./method";
 import { runQuery } from "../local-queries/run-query";
-import { decodeBqrsToExternalApiUsages } from "./bqrs";
+import { decodeBqrsToMethods } from "./bqrs";
 
 type RunQueryOptions = {
   cliServer: CodeQLCliServer;
@@ -132,7 +132,7 @@ export async function runExternalApiQueries(
     maxStep: externalApiQueriesProgressMaxStep,
   });
 
-  return decodeBqrsToExternalApiUsages(bqrsChunk);
+  return decodeBqrsToMethods(bqrsChunk);
 }
 
 type GetResultsOptions = {

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -193,7 +193,7 @@ export class ModelEditorView extends AbstractWebview<
 
         break;
       case "refreshMethods":
-        await withProgress((progress) => this.loadExternalApiUsages(progress), {
+        await withProgress((progress) => this.loadMethods(progress), {
           cancellable: false,
         });
 
@@ -227,7 +227,7 @@ export class ModelEditorView extends AbstractWebview<
 
             await Promise.all([
               this.setViewState(),
-              this.loadExternalApiUsages((update) =>
+              this.loadMethods((update) =>
                 progress({
                   ...update,
                   step: update.step + 500,
@@ -283,7 +283,7 @@ export class ModelEditorView extends AbstractWebview<
             methods: this.methods,
           }),
           this.setViewState(),
-          withProgress((progress) => this.loadExternalApiUsages(progress), {
+          withProgress((progress) => this.loadMethods(progress), {
             cancellable: false,
           }),
         ]);
@@ -311,7 +311,7 @@ export class ModelEditorView extends AbstractWebview<
 
     await Promise.all([
       this.setViewState(),
-      withProgress((progress) => this.loadExternalApiUsages(progress), {
+      withProgress((progress) => this.loadMethods(progress), {
         cancellable: false,
       }),
       this.loadExistingModeledMethods(),
@@ -357,9 +357,7 @@ export class ModelEditorView extends AbstractWebview<
     }
   }
 
-  protected async loadExternalApiUsages(
-    progress: ProgressCallback,
-  ): Promise<void> {
+  protected async loadMethods(progress: ProgressCallback): Promise<void> {
     try {
       const cancellationTokenSource = new CancellationTokenSource();
       const queryResult = await runExternalApiQueries(this.mode, {

--- a/extensions/ql-vscode/test/unit-tests/model-editor/bqrs.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/model-editor/bqrs.test.ts
@@ -233,7 +233,7 @@ describe("decodeBqrsToMethods", () => {
   it("extracts methods", () => {
     // Even though there are a number of methods with the same number of usages, the order returned should be stable:
     // - Iterating over a map (as done by .values()) is guaranteed to be in insertion order
-    // - Sorting the array of usages is guaranteed to be a stable sort
+    // - Sorting the array of methods is guaranteed to be a stable sort
     expect(decodeBqrsToMethods(chunk)).toEqual([
       {
         library: "rt",

--- a/extensions/ql-vscode/test/unit-tests/model-editor/bqrs.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/model-editor/bqrs.test.ts
@@ -1,8 +1,8 @@
-import { decodeBqrsToExternalApiUsages } from "../../../src/model-editor/bqrs";
+import { decodeBqrsToMethods } from "../../../src/model-editor/bqrs";
 import { DecodedBqrsChunk } from "../../../src/common/bqrs-cli-types";
 import { CallClassification } from "../../../src/model-editor/method";
 
-describe("decodeBqrsToExternalApiUsages", () => {
+describe("decodeBqrsToMethods", () => {
   const chunk: DecodedBqrsChunk = {
     columns: [
       { name: "usage", kind: "Entity" },
@@ -230,11 +230,11 @@ describe("decodeBqrsToExternalApiUsages", () => {
     ],
   };
 
-  it("extracts api usages", () => {
-    // Even though there are a number of usages with the same number of usages, the order returned should be stable:
+  it("extracts methods", () => {
+    // Even though there are a number of methods with the same number of usages, the order returned should be stable:
     // - Iterating over a map (as done by .values()) is guaranteed to be in insertion order
     // - Sorting the array of usages is guaranteed to be a stable sort
-    expect(decodeBqrsToExternalApiUsages(chunk)).toEqual([
+    expect(decodeBqrsToMethods(chunk)).toEqual([
       {
         library: "rt",
         libraryVersion: undefined,


### PR DESCRIPTION
All references to "external API usage" should be renamed to "method" but I spotted a couple of references remaining in the code.

None of these changes are user-visible.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
