### PR TITLE
Add simple test for ModelEditorView

### DIFF
--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/model-editor-view.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/model-editor-view.test.ts
@@ -1,0 +1,79 @@
+import { join } from "path";
+import { Mode } from "../../../../src/model-editor/shared/mode";
+import { mockDatabaseItem, mockedObject } from "../../utils/mocking.helpers";
+import { CodeQLCliServer } from "../../../../src/codeql-cli/cli";
+import { Uri, WebviewPanel } from "vscode";
+import { ModelEditorView } from "../../../../src/model-editor/model-editor-view";
+import { createMockApp } from "../../../__mocks__/appMock";
+import { mockEmptyDatabaseManager } from "../query-testing/test-runner-helpers";
+import { QueryRunner } from "../../../../src/query-server";
+import { ExtensionPack } from "../../../../src/model-editor/shared/extension-pack";
+
+describe("ModelEditorView", () => {
+  const app = createMockApp({});
+  const databaseManager = mockEmptyDatabaseManager();
+  const cliServer = mockedObject<CodeQLCliServer>({});
+  const queryRunner = mockedObject<QueryRunner>({});
+  const queryStorageDir = "/a/b/c/d";
+  const queryDir = "/a/b/c/e";
+  const databaseItem = mockDatabaseItem();
+  const extensionPack: ExtensionPack = {
+    path: "/a/b/c/f",
+    yamlPath: join("/a/b/c/f", "codeql-pack.yml"),
+    name: "codeql/test",
+    version: "0.0.0",
+    language: "java",
+    extensionTargets: {
+      "codeql/java-all": "*",
+    },
+    dataExtensions: ["models/**/*.yml"],
+  };
+  const mode = Mode.Application;
+  const updateMethodsUsagePanelState = jest.fn();
+  const showMethod = jest.fn();
+  const handleViewBecameActive = jest.fn();
+  const handleViewWasDisposed = jest.fn();
+  const isMostRecentlyActiveView = jest.fn();
+
+  let view: ModelEditorView;
+
+  beforeEach(() => {
+    view = new ModelEditorView(
+      app,
+      databaseManager,
+      cliServer,
+      queryRunner,
+      queryStorageDir,
+      queryDir,
+      databaseItem,
+      extensionPack,
+      mode,
+      updateMethodsUsagePanelState,
+      showMethod,
+      handleViewBecameActive,
+      handleViewWasDisposed,
+      isMostRecentlyActiveView,
+    );
+  });
+
+  it("sets up the view", async () => {
+    const panel = mockedObject<WebviewPanel>({
+      onDidDispose: jest.fn(),
+      webview: {
+        html: undefined,
+        cspSource: "abc",
+        onDidReceiveMessage: jest.fn(),
+        asWebviewUri: jest.fn().mockImplementation((uri: Uri) =>
+          uri.with({
+            scheme: "webview",
+          }),
+        ),
+      },
+    });
+
+    await view.restoreView(panel);
+
+    expect(panel.webview.html).toContain("<html>");
+    expect(panel.webview.html).toContain('data-view="model-editor"');
+  });
+});

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/model-editor-view.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/model-editor-view.test.ts
@@ -56,7 +56,12 @@ describe("ModelEditorView", () => {
     );
   });
 
-  it("sets up the view", async () => {
+  it("restores the view", async () => {
+    // This tests using restoreView because that's much easier to mock than using openView. For openView, we would
+    // need to mock `vscode.window.createWebviewPanel`, while for restoreView we only need to mock a given WebviewPanel.
+    //
+    // The thing we're testing inside this test is whether getPanelConfig returns the correct configuration, so there
+    // should be no differences between openView/getPanel and restoreView for that.
     const panel = mockedObject<WebviewPanel>({
       onDidDispose: jest.fn(),
       webview: {


### PR DESCRIPTION
This adds a simple test for ModelEditorView which checks that it sets up the view.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
