### PR TITLE
Implement onClick for the add/remove model buttons in the model editor

### DIFF
--- a/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
@@ -128,13 +128,11 @@ const ModelableMethodRow = forwardRef<HTMLElement | undefined, MethodRowProps>(
 
     const removeModelClickedHandlers = useMemo(
       () =>
-        modeledMethods
-          .slice(0, modeledMethods.length - 1)
-          .map((_, index) => () => {
-            const newModeledMethods = [...modeledMethods];
-            newModeledMethods.splice(index, 1);
-            onChange(method.signature, newModeledMethods);
-          }),
+        modeledMethods.map((_, index) => () => {
+          const newModeledMethods = [...modeledMethods];
+          newModeledMethods.splice(index, 1);
+          onChange(method.signature, newModeledMethods);
+        }),
       [method, modeledMethods, onChange],
     );
 

--- a/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
@@ -126,6 +126,35 @@ const ModelableMethodRow = forwardRef<HTMLElement | undefined, MethodRowProps>(
       [method, modeledMethods, onChange],
     );
 
+    const removeModelClickedHandlers = useMemo(
+      () =>
+        modeledMethods
+          .slice(0, modeledMethods.length - 1)
+          .map((_, index) => () => {
+            const newModeledMethods = [...modeledMethods];
+            newModeledMethods.splice(index, 1);
+            onChange(method.signature, newModeledMethods);
+          }),
+      [method, modeledMethods, onChange],
+    );
+
+    const handleAddModelClick = useCallback(() => {
+      const newModeledMethod: ModeledMethod = {
+        type: "none",
+        input: "",
+        output: "",
+        kind: "",
+        provenance: "manual",
+        signature: method.signature,
+        packageName: method.packageName,
+        typeName: method.typeName,
+        methodName: method.methodName,
+        methodParameters: method.methodParameters,
+      };
+      const newModeledMethods = [...modeledMethods, newModeledMethod];
+      onChange(method.signature, newModeledMethods);
+    }, [method, modeledMethods, onChange]);
+
     const jumpToMethod = useCallback(
       () => sendJumpToMethodMessage(method),
       [method],
@@ -228,6 +257,7 @@ const ModelableMethodRow = forwardRef<HTMLElement | undefined, MethodRowProps>(
                       key={index}
                       appearance="icon"
                       aria-label="Add new model"
+                      onClick={handleAddModelClick}
                       disabled={addModelButtonDisabled}
                     >
                       <Codicon name="add" />
@@ -237,6 +267,7 @@ const ModelableMethodRow = forwardRef<HTMLElement | undefined, MethodRowProps>(
                       key={index}
                       appearance="icon"
                       aria-label="Remove model"
+                      onClick={removeModelClickedHandlers[index]}
                     >
                       <Codicon name="trash" />
                     </CodiconRow>

--- a/extensions/ql-vscode/src/view/model-editor/__tests__/MethodRow.spec.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/__tests__/MethodRow.spec.tsx
@@ -368,12 +368,25 @@ describe(MethodRow.name, () => {
       },
     });
 
+    onChange.mockReset();
     await userEvent.click(screen.getByLabelText("Add new model"));
 
-    const kindInputs = screen.getAllByRole("combobox", { name: "Model type" });
-    expect(kindInputs).toHaveLength(2);
-    expect(kindInputs[0]).toHaveValue(modeledMethod.type);
-    expect(kindInputs[1]).toHaveValue("none");
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(method.signature, [
+      modeledMethod,
+      {
+        type: "none",
+        input: "",
+        output: "",
+        kind: "",
+        provenance: "manual",
+        signature: method.signature,
+        packageName: method.packageName,
+        typeName: method.typeName,
+        methodName: method.methodName,
+        methodParameters: method.methodParameters,
+      },
+    ]);
   });
 
   it("can delete the first modeled method", async () => {
@@ -390,13 +403,15 @@ describe(MethodRow.name, () => {
       },
     });
 
+    onChange.mockReset();
     await userEvent.click(screen.getAllByLabelText("Remove model")[0]);
 
-    const kindInputs = screen.getAllByRole("combobox", { name: "Model type" });
-    expect(kindInputs).toHaveLength(3);
-    expect(kindInputs[0]).toHaveValue("sink");
-    expect(kindInputs[1]).toHaveValue("none");
-    expect(kindInputs[2]).toHaveValue("summary");
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(method.signature, [
+      { ...modeledMethod, type: "sink" },
+      { ...modeledMethod, type: "none" },
+      { ...modeledMethod, type: "summary" },
+    ]);
   });
 
   it("can delete a modeled method in the middle", async () => {
@@ -413,12 +428,14 @@ describe(MethodRow.name, () => {
       },
     });
 
+    onChange.mockReset();
     await userEvent.click(screen.getAllByLabelText("Remove model")[2]);
 
-    const kindInputs = screen.getAllByRole("combobox", { name: "Model type" });
-    expect(kindInputs).toHaveLength(3);
-    expect(kindInputs[0]).toHaveValue("source");
-    expect(kindInputs[1]).toHaveValue("sink");
-    expect(kindInputs[2]).toHaveValue("summary");
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(method.signature, [
+      { ...modeledMethod, type: "source" },
+      { ...modeledMethod, type: "sink" },
+      { ...modeledMethod, type: "summary" },
+    ]);
   });
 });

