### PR TITLE
Move in-progress methods state to modeling store

### DIFF
--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -25,6 +25,7 @@ import {
 } from "../model-editor/shared/view-state";
 import { Mode } from "../model-editor/shared/mode";
 import { QueryLanguage } from "./query-language";
+import { InProgressMethods } from "../model-editor/shared/in-progress-methods";
 
 /**
  * This module contains types and code that are shared between
@@ -517,8 +518,7 @@ interface SetModifiedMethodsMessage {
 
 interface SetInProgressMethodsMessage {
   t: "setInProgressMethods";
-  packageName: string;
-  inProgressMethods: string[];
+  methods: InProgressMethods;
 }
 
 interface SwitchModeMessage {

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -76,15 +76,9 @@ export class ModelEditorView extends AbstractWebview<
       app,
       cliServer,
       queryRunner,
+      modelingStore,
       queryStorageDir,
       databaseItem,
-      async (packageName, inProgressMethods) => {
-        await this.postMessage({
-          t: "setInProgressMethods",
-          packageName,
-          inProgressMethods,
-        });
-      },
       async (modeledMethods) => {
         this.addModeledMethods(modeledMethods);
       },
@@ -679,6 +673,17 @@ export class ModelEditorView extends AbstractWebview<
           await this.postMessage({
             t: "setModifiedMethods",
             methodSignatures: [...event.modifiedMethods],
+          });
+        }
+      }),
+    );
+
+    this.push(
+      this.modelingStore.onInProgressMethodsChanged(async (event) => {
+        if (event.dbUri === this.databaseItem.databaseUri.toString()) {
+          await this.postMessage({
+            t: "setInProgressMethods",
+            methods: event.methods,
           });
         }
       }),

--- a/extensions/ql-vscode/src/model-editor/modeling-store.ts
+++ b/extensions/ql-vscode/src/model-editor/modeling-store.ts
@@ -5,10 +5,7 @@ import { DatabaseItem } from "../databases/local-databases";
 import { Method, Usage } from "./method";
 import { ModeledMethod } from "./modeled-method";
 import { INITIAL_HIDE_MODELED_METHODS_VALUE } from "./shared/hide-modeled-methods";
-import {
-  InProgressMethods,
-  setPackageInProgressMethods,
-} from "./shared/in-progress-methods";
+import { InProgressMethods } from "./shared/in-progress-methods";
 import { INITIAL_MODE, Mode } from "./shared/mode";
 
 interface InternalDbModelingState {
@@ -79,8 +76,8 @@ interface SelectedMethodChangedEvent {
 }
 
 interface InProgressMethodsChangedEvent {
-  dbUri: string;
-  methods: InProgressMethods;
+  readonly dbUri: string;
+  readonly methods: InProgressMethods;
 }
 
 export class ModelingStore extends DisposableObject {
@@ -422,11 +419,10 @@ export class ModelingStore extends DisposableObject {
   ) {
     const dbState = this.getState(dbItem);
 
-    dbState.inProgressMethods = setPackageInProgressMethods(
-      dbState.inProgressMethods,
-      packageName,
-      inProgressMethods,
-    );
+    dbState.inProgressMethods = {
+      ...dbState.inProgressMethods,
+      [packageName]: inProgressMethods,
+    };
 
     this.onInProgressMethodsChangedEventEmitter.fire({
       dbUri: dbItem.databaseUri.toString(),

--- a/extensions/ql-vscode/src/model-editor/modeling-store.ts
+++ b/extensions/ql-vscode/src/model-editor/modeling-store.ts
@@ -5,6 +5,10 @@ import { DatabaseItem } from "../databases/local-databases";
 import { Method, Usage } from "./method";
 import { ModeledMethod } from "./modeled-method";
 import { INITIAL_HIDE_MODELED_METHODS_VALUE } from "./shared/hide-modeled-methods";
+import {
+  InProgressMethods,
+  setPackageInProgressMethods,
+} from "./shared/in-progress-methods";
 import { INITIAL_MODE, Mode } from "./shared/mode";
 
 interface InternalDbModelingState {
@@ -14,6 +18,7 @@ interface InternalDbModelingState {
   mode: Mode;
   modeledMethods: Record<string, ModeledMethod[]>;
   modifiedMethodSignatures: Set<string>;
+  inProgressMethods: InProgressMethods;
   selectedMethod: Method | undefined;
   selectedUsage: Usage | undefined;
 }
@@ -73,6 +78,11 @@ interface SelectedMethodChangedEvent {
   readonly isModified: boolean;
 }
 
+interface InProgressMethodsChangedEvent {
+  dbUri: string;
+  methods: InProgressMethods;
+}
+
 export class ModelingStore extends DisposableObject {
   public readonly onActiveDbChanged: AppEvent<void>;
   public readonly onDbOpened: AppEvent<string>;
@@ -83,6 +93,7 @@ export class ModelingStore extends DisposableObject {
   public readonly onModeledMethodsChanged: AppEvent<ModeledMethodsChangedEvent>;
   public readonly onModifiedMethodsChanged: AppEvent<ModifiedMethodsChangedEvent>;
   public readonly onSelectedMethodChanged: AppEvent<SelectedMethodChangedEvent>;
+  public readonly onInProgressMethodsChanged: AppEvent<InProgressMethodsChangedEvent>;
 
   private readonly state: Map<string, InternalDbModelingState>;
   private activeDb: string | undefined;
@@ -96,6 +107,7 @@ export class ModelingStore extends DisposableObject {
   private readonly onModeledMethodsChangedEventEmitter: AppEventEmitter<ModeledMethodsChangedEvent>;
   private readonly onModifiedMethodsChangedEventEmitter: AppEventEmitter<ModifiedMethodsChangedEvent>;
   private readonly onSelectedMethodChangedEventEmitter: AppEventEmitter<SelectedMethodChangedEvent>;
+  private readonly onInProgressMethodsChangedEventEmitter: AppEventEmitter<InProgressMethodsChangedEvent>;
 
   constructor(app: App) {
     super();
@@ -148,6 +160,12 @@ export class ModelingStore extends DisposableObject {
     );
     this.onSelectedMethodChanged =
       this.onSelectedMethodChangedEventEmitter.event;
+
+    this.onInProgressMethodsChangedEventEmitter = this.push(
+      app.createEventEmitter<InProgressMethodsChangedEvent>(),
+    );
+    this.onInProgressMethodsChanged =
+      this.onInProgressMethodsChangedEventEmitter.event;
   }
 
   public initializeStateForDb(
@@ -164,6 +182,7 @@ export class ModelingStore extends DisposableObject {
       modifiedMethodSignatures: new Set(),
       selectedMethod: undefined,
       selectedUsage: undefined,
+      inProgressMethods: {},
     });
 
     this.onDbOpenedEventEmitter.fire(dbUri);
@@ -393,6 +412,25 @@ export class ModelingStore extends DisposableObject {
       usage,
       modeledMethods: dbState.modeledMethods[method.signature] ?? [],
       isModified: dbState.modifiedMethodSignatures.has(method.signature),
+    });
+  }
+
+  public setInProgressMethods(
+    dbItem: DatabaseItem,
+    packageName: string,
+    inProgressMethods: string[],
+  ) {
+    const dbState = this.getState(dbItem);
+
+    dbState.inProgressMethods = setPackageInProgressMethods(
+      dbState.inProgressMethods,
+      packageName,
+      inProgressMethods,
+    );
+
+    this.onInProgressMethodsChangedEventEmitter.fire({
+      dbUri: dbItem.databaseUri.toString(),
+      methods: dbState.inProgressMethods,
     });
   }
 

--- a/extensions/ql-vscode/src/model-editor/shared/in-progress-methods.ts
+++ b/extensions/ql-vscode/src/model-editor/shared/in-progress-methods.ts
@@ -1,18 +1,7 @@
 /**
  * An interface to help keep track of which methods are in progress for each package.
  */
