### PR TITLE
Create query: open new query in editor before downloading DB

### DIFF
--- a/extensions/ql-vscode/src/local-queries/skeleton-query-wizard.ts
+++ b/extensions/ql-vscode/src/local-queries/skeleton-query-wizard.ts
@@ -79,11 +79,7 @@ export class SkeletonQueryWizard {
       await this.createQlPack();
     }
 
-    // select existing database for language or download a new one
-    await this.selectOrDownloadDatabase();
-
-    // open a query file
-
+    // open the query file
     try {
       await this.openExampleFile();
     } catch (e: unknown) {
@@ -91,6 +87,9 @@ export class SkeletonQueryWizard {
         `Could not open example query file: ${getErrorMessage(e)}`,
       );
     }
+
+    // select existing database for language or download a new one
+    await this.selectOrDownloadDatabase();
   }
 
   private async openExampleFile() {


### PR DESCRIPTION
In the "create query" process, we should open the query as soon as it's created. Currently, it gets opened at the very end of the process, i.e. after the "download database" step. If users skip that download step (or if it fails), then the newly-created query doesn't get opened and is hard to find 🔍 


## Checklist

N/A: the "create query" command is still feature-flagged 🎌 

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
