### PR TITLE
Add missing useMemo import

### DIFF
--- a/extensions/ql-vscode/src/view/method-modeling/MultipleModeledMethodsPanel.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/MultipleModeledMethodsPanel.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { Method } from "../../model-editor/method";
 import { ModeledMethod } from "../../model-editor/modeled-method";
 import { styled } from "styled-components";


### PR DESCRIPTION
It seems like there was a semantic merge conflict between https://github.com/github/vscode-codeql/pull/2959 and https://github.com/github/vscode-codeql/pull/2952 which breaks the build. This adds the missing `useMemo` import.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