-export type InProgressMethods = Record<string, string[]>;
-
-export function setPackageInProgressMethods(
-  inProgressMethods: InProgressMethods,
-  packageName: string,
-  methods: string[],
-): InProgressMethods {
-  return {
-    ...inProgressMethods,
-    [packageName]: methods,
-  };
-}
+export type InProgressMethods = Readonly<Record<string, readonly string[]>>;
 
 export function hasInProgressMethod(
   inProgressMethods: InProgressMethods,

--- a/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
@@ -17,10 +17,7 @@ import { ModelEditorViewState } from "../../model-editor/shared/view-state";
 import { ModeledMethodsList } from "./ModeledMethodsList";
 import { percentFormatter } from "./formatters";
 import { Mode } from "../../model-editor/shared/mode";
-import {
-  InProgressMethods,
-  setPackageInProgressMethods,
-} from "../../model-editor/shared/in-progress-methods";
+import { InProgressMethods } from "../../model-editor/shared/in-progress-methods";
 import { getLanguageDisplayName } from "../../common/query-language";
 import { INITIAL_HIDE_MODELED_METHODS_VALUE } from "../../model-editor/shared/hide-modeled-methods";
 
@@ -136,15 +133,10 @@ export function ModelEditor({
           case "setModifiedMethods":
             setModifiedSignatures(new Set(msg.methodSignatures));
             break;
-          case "setInProgressMethods":
-            setInProgressMethods((oldInProgressMethods) =>
-              setPackageInProgressMethods(
-                oldInProgressMethods,
-                msg.packageName,
-                msg.inProgressMethods,
-              ),
-            );
+          case "setInProgressMethods": {
+            setInProgressMethods(msg.methods);
             break;
+          }
           case "revealMethod":
             setRevealedMethodSignature(msg.methodSignature);
 

--- a/extensions/ql-vscode/test/__mocks__/model-editor/modelingStoreMock.ts
+++ b/extensions/ql-vscode/test/__mocks__/model-editor/modelingStoreMock.ts
@@ -11,6 +11,7 @@ export function createMockModelingStore({
   onModeChanged = jest.fn(),
   onModeledMethodsChanged = jest.fn(),
   onModifiedMethodsChanged = jest.fn(),
+  onInProgressMethodsChanged = jest.fn(),
 }: {
   initializeStateForDb?: ModelingStore["initializeStateForDb"];
   getStateForActiveDb?: ModelingStore["getStateForActiveDb"];
@@ -21,6 +22,7 @@ export function createMockModelingStore({
   onModeChanged?: ModelingStore["onModeChanged"];
   onModeledMethodsChanged?: ModelingStore["onModeledMethodsChanged"];
   onModifiedMethodsChanged?: ModelingStore["onModifiedMethodsChanged"];
+  onInProgressMethodsChanged?: ModelingStore["onInProgressMethodsChanged"];
 } = {}): ModelingStore {
   return mockedObject<ModelingStore>({
     initializeStateForDb,
@@ -32,5 +34,6 @@ export function createMockModelingStore({
     onModeChanged,
     onModeledMethodsChanged,
     onModifiedMethodsChanged,
+    onInProgressMethodsChanged,
   });
 }


### PR DESCRIPTION
The state is currently in the React view but we need it in the modeling store so that it can be used by the method modeling panel too.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
