### PR TITLE
Add ability for method modeling panel to render multiple modelings of the same method

### DIFF
--- a/extensions/ql-vscode/src/stories/method-modeling/MethodModeling.stories.tsx
+++ b/extensions/ql-vscode/src/stories/method-modeling/MethodModeling.stories.tsx
@@ -18,18 +18,20 @@ const method = createMethod();
 export const MethodUnmodeled = Template.bind({});
 MethodUnmodeled.args = {
   method,
+  modeledMethods: [],
   modelingStatus: "unmodeled",
 };
 
 export const MethodModeled = Template.bind({});
 MethodModeled.args = {
   method,
-
+  modeledMethods: [],
   modelingStatus: "unsaved",
 };
 
 export const MethodSaved = Template.bind({});
 MethodSaved.args = {
   method,
+  modeledMethods: [],
   modelingStatus: "saved",
 };

--- a/extensions/ql-vscode/src/stories/method-modeling/MethodModeling.stories.tsx
+++ b/extensions/ql-vscode/src/stories/method-modeling/MethodModeling.stories.tsx
@@ -37,8 +37,24 @@ MethodSaved.args = {
   modelingStatus: "saved",
 };
 
-export const MultipleModelings = Template.bind({});
-MultipleModelings.args = {
+export const MultipleModelingsUnmodeled = Template.bind({});
+MultipleModelingsUnmodeled.args = {
+  method,
+  modeledMethods: [],
+  showMultipleModels: true,
+  modelingStatus: "saved",
+};
+
+export const MultipleModelingsModeledSingle = Template.bind({});
+MultipleModelingsModeledSingle.args = {
+  method,
+  modeledMethods: [createModeledMethod(method)],
+  showMultipleModels: true,
+  modelingStatus: "saved",
+};
+
+export const MultipleModelingsModeledMultiple = Template.bind({});
+MultipleModelingsModeledMultiple.args = {
   method,
   modeledMethods: [
     createModeledMethod(method),

--- a/extensions/ql-vscode/src/stories/method-modeling/MethodModeling.stories.tsx
+++ b/extensions/ql-vscode/src/stories/method-modeling/MethodModeling.stories.tsx
@@ -4,6 +4,7 @@ import { Meta, StoryFn } from "@storybook/react";
 
 import { MethodModeling as MethodModelingComponent } from "../../view/method-modeling/MethodModeling";
 import { createMethod } from "../../../test/factories/model-editor/method-factories";
+import { createModeledMethod } from "../../../test/factories/model-editor/modeled-method-factories";
 export default {
   title: "Method Modeling/Method Modeling",
   component: MethodModelingComponent,
@@ -33,5 +34,22 @@ export const MethodSaved = Template.bind({});
 MethodSaved.args = {
   method,
   modeledMethods: [],
+  modelingStatus: "saved",
+};
+
+export const MultipleModelings = Template.bind({});
+MultipleModelings.args = {
+  method,
+  modeledMethods: [
+    createModeledMethod(method),
+    createModeledMethod({
+      ...method,
+      type: "source",
+      input: "",
+      output: "ReturnValue",
+      kind: "remote",
+    }),
+  ],
+  showMultipleModels: true,
   modelingStatus: "saved",
 };

--- a/extensions/ql-vscode/src/view/common/icon/CodiconButton.tsx
+++ b/extensions/ql-vscode/src/view/common/icon/CodiconButton.tsx
@@ -1,0 +1,50 @@
+import * as React from "react";
+import { styled } from "styled-components";
+import classNames from "classnames";
+
+type Size = "x-small" | "small" | "medium" | "large" | "x-large";
+
+const StyledButton = styled.button<{ size: Size }>`
+  background: none;
+  color: var(--vscode-textLink-foreground);
+  border: none;
+  cursor: pointer;
+  font-size: ${(props) => props.size ?? "1em"};
+  padding: 0;
+  vertical-align: text-bottom;
+
+  &:disabled {
+    color: var(--vscode-disabledForeground);
+    cursor: default;
+  }
+`;
+
+export const CodiconButton = ({
+  size,
+  onClick,
+  className,
+  name,
+  label,
+  disabled,
+}: {
+  size?: Size;
+  onClick: (e: React.MouseEvent) => void;
+  className?: string;
+  name: string;
+  label: string;
+  disabled?: boolean;
+}) => (
+  <StyledButton
+    size={size}
+    onClick={onClick}
+    className={className}
+    disabled={disabled}
+  >
+    <span
+      role="img"
+      aria-label={label}
+      title={label}
+      className={classNames("codicon", `codicon-${name}`, className)}
+    />
+  </StyledButton>
+);

--- a/extensions/ql-vscode/src/view/common/icon/CodiconButton.tsx
+++ b/extensions/ql-vscode/src/view/common/icon/CodiconButton.tsx
@@ -39,11 +39,11 @@ export const CodiconButton = ({
     onClick={onClick}
     className={className}
     disabled={disabled}
+    aria-label={label}
+    title={label}
   >
     <span
       role="img"
-      aria-label={label}
-      title={label}
       className={classNames("codicon", `codicon-${name}`, className)}
     />
   </StyledButton>

--- a/extensions/ql-vscode/src/view/common/icon/CodiconButton.tsx
+++ b/extensions/ql-vscode/src/view/common/icon/CodiconButton.tsx
@@ -2,14 +2,11 @@ import * as React from "react";
 import { styled } from "styled-components";
 import classNames from "classnames";
 
-type Size = "x-small" | "small" | "medium" | "large" | "x-large";
-
-const StyledButton = styled.button<{ size: Size }>`
+const StyledButton = styled.button`
   background: none;
   color: var(--vscode-textLink-foreground);
   border: none;
   cursor: pointer;
-  font-size: ${(props) => props.size ?? "1em"};
   padding: 0;
   vertical-align: text-bottom;
 
@@ -20,14 +17,12 @@ const StyledButton = styled.button<{ size: Size }>`
 `;
 
 export const CodiconButton = ({
-  size,
   onClick,
   className,
   name,
   label,
   disabled,
 }: {
-  size?: Size;
   onClick: (e: React.MouseEvent) => void;
   className?: string;
   name: string;
@@ -35,7 +30,6 @@ export const CodiconButton = ({
   disabled?: boolean;
 }) => (
   <StyledButton
-    size={size}
     onClick={onClick}
     className={className}
     disabled={disabled}

--- a/extensions/ql-vscode/src/view/common/icon/index.ts
+++ b/extensions/ql-vscode/src/view/common/icon/index.ts
@@ -1,4 +1,5 @@
 export * from "./Codicon";
+export * from "./CodiconButton";
 export * from "./ErrorIcon";
 export * from "./LoadingIcon";
 export * from "./SuccessIcon";

--- a/extensions/ql-vscode/src/view/method-modeling/MethodModeling.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/MethodModeling.tsx
@@ -5,9 +5,9 @@ import { ModelingStatusIndicator } from "../model-editor/ModelingStatusIndicator
 import { Method } from "../../model-editor/method";
 import { MethodName } from "../model-editor/MethodName";
 import { ModeledMethod } from "../../model-editor/modeled-method";
-import { MethodModelingInputs } from "./MethodModelingInputs";
 import { VSCodeTag } from "@vscode/webview-ui-toolkit/react";
 import { ReviewInEditorButton } from "./ReviewInEditorButton";
+import { ModeledMethodsPanel } from "./ModeledMethodsPanel";
 
 const Container = styled.div`
   padding-top: 0.5rem;
@@ -38,10 +38,6 @@ const DependencyContainer = styled.div`
   margin-bottom: 0.8rem;
 `;
 
-const StyledMethodModelingInputs = styled(MethodModelingInputs)`
-  padding-bottom: 0.5rem;
-`;
-
 const StyledVSCodeTag = styled(VSCodeTag)<{ visible: boolean }>`
   visibility: ${(props) => (props.visible ? "visible" : "hidden")};
 `;
@@ -64,6 +60,7 @@ export const MethodModeling = ({
   modelingStatus,
   modeledMethods,
   method,
+  showMultipleModels = false,
   onChange,
 }: MethodModelingProps): JSX.Element => {
   return (
@@ -77,11 +74,10 @@ export const MethodModeling = ({
         <ModelingStatusIndicator status={modelingStatus} />
         <MethodName {...method} />
       </DependencyContainer>
-      <StyledMethodModelingInputs
+      <ModeledMethodsPanel
         method={method}
-        modeledMethod={
-          modeledMethods.length > 0 ? modeledMethods[0] : undefined
-        }
+        modeledMethods={modeledMethods}
+        showMultipleModels={showMultipleModels}
         onChange={onChange}
       />
       <ReviewInEditorButton method={method} />

--- a/extensions/ql-vscode/src/view/method-modeling/MethodModeling.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/MethodModeling.tsx
@@ -55,14 +55,14 @@ const UnsavedTag = ({ modelingStatus }: { modelingStatus: ModelingStatus }) => (
 export type MethodModelingProps = {
   modelingStatus: ModelingStatus;
   method: Method;
-  modeledMethod: ModeledMethod | undefined;
+  modeledMethods: ModeledMethod[];
   showMultipleModels?: boolean;
   onChange: (modeledMethod: ModeledMethod) => void;
 };
 
 export const MethodModeling = ({
   modelingStatus,
-  modeledMethod,
+  modeledMethods,
   method,
   onChange,
 }: MethodModelingProps): JSX.Element => {
@@ -79,7 +79,9 @@ export const MethodModeling = ({
       </DependencyContainer>
       <StyledMethodModelingInputs
         method={method}
-        modeledMethod={modeledMethod}
+        modeledMethod={
+          modeledMethods.length > 0 ? modeledMethods[0] : undefined
+        }
         onChange={onChange}
       />
       <ReviewInEditorButton method={method} />

--- a/extensions/ql-vscode/src/view/method-modeling/MethodModelingView.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/MethodModelingView.tsx
@@ -94,7 +94,7 @@ export function MethodModelingView({ initialViewState }: Props): JSX.Element {
     <MethodModeling
       modelingStatus={modelingStatus}
       method={method}
-      modeledMethod={modeledMethod}
+      modeledMethods={modeledMethod ? [modeledMethod] : []}
       showMultipleModels={viewState?.showMultipleModels}
       onChange={onChange}
     />

--- a/extensions/ql-vscode/src/view/method-modeling/ModeledMethodsPanel.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/ModeledMethodsPanel.tsx
@@ -5,7 +5,7 @@ import { Method } from "../../model-editor/method";
 import { styled } from "styled-components";
 import { MultipleModeledMethodsPanel } from "./MultipleModeledMethodsPanel";
 
-type Props = {
+export type ModeledMethodsPanelProps = {
   method: Method;
   modeledMethods: ModeledMethod[];
   showMultipleModels: boolean;
@@ -21,7 +21,7 @@ export const ModeledMethodsPanel = ({
   modeledMethods,
   showMultipleModels,
   onChange,
-}: Props) => {
+}: ModeledMethodsPanelProps) => {
   if (!showMultipleModels) {
     return (
       <SingleMethodModelingInputs

--- a/extensions/ql-vscode/src/view/method-modeling/ModeledMethodsPanel.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/ModeledMethodsPanel.tsx
@@ -1,0 +1,44 @@
+import * as React from "react";
+import { ModeledMethod } from "../../model-editor/modeled-method";
+import { MethodModelingInputs } from "./MethodModelingInputs";
+import { Method } from "../../model-editor/method";
+import { styled } from "styled-components";
+import { MultipleModeledMethodsPanel } from "./MultipleModeledMethodsPanel";
+
+type Props = {
+  method: Method;
+  modeledMethods: ModeledMethod[];
+  showMultipleModels: boolean;
+  onChange: (modeledMethod: ModeledMethod) => void;
+};
+
+const SingleMethodModelingInputs = styled(MethodModelingInputs)`
+  padding-bottom: 0.5rem;
+`;
+
+export const ModeledMethodsPanel = ({
+  method,
+  modeledMethods,
+  showMultipleModels,
+  onChange,
+}: Props) => {
+  if (!showMultipleModels) {
+    return (
+      <SingleMethodModelingInputs
+        method={method}
+        modeledMethod={
+          modeledMethods.length > 0 ? modeledMethods[0] : undefined
+        }
+        onChange={onChange}
+      />
+    );
+  }
+
+  return (
+    <MultipleModeledMethodsPanel
+      method={method}
+      modeledMethods={modeledMethods}
+      onChange={onChange}
+    />
+  );
+};

--- a/extensions/ql-vscode/src/view/method-modeling/MultipleModeledMethodsPanel.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/MultipleModeledMethodsPanel.tsx
@@ -1,0 +1,84 @@
+import * as React from "react";
+import { useCallback, useState } from "react";
+import { Method } from "../../model-editor/method";
+import { ModeledMethod } from "../../model-editor/modeled-method";
+import { styled } from "styled-components";
+import { MethodModelingInputs } from "./MethodModelingInputs";
+import { CodiconButton } from "../common";
+
+type Props = {
+  method: Method;
+  modeledMethods: ModeledMethod[];
+  onChange: (modeledMethod: ModeledMethod) => void;
+};
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+
+  padding-bottom: 0.5rem;
+  border-bottom: 0.05rem solid var(--vscode-panelSection-border);
+`;
+
+const Footer = styled.div`
+  display: flex;
+  flex-direction: row;
+`;
+
+const PaginationActions = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 0.5rem;
+`;
+
+export const MultipleModeledMethodsPanel = ({
+  method,
+  modeledMethods,
+  onChange,
+}: Props) => {
+  const [selectedIndex, setSelectedIndex] = useState<number>(0);
+
+  const handlePreviousClick = useCallback(() => {
+    setSelectedIndex((previousIndex) => previousIndex - 1);
+  }, []);
+  const handleNextClick = useCallback(() => {
+    setSelectedIndex((previousIndex) => previousIndex + 1);
+  }, []);
+
+  return (
+    <Container>
+      {modeledMethods.length > 0 && (
+        <MethodModelingInputs
+          method={method}
+          modeledMethod={modeledMethods[selectedIndex]}
+          onChange={onChange}
+        />
+      )}
+      <Footer>
+        <PaginationActions>
+          <CodiconButton
+            name="chevron-left"
+            label="Previous modeling"
+            onClick={handlePreviousClick}
+            disabled={modeledMethods.length < 2 || selectedIndex === 0}
+          />
+          {modeledMethods.length > 1 && (
+            <div>
+              {selectedIndex + 1}/{modeledMethods.length}
+            </div>
+          )}
+          <CodiconButton
+            name="chevron-right"
+            label="Next modeling"
+            onClick={handleNextClick}
+            disabled={
+              modeledMethods.length < 2 ||
+              selectedIndex === modeledMethods.length - 1
+            }
+          />
+        </PaginationActions>
+      </Footer>
+    </Container>
+  );
+};

--- a/extensions/ql-vscode/src/view/method-modeling/MultipleModeledMethodsPanel.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/MultipleModeledMethodsPanel.tsx
@@ -6,7 +6,7 @@ import { styled } from "styled-components";
 import { MethodModelingInputs } from "./MethodModelingInputs";
 import { CodiconButton } from "../common";
 
-type Props = {
+export type MultipleModeledMethodsPanelProps = {
   method: Method;
   modeledMethods: ModeledMethod[];
   onChange: (modeledMethod: ModeledMethod) => void;
@@ -36,7 +36,7 @@ export const MultipleModeledMethodsPanel = ({
   method,
   modeledMethods,
   onChange,
-}: Props) => {
+}: MultipleModeledMethodsPanelProps) => {
   const [selectedIndex, setSelectedIndex] = useState<number>(0);
 
   const handlePreviousClick = useCallback(() => {

--- a/extensions/ql-vscode/src/view/method-modeling/MultipleModeledMethodsPanel.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/MultipleModeledMethodsPanel.tsx
@@ -48,10 +48,16 @@ export const MultipleModeledMethodsPanel = ({
 
   return (
     <Container>
-      {modeledMethods.length > 0 && (
+      {modeledMethods.length > 0 ? (
         <MethodModelingInputs
           method={method}
           modeledMethod={modeledMethods[selectedIndex]}
+          onChange={onChange}
+        />
+      ) : (
+        <MethodModelingInputs
+          method={method}
+          modeledMethod={undefined}
           onChange={onChange}
         />
       )}

--- a/extensions/ql-vscode/src/view/method-modeling/__tests__/MethodModeling.spec.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/__tests__/MethodModeling.spec.tsx
@@ -16,7 +16,7 @@ describe(MethodModeling.name, () => {
     render({
       modelingStatus: "saved",
       method,
-      modeledMethod,
+      modeledMethods: [modeledMethod],
       onChange,
     });
 

--- a/extensions/ql-vscode/src/view/method-modeling/__tests__/ModeledMethodsPanel.spec.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/__tests__/ModeledMethodsPanel.spec.tsx
@@ -1,0 +1,74 @@
+import * as React from "react";
+import { render as reactRender, screen } from "@testing-library/react";
+import { createMethod } from "../../../../test/factories/model-editor/method-factories";
+import { createModeledMethod } from "../../../../test/factories/model-editor/modeled-method-factories";
+import {
+  ModeledMethodsPanel,
+  ModeledMethodsPanelProps,
+} from "../ModeledMethodsPanel";
+
+describe(ModeledMethodsPanel.name, () => {
+  const render = (props: ModeledMethodsPanelProps) =>
+    reactRender(<ModeledMethodsPanel {...props} />);
+
+  const method = createMethod();
+  const modeledMethods = [createModeledMethod(), createModeledMethod()];
+  const onChange = jest.fn();
+
+  describe("when show multiple models is disabled", () => {
+    const showMultipleModels = false;
+
+    it("renders the method modeling inputs", () => {
+      render({
+        method,
+        modeledMethods,
+        onChange,
+        showMultipleModels,
+      });
+
+      expect(screen.getAllByRole("combobox")).toHaveLength(4);
+    });
+
+    it("does not render the pagination", () => {
+      render({
+        method,
+        modeledMethods,
+        onChange,
+        showMultipleModels,
+      });
+
+      expect(
+        screen.queryByLabelText("Previous modeling"),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("Next modeling")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when show multiple models is enabled", () => {
+    const showMultipleModels = true;
+
+    it("renders the method modeling inputs once", () => {
+      render({
+        method,
+        modeledMethods,
+        onChange,
+        showMultipleModels,
+      });
+
+      expect(screen.getAllByRole("combobox")).toHaveLength(4);
+    });
+
+    it("renders the pagination", () => {
+      render({
+        method,
+        modeledMethods,
+        onChange,
+        showMultipleModels,
+      });
+
+      expect(screen.getByLabelText("Previous modeling")).toBeInTheDocument();
+      expect(screen.getByLabelText("Next modeling")).toBeInTheDocument();
+      expect(screen.getByText("1/2")).toBeInTheDocument();
+    });
+  });
+});

--- a/extensions/ql-vscode/src/view/method-modeling/__tests__/MultipleModeledMethodsPanel.spec.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/__tests__/MultipleModeledMethodsPanel.spec.tsx
@@ -1,0 +1,240 @@
+import * as React from "react";
+import { render as reactRender, screen } from "@testing-library/react";
+import { createMethod } from "../../../../test/factories/model-editor/method-factories";
+import { createModeledMethod } from "../../../../test/factories/model-editor/modeled-method-factories";
+import {
+  MultipleModeledMethodsPanel,
+  MultipleModeledMethodsPanelProps,
+} from "../MultipleModeledMethodsPanel";
+import userEvent from "@testing-library/user-event";
+import { ModeledMethod } from "../../../model-editor/modeled-method";
+
+describe(MultipleModeledMethodsPanel.name, () => {
+  const render = (props: MultipleModeledMethodsPanelProps) =>
+    reactRender(<MultipleModeledMethodsPanel {...props} />);
+
+  const method = createMethod();
+  const onChange = jest.fn();
+
+  describe("with no modeled methods", () => {
+    const modeledMethods: ModeledMethod[] = [];
+
+    it("renders the method modeling inputs once", () => {
+      render({
+        method,
+        modeledMethods,
+        onChange,
+      });
+
+      expect(screen.getAllByRole("combobox")).toHaveLength(4);
+      expect(
+        screen.getByRole("combobox", {
+          name: "Model type",
+        }),
+      ).toHaveValue("none");
+    });
+
+    it("disables all pagination", () => {
+      render({
+        method,
+        modeledMethods,
+        onChange,
+      });
+
+      expect(screen.getByLabelText("Previous modeling")).toBeDisabled();
+      expect(screen.getByLabelText("Next modeling")).toBeDisabled();
+      expect(screen.queryByText("0/0")).not.toBeInTheDocument();
+      expect(screen.queryByText("1/0")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("with one modeled method", () => {
+    const modeledMethods = [
+      createModeledMethod({
+        ...method,
+        type: "sink",
+        input: "Argument[this]",
+        output: "",
+        kind: "path-injection",
+      }),
+    ];
+
+    it("renders the method modeling inputs once", () => {
+      render({
+        method,
+        modeledMethods,
+        onChange,
+      });
+
+      expect(screen.getAllByRole("combobox")).toHaveLength(4);
+      expect(
+        screen.getByRole("combobox", {
+          name: "Model type",
+        }),
+      ).toHaveValue("sink");
+    });
+
+    it("disables all pagination", () => {
+      render({
+        method,
+        modeledMethods,
+        onChange,
+      });
+
+      expect(screen.getByLabelText("Previous modeling")).toBeDisabled();
+      expect(screen.getByLabelText("Next modeling")).toBeDisabled();
+      expect(screen.queryByText("1/1")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("with two modeled methods", () => {
+    const modeledMethods = [
+      createModeledMethod({
+        ...method,
+        type: "sink",
+        input: "Argument[this]",
+        output: "",
+        kind: "path-injection",
+      }),
+      createModeledMethod({
+        ...method,
+        type: "source",
+        input: "",
+        output: "ReturnValue",
+        kind: "remote",
+      }),
+    ];
+
+    it("renders the method modeling inputs once", () => {
+      render({
+        method,
+        modeledMethods,
+        onChange,
+      });
+
+      expect(screen.getAllByRole("combobox")).toHaveLength(4);
+      expect(
+        screen.getByRole("combobox", {
+          name: "Model type",
+        }),
+      ).toHaveValue("sink");
+    });
+
+    it("renders the pagination", () => {
+      render({
+        method,
+        modeledMethods,
+        onChange,
+      });
+
+      expect(screen.getByLabelText("Previous modeling")).toBeInTheDocument();
+      expect(screen.getByLabelText("Next modeling")).toBeInTheDocument();
+      expect(screen.getByText("1/2")).toBeInTheDocument();
+    });
+
+    it("disables the correct pagination", async () => {
+      render({
+        method,
+        modeledMethods,
+        onChange,
+      });
+
+      expect(screen.getByLabelText("Previous modeling")).toBeDisabled();
+      expect(screen.getByLabelText("Next modeling")).toBeEnabled();
+    });
+
+    it("can use the pagination", async () => {
+      render({
+        method,
+        modeledMethods,
+        onChange,
+      });
+
+      await userEvent.click(screen.getByLabelText("Next modeling"));
+
+      expect(screen.getByLabelText("Previous modeling")).toBeEnabled();
+      expect(screen.getByLabelText("Next modeling")).toBeDisabled();
+      expect(screen.getByText("2/2")).toBeInTheDocument();
+
+      expect(
+        screen.getByRole("combobox", {
+          name: "Model type",
+        }),
+      ).toHaveValue("source");
+    });
+  });
+
+  describe("with three modeled methods", () => {
+    const modeledMethods = [
+      createModeledMethod({
+        ...method,
+        type: "sink",
+        input: "Argument[this]",
+        output: "",
+        kind: "path-injection",
+      }),
+      createModeledMethod({
+        ...method,
+        type: "source",
+        input: "",
+        output: "ReturnValue",
+        kind: "remote",
+      }),
+      createModeledMethod({
+        ...method,
+        type: "source",
+        input: "",
+        output: "ReturnValue",
+        kind: "local",
+      }),
+    ];
+
+    it("can use the pagination", async () => {
+      render({
+        method,
+        modeledMethods,
+        onChange,
+      });
+
+      expect(screen.getByLabelText("Previous modeling")).toBeDisabled();
+      expect(screen.getByLabelText("Next modeling")).toBeEnabled();
+      expect(screen.getByText("1/3")).toBeInTheDocument();
+
+      await userEvent.click(screen.getByLabelText("Next modeling"));
+
+      expect(screen.getByLabelText("Previous modeling")).toBeEnabled();
+      expect(screen.getByLabelText("Next modeling")).toBeEnabled();
+      expect(screen.getByText("2/3")).toBeInTheDocument();
+
+      expect(
+        screen.getByRole("combobox", {
+          name: "Model type",
+        }),
+      ).toHaveValue("source");
+
+      await userEvent.click(screen.getByLabelText("Next modeling"));
+
+      expect(screen.getByLabelText("Previous modeling")).toBeEnabled();
+      expect(screen.getByLabelText("Next modeling")).toBeDisabled();
+      expect(screen.getByText("3/3")).toBeInTheDocument();
+
+      expect(
+        screen.getByRole("combobox", {
+          name: "Kind",
+        }),
+      ).toHaveValue("local");
+
+      await userEvent.click(screen.getByLabelText("Previous modeling"));
+
+      expect(screen.getByLabelText("Previous modeling")).toBeEnabled();
+      expect(screen.getByLabelText("Next modeling")).toBeEnabled();
+      expect(screen.getByText("2/3")).toBeInTheDocument();
+
+      expect(
+        screen.getByRole("combobox", {
+          name: "Kind",
+        }),
+      ).toHaveValue("remote");
+    });
+  });
+});

--- a/extensions/ql-vscode/test/factories/model-editor/modeled-method-factories.ts
+++ b/extensions/ql-vscode/test/factories/model-editor/modeled-method-factories.ts
@@ -13,7 +13,7 @@ export function createModeledMethod(
     type: "sink",
     input: "Argument[0]",
     output: "",
-    kind: "jndi-injection",
+    kind: "path-injection",
     provenance: "manual",
     ...data,
   };


### PR DESCRIPTION
This makes it possible for the method modeling panel to render multiple models for the same method. It does not yet add support for updating (i.e. `onChange` is unchanged) or adding/removing new methods. The appearance and behavior when the feature flag is disabled should be unchanged.

The best way to view this locally is using Storybook; there are 3 different scenarios in "Method Modeling/Method Modeling".

![Screenshot 2023-10-06 at 16 52 03](https://github.com/github/vscode-codeql/assets/1112623/0040b08f-8ef7-48b3-bfc8-6e4d0052dcbb)


## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
