### PR TITLE
Fix incorrect `ReturnType` instead of `ReturnValue`

### DIFF
--- a/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
@@ -104,7 +104,7 @@ function ModelableMethodRow(props: MethodRowProps) {
       onChange(method, {
         // If there are no arguments, we will default to "Argument[this]"
         input: argumentsList.length === 0 ? "Argument[this]" : "Argument[0]",
-        output: "ReturnType",
+        output: "ReturnValue",
         kind: "value",
         ...modeledMethod,
         type: e.target.value as ModeledMethodType,


### PR DESCRIPTION
There is 1 instance of `ReturnType` in the model editor instead of `ReturnValue`. All other instances already say `ReturnValue` and this is also correct based on occurrences in the `github/codeql` repository. This fixes this last instance.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
