### PR TITLE
Code Search: don't show rate limit warnings to users

### DIFF
--- a/extensions/ql-vscode/src/databases/ui/db-panel.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-panel.ts
@@ -423,6 +423,7 @@ export class DbPanel extends DisposableObject {
           progress,
           token,
           this.app.credentials,
+          this.app.logger,
         );
 
         token.onCancellationRequested(() => {

--- a/extensions/ql-vscode/src/databases/ui/db-panel.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-panel.ts
@@ -423,7 +423,6 @@ export class DbPanel extends DisposableObject {
           progress,
           token,
           this.app.credentials,
-          this.app.logger,
         );
 
         token.onCancellationRequested(() => {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Instead of removing the information completely we will show primary and secondary rate limit information in the extension output.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
