### PR TITLE
Indicate which language is selected in the databases view

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1870,11 +1870,11 @@
       "codeQLDatabases.languages": [
         {
           "command": "codeQLDatabases.displayAllLanguages",
-          "when": "codeQLDatabases.languageFilter != all"
+          "when": "codeQLDatabases.languageFilter != All"
         },
         {
           "command": "codeQLDatabases.displayAllLanguagesSelected",
-          "when": "codeQLDatabases.languageFilter == all"
+          "when": "codeQLDatabases.languageFilter == All"
         },
         {
           "command": "codeQLDatabases.displayCpp",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1870,11 +1870,11 @@
       "codeQLDatabases.languages": [
         {
           "command": "codeQLDatabases.displayAllLanguages",
-          "when": "codeQLDatabases.languageFilter != All"
+          "when": "codeQLDatabases.languageFilter != all"
         },
         {
           "command": "codeQLDatabases.displayAllLanguagesSelected",
-          "when": "codeQLDatabases.languageFilter == All"
+          "when": "codeQLDatabases.languageFilter == all"
         },
         {
           "command": "codeQLDatabases.displayCpp",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -758,36 +758,72 @@
         "title": "All languages"
       },
       {
+        "command": "codeQLDatabases.displayAllLanguagesSelected",
+        "title": "All languages (selected)"
+      },
+      {
         "command": "codeQLDatabases.displayCpp",
         "title": "C/C++"
+      },
+      {
+        "command": "codeQLDatabases.displayCppSelected",
+        "title": "C/C++ (selected)"
       },
       {
         "command": "codeQLDatabases.displayCsharp",
         "title": "C#"
       },
       {
+        "command": "codeQLDatabases.displayCsharpSelected",
+        "title": "C# (selected)"
+      },
+      {
         "command": "codeQLDatabases.displayGo",
         "title": "Go"
+      },
+      {
+        "command": "codeQLDatabases.displayGoSelected",
+        "title": "Go (selected)"
       },
       {
         "command": "codeQLDatabases.displayJava",
         "title": "Java/Kotlin"
       },
       {
+        "command": "codeQLDatabases.displayJavaSelected",
+        "title": "Java/Kotlin (selected)"
+      },
+      {
         "command": "codeQLDatabases.displayJavascript",
         "title": "JavaScript/TypeScript"
+      },
+      {
+        "command": "codeQLDatabases.displayJavascriptSelected",
+        "title": "JavaScript/TypeScript (selected)"
       },
       {
         "command": "codeQLDatabases.displayPython",
         "title": "Python"
       },
       {
+        "command": "codeQLDatabases.displayPythonSelected",
+        "title": "Python (selected)"
+      },
+      {
         "command": "codeQLDatabases.displayRuby",
         "title": "Ruby"
       },
       {
+        "command": "codeQLDatabases.displayRubySelected",
+        "title": "Ruby (selected)"
+      },
+      {
         "command": "codeQLDatabases.displaySwift",
         "title": "Swift"
+      },
+      {
+        "command": "codeQLDatabases.displaySwiftSelected",
+        "title": "Swift (selected)"
       },
       {
         "command": "codeQL.chooseDatabaseFolder",
@@ -1569,7 +1605,15 @@
           "when": "false"
         },
         {
+          "command": "codeQLDatabases.displayAllLanguagesSelected",
+          "when": "false"
+        },
+        {
           "command": "codeQLDatabases.displayCpp",
+          "when": "false"
+        },
+        {
+          "command": "codeQLDatabases.displayCppSelected",
           "when": "false"
         },
         {
@@ -1577,7 +1621,15 @@
           "when": "false"
         },
         {
+          "command": "codeQLDatabases.displayCsharpSelected",
+          "when": "false"
+        },
+        {
           "command": "codeQLDatabases.displayGo",
+          "when": "false"
+        },
+        {
+          "command": "codeQLDatabases.displayGoSelected",
           "when": "false"
         },
         {
@@ -1585,7 +1637,15 @@
           "when": "false"
         },
         {
+          "command": "codeQLDatabases.displayJavaSelected",
+          "when": "false"
+        },
+        {
           "command": "codeQLDatabases.displayJavascript",
+          "when": "false"
+        },
+        {
+          "command": "codeQLDatabases.displayJavascriptSelected",
           "when": "false"
         },
         {
@@ -1593,11 +1653,23 @@
           "when": "false"
         },
         {
+          "command": "codeQLDatabases.displayPythonSelected",
+          "when": "false"
+        },
+        {
           "command": "codeQLDatabases.displayRuby",
           "when": "false"
         },
         {
+          "command": "codeQLDatabases.displayRubySelected",
+          "when": "false"
+        },
+        {
           "command": "codeQLDatabases.displaySwift",
+          "when": "false"
+        },
+        {
+          "command": "codeQLDatabases.displaySwiftSelected",
           "when": "false"
         },
         {
@@ -1797,31 +1869,76 @@
       ],
       "codeQLDatabases.languages": [
         {
-          "command": "codeQLDatabases.displayAllLanguages"
+          "command": "codeQLDatabases.displayAllLanguages",
+          "when": "codeQLDatabases.languageFilter != All"
         },
         {
-          "command": "codeQLDatabases.displayCpp"
+          "command": "codeQLDatabases.displayAllLanguagesSelected",
+          "when": "codeQLDatabases.languageFilter == All"
         },
         {
-          "command": "codeQLDatabases.displayCsharp"
+          "command": "codeQLDatabases.displayCpp",
+          "when": "codeQLDatabases.languageFilter != cpp"
         },
         {
-          "command": "codeQLDatabases.displayGo"
+          "command": "codeQLDatabases.displayCppSelected",
+          "when": "codeQLDatabases.languageFilter == cpp"
         },
         {
-          "command": "codeQLDatabases.displayJava"
+          "command": "codeQLDatabases.displayCsharp",
+          "when": "codeQLDatabases.languageFilter != csharp"
         },
         {
-          "command": "codeQLDatabases.displayJavascript"
+          "command": "codeQLDatabases.displayCsharpSelected",
+          "when": "codeQLDatabases.languageFilter == csharp"
         },
         {
-          "command": "codeQLDatabases.displayPython"
+          "command": "codeQLDatabases.displayGo",
+          "when": "codeQLDatabases.languageFilter != go"
         },
         {
-          "command": "codeQLDatabases.displayRuby"
+          "command": "codeQLDatabases.displayGoSelected",
+          "when": "codeQLDatabases.languageFilter == go"
         },
         {
-          "command": "codeQLDatabases.displaySwift"
+          "command": "codeQLDatabases.displayJava",
+          "when": "codeQLDatabases.languageFilter != java"
+        },
+        {
+          "command": "codeQLDatabases.displayJavaSelected",
+          "when": "codeQLDatabases.languageFilter == java"
+        },
+        {
+          "command": "codeQLDatabases.displayJavascript",
+          "when": "codeQLDatabases.languageFilter != javascript"
+        },
+        {
+          "command": "codeQLDatabases.displayJavascriptSelected",
+          "when": "codeQLDatabases.languageFilter == javascript"
+        },
+        {
+          "command": "codeQLDatabases.displayPython",
+          "when": "codeQLDatabases.languageFilter != python"
+        },
+        {
+          "command": "codeQLDatabases.displayPythonSelected",
+          "when": "codeQLDatabases.languageFilter == python"
+        },
+        {
+          "command": "codeQLDatabases.displayRuby",
+          "when": "codeQLDatabases.languageFilter != ruby"
+        },
+        {
+          "command": "codeQLDatabases.displayRubySelected",
+          "when": "codeQLDatabases.languageFilter == ruby"
+        },
+        {
+          "command": "codeQLDatabases.displaySwift",
+          "when": "codeQLDatabases.languageFilter != swift"
+        },
+        {
+          "command": "codeQLDatabases.displaySwiftSelected",
+          "when": "codeQLDatabases.languageFilter == swift"
         }
       ]
     },

--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -228,6 +228,15 @@ export type LocalDatabasesCommands = {
   "codeQLDatabases.displayPython": () => Promise<void>;
   "codeQLDatabases.displayRuby": () => Promise<void>;
   "codeQLDatabases.displaySwift": () => Promise<void>;
+  "codeQLDatabases.displayAllLanguagesSelected": () => Promise<void>;
+  "codeQLDatabases.displayCppSelected": () => Promise<void>;
+  "codeQLDatabases.displayCsharpSelected": () => Promise<void>;
+  "codeQLDatabases.displayGoSelected": () => Promise<void>;
+  "codeQLDatabases.displayJavaSelected": () => Promise<void>;
+  "codeQLDatabases.displayJavascriptSelected": () => Promise<void>;
+  "codeQLDatabases.displayPythonSelected": () => Promise<void>;
+  "codeQLDatabases.displayRubySelected": () => Promise<void>;
+  "codeQLDatabases.displaySwiftSelected": () => Promise<void>;
 
   // Database panel context menu
   "codeQLDatabases.setCurrentDatabase": (

--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -60,7 +60,7 @@ enum SortOrder {
   DateAddedDesc = "DateAddedDesc",
 }
 
-type LanguageFilter = QueryLanguage | "all";
+type LanguageFilter = QueryLanguage | "All";
 
 /**
  * Tree data provider for the databases view.
@@ -70,7 +70,7 @@ class DatabaseTreeDataProvider
   implements TreeDataProvider<DatabaseItem>
 {
   private _sortOrder = SortOrder.NameAsc;
-  private _languageFilter = "all" as LanguageFilter;
+  private _languageFilter = "All" as LanguageFilter;
 
   private readonly _onDidChangeTreeData = this.push(
     new EventEmitter<DatabaseItem | undefined>(),
@@ -137,7 +137,7 @@ class DatabaseTreeDataProvider
     if (element === undefined) {
       // Filter items by language
       const displayItems = this.databaseManager.databaseItems.filter((item) => {
-        if (this.languageFilter === "all") {
+        if (this.languageFilter === "All") {
           return true;
         } else {
           return item.language === this.languageFilter;
@@ -269,7 +269,7 @@ export class DatabaseUI extends DisposableObject {
       "codeQLDatabases.sortByName": this.handleSortByName.bind(this),
       "codeQLDatabases.sortByDateAdded": this.handleSortByDateAdded.bind(this),
       "codeQLDatabases.displayAllLanguages":
-        this.handleChangeLanguageFilter.bind(this, "all"),
+        this.handleChangeLanguageFilter.bind(this, "All"),
       "codeQLDatabases.displayCpp": this.handleChangeLanguageFilter.bind(
         this,
         QueryLanguage.Cpp,
@@ -303,7 +303,7 @@ export class DatabaseUI extends DisposableObject {
         QueryLanguage.Swift,
       ),
       "codeQLDatabases.displayAllLanguagesSelected":
-        this.handleChangeLanguageFilter.bind(this, "all"),
+        this.handleChangeLanguageFilter.bind(this, "All"),
       "codeQLDatabases.displayCppSelected":
         this.handleChangeLanguageFilter.bind(this, QueryLanguage.Cpp),
       "codeQLDatabases.displayCsharpSelected":

--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -60,7 +60,7 @@ enum SortOrder {
   DateAddedDesc = "DateAddedDesc",
 }
 
-type LanguageFilter = QueryLanguage | "All";
+type LanguageFilter = QueryLanguage | "all";
 
 /**
  * Tree data provider for the databases view.
@@ -70,7 +70,7 @@ class DatabaseTreeDataProvider
   implements TreeDataProvider<DatabaseItem>
 {
   private _sortOrder = SortOrder.NameAsc;
-  private _languageFilter = "All" as LanguageFilter;
+  private _languageFilter = "all" as LanguageFilter;
 
   private readonly _onDidChangeTreeData = this.push(
     new EventEmitter<DatabaseItem | undefined>(),
@@ -137,7 +137,7 @@ class DatabaseTreeDataProvider
     if (element === undefined) {
       // Filter items by language
       const displayItems = this.databaseManager.databaseItems.filter((item) => {
-        if (this.languageFilter === "All") {
+        if (this.languageFilter === "all") {
           return true;
         } else {
           return item.language === this.languageFilter;
@@ -269,7 +269,7 @@ export class DatabaseUI extends DisposableObject {
       "codeQLDatabases.sortByName": this.handleSortByName.bind(this),
       "codeQLDatabases.sortByDateAdded": this.handleSortByDateAdded.bind(this),
       "codeQLDatabases.displayAllLanguages":
-        this.handleChangeLanguageFilter.bind(this, "All"),
+        this.handleChangeLanguageFilter.bind(this, "all"),
       "codeQLDatabases.displayCpp": this.handleChangeLanguageFilter.bind(
         this,
         QueryLanguage.Cpp,
@@ -303,7 +303,7 @@ export class DatabaseUI extends DisposableObject {
         QueryLanguage.Swift,
       ),
       "codeQLDatabases.displayAllLanguagesSelected":
-        this.handleChangeLanguageFilter.bind(this, "All"),
+        this.handleChangeLanguageFilter.bind(this, "all"),
       "codeQLDatabases.displayCppSelected":
         this.handleChangeLanguageFilter.bind(this, QueryLanguage.Cpp),
       "codeQLDatabases.displayCsharpSelected":

--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -302,6 +302,26 @@ export class DatabaseUI extends DisposableObject {
         this,
         QueryLanguage.Swift,
       ),
+      "codeQLDatabases.displayAllLanguagesSelected":
+        this.handleChangeLanguageFilter.bind(this, "All"),
+      "codeQLDatabases.displayCppSelected":
+        this.handleChangeLanguageFilter.bind(this, QueryLanguage.Cpp),
+      "codeQLDatabases.displayCsharpSelected":
+        this.handleChangeLanguageFilter.bind(this, QueryLanguage.CSharp),
+      "codeQLDatabases.displayGoSelected": this.handleChangeLanguageFilter.bind(
+        this,
+        QueryLanguage.Go,
+      ),
+      "codeQLDatabases.displayJavaSelected":
+        this.handleChangeLanguageFilter.bind(this, QueryLanguage.Java),
+      "codeQLDatabases.displayJavascriptSelected":
+        this.handleChangeLanguageFilter.bind(this, QueryLanguage.Javascript),
+      "codeQLDatabases.displayPythonSelected":
+        this.handleChangeLanguageFilter.bind(this, QueryLanguage.Python),
+      "codeQLDatabases.displayRubySelected":
+        this.handleChangeLanguageFilter.bind(this, QueryLanguage.Ruby),
+      "codeQLDatabases.displaySwiftSelected":
+        this.handleChangeLanguageFilter.bind(this, QueryLanguage.Swift),
       "codeQLDatabases.removeDatabase": createMultiSelectionCommand(
         this.handleRemoveDatabase.bind(this),
       ),
@@ -594,6 +614,11 @@ export class DatabaseUI extends DisposableObject {
 
   private async handleChangeLanguageFilter(languageFilter: LanguageFilter) {
     this.treeDataProvider.languageFilter = languageFilter;
+    await this.app.commands.execute(
+      "setContext",
+      "codeQLDatabases.languageFilter",
+      languageFilter,
+    );
   }
 
   private async handleUpgradeCurrentDatabase(): Promise<void> {


### PR DESCRIPTION
Adds `(selected)` after the selected language in the databases view:

https://github.com/github/vscode-codeql/assets/42641846/ef3545fa-195b-42ae-a5df-067249a78de4

There's no public VS Code API for properly selecting a menu item (https://github.com/microsoft/vscode/issues/109306), so adding a separate `...Selected` command was the closest workaround I could find 😢  See internal issue, where we discussed a bit more.

## Checklist

Still behind "canary", so no user-facing changes for now.

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
