### PR TITLE
Don't use 'as any' when checking open view

### DIFF
--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -1,5 +1,6 @@
 import {
   CancellationTokenSource,
+  Tab,
   TabInputWebview,
   Uri,
   ViewColumn,
@@ -156,28 +157,26 @@ export class ModelEditorView extends AbstractWebview<
 
   private isAModelEditorOpen(): boolean {
     return window.tabGroups.all.some((tabGroup) =>
-      tabGroup.tabs.some((tab) => {
-        const viewType =
-          tab.input instanceof TabInputWebview ? tab.input.viewType : undefined;
-
-        // The viewType has a prefix, such as "mainThreadWebview-", but if the
-        // suffix matches that should be enough to identify the view.
-        return viewType && viewType.endsWith("model-editor");
-      }),
+      tabGroup.tabs.some((tab) => this.isTabModelEditorView(tab)),
     );
   }
 
   private isAModelEditorActive(): boolean {
     return window.tabGroups.all.some((tabGroup) =>
-      tabGroup.tabs.some((tab) => {
-        const viewType =
-          tab.input instanceof TabInputWebview ? tab.input.viewType : undefined;
-
-        // The viewType has a prefix, such as "mainThreadWebview-", but if the
-        // suffix matches that should be enough to identify the view.
-        return viewType && viewType.endsWith("model-editor") && tab.isActive;
-      }),
+      tabGroup.tabs.some(
+        (tab) => this.isTabModelEditorView(tab) && tab.isActive,
+      ),
     );
+  }
+
+  private isTabModelEditorView(tab: Tab): boolean {
+    if (!(tab.input instanceof TabInputWebview)) {
+      return false;
+    }
+
+    // The viewType has a prefix, such as "mainThreadWebview-", but if the
+    // suffix matches that should be enough to identify the view.
+    return tab.input.viewType.endsWith("model-editor");
   }
 
   protected async getPanelConfig(): Promise<WebviewPanelConfig> {

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -1,4 +1,10 @@
-import { CancellationTokenSource, Uri, ViewColumn, window } from "vscode";
+import {
+  CancellationTokenSource,
+  TabInputWebview,
+  Uri,
+  ViewColumn,
+  window,
+} from "vscode";
 import {
   AbstractWebview,
   WebviewPanelConfig,
@@ -151,7 +157,9 @@ export class ModelEditorView extends AbstractWebview<
   private isAModelEditorOpen(): boolean {
     return window.tabGroups.all.some((tabGroup) =>
       tabGroup.tabs.some((tab) => {
-        const viewType: string | undefined = (tab.input as any)?.viewType;
+        const viewType =
+          tab.input instanceof TabInputWebview ? tab.input.viewType : undefined;
+
         // The viewType has a prefix, such as "mainThreadWebview-", but if the
         // suffix matches that should be enough to identify the view.
         return viewType && viewType.endsWith("model-editor");
@@ -162,7 +170,9 @@ export class ModelEditorView extends AbstractWebview<
   private isAModelEditorActive(): boolean {
     return window.tabGroups.all.some((tabGroup) =>
       tabGroup.tabs.some((tab) => {
-        const viewType: string | undefined = (tab.input as any)?.viewType;
+        const viewType =
+          tab.input instanceof TabInputWebview ? tab.input.viewType : undefined;
+
         // The viewType has a prefix, such as "mainThreadWebview-", but if the
         // suffix matches that should be enough to identify the view.
         return viewType && viewType.endsWith("model-editor") && tab.isActive;


### PR DESCRIPTION
Minor change to remove an `as any` casting. Suggested [here](https://github.com/github/vscode-codeql/pull/2851#discussion_r1335571640).

As part of that we're extracting a `isTabModelEditorView` function that is reused from two places.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
