### PR TITLE
Use language display name when asking for language

### DIFF
--- a/extensions/ql-vscode/src/databases/database-fetcher.ts
+++ b/extensions/ql-vscode/src/databases/database-fetcher.ts
@@ -32,6 +32,7 @@ import { AppCommandManager } from "../common/commands";
 import { allowHttp } from "../config";
 import { showAndLogInformationMessage } from "../common/logging";
 import { AppOctokit } from "../common/octokit";
+import { getLanguageDisplayName } from "../common/query-language";
 
 /**
  * Prompts a user to fetch a database from a remote location. Database is assumed to be an archive file.
@@ -579,10 +580,23 @@ export async function promptForLanguage(
     return languages[0];
   }
 
-  return await window.showQuickPick(languages, {
+  const items = languages
+    .map((language) => ({
+      label: getLanguageDisplayName(language),
+      description: language,
+      language,
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label));
+
+  const selectedItem = await window.showQuickPick(items, {
     placeHolder: "Select the database language to download:",
     ignoreFocusOut: true,
   });
+  if (!selectedItem) {
+    return undefined;
+  }
+
+  return selectedItem.language;
 }
 
 /**

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/local-queries/skeleton-query-wizard.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/local-queries/skeleton-query-wizard.test.ts
@@ -65,7 +65,7 @@ describe("SkeletonQueryWizard", () => {
 
   beforeEach(async () => {
     mockCli = mockedObject<CodeQLCliServer>({
-      resolveLanguages: jest
+      getSupportedLanguages: jest
         .fn()
         .mockResolvedValue([
           "ruby",
@@ -76,7 +76,6 @@ describe("SkeletonQueryWizard", () => {
           "csharp",
           "cpp",
         ]),
-      getSupportedLanguages: jest.fn(),
     });
 
     mockDatabaseManager = mockedObject<DatabaseManager>({
@@ -102,9 +101,12 @@ describe("SkeletonQueryWizard", () => {
       },
     ] as WorkspaceFolder[]);
 
-    quickPickSpy = jest
-      .spyOn(window, "showQuickPick")
-      .mockResolvedValueOnce(mockedQuickPickItem(chosenLanguage));
+    quickPickSpy = jest.spyOn(window, "showQuickPick").mockResolvedValueOnce(
+      mockedQuickPickItem({
+        label: chosenLanguage,
+        language: chosenLanguage,
+      }),
+    );
     showInputBoxSpy = jest
       .spyOn(window, "showInputBox")
       .mockResolvedValue(storagePath);

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
@@ -79,9 +79,12 @@ describe("Variant Analysis Manager", () => {
     ).fsPath;
 
     beforeEach(async () => {
-      jest
-        .spyOn(window, "showQuickPick")
-        .mockResolvedValueOnce(mockedQuickPickItem("javascript"));
+      jest.spyOn(window, "showQuickPick").mockResolvedValueOnce(
+        mockedQuickPickItem({
+          label: "JavaScript",
+          language: "javascript",
+        }),
+      );
 
       cancellationTokenSource = new CancellationTokenSource();
 

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-submission-integration.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-submission-integration.test.ts
@@ -67,7 +67,12 @@ describe("Variant Analysis Submission Integration", () => {
       await showQlDocument("query.ql");
 
       // Select target language for your query
-      quickPickSpy.mockResolvedValueOnce(mockedQuickPickItem("javascript"));
+      quickPickSpy.mockResolvedValueOnce(
+        mockedQuickPickItem({
+          label: "JavaScript",
+          language: "javascript",
+        }),
+      );
 
       await commandManager.execute("codeQL.runVariantAnalysis");
 
@@ -106,7 +111,12 @@ describe("Variant Analysis Submission Integration", () => {
       await showQlDocument("query.ql");
 
       // Select target language for your query
-      quickPickSpy.mockResolvedValueOnce(mockedQuickPickItem("javascript"));
+      quickPickSpy.mockResolvedValueOnce(
+        mockedQuickPickItem({
+          label: "JavaScript",
+          language: "javascript",
+        }),
+      );
 
       await commandManager.execute("codeQL.runVariantAnalysis");
 

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/databases/database-fetcher.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/databases/database-fetcher.test.ts
@@ -73,7 +73,12 @@ describe("database-fetcher", () => {
 
     it("should convert a GitHub nwo to a database url", async () => {
       mockRequest.mockResolvedValue(successfullMockApiResponse);
-      quickPickSpy.mockResolvedValue(mockedQuickPickItem("javascript"));
+      quickPickSpy.mockResolvedValue(
+        mockedQuickPickItem({
+          label: "JavaScript",
+          language: "javascript",
+        }),
+      );
       const githubRepo = "github/codeql";
       const result = await convertGithubNwoToDatabaseUrl(
         githubRepo,
@@ -94,7 +99,23 @@ describe("database-fetcher", () => {
       expect(owner).toBe("github");
       expect(quickPickSpy).toHaveBeenNthCalledWith(
         1,
-        ["csharp", "javascript", "ql"],
+        [
+          expect.objectContaining({
+            label: "C#",
+            description: "csharp",
+            language: "csharp",
+          }),
+          expect.objectContaining({
+            label: "JavaScript",
+            description: "javascript",
+            language: "javascript",
+          }),
+          expect.objectContaining({
+            label: "ql",
+            description: "ql",
+            language: "ql",
+          }),
+        ],
         expect.anything(),
       );
     });


### PR DESCRIPTION
This will show the language display name when asking for a language (when creating a query or when running a query without detecting the language automatically). It will also sort the languages alphabetically.

![Screenshot 2023-10-27 at 10 25 59](https://github.com/github/vscode-codeql/assets/1112623/8ddade16-e227-41c6-b7fd-cfd9edf6bbb5)

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
