### PR TITLE
Avoid double restarts of the query server

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [UNRELEASED]
 
+- Fix a bug where the query server was restarted twice after configuration changes. [#2884](https://github.com/github/vscode-codeql/pull/2884).
+
 ## 1.9.0 - 19 September 2023
 
 - Release the [CodeQL model editor](https://codeql.github.com/docs/codeql/codeql-for-visual-studio-code/using-the-codeql-model-editor) to create CodeQL model packs for Java frameworks. Open the editor using the "CodeQL: Open CodeQL Model Editor (Beta)" command. [#2823](https://github.com/github/vscode-codeql/pull/2823)

--- a/extensions/ql-vscode/src/query-server/server-process.ts
+++ b/extensions/ql-vscode/src/query-server/server-process.ts
@@ -26,6 +26,7 @@ export class ServerProcess implements Disposable {
     this.connection.end();
     this.child.stdin!.end();
     this.child.stderr!.destroy();
+    this.child.removeAllListeners();
     // TODO kill the process if it doesn't terminate after a certain time limit.
 
     // On Windows, we usually have to terminate the process before closing its stdout.


### PR DESCRIPTION
Previously, if there was an explicit restart of the query server (eg- by changing a configuration setting), then the query server process would be started twice: once by the `close` handler and once by the restart command.

By adding the `removeAllListeners` to the dispose method, we ensure that when the query server shuts down gracefully, there won't be a `close` listener that is going to restart it a second time if there is a different way of restarting it.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Replace this with a description of the changes your pull request makes.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
