### PR TITLE
Remove method and modeledMethods from SaveModeledMethods message

### DIFF
--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -543,8 +543,7 @@ interface RefreshMethods {
 
 interface SaveModeledMethods {
   t: "saveModeledMethods";
-  methods: Method[];
-  modeledMethods: Record<string, ModeledMethod>;
+  methodSignatures?: string[];
 }
 
 interface GenerateMethodMessage {

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -228,47 +228,58 @@ export class ModelEditorView extends AbstractWebview<
 
         break;
       case "saveModeledMethods":
-        await withProgress(
-          async (progress) => {
-            progress({
-              step: 1,
-              maxStep: 500 + externalApiQueriesProgressMaxStep,
-              message: "Writing model files",
-            });
-            await saveModeledMethods(
-              this.extensionPack,
-              this.databaseItem.language,
-              msg.methods,
-              msg.modeledMethods,
-              this.mode,
-              this.cliServer,
-              this.app.logger,
-            );
+        {
+          const methods = this.modelingStore.getMethods(
+            this.databaseItem,
+            msg.methodSignatures,
+          );
+          const modeledMethods = this.modelingStore.getModeledMethods(
+            this.databaseItem,
+            msg.methodSignatures,
+          );
 
-            await Promise.all([
-              this.setViewState(),
-              this.loadMethods((update) =>
-                progress({
-                  ...update,
-                  step: update.step + 500,
-                  maxStep: 500 + externalApiQueriesProgressMaxStep,
-                }),
-              ),
-            ]);
-          },
-          {
-            cancellable: false,
-          },
-        );
+          await withProgress(
+            async (progress) => {
+              progress({
+                step: 1,
+                maxStep: 500 + externalApiQueriesProgressMaxStep,
+                message: "Writing model files",
+              });
+              await saveModeledMethods(
+                this.extensionPack,
+                this.databaseItem.language,
+                methods,
+                modeledMethods,
+                this.mode,
+                this.cliServer,
+                this.app.logger,
+              );
 
-        this.modelingStore.removeModifiedMethods(
-          this.databaseItem,
-          Object.keys(msg.modeledMethods),
-        );
+              await Promise.all([
+                this.setViewState(),
+                this.loadMethods((update) =>
+                  progress({
+                    ...update,
+                    step: update.step + 500,
+                    maxStep: 500 + externalApiQueriesProgressMaxStep,
+                  }),
+                ),
+              ]);
+            },
+            {
+              cancellable: false,
+            },
+          );
 
-        void telemetryListener?.sendUIInteraction(
-          "model-editor-save-modeled-methods",
-        );
+          this.modelingStore.removeModifiedMethods(
+            this.databaseItem,
+            Object.keys(modeledMethods),
+          );
+
+          void telemetryListener?.sendUIInteraction(
+            "model-editor-save-modeled-methods",
+          );
+        }
 
         break;
       case "generateMethod":

--- a/extensions/ql-vscode/src/model-editor/modeling-store.ts
+++ b/extensions/ql-vscode/src/model-editor/modeling-store.ts
@@ -156,7 +156,7 @@ export class ModelingStore extends DisposableObject {
 
   /**
    * Returns the methods for the given database item and method signatures.
-   * If no method signatures are provided, returns all methods.
+   * If the `methodSignatures` argument not provided or is undefined, returns all methods.
    */
   public getMethods(
     dbItem: DatabaseItem,
@@ -201,7 +201,7 @@ export class ModelingStore extends DisposableObject {
 
   /**
    * Returns the modeled methods for the given database item and method signatures.
-   * If no method signatures are provided, returns all modeled methods.
+   * If the `methodSignatures` argument not provided or is undefined, returns all modeled methods.
    */
   public getModeledMethods(
     dbItem: DatabaseItem,

--- a/extensions/ql-vscode/src/model-editor/modeling-store.ts
+++ b/extensions/ql-vscode/src/model-editor/modeling-store.ts
@@ -154,6 +154,23 @@ export class ModelingStore extends DisposableObject {
     return this.state.get(this.activeDb);
   }
 
+  /**
+   * Returns the methods for the given database item and method signatures.
+   * If no method signatures are provided, returns all methods.
+   */
+  public getMethods(
+    dbItem: DatabaseItem,
+    methodSignatures?: string[],
+  ): Method[] {
+    const methods = this.getState(dbItem).methods;
+    if (!methodSignatures) {
+      return methods;
+    }
+    return methods.filter((method) =>
+      methodSignatures.includes(method.signature),
+    );
+  }
+
   public setMethods(dbItem: DatabaseItem, methods: Method[]) {
     const dbState = this.getState(dbItem);
     const dbUri = dbItem.databaseUri.toString();
@@ -180,6 +197,25 @@ export class ModelingStore extends DisposableObject {
       hideModeledMethods,
       isActiveDb: dbUri === this.activeDb,
     });
+  }
+
+  /**
+   * Returns the modeled methods for the given database item and method signatures.
+   * If no method signatures are provided, returns all modeled methods.
+   */
+  public getModeledMethods(
+    dbItem: DatabaseItem,
+    methodSignatures?: string[],
+  ): Record<string, ModeledMethod> {
+    const modeledMethods = this.getState(dbItem).modeledMethods;
+    if (!methodSignatures) {
+      return modeledMethods;
+    }
+    return Object.fromEntries(
+      Object.entries(modeledMethods).filter(([key]) =>
+        methodSignatures.includes(key),
+      ),
+    );
   }
 
   public addModeledMethods(

--- a/extensions/ql-vscode/src/model-editor/modeling-store.ts
+++ b/extensions/ql-vscode/src/model-editor/modeling-store.ts
@@ -171,7 +171,7 @@ export class ModelingStore extends DisposableObject {
 
   /**
    * Returns the methods for the given database item and method signatures.
-   * If the `methodSignatures` argument not provided or is undefined, returns all methods.
+   * If the `methodSignatures` argument is not provided or is undefined, returns all methods.
    */
   public getMethods(
     dbItem: DatabaseItem,
@@ -216,7 +216,7 @@ export class ModelingStore extends DisposableObject {
 
   /**
    * Returns the modeled methods for the given database item and method signatures.
-   * If the `methodSignatures` argument not provided or is undefined, returns all modeled methods.
+   * If the `methodSignatures` argument is not provided or is undefined, returns all modeled methods.
    */
   public getModeledMethods(
     dbItem: DatabaseItem,

--- a/extensions/ql-vscode/src/view/model-editor/LibraryRow.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/LibraryRow.tsx
@@ -78,10 +78,7 @@ export type LibraryRowProps = {
   hideModeledMethods: boolean;
   revealedMethodSignature: string | null;
   onChange: (modeledMethod: ModeledMethod) => void;
-  onSaveModelClick: (
-    methods: Method[],
-    modeledMethods: Record<string, ModeledMethod>,
-  ) => void;
+  onSaveModelClick: (methodSignatures: string[]) => void;
   onGenerateFromLlmClick: (
     dependencyName: string,
     methods: Method[],
@@ -165,11 +162,11 @@ export const LibraryRow = ({
 
   const handleSave = useCallback(
     async (e: React.MouseEvent) => {
-      onSaveModelClick(methods, modeledMethods);
+      onSaveModelClick(methods.map((m) => m.signature));
       e.stopPropagation();
       e.preventDefault();
     },
-    [methods, modeledMethods, onSaveModelClick],
+    [methods, onSaveModelClick],
   );
 
   const hasUnsavedChanges = useMemo(() => {

--- a/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
@@ -196,21 +196,15 @@ export function ModelEditor({
   const onSaveAllClick = useCallback(() => {
     vscode.postMessage({
       t: "saveModeledMethods",
-      methods,
-      modeledMethods,
     });
-  }, [methods, modeledMethods]);
+  }, []);
 
-  const onSaveModelClick = useCallback(
-    (methods: Method[], modeledMethods: Record<string, ModeledMethod>) => {
-      vscode.postMessage({
-        t: "saveModeledMethods",
-        methods,
-        modeledMethods,
-      });
-    },
-    [],
-  );
+  const onSaveModelClick = useCallback((methodSignatures: string[]) => {
+    vscode.postMessage({
+      t: "saveModeledMethods",
+      methodSignatures,
+    });
+  }, []);
 
   const onGenerateFromSourceClick = useCallback(() => {
     vscode.postMessage({

--- a/extensions/ql-vscode/src/view/model-editor/ModeledMethodsList.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModeledMethodsList.tsx
@@ -20,10 +20,7 @@ export type ModeledMethodsListProps = {
   viewState: ModelEditorViewState;
   hideModeledMethods: boolean;
   onChange: (modeledMethod: ModeledMethod) => void;
-  onSaveModelClick: (
-    methods: Method[],
-    modeledMethods: Record<string, ModeledMethod>,
-  ) => void;
+  onSaveModelClick: (methodSignatures: string[]) => void;
   onGenerateFromLlmClick: (
     packageName: string,
     methods: Method[],


### PR DESCRIPTION
Removes the `methods` and `modeledMethods` fields from `SaveModeledMethods` in favour of including `methodSignatures`. The extension host can use the `ModelingStore` to look up the methods and modelings using the method signatures.

Involves adding `getMethods` and `getModeledMethods` to `ModelingStore`.

Tested locally and seems to be saving models and updating the "unsaved" labels correctly.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
