### PR TITLE
Rename hideModeledApis => hideModeledMethods throughout the code

### DIFF
--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -565,9 +565,9 @@ interface ModelDependencyMessage {
   t: "modelDependency";
 }
 
-interface HideModeledApisMessage {
-  t: "hideModeledApis";
-  hideModeledApis: boolean;
+interface HideModeledMethodsMessage {
+  t: "hideModeledMethods";
+  hideModeledMethods: boolean;
 }
 
 export type ToModelEditorMessage =
@@ -589,7 +589,7 @@ export type FromModelEditorMessage =
   | GenerateMethodsFromLlmMessage
   | StopGeneratingMethodsFromLlmMessage
   | ModelDependencyMessage
-  | HideModeledApisMessage;
+  | HideModeledMethodsMessage;
 
 export type FromMethodModelingMessage =
   | TelemetryMessage

--- a/extensions/ql-vscode/src/model-editor/methods-usage/methods-usage-data-provider.ts
+++ b/extensions/ql-vscode/src/model-editor/methods-usage/methods-usage-data-provider.ts
@@ -13,7 +13,7 @@ import { Method, Usage } from "../method";
 import { DatabaseItem } from "../../databases/local-databases";
 import { relative } from "path";
 import { CodeQLCliServer } from "../../codeql-cli/cli";
-import { INITIAL_HIDE_MODELED_APIS_VALUE } from "../shared/hide-modeled-apis";
+import { INITIAL_HIDE_MODELED_METHODS_VALUE } from "../shared/hide-modeled-methods";
 
 export class MethodsUsageDataProvider
   extends DisposableObject
@@ -22,7 +22,7 @@ export class MethodsUsageDataProvider
   private methods: Method[] = [];
   private databaseItem: DatabaseItem | undefined = undefined;
   private sourceLocationPrefix: string | undefined = undefined;
-  private hideModeledApis: boolean = INITIAL_HIDE_MODELED_APIS_VALUE;
+  private hideModeledMethods: boolean = INITIAL_HIDE_MODELED_METHODS_VALUE;
 
   private readonly onDidChangeTreeDataEmitter = this.push(
     new EventEmitter<void>(),
@@ -46,18 +46,18 @@ export class MethodsUsageDataProvider
   public async setState(
     methods: Method[],
     databaseItem: DatabaseItem,
-    hideModeledApis: boolean,
+    hideModeledMethods: boolean,
   ): Promise<void> {
     if (
       this.methods !== methods ||
       this.databaseItem !== databaseItem ||
-      this.hideModeledApis !== hideModeledApis
+      this.hideModeledMethods !== hideModeledMethods
     ) {
       this.methods = methods;
       this.databaseItem = databaseItem;
       this.sourceLocationPrefix =
         await this.databaseItem.getSourceLocationPrefix(this.cliServer);
-      this.hideModeledApis = hideModeledApis;
+      this.hideModeledMethods = hideModeledMethods;
 
       this.onDidChangeTreeDataEmitter.fire();
     }
@@ -99,7 +99,7 @@ export class MethodsUsageDataProvider
 
   getChildren(item?: MethodsUsageTreeViewItem): MethodsUsageTreeViewItem[] {
     if (item === undefined) {
-      if (this.hideModeledApis) {
+      if (this.hideModeledMethods) {
         return this.methods.filter((api) => !api.supported);
       } else {
         return this.methods;

--- a/extensions/ql-vscode/src/model-editor/methods-usage/methods-usage-panel.ts
+++ b/extensions/ql-vscode/src/model-editor/methods-usage/methods-usage-panel.ts
@@ -26,10 +26,10 @@ export class MethodsUsagePanel extends DisposableObject {
   public async setState(
     methods: Method[],
     databaseItem: DatabaseItem,
-    hideModeledApis: boolean,
+    hideModeledMethods: boolean,
   ): Promise<void> {
-    await this.dataProvider.setState(methods, databaseItem, hideModeledApis);
-    const numOfApis = hideModeledApis
+    await this.dataProvider.setState(methods, databaseItem, hideModeledMethods);
+    const numOfApis = hideModeledMethods
       ? methods.filter((api) => !api.supported).length
       : methods.length;
     this.treeView.badge = {

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -41,7 +41,7 @@ import { join } from "path";
 import { pickExtensionPack } from "./extension-pack-picker";
 import { getLanguageDisplayName } from "../common/query-language";
 import { AutoModeler } from "./auto-modeler";
-import { INITIAL_HIDE_MODELED_APIS_VALUE } from "./shared/hide-modeled-apis";
+import { INITIAL_HIDE_MODELED_METHODS_VALUE } from "./shared/hide-modeled-methods";
 import { telemetryListener } from "../common/vscode/telemetry";
 
 export class ModelEditorView extends AbstractWebview<
@@ -51,7 +51,7 @@ export class ModelEditorView extends AbstractWebview<
   private readonly autoModeler: AutoModeler;
 
   private methods: Method[];
-  private hideModeledApis: boolean;
+  private hideModeledMethods: boolean;
 
   public constructor(
     ctx: ExtensionContext,
@@ -67,7 +67,7 @@ export class ModelEditorView extends AbstractWebview<
     private readonly updateMethodsUsagePanelState: (
       methods: Method[],
       databaseItem: DatabaseItem,
-      hideModeledApis: boolean,
+      hideModeledMethods: boolean,
     ) => Promise<void>,
     private readonly showMethod: (
       method: Method,
@@ -99,7 +99,7 @@ export class ModelEditorView extends AbstractWebview<
       },
     );
     this.methods = [];
-    this.hideModeledApis = INITIAL_HIDE_MODELED_APIS_VALUE;
+    this.hideModeledMethods = INITIAL_HIDE_MODELED_METHODS_VALUE;
   }
 
   public async openView() {
@@ -112,7 +112,7 @@ export class ModelEditorView extends AbstractWebview<
         await this.updateMethodsUsagePanelState(
           this.methods,
           this.databaseItem,
-          this.hideModeledApis,
+          this.hideModeledMethods,
         );
       }
     });
@@ -290,12 +290,12 @@ export class ModelEditorView extends AbstractWebview<
         void telemetryListener?.sendUIInteraction("model-editor-switch-modes");
 
         break;
-      case "hideModeledApis":
-        this.hideModeledApis = msg.hideModeledApis;
+      case "hideModeledMethods":
+        this.hideModeledMethods = msg.hideModeledMethods;
         await this.updateMethodsUsagePanelState(
           this.methods,
           this.databaseItem,
-          this.hideModeledApis,
+          this.hideModeledMethods,
         );
         void telemetryListener?.sendUIInteraction(
           "model-editor-hide-modeled-apis",
@@ -388,7 +388,7 @@ export class ModelEditorView extends AbstractWebview<
         await this.updateMethodsUsagePanelState(
           this.methods,
           this.databaseItem,
-          this.hideModeledApis,
+          this.hideModeledMethods,
         );
       }
     } catch (err) {

--- a/extensions/ql-vscode/src/model-editor/shared/hide-modeled-apis.ts
+++ b/extensions/ql-vscode/src/model-editor/shared/hide-modeled-apis.ts
@@ -1,1 +1,0 @@
-export const INITIAL_HIDE_MODELED_APIS_VALUE = true;

--- a/extensions/ql-vscode/src/model-editor/shared/hide-modeled-methods.ts
+++ b/extensions/ql-vscode/src/model-editor/shared/hide-modeled-methods.ts
@@ -1,0 +1,1 @@
+export const INITIAL_HIDE_MODELED_METHODS_VALUE = true;

--- a/extensions/ql-vscode/src/view/model-editor/LibraryRow.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/LibraryRow.tsx
@@ -75,7 +75,7 @@ type Props = {
   modifiedSignatures: Set<string>;
   inProgressMethods: InProgressMethods;
   viewState: ModelEditorViewState;
-  hideModeledApis: boolean;
+  hideModeledMethods: boolean;
   onChange: (
     modelName: string,
     method: Method,
@@ -103,7 +103,7 @@ export const LibraryRow = ({
   modifiedSignatures,
   inProgressMethods,
   viewState,
-  hideModeledApis,
+  hideModeledMethods,
   onChange,
   onSaveModelClick,
   onGenerateFromLlmClick,
@@ -237,7 +237,7 @@ export const LibraryRow = ({
             modifiedSignatures={modifiedSignatures}
             inProgressMethods={inProgressMethods}
             mode={viewState.mode}
-            hideModeledApis={hideModeledApis}
+            hideModeledMethods={hideModeledMethods}
             onChange={onChangeWithModelName}
           />
           <SectionDivider />

--- a/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
@@ -19,7 +19,7 @@ import { percentFormatter } from "./formatters";
 import { Mode } from "../../model-editor/shared/mode";
 import { InProgressMethods } from "../../model-editor/shared/in-progress-methods";
 import { getLanguageDisplayName } from "../../common/query-language";
-import { INITIAL_HIDE_MODELED_APIS_VALUE } from "../../model-editor/shared/hide-modeled-apis";
+import { INITIAL_HIDE_MODELED_METHODS_VALUE } from "../../model-editor/shared/hide-modeled-methods";
 
 const LoadingContainer = styled.div`
   text-align: center;
@@ -75,14 +75,14 @@ type Props = {
   initialViewState?: ModelEditorViewState;
   initialMethods?: Method[];
   initialModeledMethods?: Record<string, ModeledMethod>;
-  initialHideModeledApis?: boolean;
+  initialHideModeledMethods?: boolean;
 };
 
 export function ModelEditor({
   initialViewState,
   initialMethods = [],
   initialModeledMethods = {},
-  initialHideModeledApis = INITIAL_HIDE_MODELED_APIS_VALUE,
+  initialHideModeledMethods = INITIAL_HIDE_MODELED_METHODS_VALUE,
 }: Props): JSX.Element {
   const [viewState, setViewState] = useState<ModelEditorViewState | undefined>(
     initialViewState,
@@ -97,16 +97,16 @@ export function ModelEditor({
     new InProgressMethods(),
   );
 
-  const [hideModeledApis, setHideModeledApis] = useState(
-    initialHideModeledApis,
+  const [hideModeledMethods, setHideModeledMethods] = useState(
+    initialHideModeledMethods,
   );
 
   useEffect(() => {
     vscode.postMessage({
-      t: "hideModeledApis",
-      hideModeledApis,
+      t: "hideModeledMethods",
+      hideModeledMethods,
     });
-  }, [hideModeledApis]);
+  }, [hideModeledMethods]);
 
   const [modeledMethods, setModeledMethods] = useState<
     Record<string, ModeledMethod>
@@ -283,8 +283,8 @@ export function ModelEditor({
     });
   }, [viewState?.mode]);
 
-  const onHideModeledApis = useCallback(() => {
-    setHideModeledApis((oldHideModeledApis) => !oldHideModeledApis);
+  const onHideModeledMethods = useCallback(() => {
+    setHideModeledMethods((oldHideModeledMethods) => !oldHideModeledMethods);
   }, []);
 
   if (viewState === undefined || methods.length === 0) {
@@ -326,8 +326,8 @@ export function ModelEditor({
         <HeaderSpacer />
         <HeaderColumn>
           <VSCodeCheckbox
-            checked={hideModeledApis}
-            onChange={onHideModeledApis}
+            checked={hideModeledMethods}
+            onChange={onHideModeledMethods}
           >
             Hide modeled APIs
           </VSCodeCheckbox>
@@ -358,7 +358,7 @@ export function ModelEditor({
           modifiedSignatures={modifiedSignatures}
           inProgressMethods={inProgressMethods}
           viewState={viewState}
-          hideModeledApis={hideModeledApis}
+          hideModeledMethods={hideModeledMethods}
           onChange={onChange}
           onSaveModelClick={onSaveModelClick}
           onGenerateFromLlmClick={onGenerateFromLlmClick}

--- a/extensions/ql-vscode/src/view/model-editor/ModeledMethodDataGrid.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModeledMethodDataGrid.tsx
@@ -22,7 +22,7 @@ type Props = {
   modifiedSignatures: Set<string>;
   inProgressMethods: InProgressMethods;
   mode: Mode;
-  hideModeledApis: boolean;
+  hideModeledMethods: boolean;
   onChange: (method: Method, modeledMethod: ModeledMethod) => void;
 };
 
@@ -33,7 +33,7 @@ export const ModeledMethodDataGrid = ({
   modifiedSignatures,
   inProgressMethods,
   mode,
-  hideModeledApis,
+  hideModeledMethods,
   onChange,
 }: Props) => {
   const [methodsWithModelability, numHiddenMethods]: [
@@ -50,14 +50,14 @@ export const ModeledMethodDataGrid = ({
         (modeledMethod && modeledMethod?.type !== "none") ||
         methodIsUnsaved;
 
-      if (methodCanBeModeled || !hideModeledApis) {
+      if (methodCanBeModeled || !hideModeledMethods) {
         methodsWithModelability.push({ method, methodCanBeModeled });
       } else {
         numHiddenMethods += 1;
       }
     }
     return [methodsWithModelability, numHiddenMethods];
-  }, [hideModeledApis, methods, modeledMethods, modifiedSignatures]);
+  }, [hideModeledMethods, methods, modeledMethods, modifiedSignatures]);
 
   const someMethodsAreVisible = methodsWithModelability.length > 0;
 

--- a/extensions/ql-vscode/src/view/model-editor/ModeledMethodsList.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModeledMethodsList.tsx
@@ -17,7 +17,7 @@ type Props = {
   modifiedSignatures: Set<string>;
   inProgressMethods: InProgressMethods;
   viewState: ModelEditorViewState;
-  hideModeledApis: boolean;
+  hideModeledMethods: boolean;
   onChange: (
     modelName: string,
     method: Method,
@@ -47,7 +47,7 @@ export const ModeledMethodsList = ({
   modifiedSignatures,
   inProgressMethods,
   viewState,
-  hideModeledApis,
+  hideModeledMethods,
   onChange,
   onSaveModelClick,
   onGenerateFromLlmClick,
@@ -92,7 +92,7 @@ export const ModeledMethodsList = ({
           modifiedSignatures={modifiedSignatures}
           inProgressMethods={inProgressMethods}
           viewState={viewState}
-          hideModeledApis={hideModeledApis}
+          hideModeledMethods={hideModeledMethods}
           onChange={onChange}
           onSaveModelClick={onSaveModelClick}
           onGenerateFromLlmClick={onGenerateFromLlmClick}

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/methods-usage/methods-usage-data-provider.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/methods-usage/methods-usage-data-provider.test.ts
@@ -17,19 +17,19 @@ describe("MethodsUsageDataProvider", () => {
   });
 
   describe("setState", () => {
-    const hideModeledApis = false;
+    const hideModeledMethods = false;
     const methods: Method[] = [];
     const dbItem = mockedObject<DatabaseItem>({
       getSourceLocationPrefix: () => "test",
     });
 
     it("should not emit onDidChangeTreeData event when state has not changed", async () => {
-      await dataProvider.setState(methods, dbItem, hideModeledApis);
+      await dataProvider.setState(methods, dbItem, hideModeledMethods);
 
       const onDidChangeTreeDataListener = jest.fn();
       dataProvider.onDidChangeTreeData(onDidChangeTreeDataListener);
 
-      await dataProvider.setState(methods, dbItem, hideModeledApis);
+      await dataProvider.setState(methods, dbItem, hideModeledMethods);
 
       expect(onDidChangeTreeDataListener).not.toHaveBeenCalled();
     });
@@ -37,12 +37,12 @@ describe("MethodsUsageDataProvider", () => {
     it("should emit onDidChangeTreeData event when methods has changed", async () => {
       const methods2: Method[] = [];
 
-      await dataProvider.setState(methods, dbItem, hideModeledApis);
+      await dataProvider.setState(methods, dbItem, hideModeledMethods);
 
       const onDidChangeTreeDataListener = jest.fn();
       dataProvider.onDidChangeTreeData(onDidChangeTreeDataListener);
 
-      await dataProvider.setState(methods2, dbItem, hideModeledApis);
+      await dataProvider.setState(methods2, dbItem, hideModeledMethods);
 
       expect(onDidChangeTreeDataListener).toHaveBeenCalledTimes(1);
     });
@@ -52,23 +52,23 @@ describe("MethodsUsageDataProvider", () => {
         getSourceLocationPrefix: () => "test",
       });
 
-      await dataProvider.setState(methods, dbItem, hideModeledApis);
+      await dataProvider.setState(methods, dbItem, hideModeledMethods);
 
       const onDidChangeTreeDataListener = jest.fn();
       dataProvider.onDidChangeTreeData(onDidChangeTreeDataListener);
 
-      await dataProvider.setState(methods, dbItem2, hideModeledApis);
+      await dataProvider.setState(methods, dbItem2, hideModeledMethods);
 
       expect(onDidChangeTreeDataListener).toHaveBeenCalledTimes(1);
     });
 
-    it("should emit onDidChangeTreeData event when hideModeledApis has changed", async () => {
-      await dataProvider.setState(methods, dbItem, hideModeledApis);
+    it("should emit onDidChangeTreeData event when hideModeledMethods has changed", async () => {
+      await dataProvider.setState(methods, dbItem, hideModeledMethods);
 
       const onDidChangeTreeDataListener = jest.fn();
       dataProvider.onDidChangeTreeData(onDidChangeTreeDataListener);
 
-      await dataProvider.setState(methods, dbItem, !hideModeledApis);
+      await dataProvider.setState(methods, dbItem, !hideModeledMethods);
 
       expect(onDidChangeTreeDataListener).toHaveBeenCalledTimes(1);
     });
@@ -79,12 +79,12 @@ describe("MethodsUsageDataProvider", () => {
       });
       const methods2: Method[] = [];
 
-      await dataProvider.setState(methods, dbItem, hideModeledApis);
+      await dataProvider.setState(methods, dbItem, hideModeledMethods);
 
       const onDidChangeTreeDataListener = jest.fn();
       dataProvider.onDidChangeTreeData(onDidChangeTreeDataListener);
 
-      await dataProvider.setState(methods2, dbItem2, !hideModeledApis);
+      await dataProvider.setState(methods2, dbItem2, !hideModeledMethods);
 
       expect(onDidChangeTreeDataListener).toHaveBeenCalledTimes(1);
     });
@@ -115,15 +115,15 @@ describe("MethodsUsageDataProvider", () => {
       expect(dataProvider.getChildren(method)).toEqual([usage]);
     });
 
-    it("should show all methods if hideModeledApis is false and looking at the root", async () => {
-      const hideModeledApis = false;
-      await dataProvider.setState(methods, dbItem, hideModeledApis);
+    it("should show all methods if hideModeledMethods is false and looking at the root", async () => {
+      const hideModeledMethods = false;
+      await dataProvider.setState(methods, dbItem, hideModeledMethods);
       expect(dataProvider.getChildren().length).toEqual(2);
     });
 
-    it("should filter methods if hideModeledApis is true and looking at the root", async () => {
-      const hideModeledApis = true;
-      await dataProvider.setState(methods, dbItem, hideModeledApis);
+    it("should filter methods if hideModeledMethods is true and looking at the root", async () => {
+      const hideModeledMethods = true;
+      await dataProvider.setState(methods, dbItem, hideModeledMethods);
       expect(dataProvider.getChildren().length).toEqual(1);
     });
   });

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/methods-usage/methods-usage-panel.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/methods-usage/methods-usage-panel.test.ts
@@ -16,7 +16,7 @@ describe("MethodsUsagePanel", () => {
   });
 
   describe("setState", () => {
-    const hideModeledApis = false;
+    const hideModeledMethods = false;
     const methods: Method[] = [createMethod()];
 
     it("should update the tree view with the correct batch number", async () => {
@@ -26,7 +26,7 @@ describe("MethodsUsagePanel", () => {
       jest.spyOn(window, "createTreeView").mockReturnValue(mockTreeView);
 
       const panel = new MethodsUsagePanel(mockCliServer);
-      await panel.setState(methods, dbItem, hideModeledApis);
+      await panel.setState(methods, dbItem, hideModeledMethods);
 
       expect(mockTreeView.badge?.value).toBe(1);
     });
@@ -35,7 +35,7 @@ describe("MethodsUsagePanel", () => {
   describe("revealItem", () => {
     let mockTreeView: TreeView<unknown>;
 
-    const hideModeledApis: boolean = false;
+    const hideModeledMethods: boolean = false;
     const usage = createUsage();
 
     beforeEach(() => {
@@ -53,7 +53,7 @@ describe("MethodsUsagePanel", () => {
       ];
 
       const panel = new MethodsUsagePanel(mockCliServer);
-      await panel.setState(methods, dbItem, hideModeledApis);
+      await panel.setState(methods, dbItem, hideModeledMethods);
 
       await panel.revealItem(usage);
 
@@ -63,7 +63,7 @@ describe("MethodsUsagePanel", () => {
     it("should do nothing if usage cannot be found", async () => {
       const methods = [createMethod({})];
       const panel = new MethodsUsagePanel(mockCliServer);
-      await panel.setState(methods, dbItem, hideModeledApis);
+      await panel.setState(methods, dbItem, hideModeledMethods);
 
       await panel.revealItem(usage);
 


### PR DESCRIPTION
Renames all variables and other code called "hideModeledApis" to "hideModeledMethods" instead.

No changes in this PR are user-visible. See https://github.com/github/vscode-codeql/pull/2807 for the PR that changes the UI.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
