### PR TITLE
Add support for filtering history panel.

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -871,6 +871,7 @@ async function activateWithInstalledDistribution(
     ctx,
     queryHistoryConfigurationListener,
     labelProvider,
+    languageContext,
     async (
       from: CompletedLocalQueryInfo,
       to: CompletedLocalQueryInfo,

--- a/extensions/ql-vscode/src/query-history/query-history-manager.ts
+++ b/extensions/ql-vscode/src/query-history/query-history-manager.ts
@@ -62,6 +62,7 @@ import {
   showAndLogInformationMessage,
   showAndLogWarningMessage,
 } from "../common/logging";
+import { LanguageContextStore } from "../language-context-store";
 
 /**
  * query-history-manager.ts
@@ -141,6 +142,7 @@ export class QueryHistoryManager extends DisposableObject {
     ctx: ExtensionContext,
     private readonly queryHistoryConfigListener: QueryHistoryConfig,
     private readonly labelProvider: HistoryItemLabelProvider,
+    private readonly languageContext: LanguageContextStore,
     private readonly doCompareCallback: (
       from: CompletedLocalQueryInfo,
       to: CompletedLocalQueryInfo,
@@ -158,7 +160,7 @@ export class QueryHistoryManager extends DisposableObject {
     );
 
     this.treeDataProvider = this.push(
-      new HistoryTreeDataProvider(this.labelProvider),
+      new HistoryTreeDataProvider(this.labelProvider, this.languageContext),
     );
     this.treeView = this.push(
       window.createTreeView("codeQLQueryHistory", {
@@ -230,6 +232,12 @@ export class QueryHistoryManager extends DisposableObject {
 
     this.registerQueryHistoryScrubber(queryHistoryConfigListener, this, ctx);
     this.registerToVariantAnalysisEvents();
+
+    this.push(
+      this.languageContext.onLanguageContextChanged(async () => {
+        this.treeDataProvider.refresh();
+      }),
+    );
   }
 
   public getCommands(): QueryHistoryCommands {

--- a/extensions/ql-vscode/test/factories/query-history/local-query-history-item.ts
+++ b/extensions/ql-vscode/test/factories/query-history/local-query-history-item.ts
@@ -7,6 +7,7 @@ import {
 import { CancellationTokenSource } from "vscode";
 import { QueryResultType } from "../../../src/query-server/legacy-messages";
 import { QueryMetadata } from "../../../src/common/interface-types";
+import { QueryLanguage } from "../../../src/common/query-language";
 
 export function createMockLocalQueryInfo({
   startTime = new Date(),
@@ -16,6 +17,7 @@ export function createMockLocalQueryInfo({
   dbName = "db-name",
   hasMetadata = false,
   queryWithResults = undefined,
+  language = undefined,
 }: {
   startTime?: Date;
   resultCount?: number;
@@ -24,6 +26,7 @@ export function createMockLocalQueryInfo({
   dbName?: string;
   hasMetadata?: boolean;
   queryWithResults?: QueryWithResults | undefined;
+  language?: QueryLanguage;
 }): LocalQueryInfo {
   const cancellationToken = {
     dispose: () => {
@@ -40,6 +43,7 @@ export function createMockLocalQueryInfo({
     databaseInfo: {
       databaseUri: "databaseUri",
       name: dbName,
+      language,
     },
     start: startTime,
     id: faker.number.int().toString(),

--- a/extensions/ql-vscode/test/factories/query-history/variant-analysis-history-item.ts
+++ b/extensions/ql-vscode/test/factories/query-history/variant-analysis-history-item.ts
@@ -5,6 +5,7 @@ import {
   VariantAnalysisStatus,
 } from "../../../src/variant-analysis/shared/variant-analysis";
 import { createMockVariantAnalysis } from "../variant-analysis/shared/variant-analysis";
+import { QueryLanguage } from "../../../src/common/query-language";
 
 export function createMockVariantAnalysisHistoryItem({
   historyItemStatus = QueryStatus.InProgress,
@@ -14,6 +15,7 @@ export function createMockVariantAnalysisHistoryItem({
   userSpecifiedLabel = undefined,
   executionStartTime = undefined,
   variantAnalysis = undefined,
+  language = QueryLanguage.Javascript,
 }: {
   historyItemStatus?: QueryStatus;
   variantAnalysisStatus?: VariantAnalysisStatus;
@@ -22,6 +24,7 @@ export function createMockVariantAnalysisHistoryItem({
   userSpecifiedLabel?: string;
   executionStartTime?: number;
   variantAnalysis?: VariantAnalysis;
+  language?: QueryLanguage;
 }): VariantAnalysisHistoryItem {
   return {
     t: "variant-analysis",
@@ -34,6 +37,7 @@ export function createMockVariantAnalysisHistoryItem({
       createMockVariantAnalysis({
         status: variantAnalysisStatus,
         executionStartTime,
+        language,
       }),
     userSpecifiedLabel,
   };

--- a/extensions/ql-vscode/test/factories/variant-analysis/shared/variant-analysis.ts
+++ b/extensions/ql-vscode/test/factories/variant-analysis/shared/variant-analysis.ts
@@ -15,11 +15,13 @@ export function createMockVariantAnalysis({
   scannedRepos = createMockScannedRepos(),
   skippedRepos = createMockSkippedRepos(),
   executionStartTime = faker.number.int(),
+  language = QueryLanguage.Javascript,
 }: {
   status?: VariantAnalysisStatus;
   scannedRepos?: VariantAnalysisScannedRepository[];
   skippedRepos?: VariantAnalysisSkippedRepositories;
   executionStartTime?: number | undefined;
+  language?: QueryLanguage;
 }): VariantAnalysis {
   return {
     id: faker.number.int(),
@@ -32,7 +34,7 @@ export function createMockVariantAnalysis({
     query: {
       name: "a-query-name",
       filePath: "a-query-file-path",
-      language: QueryLanguage.Javascript,
+      language,
       text: "a-query-text",
     },
     databases: {

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-manager.test.ts
@@ -28,6 +28,7 @@ import { createMockQueryHistoryDirs } from "../../../factories/query-history/que
 import { createMockApp } from "../../../__mocks__/appMock";
 import { App } from "../../../../src/common/app";
 import { createMockCommandManager } from "../../../__mocks__/commandsMock";
+import { LanguageContextStore } from "../../../../src/language-context-store";
 
 describe("QueryHistoryManager", () => {
   const mockExtensionLocation = join(tmpDir.name, "mock-extension-location");
@@ -937,6 +938,7 @@ describe("QueryHistoryManager", () => {
         ttlInMillis: 0,
         onDidChangeConfiguration: jest.fn(),
       }),
+      new LanguageContextStore(mockApp),
       doCompareCallback,
     );
     (qhm.treeDataProvider as any).history = [...allHistory];

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/variant-analysis-history.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/variant-analysis-history.test.ts
@@ -23,6 +23,7 @@ import { QueryHistoryManager } from "../../../../src/query-history/query-history
 import { mockedObject } from "../../utils/mocking.helpers";
 import { createMockQueryHistoryDirs } from "../../../factories/query-history/query-history-dirs";
 import { createMockApp } from "../../../__mocks__/appMock";
+import { LanguageContextStore } from "../../../../src/language-context-store";
 
 // set a higher timeout since recursive delete may take a while, expecially on Windows.
 jest.setTimeout(120000);
@@ -74,8 +75,10 @@ describe("Variant Analyses and QueryHistoryManager", () => {
       join(STORAGE_DIR, "workspace-query-history.json"),
     ).queries;
 
+    const app = createMockApp({});
+
     qhm = new QueryHistoryManager(
-      createMockApp({}),
+      app,
       {} as QueryRunner,
       {} as DatabaseManager,
       localQueriesResultsViewStub,
@@ -97,6 +100,7 @@ describe("Variant Analyses and QueryHistoryManager", () => {
         ttlInMillis: 0,
         onDidChangeConfiguration: jest.fn(),
       }),
+      new LanguageContextStore(app),
       asyncNoop,
     );
     disposables.push(qhm);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

This adds language filtering to the history panel. The implementation is mostly straightforward, we only show `unknown` languages when `All` is selected.





-------
Without filter:
![image](https://github.com/github/vscode-codeql/assets/729058/12235101-3429-4c33-9ed7-2be0f486d34e)

-------
After `java` filter:
![image](https://github.com/github/vscode-codeql/assets/729058/b48d2494-ae3a-44a6-956f-f8a3412f14ba)



## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
