### PR TITLE
Use the same logic for hiding methods in model editor and usages panel

### DIFF
--- a/extensions/ql-vscode/src/model-editor/method.ts
+++ b/extensions/ql-vscode/src/model-editor/method.ts
@@ -66,6 +66,12 @@ export function getArgumentsList(methodParameters: string): string[] {
   return methodParameters.substring(1, methodParameters.length - 1).split(",");
 }
 
+/**
+ * Should we present the user with the ability to edit to modelings for this method.
+ *
+ * A method may be unmodelable if it is already modeled by CodeQL or by an extension
+ * pack other than the one currently being edited.
+ */
 export function canMethodBeModeled(
   method: Method,
   modeledMethods: readonly ModeledMethod[],

--- a/extensions/ql-vscode/src/model-editor/methods-usage/methods-usage-data-provider.ts
+++ b/extensions/ql-vscode/src/model-editor/methods-usage/methods-usage-data-provider.ts
@@ -9,7 +9,7 @@ import {
   Uri,
 } from "vscode";
 import { DisposableObject } from "../../common/disposable-object";
-import { Method, Usage } from "../method";
+import { Method, Usage, canMethodBeModeled } from "../method";
 import { DatabaseItem } from "../../databases/local-databases";
 import { relative } from "path";
 import { CodeQLCliServer } from "../../codeql-cli/cli";
@@ -146,7 +146,13 @@ export class MethodsUsageDataProvider
   getChildren(item?: MethodsUsageTreeViewItem): MethodsUsageTreeViewItem[] {
     if (item === undefined) {
       if (this.hideModeledMethods) {
-        return this.sortedTreeItems.filter((api) => !api.method.supported);
+        return this.sortedTreeItems.filter((api) =>
+          canMethodBeModeled(
+            api.method,
+            this.modeledMethods[api.method.signature] ?? [],
+            this.modifiedMethodSignatures.has(api.method.signature),
+          ),
+        );
       } else {
         return [...this.sortedTreeItems];
       }

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/methods-usage/methods-usage-data-provider.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/methods-usage/methods-usage-data-provider.test.ts
@@ -15,6 +15,7 @@ import {
 import { mockedObject } from "../../../utils/mocking.helpers";
 import { ModeledMethod } from "../../../../../src/model-editor/modeled-method";
 import { Mode } from "../../../../../src/model-editor/shared/mode";
+import { createModeledMethod } from "../../../../factories/model-editor/modeled-method-factories";
 
 describe("MethodsUsageDataProvider", () => {
   const mockCliServer = mockedObject<CodeQLCliServer>({});
@@ -226,17 +227,35 @@ describe("MethodsUsageDataProvider", () => {
   });
 
   describe("getChildren", () => {
-    const supportedMethod = createMethod({
+    const supportedUnmodeledMethod = createMethod({
+      signature: "some.supported.unmodeled.method()",
       supported: true,
     });
-
-    const unsupportedMethod = createMethod({
+    const supportedModeledMethod = createMethod({
+      signature: "some.supported.modeled.method()",
+      supported: true,
+    });
+    const unsupportedUnmodeledMethod = createMethod({
+      signature: "some.unsupported.unmodeled.method()",
+      supported: false,
+    });
+    const unsupportedModeledMethod = createMethod({
+      signature: "some.unsupported.modeled.method()",
       supported: false,
     });
 
     const mode = Mode.Application;
-    const methods: Method[] = [supportedMethod, unsupportedMethod];
+    const methods: Method[] = [
+      supportedUnmodeledMethod,
+      supportedModeledMethod,
+      unsupportedUnmodeledMethod,
+      unsupportedModeledMethod,
+    ];
     const modeledMethods: Record<string, ModeledMethod[]> = {};
+    modeledMethods[supportedModeledMethod.signature] = [createModeledMethod()];
+    modeledMethods[unsupportedModeledMethod.signature] = [
+      createModeledMethod(),
+    ];
     const modifiedMethodSignatures: Set<string> = new Set();
 
     const dbItem = mockedObject<DatabaseItem>({
@@ -246,12 +265,12 @@ describe("MethodsUsageDataProvider", () => {
     const usage = createUsage({});
 
     const methodTreeItem: MethodsUsageTreeViewItem = {
-      method: supportedMethod,
+      method: unsupportedUnmodeledMethod,
       children: [],
     };
 
     const usageTreeItem: MethodsUsageTreeViewItem = {
-      method: supportedMethod,
+      method: unsupportedUnmodeledMethod,
       usage,
       parent: methodTreeItem,
     };
@@ -275,7 +294,7 @@ describe("MethodsUsageDataProvider", () => {
         modeledMethods,
         modifiedMethodSignatures,
       );
-      expect(dataProvider.getChildren().length).toEqual(2);
+      expect(dataProvider.getChildren().length).toEqual(4);
     });
 
     it("should filter methods if hideModeledMethods is true and looking at the root", async () => {
@@ -288,7 +307,7 @@ describe("MethodsUsageDataProvider", () => {
         modeledMethods,
         modifiedMethodSignatures,
       );
-      expect(dataProvider.getChildren().length).toEqual(1);
+      expect(dataProvider.getChildren().length).toEqual(3);
     });
 
     describe("with multiple libraries", () => {


### PR DESCRIPTION
Makes sure that the model editor and the usages panel are using the same logic when deciding whether to show or hide a method.

Before this PR, you wouldn't be able to view usages of any methods that were already modeled and the modeling had been saved. We previously thought this bug only applied when you had modelings coming from an external pack, but you can reproduce it within one pack too.

Steps to reproduce:
- Add a modeling to a method
- Save the extension pack
- Click "View" on the modeled method and observe that nothing happens

With this PR, the usages panel and the model editor are fully in sync and show the same methods and clicking "View" always highlights the method in the usages panel.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
