### PR TITLE
Add view state to method modeling panel

### DIFF
--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -19,7 +19,10 @@ import { ErrorLike } from "../common/errors";
 import { DataFlowPaths } from "../variant-analysis/shared/data-flow-paths";
 import { Method, Usage } from "../model-editor/method";
 import { ModeledMethod } from "../model-editor/modeled-method";
-import { ModelEditorViewState } from "../model-editor/shared/view-state";
+import {
+  MethodModelingPanelViewState,
+  ModelEditorViewState,
+} from "../model-editor/shared/view-state";
 import { Mode } from "../model-editor/shared/mode";
 import { QueryLanguage } from "./query-language";
 
@@ -625,6 +628,11 @@ export type FromMethodModelingMessage =
   | RevealInEditorMessage
   | StartModelingMessage;
 
+interface SetMethodModelingPanelViewStateMessage {
+  t: "setMethodModelingPanelViewState";
+  viewState: MethodModelingPanelViewState;
+}
+
 interface SetMethodMessage {
   t: "setMethod";
   method: Method;
@@ -643,6 +651,7 @@ interface SetSelectedMethodMessage {
 }
 
 export type ToMethodModelingMessage =
+  | SetMethodModelingPanelViewStateMessage
   | SetMethodMessage
   | SetModeledMethodMessage
   | SetMethodModifiedMessage

--- a/extensions/ql-vscode/src/model-editor/shared/view-state.ts
+++ b/extensions/ql-vscode/src/model-editor/shared/view-state.ts
@@ -8,3 +8,7 @@ export interface ModelEditorViewState {
   showMultipleModels: boolean;
   mode: Mode;
 }
+
+export interface MethodModelingPanelViewState {
+  showMultipleModels: boolean;
+}

--- a/extensions/ql-vscode/src/view/method-modeling/MethodModeling.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/MethodModeling.tsx
@@ -40,6 +40,7 @@ export type MethodModelingProps = {
   modelingStatus: ModelingStatus;
   method: Method;
   modeledMethod: ModeledMethod | undefined;
+  showMultipleModels?: boolean;
   onChange: (modeledMethod: ModeledMethod) => void;
 };
 

--- a/extensions/ql-vscode/src/view/method-modeling/MethodModelingView.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/MethodModelingView.tsx
@@ -9,8 +9,16 @@ import { ModeledMethod } from "../../model-editor/modeled-method";
 import { vscode } from "../vscode-api";
 import { NotInModelingMode } from "./NotInModelingMode";
 import { NoMethodSelected } from "./NoMethodSelected";
+import { MethodModelingPanelViewState } from "../../model-editor/shared/view-state";
 
-export function MethodModelingView(): JSX.Element {
+type Props = {
+  initialViewState?: MethodModelingPanelViewState;
+};
+
+export function MethodModelingView({ initialViewState }: Props): JSX.Element {
+  const [viewState, setViewState] = useState<
+    MethodModelingPanelViewState | undefined
+  >(initialViewState);
   const [inModelingMode, setInModelingMode] = useState<boolean>(false);
 
   const [method, setMethod] = useState<Method | undefined>(undefined);
@@ -31,6 +39,9 @@ export function MethodModelingView(): JSX.Element {
       if (evt.origin === window.origin) {
         const msg: ToMethodModelingMessage = evt.data;
         switch (msg.t) {
+          case "setMethodModelingPanelViewState":
+            setViewState(msg.viewState);
+            break;
           case "setInModelingMode":
             setInModelingMode(msg.inModelingMode);
             break;
@@ -84,6 +95,7 @@ export function MethodModelingView(): JSX.Element {
       modelingStatus={modelingStatus}
       method={method}
       modeledMethod={modeledMethod}
+      showMultipleModels={viewState?.showMultipleModels}
       onChange={onChange}
     />
   );


### PR DESCRIPTION
This adds a view state to the method modeling panel similar to the model editor. This will be used to send the state of the show multiple models feature flag to the webview so this can be used to selectively show/hide components in the method modeling panel.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
