### PR TITLE
Set modeling mode when initialising method modeling panel

### DIFF
--- a/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
+++ b/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
@@ -68,6 +68,11 @@ export class MethodModelingViewProvider extends AbstractWebviewViewProvider<
           isModified: selectedMethod.isModified,
         });
       }
+
+      await this.postMessage({
+        t: "setInModelingMode",
+        inModelingMode: true,
+      });
     }
   }
 


### PR DESCRIPTION
This ensures that even if the model editor opens before activating the CodeQL tab, the modeling panel is initialised properly.

See interna linked issue for more details.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
