### PR TITLE
Create new queries in selected folder of queries panel

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -795,7 +795,11 @@ async function activateWithInstalledDistribution(
   );
   ctx.subscriptions.push(databaseUI);
 
-  QueriesModule.initialize(app, languageContext, cliServer);
+  const queriesModule = QueriesModule.initialize(
+    app,
+    languageContext,
+    cliServer,
+  );
 
   void extLogger.log("Initializing evaluator log viewer.");
   const evalLogViewer = new EvalLogViewer();
@@ -933,6 +937,10 @@ async function activateWithInstalledDistribution(
     languageContext,
   );
   ctx.subscriptions.push(localQueries);
+
+  queriesModule.onDidChangeSelection((event) =>
+    localQueries.setSelectedQueryTreeViewItems(event.selection),
+  );
 
   void extLogger.log("Initializing debugger factory.");
   ctx.subscriptions.push(

--- a/extensions/ql-vscode/src/local-queries/local-queries.ts
+++ b/extensions/ql-vscode/src/local-queries/local-queries.ts
@@ -63,6 +63,8 @@ export enum QuickEvalType {
 }
 
 export class LocalQueries extends DisposableObject {
+  private selectedQueryTreeViewItems: readonly QueryTreeViewItem[] = [];
+
   public constructor(
     private readonly app: App,
     private readonly queryRunner: QueryRunner,
@@ -75,6 +77,12 @@ export class LocalQueries extends DisposableObject {
     private readonly languageContextStore: LanguageContextStore,
   ) {
     super();
+  }
+
+  public setSelectedQueryTreeViewItems(
+    selection: readonly QueryTreeViewItem[],
+  ) {
+    this.selectedQueryTreeViewItems = selection;
   }
 
   public getCommands(): LocalQueryCommands {
@@ -333,6 +341,7 @@ export class LocalQueries extends DisposableObject {
           this.app.logger,
           this.databaseManager,
           contextStoragePath,
+          this.selectedQueryTreeViewItems,
           language,
         );
         await skeletonQueryWizard.execute();

--- a/extensions/ql-vscode/src/local-queries/skeleton-query-wizard.ts
+++ b/extensions/ql-vscode/src/local-queries/skeleton-query-wizard.ts
@@ -1,4 +1,4 @@
-import { dirname, join } from "path";
+import { basename, dirname, join } from "path";
 import { Uri, window as Window, workspace } from "vscode";
 import { CodeQLCliServer } from "../codeql-cli/cli";
 import { BaseLogger } from "../common/logging";
@@ -116,6 +116,18 @@ export class SkeletonQueryWizard {
       return this.determineRootStoragePath();
     }
 
+    const storagePath = await this.determineStoragePathFromSelection();
+
+    // If the user has selected a folder or file within a folder that matches the current
+    // folder name, we should create a query rather than a query pack
+    if (basename(storagePath) === this.folderName) {
+      return dirname(storagePath);
+    }
+
+    return storagePath;
+  }
+
+  private async determineStoragePathFromSelection(): Promise<string> {
     // Just like VS Code's "New File" command, if the user has selected multiple files/folders in the queries panel,
     // we will create the new file in the same folder as the first selected item.
     // See https://github.com/microsoft/vscode/blob/a8b7239d0311d4915b57c837972baf4b01394491/src/vs/workbench/contrib/files/browser/fileActions.ts#L893-L900
@@ -232,7 +244,7 @@ export class SkeletonQueryWizard {
       await qlPackGenerator.createExampleQlFile(this.fileName);
     } catch (e: unknown) {
       void this.logger.log(
-        `Could not create skeleton QL pack: ${getErrorMessage(e)}`,
+        `Could not create query example file: ${getErrorMessage(e)}`,
       );
     }
   }

--- a/extensions/ql-vscode/src/local-queries/skeleton-query-wizard.ts
+++ b/extensions/ql-vscode/src/local-queries/skeleton-query-wizard.ts
@@ -4,10 +4,7 @@ import { CodeQLCliServer } from "../codeql-cli/cli";
 import { BaseLogger } from "../common/logging";
 import { Credentials } from "../common/authentication";
 import { QueryLanguage } from "../common/query-language";
-import {
-  getFirstWorkspaceFolder,
-  isFolderAlreadyInWorkspace,
-} from "../common/vscode/workspace-folders";
+import { getFirstWorkspaceFolder } from "../common/vscode/workspace-folders";
 import { getErrorMessage } from "../common/helpers-pure";
 import { QlPackGenerator } from "./qlpack-generator";
 import { DatabaseItem, DatabaseManager } from "../databases/local-databases";
@@ -72,9 +69,9 @@ export class SkeletonQueryWizard {
 
     this.qlPackStoragePath = await this.determineStoragePath();
 
-    const skeletonPackAlreadyExists =
-      (await pathExists(join(this.qlPackStoragePath, this.folderName))) ||
-      isFolderAlreadyInWorkspace(this.folderName);
+    const skeletonPackAlreadyExists = await pathExists(
+      join(this.qlPackStoragePath, this.folderName),
+    );
 
     if (skeletonPackAlreadyExists) {
       // just create a new example query file in skeleton QL pack

--- a/extensions/ql-vscode/src/queries-panel/queries-module.ts
+++ b/extensions/ql-vscode/src/queries-panel/queries-module.ts
@@ -7,9 +7,18 @@ import { QueriesPanel } from "./queries-panel";
 import { QueryDiscovery } from "./query-discovery";
 import { QueryPackDiscovery } from "./query-pack-discovery";
 import { LanguageContextStore } from "../language-context-store";
+import { TreeViewSelectionChangeEvent } from "vscode";
+import { QueryTreeViewItem } from "./query-tree-view-item";
 
 export class QueriesModule extends DisposableObject {
   private queriesPanel: QueriesPanel | undefined;
+  private readonly onDidChangeSelectionEmitter = this.push(
+    this.app.createEventEmitter<
+      TreeViewSelectionChangeEvent<QueryTreeViewItem>
+    >(),
+  );
+
+  public readonly onDidChangeSelection = this.onDidChangeSelectionEmitter.event;
 
   private constructor(readonly app: App) {
     super();
@@ -52,6 +61,9 @@ export class QueriesModule extends DisposableObject {
     void queryDiscovery.initialRefresh();
 
     this.queriesPanel = new QueriesPanel(queryDiscovery, app);
+    this.queriesPanel.onDidChangeSelection((event) =>
+      this.onDidChangeSelectionEmitter.fire(event),
+    );
     this.push(this.queriesPanel);
   }
 }

--- a/extensions/ql-vscode/src/queries-panel/queries-panel.ts
+++ b/extensions/ql-vscode/src/queries-panel/queries-panel.ts
@@ -1,7 +1,13 @@
 import { DisposableObject } from "../common/disposable-object";
 import { QueryTreeDataProvider } from "./query-tree-data-provider";
 import { QueryDiscovery } from "./query-discovery";
-import { TextEditor, TreeView, window } from "vscode";
+import {
+  Event,
+  TextEditor,
+  TreeView,
+  TreeViewSelectionChangeEvent,
+  window,
+} from "vscode";
 import { App } from "../common/app";
 import { QueryTreeViewItem } from "./query-tree-view-item";
 
@@ -16,6 +22,7 @@ export class QueriesPanel extends DisposableObject {
     super();
 
     this.dataProvider = new QueryTreeDataProvider(queryDiscovery, app);
+    this.push(this.dataProvider);
 
     this.treeView = window.createTreeView("codeQLQueries", {
       treeDataProvider: this.dataProvider,
@@ -23,6 +30,12 @@ export class QueriesPanel extends DisposableObject {
     this.push(this.treeView);
 
     this.subscribeToTreeSelectionEvents();
+  }
+
+  public get onDidChangeSelection(): Event<
+    TreeViewSelectionChangeEvent<QueryTreeViewItem>
+  > {
+    return this.treeView.onDidChangeSelection;
   }
 
   private subscribeToTreeSelectionEvents(): void {

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/local-queries/skeleton-query-wizard.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/local-queries/skeleton-query-wizard.test.ts
@@ -8,7 +8,6 @@ import * as tmp from "tmp";
 import { TextDocument, window, workspace, WorkspaceFolder } from "vscode";
 import { extLogger } from "../../../../src/common/logging/vscode";
 import { QlPackGenerator } from "../../../../src/local-queries/qlpack-generator";
-import * as workspaceFolders from "../../../../src/common/vscode/workspace-folders";
 import {
   createFileSync,
   ensureDir,
@@ -171,11 +170,6 @@ describe("SkeletonQueryWizard", () => {
   });
 
   describe("if QL pack doesn't exist", () => {
-    beforeEach(() => {
-      jest
-        .spyOn(workspaceFolders, "isFolderAlreadyInWorkspace")
-        .mockReturnValue(false);
-    });
     it("should try to create a new QL pack based on the language", async () => {
       await wizard.execute();
 
@@ -201,10 +195,6 @@ describe("SkeletonQueryWizard", () => {
 
   describe("if QL pack exists", () => {
     beforeEach(async () => {
-      jest
-        .spyOn(workspaceFolders, "isFolderAlreadyInWorkspace")
-        .mockReturnValue(true);
-
       // create a skeleton codeql-custom-queries-${language} folder
       // with an example QL file inside
       ensureDirSync(

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/local-queries/skeleton-query-wizard.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/local-queries/skeleton-query-wizard.test.ts
@@ -442,6 +442,9 @@ describe("SkeletonQueryWizard", () => {
 
         await ensureDir(join(queriesDir.name, "folder"));
         await ensureFile(join(queriesDir.name, "queries-java", "example.ql"));
+        await ensureFile(
+          join(queriesDir.name, "codeql-custom-queries-swift", "example.ql"),
+        );
       });
 
       describe("with selected folder", () => {
@@ -507,6 +510,41 @@ describe("SkeletonQueryWizard", () => {
           const chosenPath = await wizard.determineStoragePath();
 
           expect(chosenPath).toEqual(dirname(selectedItems[0].path));
+        });
+      });
+
+      describe("with selected file with same name", () => {
+        let selectedItems: QueryTreeViewItem[];
+
+        beforeEach(async () => {
+          selectedItems = [
+            createQueryTreeFileItem(
+              "example.ql",
+              join(
+                queriesDir.name,
+                "codeql-custom-queries-swift",
+                "example.ql",
+              ),
+              "java",
+            ),
+          ];
+
+          wizard = new SkeletonQueryWizard(
+            mockCli,
+            jest.fn(),
+            credentials,
+            extLogger,
+            mockDatabaseManager,
+            storagePath,
+            selectedItems,
+            QueryLanguage.Swift,
+          );
+        });
+
+        it("returns the parent path", async () => {
+          const chosenPath = await wizard.determineStoragePath();
+
+          expect(chosenPath).toEqual(queriesDir.name);
         });
       });
 


### PR DESCRIPTION
This will change the behavior of the "Create new query" command to create the new query in the same folder as the first selected item in the queries panel. If no items are selected, the behavior is the same as before.

I've used events to communicate the selection from the queries panel to the local queries module. This is some more code and some extra complexity, but it ensures that we don't have a dependency from the local queries module to the queries panel module. This makes testing easier.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
