### PR TITLE
Remove old language context filter.

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -753,78 +753,6 @@
         "title": "Add Database Source to Workspace"
       },
       {
-        "command": "codeQLDatabases.displayAllLanguages",
-        "title": "All languages"
-      },
-      {
-        "command": "codeQLDatabases.displayAllLanguagesSelected",
-        "title": "All languages (selected)"
-      },
-      {
-        "command": "codeQLDatabases.displayCpp",
-        "title": "C/C++"
-      },
-      {
-        "command": "codeQLDatabases.displayCppSelected",
-        "title": "C/C++ (selected)"
-      },
-      {
-        "command": "codeQLDatabases.displayCsharp",
-        "title": "C#"
-      },
-      {
-        "command": "codeQLDatabases.displayCsharpSelected",
-        "title": "C# (selected)"
-      },
-      {
-        "command": "codeQLDatabases.displayGo",
-        "title": "Go"
-      },
-      {
-        "command": "codeQLDatabases.displayGoSelected",
-        "title": "Go (selected)"
-      },
-      {
-        "command": "codeQLDatabases.displayJava",
-        "title": "Java/Kotlin"
-      },
-      {
-        "command": "codeQLDatabases.displayJavaSelected",
-        "title": "Java/Kotlin (selected)"
-      },
-      {
-        "command": "codeQLDatabases.displayJavascript",
-        "title": "JavaScript/TypeScript"
-      },
-      {
-        "command": "codeQLDatabases.displayJavascriptSelected",
-        "title": "JavaScript/TypeScript (selected)"
-      },
-      {
-        "command": "codeQLDatabases.displayPython",
-        "title": "Python"
-      },
-      {
-        "command": "codeQLDatabases.displayPythonSelected",
-        "title": "Python (selected)"
-      },
-      {
-        "command": "codeQLDatabases.displayRuby",
-        "title": "Ruby"
-      },
-      {
-        "command": "codeQLDatabases.displayRubySelected",
-        "title": "Ruby (selected)"
-      },
-      {
-        "command": "codeQLDatabases.displaySwift",
-        "title": "Swift"
-      },
-      {
-        "command": "codeQLDatabases.displaySwiftSelected",
-        "title": "Swift (selected)"
-      },
-      {
         "command": "codeQL.chooseDatabaseFolder",
         "title": "CodeQL: Choose Database from Folder"
       },
@@ -1073,11 +1001,6 @@
           "command": "codeQLDatabases.sortByDateAdded",
           "when": "view == codeQLDatabases",
           "group": "1_databases@1"
-        },
-        {
-          "submenu": "codeQLDatabases.languages",
-          "when": "view == codeQLDatabases && config.codeQL.canary && config.codeQL.showLanguageFilter",
-          "group": "2_databases@0"
         },
         {
           "command": "codeQLQueries.createQuery",
@@ -1609,78 +1532,6 @@
           "when": "false"
         },
         {
-          "command": "codeQLDatabases.displayAllLanguages",
-          "when": "false"
-        },
-        {
-          "command": "codeQLDatabases.displayAllLanguagesSelected",
-          "when": "false"
-        },
-        {
-          "command": "codeQLDatabases.displayCpp",
-          "when": "false"
-        },
-        {
-          "command": "codeQLDatabases.displayCppSelected",
-          "when": "false"
-        },
-        {
-          "command": "codeQLDatabases.displayCsharp",
-          "when": "false"
-        },
-        {
-          "command": "codeQLDatabases.displayCsharpSelected",
-          "when": "false"
-        },
-        {
-          "command": "codeQLDatabases.displayGo",
-          "when": "false"
-        },
-        {
-          "command": "codeQLDatabases.displayGoSelected",
-          "when": "false"
-        },
-        {
-          "command": "codeQLDatabases.displayJava",
-          "when": "false"
-        },
-        {
-          "command": "codeQLDatabases.displayJavaSelected",
-          "when": "false"
-        },
-        {
-          "command": "codeQLDatabases.displayJavascript",
-          "when": "false"
-        },
-        {
-          "command": "codeQLDatabases.displayJavascriptSelected",
-          "when": "false"
-        },
-        {
-          "command": "codeQLDatabases.displayPython",
-          "when": "false"
-        },
-        {
-          "command": "codeQLDatabases.displayPythonSelected",
-          "when": "false"
-        },
-        {
-          "command": "codeQLDatabases.displayRuby",
-          "when": "false"
-        },
-        {
-          "command": "codeQLDatabases.displayRubySelected",
-          "when": "false"
-        },
-        {
-          "command": "codeQLDatabases.displaySwift",
-          "when": "false"
-        },
-        {
-          "command": "codeQLDatabases.displaySwiftSelected",
-          "when": "false"
-        },
-        {
           "command": "codeQLQueryHistory.openQueryContextMenu",
           "when": "false"
         },
