### PR TITLE
Enable/disable the add/remove model buttons at the right times

### DIFF
--- a/extensions/ql-vscode/src/model-editor/shared/multiple-modeled-methods.ts
+++ b/extensions/ql-vscode/src/model-editor/shared/multiple-modeled-methods.ts
@@ -1,0 +1,20 @@
+import { ModeledMethod } from "../modeled-method";
+
+export function canAddNewModeledMethod(
+  modeledMethods: ModeledMethod[],
+): boolean {
+  // Disallow adding methods when there are no modeled methods or where there is a single unmodeled method.
+  // In both of these cases the UI will already be showing the user inputs they can use for modeling.
+  return (
+    modeledMethods.length > 1 ||
+    (modeledMethods.length === 1 && modeledMethods[0].type !== "none")
+  );
+}
+
+export function canRemoveModeledMethod(
+  modeledMethods: ModeledMethod[],
+): boolean {
+  // Don't allow removing the last modeled method. In this case the user is intended to
+  // set the type to "none" instead.
+  return modeledMethods.length > 1;
+}

--- a/extensions/ql-vscode/src/view/method-modeling/MultipleModeledMethodsPanel.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/MultipleModeledMethodsPanel.tsx
@@ -2,6 +2,10 @@ import * as React from "react";
 import { useCallback, useMemo, useState } from "react";
 import { Method } from "../../model-editor/method";
 import { ModeledMethod } from "../../model-editor/modeled-method";
+import {
+  canAddNewModeledMethod,
+  canRemoveModeledMethod,
+} from "../../model-editor/shared/multiple-modeled-methods";
 import { styled } from "styled-components";
 import { MethodModelingInputs } from "./MethodModelingInputs";
 import { VSCodeButton } from "@vscode/webview-ui-toolkit/react";
