### PR TITLE
Avoid use of "as any" during error handling

### DIFF
--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -547,9 +547,7 @@ export class CodeQLCliServer implements Disposable {
         yield JSON.parse(event) as EventType;
       } catch (err) {
         throw new Error(
-          `Parsing output of ${description} failed: ${
-            (err as any).stderr || getErrorMessage(err)
-          }`,
+          `Parsing output of ${description} failed: ${getErrorMessage(err)}`,
         );
       }
     }
@@ -647,9 +645,7 @@ export class CodeQLCliServer implements Disposable {
       return JSON.parse(result) as OutputType;
     } catch (err) {
       throw new Error(
-        `Parsing output of ${description} failed: ${
-          (err as any).stderr || getErrorMessage(err)
-        }`,
+        `Parsing output of ${description} failed: ${getErrorMessage(err)}`,
       );
     }
   }

--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -19,6 +19,7 @@ import {
 } from "./distribution";
 import {
   assertNever,
+  getChildProcessErrorMessage,
   getErrorMessage,
   getErrorStack,
 } from "../common/helpers-pure";
@@ -1643,7 +1644,7 @@ export async function runCodeQlCliCommand(
     return result.stdout;
   } catch (err) {
     throw new Error(
-      `${description} failed: ${(err as any).stderr || getErrorMessage(err)}`,
+      `${description} failed: ${getChildProcessErrorMessage(err)}`,
     );
   }
 }

--- a/extensions/ql-vscode/src/common/helpers-pure.ts
+++ b/extensions/ql-vscode/src/common/helpers-pure.ts
@@ -67,3 +67,26 @@ export function asError(e: unknown): Error {
 
   return e instanceof Error ? e : new Error(String(e));
 }
+
+/**
+ * Get error message when the error may have come from a method from the `child_process` module.
+ */
+export function getChildProcessErrorMessage(e: unknown): string {
+  return isChildProcessError(e) ? e.stderr : getErrorMessage(e);
+}
+
+/**
+ * Error thrown from methods from the `child_process` module.
+ */
+interface ChildProcessError {
+  readonly stderr: string;
+}
+
+function isChildProcessError(e: unknown): e is ChildProcessError {
+  return (
+    typeof e === "object" &&
+    e !== null &&
+    "stderr" in e &&
+    typeof e.stderr === "string"
+  );
+}

--- a/extensions/ql-vscode/src/common/sarif-parser.ts
+++ b/extensions/ql-vscode/src/common/sarif-parser.ts
@@ -54,9 +54,7 @@ export async function sarifParser(
     });
   } catch (e) {
     throw new Error(
-      `Parsing output of interpretation failed: ${
-        (e as any).stderr || getErrorMessage(e)
-      }`,
+      `Parsing output of interpretation failed: ${getErrorMessage(e)}`,
     );
   }
 }


### PR DESCRIPTION
This PR removes any cases of `as any` in error handling.

There were quite a few cases where we were checking to see if `err.stderr` existed. As far as I can tell, this is useful in one case where `child_process.execFile` throws error with this field and it gives a slightly nicer error message for the user. In all of the other cases I cannot see why that field would be there and I think it's just a case of copy-pasting other code.

I wasn't sure where to put `getChildProcessErrorMessage` so I went with `helpers-pure.ts` alongside `getErrorMessage`. But I'm happy to put it in `cli.ts` or somewhere else if that would be cleaner.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
