### PR TITLE
Add "CodeQL: Trim Cache" using new mode parameter of `evaluation/clearCache`

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -729,6 +729,10 @@
         "title": "CodeQL: Clear Cache"
       },
       {
+        "command": "codeQL.trimCache",
+        "title": "CodeQL: Trim Cache"
+      },
+      {
         "command": "codeQL.installPackDependencies",
         "title": "CodeQL: Install Pack Dependencies"
       },

--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -208,6 +208,7 @@ export type LocalDatabasesCommands = {
   "codeQL.chooseDatabaseGithub": () => Promise<void>;
   "codeQL.upgradeCurrentDatabase": () => Promise<void>;
   "codeQL.clearCache": () => Promise<void>;
+  "codeQL.trimCache": () => Promise<void>;
 
   // Explorer context menu
   "codeQL.setCurrentDatabase": (uri: Uri) => Promise<void>;

--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -251,7 +251,8 @@ export class DatabaseUI extends DisposableObject {
         this.handleSetDefaultTourDatabase.bind(this),
       "codeQL.upgradeCurrentDatabase":
         this.handleUpgradeCurrentDatabase.bind(this),
-      "codeQL.clearCache": this.handleClearCache.bind(this),
+      "codeQL.clearCache": this.handleClearCache.bind(this, "clear"),
+      "codeQL.trimCache": this.handleClearCache.bind(this, "trim"),
       "codeQLDatabases.chooseDatabaseFolder":
         this.handleChooseDatabaseFolder.bind(this),
       "codeQLDatabases.chooseDatabaseArchive":
@@ -684,7 +685,7 @@ export class DatabaseUI extends DisposableObject {
     );
   }
 
-  private async handleClearCache(): Promise<void> {
+  private async handleClearCache(mode: "trim" | "clear"): Promise<void> {
     return withProgress(
       async (_progress, token) => {
         if (
@@ -694,6 +695,7 @@ export class DatabaseUI extends DisposableObject {
           await this.queryServer.clearCacheInDatabase(
             this.databaseManager.currentDatabaseItem,
             token,
+            mode,
           );
         }
       },

--- a/extensions/ql-vscode/src/query-server/new-messages.ts
+++ b/extensions/ql-vscode/src/query-server/new-messages.ts
@@ -29,6 +29,35 @@ export interface ClearCacheParams {
    * Whether the cache should actually be cleared.
    */
   dryRun: boolean;
+  /**
+   * The mode to use when trimming the disk cache.
+   */
+  mode?: CacheTrimmingMode;
+}
+
+export type CacheTrimmingMode = number;
+/**
+ * The mode to use when trimming the disk cache. This namespace is intentionally not an enum, see
+ * "for the sake of extensibility" comment above.
+ */
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace CacheTrimmingMode {
+  /** The entire cache is deleted unconditionally. */
+  export const BRUTAL = 0;
+  /** Only `cached` predicates are kept. */
+  export const NORMAL = 1;
+  /**
+   * Trim the cache down to the configured size, but *within* this limit keep anything that
+   * appears to be even possibly potentially useful in the future.
+   */
+  export const LIGHT = 2;
+  /**
+   * As {@link LIGHT}, but only if the *currently active* backend has written anything to
+   * the cache in its lifetime. (Thus it doesn't make much sense to specify this in a stand-alone
+   * CLI invocation, but we do it as a separate operation before shutting down a query server,
+   * because it can then have its own timeout).
+   */
+  export const GENTLE = 3;
 }
 
 /**

--- a/extensions/ql-vscode/src/query-server/new-query-runner.ts
+++ b/extensions/ql-vscode/src/query-server/new-query-runner.ts
@@ -7,6 +7,7 @@ import { DatabaseItem } from "../databases/local-databases";
 import {
   clearCache,
   ClearCacheParams,
+  CacheTrimmingMode,
   clearPackCache,
   deregisterDatabases,
   registerDatabases,
@@ -57,15 +58,20 @@ export class NewQueryRunner extends QueryRunner {
   async clearCacheInDatabase(
     dbItem: DatabaseItem,
     token: CancellationToken,
+    mode: "trim" | "clear",
   ): Promise<void> {
     if (dbItem.contents === undefined) {
-      throw new Error("Can't clear the cache in an invalid database.");
+      throw new Error(`Can't ${mode} the cache in an invalid database.`);
     }
 
     const db = dbItem.databaseUri.fsPath;
     const params: ClearCacheParams = {
       dryRun: false,
       db,
+      mode: {
+        trim: CacheTrimmingMode.NORMAL,
+        clear: CacheTrimmingMode.BRUTAL,
+      }[mode],
     };
     await this.qs.sendRequest(clearCache, params, token);
   }

--- a/extensions/ql-vscode/src/query-server/query-runner.ts
+++ b/extensions/ql-vscode/src/query-server/query-runner.ts
@@ -65,6 +65,7 @@ export abstract class QueryRunner {
   abstract clearCacheInDatabase(
     dbItem: DatabaseItem,
     token: CancellationToken,
+    mode: "trim" | "clear",
   ): Promise<void>;
 
   /**


### PR DESCRIPTION
The purpose of this change is to add a command to clear the cache
except for `cached` predicates. This is the
same behaviour as `codeql database cleanup --mode=normal`.
In contrast, the existing "CodeQL: Clear Cache" corresponds to `--mode=brutal`.

This change depends on adding a new `mode` parameter to the
`evaluation/clearCache` method of the query server. This is the same
method that the existing "CodeQL: Clear Cache" command targets, which means
that this solution will not fail when used with older query servers
but will have the same behaviour as the existing command.
This somewhat decouples the release process of the VSCode extension and
the CodeQL release.

Testing done so far: manual (VSCode extension debug run). I haven't seen
automated tests for the other command either.

As part of adding the new "mode" parameter to the clearCache method, the
official query server spec will need to be updated to match `new-messages.ts`
here.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
