### PR TITLE
Use selected language when creating query

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -930,6 +930,7 @@ async function activateWithInstalledDistribution(
     databaseUI,
     localQueryResultsView,
     queryStorageDir,
+    languageContext,
   );
   ctx.subscriptions.push(localQueries);
 

--- a/extensions/ql-vscode/src/language-context-store.ts
+++ b/extensions/ql-vscode/src/language-context-store.ts
@@ -67,4 +67,12 @@ export class LanguageContextStore extends DisposableObject {
       this.languageFilter === language
     );
   }
+
+  public get selectedLanguage(): QueryLanguage | undefined {
+    if (this.languageFilter === "All") {
+      return undefined;
+    }
+
+    return this.languageFilter;
+  }
 }

--- a/extensions/ql-vscode/src/local-queries/local-queries.ts
+++ b/extensions/ql-vscode/src/local-queries/local-queries.ts
@@ -50,6 +50,7 @@ import { createMultiSelectionCommand } from "../common/vscode/selection-commands
 import { findLanguage } from "../codeql-cli/query-language";
 import type { QueryTreeViewItem } from "../queries-panel/query-tree-view-item";
 import { tryGetQueryLanguage } from "../common/query-language";
+import { LanguageContextStore } from "../language-context-store";
 
 interface DatabaseQuickPickItem extends QuickPickItem {
   databaseItem: DatabaseItem;
@@ -71,6 +72,7 @@ export class LocalQueries extends DisposableObject {
     private readonly databaseUI: DatabaseUI,
     private readonly localQueryResultsView: ResultsView,
     private readonly queryStorageDir: string,
+    private readonly languageContextStore: LanguageContextStore,
   ) {
     super();
   }
@@ -323,6 +325,7 @@ export class LocalQueries extends DisposableObject {
         const credentials = isCanary() ? this.app.credentials : undefined;
         const contextStoragePath =
           this.app.workspaceStoragePath || this.app.globalStoragePath;
+        const language = this.languageContextStore.selectedLanguage;
         const skeletonQueryWizard = new SkeletonQueryWizard(
           this.cliServer,
           progress,
@@ -330,6 +333,7 @@ export class LocalQueries extends DisposableObject {
           this.app.logger,
           this.databaseManager,
           contextStoragePath,
+          language,
         );
         await skeletonQueryWizard.execute();
       },

--- a/extensions/ql-vscode/src/local-queries/skeleton-query-wizard.ts
+++ b/extensions/ql-vscode/src/local-queries/skeleton-query-wizard.ts
@@ -41,7 +41,6 @@ export const QUERY_LANGUAGE_TO_DATABASE_REPO: QueryLanguagesToDatabaseMap = {
 };
 
 export class SkeletonQueryWizard {
-  private language: QueryLanguage | undefined;
   private fileName = "example.ql";
   private qlPackStoragePath: string | undefined;
 
@@ -52,6 +51,7 @@ export class SkeletonQueryWizard {
     private readonly logger: BaseLogger,
     private readonly databaseManager: DatabaseManager,
     private readonly databaseStoragePath: string | undefined,
+    private language: QueryLanguage | undefined = undefined,
   ) {}
 
   private get folderName() {
@@ -59,8 +59,11 @@ export class SkeletonQueryWizard {
   }
 
   public async execute() {
-    // show quick pick to choose language
-    this.language = await this.chooseLanguage();
+    if (!this.language) {
+      // show quick pick to choose language
+      this.language = await this.chooseLanguage();
+    }
+
     if (!this.language) {
       return;
     }

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/local-queries/skeleton-query-wizard.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/local-queries/skeleton-query-wizard.test.ts
@@ -21,6 +21,7 @@ import * as databaseFetcher from "../../../../src/databases/database-fetcher";
 import { createMockDB } from "../../../factories/databases/databases";
 import { asError } from "../../../../src/common/helpers-pure";
 import { Setting } from "../../../../src/config";
+import { QueryLanguage } from "../../../../src/common/query-language";
 
 describe("SkeletonQueryWizard", () => {
   let mockCli: CodeQLCliServer;
@@ -132,6 +133,27 @@ describe("SkeletonQueryWizard", () => {
 
     expect(mockCli.getSupportedLanguages).toHaveBeenCalled();
     expect(quickPickSpy).toHaveBeenCalled();
+  });
+
+  describe("with language", () => {
+    beforeEach(() => {
+      wizard = new SkeletonQueryWizard(
+        mockCli,
+        jest.fn(),
+        credentials,
+        extLogger,
+        mockDatabaseManager,
+        storagePath,
+        QueryLanguage.Swift,
+      );
+    });
+
+    it("should not prompt for language", async () => {
+      await wizard.execute();
+
+      expect(mockCli.getSupportedLanguages).not.toHaveBeenCalled();
+      expect(quickPickSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe("if QL pack doesn't exist", () => {


### PR DESCRIPTION
This will change the "Create new query" command to use the selected language when creating a new query. If no language is selected, it will still prompt the user to pick a language.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
