### PR TITLE
UI polish for modeling panel

### DIFF
--- a/extensions/ql-vscode/src/view/method-modeling/MethodModeling.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/MethodModeling.tsx
@@ -10,14 +10,14 @@ import { VSCodeTag } from "@vscode/webview-ui-toolkit/react";
 import { ReviewInEditorButton } from "./ReviewInEditorButton";
 
 const Container = styled.div`
-  padding: 0.3rem;
+  padding-top: 0.5rem;
   margin-bottom: 1rem;
   width: 100%;
 `;
 
 const Title = styled.div`
-  padding-bottom: 0.3rem;
-  font-size: 0.7rem;
+  padding-bottom: 0.5rem;
+  font-size: 0.9rem;
   text-transform: uppercase;
   display: flex;
   justify-content: space-between;
@@ -35,6 +35,11 @@ const DependencyContainer = styled.div`
   padding: 0.5rem;
   word-wrap: break-word;
   word-break: break-all;
+  margin-bottom: 0.8rem;
+`;
+
+const StyledMethodModelingInputs = styled(MethodModelingInputs)`
+  padding-bottom: 0.5rem;
 `;
 
 const StyledVSCodeTag = styled(VSCodeTag)<{ visible: boolean }>`
@@ -71,7 +76,7 @@ export const MethodModeling = ({
         <ModelingStatusIndicator status={modelingStatus} />
         <MethodName {...method} />
       </DependencyContainer>
-      <MethodModelingInputs
+      <StyledMethodModelingInputs
         method={method}
         modeledMethod={modeledMethod}
         onChange={onChange}

--- a/extensions/ql-vscode/src/view/method-modeling/MethodModeling.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/MethodModeling.tsx
@@ -21,6 +21,7 @@ const Title = styled.div`
   text-transform: uppercase;
   display: flex;
   justify-content: space-between;
+  align-items: center;
 `;
 
 const DependencyContainer = styled.div`
@@ -35,6 +36,16 @@ const DependencyContainer = styled.div`
   word-wrap: break-word;
   word-break: break-all;
 `;
+
+const StyledVSCodeTag = styled(VSCodeTag)<{ visible: boolean }>`
+  visibility: ${(props) => (props.visible ? "visible" : "hidden")};
+`;
+
+const UnsavedTag = ({ modelingStatus }: { modelingStatus: ModelingStatus }) => (
+  <StyledVSCodeTag visible={modelingStatus === "unsaved"}>
+    Unsaved
+  </StyledVSCodeTag>
+);
 
 export type MethodModelingProps = {
   modelingStatus: ModelingStatus;
@@ -54,7 +65,7 @@ export const MethodModeling = ({
       <Title>
         {method.packageName}
         {method.libraryVersion && <>@{method.libraryVersion}</>}
-        {modelingStatus === "unsaved" ? <VSCodeTag>Unsaved</VSCodeTag> : null}
+        <UnsavedTag modelingStatus={modelingStatus} />
       </Title>
       <DependencyContainer>
         <ModelingStatusIndicator status={modelingStatus} />

--- a/extensions/ql-vscode/src/view/method-modeling/MethodModelingInputs.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/MethodModelingInputs.tsx
@@ -11,11 +11,14 @@ const Container = styled.div`
   padding-top: 0.5rem;
 `;
 
-const Input = styled.label``;
+const Input = styled.label`
+  display: block;
+  padding-bottom: 0.3rem;
+`;
 
 const Name = styled.span`
   display: block;
-  padding-bottom: 0.3rem;
+  padding-bottom: 0.5rem;
 `;
 
 export type MethodModelingInputsProps = {

--- a/extensions/ql-vscode/src/view/method-modeling/ReviewInEditorButton.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/ReviewInEditorButton.tsx
@@ -6,7 +6,7 @@ import TextButton from "../common/TextButton";
 import { Method } from "../../model-editor/method";
 
 const Button = styled(TextButton)`
-  margin-top: 0.5rem;
+  margin-top: 0.7rem;
 `;
 
 type Props = {


### PR DESCRIPTION
Some stylistic changes to the method modeling panel, mainly to space out elements better.

This is how it looks now

<img width="439" alt="image" src="https://github.com/github/vscode-codeql/assets/311693/134ba255-4523-4c9f-a4ea-71f312688e93">


## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
