### PR TITLE
Enable `react/jsx-key` for fragment shorthands

### DIFF
--- a/extensions/ql-vscode/.eslintrc.js
+++ b/extensions/ql-vscode/.eslintrc.js
@@ -71,6 +71,7 @@ const baseConfig = {
     "no-shadow": "off",
     "github/array-foreach": "off",
     "github/no-then": "off",
+    "react/jsx-key": ["error", { checkFragmentShorthand: true }],
   },
 };
 


### PR DESCRIPTION
This will change ESLint to give an error when you do something like this:

```tsx
{x.map((y) => <>{y.name}</>)}
```

In this case, there's no `key` being passed to the top-level element in a map. We should always explicitly pass in a key to make the best use of React. This can be fixed by doing this:

```tsx
{x.map((y) => <Fragment key={y.id}>{y.name}</Fragment>)}
```

We ran into this in #2995: https://github.com/github/vscode-codeql/pull/2995/files#r1363990725

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
