### PR TITLE
Bump minimum VS Code version to 1.82

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -299,12 +299,12 @@ const shouldUpdateOnNextActivationKey = "shouldUpdateOnNextActivation";
 
 const codeQlVersionRange = DEFAULT_DISTRIBUTION_VERSION_RANGE;
 
-// This is the minimum version of vscode that we _want_ to support. We want to update the language server library, but that
-// requires 1.67 or later. If we change the minimum version in the package.json, then anyone on an older version of vscode
+// This is the minimum version of vscode that we _want_ to support. We want to update to Node 18, but that
+// requires 1.82 or later. If we change the minimum version in the package.json, then anyone on an older version of vscode will
 // silently be unable to upgrade. So, the solution is to first bump the minimum version here and release. Then
 // bump the version in the package.json and release again. This way, anyone on an older version of vscode will get a warning
 // before silently being refused to upgrade.
-const MIN_VERSION = "1.67.0";
+const MIN_VERSION = "1.82.0";
 
 /**
  * Returns the CodeQLExtensionInterface, or an empty object if the interface is not


### PR DESCRIPTION
This changes the `MIN_VERSION` that will be used for showing warnings to `1.82.0`. 1.82 is the August release (currently the latest) and upgrades to Node.js 18. We would like to be able to upgrade to dependencies that require Node.js 18, so let's set the minimum supported version to this so we can drop support for older versions after the next release.

We can't really upgrade to a newer VS Code version for integration tests until we fully support Node.js 18, but that means dropping support for running integration tests on Node.js 16. Therefore, we need to merge this before doing our upgrade to a newer VS Code and Node.js version.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
