### PR TITLE
Avoid using "as any" in .storybook/preview.ts

### DIFF
--- a/extensions/ql-vscode/.storybook/preview.ts
+++ b/extensions/ql-vscode/.storybook/preview.ts
@@ -5,7 +5,15 @@ import { action } from "@storybook/addon-actions";
 // Allow all stories/components to use Codicons
 import "@vscode/codicons/dist/codicon.css";
 
-(window as any).acquireVsCodeApi = () => ({
+import type { VsCodeApi } from "../src/view/vscode-api";
+
+declare global {
+  interface Window {
+    acquireVsCodeApi: () => VsCodeApi;
+  }
+}
+
+window.acquireVsCodeApi = () => ({
   postMessage: action("post-vscode-message"),
   setState: action("set-vscode-state"),
 });

--- a/extensions/ql-vscode/scripts/find-deadcode.ts
+++ b/extensions/ql-vscode/scripts/find-deadcode.ts
@@ -6,6 +6,7 @@ import { exit } from "process";
 function ignoreFile(file: string): boolean {
   return (
     containsPath("gulpfile.ts", file) ||
+    containsPath(".storybook", file) ||
     containsPath(join("src", "stories"), file) ||
     pathsEqual(
       join("test", "vscode-tests", "jest-runner-installed-extensions.ts"),

--- a/extensions/ql-vscode/src/view/vscode-api.ts
+++ b/extensions/ql-vscode/src/view/vscode-api.ts
@@ -6,7 +6,7 @@ import {
   VariantAnalysisState,
 } from "../common/interface-types";
 
-interface VsCodeApi {
+export interface VsCodeApi {
   /**
    * Post message back to vscode extension.
    */

--- a/extensions/ql-vscode/tsconfig.deadcode.json
+++ b/extensions/ql-vscode/tsconfig.deadcode.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["**/*.ts*"],
+  "include": ["**/*.ts*", ".storybook/**/*.ts*"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Avoids the use of `window as any` in `.storybook/preview.ts` by declaring what the type of `Window` should be. 

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