@@ -1878,88 +1729,8 @@
           "command": "codeQL.gotoQLContextEditor",
           "when": "editorLangId == ql-summary && config.codeQL.canary"
         }
-      ],
-      "codeQLDatabases.languages": [
-        {
-          "command": "codeQLDatabases.displayAllLanguages",
-          "when": "codeQLDatabases.languageFilter"
-        },
-        {
-          "command": "codeQLDatabases.displayAllLanguagesSelected",
-          "when": "!codeQLDatabases.languageFilter"
-        },
-        {
-          "command": "codeQLDatabases.displayCpp",
-          "when": "codeQLDatabases.languageFilter != cpp"
-        },
-        {
-          "command": "codeQLDatabases.displayCppSelected",
-          "when": "codeQLDatabases.languageFilter == cpp"
-        },
-        {
-          "command": "codeQLDatabases.displayCsharp",
-          "when": "codeQLDatabases.languageFilter != csharp"
-        },
-        {
-          "command": "codeQLDatabases.displayCsharpSelected",
-          "when": "codeQLDatabases.languageFilter == csharp"
-        },
-        {
-          "command": "codeQLDatabases.displayGo",
-          "when": "codeQLDatabases.languageFilter != go"
-        },
-        {
-          "command": "codeQLDatabases.displayGoSelected",
-          "when": "codeQLDatabases.languageFilter == go"
-        },
-        {
-          "command": "codeQLDatabases.displayJava",
-          "when": "codeQLDatabases.languageFilter != java"
-        },
-        {
-          "command": "codeQLDatabases.displayJavaSelected",
-          "when": "codeQLDatabases.languageFilter == java"
-        },
-        {
-          "command": "codeQLDatabases.displayJavascript",
-          "when": "codeQLDatabases.languageFilter != javascript"
-        },
-        {
-          "command": "codeQLDatabases.displayJavascriptSelected",
-          "when": "codeQLDatabases.languageFilter == javascript"
-        },
-        {
-          "command": "codeQLDatabases.displayPython",
-          "when": "codeQLDatabases.languageFilter != python"
-        },
-        {
-          "command": "codeQLDatabases.displayPythonSelected",
-          "when": "codeQLDatabases.languageFilter == python"
-        },
-        {
-          "command": "codeQLDatabases.displayRuby",
-          "when": "codeQLDatabases.languageFilter != ruby"
-        },
-        {
-          "command": "codeQLDatabases.displayRubySelected",
-          "when": "codeQLDatabases.languageFilter == ruby"
-        },
-        {
-          "command": "codeQLDatabases.displaySwift",
-          "when": "codeQLDatabases.languageFilter != swift"
-        },
-        {
-          "command": "codeQLDatabases.displaySwiftSelected",
-          "when": "codeQLDatabases.languageFilter == swift"
-        }
       ]
     },
