### PR TITLE
Hash result set name in sorted result set path

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [UNRELEASED]
 
+- Sorted result set filenames now include a hash of the result set name instead of the full name. [#2955](https://github.com/github/vscode-codeql/pull/2955)
+
 ## 1.9.2 - 12 October 2023
 
 - Fix a bug where the query to Find Definitions in database source files would not be cancelled appropriately. [#2885](https://github.com/github/vscode-codeql/pull/2885)

--- a/extensions/ql-vscode/src/run-queries-shared.ts
+++ b/extensions/ql-vscode/src/run-queries-shared.ts
@@ -24,6 +24,7 @@ import { BaseLogger, showAndLogWarningMessage } from "./common/logging";
 import { extLogger } from "./common/logging/vscode";
 import { generateSummarySymbolsFile } from "./log-insights/summary-parser";
 import { getErrorMessage } from "./common/helpers-pure";
+import { createHash } from "crypto";
 
 /**
  * run-queries.ts
@@ -150,7 +151,12 @@ export class QueryEvaluationInfo extends QueryOutputDir {
     };
   }
   getSortedResultSetPath(resultSetName: string) {
-    return join(this.querySaveDir, `sortedResults-${resultSetName}.bqrs`);
+    const hasher = createHash("sha256");
+    hasher.update(resultSetName);
+    return join(
+      this.querySaveDir,
+      `sortedResults-${hasher.digest("hex")}.bqrs`,
+    );
   }
 
   /**

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-results.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-results.test.ts
@@ -160,7 +160,7 @@ describe("query-results", () => {
       const expectedResultsPath = join(queryPath, "results.bqrs");
       const expectedSortedResultsPath = join(
         queryPath,
-        "sortedResults-a-result-set-name.bqrs",
+        "sortedResults-cc8589f226adc134f87f2438e10075e0667571c72342068e2281e0b3b65e1092.bqrs",
       );
       expect(spy).toBeCalledWith(
         expectedResultsPath,


### PR DESCRIPTION
This PR changes the filename used for sorted result sets from using the result set name directly to using a hash. Using a hash is preferable as the result set names are generated from the named results of the final stage. It is therefore partially under user-control and may contain additional special characters that cannot be used in filenames as the RA name character set is extended.  

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
