### PR TITLE
Add reveal in editor button to method modeling panel

### DIFF
--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -575,12 +575,18 @@ interface SetModeledMethodMessage {
   method: ModeledMethod;
 }
 
+interface RevealMethodMessage {
+  t: "revealMethod";
+  method: Method;
+}
+
 export type ToModelEditorMessage =
   | SetExtensionPackStateMessage
   | SetMethodsMessage
   | SetModeledMethodsMessage
   | SetModifiedMethodsMessage
-  | SetInProgressMethodsMessage;
+  | SetInProgressMethodsMessage
+  | RevealMethodMessage;
 
 export type FromModelEditorMessage =
   | ViewLoadedMsg

--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -597,9 +597,15 @@ export type FromModelEditorMessage =
   | HideModeledMethodsMessage
   | SetModeledMethodMessage;
 
+interface RevealInEditorMessage {
+  t: "revealInModelEditor";
+  method: Method;
+}
+
 export type FromMethodModelingMessage =
   | CommonFromViewMessages
-  | SetModeledMethodMessage;
+  | SetModeledMethodMessage
+  | RevealInEditorMessage;
 
 interface SetMethodMessage {
   t: "setMethod";

--- a/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-panel.ts
+++ b/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-panel.ts
@@ -4,14 +4,23 @@ import { DisposableObject } from "../../common/disposable-object";
 import { MethodModelingViewProvider } from "./method-modeling-view-provider";
 import { Method } from "../method";
 import { ModelingStore } from "../modeling-store";
+import { ModelEditorViewTracker } from "../model-editor-view-tracker";
 
 export class MethodModelingPanel extends DisposableObject {
   private readonly provider: MethodModelingViewProvider;
 
-  constructor(app: App, modelingStore: ModelingStore) {
+  constructor(
+    app: App,
+    modelingStore: ModelingStore,
+    editorViewTracker: ModelEditorViewTracker,
+  ) {
     super();
 
-    this.provider = new MethodModelingViewProvider(app, modelingStore);
+    this.provider = new MethodModelingViewProvider(
+      app,
+      modelingStore,
+      editorViewTracker,
+    );
     this.push(
       window.registerWebviewViewProvider(
         MethodModelingViewProvider.viewType,

--- a/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
+++ b/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
@@ -10,6 +10,7 @@ import { redactableError } from "../../common/errors";
 import { Method } from "../method";
 import { ModelingStore } from "../modeling-store";
 import { AbstractWebviewViewProvider } from "../../common/vscode/abstract-webview-view-provider";
+import { assertNever } from "../../common/helpers-pure";
 
 export class MethodModelingViewProvider extends AbstractWebviewViewProvider<
   ToMethodModelingMessage,
@@ -87,6 +88,10 @@ export class MethodModelingViewProvider extends AbstractWebviewViewProvider<
         );
         break;
       }
+      case "revealInModelEditor":
+        break;
+      default:
+        assertNever(msg);
     }
   }
 

--- a/extensions/ql-vscode/src/model-editor/model-editor-module.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-module.ts
@@ -20,12 +20,14 @@ import { setUpPack } from "./model-editor-queries";
 import { MethodModelingPanel } from "./method-modeling/method-modeling-panel";
 import { ModelingStore } from "./modeling-store";
 import { showResolvableLocation } from "../databases/local-databases/locations";
+import { ModelEditorViewTracker } from "./model-editor-view-tracker";
 
 const SUPPORTED_LANGUAGES: string[] = ["java", "csharp"];
 
 export class ModelEditorModule extends DisposableObject {
   private readonly queryStorageDir: string;
   private readonly modelingStore: ModelingStore;
+  private readonly editorViewTracker: ModelEditorViewTracker<ModelEditorView>;
   private readonly methodsUsagePanel: MethodsUsagePanel;
   private readonly methodModelingPanel: MethodModelingPanel;
 
@@ -39,6 +41,7 @@ export class ModelEditorModule extends DisposableObject {
     super();
     this.queryStorageDir = join(baseQueryStorageDir, "model-editor-results");
     this.modelingStore = new ModelingStore(app);
+    this.editorViewTracker = new ModelEditorViewTracker();
     this.methodsUsagePanel = this.push(
       new MethodsUsagePanel(this.modelingStore, cliServer),
     );
@@ -148,6 +151,7 @@ export class ModelEditorModule extends DisposableObject {
             const view = new ModelEditorView(
               this.app,
               this.modelingStore,
+              this.editorViewTracker,
               this.databaseManager,
               this.cliServer,
               this.queryRunner,

--- a/extensions/ql-vscode/src/model-editor/model-editor-module.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-module.ts
@@ -46,7 +46,7 @@ export class ModelEditorModule extends DisposableObject {
       new MethodsUsagePanel(this.modelingStore, cliServer),
     );
     this.methodModelingPanel = this.push(
-      new MethodModelingPanel(app, this.modelingStore),
+      new MethodModelingPanel(app, this.modelingStore, this.editorViewTracker),
     );
 
     this.registerToModelingStoreEvents();

--- a/extensions/ql-vscode/src/model-editor/model-editor-view-tracker.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view-tracker.ts
@@ -1,5 +1,9 @@
+import { Method } from "./method";
+
 interface ModelEditorViewInterface {
   databaseUri: string;
+
+  revealMethod(method: Method): Promise<void>;
 }
 
 export class ModelEditorViewTracker<

--- a/extensions/ql-vscode/src/model-editor/model-editor-view-tracker.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view-tracker.ts
@@ -1,0 +1,37 @@
+interface ModelEditorViewInterface {
+  databaseUri: string;
+}
+
+export class ModelEditorViewTracker<
+  T extends ModelEditorViewInterface = ModelEditorViewInterface,
+> {
+  private readonly views = new Map<string, T[]>();
+
+  constructor() {}
+
+  public registerView(view: T): void {
+    const databaseUri = view.databaseUri;
+
+    if (!this.views.has(databaseUri)) {
+      this.views.set(databaseUri, []);
+    }
+
+    this.views.get(databaseUri)?.push(view);
+  }
+
+  public unregisterView(view: T): void {
+    const views = this.views.get(view.databaseUri);
+    if (!views) {
+      return;
+    }
+
+    const index = views.indexOf(view);
+    if (index !== -1) {
+      views.splice(index, 1);
+    }
+  }
+
+  public getViews(databaseUri: string): T[] {
+    return this.views.get(databaseUri) ?? [];
+  }
+}

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -347,7 +347,12 @@ export class ModelEditorView extends AbstractWebview<
   }
 
   public async revealMethod(method: Method): Promise<void> {
-    void this.app.logger.log(`Revealing method ${JSON.stringify(method)}`);
+    this.panel?.reveal();
+
+    await this.postMessage({
+      t: "revealMethod",
+      method,
+    });
   }
 
   private async setViewState(): Promise<void> {

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -42,6 +42,7 @@ import { getLanguageDisplayName } from "../common/query-language";
 import { AutoModeler } from "./auto-modeler";
 import { telemetryListener } from "../common/vscode/telemetry";
 import { ModelingStore } from "./modeling-store";
+import { ModelEditorViewTracker } from "./model-editor-view-tracker";
 
 export class ModelEditorView extends AbstractWebview<
   ToModelEditorMessage,
@@ -52,6 +53,7 @@ export class ModelEditorView extends AbstractWebview<
   public constructor(
     protected readonly app: App,
     private readonly modelingStore: ModelingStore,
+    private readonly viewTracker: ModelEditorViewTracker<ModelEditorView>,
     private readonly databaseManager: DatabaseManager,
     private readonly cliServer: CodeQLCliServer,
     private readonly queryRunner: QueryRunner,
@@ -65,6 +67,8 @@ export class ModelEditorView extends AbstractWebview<
 
     this.modelingStore.initializeStateForDb(databaseItem);
     this.registerToModelingStoreEvents();
+
+    this.viewTracker.registerView(this);
 
     this.autoModeler = new AutoModeler(
       app,
@@ -181,7 +185,7 @@ export class ModelEditorView extends AbstractWebview<
   }
 
   protected onPanelDispose(): void {
-    // Nothing to do here
+    this.viewTracker.unregisterView(this);
   }
 
   protected async onMessage(msg: FromModelEditorMessage): Promise<void> {
@@ -336,6 +340,10 @@ export class ModelEditorView extends AbstractWebview<
       }),
       this.loadExistingModeledMethods(),
     ]);
+  }
+
+  public get databaseUri(): string {
+    return this.databaseItem.databaseUri.toString();
   }
 
   private async setViewState(): Promise<void> {
@@ -497,6 +505,7 @@ export class ModelEditorView extends AbstractWebview<
       const view = new ModelEditorView(
         this.app,
         this.modelingStore,
+        this.viewTracker,
         this.databaseManager,
         this.cliServer,
         this.queryRunner,

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -346,6 +346,10 @@ export class ModelEditorView extends AbstractWebview<
     return this.databaseItem.databaseUri.toString();
   }
 
+  public async revealMethod(method: Method): Promise<void> {
+    void this.app.logger.log(`Revealing method ${JSON.stringify(method)}`);
+  }
+
   private async setViewState(): Promise<void> {
     const showLlmButton =
       this.databaseItem.language === "java" && showLlmGeneration();

--- a/extensions/ql-vscode/src/model-editor/modeling-store.ts
+++ b/extensions/ql-vscode/src/model-editor/modeling-store.ts
@@ -6,7 +6,7 @@ import { Method, Usage } from "./method";
 import { ModeledMethod } from "./modeled-method";
 import { INITIAL_HIDE_MODELED_METHODS_VALUE } from "./shared/hide-modeled-methods";
 
-interface DbModelingState {
+export interface DbModelingState {
   databaseItem: DatabaseItem;
   methods: Method[];
   hideModeledMethods: boolean;

--- a/extensions/ql-vscode/src/view/method-modeling/MethodModeling.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/MethodModeling.tsx
@@ -7,6 +7,7 @@ import { MethodName } from "../model-editor/MethodName";
 import { ModeledMethod } from "../../model-editor/modeled-method";
 import { MethodModelingInputs } from "./MethodModelingInputs";
 import { VSCodeTag } from "@vscode/webview-ui-toolkit/react";
+import { ReviewInEditorButton } from "./ReviewInEditorButton";
 
 const Container = styled.div`
   padding: 0.3rem;
@@ -64,6 +65,7 @@ export const MethodModeling = ({
         modeledMethod={modeledMethod}
         onChange={onChange}
       />
+      <ReviewInEditorButton method={method} />
     </Container>
   );
 };

--- a/extensions/ql-vscode/src/view/method-modeling/ReviewInEditorButton.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/ReviewInEditorButton.tsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+import { useCallback } from "react";
+import { styled } from "styled-components";
+import { vscode } from "../vscode-api";
+import TextButton from "../common/TextButton";
+import { Method } from "../../model-editor/method";
+
+const Button = styled(TextButton)`
+  margin-top: 0.5rem;
+`;
+
+type Props = {
+  method: Method;
+};
+
+export const ReviewInEditorButton = ({ method }: Props) => {
+  const handleClick = useCallback(() => {
+    vscode.postMessage({
+      t: "revealInModelEditor",
+      method,
+    });
+  }, [method]);
+
+  return <Button onClick={handleClick}>Review in editor</Button>;
+};

--- a/extensions/ql-vscode/src/view/model-editor/LibraryRow.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/LibraryRow.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { styled } from "styled-components";
 import { Method } from "../../model-editor/method";
 import { ModeledMethod } from "../../model-editor/modeled-method";
@@ -76,6 +76,7 @@ export type LibraryRowProps = {
   inProgressMethods: InProgressMethods;
   viewState: ModelEditorViewState;
   hideModeledMethods: boolean;
+  revealedMethodSignature: string | null;
   onChange: (modeledMethod: ModeledMethod) => void;
   onSaveModelClick: (
     methods: Method[],
@@ -100,6 +101,7 @@ export const LibraryRow = ({
   inProgressMethods,
   viewState,
   hideModeledMethods,
+  revealedMethodSignature,
   onChange,
   onSaveModelClick,
   onGenerateFromLlmClick,
@@ -116,6 +118,14 @@ export const LibraryRow = ({
   const toggleExpanded = useCallback(async () => {
     setExpanded((oldIsExpanded) => !oldIsExpanded);
   }, []);
+
+  useEffect(() => {
+    // If any of the methods in this group is the one that should be revealed, we should expand
+    // this group so the method can highlight itself.
+    if (methods.some((m) => m.signature === revealedMethodSignature)) {
+      setExpanded(true);
+    }
+  }, [methods, revealedMethodSignature]);
 
   const handleModelWithAI = useCallback(
     async (e: React.MouseEvent) => {
@@ -227,6 +237,7 @@ export const LibraryRow = ({
             inProgressMethods={inProgressMethods}
             mode={viewState.mode}
             hideModeledMethods={hideModeledMethods}
+            revealedMethodSignature={revealedMethodSignature}
             onChange={onChange}
           />
           <SectionDivider />

--- a/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
@@ -101,6 +101,10 @@ export function ModelEditor({
     initialHideModeledMethods,
   );
 
+  const [revealedMethodSignature, setRevealedMethodSignature] = useState<
+    string | null
+  >(null);
+
   useEffect(() => {
     vscode.postMessage({
       t: "hideModeledMethods",
@@ -137,6 +141,10 @@ export function ModelEditor({
               ),
             );
             break;
+          case "revealMethod":
+            setRevealedMethodSignature(msg.method.signature);
+
+            break;
           default:
             assertNever(msg);
         }
@@ -150,6 +158,20 @@ export function ModelEditor({
 
     return () => {
       window.removeEventListener("message", listener);
+    };
+  }, []);
+
+  useEffect(() => {
+    // If there is a revealed method signature, hide it when the user clicks anywhere. In this case, we do need to
+    // show the user where the method is anymore and they should have seen it.
+    const listener = () => {
+      setRevealedMethodSignature(null);
+    };
+
+    window.addEventListener("click", listener);
+
+    return () => {
+      window.removeEventListener("click", listener);
     };
   }, []);
 
@@ -323,6 +345,7 @@ export function ModelEditor({
           inProgressMethods={inProgressMethods}
           viewState={viewState}
           hideModeledMethods={hideModeledMethods}
+          revealedMethodSignature={revealedMethodSignature}
           onChange={onChange}
           onSaveModelClick={onSaveModelClick}
           onGenerateFromLlmClick={onGenerateFromLlmClick}

--- a/extensions/ql-vscode/src/view/model-editor/ModeledMethodDataGrid.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModeledMethodDataGrid.tsx
@@ -23,6 +23,7 @@ export type ModeledMethodDataGridProps = {
   inProgressMethods: InProgressMethods;
   mode: Mode;
   hideModeledMethods: boolean;
+  revealedMethodSignature: string | null;
   onChange: (modeledMethod: ModeledMethod) => void;
 };
 
@@ -34,6 +35,7 @@ export const ModeledMethodDataGrid = ({
   inProgressMethods,
   mode,
   hideModeledMethods,
+  revealedMethodSignature,
   onChange,
 }: ModeledMethodDataGridProps) => {
   const [methodsWithModelability, numHiddenMethods]: [
@@ -94,6 +96,7 @@ export const ModeledMethodDataGrid = ({
                 method.signature,
               )}
               mode={mode}
+              revealedMethodSignature={revealedMethodSignature}
               onChange={onChange}
             />
           ))}

--- a/extensions/ql-vscode/src/view/model-editor/ModeledMethodsList.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModeledMethodsList.tsx
@@ -16,6 +16,7 @@ export type ModeledMethodsListProps = {
   modeledMethods: Record<string, ModeledMethod>;
   modifiedSignatures: Set<string>;
   inProgressMethods: InProgressMethods;
+  revealedMethodSignature: string | null;
   viewState: ModelEditorViewState;
   hideModeledMethods: boolean;
   onChange: (modeledMethod: ModeledMethod) => void;
@@ -44,6 +45,7 @@ export const ModeledMethodsList = ({
   inProgressMethods,
   viewState,
   hideModeledMethods,
+  revealedMethodSignature,
   onChange,
   onSaveModelClick,
   onGenerateFromLlmClick,
@@ -89,6 +91,7 @@ export const ModeledMethodsList = ({
           inProgressMethods={inProgressMethods}
           viewState={viewState}
           hideModeledMethods={hideModeledMethods}
+          revealedMethodSignature={revealedMethodSignature}
           onChange={onChange}
           onSaveModelClick={onSaveModelClick}
           onGenerateFromLlmClick={onGenerateFromLlmClick}

--- a/extensions/ql-vscode/src/view/model-editor/__tests__/LibraryRow.spec.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/__tests__/LibraryRow.spec.tsx
@@ -43,6 +43,7 @@ describe(LibraryRow.name, () => {
         inProgressMethods={new InProgressMethods()}
         viewState={viewState}
         hideModeledMethods={false}
+        revealedMethodSignature={null}
         onChange={onChange}
         onSaveModelClick={onSaveModelClick}
         onGenerateFromLlmClick={onGenerateFromLlmClick}

--- a/extensions/ql-vscode/src/view/model-editor/__tests__/MethodRow.spec.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/__tests__/MethodRow.spec.tsx
@@ -39,6 +39,7 @@ describe(MethodRow.name, () => {
         modeledMethod={modeledMethod}
         methodIsUnsaved={false}
         modelingInProgress={false}
+        revealedMethodSignature={null}
         mode={Mode.Application}
         onChange={onChange}
         {...props}

--- a/extensions/ql-vscode/src/view/model-editor/__tests__/ModeledMethodDataGrid.spec.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/__tests__/ModeledMethodDataGrid.spec.tsx
@@ -60,6 +60,7 @@ describe(ModeledMethodDataGrid.name, () => {
         inProgressMethods={new InProgressMethods()}
         mode={Mode.Application}
         hideModeledMethods={false}
+        revealedMethodSignature={null}
         onChange={onChange}
         {...props}
       />,

--- a/extensions/ql-vscode/src/view/model-editor/__tests__/ModeledMethodsList.spec.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/__tests__/ModeledMethodsList.spec.tsx
@@ -69,6 +69,7 @@ describe(ModeledMethodsList.name, () => {
         inProgressMethods={new InProgressMethods()}
         viewState={viewState}
         hideModeledMethods={false}
+        revealedMethodSignature={null}
         onChange={onChange}
         onSaveModelClick={onSaveModelClick}
         onGenerateFromLlmClick={onGenerateFromLlmClick}

--- a/extensions/ql-vscode/src/view/vscode-api.ts
+++ b/extensions/ql-vscode/src/view/vscode-api.ts
@@ -1,5 +1,6 @@
 import {
   FromCompareViewMessage,
+  FromMethodModelingMessage,
   FromModelEditorMessage,
   FromResultsViewMsg,
   FromVariantAnalysisMessage,
@@ -15,7 +16,8 @@ export interface VsCodeApi {
       | FromResultsViewMsg
       | FromCompareViewMessage
       | FromVariantAnalysisMessage
-      | FromModelEditorMessage,
+      | FromModelEditorMessage
+      | FromMethodModelingMessage,
   ): void;
 
   /**

--- a/extensions/ql-vscode/test/__mocks__/model-editor/modelEditorViewTrackerMock.ts
+++ b/extensions/ql-vscode/test/__mocks__/model-editor/modelEditorViewTrackerMock.ts
@@ -1,0 +1,19 @@
+import { mockedObject } from "../../vscode-tests/utils/mocking.helpers";
+import { ModelEditorViewTracker } from "../../../src/model-editor/model-editor-view-tracker";
+import { ModelEditorView } from "../../../src/model-editor/model-editor-view";
+
+export function createMockModelEditorViewTracker({
+  registerView = jest.fn(),
+  unregisterView = jest.fn(),
+  getViews = jest.fn(),
+}: {
+  registerView?: ModelEditorViewTracker["registerView"];
+  unregisterView?: ModelEditorViewTracker["unregisterView"];
+  getViews?: ModelEditorViewTracker["getViews"];
+} = {}): ModelEditorViewTracker<ModelEditorView> {
+  return mockedObject<ModelEditorViewTracker<ModelEditorView>>({
+    registerView,
+    unregisterView,
+    getViews,
+  });
+}

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/model-editor-view.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/model-editor-view.test.ts
@@ -9,10 +9,12 @@ import { mockEmptyDatabaseManager } from "../query-testing/test-runner-helpers";
 import { QueryRunner } from "../../../../src/query-server";
 import { ExtensionPack } from "../../../../src/model-editor/shared/extension-pack";
 import { createMockModelingStore } from "../../../__mocks__/model-editor/modelingStoreMock";
+import { createMockModelEditorViewTracker } from "../../../__mocks__/model-editor/modelEditorViewTrackerMock";
 
 describe("ModelEditorView", () => {
   const app = createMockApp({});
   const modelingStore = createMockModelingStore();
+  const viewTracker = createMockModelEditorViewTracker();
   const databaseManager = mockEmptyDatabaseManager();
   const cliServer = mockedObject<CodeQLCliServer>({});
   const queryRunner = mockedObject<QueryRunner>({});
@@ -38,6 +40,7 @@ describe("ModelEditorView", () => {
     view = new ModelEditorView(
       app,
       modelingStore,
+      viewTracker,
       databaseManager,
       cliServer,
       queryRunner,


### PR DESCRIPTION
This adds a new reveal in editor button to the method modeling panel:

![Screenshot 2023-10-02 at 15 34 40](https://github.com/github/vscode-codeql/assets/1112623/1c02678a-d903-4c14-bd70-aae694559355)

Once clicked, it will:
- Expand the group (library/package) in which the method is located
- Scroll to the method
- Highlight the method

https://github.com/github/vscode-codeql/assets/1112623/9d33049d-1c39-421d-aaf7-6389b7418c1d

It's easiest to review this commit-by-commit, I've tried to create somewhat separate pieces.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
