### PR TITLE
Split out components in variant analysis raw results table

### DIFF
--- a/extensions/ql-vscode/src/view/variant-analysis/RawResultCell.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/RawResultCell.tsx
@@ -1,0 +1,45 @@
+import * as React from "react";
+import { VSCodeLink } from "@vscode/webview-ui-toolkit/react";
+
+import { CellValue } from "../../common/bqrs-cli-types";
+import { sendTelemetry } from "../common/telemetry";
+import { convertNonPrintableChars } from "../../common/text-utils";
+import { tryGetRemoteLocation } from "../../common/bqrs-utils";
+
+type CellProps = {
+  value: CellValue;
+  fileLinkPrefix: string;
+  sourceLocationPrefix: string;
+};
+
+const sendRawResultsLinkTelemetry = () => sendTelemetry("raw-results-link");
+
+export const RawResultCell = ({
+  value,
+  fileLinkPrefix,
+  sourceLocationPrefix,
+}: CellProps) => {
+  switch (typeof value) {
+    case "string":
+    case "number":
+    case "boolean":
+      return <span>{convertNonPrintableChars(value.toString())}</span>;
+    case "object": {
+      const url = tryGetRemoteLocation(
+        value.url,
+        fileLinkPrefix,
+        sourceLocationPrefix,
+      );
+      const safeLabel = convertNonPrintableChars(value.label);
+      if (url) {
+        return (
+          <VSCodeLink onClick={sendRawResultsLinkTelemetry} href={url}>
+            {safeLabel}
+          </VSCodeLink>
+        );
+      } else {
+        return <span>{safeLabel}</span>;
+      }
+    }
+  }
+};

--- a/extensions/ql-vscode/src/view/variant-analysis/RawResultRow.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/RawResultRow.tsx
@@ -1,0 +1,38 @@
+import * as React from "react";
+import { styled } from "styled-components";
+
+import { CellValue } from "../../common/bqrs-cli-types";
+import { RawResultCell } from "./RawResultCell";
+
+const StyledRow = styled.div`
+  border-color: var(--vscode-editor-snippetFinalTabstopHighlightBorder);
+  border-style: solid;
+  justify-content: center;
+  align-items: center;
+  padding: 0.4rem;
+  word-break: break-word;
+`;
+
+type RowProps = {
+  row: CellValue[];
+  fileLinkPrefix: string;
+  sourceLocationPrefix: string;
+};
+
+export const RawResultRow = ({
+  row,
+  fileLinkPrefix,
+  sourceLocationPrefix,
+}: RowProps) => (
+  <>
+    {row.map((cell, cellIndex) => (
+      <StyledRow key={cellIndex}>
+        <RawResultCell
+          value={cell}
+          fileLinkPrefix={fileLinkPrefix}
+          sourceLocationPrefix={sourceLocationPrefix}
+        />
+      </StyledRow>
+    ))}
+  </>
+);

--- a/extensions/ql-vscode/src/view/variant-analysis/RawResultsTable.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/RawResultsTable.tsx
@@ -1,16 +1,14 @@
 import * as React from "react";
 import { useState } from "react";
 import { styled } from "styled-components";
-import { VSCodeLink } from "@vscode/webview-ui-toolkit/react";
 import {
   CellValue,
   RawResultSet,
   ResultSetSchema,
 } from "../../common/bqrs-cli-types";
-import { tryGetRemoteLocation } from "../../common/bqrs-utils";
 import TextButton from "../common/TextButton";
-import { convertNonPrintableChars } from "../../common/text-utils";
-import { sendTelemetry, useTelemetryOnChange } from "../common/telemetry";
+import { useTelemetryOnChange } from "../common/telemetry";
+import { RawResultCell } from "./RawResultCell";
 
 const numOfResultsInContractedMode = 5;
 
@@ -40,40 +38,6 @@ const TableContainer = styled.div<TableContainerProps>`
   padding: 0.4rem;
 `;
 
