### PR TITLE
Convert InProgressMethods to an interface

### DIFF
--- a/extensions/ql-vscode/src/model-editor/shared/in-progress-methods.ts
+++ b/extensions/ql-vscode/src/model-editor/shared/in-progress-methods.ts
@@ -1,34 +1,28 @@
 /**
- * A class that keeps track of which methods are in progress for each package.
- *
- * This class is immutable and therefore is safe to be used in a React useState hook.
+ * An interface to help keep track of which methods are in progress for each package.
  */
-export class InProgressMethods {
-  // A map of in-progress method signatures for each package.
-  private readonly methodMap: ReadonlyMap<string, Set<string>>;
+export type InProgressMethods = Record<string, string[]>;
 
-  constructor(methodMap?: ReadonlyMap<string, Set<string>>) {
-    this.methodMap = methodMap ?? new Map<string, Set<string>>();
+export function setPackageInProgressMethods(
+  inProgressMethods: InProgressMethods,
+  packageName: string,
+  methods: string[],
+): InProgressMethods {
+  return {
+    ...inProgressMethods,
+    [packageName]: methods,
+  };
+}
+
+export function hasInProgressMethod(
+  inProgressMethods: InProgressMethods,
+  packageName: string,
+  method: string,
+): boolean {
+  const methods = inProgressMethods[packageName];
+  if (methods) {
+    return methods.includes(method);
   }
 
-  /**
-   * Sets the in-progress methods for the given package.
-   * Returns a new InProgressMethods instance.
-   */
-  public setPackageMethods(
-    packageName: string,
-    methods: Set<string>,
-  ): InProgressMethods {
-    const newMethodMap = new Map<string, Set<string>>(this.methodMap);
-    newMethodMap.set(packageName, methods);
-    return new InProgressMethods(newMethodMap);
-  }
-
-  public hasMethod(packageName: string, method: string): boolean {
-    const methods = this.methodMap.get(packageName);
-    if (methods) {
-      return methods.has(method);
-    }
-    return false;
-  }
+  return false;
 }

--- a/extensions/ql-vscode/src/stories/model-editor/LibraryRow.stories.tsx
+++ b/extensions/ql-vscode/src/stories/model-editor/LibraryRow.stories.tsx
@@ -5,7 +5,6 @@ import { Meta, StoryFn } from "@storybook/react";
 import { Mode } from "../../model-editor/shared/mode";
 import { LibraryRow as LibraryRowComponent } from "../../view/model-editor/LibraryRow";
 import { CallClassification } from "../../model-editor/method";
-import { InProgressMethods } from "../../model-editor/shared/in-progress-methods";
 import { createMockExtensionPack } from "../../../test/factories/model-editor/extension-pack";
 
 export default {
@@ -219,7 +218,7 @@ LibraryRow.args = {
     ],
   },
   modifiedSignatures: new Set(["org.sql2o.Sql2o#Sql2o(String)"]),
-  inProgressMethods: new InProgressMethods(),
+  inProgressMethods: {},
   viewState: {
     extensionPack: createMockExtensionPack(),
     showFlowGeneration: true,

--- a/extensions/ql-vscode/src/view/model-editor/LibraryRow.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/LibraryRow.tsx
@@ -14,7 +14,10 @@ import {
   VSCodeTag,
 } from "@vscode/webview-ui-toolkit/react";
 import { ModelEditorViewState } from "../../model-editor/shared/view-state";
-import { InProgressMethods } from "../../model-editor/shared/in-progress-methods";
+import {
+  InProgressMethods,
+  hasInProgressMethod,
+} from "../../model-editor/shared/in-progress-methods";
 
 const LibraryContainer = styled.div`
   background-color: var(--vscode-peekViewResult-background);
@@ -177,7 +180,7 @@ export const LibraryRow = ({
 
   const canStopAutoModeling = useMemo(() => {
     return methods.some((method) =>
-      inProgressMethods.hasMethod(title, method.signature),
+      hasInProgressMethod(inProgressMethods, title, method.signature),
     );
   }, [methods, title, inProgressMethods]);
 

--- a/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
@@ -17,7 +17,10 @@ import { ModelEditorViewState } from "../../model-editor/shared/view-state";
 import { ModeledMethodsList } from "./ModeledMethodsList";
 import { percentFormatter } from "./formatters";
 import { Mode } from "../../model-editor/shared/mode";
-import { InProgressMethods } from "../../model-editor/shared/in-progress-methods";
+import {
+  InProgressMethods,
+  setPackageInProgressMethods,
+} from "../../model-editor/shared/in-progress-methods";
 import { getLanguageDisplayName } from "../../common/query-language";
 import { INITIAL_HIDE_MODELED_METHODS_VALUE } from "../../model-editor/shared/hide-modeled-methods";
 
@@ -94,7 +97,7 @@ export function ModelEditor({
   );
 
   const [inProgressMethods, setInProgressMethods] = useState<InProgressMethods>(
-    new InProgressMethods(),
+    {},
   );
 
   const [hideModeledMethods, setHideModeledMethods] = useState(
@@ -135,9 +138,10 @@ export function ModelEditor({
             break;
           case "setInProgressMethods":
             setInProgressMethods((oldInProgressMethods) =>
-              oldInProgressMethods.setPackageMethods(
+              setPackageInProgressMethods(
+                oldInProgressMethods,
                 msg.packageName,
-                new Set(msg.inProgressMethods),
+                msg.inProgressMethods,
               ),
             );
             break;

--- a/extensions/ql-vscode/src/view/model-editor/ModeledMethodDataGrid.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModeledMethodDataGrid.tsx
@@ -9,7 +9,10 @@ import { Method, canMethodBeModeled } from "../../model-editor/method";
 import { ModeledMethod } from "../../model-editor/modeled-method";
 import { useMemo } from "react";
 import { sortMethods } from "../../model-editor/shared/sorting";
-import { InProgressMethods } from "../../model-editor/shared/in-progress-methods";
+import {
+  InProgressMethods,
+  hasInProgressMethod,
+} from "../../model-editor/shared/in-progress-methods";
 import { HiddenMethodsRow } from "./HiddenMethodsRow";
 import { ModelEditorViewState } from "../../model-editor/shared/view-state";
 import { ScreenReaderOnly } from "../common/ScreenReaderOnly";
@@ -107,7 +110,8 @@ export const ModeledMethodDataGrid = ({
                 methodCanBeModeled={methodCanBeModeled}
                 modeledMethods={modeledMethods}
                 methodIsUnsaved={modifiedSignatures.has(method.signature)}
-                modelingInProgress={inProgressMethods.hasMethod(
+                modelingInProgress={hasInProgressMethod(
+                  inProgressMethods,
                   packageName,
                   method.signature,
                 )}

--- a/extensions/ql-vscode/src/view/model-editor/__tests__/LibraryRow.spec.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/__tests__/LibraryRow.spec.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import { render as reactRender, screen } from "@testing-library/react";
 import { createMethod } from "../../../../test/factories/model-editor/method-factories";
 import { LibraryRow, LibraryRowProps } from "../LibraryRow";
-import { InProgressMethods } from "../../../model-editor/shared/in-progress-methods";
 import { createMockExtensionPack } from "../../../../test/factories/model-editor/extension-pack";
 import { Mode } from "../../../model-editor/shared/mode";
 import { ModelEditorViewState } from "../../../model-editor/shared/view-state";
@@ -44,7 +43,7 @@ describe(LibraryRow.name, () => {
           ],
         }}
         modifiedSignatures={new Set([method.signature])}
-        inProgressMethods={new InProgressMethods()}
+        inProgressMethods={{}}
         viewState={viewState}
         hideModeledMethods={false}
         revealedMethodSignature={null}

--- a/extensions/ql-vscode/src/view/model-editor/__tests__/ModeledMethodDataGrid.spec.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/__tests__/ModeledMethodDataGrid.spec.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import { render as reactRender, screen } from "@testing-library/react";
 import { createMethod } from "../../../../test/factories/model-editor/method-factories";
-import { InProgressMethods } from "../../../model-editor/shared/in-progress-methods";
 import { Mode } from "../../../model-editor/shared/mode";
 import {
   ModeledMethodDataGrid,
@@ -70,7 +69,7 @@ describe(ModeledMethodDataGrid.name, () => {
           ],
         }}
         modifiedSignatures={new Set([method1.signature])}
-        inProgressMethods={new InProgressMethods()}
+        inProgressMethods={{}}
         viewState={viewState}
         hideModeledMethods={false}
         revealedMethodSignature={null}

--- a/extensions/ql-vscode/src/view/model-editor/__tests__/ModeledMethodsList.spec.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/__tests__/ModeledMethodsList.spec.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import { render as reactRender, screen } from "@testing-library/react";
 import { createMethod } from "../../../../test/factories/model-editor/method-factories";
-import { InProgressMethods } from "../../../model-editor/shared/in-progress-methods";
 import { createMockExtensionPack } from "../../../../test/factories/model-editor/extension-pack";
 import { Mode } from "../../../model-editor/shared/mode";
 import { ModelEditorViewState } from "../../../model-editor/shared/view-state";
@@ -70,7 +69,7 @@ describe(ModeledMethodsList.name, () => {
           ],
         }}
         modifiedSignatures={new Set([method1.signature])}
-        inProgressMethods={new InProgressMethods()}
+        inProgressMethods={{}}
         viewState={viewState}
         hideModeledMethods={false}
         revealedMethodSignature={null}


### PR DESCRIPTION
I'd like to be able to send `InProgressMethod` objects through webview messages so changing from class to an interface since messages need to be JSON serializable.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
