### PR TITLE
Avoid use of "as any" in gulpfile.ts/deploy.ts

### DIFF
--- a/extensions/ql-vscode/gulpfile.ts/deploy.ts
+++ b/extensions/ql-vscode/gulpfile.ts/deploy.ts
@@ -9,6 +9,7 @@ import {
 } from "fs-extra";
 import { resolve, join } from "path";
 import { isDevBuild } from "./dev";
+import type * as packageJsonType from "../package.json";
 
 export interface DeployedPackage {
   distPath: string;
@@ -46,31 +47,13 @@ async function copyPackage(
   );
 }
 
-interface packageJson {
-  name: string;
-  version: string;
-}
-
-async function readPackageJson(packageJsonPath: string): Promise<packageJson> {
-  const packageJson: packageJson = JSON.parse(
-    await readFile(packageJsonPath, "utf8"),
-  );
-
-  if (!packageJson.name) {
-    throw new Error(`${packageJsonPath} is missing the 'name' field`);
-  }
-  if (!packageJson.version) {
-    throw new Error(`${packageJsonPath} is missing the 'version' field`);
-  }
-
-  return packageJson;
-}
-
 export async function deployPackage(
   packageJsonPath: string,
 ): Promise<DeployedPackage> {
   try {
-    const packageJson = await readPackageJson(packageJsonPath);
+    const packageJson: typeof packageJsonType = JSON.parse(
+      await readFile(packageJsonPath, "utf8"),
+    );
 
     const distDir = join(__dirname, "../../../dist");
     await mkdirs(distDir);

--- a/extensions/ql-vscode/gulpfile.ts/deploy.ts
+++ b/extensions/ql-vscode/gulpfile.ts/deploy.ts
@@ -47,12 +47,10 @@ async function copyPackage(
   );
 }
 
-export async function deployPackage(
-  packageJsonPath: string,
-): Promise<DeployedPackage> {
+export async function deployPackage(): Promise<DeployedPackage> {
   try {
     const packageJson: typeof packageJsonType = JSON.parse(
-      await readFile(packageJsonPath, "utf8"),
+      await readFile(resolve(__dirname, "../package.json"), "utf8"),
     );
 
     const distDir = join(__dirname, "../../../dist");

--- a/extensions/ql-vscode/gulpfile.ts/deploy.ts
+++ b/extensions/ql-vscode/gulpfile.ts/deploy.ts
@@ -46,13 +46,31 @@ async function copyPackage(
   );
 }
 
+interface packageJson {
+  name: string;
+  version: string;
+}
+
+async function readPackageJson(packageJsonPath: string): Promise<packageJson> {
+  const packageJson: packageJson = JSON.parse(
+    await readFile(packageJsonPath, "utf8"),
+  );
+
+  if (!packageJson.name) {
+    throw new Error(`${packageJsonPath} is missing the 'name' field`);
+  }
+  if (!packageJson.version) {
+    throw new Error(`${packageJsonPath} is missing the 'version' field`);
+  }
+
+  return packageJson;
+}
+
 export async function deployPackage(
   packageJsonPath: string,
 ): Promise<DeployedPackage> {
   try {
-    const packageJson: any = JSON.parse(
-      await readFile(packageJsonPath, "utf8"),
-    );
+    const packageJson = await readPackageJson(packageJsonPath);
 
     const distDir = join(__dirname, "../../../dist");
     await mkdirs(distDir);

--- a/extensions/ql-vscode/gulpfile.ts/package.ts
+++ b/extensions/ql-vscode/gulpfile.ts/package.ts
@@ -3,9 +3,7 @@ import { deployPackage } from "./deploy";
 import { spawn } from "child-process-promise";
 
 export async function packageExtension(): Promise<void> {
-  const deployedPackage = await deployPackage(
-    resolve(__dirname, "../package.json"),
-  );
+  const deployedPackage = await deployPackage();
   console.log(
     `Packaging extension '${deployedPackage.name}@${deployedPackage.version}'...`,
   );

--- a/extensions/ql-vscode/gulpfile.ts/tsconfig.json
+++ b/extensions/ql-vscode/gulpfile.ts/tsconfig.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "rootDir": "."
+    "rootDir": ".."
   },
   "include": ["*.ts"]
 }


### PR DESCRIPTION
Technically we could satisfy the linter by just removing the explicit typing and let it implicitly be typed as `any`, but that seems like cheating. This PR adds a type for the fields we actually reference and does a quick check that those fields exist.

Maybe not very necessary. If you think this is over the top for this piece of code feel free to say so.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
