### PR TITLE
Add language to local query history items

### DIFF
--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -21,6 +21,7 @@ import { Method, Usage } from "../model-editor/method";
 import { ModeledMethod } from "../model-editor/modeled-method";
 import { ModelEditorViewState } from "../model-editor/shared/view-state";
 import { Mode } from "../model-editor/shared/mode";
+import { QueryLanguage } from "./query-language";
 
 /**
  * This module contains types and code that are shared between
@@ -51,6 +52,7 @@ export const RAW_RESULTS_LIMIT = 10000;
 export interface DatabaseInfo {
   name: string;
   databaseUri: string;
+  language?: QueryLanguage;
 }
 
 /** Arbitrary query metadata */

--- a/extensions/ql-vscode/src/local-queries/local-queries.ts
+++ b/extensions/ql-vscode/src/local-queries/local-queries.ts
@@ -49,6 +49,7 @@ import { LocalQueryRun } from "./local-query-run";
 import { createMultiSelectionCommand } from "../common/vscode/selection-commands";
 import { findLanguage } from "../codeql-cli/query-language";
 import type { QueryTreeViewItem } from "../queries-panel/query-tree-view-item";
+import { tryGetQueryLanguage } from "../common/query-language";
 
 interface DatabaseQuickPickItem extends QuickPickItem {
   databaseItem: DatabaseItem;
@@ -364,6 +365,7 @@ export class LocalQueries extends DisposableObject {
     const initialInfo = await createInitialQueryInfo(selectedQuery, {
       databaseUri: dbItem.databaseUri.toString(),
       name: dbItem.name,
+      language: tryGetQueryLanguage(dbItem.language),
     });
 
     // When cancellation is requested from the query history view, we just stop the debug session.

--- a/extensions/ql-vscode/src/query-history/history-item-label-provider.ts
+++ b/extensions/ql-vscode/src/query-history/history-item-label-provider.ts
@@ -4,6 +4,7 @@ import { QueryHistoryConfig } from "../config";
 import { LocalQueryInfo } from "../query-results";
 import {
   buildRepoLabel,
+  getLanguage,
   getRawQueryName,
   QueryHistoryInfo,
 } from "./query-history-info";
@@ -19,6 +20,7 @@ interface InterpolateReplacements {
   r: string; // Result count/Empty
   s: string; // Status
   f: string; // Query file name
+  l: string; // Query language
   "%": "%"; // Percent sign
 }
 
@@ -84,6 +86,7 @@ export class HistoryItemLabelProvider {
       r: `(${resultCount} results)`,
       s: statusString,
       f: item.getQueryFileName(),
+      l: this.getLanguageLabel(item),
       "%": "%",
     };
   }
@@ -103,7 +106,13 @@ export class HistoryItemLabelProvider {
       r: resultCount,
       s: humanizeQueryStatus(item.status),
       f: basename(item.variantAnalysis.query.filePath),
+      l: this.getLanguageLabel(item),
       "%": "%",
     };
+  }
+
+  private getLanguageLabel(item: QueryHistoryInfo): string {
+    const language = getLanguage(item);
+    return language === undefined ? "unknown" : `${language}`;
   }
 }

--- a/extensions/ql-vscode/src/query-history/query-history-info.ts
+++ b/extensions/ql-vscode/src/query-history/query-history-info.ts
@@ -6,6 +6,7 @@ import {
   hasRepoScanCompleted,
   getActionsWorkflowRunUrl as getVariantAnalysisActionsWorkflowRunUrl,
 } from "../variant-analysis/shared/variant-analysis";
+import { QueryLanguage } from "../common/query-language";
 
 export type QueryHistoryInfo = LocalQueryInfo | VariantAnalysisHistoryItem;
 
