### PR TITLE
Listen to modeling setting changes in the model editor and method modeling panel

### DIFF
--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -714,7 +714,7 @@ const SHOW_MULTIPLE_MODELS = new Setting("showMultipleModels", MODEL_SETTING);
 export interface ModelConfig {
   flowGeneration: boolean;
   llmGeneration: boolean;
-  extensionsDirectory: string | undefined;
+  getExtensionsDirectory(languageId: string): string | undefined;
   showMultipleModels: boolean;
 }
 
@@ -731,29 +731,13 @@ export class ModelConfigListener extends ConfigListener implements ModelConfig {
     return !!LLM_GENERATION.getValue<boolean>();
   }
 
-  public get extensionsDirectory(): string | undefined {
-    return EXTENSIONS_DIRECTORY.getValue<string>();
+  public getExtensionsDirectory(languageId: string): string | undefined {
+    return EXTENSIONS_DIRECTORY.getValue<string>({
+      languageId,
+    });
   }
 
   public get showMultipleModels(): boolean {
     return !!SHOW_MULTIPLE_MODELS.getValue<boolean>();
   }
-}
-
-export function showFlowGeneration(): boolean {
-  return !!FLOW_GENERATION.getValue<boolean>();
-}
-
-export function showLlmGeneration(): boolean {
-  return !!LLM_GENERATION.getValue<boolean>();
-}
-
-export function getExtensionsDirectory(languageId: string): string | undefined {
-  return EXTENSIONS_DIRECTORY.getValue<string>({
-    languageId,
-  });
-}
-
-export function showMultipleModels(): boolean {
-  return !!SHOW_MULTIPLE_MODELS.getValue<boolean>();
 }

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -711,6 +711,35 @@ const LLM_GENERATION = new Setting("llmGeneration", MODEL_SETTING);
 const EXTENSIONS_DIRECTORY = new Setting("extensionsDirectory", MODEL_SETTING);
 const SHOW_MULTIPLE_MODELS = new Setting("showMultipleModels", MODEL_SETTING);
 
+export interface ModelConfig {
+  flowGeneration: boolean;
+  llmGeneration: boolean;
+  extensionsDirectory: string | undefined;
+  showMultipleModels: boolean;
+}
+
+export class ModelConfigListener extends ConfigListener implements ModelConfig {
+  protected handleDidChangeConfiguration(e: ConfigurationChangeEvent): void {
+    this.handleDidChangeConfigurationForRelevantSettings([MODEL_SETTING], e);
+  }
+
+  public get flowGeneration(): boolean {
+    return !!FLOW_GENERATION.getValue<boolean>();
+  }
+
+  public get llmGeneration(): boolean {
+    return !!LLM_GENERATION.getValue<boolean>();
+  }
+
+  public get extensionsDirectory(): string | undefined {
+    return EXTENSIONS_DIRECTORY.getValue<string>();
+  }
+
+  public get showMultipleModels(): boolean {
+    return !!SHOW_MULTIPLE_MODELS.getValue<boolean>();
+  }
+}
+
 export function showFlowGeneration(): boolean {
   return !!FLOW_GENERATION.getValue<boolean>();
 }

--- a/extensions/ql-vscode/src/model-editor/extension-pack-picker.ts
+++ b/extensions/ql-vscode/src/model-editor/extension-pack-picker.ts
@@ -11,7 +11,7 @@ import { getQlPackPath, QLPACK_FILENAMES } from "../common/ql";
 import { getErrorMessage } from "../common/helpers-pure";
 import { ExtensionPack } from "./shared/extension-pack";
 import { NotificationLogger, showAndLogErrorMessage } from "../common/logging";
