### PR TITLE
Fix jumping to usage and updating method modeling panel

### DIFF
--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -12,7 +12,7 @@ import type {
 } from "../variant-analysis/shared/variant-analysis";
 import type { QLDebugConfiguration } from "../debugger/debug-configuration";
 import type { QueryTreeViewItem } from "../queries-panel/query-tree-view-item";
-import type { Usage } from "../model-editor/method";
+import type { Method, Usage } from "../model-editor/method";
 
 // A command function matching the signature that VS Code calls when
 // a command is invoked from a context menu on a TreeView with
@@ -306,6 +306,7 @@ export type PackagingCommands = {
 export type ModelEditorCommands = {
   "codeQL.openModelEditor": () => Promise<void>;
   "codeQLModelEditor.jumpToUsageLocation": (
+    method: Method,
     usage: Usage,
     databaseItem: DatabaseItem,
   ) => Promise<void>;

--- a/extensions/ql-vscode/src/model-editor/model-editor-module.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-module.ts
@@ -177,9 +177,11 @@ export class ModelEditorModule extends DisposableObject {
         );
       },
       "codeQLModelEditor.jumpToUsageLocation": async (
+        method: Method,
         usage: Usage,
         databaseItem: DatabaseItem,
       ) => {
+        await this.methodModelingPanel.setMethod(method);
         await showResolvableLocation(usage.url, databaseItem, this.app.logger);
       },
     };


### PR DESCRIPTION
This fixes two things to do with the `codeQLModelEditor.jumpToUsageLocation` command.

When clicking a new usage, we now jump to the location in the code.

When clicking a usage from a different method, we now update the method modeling panel to show to the method.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
