### PR TITLE
Reveal opened files in queries panel

### DIFF
--- a/extensions/ql-vscode/src/queries-panel/queries-panel.ts
+++ b/extensions/ql-vscode/src/queries-panel/queries-panel.ts
@@ -1,47 +1,82 @@
 import { DisposableObject } from "../common/disposable-object";
 import { QueryTreeDataProvider } from "./query-tree-data-provider";
 import { QueryDiscovery } from "./query-discovery";
-import { window } from "vscode";
+import { TextEditor, TreeView, window } from "vscode";
 import { App } from "../common/app";
+import { QueryTreeViewItem } from "./query-tree-view-item";
 
 export class QueriesPanel extends DisposableObject {
+  private readonly dataProvider: QueryTreeDataProvider;
+  private readonly treeView: TreeView<QueryTreeViewItem>;
+
   public constructor(
     queryDiscovery: QueryDiscovery,
     readonly app: App,
   ) {
     super();
 
-    const dataProvider = new QueryTreeDataProvider(queryDiscovery, app);
+    this.dataProvider = new QueryTreeDataProvider(queryDiscovery, app);
 
-    const treeView = window.createTreeView("codeQLQueries", {
-      treeDataProvider: dataProvider,
+    this.treeView = window.createTreeView("codeQLQueries", {
+      treeDataProvider: this.dataProvider,
     });
-    this.push(treeView);
+    this.push(this.treeView);
+
+    // Keep track of whether the user has changed their text editor while
+    // the tree view was not visible. If so, we will focus the text editor
+    // in the tree view when it becomes visible.
+    let changedTextEditor: TextEditor | undefined = undefined;
 
     window.onDidChangeActiveTextEditor((textEditor) => {
+      if (!this.treeView.visible) {
+        changedTextEditor = textEditor;
+
+        return;
+      }
+
+      // Reset the changedTextEditor variable so we don't try to show it when
+      // the tree view becomes next visible.
+      changedTextEditor = undefined;
+
       if (!textEditor) {
         return;
       }
 
-      const filePath = textEditor.document.uri.fsPath;
+      void this.revealTextEditor(textEditor);
+    });
 
-      const item = dataProvider.getTreeItemByPath(filePath);
-      if (!item) {
+    this.treeView.onDidChangeVisibility((e) => {
+      if (!e.visible) {
         return;
       }
 
-      if (
-        treeView.selection.length === 1 &&
-        treeView.selection[0].path === item.path
-      ) {
-        // The item is already selected
+      if (!changedTextEditor) {
         return;
       }
 
-      void treeView.reveal(item, {
-        select: true,
-        focus: false,
-      });
+      void this.revealTextEditor(changedTextEditor);
+    });
+  }
+
+  private revealTextEditor(textEditor: TextEditor): void {
+    const filePath = textEditor.document.uri.fsPath;
+
+    const item = this.dataProvider.getTreeItemByPath(filePath);
+    if (!item) {
+      return;
+    }
+
+    if (
+      this.treeView.selection.length === 1 &&
+      this.treeView.selection[0].path === item.path
+    ) {
+      // The item is already selected
+      return;
+    }
+
+    void this.treeView.reveal(item, {
+      select: true,
+      focus: false,
     });
   }
 }

--- a/extensions/ql-vscode/src/queries-panel/queries-panel.ts
+++ b/extensions/ql-vscode/src/queries-panel/queries-panel.ts
@@ -17,5 +17,31 @@ export class QueriesPanel extends DisposableObject {
       treeDataProvider: dataProvider,
     });
     this.push(treeView);
+
+    window.onDidChangeActiveTextEditor((textEditor) => {
+      if (!textEditor) {
+        return;
+      }
+
+      const filePath = textEditor.document.uri.fsPath;
+
+      const item = dataProvider.getTreeItemByPath(filePath);
+      if (!item) {
+        return;
+      }
+
+      if (
+        treeView.selection.length === 1 &&
+        treeView.selection[0].path === item.path
+      ) {
+        // The item is already selected
+        return;
+      }
+
+      void treeView.reveal(item, {
+        select: true,
+        focus: false,
+      });
+    });
   }
 }

--- a/extensions/ql-vscode/src/queries-panel/queries-panel.ts
+++ b/extensions/ql-vscode/src/queries-panel/queries-panel.ts
@@ -60,6 +60,23 @@ export class QueriesPanel extends DisposableObject {
 
       void this.revealTextEditor(changedTextEditor);
     });
+
+    // If there is an active text editor when activating the extension, we want to show it in the tree view.
+    if (window.activeTextEditor) {
+      // We need to wait for the data provider to load its data. Without this, we will end up in a situation
+      // where we're trying to show an item that does not exist yet since the query discoverer has not yet
+      // finished running.
+      const initialEventDisposable = this.dataProvider.onDidChangeTreeData(
+        () => {
+          if (window.activeTextEditor && this.treeView.visible) {
+            void this.revealTextEditor(window.activeTextEditor);
+          }
+
+          // We only want to listen to this event once, so dispose of the listener to unsubscribe.
+          initialEventDisposable.dispose();
+        },
+      );
+    }
   }
 
   private revealTextEditor(textEditor: TextEditor): void {

--- a/extensions/ql-vscode/src/queries-panel/queries-panel.ts
+++ b/extensions/ql-vscode/src/queries-panel/queries-panel.ts
@@ -22,6 +22,10 @@ export class QueriesPanel extends DisposableObject {
     });
     this.push(this.treeView);
 
+    this.subscribeToTreeSelectionEvents();
+  }
+
+  private subscribeToTreeSelectionEvents(): void {
     // Keep track of whether the user has changed their text editor while
     // the tree view was not visible. If so, we will focus the text editor
     // in the tree view when it becomes visible.

--- a/extensions/ql-vscode/src/queries-panel/query-tree-view-item.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-tree-view-item.ts
@@ -3,7 +3,7 @@ import * as vscode from "vscode";
 export class QueryTreeViewItem extends vscode.TreeItem {
   constructor(
     name: string,
-    public readonly path: string | undefined,
+    public readonly path: string,
     public readonly children: QueryTreeViewItem[],
   ) {
     super(name);


### PR DESCRIPTION
This will focus the currently open query in the queries panel. If a file which is not a query file is opened, it does not change the selection.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