@@ -44,6 +45,17 @@ export function getQueryText(item: QueryHistoryInfo): string {
       return item.initialInfo.queryText;
     case "variant-analysis":
       return item.variantAnalysis.query.text;
+    default:
+      assertNever(item);
+  }
+}
+
+export function getLanguage(item: QueryHistoryInfo): QueryLanguage | undefined {
+  switch (item.t) {
+    case "local":
+      return item.initialInfo.databaseInfo.language;
+    case "variant-analysis":
+      return item.variantAnalysis.query.language;
     default:
       assertNever(item);
   }

--- a/extensions/ql-vscode/src/query-history/store/query-history-domain-mapper.ts
+++ b/extensions/ql-vscode/src/query-history/store/query-history-domain-mapper.ts
@@ -1,8 +1,9 @@
 import { assertNever } from "../../common/helpers-pure";
 import { QueryHistoryInfo } from "../query-history-info";
 import { mapLocalQueryInfoToDto } from "./query-history-local-query-domain-mapper";
-import { QueryHistoryItemDto } from "./query-history-dto";
+import { QueryHistoryItemDto, QueryLanguageDto } from "./query-history-dto";
 import { mapQueryHistoryVariantAnalysisToDto } from "./query-history-variant-analysis-domain-mapper";
+import { QueryLanguage } from "../../common/query-language";
 
 export function mapQueryHistoryToDto(
   queries: QueryHistoryInfo[],
@@ -16,4 +17,29 @@ export function mapQueryHistoryToDto(
       assertNever(q);
     }
   });
+}
+
+export function mapQueryLanguageToDto(
+  language: QueryLanguage,
+): QueryLanguageDto {
+  switch (language) {
+    case QueryLanguage.CSharp:
+      return QueryLanguageDto.CSharp;
+    case QueryLanguage.Cpp:
+      return QueryLanguageDto.Cpp;
+    case QueryLanguage.Go:
+      return QueryLanguageDto.Go;
+    case QueryLanguage.Java:
+      return QueryLanguageDto.Java;
+    case QueryLanguage.Javascript:
+      return QueryLanguageDto.Javascript;
+    case QueryLanguage.Python:
+      return QueryLanguageDto.Python;
+    case QueryLanguage.Ruby:
+      return QueryLanguageDto.Ruby;
+    case QueryLanguage.Swift:
+      return QueryLanguageDto.Swift;
+    default:
+      assertNever(language);
+  }
 }

--- a/extensions/ql-vscode/src/query-history/store/query-history-dto-mapper.ts
+++ b/extensions/ql-vscode/src/query-history/store/query-history-dto-mapper.ts
@@ -1,7 +1,9 @@
 import { QueryHistoryInfo } from "../query-history-info";
-import { QueryHistoryItemDto } from "./query-history-dto";
+import { QueryHistoryItemDto, QueryLanguageDto } from "./query-history-dto";
 import { mapQueryHistoryVariantAnalysisToDomainModel } from "./query-history-variant-analysis-dto-mapper";
 import { mapLocalQueryItemToDomainModel } from "./query-history-local-query-dto-mapper";
