### PR TITLE
Fix styling of "already modeled" rows when showing multiple methods

### DIFF
--- a/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
@@ -337,7 +337,9 @@ const UnmodelableMethodRow = forwardRef<
           <MethodClassifications method={method} />
         </ApiOrMethodRow>
       </DataGridCell>
-      <DataGridCell gridColumn="span 4">Method already modeled</DataGridCell>
+      <DataGridCell gridColumn={`span ${viewState.showMultipleModels ? 5 : 4}`}>
+        Method already modeled
+      </DataGridCell>
     </DataGridRow>
   );
 });

--- a/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
@@ -327,6 +327,7 @@ const UnmodelableMethodRow = forwardRef<
       <DataGridCell>
         <ApiOrMethodRow>
           <ModelingStatusIndicator status="saved" />
+          <MethodClassifications method={method} />
           <MethodName {...props.method} />
           {viewState.mode === Mode.Application && (
             <UsagesButton onClick={jumpToMethod}>
@@ -334,7 +335,6 @@ const UnmodelableMethodRow = forwardRef<
             </UsagesButton>
           )}
           <ViewLink onClick={jumpToMethod}>View</ViewLink>
-          <MethodClassifications method={method} />
         </ApiOrMethodRow>
       </DataGridCell>
       <DataGridCell gridColumn={`span ${viewState.showMultipleModels ? 5 : 4}`}>


### PR DESCRIPTION
Addresses two bugs around the `UnmodelableMethodRow` component. I believe we missed these until now because this component is only shown when the "Hide modeled methods" option is deselected.

One bug is it wasn't computing the `gridColumn: span` value correctly, so when multiple models were shown it would break the entire table layout by trying to put two rows worth of elements on the same grid row. Thankfully this visual bug only manifested when the `codeQL.model.showMultipleModels` feature flag was enabled, and there's no visual change when it isn't enabled.

Another bug is that the `MethodClassifications` component was being added at a different point than from the normal method rows. We were adding it near the end of the cell instead of near the start. This PR changes it to match the other cells.

Screenshots when `showMultipleModels` is disabled:
- Before this PR:
    <img width="1487" alt="Screenshot 2023-10-24 at 10 16 28" src="https://github.com/github/vscode-codeql/assets/3749000/4bdaa51b-d7f5-4b59-9f16-d97cef2833ef">
- After this PR:
    <img width="1487" alt="Screenshot 2023-10-24 at 10 18 33" src="https://github.com/github/vscode-codeql/assets/3749000/6e6042b0-fead-4c38-a56b-af4a38ce52ec">

Screenshots when `showMultipleModels` is enabled:
- Before this PR:
    <img width="1487" alt="Screenshot 2023-10-24 at 10 16 05" src="https://github.com/github/vscode-codeql/assets/3749000/65baea78-0dca-4354-bd89-5e904f9299d6">
- After this PR:
    <img width="1302" alt="Screenshot 2023-10-24 at 10 14 33" src="https://github.com/github/vscode-codeql/assets/3749000/d04cddd7-efae-45ce-9595-61e55cb00f42">


## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
