### PR TITLE
Add modeling indicator to method usages panel

### DIFF
--- a/extensions/ql-vscode/src/model-editor/modeling-store.ts
+++ b/extensions/ql-vscode/src/model-editor/modeling-store.ts
@@ -158,7 +158,7 @@ export class ModelingStore extends DisposableObject {
     const dbState = this.getState(dbItem);
     const dbUri = dbItem.databaseUri.toString();
 
-    dbState.methods = methods;
+    dbState.methods = [...methods];
 
     this.onMethodsChangedEventEmitter.fire({
       methods,
@@ -204,13 +204,15 @@ export class ModelingStore extends DisposableObject {
     methods: Record<string, ModeledMethod>,
   ) {
     this.changeModeledMethods(dbItem, (state) => {
-      state.modeledMethods = methods;
+      state.modeledMethods = { ...methods };
     });
   }
 
   public updateModeledMethod(dbItem: DatabaseItem, method: ModeledMethod) {
     this.changeModeledMethods(dbItem, (state) => {
-      state.modeledMethods[method.signature] = method;
+      const newModeledMethods = { ...state.modeledMethods };
+      newModeledMethods[method.signature] = method;
+      state.modeledMethods = newModeledMethods;
     });
   }
 
@@ -219,7 +221,7 @@ export class ModelingStore extends DisposableObject {
     methodSignatures: Set<string>,
   ) {
     this.changeModifiedMethods(dbItem, (state) => {
-      state.modifiedMethodSignatures = methodSignatures;
+      state.modifiedMethodSignatures = new Set(methodSignatures);
     });
   }
 
@@ -228,9 +230,11 @@ export class ModelingStore extends DisposableObject {
     methodSignatures: Iterable<string>,
   ) {
     this.changeModifiedMethods(dbItem, (state) => {
-      for (const signature of methodSignatures) {
-        state.modifiedMethodSignatures.add(signature);
-      }
+      const newModifiedMethods = new Set([
+        ...state.modifiedMethodSignatures,
+        ...methodSignatures,
+      ]);
+      state.modifiedMethodSignatures = newModifiedMethods;
     });
   }
 
@@ -243,9 +247,11 @@ export class ModelingStore extends DisposableObject {
     methodSignatures: string[],
   ) {
     this.changeModifiedMethods(dbItem, (state) => {
-      methodSignatures.forEach((signature) => {
-        state.modifiedMethodSignatures.delete(signature);
-      });
+      const newModifiedMethods = Array.from(
+        state.modifiedMethodSignatures,
+      ).filter((s) => !methodSignatures.includes(s));
+
+      state.modifiedMethodSignatures = new Set(newModifiedMethods);
     });
   }
 

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/methods-usage/methods-usage-data-provider.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/methods-usage/methods-usage-data-provider.test.ts
@@ -7,6 +7,7 @@ import {
   createUsage,
 } from "../../../../factories/model-editor/method-factories";
 import { mockedObject } from "../../../utils/mocking.helpers";
+import { ModeledMethod } from "../../../../../src/model-editor/modeled-method";
 
 describe("MethodsUsageDataProvider", () => {
   const mockCliServer = mockedObject<CodeQLCliServer>({});
@@ -19,17 +20,31 @@ describe("MethodsUsageDataProvider", () => {
   describe("setState", () => {
     const hideModeledMethods = false;
     const methods: Method[] = [];
+    const modeledMethods: Record<string, ModeledMethod> = {};
+    const modifiedMethodSignatures: Set<string> = new Set();
     const dbItem = mockedObject<DatabaseItem>({
       getSourceLocationPrefix: () => "test",
     });
 
     it("should not emit onDidChangeTreeData event when state has not changed", async () => {
-      await dataProvider.setState(methods, dbItem, hideModeledMethods);
+      await dataProvider.setState(
+        methods,
+        dbItem,
+        hideModeledMethods,
+        modeledMethods,
+        modifiedMethodSignatures,
+      );
 
       const onDidChangeTreeDataListener = jest.fn();
       dataProvider.onDidChangeTreeData(onDidChangeTreeDataListener);
 
-      await dataProvider.setState(methods, dbItem, hideModeledMethods);
+      await dataProvider.setState(
+        methods,
+        dbItem,
+        hideModeledMethods,
+        modeledMethods,
+        modifiedMethodSignatures,
+      );
 
       expect(onDidChangeTreeDataListener).not.toHaveBeenCalled();
     });
@@ -37,12 +52,24 @@ describe("MethodsUsageDataProvider", () => {
     it("should emit onDidChangeTreeData event when methods has changed", async () => {
       const methods2: Method[] = [];
 
-      await dataProvider.setState(methods, dbItem, hideModeledMethods);
+      await dataProvider.setState(
+        methods,
+        dbItem,
+        hideModeledMethods,
+        modeledMethods,
+        modifiedMethodSignatures,
+      );
 
       const onDidChangeTreeDataListener = jest.fn();
       dataProvider.onDidChangeTreeData(onDidChangeTreeDataListener);
 
-      await dataProvider.setState(methods2, dbItem, hideModeledMethods);
+      await dataProvider.setState(
+        methods2,
+        dbItem,
+        hideModeledMethods,
+        modeledMethods,
+        modifiedMethodSignatures,
+      );
 
       expect(onDidChangeTreeDataListener).toHaveBeenCalledTimes(1);
     });
@@ -52,23 +79,97 @@ describe("MethodsUsageDataProvider", () => {
         getSourceLocationPrefix: () => "test",
       });
 
-      await dataProvider.setState(methods, dbItem, hideModeledMethods);
+      await dataProvider.setState(
+        methods,
+        dbItem,
+        hideModeledMethods,
+        modeledMethods,
+        modifiedMethodSignatures,
+      );
 
       const onDidChangeTreeDataListener = jest.fn();
       dataProvider.onDidChangeTreeData(onDidChangeTreeDataListener);
 
-      await dataProvider.setState(methods, dbItem2, hideModeledMethods);
+      await dataProvider.setState(
+        methods,
+        dbItem2,
+        hideModeledMethods,
+        modeledMethods,
+        modifiedMethodSignatures,
+      );
 
       expect(onDidChangeTreeDataListener).toHaveBeenCalledTimes(1);
     });
 
     it("should emit onDidChangeTreeData event when hideModeledMethods has changed", async () => {
-      await dataProvider.setState(methods, dbItem, hideModeledMethods);
+      await dataProvider.setState(
+        methods,
+        dbItem,
+        hideModeledMethods,
+        modeledMethods,
+        modifiedMethodSignatures,
+      );
 
       const onDidChangeTreeDataListener = jest.fn();
       dataProvider.onDidChangeTreeData(onDidChangeTreeDataListener);
 
-      await dataProvider.setState(methods, dbItem, !hideModeledMethods);
+      await dataProvider.setState(
+        methods,
+        dbItem,
+        !hideModeledMethods,
+        modeledMethods,
+        modifiedMethodSignatures,
+      );
+
+      expect(onDidChangeTreeDataListener).toHaveBeenCalledTimes(1);
+    });
+
+    it("should emit onDidChangeTreeData event when modeled methods has changed", async () => {
+      const modeledMethods2: Record<string, ModeledMethod> = {};
+
+      await dataProvider.setState(
+        methods,
+        dbItem,
+        hideModeledMethods,
+        modeledMethods,
+        modifiedMethodSignatures,
+      );
+
+      const onDidChangeTreeDataListener = jest.fn();
+      dataProvider.onDidChangeTreeData(onDidChangeTreeDataListener);
+
+      await dataProvider.setState(
+        methods,
+        dbItem,
+        hideModeledMethods,
+        modeledMethods2,
+        modifiedMethodSignatures,
+      );
+
+      expect(onDidChangeTreeDataListener).toHaveBeenCalledTimes(1);
+    });
+
+    it("should emit onDidChangeTreeData event when modified method signatures has changed", async () => {
+      const modifiedMethodSignatures2: Set<string> = new Set();
+
+      await dataProvider.setState(
+        methods,
+        dbItem,
+        hideModeledMethods,
+        modeledMethods,
+        modifiedMethodSignatures,
+      );
+
+      const onDidChangeTreeDataListener = jest.fn();
+      dataProvider.onDidChangeTreeData(onDidChangeTreeDataListener);
+
+      await dataProvider.setState(
+        methods,
+        dbItem,
+        hideModeledMethods,
+        modeledMethods,
+        modifiedMethodSignatures2,
+      );
 
       expect(onDidChangeTreeDataListener).toHaveBeenCalledTimes(1);
     });
@@ -79,12 +180,24 @@ describe("MethodsUsageDataProvider", () => {
       });
       const methods2: Method[] = [];
 
-      await dataProvider.setState(methods, dbItem, hideModeledMethods);
+      await dataProvider.setState(
+        methods,
+        dbItem,
+        hideModeledMethods,
+        modeledMethods,
+        modifiedMethodSignatures,
+      );
 
       const onDidChangeTreeDataListener = jest.fn();
       dataProvider.onDidChangeTreeData(onDidChangeTreeDataListener);
 
-      await dataProvider.setState(methods2, dbItem2, !hideModeledMethods);
+      await dataProvider.setState(
+        methods2,
+        dbItem2,
+        !hideModeledMethods,
+        modeledMethods,
+        modifiedMethodSignatures,
+      );
 
       expect(onDidChangeTreeDataListener).toHaveBeenCalledTimes(1);
     });
@@ -100,6 +213,9 @@ describe("MethodsUsageDataProvider", () => {
     });
 
     const methods: Method[] = [supportedMethod, unsupportedMethod];
+    const modeledMethods: Record<string, ModeledMethod> = {};
+    const modifiedMethodSignatures: Set<string> = new Set();
+
     const dbItem = mockedObject<DatabaseItem>({
       getSourceLocationPrefix: () => "test",
     });
@@ -117,13 +233,25 @@ describe("MethodsUsageDataProvider", () => {
 
     it("should show all methods if hideModeledMethods is false and looking at the root", async () => {
       const hideModeledMethods = false;
-      await dataProvider.setState(methods, dbItem, hideModeledMethods);
+      await dataProvider.setState(
+        methods,
+        dbItem,
+        hideModeledMethods,
+        modeledMethods,
+        modifiedMethodSignatures,
+      );
       expect(dataProvider.getChildren().length).toEqual(2);
     });
 
     it("should filter methods if hideModeledMethods is true and looking at the root", async () => {
       const hideModeledMethods = true;
-      await dataProvider.setState(methods, dbItem, hideModeledMethods);
+      await dataProvider.setState(
+        methods,
+        dbItem,
+        hideModeledMethods,
+        modeledMethods,
+        modifiedMethodSignatures,
+      );
       expect(dataProvider.getChildren().length).toEqual(1);
     });
   });

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/methods-usage/methods-usage-panel.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/methods-usage/methods-usage-panel.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../../../../factories/model-editor/method-factories";
 import { ModelingStore } from "../../../../../src/model-editor/modeling-store";
 import { createMockModelingStore } from "../../../../__mocks__/model-editor/modelingStoreMock";
+import { ModeledMethod } from "../../../../../src/model-editor/modeled-method";
 
 describe("MethodsUsagePanel", () => {
   const mockCliServer = mockedObject<CodeQLCliServer>({});
@@ -20,6 +21,8 @@ describe("MethodsUsagePanel", () => {
   describe("setState", () => {
     const hideModeledMethods = false;
     const methods: Method[] = [createMethod()];
+    const modeledMethods: Record<string, ModeledMethod> = {};
+    const modifiedMethodSignatures: Set<string> = new Set();
 
     it("should update the tree view with the correct batch number", async () => {
       const mockTreeView = {
@@ -30,7 +33,13 @@ describe("MethodsUsagePanel", () => {
       const modelingStore = createMockModelingStore();
 
       const panel = new MethodsUsagePanel(modelingStore, mockCliServer);
-      await panel.setState(methods, dbItem, hideModeledMethods);
+      await panel.setState(
+        methods,
+        dbItem,
+        hideModeledMethods,
+        modeledMethods,
+        modifiedMethodSignatures,
+      );
 
       expect(mockTreeView.badge?.value).toBe(1);
     });
@@ -41,6 +50,8 @@ describe("MethodsUsagePanel", () => {
     let modelingStore: ModelingStore;
 
     const hideModeledMethods: boolean = false;
+    const modeledMethods: Record<string, ModeledMethod> = {};
+    const modifiedMethodSignatures: Set<string> = new Set();
     const usage = createUsage();
 
     beforeEach(() => {
@@ -60,7 +71,13 @@ describe("MethodsUsagePanel", () => {
       ];
 
       const panel = new MethodsUsagePanel(modelingStore, mockCliServer);
-      await panel.setState(methods, dbItem, hideModeledMethods);
+      await panel.setState(
+        methods,
+        dbItem,
+        hideModeledMethods,
+        modeledMethods,
+        modifiedMethodSignatures,
+      );
 
       await panel.revealItem(usage);
 
@@ -70,7 +87,13 @@ describe("MethodsUsagePanel", () => {
     it("should do nothing if usage cannot be found", async () => {
       const methods = [createMethod({})];
       const panel = new MethodsUsagePanel(modelingStore, mockCliServer);
-      await panel.setState(methods, dbItem, hideModeledMethods);
+      await panel.setState(
+        methods,
+        dbItem,
+        hideModeledMethods,
+        modeledMethods,
+        modifiedMethodSignatures,
+      );
 
       await panel.revealItem(usage);
 


### PR DESCRIPTION
Show modeling status in the method usages panel. See exact spec in the internal linked issue. 

<img width="518" alt="image" src="https://github.com/github/vscode-codeql/assets/311693/2e7e2d1f-606c-481e-9e70-50c4a2da6ff2">

As part of this I updated modeling store functions to make sure new objects are created when changing the top level properties of the state object. This allows us to continue using object equality to check if updates to the usages panel should happen.

## Checklist

N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
