### PR TITLE
Rename `useExtensionPacks` to `useModelPacks`

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -278,7 +278,7 @@
             "default": true,
             "description": "Enable the 'Quick Evaluation' CodeLens."
           },
-          "codeQL.runningQueries.useExtensionPacks": {
+          "codeQL.runningQueries.useModelPacks": {
             "type": "string",
             "default": "none",
             "enum": [
@@ -286,10 +286,10 @@
               "all"
             ],
             "enumDescriptions": [
-              "Do not use extension packs.",
-              "Use all extension packs found in the workspace."
+              "Do not use model packs.",
+              "Use all model packs found in the workspace."
             ],
-            "description": "Choose whether or not to run queries using extension packs. Requires CodeQL CLI v2.12.3 or later."
+            "description": "Choose whether or not to run queries using model packs. Requires CodeQL CLI v2.12.3 or later."
           }
         }
       },

--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -1254,7 +1254,7 @@ export class CodeQLCliServer implements Disposable {
     if (extensionPacksOnly) {
       if (!(await this.cliConstraints.supportsQlpacksKind())) {
         void this.logger.log(
-          "Warning: Running with extension packs is only supported by CodeQL CLI v2.12.3 or later.",
+          "Warning: Running with model packs is only supported by CodeQL CLI v2.12.3 or later.",
         );
         return {};
       }
@@ -1265,7 +1265,7 @@ export class CodeQLCliServer implements Disposable {
       ["resolve", "qlpacks"],
       args,
       `Resolving qlpack information${
-        extensionPacksOnly ? " (extension packs only)" : ""
+        extensionPacksOnly ? " (model packs only)" : ""
       }`,
     );
   }
@@ -1528,15 +1528,15 @@ export class CodeQLCliServer implements Disposable {
     return paths.length ? ["--additional-packs", paths.join(delimiter)] : [];
   }
 
-  public async useExtensionPacks(): Promise<boolean> {
+  public async useModelPacks(): Promise<boolean> {
     return (
-      this.cliConfig.useExtensionPacks &&
+      this.cliConfig.useModelPacks &&
       (await this.cliConstraints.supportsQlpacksKind())
     );
   }
 
-  public async setUseExtensionPacks(useExtensionPacks: boolean) {
-    await this.cliConfig.setUseExtensionPacks(useExtensionPacks);
+  public async setUseModelPacks(useModelPacks: boolean) {
+    await this.cliConfig.setUseModelPacks(useModelPacks);
   }
 }
 

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -147,10 +147,7 @@ const DEBUG_SETTING = new Setting("debug", RUNNING_QUERIES_SETTING);
 const MAX_PATHS = new Setting("maxPaths", RUNNING_QUERIES_SETTING);
 const RUNNING_TESTS_SETTING = new Setting("runningTests", ROOT_SETTING);
 const RESULTS_DISPLAY_SETTING = new Setting("resultsDisplay", ROOT_SETTING);
-const USE_EXTENSION_PACKS = new Setting(
-  "useExtensionPacks",
-  RUNNING_QUERIES_SETTING,
-);
+const USE_MODEL_PACKS = new Setting("useModelPacks", RUNNING_QUERIES_SETTING);
 
 export const ADDITIONAL_TEST_ARGUMENTS_SETTING = new Setting(
   "additionalTestArguments",
@@ -206,7 +203,7 @@ const CLI_SETTINGS = [
   NUMBER_OF_TEST_THREADS_SETTING,
   NUMBER_OF_THREADS_SETTING,
   MAX_PATHS,
-  USE_EXTENSION_PACKS,
+  USE_MODEL_PACKS,
 ];
 
 export interface CliConfig {
@@ -214,9 +211,9 @@ export interface CliConfig {
   numberTestThreads: number;
   numberThreads: number;
   maxPaths: number;
-  useExtensionPacks: boolean;
+  useModelPacks: boolean;
   onDidChangeConfiguration?: Event<void>;
-  setUseExtensionPacks: (useExtensionPacks: boolean) => Promise<void>;
+  setUseModelPacks: (useModelPacks: boolean) => Promise<void>;
 }
 
 export abstract class ConfigListener extends DisposableObject {
@@ -413,15 +410,15 @@ export class CliConfigListener extends ConfigListener implements CliConfig {
     return MAX_PATHS.getValue<number>();
   }
 
-  public get useExtensionPacks(): boolean {
+  public get useModelPacks(): boolean {
     // currently, we are restricting the values of this setting to 'all' or 'none'.
-    return USE_EXTENSION_PACKS.getValue() === "all";
+    return USE_MODEL_PACKS.getValue() === "all";
   }
 
   // Exposed for testing only
-  public async setUseExtensionPacks(newUseExtensionPacks: boolean) {
-    await USE_EXTENSION_PACKS.updateValue(
-      newUseExtensionPacks ? "all" : "none",
+  public async setUseModelPacks(newUseModelPacks: boolean) {
+    await USE_MODEL_PACKS.updateValue(
+      newUseModelPacks ? "all" : "none",
       ConfigurationTarget.Global,
     );
   }

--- a/extensions/ql-vscode/src/local-queries/local-queries.ts
+++ b/extensions/ql-vscode/src/local-queries/local-queries.ts
@@ -576,7 +576,7 @@ export class LocalQueries extends DisposableObject {
   public async getDefaultExtensionPacks(
     additionalPacks: string[],
   ): Promise<string[]> {
-    return (await this.cliServer.useExtensionPacks())
+    return (await this.cliServer.useModelPacks())
       ? Object.keys(await this.cliServer.resolveQlpacks(additionalPacks, true))
       : [];
   }

--- a/extensions/ql-vscode/src/model-editor/extension-pack-picker.ts
+++ b/extensions/ql-vscode/src/model-editor/extension-pack-picker.ts
@@ -26,7 +26,7 @@ export async function pickExtensionPack(
   maxStep: number,
 ): Promise<ExtensionPack | undefined> {
   progress({
-    message: "Resolving extension packs...",
+    message: "Resolving model packs...",
     step: 1,
     maxStep,
   });
@@ -43,7 +43,7 @@ export async function pickExtensionPack(
   );
 
   progress({
-    message: "Creating extension pack...",
+    message: "Creating model pack...",
     step: 2,
     maxStep,
   });
@@ -68,7 +68,7 @@ export async function pickExtensionPack(
   if (!packName) {
     void showAndLogErrorMessage(
       logger,
-      `Could not automatically name extension pack for database ${databaseItem.name}`,
+      `Could not automatically name model pack for database ${databaseItem.name}`,
     );
 
     return undefined;
@@ -89,9 +89,9 @@ export async function pickExtensionPack(
     } catch (e: unknown) {
       void showAndLogErrorMessage(
         logger,
-        `Could not read extension pack ${formatPackName(packName)}`,
+        `Could not read model pack ${formatPackName(packName)}`,
         {
-          fullMessage: `Could not read extension pack ${formatPackName(
+          fullMessage: `Could not read model pack ${formatPackName(
             packName,
           )} at ${existingExtensionPackPaths[0]}: ${getErrorMessage(e)}`,
         },
@@ -108,9 +108,9 @@ export async function pickExtensionPack(
   if (existingExtensionPackPaths?.length > 1) {
     void showAndLogErrorMessage(
       logger,
-      `Extension pack ${formatPackName(packName)} resolves to multiple paths`,
+      `Model pack ${formatPackName(packName)} resolves to multiple paths`,
       {
-        fullMessage: `Extension pack ${formatPackName(
+        fullMessage: `Model pack ${formatPackName(
           packName,
         )} resolves to multiple paths: ${existingExtensionPackPaths.join(
           ", ",
@@ -126,7 +126,7 @@ export async function pickExtensionPack(
   if (await pathExists(packPath)) {
     void showAndLogErrorMessage(
       logger,
-      `Directory ${packPath} already exists for extension pack ${formatPackName(
+      `Directory ${packPath} already exists for model pack ${formatPackName(
         packName,
       )}`,
     );

--- a/extensions/ql-vscode/src/model-editor/extensions-workspace-folder.ts
+++ b/extensions/ql-vscode/src/model-editor/extensions-workspace-folder.ts
@@ -187,7 +187,7 @@ export async function autoPickExtensionsDirectory(): Promise<Uri | undefined> {
       workspace.workspaceFolders?.length ?? 0,
       0,
       {
-        name: "CodeQL Extension Packs",
+        name: "CodeQL Model Packs",
         uri: extensionsUri,
       },
     )

--- a/extensions/ql-vscode/src/query-server/legacy/run-queries.ts
+++ b/extensions/ql-vscode/src/query-server/legacy/run-queries.ts
@@ -317,7 +317,7 @@ export async function compileAndRunQueryAgainstDatabaseCore(
   if (extensionPacks !== undefined && extensionPacks.length > 0) {
     void showAndLogWarningMessage(
       extLogger,
-      "Legacy query server does not support extension packs.",
+      "Legacy query server does not support model packs.",
     );
   }
 

--- a/extensions/ql-vscode/src/variant-analysis/run-remote-query.ts
+++ b/extensions/ql-vscode/src/variant-analysis/run-remote-query.ts
@@ -128,7 +128,7 @@ async function generateQueryPack(
     precompilationOpts = ["--no-precompile"];
   }
 
-  if (await cliServer.useExtensionPacks()) {
+  if (await cliServer.useModelPacks()) {
     await injectExtensionPacks(cliServer, queryPackDir, workspaceFolders);
   }
 
@@ -425,9 +425,7 @@ async function injectExtensionPacks(
     // ambiguity in which path to use. This is an error.
     if (paths.length > 1) {
       throw new Error(
-        `Multiple versions of extension pack '${name}' found: ${paths.join(
-          ", ",
-        )}`,
+        `Multiple versions of model pack '${name}' found: ${paths.join(", ")}`,
       );
     }
     // Add this extension pack as a dependency. It doesn't matter which

--- a/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
@@ -310,7 +310,7 @@ export function ModelEditor({
             </LinkIconButton>
             <LinkIconButton onClick={onOpenExtensionPackClick}>
               <span slot="start" className="codicon codicon-package"></span>
-              Open extension pack
+              Open model pack
             </LinkIconButton>
             <LinkIconButton onClick={onSwitchModeClick}>
               <span slot="start" className="codicon codicon-library"></span>

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/queries.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/queries.test.ts
@@ -158,7 +158,7 @@ describeWithCodeQL()("Queries", () => {
         return;
       }
 
-      await cli.setUseExtensionPacks(false);
+      await cli.setUseModelPacks(false);
       const parsedResults = await runQueryWithExtensions();
       expect(parsedResults).toEqual([1]);
     });
@@ -169,8 +169,8 @@ describeWithCodeQL()("Queries", () => {
       }
 
       console.log(`Starting 'extensions' ${mode}`);
-      console.log("Setting useExtensionPacks to true");
-      await cli.setUseExtensionPacks(true);
+      console.log("Setting useModelPacks to true");
+      await cli.setUseModelPacks(true);
       const parsedResults = await runQueryWithExtensions();
       console.log("Returned from runQueryWithExtensions");
       expect(parsedResults).toEqual([1, 2, 3, 4]);

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
@@ -255,7 +255,7 @@ describe("Variant Analysis Manager", () => {
           );
           return;
         }
-        await cli.setUseExtensionPacks(true);
+        await cli.setUseModelPacks(true);
         await doVariantAnalysisTest({
           queryPath: "data-remote-qlpack-nested/subfolder/in-pack.ql",
           expectedPackName: "github/remote-query-pack",

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/extension-pack-picker.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/extension-pack-picker.test.ts
@@ -331,7 +331,7 @@ describe("pickExtensionPack", () => {
     ).toEqual(undefined);
     expect(logger.showErrorMessage).toHaveBeenCalledTimes(1);
     expect(logger.showErrorMessage).toHaveBeenCalledWith(
-      "Could not read extension pack github/vscode-codeql-java",
+      "Could not read model pack github/vscode-codeql-java",
     );
     expect(cliServer.resolveQlpacks).toHaveBeenCalled();
   });
@@ -358,7 +358,7 @@ describe("pickExtensionPack", () => {
     ).toEqual(undefined);
     expect(logger.showErrorMessage).toHaveBeenCalledTimes(1);
     expect(logger.showErrorMessage).toHaveBeenCalledWith(
-      "Could not read extension pack github/vscode-codeql-java",
+      "Could not read model pack github/vscode-codeql-java",
     );
     expect(cliServer.resolveQlpacks).toHaveBeenCalled();
   });
@@ -395,7 +395,7 @@ describe("pickExtensionPack", () => {
     ).toEqual(undefined);
     expect(logger.showErrorMessage).toHaveBeenCalledTimes(1);
     expect(logger.showErrorMessage).toHaveBeenCalledWith(
-      "Could not read extension pack github/vscode-codeql-java",
+      "Could not read model pack github/vscode-codeql-java",
     );
     expect(cliServer.resolveQlpacks).toHaveBeenCalled();
   });
@@ -435,7 +435,7 @@ describe("pickExtensionPack", () => {
     ).toEqual(undefined);
     expect(logger.showErrorMessage).toHaveBeenCalledTimes(1);
     expect(logger.showErrorMessage).toHaveBeenCalledWith(
-      "Could not read extension pack github/vscode-codeql-java",
+      "Could not read model pack github/vscode-codeql-java",
     );
     expect(cliServer.resolveQlpacks).toHaveBeenCalled();
   });

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/extensions-workspace-folder.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/extensions-workspace-folder.test.ts
@@ -67,7 +67,7 @@ describe("autoPickExtensionsDirectory", () => {
       },
       {
         uri: extensionsDirectory,
-        name: "CodeQL Extension Packs",
+        name: "CodeQL Model Packs",
         index: 2,
       },
     ]);
@@ -96,7 +96,7 @@ describe("autoPickExtensionsDirectory", () => {
 
     expect(await autoPickExtensionsDirectory()).toEqual(extensionsDirectory);
     expect(updateWorkspaceFoldersSpy).toHaveBeenCalledWith(2, 0, {
-      name: "CodeQL Extension Packs",
+      name: "CodeQL Model Packs",
       uri: extensionsDirectory,
     });
   });
@@ -140,7 +140,7 @@ describe("autoPickExtensionsDirectory", () => {
 
     expect(await autoPickExtensionsDirectory()).toEqual(extensionsDirectory);
     expect(updateWorkspaceFoldersSpy).toHaveBeenCalledWith(2, 0, {
-      name: "CodeQL Extension Packs",
+      name: "CodeQL Model Packs",
       uri: extensionsDirectory,
     });
   });
@@ -166,7 +166,7 @@ describe("autoPickExtensionsDirectory", () => {
 
     expect(await autoPickExtensionsDirectory()).toEqual(extensionsDirectory);
     expect(updateWorkspaceFoldersSpy).toHaveBeenCalledWith(3, 0, {
-      name: "CodeQL Extension Packs",
+      name: "CodeQL Model Packs",
       uri: extensionsDirectory,
     });
   });
@@ -207,7 +207,7 @@ describe("autoPickExtensionsDirectory", () => {
 
     expect(await autoPickExtensionsDirectory()).toEqual(extensionsDirectory);
     expect(updateWorkspaceFoldersSpy).toHaveBeenCalledWith(2, 0, {
-      name: "CodeQL Extension Packs",
+      name: "CodeQL Model Packs",
       uri: extensionsDirectory,
     });
   });


### PR DESCRIPTION
This renames the `useExtensionPacks` setting to `useModelPacks`. It also changes all remaining instances of "extension pack" in public-facing texts to use "model pack" instead.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
