### PR TITLE
Use `SetMultipleModeledMethodsMessage` in modeled methods panel

### DIFF
--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -572,11 +572,6 @@ interface HideModeledMethodsMessage {
   hideModeledMethods: boolean;
 }
 
-interface SetModeledMethodMessage {
-  t: "setModeledMethod";
-  method: ModeledMethod;
-}
-
 interface SetMultipleModeledMethodsMessage {
   t: "setMultipleModeledMethods";
   methodSignature: string;
@@ -627,7 +622,7 @@ interface StartModelingMessage {
 
 export type FromMethodModelingMessage =
   | CommonFromViewMessages
-  | SetModeledMethodMessage
+  | SetMultipleModeledMethodsMessage
   | RevealInEditorMessage
   | StartModelingMessage;
 

--- a/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
+++ b/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
@@ -14,7 +14,6 @@ import { assertNever } from "../../common/helpers-pure";
 import { ModelEditorViewTracker } from "../model-editor-view-tracker";
 import { ModelConfigListener } from "../../config";
 import { DatabaseItem } from "../../databases/local-databases";
-import { convertFromLegacyModeledMethod } from "../shared/modeled-methods-legacy";
 
 export class MethodModelingViewProvider extends AbstractWebviewViewProvider<
   ToMethodModelingMessage,
@@ -108,19 +107,19 @@ export class MethodModelingViewProvider extends AbstractWebviewViewProvider<
         );
         break;
 
-      case "setModeledMethod": {
+      case "setMultipleModeledMethods": {
         if (!this.databaseItem) {
           return;
         }
 
         this.modelingStore.updateModeledMethods(
           this.databaseItem,
-          msg.method.signature,
-          convertFromLegacyModeledMethod(msg.method),
+          msg.methodSignature,
+          msg.modeledMethods,
         );
         this.modelingStore.addModifiedMethod(
           this.databaseItem,
-          msg.method.signature,
+          msg.methodSignature,
         );
         break;
       }

--- a/extensions/ql-vscode/src/model-editor/shared/modeled-methods-legacy.ts
+++ b/extensions/ql-vscode/src/model-editor/shared/modeled-methods-legacy.ts
@@ -1,22 +1,6 @@
 import { ModeledMethod } from "../modeled-method";
 
 /**
- * Converts a single ModeledMethod to a ModeledMethod[] for legacy usage. This function should always be used instead
- * of the trivial conversion to track usages of this conversion.
- *
- * This method should only be called inside a `onMessage` function (or its equivalent). If it's used anywhere else,
- * consider whether the boundary is correct: the boundary should as close as possible to the webview -> extension host
- * boundary.
- *
- * @param modeledMethod The single ModeledMethod
- */
-export function convertFromLegacyModeledMethod(
-  modeledMethod: ModeledMethod | undefined,
-): ModeledMethod[] {
-  return modeledMethod ? [modeledMethod] : [];
-}
-
-/**
  * Converts a ModeledMethod[] to a single ModeledMethod for legacy usage. This function should always be used instead
  * of the trivial conversion to track usages of this conversion.
  *

--- a/extensions/ql-vscode/src/stories/method-modeling/MultipleModeledMethodsPanel.stories.tsx
+++ b/extensions/ql-vscode/src/stories/method-modeling/MultipleModeledMethodsPanel.stories.tsx
@@ -25,8 +25,8 @@ const Template: StoryFn<typeof MultipleModeledMethodsPanelComponent> = (
   }, [args.modeledMethods]);
 
   const handleChange = useCallback(
-    (modeledMethods: ModeledMethod[]) => {
-      args.onChange(modeledMethods);
+    (methodSignature: string, modeledMethods: ModeledMethod[]) => {
+      args.onChange(methodSignature, modeledMethods);
       setModeledMethods(modeledMethods);
     },
     [args],

--- a/extensions/ql-vscode/src/view/method-modeling/MethodModeling.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/MethodModeling.tsx
@@ -53,7 +53,7 @@ export type MethodModelingProps = {
   method: Method;
   modeledMethods: ModeledMethod[];
   showMultipleModels?: boolean;
-  onChange: (modeledMethod: ModeledMethod) => void;
+  onChange: (methodSignature: string, modeledMethods: ModeledMethod[]) => void;
 };
 
 export const MethodModeling = ({

--- a/extensions/ql-vscode/src/view/method-modeling/MethodModelingView.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/MethodModelingView.tsx
@@ -86,10 +86,14 @@ export function MethodModelingView({ initialViewState }: Props): JSX.Element {
     return <MethodAlreadyModeled />;
   }
 
-  const onChange = (modeledMethod: ModeledMethod) => {
+  const onChange = (
+    methodSignature: string,
+    modeledMethods: ModeledMethod[],
+  ) => {
     vscode.postMessage({
-      t: "setModeledMethod",
-      method: modeledMethod,
+      t: "setMultipleModeledMethods",
+      methodSignature,
+      modeledMethods,
     });
   };
 

--- a/extensions/ql-vscode/src/view/method-modeling/ModeledMethodsPanel.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/ModeledMethodsPanel.tsx
@@ -11,7 +11,7 @@ export type ModeledMethodsPanelProps = {
   method: Method;
   modeledMethods: ModeledMethod[];
   showMultipleModels: boolean;
-  onChange: (modeledMethod: ModeledMethod) => void;
+  onChange: (methodSignature: string, modeledMethods: ModeledMethod[]) => void;
 };
 
 const SingleMethodModelingInputs = styled(MethodModelingInputs)`
@@ -24,9 +24,9 @@ export const ModeledMethodsPanel = ({
   showMultipleModels,
   onChange,
 }: ModeledMethodsPanelProps) => {
-  const handleMultipleChange = useCallback(
-    (modeledMethods: ModeledMethod[]) => {
-      onChange(modeledMethods[0]);
+  const handleSingleChange = useCallback(
+    (modeledMethod: ModeledMethod) => {
+      onChange(modeledMethod.signature, [modeledMethod]);
     },
     [onChange],
   );
@@ -36,7 +36,7 @@ export const ModeledMethodsPanel = ({
       <SingleMethodModelingInputs
         method={method}
         modeledMethod={convertToLegacyModeledMethod(modeledMethods)}
-        onChange={onChange}
+        onChange={handleSingleChange}
       />
     );
   }
@@ -45,7 +45,7 @@ export const ModeledMethodsPanel = ({
     <MultipleModeledMethodsPanel
       method={method}
       modeledMethods={modeledMethods}
-      onChange={handleMultipleChange}
+      onChange={onChange}
     />
   );
 };

--- a/extensions/ql-vscode/src/view/method-modeling/MultipleModeledMethodsPanel.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/MultipleModeledMethodsPanel.tsx
@@ -10,7 +10,7 @@ import { Codicon } from "../common";
 export type MultipleModeledMethodsPanelProps = {
   method: Method;
   modeledMethods: ModeledMethod[];
-  onChange: (modeledMethods: ModeledMethod[]) => void;
+  onChange: (methodSignature: string, modeledMethods: ModeledMethod[]) => void;
 };
 
 const Container = styled.div`
@@ -70,7 +70,7 @@ export const MultipleModeledMethodsPanel = ({
 
     const newModeledMethods = [...modeledMethods, newModeledMethod];
 
-    onChange(newModeledMethods);
+    onChange(method.signature, newModeledMethods);
     setSelectedIndex(newModeledMethods.length - 1);
   }, [onChange, modeledMethods, method]);
 
@@ -84,9 +84,9 @@ export const MultipleModeledMethodsPanel = ({
         ? selectedIndex - 1
         : selectedIndex;
 
-    onChange(newModeledMethods);
+    onChange(method.signature, newModeledMethods);
     setSelectedIndex(newSelectedIndex);
-  }, [onChange, modeledMethods, selectedIndex]);
+  }, [onChange, modeledMethods, selectedIndex, method]);
 
   const anyUnmodeled = useMemo(
     () =>
@@ -100,12 +100,12 @@ export const MultipleModeledMethodsPanel = ({
       if (modeledMethods.length > 0) {
         const newModeledMethods = [...modeledMethods];
         newModeledMethods[selectedIndex] = modeledMethod;
-        onChange(newModeledMethods);
+        onChange(method.signature, newModeledMethods);
       } else {
-        onChange([modeledMethod]);
+        onChange(method.signature, [modeledMethod]);
       }
     },
-    [modeledMethods, selectedIndex, onChange],
+    [modeledMethods, selectedIndex, onChange, method],
   );
 
   return (

--- a/extensions/ql-vscode/src/view/method-modeling/__tests__/MultipleModeledMethodsPanel.spec.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/__tests__/MultipleModeledMethodsPanel.spec.tsx
@@ -14,7 +14,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
     reactRender(<MultipleModeledMethodsPanel {...props} />);
 
   const method = createMethod();
-  const onChange = jest.fn<void, [ModeledMethod[]]>();
+  const onChange = jest.fn<void, [string, ModeledMethod[]]>();
 
   describe("with no modeled methods", () => {
     const modeledMethods: ModeledMethod[] = [];
@@ -138,7 +138,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
 
       await userEvent.click(screen.getByLabelText("Add modeling"));
 
-      expect(onChange).toHaveBeenCalledWith([
+      expect(onChange).toHaveBeenCalledWith(method.signature, [
         ...modeledMethods,
         {
           signature: method.signature,
@@ -265,7 +265,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
 
       await userEvent.selectOptions(modelTypeDropdown, "source");
 
-      expect(onChange).toHaveBeenCalledWith([
+      expect(onChange).toHaveBeenCalledWith(method.signature, [
         {
           signature: method.signature,
           packageName: method.packageName,
@@ -297,7 +297,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
 
       await userEvent.selectOptions(modelTypeDropdown, "sink");
 
-      expect(onChange).toHaveBeenCalledWith([
+      expect(onChange).toHaveBeenCalledWith(method.signature, [
         ...modeledMethods.slice(0, 1),
         {
           signature: method.signature,
@@ -323,7 +323,10 @@ describe(MultipleModeledMethodsPanel.name, () => {
 
       await userEvent.click(screen.getByLabelText("Delete modeling"));
 
-      expect(onChange).toHaveBeenCalledWith(modeledMethods.slice(1));
+      expect(onChange).toHaveBeenCalledWith(
+        method.signature,
+        modeledMethods.slice(1),
+      );
     });
 
     it("can add modeling", async () => {
@@ -335,7 +338,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
 
       await userEvent.click(screen.getByLabelText("Add modeling"));
 
-      expect(onChange).toHaveBeenCalledWith([
+      expect(onChange).toHaveBeenCalledWith(method.signature, [
         ...modeledMethods,
         {
           signature: method.signature,
@@ -506,7 +509,10 @@ describe(MultipleModeledMethodsPanel.name, () => {
 
       await userEvent.click(screen.getByLabelText("Delete modeling"));
 
-      expect(onChange).toHaveBeenCalledWith(modeledMethods.slice(1));
+      expect(onChange).toHaveBeenCalledWith(
+        method.signature,
+        modeledMethods.slice(1),
+      );
     });
 
     it("can delete second modeling", async () => {
@@ -519,7 +525,10 @@ describe(MultipleModeledMethodsPanel.name, () => {
       await userEvent.click(screen.getByLabelText("Next modeling"));
       await userEvent.click(screen.getByLabelText("Delete modeling"));
 
-      expect(onChange).toHaveBeenCalledWith(modeledMethods.slice(0, 1));
+      expect(onChange).toHaveBeenCalledWith(
+        method.signature,
+        modeledMethods.slice(0, 1),
+      );
     });
 
     it("can add modeling after deleting second modeling", async () => {
@@ -532,7 +541,10 @@ describe(MultipleModeledMethodsPanel.name, () => {
       await userEvent.click(screen.getByLabelText("Next modeling"));
       await userEvent.click(screen.getByLabelText("Delete modeling"));
 
-      expect(onChange).toHaveBeenCalledWith(modeledMethods.slice(0, 1));
+      expect(onChange).toHaveBeenCalledWith(
+        method.signature,
+        modeledMethods.slice(0, 1),
+      );
 
       rerender(
         <MultipleModeledMethodsPanel
@@ -545,7 +557,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
       onChange.mockReset();
       await userEvent.click(screen.getByLabelText("Add modeling"));
 
-      expect(onChange).toHaveBeenCalledWith([
+      expect(onChange).toHaveBeenCalledWith(method.signature, [
         ...modeledMethods.slice(0, 1),
         {
           signature: method.signature,


### PR DESCRIPTION
This makes the modeled methods panel send the `SetMultipleModeledMethodsMessage` message when the modeled methods change. This is the last step in wiring up the modeled methods panel; after this has been merged, it is possible to view, edit and save multiple models in the method modeling panel.

The only remaining usage of `convertToLegacyModeledMethod` is in the `ModeledMethodsPanel` when the feature flag is disabled. In this case, we're using a different code path, but once the feature flag is removed, it should be possible to remove `convertToLegacyModeledMethod`.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
