### PR TITLE
Convert RevealMethodMessage to only include method signature

### DIFF
--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -579,7 +579,7 @@ interface SetModeledMethodMessage {
 
 interface RevealMethodMessage {
   t: "revealMethod";
-  method: Method;
+  methodSignature: string;
 }
 
 export type ToModelEditorMessage =

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -355,7 +355,7 @@ export class ModelEditorView extends AbstractWebview<
 
     await this.postMessage({
       t: "revealMethod",
-      method,
+      methodSignature: method.signature,
     });
   }
 

--- a/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
@@ -142,7 +142,7 @@ export function ModelEditor({
             );
             break;
           case "revealMethod":
-            setRevealedMethodSignature(msg.method.signature);
+            setRevealedMethodSignature(msg.methodSignature);
 
             break;
           default:


### PR DESCRIPTION
We can avoid putting the entire method in the message because we only need to signature.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