-type CellProps = {
-  value: CellValue;
-  fileLinkPrefix: string;
-  sourceLocationPrefix: string;
-};
-
-const sendRawResultsLinkTelemetry = () => sendTelemetry("raw-results-link");
-
-const Cell = ({ value, fileLinkPrefix, sourceLocationPrefix }: CellProps) => {
-  switch (typeof value) {
-    case "string":
-    case "number":
-    case "boolean":
-      return <span>{convertNonPrintableChars(value.toString())}</span>;
-    case "object": {
-      const url = tryGetRemoteLocation(
-        value.url,
-        fileLinkPrefix,
-        sourceLocationPrefix,
-      );
-      const safeLabel = convertNonPrintableChars(value.label);
-      if (url) {
-        return (
-          <VSCodeLink onClick={sendRawResultsLinkTelemetry} href={url}>
-            {safeLabel}
-          </VSCodeLink>
-        );
-      } else {
-        return <span>{safeLabel}</span>;
-      }
-    }
-  }
-};
-
 type RowProps = {
   row: CellValue[];
   fileLinkPrefix: string;
@@ -84,7 +48,7 @@ const Row = ({ row, fileLinkPrefix, sourceLocationPrefix }: RowProps) => (
   <>
     {row.map((cell, cellIndex) => (
       <StyledRow key={cellIndex}>
-        <Cell
+        <RawResultCell
           value={cell}
           fileLinkPrefix={fileLinkPrefix}
           sourceLocationPrefix={sourceLocationPrefix}

--- a/extensions/ql-vscode/src/view/variant-analysis/RawResultsTable.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/RawResultsTable.tsx
@@ -1,25 +1,12 @@
 import * as React from "react";
 import { useState } from "react";
 import { styled } from "styled-components";
-import {
-  CellValue,
-  RawResultSet,
-  ResultSetSchema,
-} from "../../common/bqrs-cli-types";
+import { RawResultSet, ResultSetSchema } from "../../common/bqrs-cli-types";
 import TextButton from "../common/TextButton";
 import { useTelemetryOnChange } from "../common/telemetry";
-import { RawResultCell } from "./RawResultCell";
+import { RawResultRow } from "./RawResultRow";
 
 const numOfResultsInContractedMode = 5;
-
-const StyledRow = styled.div`
-  border-color: var(--vscode-editor-snippetFinalTabstopHighlightBorder);
-  border-style: solid;
-  justify-content: center;
-  align-items: center;
-  padding: 0.4rem;
-  word-break: break-word;
-`;
 
 type TableContainerProps = {
   columnCount: number;
@@ -37,26 +24,6 @@ const TableContainer = styled.div<TableContainerProps>`
   max-width: 45rem;
   padding: 0.4rem;
 `;
-
-type RowProps = {
-  row: CellValue[];
-  fileLinkPrefix: string;
-  sourceLocationPrefix: string;
-};
-
-const Row = ({ row, fileLinkPrefix, sourceLocationPrefix }: RowProps) => (
-  <>
-    {row.map((cell, cellIndex) => (
-      <StyledRow key={cellIndex}>
-        <RawResultCell
-          value={cell}
-          fileLinkPrefix={fileLinkPrefix}
-          sourceLocationPrefix={sourceLocationPrefix}
-        />
-      </StyledRow>
-    ))}
-  </>
-);
 
 type RawResultsTableProps = {
   schema: ResultSetSchema;
@@ -86,7 +53,7 @@ const RawResultsTable = ({
     <>
       <TableContainer columnCount={schema.columns.length}>
         {results.rows.slice(0, numOfResultsToShow).map((row, rowIndex) => (
-          <Row
+          <RawResultRow
             key={rowIndex}
             row={row}
             fileLinkPrefix={fileLinkPrefix}


### PR DESCRIPTION
This splits out the `RawResultCell` and `RawResultRow` to separate files to make the `RawResultsTable` file easier to read. There are no behaviour changes.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
