### PR TITLE
Add modeling inputs to method modeling panel

### DIFF
--- a/extensions/ql-vscode/src/stories/method-modeling/MethodModelingInputs.stories.tsx
+++ b/extensions/ql-vscode/src/stories/method-modeling/MethodModelingInputs.stories.tsx
@@ -1,0 +1,54 @@
+import * as React from "react";
+
+import { Meta, StoryFn } from "@storybook/react";
+
+import { MethodModelingInputs as MethodModelingInputsComponent } from "../../view/method-modeling/MethodModelingInputs";
+import { createMethod } from "../../../test/factories/model-editor/method-factories";
+import { createModeledMethod } from "../../../test/factories/model-editor/modeled-method-factories";
+import { useState } from "react";
+import { ModeledMethod } from "../../model-editor/modeled-method";
+import { Method } from "../../model-editor/method";
+
+export default {
+  title: "Method Modeling/Method Modeling Inputs",
+  component: MethodModelingInputsComponent,
+  argTypes: {
+    modeledMethod: {
+      control: {
+        disable: true,
+      },
+    },
+  },
+} as Meta<typeof MethodModelingInputsComponent>;
+
+const Template: StoryFn<typeof MethodModelingInputsComponent> = (args) => {
+  const [m, setModeledMethod] = useState<ModeledMethod | undefined>(
+    args.modeledMethod,
+  );
+
+  const onChange = (method: Method, modeledMethod: ModeledMethod) => {
+    setModeledMethod(modeledMethod);
+  };
+
+  return (
+    <MethodModelingInputsComponent
+      {...args}
+      modeledMethod={m}
+      onChange={onChange}
+    />
+  );
+};
+
+const method = createMethod();
+const modeledMethod = createModeledMethod();
+
+export const UnmodeledMethod = Template.bind({});
+UnmodeledMethod.args = {
+  method,
+};
+
+export const FullyModeledMethod = Template.bind({});
+FullyModeledMethod.args = {
+  method,
+  modeledMethod,
+};

--- a/extensions/ql-vscode/src/view/method-modeling/MethodModeling.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/MethodModeling.tsx
@@ -6,6 +6,8 @@ import {
 } from "../model-editor/ModelingStatusIndicator";
 import { Method } from "../../model-editor/method";
 import { MethodName } from "../model-editor/MethodName";
