### PR TITLE
Fix confusion between modeling store and view states

### DIFF
--- a/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
+++ b/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
@@ -71,6 +71,9 @@ export class MethodModelingViewProvider extends AbstractWebviewViewProvider<
     if (this.modelingStore.hasStateForActiveDb()) {
       const selectedMethod = this.modelingStore.getSelectedMethodDetails();
       if (selectedMethod) {
+        this.databaseItem = selectedMethod.databaseItem;
+        this.method = selectedMethod.method;
+
         await this.postMessage({
           t: "setSelectedMethod",
           method: selectedMethod.method,

--- a/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
+++ b/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
@@ -8,7 +8,7 @@ import { extLogger } from "../../common/logging/vscode/loggers";
 import { App } from "../../common/app";
 import { redactableError } from "../../common/errors";
 import { Method } from "../method";
-import { DbModelingState, ModelingStore } from "../modeling-store";
+import { ModelingStore } from "../modeling-store";
 import { AbstractWebviewViewProvider } from "../../common/vscode/abstract-webview-view-provider";
 import { assertNever } from "../../common/helpers-pure";
 import { ModelEditorViewTracker } from "../model-editor-view-tracker";
@@ -111,15 +111,17 @@ export class MethodModelingViewProvider extends AbstractWebviewViewProvider<
         break;
 
       case "setModeledMethod": {
-        const activeState = this.ensureActiveState();
+        if (!this.databaseItem) {
+          return;
+        }
 
         this.modelingStore.updateModeledMethods(
-          activeState.databaseItem,
+          this.databaseItem,
           msg.method.signature,
           convertFromLegacyModeledMethod(msg.method),
         );
         this.modelingStore.addModifiedMethod(
-          activeState.databaseItem,
+          this.databaseItem,
           msg.method.signature,
         );
         break;
@@ -140,25 +142,18 @@ export class MethodModelingViewProvider extends AbstractWebviewViewProvider<
   }
 
   private async revealInModelEditor(method: Method): Promise<void> {
-    const activeState = this.ensureActiveState();
+    if (!this.databaseItem) {
+      return;
+    }
 
     const views = this.editorViewTracker.getViews(
-      activeState.databaseItem.databaseUri.toString(),
+      this.databaseItem.databaseUri.toString(),
     );
     if (views.length === 0) {
       return;
     }
 
     await Promise.all(views.map((view) => view.revealMethod(method)));
-  }
-
-  private ensureActiveState(): DbModelingState {
-    const activeState = this.modelingStore.getStateForActiveDb();
-    if (!activeState) {
-      throw new Error("No active state found in modeling store");
-    }
-
-    return activeState;
   }
 
   private registerToModelingStoreEvents(): void {

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -664,16 +664,11 @@ export class ModelEditorView extends AbstractWebview<
   }
 
   private setModeledMethods(signature: string, methods: ModeledMethod[]) {
-    const state = this.modelingStore.getStateForActiveDb();
-    if (!state) {
-      throw new Error("Attempting to set modeled method without active db");
-    }
-
     this.modelingStore.updateModeledMethods(
-      state.databaseItem,
+      this.databaseItem,
       signature,
       methods,
     );
-    this.modelingStore.addModifiedMethod(state.databaseItem, signature);
+    this.modelingStore.addModifiedMethod(this.databaseItem, signature);
   }
 }

--- a/extensions/ql-vscode/src/model-editor/modeling-store.ts
+++ b/extensions/ql-vscode/src/model-editor/modeling-store.ts
@@ -347,6 +347,7 @@ export class ModelingStore extends DisposableObject {
     }
 
     return {
+      databaseItem: dbState.databaseItem,
       method: selectedMethod,
       usage: dbState.selectedUsage,
       modeledMethods: dbState.modeledMethods[selectedMethod.signature] ?? [],

--- a/extensions/ql-vscode/src/model-editor/modeling-store.ts
+++ b/extensions/ql-vscode/src/model-editor/modeling-store.ts
@@ -6,7 +6,7 @@ import { Method, Usage } from "./method";
 import { ModeledMethod } from "./modeled-method";
 import { INITIAL_HIDE_MODELED_METHODS_VALUE } from "./shared/hide-modeled-methods";
 
-export interface DbModelingState {
+interface DbModelingState {
   databaseItem: DatabaseItem;
   methods: Method[];
   hideModeledMethods: boolean;


### PR DESCRIPTION
This fixes three bugs related to the modeling store and view states:
- In the model editor view, when `setModeledMethods` was called, it would do it on the active database, instead of the database that the view was showing. This should not result in any visible bugs since the active database is always the one that is being shown (in theory), but I can imagine that it could cause issues if showing multiple model editors next to each other.
- In the method modeling panel, the "reveal in editor" button would always show the already active model editor. Therefore, if you had multiple open and were still viewing the method of the first one, it would always show the second one.
- In the method modeling panel, the same bug would cause the incorrect modeled methods to be updated.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
