### PR TITLE
Increase memory limit when running ESLint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,6 +81,8 @@ jobs:
 
       - name: Lint
         working-directory: extensions/ql-vscode
+        env:
+          NODE_OPTIONS: '--max-old-space-size=4096'
         run: |
           npm run lint
 


### PR DESCRIPTION
This increases the memory limit of Node.js when running ESLint in Actions by setting `NODE_OPTIONS=--max-old-space-size=4096`. The [`max-old-space-size` option](https://nodejs.org/api/cli.html#--max-old-space-sizesize-in-megabytes) effectively sets the memory limit of V8 (in megabytes). Since Actions has a 7GB memory limit, 4096 MB should be safe to use.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
