### PR TITLE
Fix empty message with empty SARIF path

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix a bug where the "View Query Log" action for a query history item was not working. [#2984](https://github.com/github/vscode-codeql/pull/2984)
 - Add a command to sort items in the databases view by language. [#2993](https://github.com/github/vscode-codeql/pull/2993)
 - Fix not being able to open the results directory or evaluator log for a cancelled local query run. [#2996](https://github.com/github/vscode-codeql/pull/2996)
+- Fix empty row in alert path when the SARIF location was empty. [#3018](https://github.com/github/vscode-codeql/pull/3018)
 
 ## 1.9.2 - 12 October 2023
 

--- a/extensions/ql-vscode/src/common/sarif-utils.ts
+++ b/extensions/ql-vscode/src/common/sarif-utils.ts
@@ -1,6 +1,7 @@
 import * as Sarif from "sarif";
 import type { HighlightedRegion } from "../variant-analysis/shared/analysis-result";
 import { ResolvableLocationValue } from "../common/bqrs-cli-types";
+import { isEmptyPath } from "./bqrs-utils";
 
 export interface SarifLink {
   dest: number;
@@ -111,6 +112,9 @@ export function parseSarifLocation(
     return { hint: "no artifact location" };
   if (physicalLocation.artifactLocation.uri === undefined)
     return { hint: "artifact location has no uri" };
+  if (isEmptyPath(physicalLocation.artifactLocation.uri)) {
+    return { hint: "artifact location has empty uri" };
+  }
 
   // This is not necessarily really an absolute uri; it could either be a
   // file uri or a relative uri.

--- a/extensions/ql-vscode/src/stories/results/AlertTable.stories.tsx
+++ b/extensions/ql-vscode/src/stories/results/AlertTable.stories.tsx
@@ -393,6 +393,22 @@ WithCodeFlows.args = {
                             location: {
                               physicalLocation: {
                                 artifactLocation: {
+                                  uri: "file:/",
+                                  index: 5,
+                                },
+                                region: {
+                                  startLine: 13,
+                                  startColumn: 25,
+                                  endColumn: 54,
+                                },
+                              },
+                              message: { text: "id : String" },
+                            },
+                          },
+                          {
+                            location: {
+                              physicalLocation: {
+                                artifactLocation: {
                                   uri: "src/main/java/org/example/HelloController.java",
                                   uriBaseId: "%SRCROOT%",
                                   index: 0,

--- a/extensions/ql-vscode/test/unit-tests/common/sarif-utils.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/common/sarif-utils.test.ts
@@ -76,6 +76,36 @@ describe("parsing sarif", () => {
       ).toEqual({
         hint: "artifact location has no uri",
       });
+      expect(
+        parseSarifLocation(
+          {
+            physicalLocation: {
+              artifactLocation: {
+                uri: "",
+                index: 5,
+              },
+            },
+          },
+          "",
+        ),
+      ).toEqual({
+        hint: "artifact location has empty uri",
+      });
+      expect(
+        parseSarifLocation(
+          {
+            physicalLocation: {
+              artifactLocation: {
+                uri: "file:/",
+                index: 5,
+              },
+            },
+          },
+          "",
+        ),
+      ).toEqual({
+        hint: "artifact location has empty uri",
+      });
     });
 
     it("should parse a sarif location with no region and no file protocol", () => {


### PR DESCRIPTION
This fixes an empty message when the SARIF artifact location is `file://`. I've also added it to a story to see it locally without running a query.

Before:

![Screenshot 2023-10-25 at 15 23 29](https://github.com/github/vscode-codeql/assets/1112623/4cd62439-0fb4-4f8d-8cde-bfa0dc801242)

After:

![Screenshot 2023-10-25 at 15 24 02](https://github.com/github/vscode-codeql/assets/1112623/8be7f6df-535a-4bd2-a3b0-e82d5389b553)

Query that shows this problem: `cpp/ql/src/Security/CWE/CWE-079/CgiXss.ql` with `kirxkirx/vast`.

Closes https://github.com/github/vscode-codeql/issues/1357

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
