### PR TITLE
Deselect current db when the language context changes

### DIFF
--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -141,9 +141,7 @@ class DatabaseTreeDataProvider
     return item;
   }
 
-  public async getChildren(
-    element?: DatabaseItem,
-  ): Promise<DatabaseItem[] | null | undefined> {
+  public getChildren(element?: DatabaseItem): ProviderResult<DatabaseItem[]> {
     if (element === undefined) {
       // Filter items by language
       const displayItems = this.databaseManager.databaseItems.filter((item) => {
@@ -151,19 +149,6 @@ class DatabaseTreeDataProvider
           tryGetQueryLanguage(item.language),
         );
       });
-
-      if (
-        this.currentDatabaseItem &&
-        !this.languageContext.isSelectedLanguage(
-          tryGetQueryLanguage(this.currentDatabaseItem.language),
-        )
-      ) {
-        this.currentDatabaseItem = undefined;
-        await this.databaseManager.setCurrentDatabaseItem(
-          this.currentDatabaseItem,
-        );
-        this._onDidChangeTreeData.fire(this.currentDatabaseItem);
-      }
 
       // Sort items
       return displayItems.slice(0).sort((db1, db2) => {

--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -141,7 +141,9 @@ class DatabaseTreeDataProvider
     return item;
   }
 
-  public getChildren(element?: DatabaseItem): ProviderResult<DatabaseItem[]> {
+  public async getChildren(
+    element?: DatabaseItem,
+  ): Promise<DatabaseItem[] | null | undefined> {
     if (element === undefined) {
       // Filter items by language
       const displayItems = this.databaseManager.databaseItems.filter((item) => {
@@ -149,6 +151,19 @@ class DatabaseTreeDataProvider
           tryGetQueryLanguage(item.language),
         );
       });
+
+      if (
+        this.currentDatabaseItem &&
+        !this.languageContext.isSelectedLanguage(
+          tryGetQueryLanguage(this.currentDatabaseItem.language),
+        )
+      ) {
+        this.currentDatabaseItem = undefined;
+        await this.databaseManager.setCurrentDatabaseItem(
+          this.currentDatabaseItem,
+        );
+        this._onDidChangeTreeData.fire(this.currentDatabaseItem);
+      }
 
       // Sort items
       return displayItems.slice(0).sort((db1, db2) => {

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -769,20 +769,27 @@ async function activateWithInstalledDistribution(
     fsWatcher.onDidDelete(clearPackCache);
   }
 
-  void extLogger.log("Initializing database manager.");
-  const dbm = new DatabaseManager(ctx, app, qs, cliServer, extLogger);
-
-  // Let this run async.
-  void dbm.loadPersistedState();
-
-  ctx.subscriptions.push(dbm);
-
   void extLogger.log("Initializing language context.");
   const languageContext = new LanguageContextStore(app);
 
   void extLogger.log("Initializing language selector.");
   const languageSelectionPanel = new LanguageSelectionPanel(languageContext);
   ctx.subscriptions.push(languageSelectionPanel);
+
+  void extLogger.log("Initializing database manager.");
+  const dbm = new DatabaseManager(
+    ctx,
+    app,
+    qs,
+    cliServer,
+    languageContext,
+    extLogger,
+  );
+
+  // Let this run async.
+  void dbm.loadPersistedState();
+
+  ctx.subscriptions.push(dbm);
 
   void extLogger.log("Initializing database panel.");
   const databaseUI = new DatabaseUI(

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-queries/local-databases.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-queries/local-databases.test.ts
@@ -31,6 +31,7 @@ import {
   sourceLocationUri,
 } from "../../../factories/databases/databases";
 import { findSourceArchive } from "../../../../src/databases/local-databases/database-resolver";
+import { LanguageContextStore } from "../../../../src/language-context-store";
 
 describe("local databases", () => {
   let databaseManager: DatabaseManager;
@@ -84,9 +85,10 @@ describe("local databases", () => {
       },
     );
 
+    const mockApp = createMockApp({});
     databaseManager = new DatabaseManager(
       extensionContext,
-      createMockApp({}),
+      mockApp,
       mockedObject<QueryRunner>({
         registerDatabase: registerSpy,
         deregisterDatabase: deregisterSpy,
@@ -98,6 +100,7 @@ describe("local databases", () => {
         resolveDatabase: resolveDatabaseSpy,
         packAdd: packAddSpy,
       }),
+      new LanguageContextStore(mockApp),
       mockedObject<Logger>({
         log: logSpy,
       }),


### PR DESCRIPTION
When the language context changes, we should make sure that the current database gets deselected. See internal linked issue for details 🔍 

### Notes for reviewer

- This feels a bit hacky, but seems to work. A few comments/questions about the implementation inline.
- I also haven't been able to write a test for this (since I couldn't figure out to access the relevant properties/events in the tests), so any suggestions on that front also welcome! 🙏🏽 

## Checklist

N/A—still feature-flagged for internal use ⛳

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
