### PR TITLE
Fix data flow path dropdown not updating

### DIFF
--- a/extensions/ql-vscode/src/view/common/CodePaths/CodeFlowsDropdown.tsx
+++ b/extensions/ql-vscode/src/view/common/CodePaths/CodeFlowsDropdown.tsx
@@ -12,11 +12,13 @@ const getCodeFlowName = (codeFlow: CodeFlow) => {
 
 type CodeFlowsDropdownProps = {
   codeFlows: CodeFlow[];
+  selectedCodeFlow: CodeFlow;
   setSelectedCodeFlow: (value: SetStateAction<CodeFlow>) => void;
 };
 
 export const CodeFlowsDropdown = ({
   codeFlows,
+  selectedCodeFlow,
   setSelectedCodeFlow,
 }: CodeFlowsDropdownProps) => {
   const handleChange = useCallback(
@@ -28,13 +30,12 @@ export const CodeFlowsDropdown = ({
     [setSelectedCodeFlow, codeFlows],
   );
 
+  const value = codeFlows
+    .findIndex((codeFlow) => selectedCodeFlow === codeFlow)
+    .toString();
+
   return (
-    <VSCodeDropdown
-      onChange={
-        handleChange as ((e: Event) => unknown) &
-          React.FormEventHandler<HTMLElement>
-      }
-    >
+    <VSCodeDropdown value={value} onChange={handleChange}>
       {codeFlows.map((codeFlow, index) => (
         <VSCodeOption key={index} value={index.toString()}>
           {getCodeFlowName(codeFlow)}

--- a/extensions/ql-vscode/src/view/data-flow-paths/DataFlowPaths.tsx
+++ b/extensions/ql-vscode/src/view/data-flow-paths/DataFlowPaths.tsx
@@ -60,6 +60,7 @@ export const DataFlowPaths = ({
         <PathDropdownContainer>
           <CodeFlowsDropdown
             codeFlows={codeFlows}
+            selectedCodeFlow={selectedCodeFlow}
             setSelectedCodeFlow={setSelectedCodeFlow}
           />
         </PathDropdownContainer>


### PR DESCRIPTION
This fixes an issue where the data flow path dropdown was not updating when clicking on "View paths" when the view was already open. The available data flows would change and the [`DataFlowPaths` would change its selection](https://github.com/github/vscode-codeql/blob/92ad718df13f24bc3db81e9b11ee6bbe0b612448/extensions/ql-vscode/src/view/data-flow-paths/DataFlowPaths.tsx#L44-L47), but this was not propagated to the dropdown. By explicitly passing a `value` to the dropdown, this fixes it.

Original reproduction steps (reported by `@owen-mc`):
- Click on “Show paths” for a result.
- You are taken to a new tab called “Data Flow Paths” which has a drop-down menu showing the file name (I haven’t come across a scenario when it has more than one option).
- Leave this tab open and go back to the results tab.
- Click on “Show paths” for a different result from a different file.
- Your focus is moved back to the same “Show paths” tab, which has been updated, but the drop-down menu still shows the file name from the first result. The first time that you click on it, it updates to the correct file name.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
