### PR TITLE
Revert changes to codeQLModelEditor.jumpToMethod to allow jumping to usages other than the first usage

### DIFF
--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -13,7 +13,7 @@ import type {
 import type { QLDebugConfiguration } from "../debugger/debug-configuration";
 import type { QueryTreeViewItem } from "../queries-panel/query-tree-view-item";
 import type { LanguageSelectionTreeViewItem } from "../language-selection-panel/language-selection-data-provider";
-import { Method, Usage } from "../model-editor/method";
+import type { Method, Usage } from "../model-editor/method";
 
 // A command function matching the signature that VS Code calls when
 // a command is invoked from a context menu on a TreeView with

--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -13,6 +13,7 @@ import type {
 import type { QLDebugConfiguration } from "../debugger/debug-configuration";
 import type { QueryTreeViewItem } from "../queries-panel/query-tree-view-item";
 import type { LanguageSelectionTreeViewItem } from "../language-selection-panel/language-selection-data-provider";
+import { Method, Usage } from "../model-editor/method";
 
 // A command function matching the signature that VS Code calls when
 // a command is invoked from a context menu on a TreeView with
@@ -333,7 +334,8 @@ export type ModelEditorCommands = {
   "codeQL.openModelEditor": () => Promise<void>;
   "codeQL.openModelEditorFromModelingPanel": () => Promise<void>;
   "codeQLModelEditor.jumpToMethod": (
-    methodSignature: string,
+    method: Method,
+    usage: Usage,
     databaseItem: DatabaseItem,
   ) => Promise<void>;
 };

--- a/extensions/ql-vscode/src/model-editor/methods-usage/methods-usage-data-provider.ts
+++ b/extensions/ql-vscode/src/model-editor/methods-usage/methods-usage-data-provider.ts
@@ -106,7 +106,7 @@ export class MethodsUsageDataProvider
         command: {
           title: "Show usage",
           command: "codeQLModelEditor.jumpToMethod",
-          arguments: [method.signature, this.databaseItem],
+          arguments: [method, item, this.databaseItem],
         },
       };
     }

--- a/extensions/ql-vscode/src/model-editor/model-editor-module.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-module.ts
@@ -77,10 +77,11 @@ export class ModelEditorModule extends DisposableObject {
       "codeQL.openModelEditorFromModelingPanel":
         this.openModelEditor.bind(this),
       "codeQLModelEditor.jumpToMethod": async (
-        methodSignature: string,
+        method: Method,
+        usage: Usage,
         databaseItem: DatabaseItem,
       ) => {
-        this.modelingStore.setSelectedMethod(databaseItem, methodSignature);
+        this.modelingStore.setSelectedMethod(databaseItem, method, usage);
       },
     };
   }

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -374,7 +374,17 @@ export class ModelEditorView extends AbstractWebview<
   }
 
   protected async handleJumpToMethod(methodSignature: string) {
-    this.modelingStore.setSelectedMethod(this.databaseItem, methodSignature);
+    const method = this.modelingStore.getMethod(
+      this.databaseItem,
+      methodSignature,
+    );
+    if (method) {
+      this.modelingStore.setSelectedMethod(
+        this.databaseItem,
+        method,
+        method.usages[0],
+      );
+    }
   }
 
   protected async loadExistingModeledMethods(): Promise<void> {

--- a/extensions/ql-vscode/src/model-editor/modeling-store.ts
+++ b/extensions/ql-vscode/src/model-editor/modeling-store.ts
@@ -401,6 +401,13 @@ export class ModelingStore extends DisposableObject {
     });
   }
 
+  /**
+   * Sets which method is considered to be selected. This method will be shown in the method modeling panel.
+   *
+   * The `Method` and `Usage` objects must have been retrieved from the modeling store, and not from
+   * a webview. This is because we rely on object referential identity so it must be the same object
+   * that is held internally by the modeling store.
+   */
   public setSelectedMethod(dbItem: DatabaseItem, method: Method, usage: Usage) {
     const dbState = this.getState(dbItem);
 

--- a/extensions/ql-vscode/src/model-editor/modeling-store.ts
+++ b/extensions/ql-vscode/src/model-editor/modeling-store.ts
@@ -231,6 +231,19 @@ export class ModelingStore extends DisposableObject {
   }
 
   /**
+   * Returns the method for the given database item and method signature.
+   * Returns undefined if no method exists with that signature.
+   */
+  public getMethod(
+    dbItem: DatabaseItem,
+    methodSignature: string,
+  ): Method | undefined {
+    return this.getState(dbItem).methods.find(
+      (m) => m.signature === methodSignature,
+    );
+  }
+
+  /**
    * Returns the methods for the given database item and method signatures.
    * If the `methodSignatures` argument is not provided or is undefined, returns all methods.
    */
@@ -388,17 +401,8 @@ export class ModelingStore extends DisposableObject {
     });
   }
 
-  public setSelectedMethod(dbItem: DatabaseItem, methodSignature: string) {
+  public setSelectedMethod(dbItem: DatabaseItem, method: Method, usage: Usage) {
     const dbState = this.getState(dbItem);
-
-    const method = dbState.methods.find((m) => m.signature === methodSignature);
-    if (method === undefined) {
-      throw new Error(
-        `No method with signature "${methodSignature}" found in modeling store`,
-      );
-    }
-
-    const usage = method.usages[0];
 
     dbState.selectedMethod = method;
     dbState.selectedUsage = usage;


### PR DESCRIPTION
In https://github.com/github/vscode-codeql/pull/2926 I was trying to simplify the code as much as possible, but I accidentally changed the `codeQLModelEditor.jumpToMethod` command which does need to be able to jump to usages other than the first usage.

This PR reverts the changes to that command and makes it work again. This does require adding a new `getMethod` method to the modeling store.

I did consider another way of implementing this which was to add a `usageIndex: number` field to the command. That also worked, but I decided it was safer to just revert the changes from the earlier PR and stick more closely to the original state of the code.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
