### PR TITLE
Add selected method and usage state to modeling store

### DIFF
--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -26,7 +26,6 @@ import { asError, assertNever, getErrorMessage } from "../common/helpers-pure";
 import { runFlowModelQueries } from "./flow-model-queries";
 import { promptImportGithubDatabase } from "../databases/database-fetcher";
 import { App } from "../common/app";
-import { showResolvableLocation } from "../databases/local-databases/locations";
 import { redactableError } from "../common/errors";
 import {
   externalApiQueriesProgressMaxStep,
@@ -61,10 +60,6 @@ export class ModelEditorView extends AbstractWebview<
     private readonly databaseItem: DatabaseItem,
     private readonly extensionPack: ExtensionPack,
     private mode: Mode,
-    private readonly showMethod: (
-      method: Method,
-      usage: Usage,
-    ) => Promise<void>,
   ) {
     super(app);
 
@@ -359,8 +354,7 @@ export class ModelEditorView extends AbstractWebview<
   }
 
   protected async handleJumpToUsage(method: Method, usage: Usage) {
-    await this.showMethod(method, usage);
-    await showResolvableLocation(usage.url, this.databaseItem, this.app.logger);
+    this.modelingStore.setSelectedMethod(this.databaseItem, method, usage);
   }
 
   protected async loadExistingModeledMethods(): Promise<void> {
@@ -511,7 +505,6 @@ export class ModelEditorView extends AbstractWebview<
         addedDatabase,
         modelFile,
         Mode.Framework,
-        this.showMethod,
       );
       await view.openView();
     });

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/model-editor-view.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/model-editor-view.test.ts
@@ -31,7 +31,6 @@ describe("ModelEditorView", () => {
     dataExtensions: ["models/**/*.yml"],
   };
   const mode = Mode.Application;
-  const showMethod = jest.fn();
 
   let view: ModelEditorView;
 
@@ -47,7 +46,6 @@ describe("ModelEditorView", () => {
       databaseItem,
       extensionPack,
       mode,
-      showMethod,
     );
   });
 


### PR DESCRIPTION
This removes the need for callbacks and sets us up for easily updating the method modeling panel when the selection changes.

I'm not sure about the names that I've used (referring to method and ignoring the usage part) so open to renaming. E.g. we could use `methodUsage` (it just gets a bit long e.g. `onSelectedMethodUsageChanged`).

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
