### PR TITLE
Add CommonFromViewMessages to FromModelEditorMessage

### DIFF
--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -597,7 +597,6 @@ export type ToModelEditorMessage =
 
 export type FromModelEditorMessage =
   | CommonFromViewMessages
-  | ViewLoadedMsg
   | SwitchModeMessage
   | RefreshMethods
   | OpenDatabaseMessage

--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -596,6 +596,7 @@ export type ToModelEditorMessage =
   | RevealMethodMessage;
 
 export type FromModelEditorMessage =
+  | CommonFromViewMessages
   | ViewLoadedMsg
   | SwitchModeMessage
   | RefreshMethods

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -47,7 +47,6 @@ import {
   convertFromLegacyModeledMethod,
   convertToLegacyModeledMethods,
 } from "./shared/modeled-methods-legacy";
-import { extLogger } from "../common/logging/vscode";
 
 export class ModelEditorView extends AbstractWebview<
   ToModelEditorMessage,

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -329,7 +329,7 @@ export class ModelEditorView extends AbstractWebview<
           telemetryListener,
           redactableError(
             msg.error,
-          )`Unhandled error in result comparison view: ${msg.error.message}`,
+          )`Unhandled error in model editor view: ${msg.error.message}`,
         );
         break;
       default:

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -47,6 +47,7 @@ import {
   convertFromLegacyModeledMethod,
   convertToLegacyModeledMethods,
 } from "./shared/modeled-methods-legacy";
+import { extLogger } from "../common/logging/vscode";
 
 export class ModelEditorView extends AbstractWebview<
   ToModelEditorMessage,
@@ -319,6 +320,18 @@ export class ModelEditorView extends AbstractWebview<
         );
         break;
       }
+      case "telemetry":
+        telemetryListener?.sendUIInteraction(msg.action);
+        break;
+      case "unhandledError":
+        void showAndLogExceptionWithTelemetry(
+          extLogger,
+          telemetryListener,
+          redactableError(
+            msg.error,
+          )`Unhandled error in result comparison view: ${msg.error.message}`,
+        );
+        break;
       default:
         assertNever(msg);
     }

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -325,7 +325,7 @@ export class ModelEditorView extends AbstractWebview<
         break;
       case "unhandledError":
         void showAndLogExceptionWithTelemetry(
-          extLogger,
+          this.app.logger,
           telemetryListener,
           redactableError(
             msg.error,


### PR DESCRIPTION
Not sure how we didn't notice this until now but it seems the `FromModelEditorMessage` type doesn't include `CommonFromViewMessages`. This means it doesn't include messages for telemetry or errors.

However the view could still send those messages, and they would trigger the `assertNever` and cause an error. Probably every bit of telemetry was triggering this, but we didn't notice.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
