### PR TITLE
Alternate fix for import highlighting with instantiations

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 ## [UNRELEASED]
 
+- Fix syntax highlighting directly after import statements with instantiation arguments. [#2792](https://github.com/github/vscode-codeql/pull/2792)
+
 ## 1.8.11 - 7 September 2023
 
 - Update how variant analysis results are displayed. For queries with ["path-problem" or "problem" `@kind`](https://codeql.github.com/docs/writing-codeql-queries/metadata-for-codeql-queries/#metadata-properties), you can choose to display the results as rendered alerts or as a table of raw results. For queries with any other `@kind`, the results are displayed as a table. [#2745](https://github.com/github/vscode-codeql/pull/2745) & [#2749](https://github.com/github/vscode-codeql/pull/2749)
 - When running variant analyses, don't download artifacts for repositories with no results. [#2736](https://github.com/github/vscode-codeql/pull/2736)
 - Group the extension settings, so that they're easier to find in the Settings UI. [#2706](https://github.com/github/vscode-codeql/pull/2706)
-- Fixed syntax highlighting directly after import statements with instantiation arguments. [#2792](https://github.com/github/vscode-codeql/pull/2792)
 
 ## 1.8.10 - 15 August 2023
 

--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Update how variant analysis results are displayed. For queries with ["path-problem" or "problem" `@kind`](https://codeql.github.com/docs/writing-codeql-queries/metadata-for-codeql-queries/#metadata-properties), you can choose to display the results as rendered alerts or as a table of raw results. For queries with any other `@kind`, the results are displayed as a table. [#2745](https://github.com/github/vscode-codeql/pull/2745) & [#2749](https://github.com/github/vscode-codeql/pull/2749)
 - When running variant analyses, don't download artifacts for repositories with no results. [#2736](https://github.com/github/vscode-codeql/pull/2736)
 - Group the extension settings, so that they're easier to find in the Settings UI. [#2706](https://github.com/github/vscode-codeql/pull/2706)
+- Fixed syntax highlighting directly after import statements with instantiation arguments.
 
 ## 1.8.10 - 15 August 2023
 

--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Update how variant analysis results are displayed. For queries with ["path-problem" or "problem" `@kind`](https://codeql.github.com/docs/writing-codeql-queries/metadata-for-codeql-queries/#metadata-properties), you can choose to display the results as rendered alerts or as a table of raw results. For queries with any other `@kind`, the results are displayed as a table. [#2745](https://github.com/github/vscode-codeql/pull/2745) & [#2749](https://github.com/github/vscode-codeql/pull/2749)
 - When running variant analyses, don't download artifacts for repositories with no results. [#2736](https://github.com/github/vscode-codeql/pull/2736)
 - Group the extension settings, so that they're easier to find in the Settings UI. [#2706](https://github.com/github/vscode-codeql/pull/2706)
-- Fixed syntax highlighting directly after import statements with instantiation arguments.
+- Fixed syntax highlighting directly after import statements with instantiation arguments. [#2792](https://github.com/github/vscode-codeql/pull/2792)
 
 ## 1.8.10 - 15 August 2023
 

--- a/extensions/ql-vscode/syntaxes/ql.tmLanguage.yml
+++ b/extensions/ql-vscode/syntaxes/ql.tmLanguage.yml
@@ -170,6 +170,14 @@ repository:
     match: '\]'
     name: punctuation.squarebracket.close.ql
 
+  open-angle:
+    match: '<'
+    name: punctuation.anglebracket.open.ql
+
+  close-angle:
+    match: '>'
+    name: punctuation.anglebracket.close.ql
+
   operator-or-punctuation:
     patterns:
     - include: '#relational-operator'
@@ -186,6 +194,8 @@ repository:
     - include: '#close-brace'
     - include: '#open-bracket'
     - include: '#close-bracket'
+    - include: '#open-angle'
+    - include: '#close-angle'
 
 # Keywords
   dont-care:
@@ -651,6 +661,15 @@ repository:
     - include: '#non-context-sensitive'
     - include: '#annotation'
 
+  instantiation-arguments:
+    beginPattern: '#open-angle'
+    end: '#close-angle'
+    patterns:
+    - include: '#potential-instantiation'
+
+  potential-instantiation:
+    matches: '(?#simple-id) (?#instantiation-arguments)?'
+
   # An `import` directive. Note that we parse the optional `as` clause as a separate top-level
   # directive, because otherwise it's too hard to figure out where the `import` directive ends.
   import-directive:
@@ -664,7 +683,7 @@ repository:
     name: meta.block.import-directive.ql
     patterns:
     - include: '#non-context-sensitive'
-    - match: '(?#simple-id)'
+    - match: '(?#potential-instantiation)'
       name: entity.name.type.namespace.ql
 
   # The end pattern for an `as` clause, whether on an `import` directive, in an aggregate, or on a
@@ -702,7 +721,6 @@ repository:
     - include: '#non-context-sensitive'
     - match: '(?#simple-id)|(?#at-lower-id)'
       name: entity.name.type.ql
-
 
   # A `module` declaration, whether a module definition or an alias declaration.
   module-declaration:

--- a/extensions/ql-vscode/syntaxes/ql.tmLanguage.yml
+++ b/extensions/ql-vscode/syntaxes/ql.tmLanguage.yml
@@ -661,29 +661,38 @@ repository:
     - include: '#non-context-sensitive'
     - include: '#annotation'
 
-  instantiation-arguments:
+  # The argument list of an instantiation, enclosed in angle brackets.
+  instantiation-args:
     beginPattern: '#open-angle'
-    end: '#close-angle'
+    endPattern: '#close-angle'
+    name: meta.type.parameters.ql
     patterns:
-    - include: '#potential-instantiation'
-
-  potential-instantiation:
-    matches: '(?#simple-id) (?#instantiation-arguments)?'
+    # Include `#instantiation-args` first so that `#open-angle` and `#close-angle` take precedence
+    # over `#relational-operator`.
+    - include: '#instantiation-args'
+    - include: '#non-context-sensitive'
+    - match: '(?#simple-id)'
+      name: entity.name.type.namespace.ql
 
   # An `import` directive. Note that we parse the optional `as` clause as a separate top-level
   # directive, because otherwise it's too hard to figure out where the `import` directive ends.
   import-directive:
     beginPattern: '#import'
-    # Ends with a simple-id that is not followed by a `.` or a `::`. This does not handle comments or
-    # line breaks between the simple-id and the `.` or `::`. 
-    end: '(?#simple-id) (?!\s*(\.|\:\:))'
-    endCaptures:
-      '0':
-        name: entity.name.type.namespace.ql
+    # TextMate makes it tricky to tell whether an identifier that we encounter is part of the
+    # `import` directive or whether it's the first token of the next module-level declaration.
+    # To find the end of the import directive, we'll look for a zero-width match where the previous
+    # token is either an identifier (other than `import`) or a `>`, and the next token is not a `.`,
+    # `<`, `,`, or `::`. This works for nearly all real-world `import` directives, but it will end the
+    # `import` directive too early if there is a comment or line break between two components of the
+    # module expression.
+    end: '(?<!\bimport)(?<=(?:\>)|[A-Za-z0-9_]) (?!\s*(\.|\:\:|\,|(?#open-angle)))'
     name: meta.block.import-directive.ql
     patterns:
+    # Include `#instantiation-args` first so that `#open-angle` and `#close-angle` take precedence
+    # over `#relational-operator`.
+    - include: '#instantiation-args'
     - include: '#non-context-sensitive'
-    - match: '(?#potential-instantiation)'
+    - match: '(?#simple-id)'
       name: entity.name.type.namespace.ql
 
   # The end pattern for an `as` clause, whether on an `import` directive, in an aggregate, or on a

--- a/syntaxes/ql.tmLanguage.json
+++ b/syntaxes/ql.tmLanguage.json
@@ -108,6 +108,14 @@
       "match": "(?x)\\]",
       "name": "punctuation.squarebracket.close.ql"
     },
+    "open-angle": {
+      "match": "(?x)<",
+      "name": "punctuation.anglebracket.open.ql"
+    },
+    "close-angle": {
+      "match": "(?x)>",
+      "name": "punctuation.anglebracket.close.ql"
+    },
     "operator-or-punctuation": {
       "patterns": [
         {
@@ -151,6 +159,12 @@
         },
         {
           "include": "#close-bracket"
+        },
+        {
+          "include": "#open-angle"
+        },
+        {
+          "include": "#close-angle"
         }
       ]
     },
@@ -723,6 +737,27 @@
         }
       ]
     },
+    "instantiation-arguments": {
+      "end": "(?x)#close-angle",
+      "patterns": [
+        {
+          "include": "#potential-instantiation"
+        }
+      ],
+      "begin": "(?x)((?:<))",
+      "beginCaptures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#open-angle"
+            }
+          ]
+        }
+      }
+    },
+    "potential-instantiation": {
+      "matches": "(?#simple-id) (?#instantiation-arguments)?"
+    },
     "import-directive": {
       "end": "(?x)(?:\\b [A-Za-z][0-9A-Za-z_]* (?:(?!(?:[0-9A-Za-z_])))) (?!\\s*(\\.|\\:\\:))",
       "endCaptures": {
@@ -736,7 +771,7 @@
           "include": "#non-context-sensitive"
         },
         {
-          "match": "(?x)(?:\\b [A-Za-z][0-9A-Za-z_]* (?:(?!(?:[0-9A-Za-z_]))))",
+          "match": "(?x)(?:)",
           "name": "entity.name.type.namespace.ql"
         }
       ],

