### PR TITLE
Remove redundant argument from onChange

### DIFF
--- a/extensions/ql-vscode/src/stories/method-modeling/MethodModelingInputs.stories.tsx
+++ b/extensions/ql-vscode/src/stories/method-modeling/MethodModelingInputs.stories.tsx
@@ -7,7 +7,6 @@ import { createMethod } from "../../../test/factories/model-editor/method-factor
 import { createModeledMethod } from "../../../test/factories/model-editor/modeled-method-factories";
 import { useState } from "react";
 import { ModeledMethod } from "../../model-editor/modeled-method";
-import { Method } from "../../model-editor/method";
 
 export default {
   title: "Method Modeling/Method Modeling Inputs",
@@ -26,7 +25,7 @@ const Template: StoryFn<typeof MethodModelingInputsComponent> = (args) => {
     args.modeledMethod,
   );
 
-  const onChange = (method: Method, modeledMethod: ModeledMethod) => {
+  const onChange = (modeledMethod: ModeledMethod) => {
     setModeledMethod(modeledMethod);
   };
 

--- a/extensions/ql-vscode/src/view/method-modeling/MethodModeling.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/MethodModeling.tsx
@@ -36,7 +36,7 @@ export type MethodModelingProps = {
   modelingStatus: ModelingStatus;
   method: Method;
   modeledMethod: ModeledMethod | undefined;
-  onChange: (method: Method, modeledMethod: ModeledMethod) => void;
+  onChange: (modeledMethod: ModeledMethod) => void;
 };
 
 export const MethodModeling = ({

--- a/extensions/ql-vscode/src/view/method-modeling/MethodModelingInputs.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/MethodModelingInputs.tsx
@@ -21,7 +21,7 @@ const Name = styled.span`
 export type MethodModelingInputsProps = {
   method: Method;
   modeledMethod: ModeledMethod | undefined;
-  onChange: (method: Method, modeledMethod: ModeledMethod) => void;
+  onChange: (modeledMethod: ModeledMethod) => void;
 };
 
 export const MethodModelingInputs = ({

--- a/extensions/ql-vscode/src/view/method-modeling/MethodModelingView.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/MethodModelingView.tsx
@@ -44,7 +44,7 @@ export function MethodModelingView(): JSX.Element {
 
   // For now we just store the updated method in the state but soon
   // we'll need to send it back to the other views.
-  const onChange = (method: Method, modeledMethod: ModeledMethod) => {
+  const onChange = (modeledMethod: ModeledMethod) => {
     setModeledMethod(modeledMethod);
   };
 

--- a/extensions/ql-vscode/src/view/method-modeling/__tests__/MethodModelingInputs.spec.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/__tests__/MethodModelingInputs.spec.tsx
@@ -54,7 +54,6 @@ describe(MethodModelingInputs.name, () => {
     await userEvent.selectOptions(modelTypeDropdown, "source");
 
     expect(onChange).toHaveBeenCalledWith(
-      method,
       expect.objectContaining({
         type: "source",
       }),

--- a/extensions/ql-vscode/src/view/model-editor/LibraryRow.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/LibraryRow.tsx
@@ -76,7 +76,7 @@ export type LibraryRowProps = {
   inProgressMethods: InProgressMethods;
   viewState: ModelEditorViewState;
   hideModeledMethods: boolean;
-  onChange: (method: Method, modeledMethod: ModeledMethod) => void;
+  onChange: (modeledMethod: ModeledMethod) => void;
   onSaveModelClick: (
     methods: Method[],
     modeledMethods: Record<string, ModeledMethod>,

--- a/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
@@ -56,7 +56,7 @@ export type MethodRowProps = {
   methodIsUnsaved: boolean;
   modelingInProgress: boolean;
   mode: Mode;
-  onChange: (method: Method, modeledMethod: ModeledMethod) => void;
+  onChange: (modeledMethod: ModeledMethod) => void;
 };
 
 export const MethodRow = (props: MethodRowProps) => {

--- a/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
@@ -179,14 +179,14 @@ export function ModelEditor({
     [methods],
   );
 
-  const onChange = useCallback((method: Method, model: ModeledMethod) => {
+  const onChange = useCallback((model: ModeledMethod) => {
     setModeledMethods((oldModeledMethods) => ({
       ...oldModeledMethods,
-      [method.signature]: model,
+      [model.signature]: model,
     }));
     setModifiedSignatures(
       (oldModifiedSignatures) =>
-        new Set([...oldModifiedSignatures, method.signature]),
+        new Set([...oldModifiedSignatures, model.signature]),
     );
   }, []);
 

--- a/extensions/ql-vscode/src/view/model-editor/ModelInputDropdown.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelInputDropdown.tsx
@@ -7,7 +7,7 @@ import { Method, getArgumentsList } from "../../model-editor/method";
 type Props = {
   method: Method;
   modeledMethod: ModeledMethod | undefined;
-  onChange: (method: Method, modeledMethod: ModeledMethod) => void;
+  onChange: (modeledMethod: ModeledMethod) => void;
 };
 
 export const ModelInputDropdown = ({
@@ -45,12 +45,12 @@ export const ModelInputDropdown = ({
 
       const target = e.target as HTMLSelectElement;
 
-      onChange(method, {
+      onChange({
         ...modeledMethod,
         input: target.value,
       });
     },
-    [onChange, method, modeledMethod],
+    [onChange, modeledMethod],
   );
 
   return (

--- a/extensions/ql-vscode/src/view/model-editor/ModelKindDropdown.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelKindDropdown.tsx
@@ -11,7 +11,7 @@ import { extensiblePredicateDefinitions } from "../../model-editor/predicates";
 type Props = {
   method: Method;
   modeledMethod: ModeledMethod | undefined;
-  onChange: (method: Method, modeledMethod: ModeledMethod) => void;
+  onChange: (modeledMethod: ModeledMethod) => void;
 };
 
 export const ModelKindDropdown = ({
@@ -43,12 +43,12 @@ export const ModelKindDropdown = ({
         return;
       }
 
-      onChange(method, {
+      onChange({
         ...modeledMethod,
         kind,
       });
     },
-    [method, modeledMethod, onChange],
+    [modeledMethod, onChange],
   );
 
   const handleChange = useCallback(

--- a/extensions/ql-vscode/src/view/model-editor/ModelOutputDropdown.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelOutputDropdown.tsx
@@ -7,7 +7,7 @@ import { Method, getArgumentsList } from "../../model-editor/method";
 type Props = {
   method: Method;
   modeledMethod: ModeledMethod | undefined;
-  onChange: (method: Method, modeledMethod: ModeledMethod) => void;
+  onChange: (modeledMethod: ModeledMethod) => void;
 };
 
 export const ModelOutputDropdown = ({
@@ -47,12 +47,12 @@ export const ModelOutputDropdown = ({
 
       const target = e.target as HTMLSelectElement;
 
-      onChange(method, {
+      onChange({
         ...modeledMethod,
         output: target.value,
       });
     },
-    [onChange, method, modeledMethod],
+    [onChange, modeledMethod],
   );
 
   return (

--- a/extensions/ql-vscode/src/view/model-editor/ModelTypeDropdown.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelTypeDropdown.tsx
@@ -19,7 +19,7 @@ const options: Array<{ value: ModeledMethodType; label: string }> = [
 type Props = {
   method: Method;
   modeledMethod: ModeledMethod | undefined;
-  onChange: (method: Method, modeledMethod: ModeledMethod) => void;
+  onChange: (modeledMethod: ModeledMethod) => void;
 };
 
 export const ModelTypeDropdown = ({
@@ -54,7 +54,7 @@ export const ModelTypeDropdown = ({
         methodName: method.methodName,
         methodParameters: method.methodParameters,
       };
-      onChange(method, updatedModeledMethod);
+      onChange(updatedModeledMethod);
     },
     [onChange, method, modeledMethod, argumentsList],
   );

--- a/extensions/ql-vscode/src/view/model-editor/ModeledMethodDataGrid.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModeledMethodDataGrid.tsx
@@ -23,7 +23,7 @@ export type ModeledMethodDataGridProps = {
   inProgressMethods: InProgressMethods;
   mode: Mode;
   hideModeledMethods: boolean;
-  onChange: (method: Method, modeledMethod: ModeledMethod) => void;
+  onChange: (modeledMethod: ModeledMethod) => void;
 };
 
 export const ModeledMethodDataGrid = ({

--- a/extensions/ql-vscode/src/view/model-editor/ModeledMethodsList.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModeledMethodsList.tsx
@@ -18,7 +18,7 @@ export type ModeledMethodsListProps = {
   inProgressMethods: InProgressMethods;
   viewState: ModelEditorViewState;
   hideModeledMethods: boolean;
-  onChange: (method: Method, modeledMethod: ModeledMethod) => void;
+  onChange: (modeledMethod: ModeledMethod) => void;
   onSaveModelClick: (
     methods: Method[],
     modeledMethods: Record<string, ModeledMethod>,

--- a/extensions/ql-vscode/src/view/model-editor/__tests__/MethodRow.spec.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/__tests__/MethodRow.spec.tsx
@@ -66,7 +66,7 @@ describe(MethodRow.name, () => {
     );
 
     expect(onChange).toHaveBeenCalledTimes(1);
-    expect(onChange).toHaveBeenCalledWith(method, {
+    expect(onChange).toHaveBeenCalledWith({
       ...modeledMethod,
       kind: "value",
     });

--- a/extensions/ql-vscode/src/view/model-editor/__tests__/ModelKindDropdown.spec.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/__tests__/ModelKindDropdown.spec.tsx
@@ -30,7 +30,6 @@ describe(ModelKindDropdown.name, () => {
     expect(screen.getByRole("combobox")).toHaveValue("local");
     await userEvent.selectOptions(screen.getByRole("combobox"), "remote");
     expect(onChange).toHaveBeenCalledWith(
-      method,
       expect.objectContaining({
         kind: "remote",
       }),
@@ -87,7 +86,6 @@ describe(ModelKindDropdown.name, () => {
 
     expect(screen.getByRole("combobox")).toHaveValue("local");
     expect(onChange).toHaveBeenCalledWith(
-      method,
       expect.objectContaining({
         kind: "local",
       }),


### PR DESCRIPTION
I noticed that the only thing we needed from the `Method` object in the various `onChange` callbacks was the `signature` which is also available in the `ModeledMethod` so I've removed the `method` from all the `onChange` callbacks.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
