### PR TITLE
Hide modeling panel when modeling editor is active

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1784,7 +1784,7 @@
           "type": "webview",
           "id": "codeQLMethodModeling",
           "name": "CodeQL Method Modeling",
-          "when": "config.codeQL.canary && config.codeQL.model.methodModelingView && codeql.modelEditorOpen"
+          "when": "config.codeQL.canary && config.codeQL.model.methodModelingView && codeql.modelEditorOpen && !codeql.modelEditorActive"
         }
       ]
     },

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -106,6 +106,9 @@ export class ModelEditorView extends AbstractWebview<
           this.databaseItem,
           this.hideModeledMethods,
         );
+        await this.markModelEditorAsActive();
+      } else {
+        await this.updateModelEditorActiveContext();
       }
     });
 
@@ -129,6 +132,22 @@ export class ModelEditorView extends AbstractWebview<
     );
   }
 
+  private async markModelEditorAsActive(): Promise<void> {
+    void this.app.commands.execute(
+      "setContext",
+      "codeql.modelEditorActive",
+      true,
+    );
+  }
+
+  private async updateModelEditorActiveContext(): Promise<void> {
+    await this.app.commands.execute(
+      "setContext",
+      "codeql.modelEditorActive",
+      this.isAModelEditorActive(),
+    );
+  }
+
   private isAModelEditorOpen(): boolean {
     return window.tabGroups.all.some((tabGroup) =>
       tabGroup.tabs.some((tab) => {
@@ -136,6 +155,17 @@ export class ModelEditorView extends AbstractWebview<
         // The viewType has a prefix, such as "mainThreadWebview-", but if the
         // suffix matches that should be enough to identify the view.
         return viewType && viewType.endsWith("model-editor");
+      }),
+    );
+  }
+
+  private isAModelEditorActive(): boolean {
+    return window.tabGroups.all.some((tabGroup) =>
+      tabGroup.tabs.some((tab) => {
+        const viewType: string | undefined = (tab.input as any)?.viewType;
+        // The viewType has a prefix, such as "mainThreadWebview-", but if the
+        // suffix matches that should be enough to identify the view.
+        return viewType && viewType.endsWith("model-editor") && tab.isActive;
       }),
     );
   }


### PR DESCRIPTION
We don't want to show the modeling panel if the main editor window is active, since they show similar things.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
