### PR TITLE
Move modeling status code to its own module

### DIFF
--- a/extensions/ql-vscode/src/model-editor/shared/modeling-status.ts
+++ b/extensions/ql-vscode/src/model-editor/shared/modeling-status.ts
@@ -1,0 +1,1 @@
+export type ModelingStatus = "unmodeled" | "unsaved" | "saved";

--- a/extensions/ql-vscode/src/model-editor/shared/modeling-status.ts
+++ b/extensions/ql-vscode/src/model-editor/shared/modeling-status.ts
@@ -1,1 +1,17 @@
+import { ModeledMethod } from "../modeled-method";
+
 export type ModelingStatus = "unmodeled" | "unsaved" | "saved";
+
+export function getModelingStatus(
+  modeledMethod: ModeledMethod | undefined,
+  methodIsUnsaved: boolean,
+): ModelingStatus {
+  if (modeledMethod) {
+    if (methodIsUnsaved) {
+      return "unsaved";
+    } else if (modeledMethod.type !== "none") {
+      return "saved";
+    }
+  }
+  return "unmodeled";
+}

--- a/extensions/ql-vscode/src/view/method-modeling/MethodModeling.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/MethodModeling.tsx
@@ -1,9 +1,7 @@
 import * as React from "react";
 import { styled } from "styled-components";
-import {
-  ModelingStatus,
-  ModelingStatusIndicator,
-} from "../model-editor/ModelingStatusIndicator";
+import { ModelingStatus } from "../../model-editor/shared/modeling-status";
+import { ModelingStatusIndicator } from "../model-editor/ModelingStatusIndicator";
 import { Method } from "../../model-editor/method";
 import { MethodName } from "../model-editor/MethodName";
 import { ModeledMethod } from "../../model-editor/modeled-method";

--- a/extensions/ql-vscode/src/view/method-modeling/MethodModelingView.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/MethodModelingView.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { useEffect, useState } from "react";
 import { MethodModeling } from "./MethodModeling";
-import { ModelingStatus } from "../model-editor/ModelingStatusIndicator";
+import { ModelingStatus } from "../../model-editor/shared/modeling-status";
 import { Method } from "../../model-editor/method";
 import { ToMethodModelingMessage } from "../../common/interface-types";
 import { assertNever } from "../../common/helpers-pure";

--- a/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
@@ -14,10 +14,8 @@ import { ModeledMethod } from "../../model-editor/modeled-method";
 import { ModelKindDropdown } from "./ModelKindDropdown";
 import { Mode } from "../../model-editor/shared/mode";
 import { MethodClassifications } from "./MethodClassifications";
-import {
-  ModelingStatus,
-  ModelingStatusIndicator,
-} from "./ModelingStatusIndicator";
+import { getModelingStatus } from "../../model-editor/shared/modeling-status";
+import { ModelingStatusIndicator } from "./ModelingStatusIndicator";
 import { InProgressDropdown } from "./InProgressDropdown";
 import { MethodName } from "./MethodName";
 import { ModelTypeDropdown } from "./ModelTypeDropdown";
@@ -180,18 +178,4 @@ function sendJumpToUsageMessage(method: Method) {
     // In framework mode, the first and only usage is the definition of the method
     usage: method.usages[0],
   });
-}
-
-function getModelingStatus(
-  modeledMethod: ModeledMethod | undefined,
-  methodIsUnsaved: boolean,
-): ModelingStatus {
-  if (modeledMethod) {
-    if (methodIsUnsaved) {
-      return "unsaved";
-    } else if (modeledMethod.type !== "none") {
-      return "saved";
-    }
-  }
-  return "unmodeled";
 }

--- a/extensions/ql-vscode/src/view/model-editor/ModelingStatusIndicator.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelingStatusIndicator.tsx
@@ -1,8 +1,7 @@
 import * as React from "react";
 import { assertNever } from "../../common/helpers-pure";
 import { Codicon } from "../common/icon/Codicon";
-
-export type ModelingStatus = "unmodeled" | "unsaved" | "saved";
+import { ModelingStatus } from "../../model-editor/shared/modeling-status";
 
 interface Props {
   status: ModelingStatus;


### PR DESCRIPTION
Moved modeling status code into its own module, in a shared location, so that it can be reused in the method modeling panel

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
