### PR TITLE
Add higlight on modeled method row when clicking in validation error

### DIFF
--- a/extensions/ql-vscode/src/stories/model-editor/MethodRow.stories.tsx
+++ b/extensions/ql-vscode/src/stories/model-editor/MethodRow.stories.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { Meta, StoryFn } from "@storybook/react";
 
@@ -20,12 +21,33 @@ export default {
 } as Meta<typeof MethodRowComponent>;
 
 const Template: StoryFn<typeof MethodRowComponent> = (args) => {
+  const [modeledMethods, setModeledMethods] = useState<ModeledMethod[]>(
+    args.modeledMethods,
+  );
+
+  useEffect(() => {
+    setModeledMethods(args.modeledMethods);
+  }, [args.modeledMethods]);
+
+  const handleChange = useCallback(
+    (methodSignature: string, modeledMethods: ModeledMethod[]) => {
+      args.onChange(methodSignature, modeledMethods);
+      setModeledMethods(modeledMethods);
+    },
+    [args],
+  );
+
   const gridTemplateColumns = args.viewState?.showMultipleModels
     ? MULTIPLE_MODELS_GRID_TEMPLATE_COLUMNS
     : SINGLE_MODEL_GRID_TEMPLATE_COLUMNS;
+
   return (
     <DataGrid gridTemplateColumns={gridTemplateColumns}>
-      <MethodRowComponent {...args} />
+      <MethodRowComponent
+        {...args}
+        modeledMethods={modeledMethods}
+        onChange={handleChange}
+      />
     </DataGrid>
   );
 };


### PR DESCRIPTION
This adds back the clickable link in the validation error alert. When clicking on e.g. "Modify or remove the duplicated classification.", the problematic row will be highlighted. This uses a very similar method to the focusing using `revealedMethodRow`.

I think the name `DataGridRow` for this component is still accurate, so I don't think renaming it will make it clearer how this is used.

![Screenshot 2023-10-20 at 11 40 35](https://github.com/github/vscode-codeql/assets/1112623/a16d5eb8-9fa1-45f0-9c20-0eebfa5160d1)

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