+import { ModeledMethod } from "../../model-editor/modeled-method";
+import { MethodModelingInputs } from "./MethodModelingInputs";
 
 const Container = styled.div`
   padding: 0.3rem;
@@ -33,11 +35,15 @@ const DependencyContainer = styled.div`
 export type MethodModelingProps = {
   modelingStatus: ModelingStatus;
   method: Method;
+  modeledMethod: ModeledMethod | undefined;
+  onChange: (method: Method, modeledMethod: ModeledMethod) => void;
 };
 
 export const MethodModeling = ({
   modelingStatus,
+  modeledMethod,
   method,
+  onChange,
 }: MethodModelingProps): JSX.Element => {
   return (
     <Container>
@@ -49,6 +55,11 @@ export const MethodModeling = ({
         <ModelingStatusIndicator status={modelingStatus} />
         <MethodName {...method} />
       </DependencyContainer>
+      <MethodModelingInputs
+        method={method}
+        modeledMethod={modeledMethod}
+        onChange={onChange}
+      />
     </Container>
   );
 };

--- a/extensions/ql-vscode/src/view/method-modeling/MethodModelingInputs.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/MethodModelingInputs.tsx
@@ -11,9 +11,7 @@ const Container = styled.div`
   padding-top: 0.5rem;
 `;
 
-const Input = styled.label`
-  padding-top: 0.5rem;
-`;
+const Input = styled.label``;
 
 const Name = styled.span`
   display: block;

--- a/extensions/ql-vscode/src/view/method-modeling/MethodModelingInputs.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/MethodModelingInputs.tsx
@@ -1,0 +1,56 @@
+import * as React from "react";
+import { styled } from "styled-components";
+import { Method } from "../../model-editor/method";
+import { ModeledMethod } from "../../model-editor/modeled-method";
+import { ModelTypeDropdown } from "../model-editor/ModelTypeDropdown";
+import { ModelInputDropdown } from "../model-editor/ModelInputDropdown";
+import { ModelOutputDropdown } from "../model-editor/ModelOutputDropdown";
+import { ModelKindDropdown } from "../model-editor/ModelKindDropdown";
+
+const Container = styled.div`
+  padding-top: 0.5rem;
+`;
+
+const Label = styled.span`
+  display: block;
+  padding-bottom: 0.3rem;
+`;
+
+export type MethodModelingInputsProps = {
+  method: Method;
+  modeledMethod: ModeledMethod | undefined;
+  onChange: (method: Method, modeledMethod: ModeledMethod) => void;
+};
+
+export const MethodModelingInputs = ({
+  method,
+  modeledMethod,
+  onChange,
+}: MethodModelingInputsProps): JSX.Element => {
+  const inputProps = {
+    method,
+    modeledMethod,
+    onChange,
+  };
+
+  return (
+    <>
+      <Container>
+        <Label>Model Type</Label>
+        <ModelTypeDropdown {...inputProps} />
+      </Container>
+      <Container>
+        <Label>Input</Label>
+        <ModelInputDropdown {...inputProps} />
+      </Container>
+      <Container>
+        <Label>Output</Label>
+        <ModelOutputDropdown {...inputProps} />
+      </Container>
+      <Container>
+        <Label>Kind</Label>
+        <ModelKindDropdown {...inputProps} />
+      </Container>
+    </>
+  );
+};

--- a/extensions/ql-vscode/src/view/method-modeling/MethodModelingInputs.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/MethodModelingInputs.tsx
@@ -11,7 +11,11 @@ const Container = styled.div`
   padding-top: 0.5rem;
 `;
 
-const Label = styled.span`
+const Input = styled.label`
+  padding-top: 0.5rem;
+`;
+
+const Name = styled.span`
   display: block;
   padding-bottom: 0.3rem;
 `;
@@ -36,20 +40,28 @@ export const MethodModelingInputs = ({
   return (
     <>
       <Container>
-        <Label>Model Type</Label>
-        <ModelTypeDropdown {...inputProps} />
+        <Input>
+          <Name>Model Type</Name>
+          <ModelTypeDropdown {...inputProps} />
+        </Input>
       </Container>
       <Container>
-        <Label>Input</Label>
-        <ModelInputDropdown {...inputProps} />
+        <Input>
+          <Name>Input</Name>
+          <ModelInputDropdown {...inputProps} />
+        </Input>
       </Container>
       <Container>
-        <Label>Output</Label>
-        <ModelOutputDropdown {...inputProps} />
+        <Input>
+          <Name>Output</Name>
+          <ModelOutputDropdown {...inputProps} />
+        </Input>
       </Container>
       <Container>
-        <Label>Kind</Label>
-        <ModelKindDropdown {...inputProps} />
+        <Input>
+          <Name>Kind</Name>
+          <ModelKindDropdown {...inputProps} />
+        </Input>
       </Container>
     </>
   );

--- a/extensions/ql-vscode/src/view/method-modeling/MethodModelingView.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/MethodModelingView.tsx
@@ -5,9 +5,14 @@ import { ModelingStatus } from "../model-editor/ModelingStatusIndicator";
 import { Method } from "../../model-editor/method";
 import { ToMethodModelingMessage } from "../../common/interface-types";
 import { assertNever } from "../../common/helpers-pure";
+import { ModeledMethod } from "../../model-editor/modeled-method";
 
 export function MethodModelingView(): JSX.Element {
   const [method, setMethod] = useState<Method | undefined>(undefined);
+
+  const [modeledMethod, setModeledMethod] = React.useState<
+    ModeledMethod | undefined
+  >(undefined);
 
   useEffect(() => {
     const listener = (evt: MessageEvent) => {
@@ -36,5 +41,19 @@ export function MethodModelingView(): JSX.Element {
   }
 
   const modelingStatus: ModelingStatus = "saved";
-  return <MethodModeling modelingStatus={modelingStatus} method={method} />;
+
+  // For now we just store the updated method in the state but soon
+  // we'll need to send it back to the other views.
+  const onChange = (method: Method, modeledMethod: ModeledMethod) => {
+    setModeledMethod(modeledMethod);
+  };
+
+  return (
+    <MethodModeling
+      modelingStatus={modelingStatus}
+      method={method}
+      modeledMethod={modeledMethod}
+      onChange={onChange}
+    />
+  );
 }

--- a/extensions/ql-vscode/src/view/method-modeling/__tests__/MethodModeling.spec.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/__tests__/MethodModeling.spec.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { render as reactRender, screen } from "@testing-library/react";
 import { MethodModeling, MethodModelingProps } from "../MethodModeling";
 import { createMethod } from "../../../../test/factories/model-editor/method-factories";
+import { createModeledMethod } from "../../../../test/factories/model-editor/modeled-method-factories";
 
 describe(MethodModeling.name, () => {
   const render = (props: MethodModelingProps) =>
@@ -9,10 +10,14 @@ describe(MethodModeling.name, () => {
 
   it("renders method modeling panel", () => {
     const method = createMethod();
+    const modeledMethod = createModeledMethod();
+    const onChange = jest.fn();
 
     render({
       modelingStatus: "saved",
       method,
+      modeledMethod,
+      onChange,
     });
 
     expect(

--- a/extensions/ql-vscode/src/view/method-modeling/__tests__/MethodModelingInputs.spec.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/__tests__/MethodModelingInputs.spec.tsx
@@ -32,7 +32,9 @@ describe(MethodModelingInputs.name, () => {
     // Check that all the dropdowns are rendered.
     const comboboxes = screen.getAllByRole("combobox");
     expect(comboboxes.length).toBe(4);
-    const modelTypeDropdown = comboboxes[0];
+    const modelTypeDropdown = screen.getByRole("combobox", {
+      name: "Model type",
+    });
     expect(modelTypeDropdown).toHaveValue("sink");
     const modelTypeOptions = modelTypeDropdown.querySelectorAll("option");
     expect(modelTypeOptions.length).toBe(5);
@@ -45,8 +47,9 @@ describe(MethodModelingInputs.name, () => {
       onChange,
     });
 
-    const comboboxes = screen.getAllByRole("combobox");
-    const modelTypeDropdown = comboboxes[0];
+    const modelTypeDropdown = screen.getByRole("combobox", {
+      name: "Model type",
+    });
 
     await userEvent.selectOptions(modelTypeDropdown, "source");
 
@@ -77,11 +80,18 @@ describe(MethodModelingInputs.name, () => {
       />,
     );
 
-    const comboboxes = screen.getAllByRole("combobox");
-    const modelTypeDropdown = comboboxes[0];
-    const modelInputDropdown = comboboxes[1];
-    const modelOutputDropdown = comboboxes[2];
-    const modelKindDropdown = comboboxes[3];
+    const modelTypeDropdown = screen.getByRole("combobox", {
+      name: "Model type",
+    });
+    const modelInputDropdown = screen.getByRole("combobox", {
+      name: "Input",
+    });
+    const modelOutputDropdown = screen.getByRole("combobox", {
+      name: "Output",
+    });
+    const modelKindDropdown = screen.getByRole("combobox", {
+      name: "Kind",
+    });
 
     expect(modelTypeDropdown).toHaveValue("source");
     expect(modelInputDropdown).toHaveValue("-");

--- a/extensions/ql-vscode/src/view/method-modeling/__tests__/MethodModelingInputs.spec.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/__tests__/MethodModelingInputs.spec.tsx
@@ -1,0 +1,91 @@
+import * as React from "react";
+import { render as reactRender, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  MethodModelingInputs,
+  MethodModelingInputsProps,
+} from "../MethodModelingInputs";
+import { createMethod } from "../../../../test/factories/model-editor/method-factories";
+import { createModeledMethod } from "../../../../test/factories/model-editor/modeled-method-factories";
+
+describe(MethodModelingInputs.name, () => {
+  const render = (props: MethodModelingInputsProps) =>
+    reactRender(<MethodModelingInputs {...props} />);
+
+  const method = createMethod();
+  const modeledMethod = createModeledMethod();
+  const onChange = jest.fn();
+
+  it("renders the method modeling inputs", () => {
+    render({
+      method,
+      modeledMethod,
+      onChange,
+    });
+
+    // Check that all the labels are rendered.
+    expect(screen.getByText("Model Type")).toBeInTheDocument();
+    expect(screen.getByText("Input")).toBeInTheDocument();
+    expect(screen.getByText("Output")).toBeInTheDocument();
+    expect(screen.getByText("Kind")).toBeInTheDocument();
+
+    // Check that all the dropdowns are rendered.
+    const comboboxes = screen.getAllByRole("combobox");
+    expect(comboboxes.length).toBe(4);
+    const modelTypeDropdown = comboboxes[0];
+    expect(modelTypeDropdown).toHaveValue("sink");
+    const modelTypeOptions = modelTypeDropdown.querySelectorAll("option");
+    expect(modelTypeOptions.length).toBe(5);
+  });
+
+  it("allows changing the type", async () => {
+    render({
+      method,
+      modeledMethod,
+      onChange,
+    });
+
+    const comboboxes = screen.getAllByRole("combobox");
+    const modelTypeDropdown = comboboxes[0];
+
+    await userEvent.selectOptions(modelTypeDropdown, "source");
+
+    expect(onChange).toHaveBeenCalledWith(
+      method,
+      expect.objectContaining({
+        type: "source",
+      }),
+    );
+  });
+
+  it("sets other dropdowns when model type is changed", () => {
+    const { rerender } = render({
+      method,
+      modeledMethod,
+      onChange,
+    });
+
+    const updatedModeledMethod = createModeledMethod({
+      type: "source",
+    });
+
+    rerender(
+      <MethodModelingInputs
+        method={method}
+        modeledMethod={updatedModeledMethod}
+        onChange={onChange}
+      />,
+    );
+
+    const comboboxes = screen.getAllByRole("combobox");
+    const modelTypeDropdown = comboboxes[0];
+    const modelInputDropdown = comboboxes[1];
+    const modelOutputDropdown = comboboxes[2];
+    const modelKindDropdown = comboboxes[3];
+
+    expect(modelTypeDropdown).toHaveValue("source");
+    expect(modelInputDropdown).toHaveValue("-");
+    expect(modelOutputDropdown).toHaveValue("ReturnValue");
+    expect(modelKindDropdown).toHaveValue("local");
+  });
+});


### PR DESCRIPTION
 Adds the `Model Type`, `Input`, `Output` and `Kind` drop-downs to the method modeling panel

<img width="527" alt="image" src="https://github.com/github/vscode-codeql/assets/311693/bdbde365-b091-48ea-9293-dea8d7771abf">


## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
