### PR TITLE
Fix incorrect test for `MultipleModeledMethodsPanel`

### DIFF
--- a/extensions/ql-vscode/src/view/method-modeling/__tests__/MultipleModeledMethodsPanel.spec.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/__tests__/MultipleModeledMethodsPanel.spec.tsx
@@ -378,7 +378,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         <MultipleModeledMethodsPanel
           method={method}
           modeledMethods={
-            onChange.mock.calls[onChange.mock.calls.length - 1][0]
+            onChange.mock.calls[onChange.mock.calls.length - 1][1]
           }
           onChange={onChange}
         />,
@@ -394,7 +394,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         <MultipleModeledMethodsPanel
           method={method}
           modeledMethods={
-            onChange.mock.calls[onChange.mock.calls.length - 1][0]
+            onChange.mock.calls[onChange.mock.calls.length - 1][1]
           }
           onChange={onChange}
         />,


### PR DESCRIPTION
This was caused by a semantic merge conflict resulting in the wrong `onChange` argument being used in the test.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