@@ -171,7 +175,7 @@ export const MultipleModeledMethodsPanel = ({
             appearance="icon"
             aria-label="Delete modeling"
             onClick={handleRemoveClick}
-            disabled={modeledMethods.length < 2}
+            disabled={!canRemoveModeledMethod(modeledMethods)}
           >
             <Codicon name="trash" />
           </VSCodeButton>
@@ -179,10 +183,7 @@ export const MultipleModeledMethodsPanel = ({
             appearance="icon"
             aria-label="Add modeling"
             onClick={handleAddClick}
-            disabled={
-              modeledMethods.length === 0 ||
-              (modeledMethods.length === 1 && modeledMethods[0].type === "none")
-            }
+            disabled={!canAddNewModeledMethod(modeledMethods)}
           >
             <Codicon name="add" />
           </VSCodeButton>

--- a/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
@@ -227,13 +227,18 @@ const ModelableMethodRow = forwardRef<HTMLElement | undefined, MethodRowProps>(
                     <CodiconRow
                       key={index}
                       appearance="icon"
+                      aria-label="Add new model"
                       disabled={addModelButtonDisabled}
                     >
-                      <Codicon name="add" label="Add new model" />
+                      <Codicon name="add" />
                     </CodiconRow>
                   ) : (
-                    <CodiconRow key={index} appearance="icon">
-                      <Codicon name="trash" label="Remove model" />
+                    <CodiconRow
+                      key={index}
+                      appearance="icon"
+                      aria-label="Remove model"
+                    >
+                      <Codicon name="trash" />
                     </CodiconRow>
                   ),
                 )}

--- a/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
@@ -24,6 +24,7 @@ import { ModelInputDropdown } from "./ModelInputDropdown";
 import { ModelOutputDropdown } from "./ModelOutputDropdown";
 import { ModelEditorViewState } from "../../model-editor/shared/view-state";
 import { Codicon } from "../common";
+import { canAddNewModeledMethod } from "../../model-editor/shared/multiple-modeled-methods";
 
 const MultiModelColumn = styled(VSCodeDataGridCell)`
   display: flex;
@@ -132,6 +133,8 @@ const ModelableMethodRow = forwardRef<HTMLElement | undefined, MethodRowProps>(
 
     const modelingStatus = getModelingStatus(modeledMethods, methodIsUnsaved);
 
+    const addModelButtonDisabled = !canAddNewModeledMethod(modeledMethods);
+
     return (
       <DataGridRow
         data-testid="modelable-method-row"
@@ -219,15 +222,21 @@ const ModelableMethodRow = forwardRef<HTMLElement | undefined, MethodRowProps>(
             </MultiModelColumn>
             {viewState.showMultipleModels && (
               <MultiModelColumn gridColumn={6}>
-                {modeledMethods.map((_, index) => (
-                  <CodiconRow key={index} appearance="icon" disabled={false}>
-                    {index === modeledMethods.length - 1 ? (
+                {modeledMethods.map((_, index) =>
+                  index === modeledMethods.length - 1 ? (
+                    <CodiconRow
+                      key={index}
+                      appearance="icon"
+                      disabled={addModelButtonDisabled}
+                    >
                       <Codicon name="add" label="Add new model" />
-                    ) : (
+                    </CodiconRow>
+                  ) : (
+                    <CodiconRow key={index} appearance="icon">
                       <Codicon name="trash" label="Remove model" />
-                    )}
-                  </CodiconRow>
-                ))}
+                    </CodiconRow>
+                  ),
+                )}
               </MultiModelColumn>
             )}
           </>

--- a/extensions/ql-vscode/src/view/model-editor/__tests__/MethodRow.spec.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/__tests__/MethodRow.spec.tsx
@@ -251,4 +251,111 @@ describe(MethodRow.name, () => {
     expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
     expect(screen.getByText("Method already modeled")).toBeInTheDocument();
   });
+
+  it("Doesn't show add/remove buttons when multiple methods feature flag is disabled", async () => {
+    render({
+      modeledMethods: [modeledMethod],
+      viewState: {
+        ...viewState,
+        showMultipleModels: false,
+      },
+    });
+
+    expect(screen.queryByLabelText("Add new model")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Remove model")).not.toBeInTheDocument();
+  });
+
+  it("Button to add new model is disabled when there are no modeled methods", async () => {
+    render({
+      modeledMethods: [],
+      viewState: {
+        ...viewState,
+        showMultipleModels: true,
+      },
+    });
+
+    const addButton = screen.queryByLabelText("Add new model");
+    expect(addButton).toBeInTheDocument();
+    expect(addButton).toBeDisabled();
+
+    expect(screen.queryByLabelText("Remove model")).not.toBeInTheDocument();
+  });
+
+  it("Button to add new model is disabled when there is one unmodeled method", async () => {
+    render({
+      modeledMethods: [{ ...modeledMethod, type: "none" }],
+      viewState: {
+        ...viewState,
+        showMultipleModels: true,
+      },
+    });
+
+    const addButton = screen.queryByLabelText("Add new model");
+    expect(addButton).toBeInTheDocument();
+    expect(addButton).toBeDisabled();
+
+    expect(screen.queryByLabelText("Remove model")).not.toBeInTheDocument();
+  });
+
+  it("Add button is shown and enabed when there is one modeled methods", async () => {
+    render({
+      modeledMethods: [modeledMethod],
+      viewState: {
+        ...viewState,
+        showMultipleModels: true,
+      },
+    });
+
+    const addButton = screen.queryByLabelText("Add new model");
+    expect(addButton).toBeInTheDocument();
+    expect(addButton).toBeEnabled();
+
+    expect(screen.queryByLabelText("Remove model")).not.toBeInTheDocument();
+  });
+
+  it("Add and remove buttons are shown and enabed when there are multiple modeled methods", async () => {
+    render({
+      modeledMethods: [
+        { ...modeledMethod, type: "source" },
+        { ...modeledMethod, type: "none" },
+      ],
+      viewState: {
+        ...viewState,
+        showMultipleModels: true,
+      },
+    });
+
+    const addButton = screen.queryByLabelText("Add new model");
+    expect(addButton).toBeInTheDocument();
+    expect(addButton).toBeEnabled();
+
+    const removeButton = screen.queryByLabelText("Remove model");
+    expect(removeButton).toBeInTheDocument();
+    expect(removeButton).toBeEnabled();
+  });
+
+  it("Shows add button on last row and remove button on all other rows", async () => {
+    render({
+      modeledMethods: [
+        { ...modeledMethod, type: "source" },
+        { ...modeledMethod, type: "sink" },
+        { ...modeledMethod, type: "summary" },
+        { ...modeledMethod, type: "none" },
+      ],
+      viewState: {
+        ...viewState,
+        showMultipleModels: true,
+      },
+    });
+
+    const addButtons = screen.queryAllByLabelText("Add new model");
+    expect(addButtons.length).toBe(1);
+    expect(addButtons[0]).toBeEnabled();
+
+    const removeButtons = screen.queryAllByLabelText("Remove model");
+    expect(removeButtons.length).toBe(3);
+    for (const removeButton of removeButtons) {
+      expect(removeButton).toBeEnabled();
+    }
+  });
 });

--- a/extensions/ql-vscode/src/view/model-editor/__tests__/MethodRow.spec.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/__tests__/MethodRow.spec.tsx
@@ -252,7 +252,7 @@ describe(MethodRow.name, () => {
     expect(screen.getByText("Method already modeled")).toBeInTheDocument();
   });
 
-  it("Doesn't show add/remove buttons when multiple methods feature flag is disabled", async () => {
+  it("doesn't show add/remove buttons when multiple methods feature flag is disabled", async () => {
     render({
       modeledMethods: [modeledMethod],
       viewState: {
@@ -265,7 +265,7 @@ describe(MethodRow.name, () => {
     expect(screen.queryByLabelText("Remove model")).not.toBeInTheDocument();
   });
 
-  it("Button to add new model is disabled when there are no modeled methods", async () => {
+  it("shows disabled button add new model when there are no modeled methods", async () => {
     render({
       modeledMethods: [],
       viewState: {
@@ -281,7 +281,7 @@ describe(MethodRow.name, () => {
     expect(screen.queryByLabelText("Remove model")).not.toBeInTheDocument();
   });
 
-  it("Button to add new model is disabled when there is one unmodeled method", async () => {
+  it("disabled button to add new model when there is one unmodeled method", async () => {
     render({
       modeledMethods: [{ ...modeledMethod, type: "none" }],
       viewState: {
@@ -297,7 +297,7 @@ describe(MethodRow.name, () => {
     expect(screen.queryByLabelText("Remove model")).not.toBeInTheDocument();
   });
 
-  it("Add button is shown and enabed when there is one modeled methods", async () => {
+  it("enabled button to add new model when there is one modeled method", async () => {
     render({
       modeledMethods: [modeledMethod],
       viewState: {
@@ -313,7 +313,7 @@ describe(MethodRow.name, () => {
     expect(screen.queryByLabelText("Remove model")).not.toBeInTheDocument();
   });
 
-  it("Add and remove buttons are shown and enabed when there are multiple modeled methods", async () => {
+  it("enabled add/remove model buttons when there are multiple modeled methods", async () => {
     render({
       modeledMethods: [
         { ...modeledMethod, type: "source" },
@@ -334,7 +334,7 @@ describe(MethodRow.name, () => {
     expect(removeButton).toBeEnabled();
   });
 
-  it("Shows add button on last row and remove button on all other rows", async () => {
+  it("shows add model button on last row and remove model button on all other rows", async () => {
     render({
       modeledMethods: [
         { ...modeledMethod, type: "source" },

--- a/extensions/ql-vscode/src/view/model-editor/__tests__/MethodRow.spec.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/__tests__/MethodRow.spec.tsx
@@ -276,7 +276,7 @@ describe(MethodRow.name, () => {
 
     const addButton = screen.queryByLabelText("Add new model");
     expect(addButton).toBeInTheDocument();
-    expect(addButton).toBeDisabled();
+    expect(addButton?.getElementsByTagName("input")[0]).toBeDisabled();
 
     expect(screen.queryByLabelText("Remove model")).not.toBeInTheDocument();
   });
@@ -292,7 +292,7 @@ describe(MethodRow.name, () => {
 
     const addButton = screen.queryByLabelText("Add new model");
     expect(addButton).toBeInTheDocument();
-    expect(addButton).toBeDisabled();
+    expect(addButton?.getElementsByTagName("input")[0]).toBeDisabled();
 
     expect(screen.queryByLabelText("Remove model")).not.toBeInTheDocument();
   });
@@ -308,7 +308,7 @@ describe(MethodRow.name, () => {
 
     const addButton = screen.queryByLabelText("Add new model");
     expect(addButton).toBeInTheDocument();
-    expect(addButton).toBeEnabled();
+    expect(addButton?.getElementsByTagName("input")[0]).toBeEnabled();
 
     expect(screen.queryByLabelText("Remove model")).not.toBeInTheDocument();
   });
@@ -327,11 +327,11 @@ describe(MethodRow.name, () => {
 
     const addButton = screen.queryByLabelText("Add new model");
     expect(addButton).toBeInTheDocument();
-    expect(addButton).toBeEnabled();
+    expect(addButton?.getElementsByTagName("input")[0]).toBeEnabled();
 
     const removeButton = screen.queryByLabelText("Remove model");
     expect(removeButton).toBeInTheDocument();
-    expect(removeButton).toBeEnabled();
+    expect(removeButton?.getElementsByTagName("input")[0]).toBeEnabled();
   });
 
   it("shows add model button on last row and remove model button on all other rows", async () => {
@@ -350,12 +350,12 @@ describe(MethodRow.name, () => {
 
     const addButtons = screen.queryAllByLabelText("Add new model");
     expect(addButtons.length).toBe(1);
-    expect(addButtons[0]).toBeEnabled();
+    expect(addButtons[0]?.getElementsByTagName("input")[0]).toBeEnabled();
 
     const removeButtons = screen.queryAllByLabelText("Remove model");
     expect(removeButtons.length).toBe(3);
     for (const removeButton of removeButtons) {
-      expect(removeButton).toBeEnabled();
+      expect(removeButton?.getElementsByTagName("input")[0]).toBeEnabled();
     }
   });
 });


### PR DESCRIPTION
Hooks up the `disabled` attribute for the add/remove model buttons in the model editor.

Uses the same logic as the method modeling panel, and pulls out the implementation to a shared location. Although it turns out the model editor doesn't need the logic for disabling the remove button, because it's never shown in situations when it would be disabled.

Also adds some tests that the buttons are shown / enabled at the right times.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
