### PR TITLE
Extract base functionality for WebviewViewProviders into an abstract class

### DIFF
--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -598,8 +598,7 @@ export type FromModelEditorMessage =
   | SetModeledMethodMessage;
 
 export type FromMethodModelingMessage =
-  | TelemetryMessage
-  | UnhandledErrorMessage
+  | CommonFromViewMessages
   | SetModeledMethodMessage;
 
 interface SetMethodMessage {

--- a/extensions/ql-vscode/src/common/vscode/abstract-webview-view-provider.ts
+++ b/extensions/ql-vscode/src/common/vscode/abstract-webview-view-provider.ts
@@ -64,6 +64,8 @@ export abstract class AbstractWebviewViewProvider<
       const disposable = this.disposables.pop()!;
       disposable.dispose();
     }
+
+    this.webviewView = undefined;
   }
 
   protected push<T extends Disposable>(obj: T): T {
@@ -75,6 +77,10 @@ export abstract class AbstractWebviewViewProvider<
 
   protected abstract onMessage(msg: FromMessage): Promise<void>;
 
+  /**
+   * This is called when a view first becomes visible. This may happen when the view is
+   * first loaded or when the user hides and then shows a view again.
+   */
   protected onWebViewLoaded(): void {
     // Do nothing by default.
   }

--- a/extensions/ql-vscode/src/common/vscode/abstract-webview-view-provider.ts
+++ b/extensions/ql-vscode/src/common/vscode/abstract-webview-view-provider.ts
@@ -47,8 +47,6 @@ export abstract class AbstractWebviewViewProvider<
 
     webviewView.webview.onDidReceiveMessage(async (msg) => this.onMessage(msg));
     webviewView.onDidDispose(() => this.dispose());
-
-    this.onWebViewLoaded();
   }
 
   protected get isShowingView() {

--- a/extensions/ql-vscode/src/common/vscode/abstract-webview-view-provider.ts
+++ b/extensions/ql-vscode/src/common/vscode/abstract-webview-view-provider.ts
@@ -1,0 +1,81 @@
+import * as vscode from "vscode";
+import { Uri, WebviewViewProvider } from "vscode";
+import { WebviewKind, WebviewMessage, getHtmlForWebview } from "./webview-html";
+import { Disposable } from "../disposable-object";
+import { App } from "../app";
+
+export abstract class AbstractWebviewViewProvider<
+  ToMessage extends WebviewMessage,
+  FromMessage extends WebviewMessage,
+> implements WebviewViewProvider
+{
+  protected webviewView: vscode.WebviewView | undefined = undefined;
+  private disposables: Disposable[] = [];
+
+  constructor(
+    private readonly app: App,
+    private readonly webviewKind: WebviewKind,
+  ) {}
+
+  /**
+   * This is called when a view first becomes visible. This may happen when the view is
+   * first loaded or when the user hides and then shows a view again.
+   */
+  public resolveWebviewView(
+    webviewView: vscode.WebviewView,
+    _context: vscode.WebviewViewResolveContext,
+    _token: vscode.CancellationToken,
+  ) {
+    webviewView.webview.options = {
+      enableScripts: true,
+      localResourceRoots: [Uri.file(this.app.extensionPath)],
+    };
+
+    const html = getHtmlForWebview(
+      this.app,
+      webviewView.webview,
+      this.webviewKind,
+      {
+        allowInlineStyles: true,
+        allowWasmEval: false,
+      },
+    );
+
+    webviewView.webview.html = html;
+
+    this.webviewView = webviewView;
+
+    webviewView.webview.onDidReceiveMessage(async (msg) => this.onMessage(msg));
+    webviewView.onDidDispose(() => this.dispose());
+
+    this.onWebViewLoaded();
+  }
+
+  protected get isShowingView() {
+    return this.webviewView?.visible ?? false;
+  }
+
+  protected async postMessage(msg: ToMessage): Promise<void> {
+    await this.webviewView?.webview.postMessage(msg);
+  }
+
+  protected dispose() {
+    while (this.disposables.length > 0) {
+      const disposable = this.disposables.pop()!;
+      disposable.dispose();
+    }
+  }
+
+  protected push<T extends Disposable>(obj: T): T {
+    if (obj !== undefined) {
+      this.disposables.push(obj);
+    }
+    return obj;
+  }
+
+  protected abstract onMessage(msg: FromMessage): Promise<void>;
+
+  protected onWebViewLoaded(): void {
+    // Do nothing by default.
+  }
+}

--- a/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-panel.ts
+++ b/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-panel.ts
@@ -12,7 +12,6 @@ export class MethodModelingPanel extends DisposableObject {
     super();
 
     this.provider = new MethodModelingViewProvider(app, modelingStore);
-    this.push(this.provider);
     this.push(
       window.registerWebviewViewProvider(
         MethodModelingViewProvider.viewType,

--- a/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
+++ b/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
@@ -58,6 +58,24 @@ export class MethodModelingViewProvider extends AbstractWebviewViewProvider<
     msg: FromMethodModelingMessage,
   ): Promise<void> {
     switch (msg.t) {
+      case "viewLoaded":
+        this.onWebViewLoaded();
+        break;
+
+      case "telemetry":
+        telemetryListener?.sendUIInteraction(msg.action);
+        break;
+
+      case "unhandledError":
+        void showAndLogExceptionWithTelemetry(
+          extLogger,
+          telemetryListener,
+          redactableError(
+            msg.error,
+          )`Unhandled error in method modeling view: ${msg.error.message}`,
+        );
+        break;
+
       case "setModeledMethod": {
         const activeState = this.modelingStore.getStateForActiveDb();
         if (!activeState) {
@@ -69,20 +87,6 @@ export class MethodModelingViewProvider extends AbstractWebviewViewProvider<
         );
         break;
       }
-
-      case "telemetry": {
-        telemetryListener?.sendUIInteraction(msg.action);
-        break;
-      }
-      case "unhandledError":
-        void showAndLogExceptionWithTelemetry(
-          extLogger,
-          telemetryListener,
-          redactableError(
-            msg.error,
-          )`Unhandled error in method modeling view: ${msg.error.message}`,
-        );
-        break;
     }
   }
 


### PR DESCRIPTION
This is to help with re-usability but also to make the code more readable since plumbing code etc. get moved out of the concrete class.

This also solves the issue of disposal of event subscriptions at the right time (see https://github.com/github/vscode-codeql/pull/2891). 

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
