### PR TITLE
Introduce separate tree item types in the methods usage panel

### DIFF
--- a/extensions/ql-vscode/src/model-editor/methods-usage/methods-usage-panel.ts
+++ b/extensions/ql-vscode/src/model-editor/methods-usage/methods-usage-panel.ts
@@ -56,10 +56,16 @@ export class MethodsUsagePanel extends DisposableObject {
     };
   }
 
-  public async revealItem(usage: Usage): Promise<void> {
-    const canonicalUsage = this.dataProvider.resolveCanonicalUsage(usage);
-    if (canonicalUsage !== undefined) {
-      await this.treeView.reveal(canonicalUsage);
+  public async revealItem(
+    methodSignature: string,
+    usage: Usage,
+  ): Promise<void> {
+    const usageTreeViewItem = this.dataProvider.resolveUsageTreeViewItem(
+      methodSignature,
+      usage,
+    );
+    if (usageTreeViewItem !== undefined) {
+      await this.treeView.reveal(usageTreeViewItem);
     }
   }
 

--- a/extensions/ql-vscode/src/model-editor/model-editor-module.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-module.ts
@@ -102,7 +102,7 @@ export class ModelEditorModule extends DisposableObject {
     method: Method,
     usage: Usage,
   ): Promise<void> {
-    await this.methodsUsagePanel.revealItem(usage);
+    await this.methodsUsagePanel.revealItem(method.signature, usage);
     await this.methodModelingPanel.setMethod(databaseItem, method);
     await showResolvableLocation(usage.url, databaseItem, this.app.logger);
   }

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/methods-usage/methods-usage-data-provider.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/methods-usage/methods-usage-data-provider.test.ts
@@ -3,7 +3,10 @@ import {
   CallClassification,
   Method,
 } from "../../../../../src/model-editor/method";
-import { MethodsUsageDataProvider } from "../../../../../src/model-editor/methods-usage/methods-usage-data-provider";
+import {
+  MethodsUsageDataProvider,
+  MethodsUsageTreeViewItem,
+} from "../../../../../src/model-editor/methods-usage/methods-usage-data-provider";
 import { DatabaseItem } from "../../../../../src/databases/local-databases";
 import {
   createMethod,
@@ -242,13 +245,23 @@ describe("MethodsUsageDataProvider", () => {
 
     const usage = createUsage({});
 
+    const methodTreeItem: MethodsUsageTreeViewItem = {
+      ...supportedMethod,
+      children: [],
+    };
+
+    const usageTreeItem: MethodsUsageTreeViewItem = {
+      ...usage,
+      parent: methodTreeItem,
+    };
+    methodTreeItem.children = [usageTreeItem];
+
     it("should return [] if item is a usage", async () => {
-      expect(dataProvider.getChildren(usage)).toEqual([]);
+      expect(dataProvider.getChildren(usageTreeItem)).toEqual([]);
     });
 
-    it("should return usages if item is external api usage", async () => {
-      const method = createMethod({ usages: [usage] });
-      expect(dataProvider.getChildren(method)).toEqual([usage]);
+    it("should return usages if item is method", async () => {
+      expect(dataProvider.getChildren(methodTreeItem)).toEqual([usageTreeItem]);
     });
 
     it("should show all methods if hideModeledMethods is false and looking at the root", async () => {

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/methods-usage/methods-usage-panel.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/methods-usage/methods-usage-panel.test.ts
@@ -68,11 +68,10 @@ describe("MethodsUsagePanel", () => {
     });
 
     it("should reveal the correct item in the tree view", async () => {
-      const methods = [
-        createMethod({
-          usages: [usage],
-        }),
-      ];
+      const method = createMethod({
+        usages: [usage],
+      });
+      const methods = [method];
 
       const panel = new MethodsUsagePanel(modelingStore, mockCliServer);
       await panel.setState(
@@ -84,13 +83,16 @@ describe("MethodsUsagePanel", () => {
         modifiedMethodSignatures,
       );
 
-      await panel.revealItem(usage);
+      await panel.revealItem(method.signature, usage);
 
-      expect(mockTreeView.reveal).toHaveBeenCalledWith(usage);
+      expect(mockTreeView.reveal).toHaveBeenCalledWith(
+        expect.objectContaining(usage),
+      );
     });
 
     it("should do nothing if usage cannot be found", async () => {
-      const methods = [createMethod({})];
+      const method = createMethod({});
+      const methods = [method];
       const panel = new MethodsUsagePanel(modelingStore, mockCliServer);
       await panel.setState(
         methods,
@@ -101,7 +103,7 @@ describe("MethodsUsagePanel", () => {
         modifiedMethodSignatures,
       );
 
-      await panel.revealItem(usage);
+      await panel.revealItem(method.signature, usage);
 
       expect(mockTreeView.reveal).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
This creates new tree item types for methods and usages such that these can contain references to their parent and children. This allows us to easily find the parent of a usage and to find the children of a method. This removes an expensive `find` call in `getParent`.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
