### PR TITLE
Switch `ModeledMethod` to union of types

### DIFF
--- a/extensions/ql-vscode/src/common/mutable.ts
+++ b/extensions/ql-vscode/src/common/mutable.ts
@@ -1,0 +1,6 @@
+/**
+ * Remove all readonly modifiers from a type.
+ */
+export type Mutable<T> = {
+  -readonly [P in keyof T]: T[P];
+};

--- a/extensions/ql-vscode/src/model-editor/auto-modeler.ts
+++ b/extensions/ql-vscode/src/model-editor/auto-modeler.ts
@@ -219,8 +219,6 @@ export class AutoModeler {
           {
             type: "neutral",
             kind: "sink",
-            input: "",
-            output: "",
             provenance: "ai-generated",
             signature: candidate.signature,
             packageName: candidate.packageName,

--- a/extensions/ql-vscode/src/model-editor/flow-model-queries.ts
+++ b/extensions/ql-vscode/src/model-editor/flow-model-queries.ts
@@ -5,10 +5,13 @@ import { QueryRunner } from "../query-server";
 import { CodeQLCliServer } from "../codeql-cli/cli";
 import { showAndLogExceptionWithTelemetry } from "../common/logging";
 import { extLogger } from "../common/logging/vscode";
-import { getModelsAsDataLanguage } from "./languages";
+import {
+  getModelsAsDataLanguageModel,
+  ModelsAsDataLanguagePredicates,
+} from "./languages";
 import { ProgressCallback } from "../common/vscode/progress";
 import { getOnDiskWorkspaceFolders } from "../common/vscode/workspace-folders";
-import { ModeledMethod, ModeledMethodType } from "./modeled-method";
+import { ModeledMethod } from "./modeled-method";
 import { redactableError } from "../common/errors";
 import { telemetryListener } from "../common/vscode/telemetry";
 import { runQuery } from "../local-queries/run-query";
@@ -109,7 +112,7 @@ async function resolveFlowQueries(
 }
 
 async function runSingleFlowQuery(
-  type: Exclude<ModeledMethodType, "none">,
+  type: keyof ModelsAsDataLanguagePredicates,
   queryPath: string | undefined,
   queryStep: number,
   {
@@ -154,9 +157,7 @@ async function runSingleFlowQuery(
   }
 
   // Interpret the results
-  const modelsAsDataLanguage = getModelsAsDataLanguage(language);
-
-  const definition = modelsAsDataLanguage.predicates[type];
+  const definition = getModelsAsDataLanguageModel(language, type);
 
   const bqrsPath = completedQuery.outputDir.bqrsPath;
 

--- a/extensions/ql-vscode/src/model-editor/languages/languages.ts
+++ b/extensions/ql-vscode/src/model-editor/languages/languages.ts
@@ -28,7 +28,7 @@ export function getModelsAsDataLanguageModel<
 ): NonNullable<ModelsAsDataLanguagePredicates[T]> {
   const definition = getModelsAsDataLanguage(language).predicates[model];
   if (!definition) {
-    throw new Error(`No models-as-data definition for ${model}`);
+    throw new Error(`No models-as-data predicate for ${model}`);
   }
   return definition;
 }

--- a/extensions/ql-vscode/src/model-editor/languages/languages.ts
+++ b/extensions/ql-vscode/src/model-editor/languages/languages.ts
@@ -1,5 +1,8 @@
 import { QueryLanguage } from "../../common/query-language";
-import { ModelsAsDataLanguage } from "./models-as-data";
+import {
+  ModelsAsDataLanguage,
+  ModelsAsDataLanguagePredicates,
+} from "./models-as-data";
 import { staticLanguage } from "./static";
 
 const languages: Partial<Record<QueryLanguage, ModelsAsDataLanguage>> = {
@@ -13,6 +16,19 @@ export function getModelsAsDataLanguage(
   const definition = languages[language];
   if (!definition) {
     throw new Error(`No models-as-data definition for ${language}`);
+  }
+  return definition;
+}
+
+export function getModelsAsDataLanguageModel<
+  T extends keyof ModelsAsDataLanguagePredicates,
+>(
+  language: QueryLanguage,
+  model: T,
+): NonNullable<ModelsAsDataLanguagePredicates[T]> {
+  const definition = getModelsAsDataLanguage(language).predicates[model];
+  if (!definition) {
+    throw new Error(`No models-as-data definition for ${model}`);
   }
   return definition;
 }

--- a/extensions/ql-vscode/src/model-editor/languages/models-as-data.ts
+++ b/extensions/ql-vscode/src/model-editor/languages/models-as-data.ts
@@ -1,23 +1,29 @@
 import { MethodDefinition } from "../method";
-import { ModeledMethod, ModeledMethodType } from "../modeled-method";
+import {
+  ModeledMethod,
+  NeutralModeledMethod,
+  SinkModeledMethod,
+  SourceModeledMethod,
+  SummaryModeledMethod,
+} from "../modeled-method";
 import { DataTuple } from "../model-extension-file";
 
-type GenerateMethodDefinition = (method: ModeledMethod) => DataTuple[];
+type GenerateMethodDefinition<T> = (method: T) => DataTuple[];
 type ReadModeledMethod = (row: DataTuple[]) => ModeledMethod;
 
-export type ModelsAsDataLanguageModelType = Exclude<ModeledMethodType, "none">;
-
-export type ModelsAsDataLanguagePredicate = {
+export type ModelsAsDataLanguagePredicate<T> = {
   extensiblePredicate: string;
   supportedKinds: string[];
-  generateMethodDefinition: GenerateMethodDefinition;
+  generateMethodDefinition: GenerateMethodDefinition<T>;
   readModeledMethod: ReadModeledMethod;
 };
 
-export type ModelsAsDataLanguagePredicates = Record<
-  ModelsAsDataLanguageModelType,
-  ModelsAsDataLanguagePredicate
->;
+export type ModelsAsDataLanguagePredicates = {
+  source?: ModelsAsDataLanguagePredicate<SourceModeledMethod>;
+  sink?: ModelsAsDataLanguagePredicate<SinkModeledMethod>;
+  summary?: ModelsAsDataLanguagePredicate<SummaryModeledMethod>;
+  neutral?: ModelsAsDataLanguagePredicate<NeutralModeledMethod>;
+};
 
 export type ModelsAsDataLanguage = {
   createMethodSignature: (method: MethodDefinition) => string;

--- a/extensions/ql-vscode/src/model-editor/languages/static.ts
+++ b/extensions/ql-vscode/src/model-editor/languages/static.ts
@@ -1,5 +1,5 @@
 import { ModelsAsDataLanguage } from "./models-as-data";
-import { ModeledMethodType, Provenance } from "../modeled-method";
+import { Provenance } from "../modeled-method";
 import { DataTuple } from "../model-extension-file";
 import { sharedExtensiblePredicates, sharedKinds } from "./shared";
 
@@ -34,7 +34,7 @@ export const staticLanguage: ModelsAsDataLanguage = {
         method.provenance,
       ],
       readModeledMethod: (row) => ({
-        type: "source" as ModeledMethodType,
+        type: "source",
         input: "",
         output: row[6] as string,
         kind: row[7] as string,

--- a/extensions/ql-vscode/src/model-editor/modeled-method-empty.ts
+++ b/extensions/ql-vscode/src/model-editor/modeled-method-empty.ts
@@ -1,0 +1,89 @@
+import { ModeledMethod, SinkModeledMethod } from "./modeled-method";
+import { MethodSignature } from "./method";
+import { assertNever } from "../common/helpers-pure";
+
+export function createEmptyModeledMethod(
+  type: ModeledMethod["type"],
+  methodSignature: MethodSignature,
+) {
+  const canonicalMethodSignature: MethodSignature = {
+    packageName: methodSignature.packageName,
+    typeName: methodSignature.typeName,
+    methodName: methodSignature.methodName,
+    methodParameters: methodSignature.methodParameters,
+    signature: methodSignature.signature,
+  };
+
+  switch (type) {
+    case "none":
+      return createEmptyNoneModeledMethod(canonicalMethodSignature);
+    case "source":
+      return createEmptySourceModeledMethod(canonicalMethodSignature);
+    case "sink":
+      return createEmptySinkModeledMethod(canonicalMethodSignature);
+    case "summary":
+      return createEmptySummaryModeledMethod(canonicalMethodSignature);
+    case "neutral":
+      return createEmptyNeutralModeledMethod(canonicalMethodSignature);
+    default:
+      assertNever(type);
+  }
+}
+
+function createEmptyNoneModeledMethod(
+  methodSignature: MethodSignature,
+): ModeledMethod {
+  return {
+    ...methodSignature,
+    type: "none",
+    provenance: "manual",
+  };
+}
+
+function createEmptySourceModeledMethod(
+  methodSignature: MethodSignature,
+): ModeledMethod {
+  return {
+    ...methodSignature,
+    type: "source",
+    output: "",
+    kind: "",
+    provenance: "manual",
+  };
+}
+
+function createEmptySinkModeledMethod(
+  methodSignature: MethodSignature,
+): SinkModeledMethod {
+  return {
+    ...methodSignature,
+    type: "sink",
+    input: "",
+    kind: "",
+    provenance: "manual",
+  };
+}
+
+function createEmptySummaryModeledMethod(
+  methodSignature: MethodSignature,
+): ModeledMethod {
+  return {
+    ...methodSignature,
+    type: "summary",
+    input: "",
+    output: "",
+    kind: "",
+    provenance: "manual",
+  };
+}
+
+function createEmptyNeutralModeledMethod(
+  methodSignature: MethodSignature,
+): ModeledMethod {
+  return {
+    ...methodSignature,
+    type: "neutral",
+    kind: "",
+    provenance: "manual",
+  };
+}

--- a/extensions/ql-vscode/src/model-editor/modeled-method-empty.ts
+++ b/extensions/ql-vscode/src/model-editor/modeled-method-empty.ts
@@ -36,7 +36,6 @@ function createEmptyNoneModeledMethod(
   return {
     ...methodSignature,
     type: "none",
-    provenance: "manual",
   };
 }
 

--- a/extensions/ql-vscode/src/model-editor/modeled-method.ts
+++ b/extensions/ql-vscode/src/model-editor/modeled-method.ts
@@ -19,12 +19,87 @@ export type Provenance =
   // Entered by the user in the editor manually
   | "manual";
 
-export interface ModeledMethod extends MethodSignature {
-  readonly type: ModeledMethodType;
+export interface NoneModeledMethod extends MethodSignature {
+  readonly type: "none";
+  // Provenance is always propagated
+  readonly provenance: Provenance;
+}
+
+export interface SourceModeledMethod extends MethodSignature {
+  readonly type: "source";
+  readonly output: string;
+  readonly kind: ModeledMethodKind;
+  readonly provenance: Provenance;
+}
+
+export interface SinkModeledMethod extends MethodSignature {
+  readonly type: "sink";
+  readonly input: string;
+  readonly kind: ModeledMethodKind;
+  readonly provenance: Provenance;
+}
+
+export interface SummaryModeledMethod extends MethodSignature {
+  readonly type: "summary";
   readonly input: string;
   readonly output: string;
   readonly kind: ModeledMethodKind;
   readonly provenance: Provenance;
 }
 
+export interface NeutralModeledMethod extends MethodSignature {
+  readonly type: "neutral";
+  readonly kind: ModeledMethodKind;
+  readonly provenance: Provenance;
+}
+
+export type ModeledMethod =
+  | NoneModeledMethod
+  | SourceModeledMethod
+  | SinkModeledMethod
+  | SummaryModeledMethod
+  | NeutralModeledMethod;
+
 export type ModeledMethodKind = string;
+
+export function modeledMethodSupportsKind(
+  modeledMethod: ModeledMethod,
+): modeledMethod is
+  | SourceModeledMethod
+  | SinkModeledMethod
+  | SummaryModeledMethod
+  | NeutralModeledMethod {
+  return (
+    modeledMethod.type === "source" ||
+    modeledMethod.type === "sink" ||
+    modeledMethod.type === "summary" ||
+    modeledMethod.type === "neutral"
+  );
+}
+
+export function modeledMethodSupportsInput(
+  modeledMethod: ModeledMethod,
+): modeledMethod is SinkModeledMethod | SummaryModeledMethod {
+  return modeledMethod.type === "sink" || modeledMethod.type === "summary";
+}
+
+export function modeledMethodSupportsOutput(
+  modeledMethod: ModeledMethod,
+): modeledMethod is SourceModeledMethod | SummaryModeledMethod {
+  return modeledMethod.type === "source" || modeledMethod.type === "summary";
+}
+
+export function modeledMethodSupportsProvenance(
+  modeledMethod: ModeledMethod,
+): modeledMethod is
+  | SourceModeledMethod
+  | SinkModeledMethod
+  | SummaryModeledMethod
+  | NeutralModeledMethod {
+  return (
+    modeledMethod.type === "source" ||
+    modeledMethod.type === "sink" ||
+    modeledMethod.type === "summary" ||
+    modeledMethod.type === "neutral"
+  );
+}

--- a/extensions/ql-vscode/src/model-editor/modeled-method.ts
+++ b/extensions/ql-vscode/src/model-editor/modeled-method.ts
@@ -21,8 +21,6 @@ export type Provenance =
 
 export interface NoneModeledMethod extends MethodSignature {
   readonly type: "none";
-  // Provenance is always propagated
-  readonly provenance: Provenance;
 }
 
 export interface SourceModeledMethod extends MethodSignature {

--- a/extensions/ql-vscode/src/model-editor/shared/validation.ts
+++ b/extensions/ql-vscode/src/model-editor/shared/validation.ts
@@ -1,4 +1,4 @@
-import { ModeledMethod } from "../modeled-method";
+import { ModeledMethod, NeutralModeledMethod } from "../modeled-method";
 import { MethodSignature } from "../method";
 import { assertNever } from "../../common/helpers-pure";
 
@@ -37,16 +37,12 @@ function canonicalizeModeledMethod(
       return {
         ...methodSignature,
         type: "none",
-        input: "",
-        output: "",
-        kind: "",
         provenance: "manual",
       };
     case "source":
       return {
         ...methodSignature,
         type: "source",
-        input: "",
         output: modeledMethod.output,
         kind: modeledMethod.kind,
         provenance: "manual",
@@ -56,7 +52,6 @@ function canonicalizeModeledMethod(
         ...methodSignature,
         type: "sink",
         input: modeledMethod.input,
-        output: "",
         kind: modeledMethod.kind,
         provenance: "manual",
       };
@@ -73,13 +68,11 @@ function canonicalizeModeledMethod(
       return {
         ...methodSignature,
         type: "neutral",
-        input: "",
-        output: "",
         kind: modeledMethod.kind,
         provenance: "manual",
       };
     default:
-      assertNever(modeledMethod.type);
+      assertNever(modeledMethod);
   }
 }
 
@@ -118,7 +111,8 @@ export function validateModeledMethods(
   }
 
   const neutralModeledMethods = consideredModeledMethods.filter(
-    (modeledMethod) => modeledMethod.type === "neutral",
+    (modeledMethod): modeledMethod is NeutralModeledMethod =>
+      modeledMethod.type === "neutral",
   );
 
   const neutralModeledMethodsByKind = new Map<string, ModeledMethod[]>();

--- a/extensions/ql-vscode/src/model-editor/shared/validation.ts
+++ b/extensions/ql-vscode/src/model-editor/shared/validation.ts
@@ -37,7 +37,6 @@ function canonicalizeModeledMethod(
       return {
         ...methodSignature,
         type: "none",
-        provenance: "manual",
       };
     case "source":
       return {

--- a/extensions/ql-vscode/src/stories/method-modeling/MethodModeling.stories.tsx
+++ b/extensions/ql-vscode/src/stories/method-modeling/MethodModeling.stories.tsx
@@ -4,7 +4,11 @@ import { Meta, StoryFn } from "@storybook/react";
 
 import { MethodModeling as MethodModelingComponent } from "../../view/method-modeling/MethodModeling";
 import { createMethod } from "../../../test/factories/model-editor/method-factories";
-import { createModeledMethod } from "../../../test/factories/model-editor/modeled-method-factories";
+import {
+  createNeutralModeledMethod,
+  createSinkModeledMethod,
+  createSourceModeledMethod,
+} from "../../../test/factories/model-editor/modeled-method-factories";
 export default {
   title: "Method Modeling/Method Modeling",
   component: MethodModelingComponent,
@@ -48,7 +52,7 @@ MultipleModelingsUnmodeled.args = {
 export const MultipleModelingsModeledSingle = Template.bind({});
 MultipleModelingsModeledSingle.args = {
   method,
-  modeledMethods: [createModeledMethod(method)],
+  modeledMethods: [createSinkModeledMethod(method)],
   showMultipleModels: true,
   modelingStatus: "saved",
 };
@@ -57,11 +61,10 @@ export const MultipleModelingsModeledMultiple = Template.bind({});
 MultipleModelingsModeledMultiple.args = {
   method,
   modeledMethods: [
-    createModeledMethod(method),
-    createModeledMethod({
+    createSinkModeledMethod(method),
+    createSourceModeledMethod({
       ...method,
       type: "source",
-      input: "",
       output: "ReturnValue",
       kind: "remote",
     }),
@@ -74,11 +77,8 @@ export const MultipleModelingsValidationFailedNeutral = Template.bind({});
 MultipleModelingsValidationFailedNeutral.args = {
   method,
   modeledMethods: [
-    createModeledMethod(method),
-    createModeledMethod({
-      ...method,
-      type: "neutral",
-    }),
+    createSinkModeledMethod(method),
+    createNeutralModeledMethod(method),
   ],
   showMultipleModels: true,
   modelingStatus: "unsaved",
@@ -88,15 +88,13 @@ export const MultipleModelingsValidationFailedDuplicate = Template.bind({});
 MultipleModelingsValidationFailedDuplicate.args = {
   method,
   modeledMethods: [
-    createModeledMethod(method),
-    createModeledMethod({
+    createSinkModeledMethod(method),
+    createSourceModeledMethod({
       ...method,
-      type: "source",
-      input: "",
       output: "ReturnValue",
       kind: "remote",
     }),
-    createModeledMethod(method),
+    createSinkModeledMethod(method),
   ],
   showMultipleModels: true,
   modelingStatus: "unsaved",

--- a/extensions/ql-vscode/src/stories/method-modeling/MethodModelingInputs.stories.tsx
+++ b/extensions/ql-vscode/src/stories/method-modeling/MethodModelingInputs.stories.tsx
@@ -4,7 +4,7 @@ import { Meta, StoryFn } from "@storybook/react";
 
 import { MethodModelingInputs as MethodModelingInputsComponent } from "../../view/method-modeling/MethodModelingInputs";
 import { createMethod } from "../../../test/factories/model-editor/method-factories";
-import { createModeledMethod } from "../../../test/factories/model-editor/modeled-method-factories";
+import { createSinkModeledMethod } from "../../../test/factories/model-editor/modeled-method-factories";
 import { useState } from "react";
 import { ModeledMethod } from "../../model-editor/modeled-method";
 
@@ -39,7 +39,7 @@ const Template: StoryFn<typeof MethodModelingInputsComponent> = (args) => {
 };
 
 const method = createMethod();
-const modeledMethod = createModeledMethod();
+const modeledMethod = createSinkModeledMethod();
 
 export const UnmodeledMethod = Template.bind({});
 UnmodeledMethod.args = {

--- a/extensions/ql-vscode/src/stories/method-modeling/MultipleModeledMethodsPanel.stories.tsx
+++ b/extensions/ql-vscode/src/stories/method-modeling/MultipleModeledMethodsPanel.stories.tsx
@@ -5,7 +5,10 @@ import { Meta, StoryFn } from "@storybook/react";
 
 import { MultipleModeledMethodsPanel as MultipleModeledMethodsPanelComponent } from "../../view/method-modeling/MultipleModeledMethodsPanel";
 import { createMethod } from "../../../test/factories/model-editor/method-factories";
-import { createModeledMethod } from "../../../test/factories/model-editor/modeled-method-factories";
+import {
+  createSinkModeledMethod,
+  createSourceModeledMethod,
+} from "../../../test/factories/model-editor/modeled-method-factories";
 import { ModeledMethod } from "../../model-editor/modeled-method";
 
 export default {
@@ -52,18 +55,16 @@ Unmodeled.args = {
 export const Single = Template.bind({});
 Single.args = {
   method,
-  modeledMethods: [createModeledMethod(method)],
+  modeledMethods: [createSinkModeledMethod(method)],
 };
 
 export const Multiple = Template.bind({});
 Multiple.args = {
   method,
   modeledMethods: [
-    createModeledMethod(method),
-    createModeledMethod({
+    createSinkModeledMethod(method),
+    createSourceModeledMethod({
       ...method,
-      type: "source",
-      input: "",
       output: "ReturnValue",
       kind: "remote",
     }),

--- a/extensions/ql-vscode/src/stories/model-editor/LibraryRow.stories.tsx
+++ b/extensions/ql-vscode/src/stories/model-editor/LibraryRow.stories.tsx
@@ -149,7 +149,6 @@ LibraryRow.args = {
       {
         type: "sink",
         input: "Argument[0]",
-        output: "",
         kind: "jndi-injection",
         provenance: "df-generated",
         signature: "org.sql2o.Sql2o#Sql2o(String)",
@@ -190,9 +189,7 @@ LibraryRow.args = {
     "org.sql2o.Query#executeScalar(Class)": [
       {
         type: "neutral",
-        input: "",
-        output: "",
-        kind: "",
+        kind: "summary",
         provenance: "df-generated",
         signature: "org.sql2o.Query#executeScalar(Class)",
         packageName: "org.sql2o",
@@ -204,9 +201,7 @@ LibraryRow.args = {
     "org.sql2o.Sql2o#Sql2o(String,String,String)": [
       {
         type: "neutral",
-        input: "",
-        output: "",
-        kind: "",
+        kind: "sink",
         provenance: "df-generated",
         signature: "org.sql2o.Sql2o#Sql2o(String,String,String)",
         packageName: "org.sql2o",

--- a/extensions/ql-vscode/src/stories/model-editor/ModelEditor.stories.tsx
+++ b/extensions/ql-vscode/src/stories/model-editor/ModelEditor.stories.tsx
@@ -219,7 +219,6 @@ ModelEditor.args = {
       {
         type: "sink",
         input: "Argument[0]",
-        output: "",
         kind: "jndi-injection",
         provenance: "df-generated",
         signature: "org.sql2o.Sql2o#Sql2o(String)",
@@ -260,9 +259,7 @@ ModelEditor.args = {
     "org.sql2o.Query#executeScalar(Class)": [
       {
         type: "neutral",
-        input: "",
-        output: "",
-        kind: "",
+        kind: "sink",
         provenance: "df-generated",
         signature: "org.sql2o.Query#executeScalar(Class)",
         packageName: "org.sql2o",
@@ -274,9 +271,7 @@ ModelEditor.args = {
     "org.sql2o.Sql2o#Sql2o(String,String,String)": [
       {
         type: "neutral",
-        input: "",
-        output: "",
-        kind: "",
+        kind: "sink",
         provenance: "df-generated",
         signature: "org.sql2o.Sql2o#Sql2o(String,String,String)",
         packageName: "org.sql2o",

--- a/extensions/ql-vscode/src/view/method-modeling/MultipleModeledMethodsPanel.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/MultipleModeledMethodsPanel.tsx
@@ -94,9 +94,6 @@ export const MultipleModeledMethodsPanel = ({
   const handleAddClick = useCallback(() => {
     const newModeledMethod: ModeledMethod = {
       type: "none",
-      input: "",
-      output: "",
-      kind: "",
       provenance: "manual",
       signature: method.signature,
       packageName: method.packageName,

--- a/extensions/ql-vscode/src/view/method-modeling/MultipleModeledMethodsPanel.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/MultipleModeledMethodsPanel.tsx
@@ -13,6 +13,7 @@ import { Codicon } from "../common";
 import { validateModeledMethods } from "../../model-editor/shared/validation";
 import { ModeledMethodAlert } from "./ModeledMethodAlert";
 import { QueryLanguage } from "../../common/query-language";
+import { createEmptyModeledMethod } from "../../model-editor/modeled-method-empty";
 
 export type MultipleModeledMethodsPanelProps = {
   language: QueryLanguage;
@@ -92,15 +93,10 @@ export const MultipleModeledMethodsPanel = ({
   );
 
   const handleAddClick = useCallback(() => {
-    const newModeledMethod: ModeledMethod = {
-      type: "none",
-      provenance: "manual",
-      signature: method.signature,
-      packageName: method.packageName,
-      typeName: method.typeName,
-      methodName: method.methodName,
-      methodParameters: method.methodParameters,
-    };
+    const newModeledMethod: ModeledMethod = createEmptyModeledMethod(
+      "none",
+      method,
+    );
 
     const newModeledMethods = [...modeledMethods, newModeledMethod];
 

--- a/extensions/ql-vscode/src/view/method-modeling/__tests__/MethodModeling.spec.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/__tests__/MethodModeling.spec.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { render as reactRender, screen } from "@testing-library/react";
 import { MethodModeling, MethodModelingProps } from "../MethodModeling";
 import { createMethod } from "../../../../test/factories/model-editor/method-factories";
-import { createModeledMethod } from "../../../../test/factories/model-editor/modeled-method-factories";
+import { createSinkModeledMethod } from "../../../../test/factories/model-editor/modeled-method-factories";
 import { QueryLanguage } from "../../../common/query-language";
 
 describe(MethodModeling.name, () => {
@@ -11,7 +11,7 @@ describe(MethodModeling.name, () => {
 
   it("renders method modeling panel", () => {
     const method = createMethod();
-    const modeledMethod = createModeledMethod();
+    const modeledMethod = createSinkModeledMethod();
     const isModelingInProgress = false;
     const onChange = jest.fn();
 

--- a/extensions/ql-vscode/src/view/method-modeling/__tests__/MethodModelingInputs.spec.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/__tests__/MethodModelingInputs.spec.tsx
@@ -6,8 +6,12 @@ import {
   MethodModelingInputsProps,
 } from "../MethodModelingInputs";
 import { createMethod } from "../../../../test/factories/model-editor/method-factories";
-import { createModeledMethod } from "../../../../test/factories/model-editor/modeled-method-factories";
+import {
+  createMethodSignature,
+  createSinkModeledMethod,
+} from "../../../../test/factories/model-editor/modeled-method-factories";
 import { QueryLanguage } from "../../../common/query-language";
+import { createEmptyModeledMethod } from "../../../model-editor/modeled-method-empty";
 
 describe(MethodModelingInputs.name, () => {
   const render = (props: MethodModelingInputsProps) =>
@@ -15,7 +19,7 @@ describe(MethodModelingInputs.name, () => {
 
   const language = QueryLanguage.Java;
   const method = createMethod();
-  const modeledMethod = createModeledMethod();
+  const modeledMethod = createSinkModeledMethod();
   const isModelingInProgress = false;
   const onChange = jest.fn();
 
@@ -76,9 +80,10 @@ describe(MethodModelingInputs.name, () => {
       onChange,
     });
 
-    const updatedModeledMethod = createModeledMethod({
-      type: "source",
-    });
+    const updatedModeledMethod = createEmptyModeledMethod(
+      "source",
+      createMethodSignature(),
+    );
 
     rerender(
       <MethodModelingInputs

--- a/extensions/ql-vscode/src/view/method-modeling/__tests__/ModeledMethodsPanel.spec.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/__tests__/ModeledMethodsPanel.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { render as reactRender, screen } from "@testing-library/react";
 import { createMethod } from "../../../../test/factories/model-editor/method-factories";
-import { createModeledMethod } from "../../../../test/factories/model-editor/modeled-method-factories";
+import { createSinkModeledMethod } from "../../../../test/factories/model-editor/modeled-method-factories";
 import {
   ModeledMethodsPanel,
   ModeledMethodsPanelProps,
@@ -14,7 +14,7 @@ describe(ModeledMethodsPanel.name, () => {
 
   const language = QueryLanguage.Java;
   const method = createMethod();
-  const modeledMethods = [createModeledMethod(), createModeledMethod()];
+  const modeledMethods = [createSinkModeledMethod(), createSinkModeledMethod()];
   const isModelingInProgress = false;
   const onChange = jest.fn();
 

--- a/extensions/ql-vscode/src/view/method-modeling/__tests__/MultipleModeledMethodsPanel.spec.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/__tests__/MultipleModeledMethodsPanel.spec.tsx
@@ -1,7 +1,11 @@
 import * as React from "react";
 import { render as reactRender, screen, waitFor } from "@testing-library/react";
 import { createMethod } from "../../../../test/factories/model-editor/method-factories";
-import { createModeledMethod } from "../../../../test/factories/model-editor/modeled-method-factories";
+import {
+  createNoneModeledMethod,
+  createSinkModeledMethod,
+  createSourceModeledMethod,
+} from "../../../../test/factories/model-editor/modeled-method-factories";
 import {
   MultipleModeledMethodsPanel,
   MultipleModeledMethodsPanelProps,
@@ -82,11 +86,10 @@ describe(MultipleModeledMethodsPanel.name, () => {
 
   describe("with one modeled method", () => {
     const modeledMethods = [
-      createModeledMethod({
+      createSinkModeledMethod({
         ...method,
         type: "sink",
         input: "Argument[this]",
-        output: "",
         kind: "path-injection",
       }),
     ];
@@ -164,9 +167,6 @@ describe(MultipleModeledMethodsPanel.name, () => {
           methodName: method.methodName,
           methodParameters: method.methodParameters,
           type: "none",
-          input: "",
-          output: "",
-          kind: "",
           provenance: "manual",
         },
       ]);
@@ -201,19 +201,11 @@ describe(MultipleModeledMethodsPanel.name, () => {
 
   describe("with two modeled methods", () => {
     const modeledMethods = [
-      createModeledMethod({
+      createSinkModeledMethod({
         ...method,
-        type: "sink",
-        input: "Argument[this]",
-        output: "",
-        kind: "path-injection",
       }),
-      createModeledMethod({
+      createSourceModeledMethod({
         ...method,
-        type: "source",
-        input: "",
-        output: "ReturnValue",
-        kind: "remote",
       }),
     ];
 
@@ -367,7 +359,6 @@ describe(MultipleModeledMethodsPanel.name, () => {
           methodName: method.methodName,
           methodParameters: method.methodParameters,
           type: "source",
-          input: "Argument[this]",
           output: "ReturnValue",
           kind: "value",
           provenance: "manual",
@@ -403,7 +394,6 @@ describe(MultipleModeledMethodsPanel.name, () => {
           methodParameters: method.methodParameters,
           type: "sink",
           input: "Argument[this]",
-          output: "ReturnValue",
           kind: "value",
           provenance: "manual",
         },
@@ -447,9 +437,6 @@ describe(MultipleModeledMethodsPanel.name, () => {
           methodName: method.methodName,
           methodParameters: method.methodParameters,
           type: "none",
-          input: "",
-          output: "",
-          kind: "",
           provenance: "manual",
         },
       ]);
@@ -553,24 +540,18 @@ describe(MultipleModeledMethodsPanel.name, () => {
 
   describe("with three modeled methods", () => {
     const modeledMethods = [
-      createModeledMethod({
+      createSinkModeledMethod({
         ...method,
-        type: "sink",
         input: "Argument[this]",
-        output: "",
         kind: "path-injection",
       }),
-      createModeledMethod({
+      createSourceModeledMethod({
         ...method,
-        type: "source",
-        input: "",
         output: "ReturnValue",
         kind: "remote",
       }),
-      createModeledMethod({
+      createSourceModeledMethod({
         ...method,
-        type: "source",
-        input: "",
         output: "ReturnValue",
         kind: "local",
       }),
@@ -719,19 +700,14 @@ describe(MultipleModeledMethodsPanel.name, () => {
 
   describe("with 1 modeled and 1 unmodeled method", () => {
     const modeledMethods = [
-      createModeledMethod({
+      createSinkModeledMethod({
         ...method,
         type: "sink",
         input: "Argument[this]",
-        output: "",
         kind: "path-injection",
       }),
-      createModeledMethod({
+      createNoneModeledMethod({
         ...method,
-        type: "none",
-        input: "",
-        output: "",
-        kind: "",
       }),
     ];
 
@@ -823,9 +799,6 @@ describe(MultipleModeledMethodsPanel.name, () => {
           methodName: method.methodName,
           methodParameters: method.methodParameters,
           type: "none",
-          input: "",
-          output: "",
-          kind: "",
           provenance: "manual",
         },
       ]);
@@ -834,10 +807,10 @@ describe(MultipleModeledMethodsPanel.name, () => {
 
   describe("with duplicate modeled methods", () => {
     const modeledMethods = [
-      createModeledMethod({
+      createSinkModeledMethod({
         ...method,
       }),
-      createModeledMethod({
+      createSinkModeledMethod({
         ...method,
       }),
     ];

--- a/extensions/ql-vscode/src/view/method-modeling/__tests__/MultipleModeledMethodsPanel.spec.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/__tests__/MultipleModeledMethodsPanel.spec.tsx
@@ -167,7 +167,6 @@ describe(MultipleModeledMethodsPanel.name, () => {
           methodName: method.methodName,
           methodParameters: method.methodParameters,
           type: "none",
-          provenance: "manual",
         },
       ]);
     });
@@ -437,7 +436,6 @@ describe(MultipleModeledMethodsPanel.name, () => {
           methodName: method.methodName,
           methodParameters: method.methodParameters,
           type: "none",
-          provenance: "manual",
         },
       ]);
     });
@@ -799,7 +797,6 @@ describe(MultipleModeledMethodsPanel.name, () => {
           methodName: method.methodName,
           methodParameters: method.methodParameters,
           type: "none",
-          provenance: "manual",
         },
       ]);
     });

--- a/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
@@ -33,6 +33,7 @@ import { canAddNewModeledMethod } from "../../model-editor/shared/multiple-model
 import { DataGridCell, DataGridRow } from "../common/DataGrid";
 import { validateModeledMethods } from "../../model-editor/shared/validation";
 import { ModeledMethodAlert } from "../method-modeling/ModeledMethodAlert";
+import { createEmptyModeledMethod } from "../../model-editor/modeled-method-empty";
 
 const ApiOrMethodRow = styled.div`
   min-height: calc(var(--input-height) * 1px);
@@ -165,15 +166,10 @@ const ModelableMethodRow = forwardRef<HTMLElement | undefined, MethodRowProps>(
     );
 
     const handleAddModelClick = useCallback(() => {
-      const newModeledMethod: ModeledMethod = {
-        type: "none",
-        provenance: "manual",
-        signature: method.signature,
-        packageName: method.packageName,
-        typeName: method.typeName,
-        methodName: method.methodName,
-        methodParameters: method.methodParameters,
-      };
+      const newModeledMethod: ModeledMethod = createEmptyModeledMethod(
+        "none",
+        method,
+      );
       const newModeledMethods = [...modeledMethods, newModeledMethod];
       onChange(method.signature, newModeledMethods);
     }, [method, modeledMethods, onChange]);
@@ -356,17 +352,7 @@ function modeledMethodsToDisplay(
   viewState: ModelEditorViewState,
 ): ModeledMethod[] {
   if (modeledMethods.length === 0) {
-    return [
-      {
-        type: "none",
-        provenance: "manual",
-        signature: method.signature,
-        packageName: method.packageName,
-        typeName: method.typeName,
-        methodName: method.methodName,
-        methodParameters: method.methodParameters,
-      },
-    ];
+    return [createEmptyModeledMethod("none", method)];
   }
 
   if (viewState.showMultipleModels) {

--- a/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
@@ -167,9 +167,6 @@ const ModelableMethodRow = forwardRef<HTMLElement | undefined, MethodRowProps>(
     const handleAddModelClick = useCallback(() => {
       const newModeledMethod: ModeledMethod = {
         type: "none",
-        input: "",
-        output: "",
-        kind: "",
         provenance: "manual",
         signature: method.signature,
         packageName: method.packageName,
@@ -362,9 +359,6 @@ function modeledMethodsToDisplay(
     return [
       {
         type: "none",
-        input: "",
-        output: "",
-        kind: "",
         provenance: "manual",
         signature: method.signature,
         packageName: method.packageName,

--- a/extensions/ql-vscode/src/view/model-editor/ModelInputDropdown.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelInputDropdown.tsx
@@ -1,7 +1,10 @@
 import * as React from "react";
 import { ChangeEvent, useCallback, useMemo } from "react";
 import { Dropdown } from "../common/Dropdown";
-import { ModeledMethod } from "../../model-editor/modeled-method";
+import {
+  ModeledMethod,
+  modeledMethodSupportsInput,
+} from "../../model-editor/modeled-method";
 import { Method, getArgumentsList } from "../../model-editor/method";
 
 type Props = {
@@ -32,14 +35,13 @@ export const ModelInputDropdown = ({
   );
 
   const enabled = useMemo(
-    () =>
-      modeledMethod?.type && ["sink", "summary"].includes(modeledMethod?.type),
-    [modeledMethod?.type],
+    () => modeledMethod && modeledMethodSupportsInput(modeledMethod),
+    [modeledMethod],
   );
 
   const handleChange = useCallback(
     (e: ChangeEvent<HTMLSelectElement>) => {
-      if (!modeledMethod) {
+      if (!modeledMethod || !modeledMethodSupportsInput(modeledMethod)) {
         return;
       }
 
@@ -53,9 +55,14 @@ export const ModelInputDropdown = ({
     [onChange, modeledMethod],
   );
 
+  const value =
+    modeledMethod && modeledMethodSupportsInput(modeledMethod)
+      ? modeledMethod.input
+      : undefined;
+
   return (
     <Dropdown
-      value={modeledMethod?.input}
+      value={value}
       options={options}
       disabled={!enabled}
       onChange={handleChange}

--- a/extensions/ql-vscode/src/view/model-editor/ModelKindDropdown.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelKindDropdown.tsx
@@ -4,6 +4,7 @@ import type {
   ModeledMethod,
   ModeledMethodKind,
 } from "../../model-editor/modeled-method";
+import { modeledMethodSupportsKind } from "../../model-editor/modeled-method";
 import { Dropdown } from "../common/Dropdown";
 import { Method } from "../../model-editor/method";
 import { getModelsAsDataLanguage } from "../../model-editor/languages";
@@ -44,7 +45,7 @@ export const ModelKindDropdown = ({
 
   const onChangeKind = useCallback(
     (kind: ModeledMethodKind) => {
-      if (!modeledMethod) {
+      if (!modeledMethod || !modeledMethodSupportsKind(modeledMethod)) {
         return;
       }
 
@@ -66,19 +67,26 @@ export const ModelKindDropdown = ({
     [onChangeKind],
   );
 
+  const value =
+    modeledMethod && modeledMethodSupportsKind(modeledMethod)
+      ? modeledMethod.kind
+      : undefined;
+
   useEffect(() => {
-    const value = modeledMethod?.kind ?? "";
+    if (!modeledMethod || !modeledMethodSupportsKind(modeledMethod)) {
+      return;
+    }
 
     if (kinds.length === 0 && value !== "") {
       onChangeKind("");
-    } else if (kinds.length > 0 && !kinds.includes(value)) {
+    } else if (kinds.length > 0 && !kinds.includes(value ?? "")) {
       onChangeKind(kinds[0]);
     }
-  }, [modeledMethod?.kind, kinds, onChangeKind]);
+  }, [modeledMethod, value, kinds, onChangeKind]);
 
   return (
     <Dropdown
-      value={modeledMethod?.kind}
+      value={value ?? undefined}
       options={options}
       disabled={disabled}
       onChange={handleChange}

--- a/extensions/ql-vscode/src/view/model-editor/ModelKindDropdown.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelKindDropdown.tsx
@@ -86,7 +86,7 @@ export const ModelKindDropdown = ({
 
   return (
     <Dropdown
-      value={value ?? undefined}
+      value={value}
       options={options}
       disabled={disabled}
       onChange={handleChange}

--- a/extensions/ql-vscode/src/view/model-editor/ModelOutputDropdown.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelOutputDropdown.tsx
@@ -1,7 +1,10 @@
 import * as React from "react";
 import { ChangeEvent, useCallback, useMemo } from "react";
 import { Dropdown } from "../common/Dropdown";
-import { ModeledMethod } from "../../model-editor/modeled-method";
+import {
+  ModeledMethod,
+  modeledMethodSupportsOutput,
+} from "../../model-editor/modeled-method";
 import { Method, getArgumentsList } from "../../model-editor/method";
 
 type Props = {
@@ -33,15 +36,13 @@ export const ModelOutputDropdown = ({
   );
 
   const enabled = useMemo(
-    () =>
-      modeledMethod?.type &&
-      ["source", "summary"].includes(modeledMethod?.type),
-    [modeledMethod?.type],
+    () => modeledMethod && modeledMethodSupportsOutput(modeledMethod),
+    [modeledMethod],
   );
 
   const handleChange = useCallback(
     (e: ChangeEvent<HTMLSelectElement>) => {
-      if (!modeledMethod) {
+      if (!modeledMethod || !modeledMethodSupportsOutput(modeledMethod)) {
         return;
       }
 
@@ -55,9 +56,14 @@ export const ModelOutputDropdown = ({
     [onChange, modeledMethod],
   );
 
+  const value =
+    modeledMethod && modeledMethodSupportsOutput(modeledMethod)
+      ? modeledMethod.output
+      : undefined;
+
   return (
     <Dropdown
-      value={modeledMethod?.output}
+      value={value}
       options={options}
       disabled={!enabled}
       onChange={handleChange}

--- a/extensions/ql-vscode/src/view/model-editor/ModelTypeDropdown.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelTypeDropdown.tsx
@@ -3,10 +3,13 @@ import { ChangeEvent, useCallback, useMemo } from "react";
 import { Dropdown } from "../common/Dropdown";
 import {
   ModeledMethod,
+  modeledMethodSupportsProvenance,
   ModeledMethodType,
   Provenance,
 } from "../../model-editor/modeled-method";
 import { Method, getArgumentsList } from "../../model-editor/method";
+import { createEmptyModeledMethod } from "../../model-editor/modeled-method-empty";
+import { Mutable } from "../../common/mutable";
 
 const options: Array<{ value: ModeledMethodType; label: string }> = [
   { value: "none", label: "Unmodeled" },
@@ -35,25 +38,36 @@ export const ModelTypeDropdown = ({
   const handleChange = useCallback(
     (e: ChangeEvent<HTMLSelectElement>) => {
       let newProvenance: Provenance = "manual";
-      if (modeledMethod?.provenance === "df-generated") {
-        newProvenance = "df-manual";
-      } else if (modeledMethod?.provenance === "ai-generated") {
-        newProvenance = "ai-manual";
+      if (modeledMethod && modeledMethodSupportsProvenance(modeledMethod)) {
+        if (modeledMethod.provenance === "df-generated") {
+          newProvenance = "df-manual";
+        } else if (modeledMethod.provenance === "ai-generated") {
+          newProvenance = "ai-manual";
+        }
       }
 
-      const updatedModeledMethod: ModeledMethod = {
-        // If there are no arguments, we will default to "Argument[this]"
-        input: argumentsList.length === 0 ? "Argument[this]" : "Argument[0]",
-        output: "ReturnValue",
-        kind: "value",
-        type: e.target.value as ModeledMethodType,
-        provenance: newProvenance,
-        signature: method.signature,
-        packageName: method.packageName,
-        typeName: method.typeName,
-        methodName: method.methodName,
-        methodParameters: method.methodParameters,
+      const emptyModeledMethod = createEmptyModeledMethod(
+        e.target.value as ModeledMethodType,
+        method,
+      );
+      const updatedModeledMethod: Mutable<ModeledMethod> = {
+        ...emptyModeledMethod,
       };
+      if ("input" in updatedModeledMethod) {
+        // If there are no arguments, we will default to "Argument[this]"
+        updatedModeledMethod.input =
+          argumentsList.length === 0 ? "Argument[this]" : "Argument[0]";
+      }
+      if ("output" in updatedModeledMethod) {
+        updatedModeledMethod.output = "ReturnValue";
+      }
+      if ("provenance" in updatedModeledMethod) {
+        updatedModeledMethod.provenance = newProvenance;
+      }
+      if ("kind" in updatedModeledMethod) {
+        updatedModeledMethod.kind = "value";
+      }
+
       onChange(updatedModeledMethod);
     },
     [onChange, method, modeledMethod, argumentsList],

--- a/extensions/ql-vscode/src/view/model-editor/__tests__/LibraryRow.spec.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/__tests__/LibraryRow.spec.tsx
@@ -27,7 +27,6 @@ describe(LibraryRow.name, () => {
               ...method,
               type: "sink",
               input: "Argument[0]",
-              output: "",
               kind: "jndi-injection",
               provenance: "df-generated",
             },

--- a/extensions/ql-vscode/src/view/model-editor/__tests__/MethodRow.spec.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/__tests__/MethodRow.spec.tsx
@@ -78,7 +78,6 @@ describe(MethodRow.name, () => {
     expect(onChange).toHaveBeenCalledWith(method.signature, [
       {
         type: "source",
-        input: "Argument[0]",
         output: "ReturnValue",
         kind: "value",
         provenance: "manual",
@@ -367,9 +366,6 @@ describe(MethodRow.name, () => {
       modeledMethod,
       {
         type: "none",
-        input: "",
-        output: "",
-        kind: "",
         provenance: "manual",
         signature: method.signature,
         packageName: method.packageName,

--- a/extensions/ql-vscode/src/view/model-editor/__tests__/MethodRow.spec.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/__tests__/MethodRow.spec.tsx
@@ -366,7 +366,6 @@ describe(MethodRow.name, () => {
       modeledMethod,
       {
         type: "none",
-        provenance: "manual",
         signature: method.signature,
         packageName: method.packageName,
         typeName: method.typeName,

--- a/extensions/ql-vscode/src/view/model-editor/__tests__/ModelKindDropdown.spec.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/__tests__/ModelKindDropdown.spec.tsx
@@ -3,7 +3,11 @@ import { render, screen } from "@testing-library/react";
 import { ModelKindDropdown } from "../ModelKindDropdown";
 import userEvent from "@testing-library/user-event";
 import { createMethod } from "../../../../test/factories/model-editor/method-factories";
-import { createModeledMethod } from "../../../../test/factories/model-editor/modeled-method-factories";
+import {
+  createNoneModeledMethod,
+  createSinkModeledMethod,
+  createSourceModeledMethod,
+} from "../../../../test/factories/model-editor/modeled-method-factories";
 import { QueryLanguage } from "../../../common/query-language";
 
 describe(ModelKindDropdown.name, () => {
@@ -15,8 +19,7 @@ describe(ModelKindDropdown.name, () => {
   });
 
   it("allows changing the kind", async () => {
-    const modeledMethod = createModeledMethod({
-      type: "source",
+    const modeledMethod = createSourceModeledMethod({
       kind: "local",
     });
 
@@ -40,8 +43,7 @@ describe(ModelKindDropdown.name, () => {
 
   it("resets the kind when changing the supported kinds", () => {
     const method = createMethod();
-    const modeledMethod = createModeledMethod({
-      type: "source",
+    const modeledMethod = createSourceModeledMethod({
       kind: "local",
     });
 
@@ -58,8 +60,7 @@ describe(ModelKindDropdown.name, () => {
     expect(onChange).not.toHaveBeenCalled();
 
     // Changing the type to sink should update the supported kinds
-    const updatedModeledMethod = createModeledMethod({
-      type: "sink",
+    const updatedModeledMethod = createSinkModeledMethod({
       kind: "local",
     });
 
@@ -77,8 +78,9 @@ describe(ModelKindDropdown.name, () => {
 
   it("sets the kind when value is undefined", () => {
     const method = createMethod();
-    const modeledMethod = createModeledMethod({
+    const modeledMethod = createSourceModeledMethod({
       type: "source",
+      kind: undefined,
     });
 
     render(
@@ -100,10 +102,7 @@ describe(ModelKindDropdown.name, () => {
 
   it("does not call onChange when unmodeled and the kind is valid", () => {
     const method = createMethod();
-    const modeledMethod = createModeledMethod({
-      type: "none",
-      kind: "",
-    });
+    const modeledMethod = createNoneModeledMethod();
 
     render(
       <ModelKindDropdown
@@ -115,29 +114,5 @@ describe(ModelKindDropdown.name, () => {
     );
 
     expect(onChange).not.toHaveBeenCalled();
-  });
-
-  it("calls onChange when unmodeled and the kind is valid", () => {
-    const method = createMethod();
-    const modeledMethod = createModeledMethod({
-      type: "none",
-      kind: "local",
-    });
-
-    render(
-      <ModelKindDropdown
-        language={QueryLanguage.Java}
-        method={method}
-        modeledMethod={modeledMethod}
-        onChange={onChange}
-      />,
-    );
-
-    expect(onChange).toHaveBeenCalledTimes(1);
-    expect(onChange).toHaveBeenCalledWith(
-      expect.objectContaining({
-        kind: "",
-      }),
-    );
   });
 });

--- a/extensions/ql-vscode/src/view/model-editor/__tests__/ModeledMethodDataGrid.spec.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/__tests__/ModeledMethodDataGrid.spec.tsx
@@ -53,7 +53,6 @@ describe(ModeledMethodDataGrid.name, () => {
               ...method1,
               type: "sink",
               input: "Argument[0]",
-              output: "",
               kind: "jndi-injection",
               provenance: "df-generated",
             },

--- a/extensions/ql-vscode/src/view/model-editor/__tests__/ModeledMethodsList.spec.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/__tests__/ModeledMethodsList.spec.tsx
@@ -53,7 +53,6 @@ describe(ModeledMethodsList.name, () => {
               ...method1,
               type: "sink",
               input: "Argument[0]",
-              output: "",
               kind: "jndi-injection",
               provenance: "df-generated",
             },

--- a/extensions/ql-vscode/test/factories/model-editor/modeled-method-factories.ts
+++ b/extensions/ql-vscode/test/factories/model-editor/modeled-method-factories.ts
@@ -1,8 +1,15 @@
-import { ModeledMethod } from "../../../src/model-editor/modeled-method";
+import {
+  NeutralModeledMethod,
+  NoneModeledMethod,
+  SinkModeledMethod,
+  SourceModeledMethod,
+  SummaryModeledMethod,
+} from "../../../src/model-editor/modeled-method";
+import { MethodSignature } from "../../../src/model-editor/method";
 
-export function createModeledMethod(
-  data: Partial<ModeledMethod> = {},
-): ModeledMethod {
+export function createMethodSignature(
+  data: Partial<MethodSignature> = {},
+): MethodSignature {
   return {
     libraryVersion: "1.6.0",
     signature: "org.sql2o.Connection#createQuery(String)",
@@ -10,10 +17,68 @@ export function createModeledMethod(
     typeName: "Connection",
     methodName: "createQuery",
     methodParameters: "(String)",
+    ...data,
+  };
+}
+
+export function createNoneModeledMethod(
+  data: Partial<NoneModeledMethod> = {},
+): NoneModeledMethod {
+  return {
+    ...createMethodSignature(),
+    type: "none",
+    provenance: "manual",
+    ...data,
+  };
+}
+
+export function createSinkModeledMethod(
+  data: Partial<SinkModeledMethod> = {},
+): SinkModeledMethod {
+  return {
+    ...createMethodSignature(),
     type: "sink",
     input: "Argument[0]",
-    output: "",
     kind: "path-injection",
+    provenance: "manual",
+    ...data,
+  };
+}
+
+export function createSourceModeledMethod(
+  data: Partial<SourceModeledMethod> = {},
+): SourceModeledMethod {
+  return {
+    ...createMethodSignature(),
+    type: "source",
+    output: "ReturnValue",
+    kind: "remote",
+    provenance: "manual",
+    ...data,
+  };
+}
+
+export function createSummaryModeledMethod(
+  data: Partial<SummaryModeledMethod> = {},
+): SummaryModeledMethod {
+  return {
+    ...createMethodSignature(),
+    type: "summary",
+    input: "Argument[this]",
+    output: "ReturnValue",
+    kind: "taint",
+    provenance: "manual",
+    ...data,
+  };
+}
+
+export function createNeutralModeledMethod(
+  data: Partial<NeutralModeledMethod> = {},
+): NeutralModeledMethod {
+  return {
+    ...createMethodSignature(),
+    type: "neutral",
+    kind: "summary",
     provenance: "manual",
     ...data,
   };

--- a/extensions/ql-vscode/test/factories/model-editor/modeled-method-factories.ts
+++ b/extensions/ql-vscode/test/factories/model-editor/modeled-method-factories.ts
@@ -27,7 +27,6 @@ export function createNoneModeledMethod(
   return {
     ...createMethodSignature(),
     type: "none",
-    provenance: "manual",
     ...data,
   };
 }

--- a/extensions/ql-vscode/test/unit-tests/model-editor/auto-model.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/model-editor/auto-model.test.ts
@@ -103,9 +103,7 @@ describe("getCandidates", () => {
       "org.my.A#x()": [
         {
           type: "neutral",
-          kind: "",
-          input: "",
-          output: "",
+          kind: "sink",
           provenance: "manual",
           signature: "org.my.A#x()",
           packageName: "org.my",

--- a/extensions/ql-vscode/test/unit-tests/model-editor/modeled-method.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/model-editor/modeled-method.test.ts
@@ -1,0 +1,52 @@
+import { createNoneModeledMethod } from "../../factories/model-editor/modeled-method-factories";
+import {
+  ModeledMethod,
+  modeledMethodSupportsInput,
+  modeledMethodSupportsKind,
+  modeledMethodSupportsOutput,
+  modeledMethodSupportsProvenance,
+} from "../../../src/model-editor/modeled-method";
+
+describe("modeledMethodSupportsKind", () => {
+  const modeledMethod = createNoneModeledMethod() as ModeledMethod;
+
+  it("can access the kind property", () => {
+    // These are more type tests than unit tests, but they're still useful.
+    if (modeledMethodSupportsKind(modeledMethod)) {
+      expect(modeledMethod.kind).not.toBeUndefined(); // never hit
+    }
+  });
+});
+
+describe("modeledMethodSupportsInput", () => {
+  const modeledMethod = createNoneModeledMethod() as ModeledMethod;
+
+  it("can access the input property", () => {
+    // These are more type tests than unit tests, but they're still useful.
+    if (modeledMethodSupportsInput(modeledMethod)) {
+      expect(modeledMethod.input).not.toBeUndefined(); // never hit
+    }
+  });
+});
+
+describe("modeledMethodSupportsOutput", () => {
+  const modeledMethod = createNoneModeledMethod() as ModeledMethod;
+
+  it("can access the output property", () => {
+    // These are more type tests than unit tests, but they're still useful.
+    if (modeledMethodSupportsOutput(modeledMethod)) {
+      expect(modeledMethod.output).not.toBeUndefined(); // never hit
+    }
+  });
+});
+
+describe("modeledMethodSupportsProvenance", () => {
+  const modeledMethod = createNoneModeledMethod() as ModeledMethod;
+
+  it("can access the provenance property", () => {
+    // These are more type tests than unit tests, but they're still useful.
+    if (modeledMethodSupportsProvenance(modeledMethod)) {
+      expect(modeledMethod.provenance).not.toBeUndefined();
+    }
+  });
+});

--- a/extensions/ql-vscode/test/unit-tests/model-editor/yaml.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/model-editor/yaml.test.ts
@@ -15,7 +15,6 @@ describe("createDataExtensionYaml", () => {
       {
         type: "sink",
         input: "Argument[0]",
-        output: "",
         kind: "sql",
         provenance: "df-generated",
         signature: "org.sql2o.Connection#createQuery(String)",
@@ -230,7 +229,6 @@ describe("createDataExtensionYamlsForApplicationMode", () => {
           {
             type: "sink",
             input: "Argument[0]",
-            output: "",
             kind: "sql",
             provenance: "df-generated",
             signature: "org.sql2o.Connection#createQuery(String)",
@@ -243,8 +241,6 @@ describe("createDataExtensionYamlsForApplicationMode", () => {
         "org.springframework.boot.SpringApplication#run(Class,String[])": [
           {
             type: "neutral",
-            input: "",
-            output: "",
             kind: "summary",
             provenance: "manual",
             signature:
@@ -259,7 +255,6 @@ describe("createDataExtensionYamlsForApplicationMode", () => {
           {
             type: "sink",
             input: "Argument[0]",
-            output: "",
             kind: "jndi",
             provenance: "manual",
             signature: "org.sql2o.Sql2o#Sql2o(String,String,String)",
@@ -474,7 +469,6 @@ describe("createDataExtensionYamlsForApplicationMode", () => {
           {
             type: "sink",
             input: "Argument[0]",
-            output: "",
             kind: "sql",
             provenance: "df-generated",
             signature: "org.sql2o.Connection#createQuery(String)",
@@ -487,8 +481,6 @@ describe("createDataExtensionYamlsForApplicationMode", () => {
         "org.springframework.boot.SpringApplication#run(Class,String[])": [
           {
             type: "neutral",
-            input: "",
-            output: "",
             kind: "summary",
             provenance: "manual",
             signature:
@@ -503,7 +495,6 @@ describe("createDataExtensionYamlsForApplicationMode", () => {
           {
             type: "sink",
             input: "Argument[0]",
-            output: "",
             kind: "jndi",
             provenance: "manual",
             signature: "org.sql2o.Sql2o#Sql2o(String,String,String)",
@@ -519,8 +510,6 @@ describe("createDataExtensionYamlsForApplicationMode", () => {
           "org.sql2o.Connection#createQuery(String)": [
             {
               type: "neutral",
-              input: "",
-              output: "",
               kind: "summary",
               provenance: "manual",
               signature: "org.sql2o.Connection#createQuery(String)",
@@ -533,8 +522,6 @@ describe("createDataExtensionYamlsForApplicationMode", () => {
           "org.sql2o.Query#executeScalar(Class)": [
             {
               type: "neutral",
-              input: "",
-              output: "",
               kind: "summary",
               provenance: "manual",
               signature: "org.sql2o.Query#executeScalar(Class)",
@@ -718,7 +705,6 @@ describe("createDataExtensionYamlsForFrameworkMode", () => {
           {
             type: "sink",
             input: "Argument[0]",
-            output: "",
             kind: "sql",
             provenance: "df-generated",
             signature: "org.sql2o.Connection#createQuery(String)",
@@ -732,7 +718,6 @@ describe("createDataExtensionYamlsForFrameworkMode", () => {
           {
             type: "sink",
             input: "Argument[0]",
-            output: "",
             kind: "jndi",
             provenance: "manual",
             signature: "org.sql2o.Sql2o#Sql2o(String,String,String)",
@@ -874,7 +859,6 @@ describe("createDataExtensionYamlsForFrameworkMode", () => {
           {
             type: "sink",
             input: "Argument[0]",
-            output: "",
             kind: "sql",
             provenance: "df-generated",
             signature: "org.sql2o.Connection#createQuery(String)",
@@ -888,7 +872,6 @@ describe("createDataExtensionYamlsForFrameworkMode", () => {
           {
             type: "sink",
             input: "Argument[0]",
-            output: "",
             kind: "jndi",
             provenance: "manual",
             signature: "org.sql2o.Sql2o#Sql2o(String,String,String)",
@@ -904,8 +887,6 @@ describe("createDataExtensionYamlsForFrameworkMode", () => {
           "org.sql2o.Connection#createQuery(String)": [
             {
               type: "neutral",
-              input: "",
-              output: "",
               kind: "summary",
               provenance: "manual",
               signature: "org.sql2o.Connection#createQuery(String)",
@@ -918,8 +899,6 @@ describe("createDataExtensionYamlsForFrameworkMode", () => {
           "org.sql2o.Query#executeScalar(Class)": [
             {
               type: "neutral",
-              input: "",
-              output: "",
               kind: "summary",
               provenance: "manual",
               signature: "org.sql2o.Query#executeScalar(Class)",

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/methods-usage/methods-usage-data-provider.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/methods-usage/methods-usage-data-provider.test.ts
@@ -15,7 +15,7 @@ import {
 import { mockedObject } from "../../../utils/mocking.helpers";
 import { ModeledMethod } from "../../../../../src/model-editor/modeled-method";
 import { Mode } from "../../../../../src/model-editor/shared/mode";
-import { createModeledMethod } from "../../../../factories/model-editor/modeled-method-factories";
+import { createSinkModeledMethod } from "../../../../factories/model-editor/modeled-method-factories";
 
 describe("MethodsUsageDataProvider", () => {
   const mockCliServer = mockedObject<CodeQLCliServer>({});
@@ -252,9 +252,11 @@ describe("MethodsUsageDataProvider", () => {
       unsupportedModeledMethod,
     ];
     const modeledMethods: Record<string, ModeledMethod[]> = {};
-    modeledMethods[supportedModeledMethod.signature] = [createModeledMethod()];
+    modeledMethods[supportedModeledMethod.signature] = [
+      createSinkModeledMethod(),
+    ];
     modeledMethods[unsupportedModeledMethod.signature] = [
-      createModeledMethod(),
+      createSinkModeledMethod(),
     ];
     const modifiedMethodSignatures: Set<string> = new Set();
 


### PR DESCRIPTION
This switches the `ModeledMethod` type from 1 type containing all fields to a union of multiple types where each type accurately represents which fields are present for a specific model. This allows more disjointed models to be represented more accurately, such as type models. For type models, having` input`, `output`, etc. doesn't make sense. It instead has fields like `type1`, `type2` and `path`. I don't think adding these properties to every modeled method makes sense, so this is a solution which allows us to represent both models.

This is a very large changeset, but I don't think splitting it up would be helpful (I don't really see how). A lot of the changes are changes to method names or removing unnecessary properties.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
