### PR TITLE
Implement editing / saving multiple modeled methods from the model editor

### DIFF
--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -614,7 +614,7 @@ export type FromModelEditorMessage =
   | StopGeneratingMethodsFromLlmMessage
   | ModelDependencyMessage
   | HideModeledMethodsMessage
-  | SetModeledMethodMessage;
+  | SetMultipleModeledMethodsMessage;
 
 interface RevealInEditorMessage {
   t: "revealInModelEditor";

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -43,7 +43,6 @@ import { AutoModeler } from "./auto-modeler";
 import { telemetryListener } from "../common/vscode/telemetry";
 import { ModelingStore } from "./modeling-store";
 import { ModelEditorViewTracker } from "./model-editor-view-tracker";
-import { convertFromLegacyModeledMethod } from "./shared/modeled-methods-legacy";
 
 export class ModelEditorView extends AbstractWebview<
   ToModelEditorMessage,
@@ -309,11 +308,8 @@ export class ModelEditorView extends AbstractWebview<
           "model-editor-hide-modeled-methods",
         );
         break;
-      case "setModeledMethod": {
-        this.setModeledMethods(
-          msg.method.signature,
-          convertFromLegacyModeledMethod(msg.method),
-        );
+      case "setMultipleModeledMethods": {
+        this.setModeledMethods(msg.methodSignature, msg.modeledMethods);
         break;
       }
       case "telemetry":

--- a/extensions/ql-vscode/src/model-editor/shared/modeling-status.ts
+++ b/extensions/ql-vscode/src/model-editor/shared/modeling-status.ts
@@ -3,13 +3,13 @@ import { ModeledMethod } from "../modeled-method";
 export type ModelingStatus = "unmodeled" | "unsaved" | "saved";
 
 export function getModelingStatus(
-  modeledMethods: ModeledMethod[],
+  modeledMethods: Array<ModeledMethod | undefined>,
   methodIsUnsaved: boolean,
 ): ModelingStatus {
   if (modeledMethods.length > 0) {
     if (methodIsUnsaved) {
       return "unsaved";
-    } else if (modeledMethods.some((m) => m.type !== "none")) {
+    } else if (modeledMethods.some((m) => m && m.type !== "none")) {
       return "saved";
     }
   }

--- a/extensions/ql-vscode/src/view/model-editor/LibraryRow.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/LibraryRow.tsx
@@ -77,7 +77,7 @@ export type LibraryRowProps = {
   viewState: ModelEditorViewState;
   hideModeledMethods: boolean;
   revealedMethodSignature: string | null;
-  onChange: (modeledMethod: ModeledMethod) => void;
+  onChange: (methodSignature: string, modeledMethods: ModeledMethod[]) => void;
   onSaveModelClick: (methodSignatures: string[]) => void;
   onGenerateFromLlmClick: (
     dependencyName: string,

--- a/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
@@ -104,13 +104,8 @@ const ModelableMethodRow = forwardRef<HTMLElement | undefined, MethodRowProps>(
     } = props;
 
     const modeledMethods: Array<ModeledMethod | undefined> = useMemo(
-      () =>
-        modeledMethodsProp.length === 0
-          ? [undefined]
-          : viewState.showMultipleModels
-          ? modeledMethodsProp
-          : modeledMethodsProp.slice(0, 1),
-      [modeledMethodsProp, viewState],
+      () => modeledMethodsToDisplay(modeledMethodsProp, method, viewState),
+      [modeledMethodsProp, method, viewState],
     );
 
     const modeledMethodChangedHandlers = useMemo(
@@ -264,4 +259,20 @@ function sendJumpToMethodMessage(method: Method) {
     t: "jumpToMethod",
     methodSignature: method.signature,
   });
+}
+
+function modeledMethodsToDisplay(
+  modeledMethods: ModeledMethod[],
+  method: Method,
+  viewState: ModelEditorViewState,
+): Array<ModeledMethod | undefined> {
+  if (modeledMethods.length === 0) {
+    return [undefined];
+  }
+
+  if (viewState.showMultipleModels) {
+    return modeledMethods;
+  } else {
+    return modeledMethods.slice(0, 1);
+  }
 }

--- a/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
@@ -68,7 +68,7 @@ export type MethodRowProps = {
   modelingInProgress: boolean;
   viewState: ModelEditorViewState;
   revealedMethodSignature: string | null;
-  onChange: (modeledMethod: ModeledMethod) => void;
+  onChange: (methodSignature: string, modeledMethods: ModeledMethod[]) => void;
 };
 
 export const MethodRow = (props: MethodRowProps) => {
@@ -111,6 +111,21 @@ const ModelableMethodRow = forwardRef<HTMLElement | undefined, MethodRowProps>(
           ? modeledMethodsProp
           : modeledMethodsProp.slice(0, 1),
       [modeledMethodsProp, viewState],
+    );
+
+    const modeledMethodChangedHandlers = useMemo(
+      () =>
+        modeledMethods.map((_, index) => (modeledMethod: ModeledMethod) => {
+          const newModeledMethods = [...modeledMethods];
+          newModeledMethods[index] = modeledMethod;
+          onChange(
+            method.signature,
+            newModeledMethods.filter(
+              (m): m is ModeledMethod => m !== undefined,
+            ),
+          );
+        }),
+      [method, modeledMethods, onChange],
     );
 
     const jumpToMethod = useCallback(
@@ -164,7 +179,7 @@ const ModelableMethodRow = forwardRef<HTMLElement | undefined, MethodRowProps>(
                   key={index}
                   method={method}
                   modeledMethod={modeledMethod}
-                  onChange={onChange}
+                  onChange={modeledMethodChangedHandlers[index]}
                 />
               ))}
             </MultiModelColumn>
@@ -174,7 +189,7 @@ const ModelableMethodRow = forwardRef<HTMLElement | undefined, MethodRowProps>(
                   key={index}
                   method={method}
                   modeledMethod={modeledMethod}
-                  onChange={onChange}
+                  onChange={modeledMethodChangedHandlers[index]}
                 />
               ))}
             </MultiModelColumn>
@@ -184,7 +199,7 @@ const ModelableMethodRow = forwardRef<HTMLElement | undefined, MethodRowProps>(
                   key={index}
                   method={method}
                   modeledMethod={modeledMethod}
-                  onChange={onChange}
+                  onChange={modeledMethodChangedHandlers[index]}
                 />
               ))}
             </MultiModelColumn>
