### PR TITLE
Move modeled and modified method state to store

### DIFF
--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -500,14 +500,14 @@ interface SetMethodsMessage {
   methods: Method[];
 }
 
-interface LoadModeledMethodsMessage {
-  t: "loadModeledMethods";
-  modeledMethods: Record<string, ModeledMethod>;
+interface SetModeledMethodsMessage {
+  t: "setModeledMethods";
+  methods: Record<string, ModeledMethod>;
 }
 
-interface AddModeledMethodsMessage {
-  t: "addModeledMethods";
-  modeledMethods: Record<string, ModeledMethod>;
+interface SetModifiedMethodsMessage {
+  t: "setModifiedMethods";
+  methodSignatures: string[];
 }
 
 interface SetInProgressMethodsMessage {
@@ -570,11 +570,16 @@ interface HideModeledMethodsMessage {
   hideModeledMethods: boolean;
 }
 
+interface SetModeledMethodMessage {
+  t: "setModeledMethod";
+  method: ModeledMethod;
+}
+
 export type ToModelEditorMessage =
   | SetExtensionPackStateMessage
   | SetMethodsMessage
-  | LoadModeledMethodsMessage
-  | AddModeledMethodsMessage
+  | SetModeledMethodsMessage
+  | SetModifiedMethodsMessage
   | SetInProgressMethodsMessage;
 
 export type FromModelEditorMessage =
@@ -589,7 +594,8 @@ export type FromModelEditorMessage =
   | GenerateMethodsFromLlmMessage
   | StopGeneratingMethodsFromLlmMessage
   | ModelDependencyMessage
-  | HideModeledMethodsMessage;
+  | HideModeledMethodsMessage
+  | SetModeledMethodMessage;
 
 export type FromMethodModelingMessage =
   | TelemetryMessage

--- a/extensions/ql-vscode/src/model-editor/modeling-store.ts
+++ b/extensions/ql-vscode/src/model-editor/modeling-store.ts
@@ -101,7 +101,7 @@ export class ModelingStore extends DisposableObject {
       methods: [],
       hideModeledMethods: INITIAL_HIDE_MODELED_METHODS_VALUE,
       modeledMethods: {},
-      modifiedMethodSignatures: new Set<string>(),
+      modifiedMethodSignatures: new Set(),
     });
   }
 

--- a/extensions/ql-vscode/src/model-editor/modeling-store.ts
+++ b/extensions/ql-vscode/src/model-editor/modeling-store.ts
@@ -220,13 +220,13 @@ export class ModelingStore extends DisposableObject {
 
   public addModifiedMethods(
     dbItem: DatabaseItem,
-    methodSignatures: Set<string>,
+    methodSignatures: Iterable<string>,
   ) {
     const state = this.getState(dbItem);
 
-    methodSignatures.forEach((signature) => {
+    for (const signature of methodSignatures) {
       state.modifiedMethodSignatures.add(signature);
-    });
+    }
 
     this.onModifiedMethodsChangedEventEmitter.fire({
       modifiedMethods: state.modifiedMethodSignatures,
@@ -236,7 +236,7 @@ export class ModelingStore extends DisposableObject {
   }
 
   public addModifiedMethod(dbItem: DatabaseItem, methodSignature: string) {
-    this.addModifiedMethods(dbItem, new Set<string>([methodSignature]));
+    this.addModifiedMethods(dbItem, [methodSignature]);
   }
 
   public removeModifiedMethods(

--- a/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
@@ -123,32 +123,11 @@ export function ModelEditor({
           case "setMethods":
             setMethods(msg.methods);
             break;
-          case "loadModeledMethods":
-            setModeledMethods((oldModeledMethods) => {
-              return {
-                ...msg.modeledMethods,
-                ...oldModeledMethods,
-              };
-            });
+          case "setModeledMethods":
+            setModeledMethods(msg.methods);
             break;
-          case "addModeledMethods":
-            setModeledMethods((oldModeledMethods) => {
-              return {
-                ...msg.modeledMethods,
-                ...Object.fromEntries(
-                  Object.entries(oldModeledMethods).filter(
-                    ([, value]) => value.type !== "none",
-                  ),
-                ),
-              };
-            });
-            setModifiedSignatures(
-              (oldModifiedSignatures) =>
-                new Set([
-                  ...oldModifiedSignatures,
-                  ...Object.keys(msg.modeledMethods),
-                ]),
-            );
+          case "setModifiedMethods":
+            setModifiedSignatures(new Set(msg.methodSignatures));
             break;
           case "setInProgressMethods":
             setInProgressMethods((oldInProgressMethods) =>
@@ -180,14 +159,10 @@ export function ModelEditor({
   );
 
   const onChange = useCallback((model: ModeledMethod) => {
-    setModeledMethods((oldModeledMethods) => ({
-      ...oldModeledMethods,
-      [model.signature]: model,
-    }));
-    setModifiedSignatures(
-      (oldModifiedSignatures) =>
-        new Set([...oldModifiedSignatures, model.signature]),
-    );
+    vscode.postMessage({
+      t: "setModeledMethod",
+      method: model,
+    });
   }, []);
 
   const onRefreshClick = useCallback(() => {
@@ -202,7 +177,6 @@ export function ModelEditor({
       methods,
       modeledMethods,
     });
-    setModifiedSignatures(new Set());
   }, [methods, modeledMethods]);
 
   const onSaveModelClick = useCallback(
@@ -211,13 +185,6 @@ export function ModelEditor({
         t: "saveModeledMethods",
         methods,
         modeledMethods,
-      });
-      setModifiedSignatures((oldModifiedSignatures) => {
-        const newModifiedSignatures = new Set([...oldModifiedSignatures]);
-        for (const method of methods) {
-          newModifiedSignatures.delete(method.signature);
-        }
-        return newModifiedSignatures;
       });
     },
     [],

--- a/extensions/ql-vscode/test/__mocks__/model-editor/modelingStoreMock.ts
+++ b/extensions/ql-vscode/test/__mocks__/model-editor/modelingStoreMock.ts
@@ -8,6 +8,8 @@ export function createMockModelingStore({
   onDbClosed = jest.fn(),
   onMethodsChanged = jest.fn(),
   onHideModeledMethodsChanged = jest.fn(),
+  onModeledMethodsChanged = jest.fn(),
+  onModifiedMethodsChanged = jest.fn(),
 }: {
   initializeStateForDb?: ModelingStore["initializeStateForDb"];
   getStateForActiveDb?: ModelingStore["getStateForActiveDb"];
@@ -15,6 +17,8 @@ export function createMockModelingStore({
   onDbClosed?: ModelingStore["onDbClosed"];
   onMethodsChanged?: ModelingStore["onMethodsChanged"];
   onHideModeledMethodsChanged?: ModelingStore["onHideModeledMethodsChanged"];
+  onModeledMethodsChanged?: ModelingStore["onModeledMethodsChanged"];
+  onModifiedMethodsChanged?: ModelingStore["onModifiedMethodsChanged"];
 } = {}): ModelingStore {
   return mockedObject<ModelingStore>({
     initializeStateForDb,
@@ -23,5 +27,7 @@ export function createMockModelingStore({
     onDbClosed,
     onMethodsChanged,
     onHideModeledMethodsChanged,
+    onModeledMethodsChanged,
+    onModifiedMethodsChanged,
   });
 }


### PR DESCRIPTION
Move some more state into the new modeling store. In this PR we move the modeled methods and modified methods state.

By moving this state out of the React view, the view gets simplified and uses React state only to store what it has been told by the extension host - it doesn't make any changes to the state directly by itself.

With this move we could also add some test coverage around the more complicated state update functions (e.g. `addModeledMethods`). This will be done in a future PR.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
