### PR TITLE
Only allow a single model editor per database

### DIFF
--- a/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
+++ b/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
@@ -149,14 +149,10 @@ export class MethodModelingViewProvider extends AbstractWebviewViewProvider<
       return;
     }
 
-    const views = this.editorViewTracker.getViews(
+    const view = this.editorViewTracker.getView(
       this.databaseItem.databaseUri.toString(),
     );
-    if (views.length === 0) {
-      return;
-    }
-
-    await Promise.all(views.map((view) => view.revealMethod(method)));
+    await view?.revealMethod(method);
   }
 
   private registerToModelingStoreEvents(): void {

--- a/extensions/ql-vscode/src/model-editor/model-editor-module.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-module.ts
@@ -128,6 +128,15 @@ export class ModelEditorModule extends DisposableObject {
         return;
       }
 
+      const existingViews = this.editorViewTracker.getViews(
+        db.databaseUri.toString(),
+      );
+      if (existingViews.length > 0) {
+        await Promise.all(existingViews.map((view) => view.focusView()));
+
+        return;
+      }
+
       return withProgress(
         async (progress) => {
           const maxStep = 4;
@@ -191,6 +200,17 @@ export class ModelEditorModule extends DisposableObject {
             step: 4,
             maxStep,
           });
+
+          // Check again just before opening the editor to ensure no model editor has been opened between
+          // our first check and now.
+          const existingViews = this.editorViewTracker.getViews(
+            db.databaseUri.toString(),
+          );
+          if (existingViews.length > 0) {
+            await Promise.all(existingViews.map((view) => view.focusView()));
+
+            return;
+          }
 
           const view = new ModelEditorView(
             this.app,

--- a/extensions/ql-vscode/src/model-editor/model-editor-module.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-module.ts
@@ -128,11 +128,11 @@ export class ModelEditorModule extends DisposableObject {
         return;
       }
 
-      const existingViews = this.editorViewTracker.getViews(
+      const existingView = this.editorViewTracker.getView(
         db.databaseUri.toString(),
       );
-      if (existingViews.length > 0) {
-        await Promise.all(existingViews.map((view) => view.focusView()));
+      if (existingView) {
+        await existingView.focusView();
 
         return;
       }
@@ -203,11 +203,11 @@ export class ModelEditorModule extends DisposableObject {
 
           // Check again just before opening the editor to ensure no model editor has been opened between
           // our first check and now.
-          const existingViews = this.editorViewTracker.getViews(
+          const existingView = this.editorViewTracker.getView(
             db.databaseUri.toString(),
           );
-          if (existingViews.length > 0) {
-            await Promise.all(existingViews.map((view) => view.focusView()));
+          if (existingView) {
+            await existingView.focusView();
 
             return;
           }

--- a/extensions/ql-vscode/src/model-editor/model-editor-view-tracker.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view-tracker.ts
@@ -9,33 +9,25 @@ interface ModelEditorViewInterface {
 export class ModelEditorViewTracker<
   T extends ModelEditorViewInterface = ModelEditorViewInterface,
 > {
-  private readonly views = new Map<string, T[]>();
+  private readonly views = new Map<string, T>();
 
   constructor() {}
 
   public registerView(view: T): void {
     const databaseUri = view.databaseUri;
 
-    if (!this.views.has(databaseUri)) {
-      this.views.set(databaseUri, []);
+    if (this.views.has(databaseUri)) {
+      throw new Error(`View for database ${databaseUri} already registered`);
     }
 
-    this.views.get(databaseUri)?.push(view);
+    this.views.set(databaseUri, view);
   }
 
   public unregisterView(view: T): void {
-    const views = this.views.get(view.databaseUri);
-    if (!views) {
-      return;
-    }
-
-    const index = views.indexOf(view);
-    if (index !== -1) {
-      views.splice(index, 1);
-    }
+    this.views.delete(view.databaseUri);
   }
 
-  public getViews(databaseUri: string): T[] {
-    return this.views.get(databaseUri) ?? [];
+  public getView(databaseUri: string): T | undefined {
+    return this.views.get(databaseUri);
   }
 }

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -524,11 +524,11 @@ export class ModelEditorView extends AbstractWebview<
         return;
       }
 
-      let existingViews = this.viewTracker.getViews(
+      let existingView = this.viewTracker.getView(
         addedDatabase.databaseUri.toString(),
       );
-      if (existingViews.length > 0) {
-        await Promise.all(existingViews.map((view) => view.focusView()));
+      if (existingView) {
+        await existingView.focusView();
 
         return;
       }
@@ -547,11 +547,11 @@ export class ModelEditorView extends AbstractWebview<
 
       // Check again just before opening the editor to ensure no model editor has been opened between
       // our first check and now.
-      existingViews = this.viewTracker.getViews(
+      existingView = this.viewTracker.getView(
         addedDatabase.databaseUri.toString(),
       );
-      if (existingViews.length > 0) {
-        await Promise.all(existingViews.map((view) => view.focusView()));
+      if (existingView) {
+        await existingView.focusView();
 
         return;
       }

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -352,6 +352,10 @@ export class ModelEditorView extends AbstractWebview<
     return this.databaseItem.databaseUri.toString();
   }
 
+  public async focusView(): Promise<void> {
+    this.panel?.reveal();
+  }
+
   public async revealMethod(method: Method): Promise<void> {
     this.panel?.reveal();
 
@@ -520,6 +524,15 @@ export class ModelEditorView extends AbstractWebview<
         return;
       }
 
+      let existingViews = this.viewTracker.getViews(
+        addedDatabase.databaseUri.toString(),
+      );
+      if (existingViews.length > 0) {
+        await Promise.all(existingViews.map((view) => view.focusView()));
+
+        return;
+      }
+
       const modelFile = await pickExtensionPack(
         this.cliServer,
         addedDatabase,
@@ -529,6 +542,17 @@ export class ModelEditorView extends AbstractWebview<
         3,
       );
       if (!modelFile) {
+        return;
+      }
+
+      // Check again just before opening the editor to ensure no model editor has been opened between
+      // our first check and now.
+      existingViews = this.viewTracker.getViews(
+        addedDatabase.databaseUri.toString(),
+      );
+      if (existingViews.length > 0) {
+        await Promise.all(existingViews.map((view) => view.focusView()));
+
         return;
       }
 

--- a/extensions/ql-vscode/test/__mocks__/model-editor/modelEditorViewTrackerMock.ts
+++ b/extensions/ql-vscode/test/__mocks__/model-editor/modelEditorViewTrackerMock.ts
@@ -5,15 +5,15 @@ import { ModelEditorView } from "../../../src/model-editor/model-editor-view";
 export function createMockModelEditorViewTracker({
   registerView = jest.fn(),
   unregisterView = jest.fn(),
-  getViews = jest.fn(),
+  getView = jest.fn(),
 }: {
   registerView?: ModelEditorViewTracker["registerView"];
   unregisterView?: ModelEditorViewTracker["unregisterView"];
-  getViews?: ModelEditorViewTracker["getViews"];
+  getView?: ModelEditorViewTracker["getView"];
 } = {}): ModelEditorViewTracker<ModelEditorView> {
   return mockedObject<ModelEditorViewTracker<ModelEditorView>>({
     registerView,
     unregisterView,
-    getViews,
+    getView,
   });
 }


### PR DESCRIPTION
This will only allow opening a single model editor per database. When a new model editor is opened for which a model editor already exists, it will focus the existing one.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
