### PR TITLE
Introduce modeling store and move some state there 

### DIFF
--- a/extensions/ql-vscode/src/model-editor/model-editor-module.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-module.ts
@@ -19,11 +19,13 @@ import { showResolvableLocation } from "../databases/local-databases/locations";
 import { Method, Usage } from "./method";
 import { setUpPack } from "./model-editor-queries";
 import { MethodModelingPanel } from "./method-modeling/method-modeling-panel";
+import { ModelingStore } from "./modeling-store";
 
 const SUPPORTED_LANGUAGES: string[] = ["java", "csharp"];
 
 export class ModelEditorModule extends DisposableObject {
   private readonly queryStorageDir: string;
+  private readonly modelingStore: ModelingStore;
   private readonly methodsUsagePanel: MethodsUsagePanel;
   private readonly methodModelingPanel: MethodModelingPanel;
 
@@ -38,6 +40,7 @@ export class ModelEditorModule extends DisposableObject {
   ) {
     super();
     this.queryStorageDir = join(baseQueryStorageDir, "model-editor-results");
+    this.modelingStore = new ModelingStore(app);
     this.methodsUsagePanel = this.push(new MethodsUsagePanel(cliServer));
     this.methodModelingPanel = this.push(new MethodModelingPanel(app));
   }
@@ -153,6 +156,7 @@ export class ModelEditorModule extends DisposableObject {
 
             const view = new ModelEditorView(
               this.app,
+              this.modelingStore,
               this.databaseManager,
               this.cliServer,
               this.queryRunner,

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -43,6 +43,7 @@ import { getLanguageDisplayName } from "../common/query-language";
 import { AutoModeler } from "./auto-modeler";
 import { INITIAL_HIDE_MODELED_METHODS_VALUE } from "./shared/hide-modeled-methods";
 import { telemetryListener } from "../common/vscode/telemetry";
+import { ModelingStore } from "./modeling-store";
 
 export class ModelEditorView extends AbstractWebview<
   ToModelEditorMessage,
@@ -55,6 +56,7 @@ export class ModelEditorView extends AbstractWebview<
 
   public constructor(
     protected readonly app: App,
+    private readonly modelingStore: ModelingStore,
     private readonly databaseManager: DatabaseManager,
     private readonly cliServer: CodeQLCliServer,
     private readonly queryRunner: QueryRunner,
@@ -79,6 +81,8 @@ export class ModelEditorView extends AbstractWebview<
     ) => boolean,
   ) {
     super(app);
+
+    this.modelingStore.initializeStateForDb(databaseItem);
 
     this.autoModeler = new AutoModeler(
       app,
@@ -527,6 +531,7 @@ export class ModelEditorView extends AbstractWebview<
 
       const view = new ModelEditorView(
         this.app,
+        this.modelingStore,
         this.databaseManager,
         this.cliServer,
         this.queryRunner,

--- a/extensions/ql-vscode/src/model-editor/modeling-store.ts
+++ b/extensions/ql-vscode/src/model-editor/modeling-store.ts
@@ -1,0 +1,64 @@
+import { App } from "../common/app";
+import { DisposableObject } from "../common/disposable-object";
+import { AppEvent, AppEventEmitter } from "../common/events";
+import { DatabaseItem } from "../databases/local-databases";
+
+interface DbModelingState {
+  // Currently empty but will soon contain information about methods, etc.
+}
+
+export class ModelingStore extends DisposableObject {
+  public readonly onActiveDbChanged: AppEvent<void>;
+  public readonly onDbClosed: AppEvent<string>;
+
+  private state: Map<string, DbModelingState>;
+  private activeDb: string | undefined;
+
+  private readonly onActiveDbChangedEventEmitter: AppEventEmitter<void>;
+  private readonly onDbClosedEventEmitter: AppEventEmitter<string>;
+
+  constructor(app: App) {
+    super();
+
+    // State initialization
+    this.activeDb = undefined;
+    this.state = new Map<string, DbModelingState>();
+
+    // Event initialization
+    this.onActiveDbChangedEventEmitter = this.push(
+      app.createEventEmitter<void>(),
+    );
+    this.onActiveDbChanged = this.onActiveDbChangedEventEmitter.event;
+
+    this.onDbClosedEventEmitter = this.push(app.createEventEmitter<string>());
+    this.onDbClosed = this.onDbClosedEventEmitter.event;
+  }
+
+  public initializeStateForDb(databaseItem: DatabaseItem) {
+    const dbUri = databaseItem.databaseUri.toString();
+    this.state.set(dbUri, {
+      databaseItem,
+    });
+  }
+
+  public setActiveDb(databaseItem: DatabaseItem) {
+    this.activeDb = databaseItem.databaseUri.toString();
+    this.onActiveDbChangedEventEmitter.fire();
+  }
+
+  public removeDb(databaseItem: DatabaseItem) {
+    const dbUri = databaseItem.databaseUri.toString();
+
+    if (!this.state.has(dbUri)) {
+      throw Error("Cannot remove a database that has not been initialized");
+    }
+
+    if (this.activeDb === dbUri) {
+      this.activeDb = undefined;
+      this.onActiveDbChangedEventEmitter.fire();
+    }
+
+    this.state.delete(dbUri);
+    this.onDbClosedEventEmitter.fire(dbUri);
+  }
+}

--- a/extensions/ql-vscode/src/model-editor/modeling-store.ts
+++ b/extensions/ql-vscode/src/model-editor/modeling-store.ts
@@ -2,26 +2,44 @@ import { App } from "../common/app";
 import { DisposableObject } from "../common/disposable-object";
 import { AppEvent, AppEventEmitter } from "../common/events";
 import { DatabaseItem } from "../databases/local-databases";
+import { Method } from "./method";
+import { INITIAL_HIDE_MODELED_METHODS_VALUE } from "./shared/hide-modeled-methods";
 
 interface DbModelingState {
-  // Currently empty but will soon contain information about methods, etc.
+  databaseItem: DatabaseItem;
+  methods: Method[];
+  hideModeledMethods: boolean;
+}
+
+interface MethodsChangedEvent {
+  methods: Method[];
+  dbUri: string;
+  isActiveDb: boolean;
+}
+
+interface HideModeledMethodsChangedEvent {
+  hideModeledMethods: boolean;
+  isActiveDb: boolean;
 }
 
 export class ModelingStore extends DisposableObject {
   public readonly onActiveDbChanged: AppEvent<void>;
   public readonly onDbClosed: AppEvent<string>;
+  public readonly onMethodsChanged: AppEvent<MethodsChangedEvent>;
+  public readonly onHideModeledMethodsChanged: AppEvent<HideModeledMethodsChangedEvent>;
 
-  private state: Map<string, DbModelingState>;
+  private readonly state: Map<string, DbModelingState>;
   private activeDb: string | undefined;
 
   private readonly onActiveDbChangedEventEmitter: AppEventEmitter<void>;
   private readonly onDbClosedEventEmitter: AppEventEmitter<string>;
+  private readonly onMethodsChangedEventEmitter: AppEventEmitter<MethodsChangedEvent>;
+  private readonly onHideModeledMethodsChangedEventEmitter: AppEventEmitter<HideModeledMethodsChangedEvent>;
 
   constructor(app: App) {
     super();
 
     // State initialization
-    this.activeDb = undefined;
     this.state = new Map<string, DbModelingState>();
 
     // Event initialization
@@ -32,12 +50,25 @@ export class ModelingStore extends DisposableObject {
 
     this.onDbClosedEventEmitter = this.push(app.createEventEmitter<string>());
     this.onDbClosed = this.onDbClosedEventEmitter.event;
+
+    this.onMethodsChangedEventEmitter = this.push(
+      app.createEventEmitter<MethodsChangedEvent>(),
+    );
+    this.onMethodsChanged = this.onMethodsChangedEventEmitter.event;
+
+    this.onHideModeledMethodsChangedEventEmitter = this.push(
+      app.createEventEmitter<HideModeledMethodsChangedEvent>(),
+    );
+    this.onHideModeledMethodsChanged =
+      this.onHideModeledMethodsChangedEventEmitter.event;
   }
 
   public initializeStateForDb(databaseItem: DatabaseItem) {
     const dbUri = databaseItem.databaseUri.toString();
     this.state.set(dbUri, {
       databaseItem,
+      methods: [],
+      hideModeledMethods: INITIAL_HIDE_MODELED_METHODS_VALUE,
     });
   }
 
@@ -60,5 +91,51 @@ export class ModelingStore extends DisposableObject {
 
     this.state.delete(dbUri);
     this.onDbClosedEventEmitter.fire(dbUri);
+  }
+
+  public getStateForActiveDb(): DbModelingState | undefined {
+    if (!this.activeDb) {
+      return undefined;
+    }
+
+    return this.state.get(this.activeDb);
+  }
+
+  public setMethods(dbItem: DatabaseItem, methods: Method[]) {
+    const dbState = this.getState(dbItem);
+    const dbUri = dbItem.databaseUri.toString();
+
+    dbState.methods = methods;
+
+    this.onMethodsChangedEventEmitter.fire({
+      methods,
+      dbUri,
+      isActiveDb: dbUri === this.activeDb,
+    });
+  }
+
+  public setHideModeledMethods(
+    dbItem: DatabaseItem,
+    hideModeledMethods: boolean,
+  ) {
+    const dbState = this.getState(dbItem);
+    const dbUri = dbItem.databaseUri.toString();
+
+    dbState.hideModeledMethods = hideModeledMethods;
+
+    this.onHideModeledMethodsChangedEventEmitter.fire({
+      hideModeledMethods,
+      isActiveDb: dbUri === this.activeDb,
+    });
+  }
+
+  private getState(databaseItem: DatabaseItem): DbModelingState {
+    if (!this.state.has(databaseItem.databaseUri.toString())) {
+      throw Error(
+        "Cannot get state for a database that has not been initialized",
+      );
+    }
+
+    return this.state.get(databaseItem.databaseUri.toString())!;
   }
 }

--- a/extensions/ql-vscode/test/__mocks__/model-editor/modelingStoreMock.ts
+++ b/extensions/ql-vscode/test/__mocks__/model-editor/modelingStoreMock.ts
@@ -1,0 +1,27 @@
+import { mockedObject } from "../../vscode-tests/utils/mocking.helpers";
+import { ModelingStore } from "../../../src/model-editor/modeling-store";
+
+export function createMockModelingStore({
+  initializeStateForDb = jest.fn(),
+  getStateForActiveDb = jest.fn(),
+  onActiveDbChanged = jest.fn(),
+  onDbClosed = jest.fn(),
+  onMethodsChanged = jest.fn(),
+  onHideModeledMethodsChanged = jest.fn(),
+}: {
+  initializeStateForDb?: ModelingStore["initializeStateForDb"];
+  getStateForActiveDb?: ModelingStore["getStateForActiveDb"];
+  onActiveDbChanged?: ModelingStore["onActiveDbChanged"];
+  onDbClosed?: ModelingStore["onDbClosed"];
+  onMethodsChanged?: ModelingStore["onMethodsChanged"];
+  onHideModeledMethodsChanged?: ModelingStore["onHideModeledMethodsChanged"];
+} = {}): ModelingStore {
+  return mockedObject<ModelingStore>({
+    initializeStateForDb,
+    getStateForActiveDb,
+    onActiveDbChanged,
+    onDbClosed,
+    onMethodsChanged,
+    onHideModeledMethodsChanged,
+  });
+}

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/methods-usage/methods-usage-panel.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/methods-usage/methods-usage-panel.test.ts
@@ -8,6 +8,8 @@ import {
   createMethod,
   createUsage,
 } from "../../../../factories/model-editor/method-factories";
+import { ModelingStore } from "../../../../../src/model-editor/modeling-store";
+import { createMockModelingStore } from "../../../../__mocks__/model-editor/modelingStoreMock";
 
 describe("MethodsUsagePanel", () => {
   const mockCliServer = mockedObject<CodeQLCliServer>({});
@@ -25,7 +27,9 @@ describe("MethodsUsagePanel", () => {
       } as TreeView<unknown>;
       jest.spyOn(window, "createTreeView").mockReturnValue(mockTreeView);
 
-      const panel = new MethodsUsagePanel(mockCliServer);
+      const modelingStore = createMockModelingStore();
+
+      const panel = new MethodsUsagePanel(modelingStore, mockCliServer);
       await panel.setState(methods, dbItem, hideModeledMethods);
 
       expect(mockTreeView.badge?.value).toBe(1);
@@ -34,6 +38,7 @@ describe("MethodsUsagePanel", () => {
 
   describe("revealItem", () => {
     let mockTreeView: TreeView<unknown>;
+    let modelingStore: ModelingStore;
 
     const hideModeledMethods: boolean = false;
     const usage = createUsage();
@@ -43,6 +48,8 @@ describe("MethodsUsagePanel", () => {
         reveal: jest.fn(),
       });
       jest.spyOn(window, "createTreeView").mockReturnValue(mockTreeView);
+
+      modelingStore = createMockModelingStore();
     });
 
     it("should reveal the correct item in the tree view", async () => {
@@ -52,7 +59,7 @@ describe("MethodsUsagePanel", () => {
         }),
       ];
 
-      const panel = new MethodsUsagePanel(mockCliServer);
+      const panel = new MethodsUsagePanel(modelingStore, mockCliServer);
       await panel.setState(methods, dbItem, hideModeledMethods);
 
       await panel.revealItem(usage);
@@ -62,7 +69,7 @@ describe("MethodsUsagePanel", () => {
 
     it("should do nothing if usage cannot be found", async () => {
       const methods = [createMethod({})];
-      const panel = new MethodsUsagePanel(mockCliServer);
+      const panel = new MethodsUsagePanel(modelingStore, mockCliServer);
       await panel.setState(methods, dbItem, hideModeledMethods);
 
       await panel.revealItem(usage);

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/model-editor-view.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/model-editor-view.test.ts
@@ -8,9 +8,11 @@ import { createMockApp } from "../../../__mocks__/appMock";
 import { mockEmptyDatabaseManager } from "../query-testing/test-runner-helpers";
 import { QueryRunner } from "../../../../src/query-server";
 import { ExtensionPack } from "../../../../src/model-editor/shared/extension-pack";
+import { ModelingStore } from "../../../../src/model-editor/modeling-store";
 
 describe("ModelEditorView", () => {
   const app = createMockApp({});
+  const modelingStore = mockedObject<ModelingStore>({});
   const databaseManager = mockEmptyDatabaseManager();
   const cliServer = mockedObject<CodeQLCliServer>({});
   const queryRunner = mockedObject<QueryRunner>({});
@@ -40,6 +42,7 @@ describe("ModelEditorView", () => {
   beforeEach(() => {
     view = new ModelEditorView(
       app,
+      modelingStore,
       databaseManager,
       cliServer,
       queryRunner,

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/model-editor-view.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/model-editor-view.test.ts
@@ -8,11 +8,11 @@ import { createMockApp } from "../../../__mocks__/appMock";
 import { mockEmptyDatabaseManager } from "../query-testing/test-runner-helpers";
 import { QueryRunner } from "../../../../src/query-server";
 import { ExtensionPack } from "../../../../src/model-editor/shared/extension-pack";
-import { ModelingStore } from "../../../../src/model-editor/modeling-store";
+import { createMockModelingStore } from "../../../__mocks__/model-editor/modelingStoreMock";
 
 describe("ModelEditorView", () => {
   const app = createMockApp({});
-  const modelingStore = mockedObject<ModelingStore>({});
+  const modelingStore = createMockModelingStore();
   const databaseManager = mockEmptyDatabaseManager();
   const cliServer = mockedObject<CodeQLCliServer>({});
   const queryRunner = mockedObject<QueryRunner>({});
@@ -31,11 +31,7 @@ describe("ModelEditorView", () => {
     dataExtensions: ["models/**/*.yml"],
   };
   const mode = Mode.Application;
-  const updateMethodsUsagePanelState = jest.fn();
   const showMethod = jest.fn();
-  const handleViewBecameActive = jest.fn();
-  const handleViewWasDisposed = jest.fn();
-  const isMostRecentlyActiveView = jest.fn();
 
   let view: ModelEditorView;
 
@@ -51,11 +47,7 @@ describe("ModelEditorView", () => {
       databaseItem,
       extensionPack,
       mode,
-      updateMethodsUsagePanelState,
       showMethod,
-      handleViewBecameActive,
-      handleViewWasDisposed,
-      isMostRecentlyActiveView,
     );
   });
 


### PR DESCRIPTION
Introduces a new `ModelingStore` that will be responsible for managing state related to method modeling. It stores state per database we're modeling. 

In this PR we take the first few steps to get there:
- Introducing the new `ModelingStore` and wiring it up to the module/views.
- Adding the knowledge around active database being modeled to the store.
- Moving the `methods` and `hideModeledMethods` bits of state to the new store.
- Using the three pieces of data (`methods`, `hideModeledMethods` and active db state) and wiring up events/event emitters in order to remove the various callbacks used in the methods usage panel.

There are no guards to enforce that the state doesn't get mutated outside of the store yet. It's something I think we should do, but I didn't want to add more to this PR.

We also don't enforce that a user is only allowed to open 1 model editor per database they're modeling yet but since that is a bit of a corner case, I think that's okay.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