--- a/syntaxes/ql.tmLanguage.json
+++ b/syntaxes/ql.tmLanguage.json
@@ -675,9 +675,9 @@
               "begin": "(?x)(?<=/\\*\\*)([^*]|\\*(?!/))*$",
               "while": "(?x)(^|\\G)\\s*([^*]|\\*(?!/))(?=([^*]|[*](?!/))*$)",
               "patterns": [
-                
-                
-                
+
+
+
                 {
                   "match": "(?x)\\G\\s* (@\\S+)",
                   "name": "keyword.tag.ql"
@@ -737,11 +737,18 @@
         }
       ]
     },
-    "instantiation-arguments": {
-      "end": "(?x)#close-angle",
+    "instantiation-args": {
+      "name": "meta.type.parameters.ql",
       "patterns": [
         {
-          "include": "#potential-instantiation"
+          "include": "#instantiation-args"
+        },
+        {
+          "include": "#non-context-sensitive"
+        },
+        {
+          "match": "(?x)(?:\\b [A-Za-z][0-9A-Za-z_]* (?:(?!(?:[0-9A-Za-z_]))))",
+          "name": "entity.name.type.namespace.ql"
         }
       ],
       "begin": "(?x)((?:<))",
@@ -753,25 +760,30 @@
             }
           ]
         }
