### PR TITLE
Only download automodel query pack when relevant

### DIFF
--- a/extensions/ql-vscode/src/model-editor/model-editor-queries.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-queries.ts
@@ -4,6 +4,7 @@ import { writeFile } from "fs-extra";
 import { dump } from "js-yaml";
 import { prepareExternalApiQuery } from "./external-api-usage-queries";
 import { CodeQLCliServer } from "../codeql-cli/cli";
+import { showLlmGeneration } from "../config";
 
 /**
  * setUpPack sets up a directory to use for the data extension editor queries.
@@ -40,7 +41,10 @@ export async function setUpPack(
 
   // Install the other needed query packs
   await cliServer.packDownload([`codeql/${language}-queries`]);
-  await cliServer.packDownload([`codeql/${language}-automodel-queries`]);
+
+  if (language === "java" && showLlmGeneration()) {
+    await cliServer.packDownload([`codeql/${language}-automodel-queries`]);
+  }
 
   return true;
 }


### PR DESCRIPTION
Only download the automodel query pack for java and only if the relevant feature flag is enabled.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
