### PR TITLE
Keep reference to original items in usage data provider

### DIFF
--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/methods-usage/methods-usage-data-provider.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/methods-usage/methods-usage-data-provider.test.ts
@@ -246,12 +246,13 @@ describe("MethodsUsageDataProvider", () => {
     const usage = createUsage({});
 
     const methodTreeItem: MethodsUsageTreeViewItem = {
-      ...supportedMethod,
+      method: supportedMethod,
       children: [],
     };
 
     const usageTreeItem: MethodsUsageTreeViewItem = {
-      ...usage,
+      method: supportedMethod,
+      usage,
       parent: methodTreeItem,
     };
     methodTreeItem.children = [usageTreeItem];
@@ -383,7 +384,9 @@ describe("MethodsUsageDataProvider", () => {
           expect(
             dataProvider
               .getChildren()
-              .map((item) => (item as Method).signature),
+              .map(
+                (item) => (item as MethodsUsageTreeViewItem).method.signature,
+              ),
           ).toEqual(["b.a.C.d()", "b.a.C.b()", "b.a.C.a()", "a.b.C.d()"]);
           // reasoning for sort order:
           // b.a.C.d() has more usages than b.a.C.b()

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/methods-usage/methods-usage-panel.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/methods-usage/methods-usage-panel.test.ts
@@ -86,7 +86,10 @@ describe("MethodsUsagePanel", () => {
       await panel.revealItem(method.signature, usage);
 
       expect(mockTreeView.reveal).toHaveBeenCalledWith(
-        expect.objectContaining(usage),
+        expect.objectContaining({
+          method,
+          usage,
+        }),
       );
     });
 


### PR DESCRIPTION
This changes the usage data provider tree items to keep a reference to the method and usage instead of only including their properties in the tree item. This makes it easier to find the original method and usage when revealing an item in the tree. It also removes the `getParent` call in `getTreeItem`.

The main reason for this fix is to ensure `codeQLModelEditor.jumpToMethod` gets the correct `usage` argument. It received the tree item before, but now we can actually pass the usage that was clicked on.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
