### PR TITLE
Re-open method modeling panel if closed

### DIFF
--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -59,6 +59,8 @@ export type ExplorerSelectionCommandFunction<Item> = (
 type BuiltInVsCodeCommands = {
   // The codeQLDatabases.focus command is provided by VS Code because we've registered the custom view
   "codeQLDatabases.focus": () => Promise<void>;
+  // The codeQLMethodModeling.focus command is provided by VS Code because we've registered the custom view
+  "codeQLMethodModeling.focus": () => Promise<void>;
   "markdown.showPreviewToSide": (uri: Uri) => Promise<void>;
   "workbench.action.closeActiveEditor": () => Promise<void>;
   revealFileInOS: (uri: Uri) => Promise<void>;

--- a/extensions/ql-vscode/src/common/vscode/abstract-webview-view-provider.ts
+++ b/extensions/ql-vscode/src/common/vscode/abstract-webview-view-provider.ts
@@ -53,14 +53,6 @@ export abstract class AbstractWebviewViewProvider<
     return this.webviewView?.visible ?? false;
   }
 
-  public get isWebviewViewResolved() {
-    return this.webviewView !== undefined;
-  }
-
-  public async show(): Promise<void> {
-    this.webviewView?.show(true);
-  }
-
   protected async postMessage(msg: ToMessage): Promise<void> {
     await this.webviewView?.webview.postMessage(msg);
   }

--- a/extensions/ql-vscode/src/common/vscode/abstract-webview-view-provider.ts
+++ b/extensions/ql-vscode/src/common/vscode/abstract-webview-view-provider.ts
@@ -53,6 +53,14 @@ export abstract class AbstractWebviewViewProvider<
     return this.webviewView?.visible ?? false;
   }
 
+  public get isWebviewViewResolved() {
+    return this.webviewView !== undefined;
+  }
+
+  public async show(): Promise<void> {
+    this.webviewView?.show(true);
+  }
+
   protected async postMessage(msg: ToMessage): Promise<void> {
     await this.webviewView?.webview.postMessage(msg);
   }

--- a/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-panel.ts
+++ b/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-panel.ts
@@ -35,10 +35,6 @@ export class MethodModelingPanel extends DisposableObject {
   }
 
   public async show(): Promise<void> {
-    if (this.provider.isWebviewViewResolved) {
-      await this.provider.show();
-    } else {
-      await this.app.commands.execute("codeQLMethodModeling.focus");
-    }
+    await this.app.commands.execute("codeQLMethodModeling.focus");
   }
 }

--- a/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-panel.ts
+++ b/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-panel.ts
@@ -10,7 +10,7 @@ export class MethodModelingPanel extends DisposableObject {
   private readonly provider: MethodModelingViewProvider;
 
   constructor(
-    app: App,
+    private readonly app: App,
     modelingStore: ModelingStore,
     editorViewTracker: ModelEditorViewTracker,
   ) {
@@ -25,11 +25,20 @@ export class MethodModelingPanel extends DisposableObject {
       window.registerWebviewViewProvider(
         MethodModelingViewProvider.viewType,
         this.provider,
+        { webviewOptions: { retainContextWhenHidden: true } },
       ),
     );
   }
 
   public async setMethod(method: Method): Promise<void> {
     await this.provider.setMethod(method);
+  }
+
+  public async show(): Promise<void> {
+    if (this.provider.isWebviewViewResolved) {
+      await this.provider.show();
+    } else {
+      await this.app.commands.execute("codeQLMethodModeling.focus");
+    }
   }
 }

--- a/extensions/ql-vscode/src/model-editor/model-editor-module.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-module.ts
@@ -188,6 +188,7 @@ export class ModelEditorModule extends DisposableObject {
         databaseItem: DatabaseItem,
       ) => {
         this.modelingStore.setSelectedMethod(databaseItem, method, usage);
+        await this.methodModelingPanel.show();
       },
     };
   }


### PR DESCRIPTION
If a user manually closes the method modeling panel, there is no good way for them to find it again. They'll need to know to trigger the "Focus on CodeQL Method Modeling View" command from the command pallet. With this PR, the panel gets automatically re-opened. More details in the internal linked issue.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
