### PR TITLE
Add empty states for modeling panel

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1016,6 +1016,10 @@
         "title": "CodeQL: Open CodeQL Model Editor (Beta)"
       },
       {
+        "command": "codeQL.openModelEditorFromModelingPanel",
+        "title": "CodeQL: Open CodeQL Model Editor (Beta)"
+      },
+      {
         "command": "codeQL.mockGitHubApiServer.startRecording",
         "title": "CodeQL: Mock GitHub API Server: Start Scenario Recording"
       },
@@ -1499,6 +1503,10 @@
         },
         {
           "command": "codeQL.openModelEditor"
+        },
+        {
+          "command": "codeQL.openModelEditorFromModelingPanel",
+          "when": "false"
         },
         {
           "command": "codeQLQueries.runLocalQueryContextMenu",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1016,10 +1016,6 @@
         "title": "CodeQL: Open CodeQL Model Editor (Beta)"
       },
       {
-        "command": "codeQL.openModelEditorFromModelingPanel",
-        "title": "CodeQL: Open CodeQL Model Editor (Beta)"
-      },
-      {
         "command": "codeQL.mockGitHubApiServer.startRecording",
         "title": "CodeQL: Mock GitHub API Server: Start Scenario Recording"
       },
@@ -1503,10 +1499,6 @@
         },
         {
           "command": "codeQL.openModelEditor"
-        },
-        {
-          "command": "codeQL.openModelEditorFromModelingPanel",
-          "when": "false"
         },
         {
           "command": "codeQLQueries.runLocalQueryContextMenu",

--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -323,6 +323,7 @@ export type PackagingCommands = {
 
 export type ModelEditorCommands = {
   "codeQL.openModelEditor": () => Promise<void>;
+  "codeQL.openModelEditorFromModelingPanel": () => Promise<void>;
   "codeQLModelEditor.jumpToUsageLocation": (
     method: Method,
     usage: Usage,

--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -610,10 +610,15 @@ interface RevealInEditorMessage {
   method: Method;
 }
 
+interface StartModelingMessage {
+  t: "startModeling";
+}
+
 export type FromMethodModelingMessage =
   | CommonFromViewMessages
   | SetModeledMethodMessage
-  | RevealInEditorMessage;
+  | RevealInEditorMessage
+  | StartModelingMessage;
 
 interface SetMethodMessage {
   t: "setMethod";

--- a/extensions/ql-vscode/src/common/vscode/abstract-webview-view-provider.ts
+++ b/extensions/ql-vscode/src/common/vscode/abstract-webview-view-provider.ts
@@ -13,7 +13,7 @@ export abstract class AbstractWebviewViewProvider<
   private disposables: Disposable[] = [];
 
   constructor(
-    private readonly app: App,
+    protected readonly app: App,
     private readonly webviewKind: WebviewKind,
   ) {}
 

--- a/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
+++ b/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
@@ -92,6 +92,10 @@ export class MethodModelingViewProvider extends AbstractWebviewViewProvider<
         await this.revealInModelEditor(msg.method);
 
         break;
+
+      case "startModeling":
+        await this.app.commands.execute("codeQL.openModelEditor");
+        break;
       default:
         assertNever(msg);
     }

--- a/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
+++ b/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
@@ -94,7 +94,9 @@ export class MethodModelingViewProvider extends AbstractWebviewViewProvider<
         break;
 
       case "startModeling":
-        await this.app.commands.execute("codeQL.openModelEditor");
+        await this.app.commands.execute(
+          "codeQL.openModelEditorFromModelingPanel",
+        );
         break;
       default:
         assertNever(msg);

--- a/extensions/ql-vscode/src/stories/common/ResponsiveContainer.stories.tsx
+++ b/extensions/ql-vscode/src/stories/common/ResponsiveContainer.stories.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+
+import { Meta, StoryFn } from "@storybook/react";
+
+import { ResponsiveContainer as ResponsiveContainerComponent } from "../../view/common/ResponsiveContainer";
+
+export default {
+  title: "Responsive Container",
+  component: ResponsiveContainerComponent,
+} as Meta<typeof ResponsiveContainerComponent>;
+
+const Template: StoryFn<typeof ResponsiveContainerComponent> = (args) => (
+  <ResponsiveContainerComponent>
+    <span>Hello</span>
+  </ResponsiveContainerComponent>
+);
+
+export const ResponsiveContainer = Template.bind({});

--- a/extensions/ql-vscode/src/stories/method-modeling/NoMethodSelected.stories.tsx
+++ b/extensions/ql-vscode/src/stories/method-modeling/NoMethodSelected.stories.tsx
@@ -1,0 +1,16 @@
+import * as React from "react";
+
+import { Meta, StoryFn } from "@storybook/react";
+
+import { NoMethodSelected as NoMethodSelectedComponent } from "../../view/method-modeling/NoMethodSelected";
+
+export default {
+  title: "Method Modeling/No Method Selected",
+  component: NoMethodSelectedComponent,
+} as Meta<typeof NoMethodSelectedComponent>;
+
+const Template: StoryFn<typeof NoMethodSelectedComponent> = () => (
+  <NoMethodSelectedComponent />
+);
+
+export const NoMethodSelected = Template.bind({});

--- a/extensions/ql-vscode/src/stories/method-modeling/NotInModelingMode.stories.tsx
+++ b/extensions/ql-vscode/src/stories/method-modeling/NotInModelingMode.stories.tsx
@@ -1,0 +1,16 @@
+import * as React from "react";
+
+import { Meta, StoryFn } from "@storybook/react";
+
+import { NotInModelingMode as NotInModelingModeComponent } from "../../view/method-modeling/NotInModelingMode";
+
+export default {
+  title: "Method Modeling/Not In Modeling Mode",
+  component: NotInModelingModeComponent,
+} as Meta<typeof NotInModelingModeComponent>;
+
+const Template: StoryFn<typeof NotInModelingModeComponent> = () => (
+  <NotInModelingModeComponent />
+);
+
+export const NotInModelingMode = Template.bind({});

--- a/extensions/ql-vscode/src/view/common/ResponsiveContainer.tsx
+++ b/extensions/ql-vscode/src/view/common/ResponsiveContainer.tsx
@@ -1,0 +1,15 @@
+import { styled } from "styled-components";
+
+export const ResponsiveContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  height: 100vh;
+
+  @media (min-height: 300px) {
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+  }
+`;

--- a/extensions/ql-vscode/src/view/method-modeling/NoMethodSelected.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/NoMethodSelected.tsx
@@ -1,0 +1,8 @@
+import * as React from "react";
+import { ResponsiveContainer } from "../common/ResponsiveContainer";
+
+export const NoMethodSelected = () => {
+  return (
+    <ResponsiveContainer>Select an API or method to model</ResponsiveContainer>
+  );
+};

--- a/extensions/ql-vscode/src/view/method-modeling/NotInModelingMode.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/NotInModelingMode.tsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+import { useCallback } from "react";
+import { vscode } from "../vscode-api";
+import { styled } from "styled-components";
+import TextButton from "../common/TextButton";
+import { ResponsiveContainer } from "../common/ResponsiveContainer";
+
+const Button = styled(TextButton)`
+  margin-top: 0.2rem;
+`;
+
+export const NotInModelingMode = () => {
+  const handleClick = useCallback(() => {
+    vscode.postMessage({
+      t: "startModeling",
+    });
+  }, []);
+
+  return (
+    <ResponsiveContainer>
+      <span>Not in modeling mode</span>
+      <Button onClick={handleClick}>Start modeling</Button>
+    </ResponsiveContainer>
+  );
+};


### PR DESCRIPTION
Added components for the empty states of the method modeling panel. These are not yet hooked to anything.

As part of this I've introduced a reusable component that I've called "ResponsiveContainer", please let me know if you can think of a better name!

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