+      },
+      "end": "(?x)((?:>))",
+      "endCaptures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#close-angle"
+            }
+          ]
+        }
       }
     },
-    "potential-instantiation": {
-      "matches": "(?#simple-id) (?#instantiation-arguments)?"
-    },
     "import-directive": {
-      "end": "(?x)(?:\\b [A-Za-z][0-9A-Za-z_]* (?:(?!(?:[0-9A-Za-z_])))) (?!\\s*(\\.|\\:\\:))",
-      "endCaptures": {
-        "0": {
-          "name": "entity.name.type.namespace.ql"
-        }
-      },
+      "end": "(?x)(?<!\\bimport)(?<=(?:\\>)|[A-Za-z0-9_]) (?!\\s*(\\.|\\:\\:|\\,|(?:<)))",
       "name": "meta.block.import-directive.ql",
       "patterns": [
+        {
+          "include": "#instantiation-args"
+        },
         {
           "include": "#non-context-sensitive"
         },
         {
-          "match": "(?x)(?:)",
+          "match": "(?x)(?:\\b [A-Za-z][0-9A-Za-z_]* (?:(?!(?:[0-9A-Za-z_]))))",
           "name": "entity.name.type.namespace.ql"
         }
       ],


### PR DESCRIPTION
This is an alternate fix for https://github.com/github/vscode-codeql/pull/2792. It updates the heuristic for finding the end of an import directive. The new heuristic matches a zero-width string that is preceded by a character that could end the import directive (identifier, `>`) and is not followed by a character that would continue the import directive (`,`, `.`, `<`, `::`).