### PR TITLE
Ensure modified methods updated after changing a method from the modeling panel

### DIFF
--- a/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
+++ b/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
@@ -100,6 +100,10 @@ export class MethodModelingViewProvider extends AbstractWebviewViewProvider<
           activeState.databaseItem,
           msg.method,
         );
+        this.modelingStore.addModifiedMethod(
+          activeState.databaseItem,
+          msg.method.signature,
+        );
         break;
       }
       case "revealInModelEditor":


### PR DESCRIPTION
Small change to make sure we update the modified methods state when the modeled method gets updated. If we don't do that we can end up in a situation where the state/UI is out of date. For example the following bug exists in the current code:
1. Open model editor
2. Click view on some method
3. Change to source (see it being marked as modeled)
4. Click on another method from the method usages panel 
5. Change to flow summary

At this point the second method should be marked as modeled, but it isn't.


## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