+import { QueryLanguage } from "../../common/query-language";
+import { assertNever } from "../../common/helpers-pure";
 
 export function mapQueryHistoryToDomainModel(
   queries: QueryHistoryItemDto[],
@@ -19,4 +21,29 @@ export function mapQueryHistoryToDomainModel(
       )}`,
     );
   });
+}
+
+export function mapQueryLanguageToDomainModel(
+  language: QueryLanguageDto,
+): QueryLanguage {
+  switch (language) {
+    case QueryLanguageDto.CSharp:
+      return QueryLanguage.CSharp;
+    case QueryLanguageDto.Cpp:
+      return QueryLanguage.Cpp;
+    case QueryLanguageDto.Go:
+      return QueryLanguage.Go;
+    case QueryLanguageDto.Java:
+      return QueryLanguage.Java;
+    case QueryLanguageDto.Javascript:
+      return QueryLanguage.Javascript;
+    case QueryLanguageDto.Python:
+      return QueryLanguage.Python;
+    case QueryLanguageDto.Ruby:
+      return QueryLanguage.Ruby;
+    case QueryLanguageDto.Swift:
+      return QueryLanguage.Swift;
+    default:
+      assertNever(language);
+  }
 }

--- a/extensions/ql-vscode/src/query-history/store/query-history-dto.ts
+++ b/extensions/ql-vscode/src/query-history/store/query-history-dto.ts
@@ -12,3 +12,14 @@ export interface QueryHistoryDto {
 export type QueryHistoryItemDto =
   | QueryHistoryLocalQueryDto
   | QueryHistoryVariantAnalysisDto;
+
+export enum QueryLanguageDto {
+  CSharp = "csharp",
+  Cpp = "cpp",
+  Go = "go",
+  Java = "java",
+  Javascript = "javascript",
+  Python = "python",
+  Ruby = "ruby",
+  Swift = "swift",
+}

--- a/extensions/ql-vscode/src/query-history/store/query-history-local-query-domain-mapper.ts
+++ b/extensions/ql-vscode/src/query-history/store/query-history-local-query-domain-mapper.ts
@@ -17,6 +17,7 @@ import {
   SortDirection,
   SortedResultSetInfo,
 } from "../../common/interface-types";
+import { mapQueryLanguageToDto } from "./query-history-domain-mapper";
 
 export function mapLocalQueryInfoToDto(
   query: LocalQueryInfo,
@@ -101,6 +102,10 @@ function mapInitialQueryInfoToDto(
     databaseInfo: {
       databaseUri: localQueryInitialInfo.databaseInfo.databaseUri,
       name: localQueryInitialInfo.databaseInfo.name,
+      language:
+        localQueryInitialInfo.databaseInfo.language === undefined
+          ? undefined
+          : mapQueryLanguageToDto(localQueryInitialInfo.databaseInfo.language),
     },
     start: localQueryInitialInfo.start,
     id: localQueryInitialInfo.id,

--- a/extensions/ql-vscode/src/query-history/store/query-history-local-query-dto-mapper.ts
+++ b/extensions/ql-vscode/src/query-history/store/query-history-local-query-dto-mapper.ts
@@ -20,6 +20,7 @@ import {
   SortDirection,
   SortedResultSetInfo,
 } from "../../common/interface-types";
+import { mapQueryLanguageToDomainModel } from "./query-history-dto-mapper";
 
 export function mapLocalQueryItemToDomainModel(
   localQuery: QueryHistoryLocalQueryDto,
@@ -82,6 +83,10 @@ function mapInitialQueryInfoToDomainModel(
     databaseInfo: {
       databaseUri: initialInfo.databaseInfo.databaseUri,
       name: initialInfo.databaseInfo.name,
+      language:
+        initialInfo.databaseInfo.language === undefined
+          ? undefined
+          : mapQueryLanguageToDomainModel(initialInfo.databaseInfo.language),
     },
     start: new Date(initialInfo.start),
     id: initialInfo.id,

--- a/extensions/ql-vscode/src/query-history/store/query-history-local-query-dto.ts
+++ b/extensions/ql-vscode/src/query-history/store/query-history-local-query-dto.ts
@@ -1,6 +1,8 @@
 // Contains models and consts for the data we want to store in the query history store.
 // Changes to these models should be done carefully and account for backwards compatibility of data.
 
+import { QueryLanguageDto } from "./query-history-dto";
+
 export interface QueryHistoryLocalQueryDto {
   initialInfo: InitialQueryInfoDto;
   t: "local";
@@ -27,6 +29,7 @@ export interface InitialQueryInfoDto {
 interface DatabaseInfoDto {
   name: string;
   databaseUri: string;
+  language?: QueryLanguageDto;
 }
 
 interface PositionDto {

--- a/extensions/ql-vscode/src/query-history/store/query-history-variant-analysis-domain-mapper.ts
+++ b/extensions/ql-vscode/src/query-history/store/query-history-variant-analysis-domain-mapper.ts
@@ -1,6 +1,5 @@
 import {
   QueryHistoryVariantAnalysisDto,
-  QueryLanguageDto,
   QueryStatusDto,
   VariantAnalysisDto,
   VariantAnalysisFailureReasonDto,
@@ -22,9 +21,9 @@ import {
   VariantAnalysisStatus,
 } from "../../variant-analysis/shared/variant-analysis";
 import { assertNever } from "../../common/helpers-pure";
-import { QueryLanguage } from "../../common/query-language";
 import { QueryStatus } from "../query-status";
 import { VariantAnalysisHistoryItem } from "../variant-analysis-history-item";
+import { mapQueryLanguageToDto } from "./query-history-domain-mapper";
 
 export function mapQueryHistoryVariantAnalysisToDto(
   item: VariantAnalysisHistoryItem,
@@ -196,29 +195,6 @@ function mapVariantAnalysisStatusToDto(
       return VariantAnalysisStatusDto.Canceled;
     default:
       assertNever(status);
-  }
-}
-
-function mapQueryLanguageToDto(language: QueryLanguage): QueryLanguageDto {
-  switch (language) {
-    case QueryLanguage.CSharp:
-      return QueryLanguageDto.CSharp;
-    case QueryLanguage.Cpp:
-      return QueryLanguageDto.Cpp;
-    case QueryLanguage.Go:
-      return QueryLanguageDto.Go;
-    case QueryLanguage.Java:
-      return QueryLanguageDto.Java;
-    case QueryLanguage.Javascript:
-      return QueryLanguageDto.Javascript;
-    case QueryLanguage.Python:
-      return QueryLanguageDto.Python;
-    case QueryLanguage.Ruby:
-      return QueryLanguageDto.Ruby;
-    case QueryLanguage.Swift:
-      return QueryLanguageDto.Swift;
-    default:
-      assertNever(language);
   }
 }
 

--- a/extensions/ql-vscode/src/query-history/store/query-history-variant-analysis-dto-mapper.ts
+++ b/extensions/ql-vscode/src/query-history/store/query-history-variant-analysis-dto-mapper.ts
@@ -1,6 +1,5 @@
 import {
   QueryHistoryVariantAnalysisDto,
-  QueryLanguageDto,
   QueryStatusDto,
   VariantAnalysisDto,
   VariantAnalysisFailureReasonDto,
@@ -22,9 +21,9 @@ import {
   VariantAnalysisStatus,
 } from "../../variant-analysis/shared/variant-analysis";
 import { assertNever } from "../../common/helpers-pure";
-import { QueryLanguage } from "../../common/query-language";
 import { QueryStatus } from "../query-status";
 import { VariantAnalysisHistoryItem } from "../variant-analysis-history-item";
+import { mapQueryLanguageToDomainModel } from "./query-history-dto-mapper";
 
 export function mapQueryHistoryVariantAnalysisToDomainModel(
   item: QueryHistoryVariantAnalysisDto,
@@ -212,31 +211,6 @@ function mapVariantAnalysisStatusToDomainModel(
       return VariantAnalysisStatus.Canceled;
     default:
       assertNever(status);
-  }
-}
-
-function mapQueryLanguageToDomainModel(
-  language: QueryLanguageDto,
-): QueryLanguage {
-  switch (language) {
-    case QueryLanguageDto.CSharp:
-      return QueryLanguage.CSharp;
-    case QueryLanguageDto.Cpp:
-      return QueryLanguage.Cpp;
-    case QueryLanguageDto.Go:
-      return QueryLanguage.Go;
-    case QueryLanguageDto.Java:
-      return QueryLanguage.Java;
-    case QueryLanguageDto.Javascript:
-      return QueryLanguage.Javascript;
-    case QueryLanguageDto.Python:
-      return QueryLanguage.Python;
-    case QueryLanguageDto.Ruby:
-      return QueryLanguage.Ruby;
-    case QueryLanguageDto.Swift:
-      return QueryLanguage.Swift;
-    default:
-      assertNever(language);
   }
 }
 

--- a/extensions/ql-vscode/src/query-history/store/query-history-variant-analysis-dto.ts
+++ b/extensions/ql-vscode/src/query-history/store/query-history-variant-analysis-dto.ts
@@ -1,6 +1,8 @@
 // Contains models and consts for the data we want to store in the query history store.
 // Changes to these models should be done carefully and account for backwards compatibility of data.
 
+import { QueryLanguageDto } from "./query-history-dto";
+
 export interface QueryHistoryVariantAnalysisDto {
   readonly t: "variant-analysis";
   failureReason?: string;
@@ -95,17 +97,6 @@ export enum VariantAnalysisStatusDto {
   Succeeded = "succeeded",
   Failed = "failed",
   Canceled = "canceled",
-}
-
-export enum QueryLanguageDto {
-  CSharp = "csharp",
-  Cpp = "cpp",
-  Go = "go",
-  Java = "java",
-  Javascript = "javascript",
-  Python = "python",
-  Ruby = "ruby",
-  Swift = "swift",
 }
 
 export enum QueryStatusDto {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

This adds language to local query history items, similar to what variant analysis items have. Note that old history items wont have this field so we have to handle undefined language.
I havent touched the DTOs and mappers before so I was not sure whether I need to do more to make it work.


Few notes:
1. I added it to `DatabaseInfo` based on @shati-patel's suggestion. But I think we are open to other places as well.
2. I moved things related to QueryLanguage from the variant analysis mappers and DTOs to the general mappers and DTOs.
3. I added the option to show the language in the history item as that was nice for testing and it possibly seems useful. I am happy to remove that again.

To test I ran VSCode with a custom format:
```
"codeQL.queryHistory.format": "%q on %d (%l) - %s %r [%t]",`
```
and ran an extra local query:
![Screenshot from 2023-09-29 12-14-02](https://github.com/github/vscode-codeql/assets/729058/fae322d8-5db8-477f-b173-55fd3e4e1c44)



## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
