### PR TITLE
Dispose event subscriptions in method modeling view

### DIFF
--- a/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
+++ b/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
@@ -116,38 +116,44 @@ export class MethodModelingViewProvider
   }
 
   private registerToModelingStoreEvents(): void {
-    this.modelingStore.onModeledMethodsChanged(async (e) => {
-      if (this.webviewView && e.isActiveDb) {
-        const modeledMethod = e.modeledMethods[this.method?.signature ?? ""];
-        if (modeledMethod) {
+    this.push(
+      this.modelingStore.onModeledMethodsChanged(async (e) => {
+        if (this.webviewView && e.isActiveDb) {
+          const modeledMethod = e.modeledMethods[this.method?.signature ?? ""];
+          if (modeledMethod) {
+            await this.webviewView.webview.postMessage({
+              t: "setModeledMethod",
+              method: modeledMethod,
+            });
+          }
+        }
+      }),
+    );
+
+    this.push(
+      this.modelingStore.onModifiedMethodsChanged(async (e) => {
+        if (this.webviewView && e.isActiveDb && this.method) {
+          const isModified = e.modifiedMethods.has(this.method.signature);
           await this.webviewView.webview.postMessage({
-            t: "setModeledMethod",
-            method: modeledMethod,
+            t: "setMethodModified",
+            isModified,
           });
         }
-      }
-    });
+      }),
+    );
 
-    this.modelingStore.onModifiedMethodsChanged(async (e) => {
-      if (this.webviewView && e.isActiveDb && this.method) {
-        const isModified = e.modifiedMethods.has(this.method.signature);
-        await this.webviewView.webview.postMessage({
-          t: "setMethodModified",
-          isModified,
-        });
-      }
-    });
-
-    this.modelingStore.onSelectedMethodChanged(async (e) => {
-      if (this.webviewView) {
-        this.method = e.method;
-        await this.webviewView.webview.postMessage({
-          t: "setSelectedMethod",
-          method: e.method,
-          modeledMethod: e.modeledMethod,
-          isModified: e.isModified,
-        });
-      }
-    });
+    this.push(
+      this.modelingStore.onSelectedMethodChanged(async (e) => {
+        if (this.webviewView) {
+          this.method = e.method;
+          await this.webviewView.webview.postMessage({
+            t: "setSelectedMethod",
+            method: e.method,
+            modeledMethod: e.modeledMethod,
+            isModified: e.isModified,
+          });
+        }
+      }),
+    );
   }
 }


### PR DESCRIPTION
Now that the view provider is disposable, we can make sure we dispose of event subscriptions. 

I suggest using "Hide whitespace" in the diff for easy of review.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
