### PR TITLE
Packaging: Remove ML-powered queries pack from known list

### DIFF
--- a/extensions/ql-vscode/src/common/query-language.ts
+++ b/extensions/ql-vscode/src/common/query-language.ts
@@ -40,10 +40,7 @@ export const PACKS_BY_QUERY_LANGUAGE = {
   ],
   [QueryLanguage.Go]: ["codeql/go-queries"],
   [QueryLanguage.Java]: ["codeql/java-queries"],
-  [QueryLanguage.Javascript]: [
-    "codeql/javascript-queries",
-    "codeql/javascript-experimental-atm-queries",
-  ],
+  [QueryLanguage.Javascript]: ["codeql/javascript-queries"],
   [QueryLanguage.Python]: ["codeql/python-queries"],
   [QueryLanguage.Ruby]: ["codeql/ruby-queries"],
 };


### PR DESCRIPTION
ML-powered queries are [now deprecated](https://github.blog/changelog/2023-09-29-codeql-code-scanning-deprecates-ml-powered-alerts/), so this PR removes the ML-powered queries pack from the list we'll download by default for JavaScript.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
