### PR TITLE
Move modeling events to new ModelingEvents class

### DIFF
--- a/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-panel.ts
+++ b/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-panel.ts
@@ -7,6 +7,7 @@ import { ModelingStore } from "../modeling-store";
 import { ModelEditorViewTracker } from "../model-editor-view-tracker";
 import { ModelConfigListener } from "../../config";
 import { DatabaseItem } from "../../databases/local-databases";
+import { ModelingEvents } from "../modeling-events";
 
 export class MethodModelingPanel extends DisposableObject {
   private readonly provider: MethodModelingViewProvider;
@@ -14,6 +15,7 @@ export class MethodModelingPanel extends DisposableObject {
   constructor(
     app: App,
     modelingStore: ModelingStore,
+    modelingEvents: ModelingEvents,
     editorViewTracker: ModelEditorViewTracker,
   ) {
     super();
@@ -26,6 +28,7 @@ export class MethodModelingPanel extends DisposableObject {
     this.provider = new MethodModelingViewProvider(
       app,
       modelingStore,
+      modelingEvents,
       editorViewTracker,
       modelConfig,
     );

--- a/extensions/ql-vscode/src/model-editor/methods-usage/methods-usage-panel.ts
+++ b/extensions/ql-vscode/src/model-editor/methods-usage/methods-usage-panel.ts
@@ -10,6 +10,7 @@ import { CodeQLCliServer } from "../../codeql-cli/cli";
 import { ModelingStore } from "../modeling-store";
 import { ModeledMethod } from "../modeled-method";
 import { Mode } from "../shared/mode";
+import { ModelingEvents } from "../modeling-events";
 
 export class MethodsUsagePanel extends DisposableObject {
   private readonly dataProvider: MethodsUsageDataProvider;
@@ -17,6 +18,7 @@ export class MethodsUsagePanel extends DisposableObject {
 
   public constructor(
     private readonly modelingStore: ModelingStore,
+    private readonly modelingEvents: ModelingEvents,
     cliServer: CodeQLCliServer,
   ) {
     super();
@@ -28,7 +30,7 @@ export class MethodsUsagePanel extends DisposableObject {
     });
     this.push(this.treeView);
 
-    this.registerToModelingStoreEvents();
+    this.registerToModelingEvents();
   }
 
   public async setState(
@@ -69,15 +71,15 @@ export class MethodsUsagePanel extends DisposableObject {
     }
   }
 
-  private registerToModelingStoreEvents(): void {
+  private registerToModelingEvents(): void {
     this.push(
-      this.modelingStore.onActiveDbChanged(async () => {
+      this.modelingEvents.onActiveDbChanged(async () => {
         await this.handleStateChangeEvent();
       }),
     );
 
     this.push(
-      this.modelingStore.onMethodsChanged(async (event) => {
+      this.modelingEvents.onMethodsChanged(async (event) => {
         if (event.isActiveDb) {
           await this.handleStateChangeEvent();
         }
@@ -85,7 +87,7 @@ export class MethodsUsagePanel extends DisposableObject {
     );
 
     this.push(
-      this.modelingStore.onHideModeledMethodsChanged(async (event) => {
+      this.modelingEvents.onHideModeledMethodsChanged(async (event) => {
         if (event.isActiveDb) {
           await this.handleStateChangeEvent();
         }
@@ -93,7 +95,7 @@ export class MethodsUsagePanel extends DisposableObject {
     );
 
     this.push(
-      this.modelingStore.onModeChanged(async (event) => {
+      this.modelingEvents.onModeChanged(async (event) => {
         if (event.isActiveDb) {
           await this.handleStateChangeEvent();
         }
@@ -101,7 +103,7 @@ export class MethodsUsagePanel extends DisposableObject {
     );
 
     this.push(
-      this.modelingStore.onModifiedMethodsChanged(async (event) => {
+      this.modelingEvents.onModifiedMethodsChanged(async (event) => {
         if (event.isActiveDb) {
           await this.handleStateChangeEvent();
         }

--- a/extensions/ql-vscode/src/model-editor/model-editor-module.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-module.ts
@@ -21,12 +21,14 @@ import { ModelingStore } from "./modeling-store";
 import { showResolvableLocation } from "../databases/local-databases/locations";
 import { ModelEditorViewTracker } from "./model-editor-view-tracker";
 import { ModelConfigListener } from "../config";
+import { ModelingEvents } from "./modeling-events";
 
 const SUPPORTED_LANGUAGES: string[] = ["java", "csharp"];
 
 export class ModelEditorModule extends DisposableObject {
   private readonly queryStorageDir: string;
   private readonly modelingStore: ModelingStore;
+  private readonly modelingEvents: ModelingEvents;
   private readonly editorViewTracker: ModelEditorViewTracker<ModelEditorView>;
   private readonly methodsUsagePanel: MethodsUsagePanel;
   private readonly methodModelingPanel: MethodModelingPanel;
@@ -40,16 +42,22 @@ export class ModelEditorModule extends DisposableObject {
   ) {
     super();
     this.queryStorageDir = join(baseQueryStorageDir, "model-editor-results");
-    this.modelingStore = new ModelingStore(app);
+    this.modelingEvents = new ModelingEvents(app);
+    this.modelingStore = new ModelingStore(this.modelingEvents);
     this.editorViewTracker = new ModelEditorViewTracker();
     this.methodsUsagePanel = this.push(
-      new MethodsUsagePanel(this.modelingStore, cliServer),
+      new MethodsUsagePanel(this.modelingStore, this.modelingEvents, cliServer),
     );
     this.methodModelingPanel = this.push(
-      new MethodModelingPanel(app, this.modelingStore, this.editorViewTracker),
+      new MethodModelingPanel(
+        app,
+        this.modelingStore,
+        this.modelingEvents,
+        this.editorViewTracker,
+      ),
     );
 
-    this.registerToModelingStoreEvents();
+    this.registerToModelingEvents();
   }
 
   public static async initialize(
@@ -90,9 +98,9 @@ export class ModelEditorModule extends DisposableObject {
     await ensureDir(this.queryStorageDir);
   }
 
-  private registerToModelingStoreEvents(): void {
+  private registerToModelingEvents(): void {
     this.push(
-      this.modelingStore.onSelectedMethodChanged(async (event) => {
+      this.modelingEvents.onSelectedMethodChanged(async (event) => {
         await this.showMethod(event.databaseItem, event.method, event.usage);
       }),
     );
@@ -215,6 +223,7 @@ export class ModelEditorModule extends DisposableObject {
           const view = new ModelEditorView(
             this.app,
             this.modelingStore,
+            this.modelingEvents,
             this.editorViewTracker,
             modelConfig,
             this.databaseManager,
@@ -226,7 +235,7 @@ export class ModelEditorModule extends DisposableObject {
             modelFile,
           );
 
-          this.modelingStore.onDbClosed(async (dbUri) => {
+          this.modelingEvents.onDbClosed(async (dbUri) => {
             if (dbUri === db.databaseUri.toString()) {
               await cleanupQueryDir();
             }

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -43,6 +43,7 @@ import { AutoModeler } from "./auto-modeler";
 import { telemetryListener } from "../common/vscode/telemetry";
 import { ModelingStore } from "./modeling-store";
 import { ModelEditorViewTracker } from "./model-editor-view-tracker";
+import { ModelingEvents } from "./modeling-events";
 
 export class ModelEditorView extends AbstractWebview<
   ToModelEditorMessage,
@@ -53,6 +54,7 @@ export class ModelEditorView extends AbstractWebview<
   public constructor(
     protected readonly app: App,
     private readonly modelingStore: ModelingStore,
+    private readonly modelingEvents: ModelingEvents,
     private readonly viewTracker: ModelEditorViewTracker<ModelEditorView>,
     private readonly modelConfig: ModelConfigListener,
     private readonly databaseManager: DatabaseManager,
@@ -67,7 +69,7 @@ export class ModelEditorView extends AbstractWebview<
     super(app);
 
     this.modelingStore.initializeStateForDb(databaseItem, initialMode);
-    this.registerToModelingStoreEvents();
+    this.registerToModelingEvents();
     this.registerToModelConfigEvents();
 
     this.viewTracker.registerView(this);
@@ -567,6 +569,7 @@ export class ModelEditorView extends AbstractWebview<
       const view = new ModelEditorView(
         this.app,
         this.modelingStore,
+        this.modelingEvents,
         this.viewTracker,
         this.modelConfig,
         this.databaseManager,
@@ -655,9 +658,9 @@ export class ModelEditorView extends AbstractWebview<
     return addedDatabase;
   }
 
-  private registerToModelingStoreEvents() {
+  private registerToModelingEvents() {
     this.push(
-      this.modelingStore.onMethodsChanged(async (event) => {
+      this.modelingEvents.onMethodsChanged(async (event) => {
         if (event.dbUri === this.databaseItem.databaseUri.toString()) {
           await this.postMessage({
             t: "setMethods",
@@ -668,7 +671,7 @@ export class ModelEditorView extends AbstractWebview<
     );
 
     this.push(
-      this.modelingStore.onModeledMethodsChanged(async (event) => {
+      this.modelingEvents.onModeledMethodsChanged(async (event) => {
         if (event.dbUri === this.databaseItem.databaseUri.toString()) {
           await this.postMessage({
             t: "setModeledMethods",
@@ -679,7 +682,7 @@ export class ModelEditorView extends AbstractWebview<
     );
 
     this.push(
-      this.modelingStore.onModifiedMethodsChanged(async (event) => {
+      this.modelingEvents.onModifiedMethodsChanged(async (event) => {
         if (event.dbUri === this.databaseItem.databaseUri.toString()) {
           await this.postMessage({
             t: "setModifiedMethods",
@@ -690,7 +693,7 @@ export class ModelEditorView extends AbstractWebview<
     );
 
     this.push(
-      this.modelingStore.onInProgressMethodsChanged(async (event) => {
+      this.modelingEvents.onInProgressMethodsChanged(async (event) => {
         if (event.dbUri === this.databaseItem.databaseUri.toString()) {
           await this.postMessage({
             t: "setInProgressMethods",

--- a/extensions/ql-vscode/src/model-editor/modeling-events.ts
+++ b/extensions/ql-vscode/src/model-editor/modeling-events.ts
@@ -1,0 +1,221 @@
+import { App } from "../common/app";
+import { DisposableObject } from "../common/disposable-object";
+import { AppEvent, AppEventEmitter } from "../common/events";
+import { DatabaseItem } from "../databases/local-databases";
+import { Method, Usage } from "./method";
+import { ModeledMethod } from "./modeled-method";
+import { Mode } from "./shared/mode";
+
+interface MethodsChangedEvent {
+  readonly methods: readonly Method[];
+  readonly dbUri: string;
+  readonly isActiveDb: boolean;
+}
+
+interface HideModeledMethodsChangedEvent {
+  readonly hideModeledMethods: boolean;
+  readonly isActiveDb: boolean;
+}
+
+interface ModeChangedEvent {
+  readonly mode: Mode;
+  readonly isActiveDb: boolean;
+}
+
+interface ModeledMethodsChangedEvent {
+  readonly modeledMethods: Readonly<Record<string, ModeledMethod[]>>;
+  readonly dbUri: string;
+  readonly isActiveDb: boolean;
+}
+
+interface ModifiedMethodsChangedEvent {
+  readonly modifiedMethods: ReadonlySet<string>;
+  readonly dbUri: string;
+  readonly isActiveDb: boolean;
+}
+
+interface SelectedMethodChangedEvent {
+  readonly databaseItem: DatabaseItem;
+  readonly method: Method;
+  readonly usage: Usage;
+  readonly modeledMethods: readonly ModeledMethod[];
+  readonly isModified: boolean;
+  readonly isInProgress: boolean;
+}
+
+interface InProgressMethodsChangedEvent {
+  readonly dbUri: string;
+  readonly methods: ReadonlySet<string>;
+}
+
+export class ModelingEvents extends DisposableObject {
+  public readonly onActiveDbChanged: AppEvent<void>;
+  public readonly onDbOpened: AppEvent<string>;
+  public readonly onDbClosed: AppEvent<string>;
+  public readonly onMethodsChanged: AppEvent<MethodsChangedEvent>;
+  public readonly onHideModeledMethodsChanged: AppEvent<HideModeledMethodsChangedEvent>;
+  public readonly onModeChanged: AppEvent<ModeChangedEvent>;
+  public readonly onModeledMethodsChanged: AppEvent<ModeledMethodsChangedEvent>;
+  public readonly onModifiedMethodsChanged: AppEvent<ModifiedMethodsChangedEvent>;
+  public readonly onSelectedMethodChanged: AppEvent<SelectedMethodChangedEvent>;
+  public readonly onInProgressMethodsChanged: AppEvent<InProgressMethodsChangedEvent>;
+
+  private readonly onActiveDbChangedEventEmitter: AppEventEmitter<void>;
+  private readonly onDbOpenedEventEmitter: AppEventEmitter<string>;
+  private readonly onDbClosedEventEmitter: AppEventEmitter<string>;
+  private readonly onMethodsChangedEventEmitter: AppEventEmitter<MethodsChangedEvent>;
+  private readonly onHideModeledMethodsChangedEventEmitter: AppEventEmitter<HideModeledMethodsChangedEvent>;
+  private readonly onModeChangedEventEmitter: AppEventEmitter<ModeChangedEvent>;
+  private readonly onModeledMethodsChangedEventEmitter: AppEventEmitter<ModeledMethodsChangedEvent>;
+  private readonly onModifiedMethodsChangedEventEmitter: AppEventEmitter<ModifiedMethodsChangedEvent>;
+  private readonly onSelectedMethodChangedEventEmitter: AppEventEmitter<SelectedMethodChangedEvent>;
+  private readonly onInProgressMethodsChangedEventEmitter: AppEventEmitter<InProgressMethodsChangedEvent>;
+
+  constructor(app: App) {
+    super();
+
+    this.onActiveDbChangedEventEmitter = this.push(
+      app.createEventEmitter<void>(),
+    );
+    this.onActiveDbChanged = this.onActiveDbChangedEventEmitter.event;
+
+    this.onDbOpenedEventEmitter = this.push(app.createEventEmitter<string>());
+    this.onDbOpened = this.onDbOpenedEventEmitter.event;
+
+    this.onDbClosedEventEmitter = this.push(app.createEventEmitter<string>());
+    this.onDbClosed = this.onDbClosedEventEmitter.event;
+
+    this.onMethodsChangedEventEmitter = this.push(
+      app.createEventEmitter<MethodsChangedEvent>(),
+    );
+    this.onMethodsChanged = this.onMethodsChangedEventEmitter.event;
+
+    this.onHideModeledMethodsChangedEventEmitter = this.push(
+      app.createEventEmitter<HideModeledMethodsChangedEvent>(),
+    );
+    this.onHideModeledMethodsChanged =
+      this.onHideModeledMethodsChangedEventEmitter.event;
+
+    this.onModeChangedEventEmitter = this.push(
+      app.createEventEmitter<ModeChangedEvent>(),
+    );
+    this.onModeChanged = this.onModeChangedEventEmitter.event;
+
+    this.onModeledMethodsChangedEventEmitter = this.push(
+      app.createEventEmitter<ModeledMethodsChangedEvent>(),
+    );
+    this.onModeledMethodsChanged =
+      this.onModeledMethodsChangedEventEmitter.event;
+
+    this.onModifiedMethodsChangedEventEmitter = this.push(
+      app.createEventEmitter<ModifiedMethodsChangedEvent>(),
+    );
+    this.onModifiedMethodsChanged =
+      this.onModifiedMethodsChangedEventEmitter.event;
+
+    this.onSelectedMethodChangedEventEmitter = this.push(
+      app.createEventEmitter<SelectedMethodChangedEvent>(),
+    );
+    this.onSelectedMethodChanged =
+      this.onSelectedMethodChangedEventEmitter.event;
+
+    this.onInProgressMethodsChangedEventEmitter = this.push(
+      app.createEventEmitter<InProgressMethodsChangedEvent>(),
+    );
+    this.onInProgressMethodsChanged =
+      this.onInProgressMethodsChangedEventEmitter.event;
+  }
+
+  public fireActiveDbChangedEvent() {
+    this.onActiveDbChangedEventEmitter.fire();
+  }
+
+  public fireDbOpenedEvent(dbUri: string) {
+    this.onDbOpenedEventEmitter.fire(dbUri);
+  }
+
+  public fireDbClosedEvent(dbUri: string) {
+    this.onDbClosedEventEmitter.fire(dbUri);
+  }
+
+  public fireMethodsChangedEvent(
+    methods: Method[],
+    dbUri: string,
+    isActiveDb: boolean,
+  ) {
+    this.onMethodsChangedEventEmitter.fire({
+      methods,
+      dbUri,
+      isActiveDb,
+    });
+  }
+
+  public fireHideModeledMethodsChangedEvent(
+    hideModeledMethods: boolean,
+    isActiveDb: boolean,
+  ) {
+    this.onHideModeledMethodsChangedEventEmitter.fire({
+      hideModeledMethods,
+      isActiveDb,
+    });
+  }
+
+  public fireModeChangedEvent(mode: Mode, isActiveDb: boolean) {
+    this.onModeChangedEventEmitter.fire({
+      mode,
+      isActiveDb,
+    });
+  }
+
+  public fireModeledMethodsChangedEvent(
+    modeledMethods: Record<string, ModeledMethod[]>,
+    dbUri: string,
+    isActiveDb: boolean,
+  ) {
+    this.onModeledMethodsChangedEventEmitter.fire({
+      modeledMethods,
+      dbUri,
+      isActiveDb,
+    });
+  }
+
+  public fireModifiedMethodsChangedEvent(
+    modifiedMethods: ReadonlySet<string>,
+    dbUri: string,
+    isActiveDb: boolean,
+  ) {
+    this.onModifiedMethodsChangedEventEmitter.fire({
+      modifiedMethods,
+      dbUri,
+      isActiveDb,
+    });
+  }
+
+  public fireSelectedMethodChangedEvent(
+    databaseItem: DatabaseItem,
+    method: Method,
+    usage: Usage,
+    modeledMethods: ModeledMethod[],
+    isModified: boolean,
+    isInProgress: boolean,
+  ) {
+    this.onSelectedMethodChangedEventEmitter.fire({
+      databaseItem,
+      method,
+      usage,
+      modeledMethods,
+      isModified,
+      isInProgress,
+    });
+  }
+
+  public fireInProgressMethodsChangedEvent(
+    dbUri: string,
+    methods: ReadonlySet<string>,
+  ) {
+    this.onInProgressMethodsChangedEventEmitter.fire({
+      dbUri,
+      methods,
+    });
+  }
+}

--- a/extensions/ql-vscode/test/__mocks__/model-editor/modelingEventsMock.ts
+++ b/extensions/ql-vscode/test/__mocks__/model-editor/modelingEventsMock.ts
@@ -1,0 +1,33 @@
+import { mockedObject } from "../../vscode-tests/utils/mocking.helpers";
+import { ModelingEvents } from "../../../src/model-editor/modeling-events";
+
+export function createMockModelingEvents({
+  onActiveDbChanged = jest.fn(),
+  onDbClosed = jest.fn(),
+  onMethodsChanged = jest.fn(),
+  onHideModeledMethodsChanged = jest.fn(),
+  onModeChanged = jest.fn(),
+  onModeledMethodsChanged = jest.fn(),
+  onModifiedMethodsChanged = jest.fn(),
+  onInProgressMethodsChanged = jest.fn(),
+}: {
+  onActiveDbChanged?: ModelingEvents["onActiveDbChanged"];
+  onDbClosed?: ModelingEvents["onDbClosed"];
+  onMethodsChanged?: ModelingEvents["onMethodsChanged"];
+  onHideModeledMethodsChanged?: ModelingEvents["onHideModeledMethodsChanged"];
+  onModeChanged?: ModelingEvents["onModeChanged"];
+  onModeledMethodsChanged?: ModelingEvents["onModeledMethodsChanged"];
+  onModifiedMethodsChanged?: ModelingEvents["onModifiedMethodsChanged"];
+  onInProgressMethodsChanged?: ModelingEvents["onInProgressMethodsChanged"];
+} = {}): ModelingEvents {
+  return mockedObject<ModelingEvents>({
+    onActiveDbChanged,
+    onDbClosed,
+    onMethodsChanged,
+    onHideModeledMethodsChanged,
+    onModeChanged,
+    onModeledMethodsChanged,
+    onModifiedMethodsChanged,
+    onInProgressMethodsChanged,
+  });
+}

--- a/extensions/ql-vscode/test/__mocks__/model-editor/modelingStoreMock.ts
+++ b/extensions/ql-vscode/test/__mocks__/model-editor/modelingStoreMock.ts
@@ -4,36 +4,12 @@ import { ModelingStore } from "../../../src/model-editor/modeling-store";
 export function createMockModelingStore({
   initializeStateForDb = jest.fn(),
   getStateForActiveDb = jest.fn(),
-  onActiveDbChanged = jest.fn(),
-  onDbClosed = jest.fn(),
-  onMethodsChanged = jest.fn(),
-  onHideModeledMethodsChanged = jest.fn(),
-  onModeChanged = jest.fn(),
-  onModeledMethodsChanged = jest.fn(),
-  onModifiedMethodsChanged = jest.fn(),
-  onInProgressMethodsChanged = jest.fn(),
 }: {
   initializeStateForDb?: ModelingStore["initializeStateForDb"];
   getStateForActiveDb?: ModelingStore["getStateForActiveDb"];
-  onActiveDbChanged?: ModelingStore["onActiveDbChanged"];
-  onDbClosed?: ModelingStore["onDbClosed"];
-  onMethodsChanged?: ModelingStore["onMethodsChanged"];
-  onHideModeledMethodsChanged?: ModelingStore["onHideModeledMethodsChanged"];
-  onModeChanged?: ModelingStore["onModeChanged"];
-  onModeledMethodsChanged?: ModelingStore["onModeledMethodsChanged"];
-  onModifiedMethodsChanged?: ModelingStore["onModifiedMethodsChanged"];
-  onInProgressMethodsChanged?: ModelingStore["onInProgressMethodsChanged"];
 } = {}): ModelingStore {
   return mockedObject<ModelingStore>({
     initializeStateForDb,
     getStateForActiveDb,
-    onActiveDbChanged,
-    onDbClosed,
-    onMethodsChanged,
-    onHideModeledMethodsChanged,
-    onModeChanged,
-    onModeledMethodsChanged,
-    onModifiedMethodsChanged,
-    onInProgressMethodsChanged,
   });
 }

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/methods-usage/methods-usage-panel.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/methods-usage/methods-usage-panel.test.ts
@@ -12,6 +12,8 @@ import { ModelingStore } from "../../../../../src/model-editor/modeling-store";
 import { createMockModelingStore } from "../../../../__mocks__/model-editor/modelingStoreMock";
 import { ModeledMethod } from "../../../../../src/model-editor/modeled-method";
 import { Mode } from "../../../../../src/model-editor/shared/mode";
+import { createMockModelingEvents } from "../../../../__mocks__/model-editor/modelingEventsMock";
+import { ModelingEvents } from "../../../../../src/model-editor/modeling-events";
 
 describe("MethodsUsagePanel", () => {
   const mockCliServer = mockedObject<CodeQLCliServer>({});
@@ -33,8 +35,13 @@ describe("MethodsUsagePanel", () => {
       jest.spyOn(window, "createTreeView").mockReturnValue(mockTreeView);
 
       const modelingStore = createMockModelingStore();
+      const modelingEvents = createMockModelingEvents();
 
-      const panel = new MethodsUsagePanel(modelingStore, mockCliServer);
+      const panel = new MethodsUsagePanel(
+        modelingStore,
+        modelingEvents,
+        mockCliServer,
+      );
       await panel.setState(
         methods,
         dbItem,
@@ -51,6 +58,7 @@ describe("MethodsUsagePanel", () => {
   describe("revealItem", () => {
     let mockTreeView: TreeView<unknown>;
     let modelingStore: ModelingStore;
+    let modelingEvents: ModelingEvents;
 
     const hideModeledMethods: boolean = false;
     const mode = Mode.Application;
@@ -65,6 +73,7 @@ describe("MethodsUsagePanel", () => {
       jest.spyOn(window, "createTreeView").mockReturnValue(mockTreeView);
 
       modelingStore = createMockModelingStore();
+      modelingEvents = createMockModelingEvents();
     });
 
     it("should reveal the correct item in the tree view", async () => {
@@ -73,7 +82,11 @@ describe("MethodsUsagePanel", () => {
       });
       const methods = [method];
 
-      const panel = new MethodsUsagePanel(modelingStore, mockCliServer);
+      const panel = new MethodsUsagePanel(
+        modelingStore,
+        modelingEvents,
+        mockCliServer,
+      );
       await panel.setState(
         methods,
         dbItem,
@@ -96,7 +109,11 @@ describe("MethodsUsagePanel", () => {
     it("should do nothing if usage cannot be found", async () => {
       const method = createMethod({});
       const methods = [method];
-      const panel = new MethodsUsagePanel(modelingStore, mockCliServer);
+      const panel = new MethodsUsagePanel(
+        modelingStore,
+        modelingEvents,
+        mockCliServer,
+      );
       await panel.setState(
         methods,
         dbItem,

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/model-editor-view.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/model-editor-view.test.ts
@@ -11,10 +11,12 @@ import { ExtensionPack } from "../../../../src/model-editor/shared/extension-pac
 import { createMockModelingStore } from "../../../__mocks__/model-editor/modelingStoreMock";
 import { createMockModelEditorViewTracker } from "../../../__mocks__/model-editor/modelEditorViewTrackerMock";
 import { ModelConfigListener } from "../../../../src/config";
+import { createMockModelingEvents } from "../../../__mocks__/model-editor/modelingEventsMock";
 
 describe("ModelEditorView", () => {
   const app = createMockApp({});
   const modelingStore = createMockModelingStore();
+  const modelingEvents = createMockModelingEvents();
   const viewTracker = createMockModelEditorViewTracker();
   const modelConfig = mockedObject<ModelConfigListener>({
     onDidChangeConfiguration: jest.fn(),
@@ -44,6 +46,7 @@ describe("ModelEditorView", () => {
     view = new ModelEditorView(
       app,
       modelingStore,
+      modelingEvents,
       viewTracker,
       modelConfig,
       databaseManager,


### PR DESCRIPTION
As part of the method modeling panel work, we introduced a new `ModelingStore` that is used to hold state around modeling and publishing events that the various panels subscribe to. The events are currently part of the `ModelingStore`.

In this PR we introduce a new `ModelingEvents` class and move all the events there. In the future, we can have UI interactions also represented by events.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
