### PR TITLE
Hook method modeling view to modeling store

### DIFF
--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -599,11 +599,28 @@ export type FromModelEditorMessage =
 
 export type FromMethodModelingMessage =
   | TelemetryMessage
-  | UnhandledErrorMessage;
+  | UnhandledErrorMessage
+  | SetModeledMethodMessage;
 
 interface SetMethodMessage {
   t: "setMethod";
   method: Method;
 }
 
-export type ToMethodModelingMessage = SetMethodMessage;
+interface SetMethodModifiedMessage {
+  t: "setMethodModified";
+  isModified: boolean;
+}
+
+interface SetSelectedMethodMessage {
+  t: "setSelectedMethod";
+  method: Method;
+  modeledMethod: ModeledMethod;
+  isModified: boolean;
+}
+
+export type ToMethodModelingMessage =
+  | SetMethodMessage
+  | SetModeledMethodMessage
+  | SetMethodModifiedMessage
+  | SetSelectedMethodMessage;

--- a/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-panel.ts
+++ b/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-panel.ts
@@ -3,14 +3,15 @@ import { App } from "../../common/app";
 import { DisposableObject } from "../../common/disposable-object";
 import { MethodModelingViewProvider } from "./method-modeling-view-provider";
 import { Method } from "../method";
+import { ModelingStore } from "../modeling-store";
 
 export class MethodModelingPanel extends DisposableObject {
   private readonly provider: MethodModelingViewProvider;
 
-  constructor(app: App) {
+  constructor(app: App, modelingStore: ModelingStore) {
     super();
 
-    this.provider = new MethodModelingViewProvider(app);
+    this.provider = new MethodModelingViewProvider(app, modelingStore);
     this.push(this.provider);
     this.push(
       window.registerWebviewViewProvider(

--- a/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
+++ b/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
@@ -116,12 +116,7 @@ export class MethodModelingViewProvider
     });
 
     this.modelingStore.onModifiedMethodsChanged(async (e) => {
-      if (
-        this.webviewView &&
-        e.isActiveDb &&
-        this.method &&
-        this.method.signature
-      ) {
+      if (this.webviewView && e.isActiveDb && this.method) {
         const isModified = e.modifiedMethods.has(this.method.signature);
         await this.webviewView.webview.postMessage({
           t: "setMethodModified",

--- a/extensions/ql-vscode/src/model-editor/model-editor-module.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-module.ts
@@ -42,7 +42,9 @@ export class ModelEditorModule extends DisposableObject {
     this.methodsUsagePanel = this.push(
       new MethodsUsagePanel(this.modelingStore, cliServer),
     );
-    this.methodModelingPanel = this.push(new MethodModelingPanel(app));
+    this.methodModelingPanel = this.push(
+      new MethodModelingPanel(app, this.modelingStore),
+    );
 
     this.registerToModelingStoreEvents();
   }


### PR DESCRIPTION
Hooks the method modeling panel to the modeling store so that the method modeling panel deals with updates events from the store, but that it also sends updates when the dropdown values change.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