-    "submenus": [
-      {
-        "id": "codeQLDatabases.languages",
-        "label": "Languages"
-      }
-    ],
     "viewsContainers": {
       "activitybar": [
         {

--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -227,24 +227,6 @@ export type LocalDatabasesCommands = {
   "codeQLDatabases.chooseDatabaseGithub": () => Promise<void>;
   "codeQLDatabases.sortByName": () => Promise<void>;
   "codeQLDatabases.sortByDateAdded": () => Promise<void>;
-  "codeQLDatabases.displayAllLanguages": () => Promise<void>;
-  "codeQLDatabases.displayCpp": () => Promise<void>;
-  "codeQLDatabases.displayCsharp": () => Promise<void>;
-  "codeQLDatabases.displayGo": () => Promise<void>;
-  "codeQLDatabases.displayJava": () => Promise<void>;
-  "codeQLDatabases.displayJavascript": () => Promise<void>;
-  "codeQLDatabases.displayPython": () => Promise<void>;
-  "codeQLDatabases.displayRuby": () => Promise<void>;
-  "codeQLDatabases.displaySwift": () => Promise<void>;
-  "codeQLDatabases.displayAllLanguagesSelected": () => Promise<void>;
-  "codeQLDatabases.displayCppSelected": () => Promise<void>;
-  "codeQLDatabases.displayCsharpSelected": () => Promise<void>;
-  "codeQLDatabases.displayGoSelected": () => Promise<void>;
-  "codeQLDatabases.displayJavaSelected": () => Promise<void>;
-  "codeQLDatabases.displayJavascriptSelected": () => Promise<void>;
-  "codeQLDatabases.displayPythonSelected": () => Promise<void>;
-  "codeQLDatabases.displayRubySelected": () => Promise<void>;
-  "codeQLDatabases.displaySwiftSelected": () => Promise<void>;
 
   // Database panel context menu
   "codeQLDatabases.setCurrentDatabase": (

--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -51,7 +51,7 @@ import {
   createMultiSelectionCommand,
   createSingleSelectionCommand,
 } from "../common/vscode/selection-commands";
-import { QueryLanguage, tryGetQueryLanguage } from "../common/query-language";
+import { tryGetQueryLanguage } from "../common/query-language";
 import { LanguageContextStore } from "../language-context-store";
 
 enum SortOrder {
@@ -218,7 +218,7 @@ export class DatabaseUI extends DisposableObject {
   public constructor(
     private app: App,
     private databaseManager: DatabaseManager,
-    private languageContext: LanguageContextStore,
+    languageContext: LanguageContextStore,
     private readonly queryServer: QueryRunner | undefined,
     private readonly storagePath: string,
     readonly extensionPath: string,
@@ -265,60 +265,6 @@ export class DatabaseUI extends DisposableObject {
         this.handleMakeCurrentDatabase.bind(this),
       "codeQLDatabases.sortByName": this.handleSortByName.bind(this),
       "codeQLDatabases.sortByDateAdded": this.handleSortByDateAdded.bind(this),
-      "codeQLDatabases.displayAllLanguages":
-        this.handleClearLanguageFilter.bind(this),
-      "codeQLDatabases.displayCpp": this.handleChangeLanguageFilter.bind(
-        this,
-        QueryLanguage.Cpp,
-      ),
-      "codeQLDatabases.displayCsharp": this.handleChangeLanguageFilter.bind(
-        this,
-        QueryLanguage.CSharp,
-      ),
-      "codeQLDatabases.displayGo": this.handleChangeLanguageFilter.bind(
-        this,
-        QueryLanguage.Go,
-      ),
-      "codeQLDatabases.displayJava": this.handleChangeLanguageFilter.bind(
-        this,
-        QueryLanguage.Java,
-      ),
-      "codeQLDatabases.displayJavascript": this.handleChangeLanguageFilter.bind(
-        this,
-        QueryLanguage.Javascript,
-      ),
-      "codeQLDatabases.displayPython": this.handleChangeLanguageFilter.bind(
-        this,
-        QueryLanguage.Python,
-      ),
-      "codeQLDatabases.displayRuby": this.handleChangeLanguageFilter.bind(
-        this,
-        QueryLanguage.Ruby,
-      ),
-      "codeQLDatabases.displaySwift": this.handleChangeLanguageFilter.bind(
-        this,
-        QueryLanguage.Swift,
-      ),
-      "codeQLDatabases.displayAllLanguagesSelected":
-        this.handleClearLanguageFilter.bind(this),
-      "codeQLDatabases.displayCppSelected":
-        this.handleChangeLanguageFilter.bind(this, QueryLanguage.Cpp),
-      "codeQLDatabases.displayCsharpSelected":
-        this.handleChangeLanguageFilter.bind(this, QueryLanguage.CSharp),
-      "codeQLDatabases.displayGoSelected": this.handleChangeLanguageFilter.bind(
-        this,
-        QueryLanguage.Go,
-      ),
-      "codeQLDatabases.displayJavaSelected":
-        this.handleChangeLanguageFilter.bind(this, QueryLanguage.Java),
-      "codeQLDatabases.displayJavascriptSelected":
-        this.handleChangeLanguageFilter.bind(this, QueryLanguage.Javascript),
-      "codeQLDatabases.displayPythonSelected":
-        this.handleChangeLanguageFilter.bind(this, QueryLanguage.Python),
-      "codeQLDatabases.displayRubySelected":
-        this.handleChangeLanguageFilter.bind(this, QueryLanguage.Ruby),
-      "codeQLDatabases.displaySwiftSelected":
-        this.handleChangeLanguageFilter.bind(this, QueryLanguage.Swift),
       "codeQLDatabases.removeDatabase": createMultiSelectionCommand(
         this.handleRemoveDatabase.bind(this),
       ),
@@ -607,14 +553,6 @@ export class DatabaseUI extends DisposableObject {
     } else {
       this.treeDataProvider.sortOrder = SortOrder.DateAddedAsc;
     }
-  }
-
-  private async handleClearLanguageFilter() {
-    await this.languageContext.clearLanguageContext();
-  }
-
-  private async handleChangeLanguageFilter(languageFilter: QueryLanguage) {
-    await this.languageContext.setLanguageContext(languageFilter);
   }
 
   private async handleUpgradeCurrentDatabase(): Promise<void> {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

This removes the old way of filtering the language context now that we have the language filter panel.
For reference the old way was introduced here:
- https://github.com/github/vscode-codeql/pull/2856
- https://github.com/github/vscode-codeql/pull/2871

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
