### PR TITLE
Fix neutral model validation to consider kind

### DIFF
--- a/extensions/ql-vscode/src/view/method-modeling/__tests__/MultipleModeledMethodsPanel.spec.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/__tests__/MultipleModeledMethodsPanel.spec.tsx
@@ -387,6 +387,24 @@ describe(MultipleModeledMethodsPanel.name, () => {
 
       await userEvent.selectOptions(modelTypeDropdown, "neutral");
 
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+
+      rerender(
+        <MultipleModeledMethodsPanel
+          method={method}
+          modeledMethods={
+            onChange.mock.calls[onChange.mock.calls.length - 1][0]
+          }
+          onChange={onChange}
+        />,
+      );
+
+      const kindDropdown = screen.getByRole("combobox", {
+        name: "Kind",
+      });
+
+      await userEvent.selectOptions(kindDropdown, "source");
+
       rerender(
         <MultipleModeledMethodsPanel
           method={method}

--- a/extensions/ql-vscode/test/unit-tests/model-editor/shared/validation.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/model-editor/shared/validation.test.ts
@@ -246,6 +246,7 @@ describe(validateModeledMethods.name, () => {
       }),
       createModeledMethod({
         type: "neutral",
+        kind: "sink",
       }),
     ];
 
@@ -261,16 +262,34 @@ describe(validateModeledMethods.name, () => {
     ]);
   });
 
-  it("should give an error with duplicate neutral combined with other models", () => {
+  it("should not give an error with other neutral combined with other models", () => {
     const modeledMethods = [
-      createModeledMethod({
-        type: "neutral",
-      }),
       createModeledMethod({
         type: "sink",
       }),
       createModeledMethod({
         type: "neutral",
+        kind: "summary",
+      }),
+    ];
+
+    const errors = validateModeledMethods(modeledMethods);
+
+    expect(errors).toEqual([]);
+  });
+
+  it("should give an error with duplicate neutral combined with other models", () => {
+    const modeledMethods = [
+      createModeledMethod({
+        type: "neutral",
+        kind: "summary",
+      }),
+      createModeledMethod({
+        type: "summary",
+      }),
+      createModeledMethod({
+        type: "neutral",
+        kind: "summary",
       }),
     ];
 
@@ -299,12 +318,14 @@ describe(validateModeledMethods.name, () => {
       }),
       createModeledMethod({
         type: "neutral",
+        kind: "sink",
       }),
       createModeledMethod({
         type: "sink",
       }),
       createModeledMethod({
         type: "neutral",
+        kind: "sink",
       }),
     ];
 


### PR DESCRIPTION
This fixes a bug where the validation of modeled methods would not consider the kind of the modeled method, and would therefore give an error when there was e.g. a neutral sink and a non-neutral summary.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
