### PR TITLE
Fix unmodeled methods always being marked as unsaved

### DIFF
--- a/extensions/ql-vscode/src/view/model-editor/ModelKindDropdown.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelKindDropdown.tsx
@@ -63,7 +63,16 @@ export const ModelKindDropdown = ({
 
   useEffect(() => {
     const value = modeledMethod?.kind;
-    if (value === undefined && kinds.length > 0) {
+
+    if (kinds.length === 0) {
+      if (value !== "") {
+        onChangeKind("");
+      }
+
+      return;
+    }
+
+    if (value === undefined) {
       onChangeKind(kinds[0]);
     }
 

--- a/extensions/ql-vscode/src/view/model-editor/ModelKindDropdown.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelKindDropdown.tsx
@@ -62,21 +62,11 @@ export const ModelKindDropdown = ({
   );
 
   useEffect(() => {
-    const value = modeledMethod?.kind;
+    const value = modeledMethod?.kind ?? "";
 
-    if (kinds.length === 0) {
-      if (value !== "") {
-        onChangeKind("");
-      }
-
-      return;
-    }
-
-    if (value === undefined) {
-      onChangeKind(kinds[0]);
-    }
-
-    if (value !== undefined && !kinds.includes(value)) {
+    if (kinds.length === 0 && value !== "") {
+      onChangeKind("");
+    } else if (kinds.length > 0 && !kinds.includes(value)) {
       onChangeKind(kinds[0]);
     }
   }, [modeledMethod?.kind, kinds, onChangeKind]);

--- a/extensions/ql-vscode/src/view/model-editor/__tests__/ModelKindDropdown.spec.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/__tests__/ModelKindDropdown.spec.tsx
@@ -92,4 +92,45 @@ describe(ModelKindDropdown.name, () => {
       }),
     );
   });
+
+  it("does not call onChange when unmodeled and the kind is valid", () => {
+    const method = createMethod();
+    const modeledMethod = createModeledMethod({
+      type: "none",
+      kind: "",
+    });
+
+    render(
+      <ModelKindDropdown
+        method={method}
+        modeledMethod={modeledMethod}
+        onChange={onChange}
+      />,
+    );
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("calls onChange when unmodeled and the kind is valid", () => {
+    const method = createMethod();
+    const modeledMethod = createModeledMethod({
+      type: "none",
+      kind: "local",
+    });
+
+    render(
+      <ModelKindDropdown
+        method={method}
+        modeledMethod={modeledMethod}
+        onChange={onChange}
+      />,
+    );
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "",
+      }),
+    );
+  });
 });


### PR DESCRIPTION
When opening a library group in the model editor, unmodeled methods would always be marked as unsaved, even if there were no changes. This was because the `ModelKindDropdown` component did not properly take into account that the `kind` for an unmodeled method should be an empty string. It would always try setting it to `undefined`, which would cause the method to be marked as unsaved. This fixes it by checking if there are valid kinds before setting the kind to the first one.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
