### PR TITLE
Only show flow generation button when supported

### DIFF
--- a/extensions/ql-vscode/src/model-editor/flow-model-queries.ts
+++ b/extensions/ql-vscode/src/model-editor/flow-model-queries.ts
@@ -15,6 +15,17 @@ import { runQuery } from "../local-queries/run-query";
 import { resolveQueries } from "../local-queries";
 import { QueryLanguage } from "../common/query-language";
 
+const FLOW_MODEL_SUPPORTED_LANGUAGES = [
+  QueryLanguage.CSharp,
+  QueryLanguage.Java,
+];
+
+export function isFlowModelGenerationSupported(
+  language: QueryLanguage,
+): boolean {
+  return FLOW_MODEL_SUPPORTED_LANGUAGES.includes(language);
+}
+
 type FlowModelOptions = {
   cliServer: CodeQLCliServer;
   queryRunner: QueryRunner;

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -23,7 +23,10 @@ import {
 import { DatabaseItem, DatabaseManager } from "../databases/local-databases";
 import { CodeQLCliServer } from "../codeql-cli/cli";
 import { asError, assertNever, getErrorMessage } from "../common/helpers-pure";
-import { runFlowModelQueries } from "./flow-model-queries";
+import {
+  isFlowModelGenerationSupported,
+  runFlowModelQueries,
+} from "./flow-model-queries";
 import { promptImportGithubDatabase } from "../databases/database-fetcher";
 import { App } from "../common/app";
 import { redactableError } from "../common/errors";
@@ -363,6 +366,10 @@ export class ModelEditorView extends AbstractWebview<
   }
 
   private async setViewState(): Promise<void> {
+    const showFlowGeneration =
+      this.modelConfig.flowGeneration &&
+      isFlowModelGenerationSupported(this.language);
+
     const showLlmButton =
       this.databaseItem.language === "java" && this.modelConfig.llmGeneration;
 
@@ -374,7 +381,7 @@ export class ModelEditorView extends AbstractWebview<
       viewState: {
         extensionPack: this.extensionPack,
         language: this.language,
-        showFlowGeneration: this.modelConfig.flowGeneration,
+        showFlowGeneration,
         showLlmButton,
         showMultipleModels: this.modelConfig.showMultipleModels,
         mode: this.modelingStore.getMode(this.databaseItem),


### PR DESCRIPTION
This will hide the flow generation button for non-supported languages. Currently, all languages supported by the model editor also have support for flow generation.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
