### PR TITLE
Remove codeQL.model.editor feature flag

### DIFF
--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -145,8 +145,6 @@ Run one of the above MRVAs, but cancel it from within VS Code:
 
 ### CodeQL Model Editor
 
-Note the tests here require the feature flag: `codeQL.model.editor`
-
 #### Test Case 1: Opening the model editor
 
 1. Download the `sofastack/sofa-jraft` java database from GitHub.

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1429,8 +1429,7 @@
           "when": "false"
         },
         {
-          "command": "codeQL.openModelEditor",
-          "when": "config.codeQL.canary && config.codeQL.model.editor"
+          "command": "codeQL.openModelEditor"
         },
         {
           "command": "codeQLQueries.runLocalQueryContextMenu",


### PR DESCRIPTION
Makes the model editor available without either the `codeQL.model.editor` or `codeQL.canary` feature flags.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
