### PR TITLE
Make MethodModelingViewProvider a disposable object

### DIFF
--- a/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-panel.ts
+++ b/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-panel.ts
@@ -11,6 +11,7 @@ export class MethodModelingPanel extends DisposableObject {
     super();
 
     this.provider = new MethodModelingViewProvider(app);
+    this.push(this.provider);
     this.push(
       window.registerWebviewViewProvider(
         MethodModelingViewProvider.viewType,

--- a/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
+++ b/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
@@ -8,13 +8,19 @@ import { extLogger } from "../../common/logging/vscode/loggers";
 import { App } from "../../common/app";
 import { redactableError } from "../../common/errors";
 import { Method } from "../method";
+import { DisposableObject } from "../../common/disposable-object";
 
-export class MethodModelingViewProvider implements WebviewViewProvider {
+export class MethodModelingViewProvider
+  extends DisposableObject
+  implements WebviewViewProvider
+{
   public static readonly viewType = "codeQLMethodModeling";
 
   private webviewView: vscode.WebviewView | undefined = undefined;
 
-  constructor(private readonly app: App) {}
+  constructor(private readonly app: App) {
+    super();
+  }
 
   /**
    * This is called when a view first becomes visible. This may happen when the view is


### PR DESCRIPTION
This will allow us to make sure we dispose of subscriptions to events (that we'll register to in the near future).

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
