### PR TITLE
Use one grid cell per model input, and have the method name span multiple rows

### DIFF
--- a/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
@@ -25,12 +25,6 @@ import { Codicon } from "../common";
 import { canAddNewModeledMethod } from "../../model-editor/shared/multiple-modeled-methods";
 import { DataGridCell, DataGridRow } from "../common/DataGrid";
 
-const MultiModelColumn = styled(DataGridCell)`
-  display: flex;
-  flex-direction: column;
-  gap: 0.5em;
-`;
-
 const ApiOrMethodRow = styled.div`
   min-height: calc(var(--input-height) * 1px);
   display: flex;
@@ -162,7 +156,7 @@ const ModelableMethodRow = forwardRef<HTMLElement | undefined, MethodRowProps>(
         ref={ref}
         focused={revealedMethodSignature === method.signature}
       >
-        <DataGridCell>
+        <DataGridCell gridRow={`span ${modeledMethods.length}`}>
           <ApiOrMethodRow>
             <ModelingStatusIndicator status={modelingStatus} />
             <MethodClassifications method={method} />
@@ -199,54 +193,41 @@ const ModelableMethodRow = forwardRef<HTMLElement | undefined, MethodRowProps>(
             )}
           </>
         )}
-        {!props.modelingInProgress && (
-          <>
-            <MultiModelColumn>
-              {modeledMethods.map((modeledMethod, index) => (
+        {!props.modelingInProgress &&
+          modeledMethods.map((modeledMethod, index) => (
+            <>
+              <DataGridCell>
                 <ModelTypeDropdown
-                  key={index}
                   method={method}
                   modeledMethod={modeledMethod}
                   onChange={modeledMethodChangedHandlers[index]}
                 />
-              ))}
-            </MultiModelColumn>
-            <MultiModelColumn>
-              {modeledMethods.map((modeledMethod, index) => (
+              </DataGridCell>
+              <DataGridCell>
                 <ModelInputDropdown
-                  key={index}
                   method={method}
                   modeledMethod={modeledMethod}
                   onChange={modeledMethodChangedHandlers[index]}
                 />
-              ))}
-            </MultiModelColumn>
-            <MultiModelColumn>
-              {modeledMethods.map((modeledMethod, index) => (
+              </DataGridCell>
+              <DataGridCell>
                 <ModelOutputDropdown
-                  key={index}
                   method={method}
                   modeledMethod={modeledMethod}
                   onChange={modeledMethodChangedHandlers[index]}
                 />
-              ))}
-            </MultiModelColumn>
-            <MultiModelColumn>
-              {modeledMethods.map((modeledMethod, index) => (
+              </DataGridCell>
+              <DataGridCell>
                 <ModelKindDropdown
-                  key={index}
                   method={method}
                   modeledMethod={modeledMethod}
                   onChange={modeledMethodChangedHandlers[index]}
                 />
-              ))}
-            </MultiModelColumn>
-            {viewState.showMultipleModels && (
-              <MultiModelColumn>
-                {modeledMethods.map((_, index) =>
-                  index === modeledMethods.length - 1 ? (
+              </DataGridCell>
+              {viewState.showMultipleModels && (
+                <DataGridCell>
+                  {index === modeledMethods.length - 1 ? (
                     <CodiconRow
-                      key={index}
                       appearance="icon"
                       aria-label="Add new model"
                       onClick={handleAddModelClick}
@@ -256,19 +237,17 @@ const ModelableMethodRow = forwardRef<HTMLElement | undefined, MethodRowProps>(
                     </CodiconRow>
                   ) : (
                     <CodiconRow
-                      key={index}
                       appearance="icon"
                       aria-label="Remove model"
                       onClick={removeModelClickedHandlers[index]}
                     >
                       <Codicon name="trash" />
                     </CodiconRow>
-                  ),
-                )}
-              </MultiModelColumn>
-            )}
-          </>
-        )}
+                  )}
+                </DataGridCell>
+              )}
+            </>
+          ))}
       </DataGridRow>
     );
   },

--- a/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
@@ -4,7 +4,14 @@ import {
   VSCodeProgressRing,
 } from "@vscode/webview-ui-toolkit/react";
 import * as React from "react";
-import { forwardRef, useCallback, useEffect, useMemo, useRef } from "react";
+import {
+  Fragment,
+  forwardRef,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+} from "react";
 import { styled } from "styled-components";
 import { vscode } from "../vscode-api";
 
@@ -195,7 +202,7 @@ const ModelableMethodRow = forwardRef<HTMLElement | undefined, MethodRowProps>(
         )}
         {!props.modelingInProgress &&
           modeledMethods.map((modeledMethod, index) => (
-            <>
+            <Fragment key={index}>
               <DataGridCell>
                 <ModelTypeDropdown
                   method={method}
@@ -246,7 +253,7 @@ const ModelableMethodRow = forwardRef<HTMLElement | undefined, MethodRowProps>(
                   )}
                 </DataGridCell>
               )}
-            </>
+            </Fragment>
           ))}
       </DataGridRow>
     );


### PR DESCRIPTION
This follows on from https://github.com/github/vscode-codeql/pull/2990.

This addresses the point of using `MultiModelColumn` to fit multiple inputs for a certain field but different models into a single grid cell. Instead, we use one grid cell per input, and use `gridRow="span N"` to make the method name span multiple rows.

Here's what it looks like:
<img width="1140" alt="Screenshot 2023-10-18 at 15 16 39" src="https://github.com/github/vscode-codeql/assets/3749000/4687ae76-7529-4b88-a8d6-442b6a5d1868">

I've used a narrow window width so things flow onto multiple lines. The grid lines are visible because I've highlighted that element in the developer tools. Sadly the grid lines don't show where cells span multiple rows/columns, but you can see by the contents that it's working.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
