### PR TITLE
Use base postMessage instead of webview one

### DIFF
--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -628,7 +628,7 @@ interface SetMethodModifiedMessage {
 interface SetSelectedMethodMessage {
   t: "setSelectedMethod";
   method: Method;
-  modeledMethod: ModeledMethod;
+  modeledMethod?: ModeledMethod;
   isModified: boolean;
 }
 

--- a/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
+++ b/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
@@ -125,7 +125,7 @@ export class MethodModelingViewProvider extends AbstractWebviewViewProvider<
         if (this.webviewView && e.isActiveDb) {
           const modeledMethod = e.modeledMethods[this.method?.signature ?? ""];
           if (modeledMethod) {
-            await this.webviewView.webview.postMessage({
+            await this.postMessage({
               t: "setModeledMethod",
               method: modeledMethod,
             });
@@ -138,7 +138,7 @@ export class MethodModelingViewProvider extends AbstractWebviewViewProvider<
       this.modelingStore.onModifiedMethodsChanged(async (e) => {
         if (this.webviewView && e.isActiveDb && this.method) {
           const isModified = e.modifiedMethods.has(this.method.signature);
-          await this.webviewView.webview.postMessage({
+          await this.postMessage({
             t: "setMethodModified",
             isModified,
           });
@@ -150,7 +150,7 @@ export class MethodModelingViewProvider extends AbstractWebviewViewProvider<
       this.modelingStore.onSelectedMethodChanged(async (e) => {
         if (this.webviewView) {
           this.method = e.method;
-          await this.webviewView.webview.postMessage({
+          await this.postMessage({
             t: "setSelectedMethod",
             method: e.method,
             modeledMethod: e.modeledMethod,


### PR DESCRIPTION
I noticed we were still using `this.webviewView.webview.postMessage` in a couple of places in the method modeling panel so I fixed that and by doing that a type mismatch was flagged and fixed.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
