### PR TITLE
Apply language context to queries panel

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -790,7 +790,7 @@ async function activateWithInstalledDistribution(
   );
   ctx.subscriptions.push(databaseUI);
 
-  QueriesModule.initialize(app, cliServer);
+  QueriesModule.initialize(app, languageContext, cliServer);
 
   void extLogger.log("Initializing evaluator log viewer.");
   const evalLogViewer = new EvalLogViewer();

--- a/extensions/ql-vscode/src/queries-panel/queries-module.ts
+++ b/extensions/ql-vscode/src/queries-panel/queries-module.ts
@@ -6,6 +6,7 @@ import { DisposableObject } from "../common/disposable-object";
 import { QueriesPanel } from "./queries-panel";
 import { QueryDiscovery } from "./query-discovery";
 import { QueryPackDiscovery } from "./query-pack-discovery";
+import { LanguageContextStore } from "../language-context-store";
 
 export class QueriesModule extends DisposableObject {
   private queriesPanel: QueriesPanel | undefined;
@@ -16,16 +17,21 @@ export class QueriesModule extends DisposableObject {
 
   public static initialize(
     app: App,
+    languageContext: LanguageContextStore,
     cliServer: CodeQLCliServer,
   ): QueriesModule {
     const queriesModule = new QueriesModule(app);
     app.subscriptions.push(queriesModule);
 
-    queriesModule.initialize(app, cliServer);
+    queriesModule.initialize(app, languageContext, cliServer);
     return queriesModule;
   }
 
-  private initialize(app: App, cliServer: CodeQLCliServer): void {
+  private initialize(
+    app: App,
+    langauageContext: LanguageContextStore,
+    cliServer: CodeQLCliServer,
+  ): void {
     // Currently, we only want to expose the new panel when we are in canary mode
     // and the user has enabled the "Show queries panel" flag.
     if (!isCanary() || !showQueriesPanel()) {
@@ -38,8 +44,9 @@ export class QueriesModule extends DisposableObject {
     void queryPackDiscovery.initialRefresh();
 
     const queryDiscovery = new QueryDiscovery(
-      app.environment,
+      app,
       queryPackDiscovery,
+      langauageContext,
     );
     this.push(queryDiscovery);
     void queryDiscovery.initialRefresh();

--- a/extensions/ql-vscode/test/__mocks__/appMock.ts
+++ b/extensions/ql-vscode/test/__mocks__/appMock.ts
@@ -56,7 +56,7 @@ class MockAppEventEmitter<T> implements AppEventEmitter<T> {
 
   constructor() {
     this.event = () => {
-      return {} as Disposable;
+      return new MockAppEvent();
     };
   }
 
@@ -69,7 +69,17 @@ class MockAppEventEmitter<T> implements AppEventEmitter<T> {
   }
 }
 
-export function createMockEnvironmentContext(): EnvironmentContext {
+class MockAppEvent implements Disposable {
+  public fire(): void {
+    // no-op
+  }
+
+  public dispose() {
+    // no-op
+  }
+}
+
+function createMockEnvironmentContext(): EnvironmentContext {
   return {
     language: "en-US",
   };


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->



This adds language filtering to the queries panel. Adding the filtering was trivial, however there were a few other tweaks I had to make.


1. Previously we made `onDidChangeQueries` the same as `onDidChangePathData`. However if we integrated with that it would require a full rescan of the file system to apply a filter which felt quite slow for me. Instead we create a specific emitter for `onDidChangeQueries` which is triggered by either the filesystem changing or the filter changing.
2. Initially my tests failed when trying to dispose `this.languageContext.onLanguageContextChanged`. This was because the MockApp created a MockEventEmitter which returned `{}` as disposable. However `{}` is actually not disposable (because it lacks the method). So I changed it to return something that is actually disposable.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
