### PR TITLE
Make use of modeled-methods-legacy.ts in the webview code

### DIFF
--- a/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
+++ b/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
@@ -17,7 +17,7 @@ import { DatabaseItem } from "../../databases/local-databases";
 import {
   convertFromLegacyModeledMethod,
   convertToLegacyModeledMethod,
-} from "../modeled-methods-legacy";
+} from "../shared/modeled-methods-legacy";
 
 export class MethodModelingViewProvider extends AbstractWebviewViewProvider<
   ToMethodModelingMessage,

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -46,7 +46,7 @@ import { ModelEditorViewTracker } from "./model-editor-view-tracker";
 import {
   convertFromLegacyModeledMethod,
   convertToLegacyModeledMethods,
-} from "./modeled-methods-legacy";
+} from "./shared/modeled-methods-legacy";
 
 export class ModelEditorView extends AbstractWebview<
   ToModelEditorMessage,

--- a/extensions/ql-vscode/src/model-editor/shared/modeled-methods-legacy.ts
+++ b/extensions/ql-vscode/src/model-editor/shared/modeled-methods-legacy.ts
@@ -37,8 +37,10 @@ export function convertToLegacyModeledMethods(
  *
  * @param modeledMethod The single ModeledMethod
  */
-export function convertFromLegacyModeledMethod(modeledMethod: ModeledMethod) {
-  return [modeledMethod];
+export function convertFromLegacyModeledMethod(
+  modeledMethod: ModeledMethod | undefined,
+): ModeledMethod[] {
+  return modeledMethod ? [modeledMethod] : [];
 }
 
 /**

--- a/extensions/ql-vscode/src/model-editor/shared/modeled-methods-legacy.ts
+++ b/extensions/ql-vscode/src/model-editor/shared/modeled-methods-legacy.ts
@@ -1,4 +1,4 @@
-import { ModeledMethod } from "./modeled-method";
+import { ModeledMethod } from "../modeled-method";
 
 /**
  * Converts a record of a single ModeledMethod indexed by signature to a record of ModeledMethod[] indexed by signature

--- a/extensions/ql-vscode/src/view/method-modeling/MethodModelingView.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/MethodModelingView.tsx
@@ -10,6 +10,7 @@ import { vscode } from "../vscode-api";
 import { NotInModelingMode } from "./NotInModelingMode";
 import { NoMethodSelected } from "./NoMethodSelected";
 import { MethodModelingPanelViewState } from "../../model-editor/shared/view-state";
+import { convertFromLegacyModeledMethod } from "../../model-editor/shared/modeled-methods-legacy";
 
 type Props = {
   initialViewState?: MethodModelingPanelViewState;
@@ -31,7 +32,10 @@ export function MethodModelingView({ initialViewState }: Props): JSX.Element {
 
   const modelingStatus = useMemo(
     () =>
-      getModelingStatus(modeledMethod ? [modeledMethod] : [], isMethodModified),
+      getModelingStatus(
+        convertFromLegacyModeledMethod(modeledMethod),
+        isMethodModified,
+      ),
     [modeledMethod, isMethodModified],
   );
 
@@ -95,7 +99,7 @@ export function MethodModelingView({ initialViewState }: Props): JSX.Element {
     <MethodModeling
       modelingStatus={modelingStatus}
       method={method}
-      modeledMethods={modeledMethod ? [modeledMethod] : []}
+      modeledMethods={convertFromLegacyModeledMethod(modeledMethod)}
       showMultipleModels={viewState?.showMultipleModels}
       onChange={onChange}
     />

--- a/extensions/ql-vscode/src/view/method-modeling/ModeledMethodsPanel.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/ModeledMethodsPanel.tsx
@@ -4,6 +4,7 @@ import { MethodModelingInputs } from "./MethodModelingInputs";
 import { Method } from "../../model-editor/method";
 import { styled } from "styled-components";
 import { MultipleModeledMethodsPanel } from "./MultipleModeledMethodsPanel";
+import { convertToLegacyModeledMethod } from "../../model-editor/shared/modeled-methods-legacy";
 
 export type ModeledMethodsPanelProps = {
   method: Method;
@@ -26,9 +27,7 @@ export const ModeledMethodsPanel = ({
     return (
       <SingleMethodModelingInputs
         method={method}
-        modeledMethod={
-          modeledMethods.length > 0 ? modeledMethods[0] : undefined
-        }
+        modeledMethod={convertToLegacyModeledMethod(modeledMethods)}
         onChange={onChange}
       />
     );


### PR DESCRIPTION
This PR moves `modeled-methods-legacy.ts` to the `/shared` directory, so it's easier to use it in the webview code. We then make use of its methods in a few places that are currently doing their own custom conversion. So this PR doesn't add any new conversion points but does make them more standardised.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
