### PR TITLE
Add $ to columnCount prop used by styled component

### DIFF
--- a/extensions/ql-vscode/src/view/variant-analysis/RawResultsTable.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/RawResultsTable.tsx
@@ -9,7 +9,7 @@ import { RawResultRow } from "./RawResultRow";
 const numOfResultsInContractedMode = 5;
 
 type TableContainerProps = {
-  columnCount: number;
+  $columnCount: number;
 };
 
 const TableContainer = styled.div<TableContainerProps>`
@@ -18,7 +18,7 @@ const TableContainer = styled.div<TableContainerProps>`
   // minimum width of 1fr is auto, not 0.
   // https://css-tricks.com/equal-width-columns-in-css-grid-are-kinda-weird/
   grid-template-columns: repeat(
-    ${(props) => props.columnCount},
+    ${(props) => props.$columnCount},
     minmax(0, 1fr)
   );
   max-width: 45rem;
@@ -51,7 +51,7 @@ const RawResultsTable = ({
 
   return (
     <>
-      <TableContainer columnCount={schema.columns.length}>
+      <TableContainer $columnCount={schema.columns.length}>
         {results.rows.slice(0, numOfResultsToShow).map((row, rowIndex) => (
           <RawResultRow
             key={rowIndex}


### PR DESCRIPTION
This stops the following error from appearing during tests:
<img width="1491" alt="Screenshot 2023-10-18 at 11 50 08" src="https://github.com/github/vscode-codeql/assets/3749000/6ccf2366-767e-489a-984a-34ab8976d8e6">

I'm not totally sure if this has an effect on behaviour in production. Perhaps it was working but just with a warning.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
