### PR TITLE
Ensure the `logFileLocation` is set

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Sorted result set filenames now include a hash of the result set name instead of the full name. [#2955](https://github.com/github/vscode-codeql/pull/2955)
 - The "Install Pack Dependencies" will now only list CodeQL packs located in the workspace. [#2960](https://github.com/github/vscode-codeql/pull/2960)
+- Fix a bug where the "View Query Log" action for a query history item was not working. [#2984](https://github.com/github/vscode-codeql/pull/2984)
 
 ## 1.9.2 - 12 October 2023
 

--- a/extensions/ql-vscode/src/query-results.ts
+++ b/extensions/ql-vscode/src/query-results.ts
@@ -74,10 +74,7 @@ export class CompletedQueryInfo implements QueryWithResults {
      * Map from result set name to SortedResultSetInfo.
      */
     public sortedResultsInfo: Record<string, SortedResultSetInfo> = {},
-  ) {
-    // The log path is only set when loading from the query history.
-    this.logFileLocation = logFileLocation ?? this.query.logPath;
-  }
+  ) {}
 
   setResultCount(value: number) {
     this.resultCount = value;
@@ -293,7 +290,7 @@ export class LocalQueryInfo {
     this.completedQuery = new CompletedQueryInfo(
       info.query,
       info.result,
-      info.logFileLocation,
+      info.query.logPath,
       info.successful,
       info.message,
       undefined,

--- a/extensions/ql-vscode/src/query-results.ts
+++ b/extensions/ql-vscode/src/query-results.ts
@@ -74,7 +74,10 @@ export class CompletedQueryInfo implements QueryWithResults {
      * Map from result set name to SortedResultSetInfo.
      */
     public sortedResultsInfo: Record<string, SortedResultSetInfo> = {},
-  ) {}
+  ) {
+    // The log path is only set when loading from the query history.
+    this.logFileLocation = logFileLocation ?? this.query.logPath;
+  }
 
   setResultCount(value: number) {
     this.resultCount = value;


### PR DESCRIPTION
`logFileLocation` was not set after a query finishes running. I don't know when this bug was introduced. I think it goes as far back as the refactor to remove the old query server.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Replace this with a description of the changes your pull request makes.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
