### PR TITLE
Fix bug when selecting method without modeled methods

### DIFF
--- a/extensions/ql-vscode/src/model-editor/modeling-store.ts
+++ b/extensions/ql-vscode/src/model-editor/modeling-store.ts
@@ -330,7 +330,7 @@ export class ModelingStore extends DisposableObject {
       databaseItem: dbItem,
       method,
       usage,
-      modeledMethods: dbState.modeledMethods[method.signature],
+      modeledMethods: dbState.modeledMethods[method.signature] ?? [],
       isModified: dbState.modifiedMethodSignatures.has(method.signature),
     });
   }
@@ -349,7 +349,7 @@ export class ModelingStore extends DisposableObject {
     return {
       method: selectedMethod,
       usage: dbState.selectedUsage,
-      modeledMethods: dbState.modeledMethods[selectedMethod.signature],
+      modeledMethods: dbState.modeledMethods[selectedMethod.signature] ?? [],
       isModified: dbState.modifiedMethodSignatures.has(
         selectedMethod.signature,
       ),


### PR DESCRIPTION
When selecting a method that has no modeled methods, the modeling state would not contain an entry for the method signature. This would cause the `modeledMethods` to be `undefined`, which is not allowed according to its type.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
