### PR TITLE
Clean up model editor onChange callback

### DIFF
--- a/extensions/ql-vscode/src/view/model-editor/LibraryRow.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/LibraryRow.tsx
@@ -76,11 +76,7 @@ export type LibraryRowProps = {
   inProgressMethods: InProgressMethods;
   viewState: ModelEditorViewState;
   hideModeledMethods: boolean;
-  onChange: (
-    modelName: string,
-    method: Method,
-    modeledMethod: ModeledMethod,
-  ) => void;
+  onChange: (method: Method, modeledMethod: ModeledMethod) => void;
   onSaveModelClick: (
     methods: Method[],
     modeledMethods: Record<string, ModeledMethod>,
@@ -166,13 +162,6 @@ export const LibraryRow = ({
     [methods, modeledMethods, onSaveModelClick],
   );
 
-  const onChangeWithModelName = useCallback(
-    (method: Method, modeledMethod: ModeledMethod) => {
-      onChange(title, method, modeledMethod);
-    },
-    [onChange, title],
-  );
-
   const hasUnsavedChanges = useMemo(() => {
     return methods.some((method) => modifiedSignatures.has(method.signature));
   }, [methods, modifiedSignatures]);
@@ -238,7 +227,7 @@ export const LibraryRow = ({
             inProgressMethods={inProgressMethods}
             mode={viewState.mode}
             hideModeledMethods={hideModeledMethods}
-            onChange={onChangeWithModelName}
+            onChange={onChange}
           />
           <SectionDivider />
           <ButtonsContainer>

--- a/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
@@ -179,19 +179,16 @@ export function ModelEditor({
     [methods],
   );
 
-  const onChange = useCallback(
-    (modelName: string, method: Method, model: ModeledMethod) => {
-      setModeledMethods((oldModeledMethods) => ({
-        ...oldModeledMethods,
-        [method.signature]: model,
-      }));
-      setModifiedSignatures(
-        (oldModifiedSignatures) =>
-          new Set([...oldModifiedSignatures, method.signature]),
-      );
-    },
-    [],
-  );
+  const onChange = useCallback((method: Method, model: ModeledMethod) => {
+    setModeledMethods((oldModeledMethods) => ({
+      ...oldModeledMethods,
+      [method.signature]: model,
+    }));
+    setModifiedSignatures(
+      (oldModifiedSignatures) =>
+        new Set([...oldModifiedSignatures, method.signature]),
+    );
+  }, []);
 
   const onRefreshClick = useCallback(() => {
     vscode.postMessage({

--- a/extensions/ql-vscode/src/view/model-editor/ModeledMethodsList.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModeledMethodsList.tsx
@@ -18,11 +18,7 @@ export type ModeledMethodsListProps = {
   inProgressMethods: InProgressMethods;
   viewState: ModelEditorViewState;
   hideModeledMethods: boolean;
-  onChange: (
-    modelName: string,
-    method: Method,
-    modeledMethod: ModeledMethod,
-  ) => void;
+  onChange: (method: Method, modeledMethod: ModeledMethod) => void;
   onSaveModelClick: (
     methods: Method[],
     modeledMethods: Record<string, ModeledMethod>,


### PR DESCRIPTION
I noticed that we weren't using the `modelName` in the `onChange` callback of the `ModelEditor` so I've removed it and cleaned up.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