--- a/extensions/ql-vscode/src/view/model-editor/__tests__/MethodRow.spec.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/__tests__/MethodRow.spec.tsx
@@ -358,4 +358,67 @@ describe(MethodRow.name, () => {
       expect(removeButton?.getElementsByTagName("input")[0]).toBeEnabled();
     }
   });
+
+  it("can add a new model", async () => {
+    render({
+      modeledMethods: [modeledMethod],
+      viewState: {
+        ...viewState,
+        showMultipleModels: true,
+      },
+    });
+
+    await userEvent.click(screen.getByLabelText("Add new model"));
+
+    const kindInputs = screen.getAllByRole("combobox", { name: "Model type" });
+    expect(kindInputs).toHaveLength(2);
+    expect(kindInputs[0]).toHaveValue(modeledMethod.type);
+    expect(kindInputs[1]).toHaveValue("none");
+  });
+
+  it("can delete the first modeled method", async () => {
+    render({
+      modeledMethods: [
+        { ...modeledMethod, type: "source" },
+        { ...modeledMethod, type: "sink" },
+        { ...modeledMethod, type: "none" },
+        { ...modeledMethod, type: "summary" },
+      ],
+      viewState: {
+        ...viewState,
+        showMultipleModels: true,
+      },
+    });
+
+    await userEvent.click(screen.getAllByLabelText("Remove model")[0]);
+
+    const kindInputs = screen.getAllByRole("combobox", { name: "Model type" });
+    expect(kindInputs).toHaveLength(3);
+    expect(kindInputs[0]).toHaveValue("sink");
+    expect(kindInputs[1]).toHaveValue("none");
+    expect(kindInputs[2]).toHaveValue("summary");
+  });
+
+  it("can delete a modeled method in the middle", async () => {
+    render({
+      modeledMethods: [
+        { ...modeledMethod, type: "source" },
+        { ...modeledMethod, type: "sink" },
+        { ...modeledMethod, type: "none" },
+        { ...modeledMethod, type: "summary" },
+      ],
+      viewState: {
+        ...viewState,
+        showMultipleModels: true,
+      },
+    });
+
+    await userEvent.click(screen.getAllByLabelText("Remove model")[2]);
+
+    const kindInputs = screen.getAllByRole("combobox", { name: "Model type" });
+    expect(kindInputs).toHaveLength(3);
+    expect(kindInputs[0]).toHaveValue("source");
+    expect(kindInputs[1]).toHaveValue("sink");
+    expect(kindInputs[2]).toHaveValue("summary");
+  });
 });


### PR DESCRIPTION
Hooks up the actual `onClick` handler for the add/remove model buttons.

Also adds tests. I couldn't think of any more edge cases to test, but if there are some please let me know and I'll add tests for those.

(While testing, I did spot one bug where the method modeling panel didn't update perfectly. I'll open a separate PR for this.)

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
