### PR TITLE
Fix MethodRow stories to not all show as modeled

### DIFF
--- a/extensions/ql-vscode/src/stories/model-editor/MethodRow.stories.tsx
+++ b/extensions/ql-vscode/src/stories/model-editor/MethodRow.stories.tsx
@@ -27,7 +27,7 @@ const method: Method = {
   methodName: "open",
   methodParameters: "()",
   supported: false,
-  supportedType: "summary",
+  supportedType: "none",
   usages: [
     {
       label: "open(...)",
@@ -70,30 +70,35 @@ export const Unmodeled = Template.bind({});
 Unmodeled.args = {
   method,
   modeledMethod: undefined,
+  methodCanBeModeled: true,
 };
 
 export const Source = Template.bind({});
 Source.args = {
   method,
   modeledMethod: { ...modeledMethod, type: "source" },
+  methodCanBeModeled: true,
 };
 
 export const Sink = Template.bind({});
 Sink.args = {
   method,
   modeledMethod: { ...modeledMethod, type: "sink" },
+  methodCanBeModeled: true,
 };
 
 export const Summary = Template.bind({});
 Summary.args = {
   method,
   modeledMethod: { ...modeledMethod, type: "summary" },
+  methodCanBeModeled: true,
 };
 
 export const Neutral = Template.bind({});
 Neutral.args = {
   method,
   modeledMethod: { ...modeledMethod, type: "neutral" },
+  methodCanBeModeled: true,
 };
 
 export const AlreadyModeled = Template.bind({});
@@ -107,4 +112,5 @@ ModelingInProgress.args = {
   method,
   modeledMethod,
   modelingInProgress: true,
+  methodCanBeModeled: true,
 };


### PR DESCRIPTION

I noticed that all the stories for the `MethodRow` component were. showing as `Method already modeled` so this fixes that.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
