### PR TITLE
Show error message for no workspace folders with model editor

### DIFF
--- a/extensions/ql-vscode/src/model-editor/extension-pack-picker.ts
+++ b/extensions/ql-vscode/src/model-editor/extension-pack-picker.ts
@@ -64,7 +64,7 @@ export async function pickExtensionPack(
   // If the setting is not set, automatically pick a suitable directory
   const extensionsDirectory = userExtensionsDirectory
     ? Uri.file(userExtensionsDirectory)
-    : await autoPickExtensionsDirectory();
+    : await autoPickExtensionsDirectory(logger);
 
   if (!extensionsDirectory) {
     return undefined;

--- a/extensions/ql-vscode/src/model-editor/extensions-workspace-folder.ts
+++ b/extensions/ql-vscode/src/model-editor/extensions-workspace-folder.ts
@@ -2,6 +2,7 @@ import { FileType, Uri, workspace, WorkspaceFolder } from "vscode";
 import { getOnDiskWorkspaceFoldersObjects } from "../common/vscode/workspace-folders";
 import { extLogger } from "../common/logging/vscode";
 import { tmpdir } from "../common/files";
+import { NotificationLogger, showAndLogErrorMessage } from "../common/logging";
 
 /**
  * Returns the ancestors of this path in order from furthest to closest (i.e. root of filesystem to parent directory)
@@ -143,8 +144,19 @@ async function findGitFolder(
  *    for which the .git directory is closest to a workspace folder
  * 6. If none of the above apply, return `undefined`
  */
-export async function autoPickExtensionsDirectory(): Promise<Uri | undefined> {
+export async function autoPickExtensionsDirectory(
+  logger: NotificationLogger,
+): Promise<Uri | undefined> {
   const workspaceFolders = getOnDiskWorkspaceFoldersObjects();
+
+  // If there are no on-disk workspace folders, we can't do anything
+  if (workspaceFolders.length === 0) {
+    void showAndLogErrorMessage(
+      logger,
+      `Could not find any on-disk workspace folders. Please ensure that you have opened a folder or workspace.`,
+    );
+    return undefined;
+  }
 
   // If there's only 1 workspace folder, use the `.github/codeql/extensions` directory in that folder
   if (workspaceFolders.length === 1) {


### PR DESCRIPTION
It is possible to open the model editor without opening a folder, but this gave an unhelpful error message. This adds a more helpful error message.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
