### PR TITLE
Add ability to filter DB view by language

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -754,6 +754,42 @@
         "title": "Add Database Source to Workspace"
       },
       {
+        "command": "codeQLDatabases.displayAllLanguages",
+        "title": "All languages"
+      },
+      {
+        "command": "codeQLDatabases.displayCpp",
+        "title": "C/C++"
+      },
+      {
+        "command": "codeQLDatabases.displayCsharp",
+        "title": "C#"
+      },
+      {
+        "command": "codeQLDatabases.displayGo",
+        "title": "Go"
+      },
+      {
+        "command": "codeQLDatabases.displayJava",
+        "title": "Java/Kotlin"
+      },
+      {
+        "command": "codeQLDatabases.displayJavascript",
+        "title": "JavaScript/TypeScript"
+      },
+      {
+        "command": "codeQLDatabases.displayPython",
+        "title": "Python"
+      },
+      {
+        "command": "codeQLDatabases.displayRuby",
+        "title": "Ruby"
+      },
+      {
+        "command": "codeQLDatabases.displaySwift",
+        "title": "Swift"
+      },
+      {
         "command": "codeQL.chooseDatabaseFolder",
         "title": "CodeQL: Choose Database from Folder"
       },
@@ -1002,6 +1038,11 @@
           "command": "codeQLDatabases.sortByDateAdded",
           "when": "view == codeQLDatabases",
           "group": "1_databases@1"
+        },
+        {
+          "submenu": "codeQLDatabases.languages",
+          "when": "view == codeQLDatabases && config.codeQL.canary",
+          "group": "2_databases@0"
         },
         {
           "command": "codeQLQueries.createQuery",
@@ -1524,6 +1565,42 @@
           "when": "false"
         },
         {
+          "command": "codeQLDatabases.displayAllLanguages",
+          "when": "false"
+        },
+        {
+          "command": "codeQLDatabases.displayCpp",
+          "when": "false"
+        },
+        {
+          "command": "codeQLDatabases.displayCsharp",
+          "when": "false"
+        },
+        {
+          "command": "codeQLDatabases.displayGo",
+          "when": "false"
+        },
+        {
+          "command": "codeQLDatabases.displayJava",
+          "when": "false"
+        },
+        {
+          "command": "codeQLDatabases.displayJavascript",
+          "when": "false"
+        },
+        {
+          "command": "codeQLDatabases.displayPython",
+          "when": "false"
+        },
+        {
+          "command": "codeQLDatabases.displayRuby",
+          "when": "false"
+        },
+        {
+          "command": "codeQLDatabases.displaySwift",
+          "when": "false"
+        },
+        {
           "command": "codeQLQueryHistory.openQueryContextMenu",
           "when": "false"
         },
@@ -1717,8 +1794,43 @@
           "command": "codeQL.gotoQLContextEditor",
           "when": "editorLangId == ql-summary && config.codeQL.canary"
         }
+      ],
+      "codeQLDatabases.languages": [
+        {
+          "command": "codeQLDatabases.displayAllLanguages"
+        },
+        {
+          "command": "codeQLDatabases.displayCpp"
+        },
+        {
+          "command": "codeQLDatabases.displayCsharp"
+        },
+        {
+          "command": "codeQLDatabases.displayGo"
+        },
+        {
+          "command": "codeQLDatabases.displayJava"
+        },
+        {
+          "command": "codeQLDatabases.displayJavascript"
+        },
+        {
+          "command": "codeQLDatabases.displayPython"
+        },
+        {
+          "command": "codeQLDatabases.displayRuby"
+        },
+        {
+          "command": "codeQLDatabases.displaySwift"
+        }
       ]
     },
