### PR TITLE
Add language context store.

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1870,11 +1870,11 @@
       "codeQLDatabases.languages": [
         {
           "command": "codeQLDatabases.displayAllLanguages",
-          "when": "codeQLDatabases.languageFilter != All"
+          "when": "codeQLDatabases.languageFilter"
         },
         {
           "command": "codeQLDatabases.displayAllLanguagesSelected",
-          "when": "codeQLDatabases.languageFilter == All"
+          "when": "!codeQLDatabases.languageFilter"
         },
         {
           "command": "codeQLDatabases.displayCpp",

--- a/extensions/ql-vscode/src/common/query-language.ts
+++ b/extensions/ql-vscode/src/common/query-language.ts
@@ -62,3 +62,9 @@ export const dbSchemeToLanguage: Record<string, QueryLanguage> = {
 export function isQueryLanguage(language: string): language is QueryLanguage {
   return Object.values(QueryLanguage).includes(language as QueryLanguage);
 }
+
+export function tryGetQueryLanguage(
+  language: string,
+): QueryLanguage | undefined {
+  return isQueryLanguage(language) ? language : undefined;
+}

--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -607,21 +607,11 @@ export class DatabaseUI extends DisposableObject {
   }
 
   private async handleClearLanguageFilter() {
-    this.languageContext.clearLanguageContext();
-    await this.app.commands.execute(
-      "setContext",
-      "codeQLDatabases.languageFilter",
-      "All",
-    );
+    await this.languageContext.clearLanguageContext();
   }
 
   private async handleChangeLanguageFilter(languageFilter: QueryLanguage) {
-    this.languageContext.setLanguageContext(languageFilter);
-    await this.app.commands.execute(
-      "setContext",
-      "codeQLDatabases.languageFilter",
-      languageFilter,
-    );
+    await this.languageContext.setLanguageContext(languageFilter);
   }
 
   private async handleUpgradeCurrentDatabase(): Promise<void> {

--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -51,7 +51,7 @@ import {
   createMultiSelectionCommand,
   createSingleSelectionCommand,
 } from "../common/vscode/selection-commands";
-import { QueryLanguage } from "../common/query-language";
+import { QueryLanguage, tryGetQueryLanguage } from "../common/query-language";
 import { LanguageContextStore } from "../language-context-store";
 
 enum SortOrder {
@@ -143,7 +143,9 @@ class DatabaseTreeDataProvider
     if (element === undefined) {
       // Filter items by language
       const displayItems = this.databaseManager.databaseItems.filter((item) => {
-        return this.languageContext.shouldInclude(item.language);
+        return this.languageContext.shouldInclude(
+          tryGetQueryLanguage(item.language),
+        );
       });
 
       // Sort items

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -135,6 +135,7 @@ import { TestManagerBase } from "./query-testing/test-manager-base";
 import { NewQueryRunner, QueryRunner, QueryServerClient } from "./query-server";
 import { QueriesModule } from "./queries-panel/queries-module";
 import { OpenReferencedFileCodeLensProvider } from "./local-queries/open-referenced-file-code-lens-provider";
+import { LanguageContextStore } from "./language-context-store";
 
 /**
  * extension.ts
@@ -774,10 +775,15 @@ async function activateWithInstalledDistribution(
   void dbm.loadPersistedState();
 
   ctx.subscriptions.push(dbm);
+
+  void extLogger.log("Initializing language context.");
+  const languageContext = new LanguageContextStore(app);
+
   void extLogger.log("Initializing database panel.");
   const databaseUI = new DatabaseUI(
     app,
     dbm,
+    languageContext,
     qs,
     getContextStoragePath(ctx),
     ctx.extensionPath,

--- a/extensions/ql-vscode/src/language-context-store.ts
+++ b/extensions/ql-vscode/src/language-context-store.ts
@@ -33,7 +33,10 @@ export class LanguageContextStore extends DisposableObject {
     this.onLanguageContextChangedEmitter.fire();
   }
 
-  // TODO: comment on why string is used here
+  // This method takes a string to allow it to be used in cases
+  // where the language is not always a known one.
+  // The semantics of such an unknown langauge is that it is
+  // only included if the current language context is "All".
   public shouldInclude(language: string): boolean {
     return this.state === "All" || this.state === language;
   }

--- a/extensions/ql-vscode/src/language-context-store.ts
+++ b/extensions/ql-vscode/src/language-context-store.ts
@@ -43,11 +43,7 @@ export class LanguageContextStore extends DisposableObject {
     );
   }
 
-  // This method takes a string to allow it to be used in cases
-  // where the language is not always a known one.
-  // The semantics of such an unknown langauge is that it is
-  // only included if the current language context is "All".
-  public shouldInclude(language: string): boolean {
+  public shouldInclude(language: QueryLanguage | undefined): boolean {
     return this.languageFilter === "All" || this.languageFilter === language;
   }
 }

--- a/extensions/ql-vscode/src/language-context-store.ts
+++ b/extensions/ql-vscode/src/language-context-store.ts
@@ -1,0 +1,40 @@
+import { App } from "./common/app";
+import { DisposableObject } from "./common/disposable-object";
+import { AppEvent, AppEventEmitter } from "./common/events";
+import { QueryLanguage } from "./common/query-language";
+
+type LanguageFilter = QueryLanguage | "All";
+
+export class LanguageContextStore extends DisposableObject {
+  public readonly onLanguageContextChanged: AppEvent<void>;
+  private readonly onLanguageContextChangedEmitter: AppEventEmitter<void>;
+
+  private state: LanguageFilter;
+
+  constructor(app: App) {
+    super();
+    // State initialization
+    this.state = "All";
+
+    // Set up event emitters
+    this.onLanguageContextChangedEmitter = this.push(
+      app.createEventEmitter<void>(),
+    );
+    this.onLanguageContextChanged = this.onLanguageContextChangedEmitter.event;
+  }
+
+  public clearLanguageContext() {
+    this.state = "All";
+    this.onLanguageContextChangedEmitter.fire();
+  }
+
+  public setLanguageContext(language: QueryLanguage) {
+    this.state = language;
+    this.onLanguageContextChangedEmitter.fire();
+  }
+
+  // TODO: comment on why string is used here
+  public shouldInclude(language: string): boolean {
+    return this.state === "All" || this.state === language;
+  }
+}

--- a/extensions/ql-vscode/src/language-context-store.ts
+++ b/extensions/ql-vscode/src/language-context-store.ts
@@ -11,7 +11,7 @@ export class LanguageContextStore extends DisposableObject {
 
   private state: LanguageFilter;
 
-  constructor(app: App) {
+  constructor(private readonly app: App) {
     super();
     // State initialization
     this.state = "All";
@@ -23,14 +23,24 @@ export class LanguageContextStore extends DisposableObject {
     this.onLanguageContextChanged = this.onLanguageContextChangedEmitter.event;
   }
 
-  public clearLanguageContext() {
+  public async clearLanguageContext() {
     this.state = "All";
     this.onLanguageContextChangedEmitter.fire();
+    await this.app.commands.execute(
+      "setContext",
+      "codeQLDatabases.languageFilter",
+      "",
+    );
   }
 
-  public setLanguageContext(language: QueryLanguage) {
+  public async setLanguageContext(language: QueryLanguage) {
     this.state = language;
     this.onLanguageContextChangedEmitter.fire();
+    await this.app.commands.execute(
+      "setContext",
+      "codeQLDatabases.languageFilter",
+      language,
+    );
   }
 
   // This method takes a string to allow it to be used in cases

--- a/extensions/ql-vscode/src/language-context-store.ts
+++ b/extensions/ql-vscode/src/language-context-store.ts
@@ -9,12 +9,12 @@ export class LanguageContextStore extends DisposableObject {
   public readonly onLanguageContextChanged: AppEvent<void>;
   private readonly onLanguageContextChangedEmitter: AppEventEmitter<void>;
 
-  private state: LanguageFilter;
+  private languageFilter: LanguageFilter;
 
   constructor(private readonly app: App) {
     super();
     // State initialization
-    this.state = "All";
+    this.languageFilter = "All";
 
     // Set up event emitters
     this.onLanguageContextChangedEmitter = this.push(
@@ -24,7 +24,7 @@ export class LanguageContextStore extends DisposableObject {
   }
 
   public async clearLanguageContext() {
-    this.state = "All";
+    this.languageFilter = "All";
     this.onLanguageContextChangedEmitter.fire();
     await this.app.commands.execute(
       "setContext",
@@ -34,7 +34,7 @@ export class LanguageContextStore extends DisposableObject {
   }
 
   public async setLanguageContext(language: QueryLanguage) {
-    this.state = language;
+    this.languageFilter = language;
     this.onLanguageContextChangedEmitter.fire();
     await this.app.commands.execute(
       "setContext",
@@ -48,6 +48,6 @@ export class LanguageContextStore extends DisposableObject {
   // The semantics of such an unknown langauge is that it is
   // only included if the current language context is "All".
   public shouldInclude(language: string): boolean {
-    return this.state === "All" || this.state === language;
+    return this.languageFilter === "All" || this.languageFilter === language;
   }
 }

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/databases/local-databases-ui.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/databases/local-databases-ui.test.ts
@@ -99,6 +99,11 @@ describe("local-databases-ui", () => {
           /**/
         },
       } as any,
+      {
+        onLanguageContextChanged: () => {
+          /**/
+        },
+      } as any,
       {} as any,
       storageDir,
       storageDir,


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

This adds an explicit store to contain the Language filter state outside of the databases panel. It is based on `modeling-store.ts`.

There are two points that are somewhat interesting:
- We encapsulated the LanguageState inside the store, so that the users do not need to know how "All" is implemented. This might not be needed or sufficient in the future, but for now it seemed pretty nice to do.
- The `shouldInclude` method takes a string which is asymmetric with with the `setLanguageContext`. This is because we actually check with an arbitrary string (because that is what the database item has). I wonder if there is a better way to do this.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