@@ -194,7 +209,7 @@ const ModelableMethodRow = forwardRef<HTMLElement | undefined, MethodRowProps>(
                   key={index}
                   method={method}
                   modeledMethod={modeledMethod}
-                  onChange={onChange}
+                  onChange={modeledMethodChangedHandlers[index]}
                 />
               ))}
             </MultiModelColumn>

--- a/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
@@ -103,7 +103,7 @@ const ModelableMethodRow = forwardRef<HTMLElement | undefined, MethodRowProps>(
       onChange,
     } = props;
 
-    const modeledMethods: Array<ModeledMethod | undefined> = useMemo(
+    const modeledMethods = useMemo(
       () => modeledMethodsToDisplay(modeledMethodsProp, method, viewState),
       [modeledMethodsProp, method, viewState],
     );
@@ -113,12 +113,7 @@ const ModelableMethodRow = forwardRef<HTMLElement | undefined, MethodRowProps>(
         modeledMethods.map((_, index) => (modeledMethod: ModeledMethod) => {
           const newModeledMethods = [...modeledMethods];
           newModeledMethods[index] = modeledMethod;
-          onChange(
-            method.signature,
-            newModeledMethods.filter(
-              (m): m is ModeledMethod => m !== undefined,
-            ),
-          );
+          onChange(method.signature, newModeledMethods);
         }),
       [method, modeledMethods, onChange],
     );
@@ -265,9 +260,22 @@ function modeledMethodsToDisplay(
   modeledMethods: ModeledMethod[],
   method: Method,
   viewState: ModelEditorViewState,
-): Array<ModeledMethod | undefined> {
+): ModeledMethod[] {
   if (modeledMethods.length === 0) {
-    return [undefined];
+    return [
+      {
+        type: "none",
+        input: "",
+        output: "",
+        kind: "",
+        provenance: "manual",
+        signature: method.signature,
+        packageName: method.packageName,
+        typeName: method.typeName,
+        methodName: method.methodName,
+        methodParameters: method.methodParameters,
+      },
+    ];
   }
 
   if (viewState.showMultipleModels) {

--- a/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
@@ -5,7 +5,7 @@ import {
   VSCodeProgressRing,
 } from "@vscode/webview-ui-toolkit/react";
 import * as React from "react";
-import { forwardRef, useCallback, useEffect, useRef } from "react";
+import { forwardRef, useCallback, useEffect, useMemo, useRef } from "react";
 import { styled } from "styled-components";
 import { vscode } from "../vscode-api";
 
@@ -103,9 +103,15 @@ const ModelableMethodRow = forwardRef<HTMLElement | undefined, MethodRowProps>(
       onChange,
     } = props;
 
-    const modeledMethods = viewState.showMultipleModels
-      ? modeledMethodsProp
-      : modeledMethodsProp.slice(0, 1);
+    const modeledMethods: Array<ModeledMethod | undefined> = useMemo(
+      () =>
+        modeledMethodsProp.length === 0
+          ? [undefined]
+          : viewState.showMultipleModels
+          ? modeledMethodsProp
+          : modeledMethodsProp.slice(0, 1),
+      [modeledMethodsProp, viewState],
+    );
 
     const jumpToMethod = useCallback(
       () => sendJumpToMethodMessage(method),
@@ -153,7 +159,7 @@ const ModelableMethodRow = forwardRef<HTMLElement | undefined, MethodRowProps>(
         {!props.modelingInProgress && (
           <>
             <MultiModelColumn gridColumn={2}>
-              {forEachModeledMethod(modeledMethods, (modeledMethod, index) => (
+              {modeledMethods.map((modeledMethod, index) => (
                 <ModelTypeDropdown
                   key={index}
                   method={method}
@@ -163,7 +169,7 @@ const ModelableMethodRow = forwardRef<HTMLElement | undefined, MethodRowProps>(
               ))}
             </MultiModelColumn>
             <MultiModelColumn gridColumn={3}>
-              {forEachModeledMethod(modeledMethods, (modeledMethod, index) => (
+              {modeledMethods.map((modeledMethod, index) => (
                 <ModelInputDropdown
                   key={index}
                   method={method}
@@ -173,7 +179,7 @@ const ModelableMethodRow = forwardRef<HTMLElement | undefined, MethodRowProps>(
               ))}
             </MultiModelColumn>
             <MultiModelColumn gridColumn={4}>
-              {forEachModeledMethod(modeledMethods, (modeledMethod, index) => (
+              {modeledMethods.map((modeledMethod, index) => (
                 <ModelOutputDropdown
                   key={index}
                   method={method}
@@ -183,7 +189,7 @@ const ModelableMethodRow = forwardRef<HTMLElement | undefined, MethodRowProps>(
               ))}
             </MultiModelColumn>
             <MultiModelColumn gridColumn={5}>
-              {forEachModeledMethod(modeledMethods, (modeledMethod, index) => (
+              {modeledMethods.map((modeledMethod, index) => (
                 <ModelKindDropdown
                   key={index}
                   method={method}
@@ -243,18 +249,4 @@ function sendJumpToMethodMessage(method: Method) {
     t: "jumpToMethod",
     methodSignature: method.signature,
   });
-}
-
-function forEachModeledMethod(
-  modeledMethods: ModeledMethod[],
-  renderer: (
-    modeledMethod: ModeledMethod | undefined,
-    index: number,
-  ) => JSX.Element,
-): JSX.Element | JSX.Element[] {
-  if (modeledMethods.length === 0) {
-    return renderer(undefined, 0);
-  } else {
-    return modeledMethods.map(renderer);
-  }
 }

--- a/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
@@ -180,12 +180,16 @@ export function ModelEditor({
     [methods],
   );
 
-  const onChange = useCallback((model: ModeledMethod) => {
-    vscode.postMessage({
-      t: "setModeledMethod",
-      method: model,
-    });
-  }, []);
+  const onChange = useCallback(
+    (methodSignature: string, modeledMethods: ModeledMethod[]) => {
+      vscode.postMessage({
+        t: "setMultipleModeledMethods",
+        methodSignature,
+        modeledMethods,
+      });
+    },
+    [],
+  );
 
   const onRefreshClick = useCallback(() => {
     vscode.postMessage({

--- a/extensions/ql-vscode/src/view/model-editor/ModeledMethodDataGrid.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModeledMethodDataGrid.tsx
@@ -24,7 +24,7 @@ export type ModeledMethodDataGridProps = {
   viewState: ModelEditorViewState;
   hideModeledMethods: boolean;
   revealedMethodSignature: string | null;
-  onChange: (modeledMethod: ModeledMethod) => void;
+  onChange: (methodSignature: string, modeledMethods: ModeledMethod[]) => void;
 };
 
 export const ModeledMethodDataGrid = ({

--- a/extensions/ql-vscode/src/view/model-editor/ModeledMethodsList.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModeledMethodsList.tsx
@@ -19,7 +19,7 @@ export type ModeledMethodsListProps = {
   revealedMethodSignature: string | null;
   viewState: ModelEditorViewState;
   hideModeledMethods: boolean;
-  onChange: (modeledMethod: ModeledMethod) => void;
+  onChange: (methodSignature: string, modeledMethods: ModeledMethod[]) => void;
   onSaveModelClick: (methodSignatures: string[]) => void;
   onGenerateFromLlmClick: (
     packageName: string,

--- a/extensions/ql-vscode/src/view/model-editor/__tests__/MethodRow.spec.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/__tests__/MethodRow.spec.tsx
@@ -85,10 +85,12 @@ describe(MethodRow.name, () => {
     );
 
     expect(onChange).toHaveBeenCalledTimes(1);
-    expect(onChange).toHaveBeenCalledWith({
-      ...modeledMethod,
-      kind: "value",
-    });
+    expect(onChange).toHaveBeenCalledWith(method.signature, [
+      {
+        ...modeledMethod,
+        kind: "value",
+      },
+    ]);
   });
 
   it("has the correct input options", () => {

--- a/extensions/ql-vscode/src/view/model-editor/__tests__/MethodRow.spec.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/__tests__/MethodRow.spec.tsx
@@ -72,6 +72,33 @@ describe(MethodRow.name, () => {
     expect(screen.queryByLabelText("Loading")).not.toBeInTheDocument();
   });
 
+  it("can change the type when there is no modeled method", async () => {
+    render({ modeledMethods: [] });
+
+    onChange.mockReset();
+
+    await userEvent.selectOptions(
+      screen.getByRole("combobox", { name: "Model type" }),
+      "source",
+    );
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(method.signature, [
+      {
+        type: "source",
+        input: "Argument[0]",
+        output: "ReturnValue",
+        kind: "value",
+        provenance: "manual",
+        signature: method.signature,
+        packageName: method.packageName,
+        typeName: method.typeName,
+        methodName: method.methodName,
+        methodParameters: method.methodParameters,
+      },
+    ]);
+  });
+
   it("can change the kind", async () => {
     render();
 
@@ -180,6 +207,38 @@ describe(MethodRow.name, () => {
     const kindInputs = screen.getAllByRole("combobox", { name: "Model type" });
     expect(kindInputs.length).toBe(1);
     expect(kindInputs[0]).toHaveValue("source");
+  });
+
+  it("can update fields when there are multiple models", async () => {
+    render({
+      modeledMethods: [
+        { ...modeledMethod, type: "source" },
+        { ...modeledMethod, type: "sink", kind: "code-injection" },
+        { ...modeledMethod, type: "summary" },
+      ],
+      viewState: {
+        ...viewState,
+        showMultipleModels: true,
+      },
+    });
+
+    onChange.mockReset();
+
+    expect(screen.getAllByRole("combobox", { name: "Kind" })[1]).toHaveValue(
+      "code-injection",
+    );
+
+    await userEvent.selectOptions(
+      screen.getAllByRole("combobox", { name: "Kind" })[1],
+      "sql-injection",
+    );
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(method.signature, [
+      { ...modeledMethod, type: "source" },
+      { ...modeledMethod, type: "sink", kind: "sql-injection" },
+      { ...modeledMethod, type: "summary" },
+    ]);
   });
 
   it("renders an unmodelable method", () => {


### PR DESCRIPTION
Switches to using `SetMultipleModeledMethodsMessage` in `FromModelEditorMessage`, and therefore allows editing and saving multiple modeled methods in the model editor.

The only tricky bit was constructing the `onChange` handlers for the input components. That bit could use some scrutiny when reviewing.

Tested locally and appears to be working correctly, both when the feature flag is disabled and enabled.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
