### PR TITLE
Fix decoding source map with VS Code internal files

### DIFF
--- a/extensions/ql-vscode/scripts/source-map.ts
+++ b/extensions/ql-vscode/scripts/source-map.ts
@@ -137,7 +137,7 @@ async function extractSourceMap() {
           }
         }
 
-        const sourceMap = rawSourceMaps.get(file) as RawSourceMap | null;
+        const sourceMap = rawSourceMaps.get(file);
         if (!sourceMap) {
           return match;
         }


### PR DESCRIPTION
This makes it possible to decode source maps containing references to code that is not part of the extension. If it finds any such references, it will simply not decode the source map and use the original stack trace instead.

Example stack trace:

```
Unhandled error: Error: Illegal argument: character must be non-negative
    at w (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:10:1101)
    at new s (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:121:4419)
    at new o (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:121:5899)
    at asRange (/Users/user/.vscode/extensions/github.vscode-codeql-1.9.2/out/extension.js:55430:24)
    at asDiagnostic (/Users/user/.vscode/extensions/github.vscode-codeql-1.9.2/out/extension.js:55364:66)
    at convertBatch (/Users/user/.vscode/extensions/github.vscode-codeql-1.9.2/out/extension.js:54258:23)
    at Object.map2 [as map] (/Users/user/.vscode/extensions/github.vscode-codeql-1.9.2/out/extension.js:54266:19)
    at Object.asDiagnostics (/Users/user/.vscode/extensions/github.vscode-codeql-1.9.2/out/extension.js:55354:22)
    at CodeQLLanguageClient.workDiagnosticQueue (/Users/user/.vscode/extensions/github.vscode-codeql-1.9.2/out/extension.js:63122:19)
    at Immediate.<anonymous> (/Users/user/.vscode/extensions/github.vscode-codeql-1.9.2/out/extension.js:63107:16)
    at processImmediate (node:internal/timers:476:21)
```

Decoded:

```
Unhandled error: Error: Illegal argument: character must be non-negative
    at w (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:10:1101)
    at new s (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:121:4419)
    at new o (/Applications/Visual Studio Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:121:5899)
    at asRange (/Users/user/.vscode/extensions/github.vscode-codeql-1.9.2/node_modules/vscode-languageclient/lib/common/protocolConverter.js:140:23)
    at asDiagnostic (/Users/user/.vscode/extensions/github.vscode-codeql-1.9.2/node_modules/vscode-languageclient/lib/common/protocolConverter.js:70:65)
    at convertBatch (/Users/user/.vscode/extensions/github.vscode-codeql-1.9.2/node_modules/vscode-languageclient/lib/common/utils/async.js:193:24)
    at Object.map2 [as map] (/Users/user/.vscode/extensions/github.vscode-codeql-1.9.2/node_modules/vscode-languageclient/lib/common/utils/async.js:202:16)
    at Object.asDiagnostics (/Users/user/.vscode/extensions/github.vscode-codeql-1.9.2/node_modules/vscode-languageclient/lib/common/protocolConverter.js:60:21)
    at CodeQLLanguageClient.workDiagnosticQueue (/Users/user/.vscode/extensions/github.vscode-codeql-1.9.2/node_modules/vscode-languageclient/lib/common/client.js:1012:18)
    at Immediate.<anonymous> (/Users/user/.vscode/extensions/github.vscode-codeql-1.9.2/node_modules/vscode-languageclient/lib/common/client.js:997:84)
    at processImmediate (node:internal/timers:476:21)
```

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
