### PR TITLE
Convert `modeled-method-fs.ts` to handle multiple models per method

### DIFF
--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -43,6 +43,10 @@ import { AutoModeler } from "./auto-modeler";
 import { telemetryListener } from "../common/vscode/telemetry";
 import { ModelingStore } from "./modeling-store";
 import { ModelEditorViewTracker } from "./model-editor-view-tracker";
+import {
+  convertFromLegacyModeledMethods,
+  convertToLegacyModeledMethods,
+} from "./modeled-methods-legacy";
 
 export class ModelEditorView extends AbstractWebview<
   ToModelEditorMessage,
@@ -235,7 +239,7 @@ export class ModelEditorView extends AbstractWebview<
               this.extensionPack,
               this.databaseItem.language,
               msg.methods,
-              msg.modeledMethods,
+              convertFromLegacyModeledMethods(msg.modeledMethods),
               this.mode,
               this.cliServer,
               this.app.logger,
@@ -381,7 +385,10 @@ export class ModelEditorView extends AbstractWebview<
         this.cliServer,
         this.app.logger,
       );
-      this.modelingStore.setModeledMethods(this.databaseItem, modeledMethods);
+      this.modelingStore.setModeledMethods(
+        this.databaseItem,
+        convertToLegacyModeledMethods(modeledMethods),
+      );
     } catch (e: unknown) {
       void showAndLogErrorMessage(
         this.app.logger,

--- a/extensions/ql-vscode/src/model-editor/modeled-method-fs.ts
+++ b/extensions/ql-vscode/src/model-editor/modeled-method-fs.ts
@@ -89,7 +89,7 @@ export async function loadModeledMethods(
   for (const modeledMethods of Object.values(modeledMethodsByFile)) {
     for (const [key, value] of Object.entries(modeledMethods)) {
       if (!(key in existingModeledMethods)) {
-        existingModeledMethods[key] = value;
+        existingModeledMethods[key] = [];
       }
 
       existingModeledMethods[key].push(...value);

--- a/extensions/ql-vscode/src/model-editor/modeled-methods-legacy.ts
+++ b/extensions/ql-vscode/src/model-editor/modeled-methods-legacy.ts
@@ -21,13 +21,3 @@ export function convertToLegacyModeledMethods(
     }),
   );
 }
-
-export function convertFromLegacyModeledMethodsFiles(
-  modeledMethods: Record<string, Record<string, ModeledMethod>>,
-): Record<string, Record<string, ModeledMethod[]>> {
-  return Object.fromEntries(
-    Object.entries(modeledMethods).map(([filename, modeledMethods]) => {
-      return [filename, convertFromLegacyModeledMethods(modeledMethods)];
-    }),
-  );
-}


### PR DESCRIPTION
This will change the input/output types for modeled methods in the `modeled-method-fs.ts` file to take in multiple models per method. This removes the need for conversion functions between this file and `yaml.ts` files. Instead, the conversion functions are done when calling any functions defined in `modeled-method-fs.ts` files.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
