### PR TITLE
Track db related to modeled method and react when it closes

### DIFF
--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -634,7 +634,7 @@ interface SetMethodModelingPanelViewStateMessage {
 
 interface SetMethodMessage {
   t: "setMethod";
-  method: Method;
+  method: Method | undefined;
 }
 
 interface SetMethodModifiedMessage {

--- a/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-panel.ts
+++ b/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-panel.ts
@@ -6,6 +6,7 @@ import { Method } from "../method";
 import { ModelingStore } from "../modeling-store";
 import { ModelEditorViewTracker } from "../model-editor-view-tracker";
 import { ModelConfigListener } from "../../config";
+import { DatabaseItem } from "../../databases/local-databases";
 
 export class MethodModelingPanel extends DisposableObject {
   private readonly provider: MethodModelingViewProvider;
@@ -36,7 +37,10 @@ export class MethodModelingPanel extends DisposableObject {
     );
   }
 
-  public async setMethod(method: Method): Promise<void> {
-    await this.provider.setMethod(method);
+  public async setMethod(
+    databaseItem: DatabaseItem,
+    method: Method,
+  ): Promise<void> {
+    await this.provider.setMethod(databaseItem, method);
   }
 }

--- a/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
+++ b/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
@@ -13,6 +13,7 @@ import { AbstractWebviewViewProvider } from "../../common/vscode/abstract-webvie
 import { assertNever } from "../../common/helpers-pure";
 import { ModelEditorViewTracker } from "../model-editor-view-tracker";
 import { ModelConfigListener } from "../../config";
+import { DatabaseItem } from "../../databases/local-databases";
 
 export class MethodModelingViewProvider extends AbstractWebviewViewProvider<
   ToMethodModelingMessage,
@@ -21,6 +22,7 @@ export class MethodModelingViewProvider extends AbstractWebviewViewProvider<
   public static readonly viewType = "codeQLMethodModeling";
 
   private method: Method | undefined = undefined;
+  private databaseItem: DatabaseItem | undefined = undefined;
 
   constructor(
     app: App,
@@ -46,8 +48,12 @@ export class MethodModelingViewProvider extends AbstractWebviewViewProvider<
     });
   }
 
-  public async setMethod(method: Method): Promise<void> {
+  public async setMethod(
+    databaseItem: DatabaseItem | undefined,
+    method: Method | undefined,
+  ): Promise<void> {
     this.method = method;
+    this.databaseItem = databaseItem;
 
     if (this.isShowingView) {
       await this.postMessage({
@@ -170,6 +176,8 @@ export class MethodModelingViewProvider extends AbstractWebviewViewProvider<
       this.modelingStore.onSelectedMethodChanged(async (e) => {
         if (this.webviewView) {
           this.method = e.method;
+          this.databaseItem = e.databaseItem;
+
           await this.postMessage({
             t: "setSelectedMethod",
             method: e.method,
@@ -190,12 +198,16 @@ export class MethodModelingViewProvider extends AbstractWebviewViewProvider<
     );
 
     this.push(
-      this.modelingStore.onDbClosed(async () => {
+      this.modelingStore.onDbClosed(async (dbUri) => {
         if (!this.modelingStore.anyDbsBeingModeled()) {
           await this.postMessage({
             t: "setInModelingMode",
             inModelingMode: false,
           });
+        }
+
+        if (dbUri === this.databaseItem?.databaseUri.toString()) {
+          await this.setMethod(undefined, undefined);
         }
       }),
     );

--- a/extensions/ql-vscode/src/model-editor/model-editor-module.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-module.ts
@@ -105,7 +105,7 @@ export class ModelEditorModule extends DisposableObject {
     usage: Usage,
   ): Promise<void> {
     await this.methodsUsagePanel.revealItem(usage);
-    await this.methodModelingPanel.setMethod(method);
+    await this.methodModelingPanel.setMethod(databaseItem, method);
     await showResolvableLocation(usage.url, databaseItem, this.app.logger);
   }
 


### PR DESCRIPTION
This removes the following bug:
1. Open model editor against db X
2. Click view on some method A
3. Open model editor against db Y
4. Click view on some method B
5. Close the model editor tab for db Y
=> At this point the method modeling panel is showing method B even though the model editor for db Y has been closed.

This PR fixes this so that we go back to the "Select an API or method to model" state.


## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