+    "submenus": [
+      {
+        "id": "codeQLDatabases.languages",
+        "label": "Languages"
+      }
+    ],
     "viewsContainers": {
       "activitybar": [
         {

--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -219,6 +219,15 @@ export type LocalDatabasesCommands = {
   "codeQLDatabases.chooseDatabaseGithub": () => Promise<void>;
   "codeQLDatabases.sortByName": () => Promise<void>;
   "codeQLDatabases.sortByDateAdded": () => Promise<void>;
+  "codeQLDatabases.displayAllLanguages": () => Promise<void>;
+  "codeQLDatabases.displayCpp": () => Promise<void>;
+  "codeQLDatabases.displayCsharp": () => Promise<void>;
+  "codeQLDatabases.displayGo": () => Promise<void>;
+  "codeQLDatabases.displayJava": () => Promise<void>;
+  "codeQLDatabases.displayJavascript": () => Promise<void>;
+  "codeQLDatabases.displayPython": () => Promise<void>;
+  "codeQLDatabases.displayRuby": () => Promise<void>;
+  "codeQLDatabases.displaySwift": () => Promise<void>;
 
   // Database panel context menu
   "codeQLDatabases.setCurrentDatabase": (

--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -51,12 +51,25 @@ import {
   createMultiSelectionCommand,
   createSingleSelectionCommand,
 } from "../common/vscode/selection-commands";
+import { QueryLanguage } from "../common/query-language";
 
 enum SortOrder {
   NameAsc = "NameAsc",
   NameDesc = "NameDesc",
   DateAddedAsc = "DateAddedAsc",
   DateAddedDesc = "DateAddedDesc",
+}
+
+enum LanguageFilter {
+  All = "All",
+  Cpp = QueryLanguage.Cpp,
+  CSharp = QueryLanguage.CSharp,
+  Go = QueryLanguage.Go,
+  Java = QueryLanguage.Java,
+  Javascript = QueryLanguage.Javascript,
+  Python = QueryLanguage.Python,
+  Ruby = QueryLanguage.Ruby,
+  Swift = QueryLanguage.Swift,
 }
 
 /**
@@ -67,6 +80,7 @@ class DatabaseTreeDataProvider
   implements TreeDataProvider<DatabaseItem>
 {
   private _sortOrder = SortOrder.NameAsc;
+  private _languageFilter = LanguageFilter.All;
 
   private readonly _onDidChangeTreeData = this.push(
     new EventEmitter<DatabaseItem | undefined>(),
@@ -131,7 +145,17 @@ class DatabaseTreeDataProvider
 
   public getChildren(element?: DatabaseItem): ProviderResult<DatabaseItem[]> {
     if (element === undefined) {
-      return this.databaseManager.databaseItems.slice(0).sort((db1, db2) => {
+      // Filter items by language
+      const displayItems = this.databaseManager.databaseItems.filter((item) => {
+        if (this.languageFilter === LanguageFilter.All) {
+          return true;
+        } else {
+          return item.language === this.languageFilter;
+        }
+      });
+
+      // Sort items
+      return displayItems.slice(0).sort((db1, db2) => {
         switch (this.sortOrder) {
           case SortOrder.NameAsc:
             return db1.name.localeCompare(db2.name, env.language);
@@ -162,6 +186,15 @@ class DatabaseTreeDataProvider
 
   public set sortOrder(newSortOrder: SortOrder) {
     this._sortOrder = newSortOrder;
+    this._onDidChangeTreeData.fire(undefined);
+  }
+
+  public get languageFilter() {
+    return this._languageFilter;
+  }
+
+  public set languageFilter(newLanguageFilter: LanguageFilter) {
+    this._languageFilter = newLanguageFilter;
     this._onDidChangeTreeData.fire(undefined);
   }
 }
@@ -245,6 +278,40 @@ export class DatabaseUI extends DisposableObject {
         this.handleMakeCurrentDatabase.bind(this),
       "codeQLDatabases.sortByName": this.handleSortByName.bind(this),
       "codeQLDatabases.sortByDateAdded": this.handleSortByDateAdded.bind(this),
+      "codeQLDatabases.displayAllLanguages":
+        this.handleChangeLanguageFilter.bind(this, LanguageFilter.All),
+      "codeQLDatabases.displayCpp": this.handleChangeLanguageFilter.bind(
+        this,
+        LanguageFilter.Cpp,
+      ),
+      "codeQLDatabases.displayCsharp": this.handleChangeLanguageFilter.bind(
+        this,
+        LanguageFilter.CSharp,
+      ),
+      "codeQLDatabases.displayGo": this.handleChangeLanguageFilter.bind(
+        this,
+        LanguageFilter.Go,
+      ),
+      "codeQLDatabases.displayJava": this.handleChangeLanguageFilter.bind(
+        this,
+        LanguageFilter.Java,
+      ),
+      "codeQLDatabases.displayJavascript": this.handleChangeLanguageFilter.bind(
+        this,
+        LanguageFilter.Javascript,
+      ),
+      "codeQLDatabases.displayPython": this.handleChangeLanguageFilter.bind(
+        this,
+        LanguageFilter.Python,
+      ),
+      "codeQLDatabases.displayRuby": this.handleChangeLanguageFilter.bind(
+        this,
+        LanguageFilter.Ruby,
+      ),
+      "codeQLDatabases.displaySwift": this.handleChangeLanguageFilter.bind(
+        this,
+        LanguageFilter.Swift,
+      ),
       "codeQLDatabases.removeDatabase": createMultiSelectionCommand(
         this.handleRemoveDatabase.bind(this),
       ),
@@ -533,6 +600,10 @@ export class DatabaseUI extends DisposableObject {
     } else {
       this.treeDataProvider.sortOrder = SortOrder.DateAddedAsc;
     }
+  }
+
+  private async handleChangeLanguageFilter(languageFilter: LanguageFilter) {
+    this.treeDataProvider.languageFilter = languageFilter;
   }
 
   private async handleUpgradeCurrentDatabase(): Promise<void> {

--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -60,17 +60,7 @@ enum SortOrder {
   DateAddedDesc = "DateAddedDesc",
 }
 
-enum LanguageFilter {
-  All = "All",
-  Cpp = QueryLanguage.Cpp,
-  CSharp = QueryLanguage.CSharp,
-  Go = QueryLanguage.Go,
-  Java = QueryLanguage.Java,
-  Javascript = QueryLanguage.Javascript,
-  Python = QueryLanguage.Python,
-  Ruby = QueryLanguage.Ruby,
-  Swift = QueryLanguage.Swift,
-}
+type LanguageFilter = QueryLanguage | "All";
 
 /**
  * Tree data provider for the databases view.
@@ -80,7 +70,7 @@ class DatabaseTreeDataProvider
   implements TreeDataProvider<DatabaseItem>
 {
   private _sortOrder = SortOrder.NameAsc;
-  private _languageFilter = LanguageFilter.All;
+  private _languageFilter = "All" as LanguageFilter;
 
   private readonly _onDidChangeTreeData = this.push(
     new EventEmitter<DatabaseItem | undefined>(),
@@ -147,7 +137,7 @@ class DatabaseTreeDataProvider
     if (element === undefined) {
       // Filter items by language
       const displayItems = this.databaseManager.databaseItems.filter((item) => {
-        if (this.languageFilter === LanguageFilter.All) {
+        if (this.languageFilter === "All") {
           return true;
         } else {
           return item.language === this.languageFilter;
@@ -279,38 +269,38 @@ export class DatabaseUI extends DisposableObject {
       "codeQLDatabases.sortByName": this.handleSortByName.bind(this),
       "codeQLDatabases.sortByDateAdded": this.handleSortByDateAdded.bind(this),
       "codeQLDatabases.displayAllLanguages":
-        this.handleChangeLanguageFilter.bind(this, LanguageFilter.All),
+        this.handleChangeLanguageFilter.bind(this, "All"),
       "codeQLDatabases.displayCpp": this.handleChangeLanguageFilter.bind(
         this,
-        LanguageFilter.Cpp,
+        QueryLanguage.Cpp,
       ),
       "codeQLDatabases.displayCsharp": this.handleChangeLanguageFilter.bind(
         this,
-        LanguageFilter.CSharp,
+        QueryLanguage.CSharp,
       ),
       "codeQLDatabases.displayGo": this.handleChangeLanguageFilter.bind(
         this,
-        LanguageFilter.Go,
+        QueryLanguage.Go,
       ),
       "codeQLDatabases.displayJava": this.handleChangeLanguageFilter.bind(
         this,
-        LanguageFilter.Java,
+        QueryLanguage.Java,
       ),
       "codeQLDatabases.displayJavascript": this.handleChangeLanguageFilter.bind(
         this,
-        LanguageFilter.Javascript,
+        QueryLanguage.Javascript,
       ),
       "codeQLDatabases.displayPython": this.handleChangeLanguageFilter.bind(
         this,
-        LanguageFilter.Python,
+        QueryLanguage.Python,
       ),
       "codeQLDatabases.displayRuby": this.handleChangeLanguageFilter.bind(
         this,
-        LanguageFilter.Ruby,
+        QueryLanguage.Ruby,
       ),
       "codeQLDatabases.displaySwift": this.handleChangeLanguageFilter.bind(
         this,
-        LanguageFilter.Swift,
+        QueryLanguage.Swift,
       ),
       "codeQLDatabases.removeDatabase": createMultiSelectionCommand(
         this.handleRemoveDatabase.bind(this),


### PR DESCRIPTION
Adds a language menu to the databases view:

https://github.com/github/vscode-codeql/assets/42641846/b08a565b-c231-4af9-8571-c5d40e5d9a00

## Reviewing notes

- A lot of the changes are command-wrangling. The main changes are in [`local-databases-ui.ts`](https://github.com/github/vscode-codeql/pull/2856/files#diff-24cce3c26831674245c5877c9683c8c8250c8595c4fa0d1eeece5c9b50bc5c8c).
- This still needs quite a lot of polishing (see internal issue as well) and testing, but I'm keen for any initial feedback on the approach, and then I can polish stuff in follow-up PRs! 💅🏼


## Checklist

⚠️ I've hidden the new language menu behind the `canary` flag, since it's still WIP. No user-facing changes yet. 

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
