### PR TITLE
Add stack trace to unhandled error log message

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -1164,13 +1164,16 @@ function addUnhandledRejectionListener() {
       const message = redactableError(
         asError(error),
       )`Unhandled error: ${getErrorMessage(error)}`;
+      const stack = getErrorStack(error);
+      const fullMessage = stack
+        ? `Unhandled error: ${stack}`
+        : message.fullMessage;
+
       // Add a catch so that showAndLogExceptionWithTelemetry fails, we avoid
       // triggering "unhandledRejection" and avoid an infinite loop
-      showAndLogExceptionWithTelemetry(
-        extLogger,
-        telemetryListener,
-        message,
-      ).catch((telemetryError: unknown) => {
+      showAndLogExceptionWithTelemetry(extLogger, telemetryListener, message, {
+        fullMessage,
+      }).catch((telemetryError: unknown) => {
         void extLogger.log(
           `Failed to send error telemetry: ${getErrorMessage(telemetryError)}`,
         );


### PR DESCRIPTION
This change sets the `fullMessage` of the `showAndLogExceptionWithTelemetry` call to include the stack trace. This makes it possible to find the source of the error rather than only knowing that a specific error occurred. If the error does not have a stack trace (which should be rare) the message will be the same as before.

![Screenshot 2023-10-10 at 15 47 33](https://github.com/github/vscode-codeql/assets/1112623/948788f1-4703-45a8-98eb-022a0c6e128c)


## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