-import { getExtensionsDirectory } from "../config";
+import { ModelConfig } from "../config";
 import {
   autoNameExtensionPack,
   ExtensionPackName,
@@ -28,6 +28,7 @@ const extensionPackValidate = ajv.compile(extensionPackMetadataSchemaJson);
 export async function pickExtensionPack(
   cliServer: Pick<CodeQLCliServer, "resolveQlpacks">,
   databaseItem: Pick<DatabaseItem, "name" | "language">,
+  modelConfig: ModelConfig,
   logger: NotificationLogger,
   progress: ProgressCallback,
   maxStep: number,
@@ -56,7 +57,9 @@ export async function pickExtensionPack(
   });
 
   // Get the `codeQL.model.extensionsDirectory` setting for the language
-  const userExtensionsDirectory = getExtensionsDirectory(databaseItem.language);
+  const userExtensionsDirectory = modelConfig.getExtensionsDirectory(
+    databaseItem.language,
+  );
 
   // If the setting is not set, automatically pick a suitable directory
   const extensionsDirectory = userExtensionsDirectory

--- a/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-panel.ts
+++ b/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-panel.ts
@@ -5,6 +5,7 @@ import { MethodModelingViewProvider } from "./method-modeling-view-provider";
 import { Method } from "../method";
 import { ModelingStore } from "../modeling-store";
 import { ModelEditorViewTracker } from "../model-editor-view-tracker";
+import { ModelConfigListener } from "../../config";
 
 export class MethodModelingPanel extends DisposableObject {
   private readonly provider: MethodModelingViewProvider;
@@ -16,10 +17,16 @@ export class MethodModelingPanel extends DisposableObject {
   ) {
     super();
 
+    // This is here instead of in MethodModelingViewProvider because we need to
+    // dispose this when the extension gets disposed, not when the webview gets
+    // disposed.
+    const modelConfig = this.push(new ModelConfigListener());
+
     this.provider = new MethodModelingViewProvider(
       app,
       modelingStore,
       editorViewTracker,
+      modelConfig,
     );
     this.push(
       window.registerWebviewViewProvider(

--- a/extensions/ql-vscode/src/model-editor/model-editor-module.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-module.ts
@@ -21,6 +21,7 @@ import { MethodModelingPanel } from "./method-modeling/method-modeling-panel";
 import { ModelingStore } from "./modeling-store";
 import { showResolvableLocation } from "../databases/local-databases/locations";
 import { ModelEditorViewTracker } from "./model-editor-view-tracker";
+import { ModelConfigListener } from "../config";
 
 const SUPPORTED_LANGUAGES: string[] = ["java", "csharp"];
 
@@ -150,9 +151,12 @@ export class ModelEditorModule extends DisposableObject {
             return;
           }
 
+          const modelConfig = this.push(new ModelConfigListener());
+
           const modelFile = await pickExtensionPack(
             this.cliServer,
             db,
+            modelConfig,
             this.app.logger,
             progress,
             maxStep,
@@ -172,7 +176,12 @@ export class ModelEditorModule extends DisposableObject {
             unsafeCleanup: true,
           });
 
-          const success = await setUpPack(this.cliServer, queryDir, language);
+          const success = await setUpPack(
+            this.cliServer,
+            queryDir,
+            language,
+            modelConfig,
+          );
           if (!success) {
             await cleanupQueryDir();
             return;
@@ -188,6 +197,7 @@ export class ModelEditorModule extends DisposableObject {
             this.app,
             this.modelingStore,
             this.editorViewTracker,
+            modelConfig,
             this.databaseManager,
             this.cliServer,
             this.queryRunner,

--- a/extensions/ql-vscode/src/model-editor/model-editor-queries.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-queries.ts
@@ -4,7 +4,7 @@ import { writeFile } from "fs-extra";
 import { dump } from "js-yaml";
 import { prepareExternalApiQuery } from "./external-api-usage-queries";
 import { CodeQLCliServer } from "../codeql-cli/cli";
-import { showLlmGeneration } from "../config";
+import { ModelConfig } from "../config";
 import { Mode } from "./shared/mode";
 import { resolveQueriesFromPacks } from "../local-queries";
 import { modeTag } from "./mode-tag";
@@ -28,12 +28,14 @@ export const syntheticQueryPackName = "codeql/external-api-usage";
  * @param cliServer The CodeQL CLI server to use.
  * @param queryDir The directory to set up.
  * @param language The language to use for the queries.
+ * @param modelConfig The model config to use.
  * @returns true if the setup was successful, false otherwise.
  */
 export async function setUpPack(
   cliServer: CodeQLCliServer,
   queryDir: string,
   language: QueryLanguage,
+  modelConfig: ModelConfig,
 ): Promise<boolean> {
   // Download the required query packs
   await cliServer.packDownload([`codeql/${language}-queries`]);
@@ -84,7 +86,7 @@ export async function setUpPack(
   }
 
   // Download any other required packs
-  if (language === "java" && showLlmGeneration()) {
+  if (language === "java" && modelConfig.llmGeneration) {
     await cliServer.packDownload([`codeql/${language}-automodel-queries`]);
   }
 

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -17,8 +17,8 @@ import {
 import { ProgressCallback, withProgress } from "../common/vscode/progress";
 import { QueryRunner } from "../query-server";
 import {
-  showAndLogExceptionWithTelemetry,
   showAndLogErrorMessage,
+  showAndLogExceptionWithTelemetry,
 } from "../common/logging";
 import { DatabaseItem, DatabaseManager } from "../databases/local-databases";
 import { CodeQLCliServer } from "../codeql-cli/cli";
@@ -34,11 +34,7 @@ import {
 import { Method, Usage } from "./method";
 import { ModeledMethod } from "./modeled-method";
 import { ExtensionPack } from "./shared/extension-pack";
-import {
-  showFlowGeneration,
-  showLlmGeneration,
-  showMultipleModels,
-} from "../config";
+import { ModelConfigListener } from "../config";
 import { Mode } from "./shared/mode";
 import { loadModeledMethods, saveModeledMethods } from "./modeled-method-fs";
 import { pickExtensionPack } from "./extension-pack-picker";
@@ -58,6 +54,7 @@ export class ModelEditorView extends AbstractWebview<
     protected readonly app: App,
     private readonly modelingStore: ModelingStore,
     private readonly viewTracker: ModelEditorViewTracker<ModelEditorView>,
+    private readonly modelConfig: ModelConfigListener,
     private readonly databaseManager: DatabaseManager,
     private readonly cliServer: CodeQLCliServer,
     private readonly queryRunner: QueryRunner,
@@ -71,6 +68,7 @@ export class ModelEditorView extends AbstractWebview<
 
     this.modelingStore.initializeStateForDb(databaseItem);
     this.registerToModelingStoreEvents();
+    this.registerToModelConfigEvents();
 
     this.viewTracker.registerView(this);
 
@@ -334,15 +332,15 @@ export class ModelEditorView extends AbstractWebview<
 
   private async setViewState(): Promise<void> {
     const showLlmButton =
-      this.databaseItem.language === "java" && showLlmGeneration();
+      this.databaseItem.language === "java" && this.modelConfig.llmGeneration;
 
     await this.postMessage({
       t: "setModelEditorViewState",
       viewState: {
         extensionPack: this.extensionPack,
-        showFlowGeneration: showFlowGeneration(),
+        showFlowGeneration: this.modelConfig.flowGeneration,
         showLlmButton,
-        showMultipleModels: showMultipleModels(),
+        showMultipleModels: this.modelConfig.showMultipleModels,
         mode: this.mode,
       },
     });
@@ -481,6 +479,7 @@ export class ModelEditorView extends AbstractWebview<
       const modelFile = await pickExtensionPack(
         this.cliServer,
         addedDatabase,
+        this.modelConfig,
         this.app.logger,
         progress,
         3,
@@ -493,6 +492,7 @@ export class ModelEditorView extends AbstractWebview<
         this.app,
         this.modelingStore,
         this.viewTracker,
+        this.modelConfig,
         this.databaseManager,
         this.cliServer,
         this.queryRunner,
@@ -610,6 +610,14 @@ export class ModelEditorView extends AbstractWebview<
             methodSignatures: [...event.modifiedMethods],
           });
         }
+      }),
+    );
+  }
+
+  private registerToModelConfigEvents() {
+    this.push(
+      this.modelConfig.onDidChangeConfiguration(() => {
+        void this.setViewState();
       }),
     );
   }

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/model-editor-queries.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/model-editor-queries.test.ts
@@ -8,6 +8,7 @@ import { QueryLanguage } from "../../../../src/common/query-language";
 import { Mode } from "../../../../src/model-editor/shared/mode";
 import { mockedObject } from "../../utils/mocking.helpers";
 import { CodeQLCliServer } from "../../../../src/codeql-cli/cli";
+import { ModelConfig } from "../../../../src/config";
 
 describe("setUpPack", () => {
   let queryDir: string;
@@ -32,8 +33,11 @@ describe("setUpPack", () => {
         packInstall: jest.fn(),
         resolveQueriesInSuite: jest.fn().mockResolvedValue([]),
       });
+      const modelConfig = mockedObject<ModelConfig>({
+        llmGeneration: false,
+      });
 
-      await setUpPack(cliServer, queryDir, language);
+      await setUpPack(cliServer, queryDir, language, modelConfig);
 
       const queryFiles = await readdir(queryDir);
       expect(queryFiles.sort()).toEqual(
@@ -89,8 +93,11 @@ describe("setUpPack", () => {
           .fn()
           .mockResolvedValue(["/a/b/c/ApplicationModeEndpoints.ql"]),
       });
+      const modelConfig = mockedObject<ModelConfig>({
+        llmGeneration: false,
+      });
 
-      await setUpPack(cliServer, queryDir, language);
+      await setUpPack(cliServer, queryDir, language, modelConfig);
 
       const queryFiles = await readdir(queryDir);
       expect(queryFiles.sort()).toEqual(["codeql-pack.yml"].sort());

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/model-editor-view.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/model-editor-view.test.ts
@@ -10,11 +10,15 @@ import { QueryRunner } from "../../../../src/query-server";
 import { ExtensionPack } from "../../../../src/model-editor/shared/extension-pack";
 import { createMockModelingStore } from "../../../__mocks__/model-editor/modelingStoreMock";
 import { createMockModelEditorViewTracker } from "../../../__mocks__/model-editor/modelEditorViewTrackerMock";
+import { ModelConfigListener } from "../../../../src/config";
 
 describe("ModelEditorView", () => {
   const app = createMockApp({});
   const modelingStore = createMockModelingStore();
   const viewTracker = createMockModelEditorViewTracker();
+  const modelConfig = mockedObject<ModelConfigListener>({
+    onDidChangeConfiguration: jest.fn(),
+  });
   const databaseManager = mockEmptyDatabaseManager();
   const cliServer = mockedObject<CodeQLCliServer>({});
   const queryRunner = mockedObject<QueryRunner>({});
@@ -41,6 +45,7 @@ describe("ModelEditorView", () => {
       app,
       modelingStore,
       viewTracker,
+      modelConfig,
       databaseManager,
       cliServer,
       queryRunner,


### PR DESCRIPTION
This introduces two new types: `ModelConfig` and `ModelConfigListener`. These types can now be used to retrieve config settings relating to modeling. These types can also be used to listen to changes of the modeling settings which makes it possible for the views to use a new view state without a restart.

These types also make it easier to mock settings in tests.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
