### PR TITLE
Rename 'open database' button and only show if source available

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add support for the `telemetry.telemetryLevel` setting. For more information, see the [telemetry documentation](https://codeql.github.com/docs/codeql-for-visual-studio-code/about-telemetry-in-codeql-for-visual-studio-code). [#2824](https://github.com/github/vscode-codeql/pull/2824).
 - Fix syntax highlighting directly after import statements with instantiation arguments. [#2792](https://github.com/github/vscode-codeql/pull/2792)
 - The `debug.saveBeforeStart` setting is now respected when running variant analyses. [#2950](https://github.com/github/vscode-codeql/pull/2950)
+- The 'open database' button of the model editor was renamed to 'open source'. Also, it's now only available if the source archive is available as a workspace folder. [#2945](https://github.com/github/vscode-codeql/pull/2945)
 
 ## 1.9.1 - 29 September 2023
 

--- a/extensions/ql-vscode/src/databases/local-databases/database-item-impl.ts
+++ b/extensions/ql-vscode/src/databases/local-databases/database-item-impl.ts
@@ -167,6 +167,15 @@ export class DatabaseItemImpl implements DatabaseItem {
     return encodeArchiveBasePath(sourceArchive.fsPath);
   }
 
+  /**
+   * Returns true if the database's source archive is in the workspace.
+   */
+  public hasSourceArchiveInExplorer(): boolean {
+    return (vscode.workspace.workspaceFolders || []).some((folder) =>
+      this.belongsToSourceArchiveExplorerUri(folder.uri),
+    );
+  }
+
   public verifyZippedSources(): string | undefined {
     const sourceArchive = this.sourceArchive;
     if (sourceArchive === undefined) {

--- a/extensions/ql-vscode/src/databases/local-databases/database-item.ts
+++ b/extensions/ql-vscode/src/databases/local-databases/database-item.ts
@@ -57,6 +57,11 @@ export interface DatabaseItem {
   getSourceArchiveExplorerUri(): vscode.Uri;
 
   /**
+   * Returns true if the database's source archive is in the workspace.
+   */
+  hasSourceArchiveInExplorer(): boolean;
+
+  /**
    * Holds if `uri` belongs to this database's source archive.
    */
   belongsToSourceArchiveExplorerUri(uri: vscode.Uri): boolean;

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -5,6 +5,7 @@ import {
   Uri,
   ViewColumn,
   window,
+  workspace,
 } from "vscode";
 import {
   AbstractWebview,
@@ -362,6 +363,11 @@ export class ModelEditorView extends AbstractWebview<
     const showLlmButton =
       this.databaseItem.language === "java" && this.modelConfig.llmGeneration;
 
+    const sourceArchiveAvailable = workspace.workspaceFolders?.some(
+      (f) =>
+        f.uri.fsPath === this.databaseItem.getSourceArchiveExplorerUri().fsPath,
+    );
+
     await this.postMessage({
       t: "setModelEditorViewState",
       viewState: {
@@ -370,6 +376,7 @@ export class ModelEditorView extends AbstractWebview<
         showLlmButton,
         showMultipleModels: this.modelConfig.showMultipleModels,
         mode: this.mode,
+        sourceArchiveAvailable: !!sourceArchiveAvailable,
       },
     });
   }

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -5,7 +5,6 @@ import {
   Uri,
   ViewColumn,
   window,
-  workspace,
 } from "vscode";
 import {
   AbstractWebview,
@@ -363,10 +362,8 @@ export class ModelEditorView extends AbstractWebview<
     const showLlmButton =
       this.databaseItem.language === "java" && this.modelConfig.llmGeneration;
 
-    const sourceArchiveAvailable = workspace.workspaceFolders?.some(
-      (f) =>
-        f.uri.fsPath === this.databaseItem.getSourceArchiveExplorerUri().fsPath,
-    );
+    const sourceArchiveAvailable =
+      this.databaseItem.hasSourceArchiveInExplorer();
 
     await this.postMessage({
       t: "setModelEditorViewState",
@@ -376,7 +373,7 @@ export class ModelEditorView extends AbstractWebview<
         showLlmButton,
         showMultipleModels: this.modelConfig.showMultipleModels,
         mode: this.mode,
-        sourceArchiveAvailable: !!sourceArchiveAvailable,
+        sourceArchiveAvailable,
       },
     });
   }

--- a/extensions/ql-vscode/src/model-editor/shared/view-state.ts
+++ b/extensions/ql-vscode/src/model-editor/shared/view-state.ts
@@ -7,6 +7,7 @@ export interface ModelEditorViewState {
   showLlmButton: boolean;
   showMultipleModels: boolean;
   mode: Mode;
+  sourceArchiveAvailable: boolean;
 }
 
 export interface MethodModelingPanelViewState {

--- a/extensions/ql-vscode/src/stories/model-editor/LibraryRow.stories.tsx
+++ b/extensions/ql-vscode/src/stories/model-editor/LibraryRow.stories.tsx
@@ -226,6 +226,7 @@ LibraryRow.args = {
     showLlmButton: true,
     showMultipleModels: true,
     mode: Mode.Application,
+    sourceArchiveAvailable: true,
   },
   hideModeledMethods: false,
 };

--- a/extensions/ql-vscode/src/stories/model-editor/MethodRow.stories.tsx
+++ b/extensions/ql-vscode/src/stories/model-editor/MethodRow.stories.tsx
@@ -75,6 +75,7 @@ const viewState: ModelEditorViewState = {
   showLlmButton: true,
   showMultipleModels: true,
   mode: Mode.Application,
+  sourceArchiveAvailable: true,
 };
 
 export const Unmodeled = Template.bind({});

--- a/extensions/ql-vscode/src/stories/model-editor/ModelEditor.stories.tsx
+++ b/extensions/ql-vscode/src/stories/model-editor/ModelEditor.stories.tsx
@@ -32,6 +32,7 @@ ModelEditor.args = {
     showLlmButton: true,
     showMultipleModels: true,
     mode: Mode.Application,
+    sourceArchiveAvailable: true,
   },
   initialMethods: [
     {

--- a/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
@@ -282,10 +282,12 @@ export function ModelEditor({
             <>{viewState.extensionPack.name}</>
           </HeaderRow>
           <HeaderRow>
-            <LinkIconButton onClick={onOpenDatabaseClick}>
-              <span slot="start" className="codicon codicon-package"></span>
-              Open database
-            </LinkIconButton>
+            {viewState.sourceArchiveAvailable && (
+              <LinkIconButton onClick={onOpenDatabaseClick}>
+                <span slot="start" className="codicon codicon-package"></span>
+                Open source
+              </LinkIconButton>
+            )}
             <LinkIconButton onClick={onOpenExtensionPackClick}>
               <span slot="start" className="codicon codicon-package"></span>
               Open extension pack

--- a/extensions/ql-vscode/src/view/model-editor/__tests__/LibraryRow.spec.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/__tests__/LibraryRow.spec.tsx
@@ -22,6 +22,7 @@ describe(LibraryRow.name, () => {
     showLlmButton: false,
     showMultipleModels: false,
     extensionPack: createMockExtensionPack(),
+    sourceArchiveAvailable: true,
   };
 
   const render = (props: Partial<LibraryRowProps> = {}) =>

--- a/extensions/ql-vscode/src/view/model-editor/__tests__/MethodRow.spec.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/__tests__/MethodRow.spec.tsx
@@ -39,6 +39,7 @@ describe(MethodRow.name, () => {
     showLlmButton: false,
     showMultipleModels: false,
     extensionPack: createMockExtensionPack(),
+    sourceArchiveAvailable: true,
   };
 
   const render = (props: Partial<MethodRowProps> = {}) =>

--- a/extensions/ql-vscode/src/view/model-editor/__tests__/ModeledMethodDataGrid.spec.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/__tests__/ModeledMethodDataGrid.spec.tsx
@@ -49,6 +49,7 @@ describe(ModeledMethodDataGrid.name, () => {
     showLlmButton: false,
     showMultipleModels: false,
     extensionPack: createMockExtensionPack(),
+    sourceArchiveAvailable: true,
   };
 
   const render = (props: Partial<ModeledMethodDataGridProps> = {}) =>

--- a/extensions/ql-vscode/src/view/model-editor/__tests__/ModeledMethodsList.spec.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/__tests__/ModeledMethodsList.spec.tsx
@@ -50,6 +50,7 @@ describe(ModeledMethodsList.name, () => {
     showLlmButton: false,
     showMultipleModels: false,
     extensionPack: createMockExtensionPack(),
+    sourceArchiveAvailable: true,
   };
 
   const render = (props: Partial<ModeledMethodsListProps> = {}) =>


### PR DESCRIPTION
Rename 'open database' button of the model editor to 'open source' and hide it if the source is not available as a workspace folder.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
