### PR TITLE
Remove resolveCanonicalUsage method

### DIFF
--- a/extensions/ql-vscode/src/model-editor/methods-usage/methods-usage-data-provider.ts
+++ b/extensions/ql-vscode/src/model-editor/methods-usage/methods-usage-data-provider.ts
@@ -164,35 +164,12 @@ export class MethodsUsageDataProvider
       return this.methods.find((e) => e.usages.includes(item));
     }
   }
-
-  public resolveCanonicalUsage(usage: Usage): Usage | undefined {
-    for (const method of this.methods) {
-      for (const u of method.usages) {
-        if (usagesAreEqual(u, usage)) {
-          return u;
-        }
-      }
-    }
-    return undefined;
-  }
 }
 
 export type MethodsUsageTreeViewItem = Method | Usage;
 
 function isExternalApiUsage(item: MethodsUsageTreeViewItem): item is Method {
   return (item as any).usages !== undefined;
-}
-
-function usagesAreEqual(u1: Usage, u2: Usage): boolean {
-  return (
-    u1.label === u2.label &&
-    u1.classification === u2.classification &&
-    u1.url.uri === u2.url.uri &&
-    u1.url.startLine === u2.url.startLine &&
-    u1.url.startColumn === u2.url.startColumn &&
-    u1.url.endLine === u2.url.endLine &&
-    u1.url.endColumn === u2.url.endColumn
-  );
 }
 
 function sortMethodsInGroups(methods: readonly Method[], mode: Mode): Method[] {

--- a/extensions/ql-vscode/src/model-editor/methods-usage/methods-usage-panel.ts
+++ b/extensions/ql-vscode/src/model-editor/methods-usage/methods-usage-panel.ts
@@ -57,10 +57,7 @@ export class MethodsUsagePanel extends DisposableObject {
   }
 
   public async revealItem(usage: Usage): Promise<void> {
-    const canonicalUsage = this.dataProvider.resolveCanonicalUsage(usage);
-    if (canonicalUsage !== undefined) {
-      await this.treeView.reveal(canonicalUsage);
-    }
+    await this.treeView.reveal(usage);
   }
 
   private registerToModelingStoreEvents(): void {


### PR DESCRIPTION
Another benefit of the modeleing store is that we no longer need the `resolveCanonicalUsage` method.

This was needed because we were passing `Method` objects to and from the webview and this caused them to become new javascript objects. We now keep the canonical objects purely on the extension host side, so when jumping to a usage we already have the canonical objects available.

When testing this, remember to merge in https://github.com/github/vscode-codeql/pull/2977. These do not conflict, but jumping to usages does not work without that PR.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
