### PR TITLE
Hide the language filter behind an extra flag

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1077,7 +1077,7 @@
         },
         {
           "submenu": "codeQLDatabases.languages",
-          "when": "view == codeQLDatabases && config.codeQL.canary",
+          "when": "view == codeQLDatabases && config.codeQL.canary && config.codeQL.showLanguageFilter",
           "group": "2_databases@0"
         },
         {


### PR DESCRIPTION
Since we're reconsidering the design, let's hide the language filter even more, before it makes it into a release.

For development purposes, you can add `"codeQL.showLanguageFilter": true` to your settings to un-hide the language filter menu (FYI @starcke).

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
