### PR TITLE
Remove `extLogger` imports from model editor

### DIFF
--- a/extensions/ql-vscode/src/model-editor/auto-modeler.ts
+++ b/extensions/ql-vscode/src/model-editor/auto-modeler.ts
@@ -1,6 +1,5 @@
 import { Method, MethodSignature } from "./method";
 import { ModeledMethod } from "./modeled-method";
-import { extLogger } from "../common/logging/vscode";
 import { load as loadYaml } from "js-yaml";
 import { ProgressCallback, withProgress } from "../common/vscode/progress";
 import { createAutoModelRequest, getCandidates } from "./auto-model";
@@ -84,7 +83,7 @@ export class AutoModeler {
    * @param packageName The name of the package to stop modeling.
    */
   public async stopModeling(packageName: string): Promise<void> {
-    void extLogger.log(`Stopping modeling for package ${packageName}`);
+    void this.app.logger.log(`Stopping modeling for package ${packageName}`);
     const cancellationTokenSource = this.jobs.get(packageName);
     if (cancellationTokenSource) {
       cancellationTokenSource.cancel();
@@ -107,7 +106,7 @@ export class AutoModeler {
     mode: Mode,
     cancellationTokenSource: CancellationTokenSource,
   ): Promise<void> {
-    void extLogger.log(`Modeling package ${packageName}`);
+    void this.app.logger.log(`Modeling package ${packageName}`);
 
     const candidateBatchSize = this.modelConfig.llmGenerationBatchSize;
 
@@ -117,7 +116,7 @@ export class AutoModeler {
 
       // If there are no candidates, there is nothing to model and we just return
       if (allCandidateMethods.length === 0) {
-        void extLogger.log("No candidates to model. Stopping.");
+        void this.app.logger.log("No candidates to model. Stopping.");
         return;
       }
 
@@ -175,7 +174,7 @@ export class AutoModeler {
     progress: ProgressCallback,
     cancellationTokenSource: CancellationTokenSource,
   ): Promise<void> {
-    void extLogger.log("Executing auto-model queries");
+    void this.app.logger.log("Executing auto-model queries");
 
     const usages = await runAutoModelQueries({
       mode,
@@ -193,7 +192,7 @@ export class AutoModeler {
 
     const request = await createAutoModelRequest(mode, usages);
 
-    void extLogger.log("Calling auto-model API");
+    void this.app.logger.log("Calling auto-model API");
 
     const response = await this.callAutoModelApi(request);
     if (!response) {

--- a/extensions/ql-vscode/src/model-editor/extensions-workspace-folder.ts
+++ b/extensions/ql-vscode/src/model-editor/extensions-workspace-folder.ts
@@ -1,6 +1,5 @@
 import { FileType, Uri, workspace, WorkspaceFolder } from "vscode";
 import { getOnDiskWorkspaceFoldersObjects } from "../common/vscode/workspace-folders";
-import { extLogger } from "../common/logging/vscode";
 import { tmpdir } from "../common/files";
 import { NotificationLogger, showAndLogErrorMessage } from "../common/logging";
 
@@ -180,7 +179,7 @@ export async function autoPickExtensionsDirectory(
   // Get the root workspace directory, i.e. the common root directory of all workspace folders
   const rootDirectory = await getRootWorkspaceDirectory();
   if (!rootDirectory) {
-    void extLogger.log("Unable to determine root workspace directory");
+    void logger.log("Unable to determine root workspace directory");
 
     return undefined;
   }
@@ -204,7 +203,7 @@ export async function autoPickExtensionsDirectory(
       },
     )
   ) {
-    void extLogger.log(
+    void logger.log(
       `Failed to add workspace folder for extensions at ${extensionsUri.fsPath}`,
     );
     return undefined;

--- a/extensions/ql-vscode/src/model-editor/flow-model-queries.ts
+++ b/extensions/ql-vscode/src/model-editor/flow-model-queries.ts
@@ -3,8 +3,10 @@ import { DatabaseItem } from "../databases/local-databases";
 import { basename } from "path";
 import { QueryRunner } from "../query-server";
 import { CodeQLCliServer } from "../codeql-cli/cli";
-import { showAndLogExceptionWithTelemetry } from "../common/logging";
-import { extLogger } from "../common/logging/vscode";
+import {
+  NotificationLogger,
+  showAndLogExceptionWithTelemetry,
+} from "../common/logging";
 import { getModelsAsDataLanguage } from "./languages";
 import { ProgressCallback } from "../common/vscode/progress";
 import { getOnDiskWorkspaceFolders } from "../common/vscode/workspace-folders";
@@ -29,6 +31,7 @@ export function isFlowModelGenerationSupported(
 type FlowModelOptions = {
   cliServer: CodeQLCliServer;
   queryRunner: QueryRunner;
+  logger: NotificationLogger;
   queryStorageDir: string;
   databaseItem: DatabaseItem;
   language: QueryLanguage;
@@ -115,6 +118,7 @@ async function runSingleFlowQuery(
   {
     cliServer,
     queryRunner,
+    logger,
     queryStorageDir,
     databaseItem,
     language,
@@ -125,7 +129,7 @@ async function runSingleFlowQuery(
   // Check that the right query was found
   if (queryPath === undefined) {
     void showAndLogExceptionWithTelemetry(
-      extLogger,
+      logger,
       telemetryListener,
       redactableError`Failed to find ${type} query`,
     );
@@ -163,7 +167,7 @@ async function runSingleFlowQuery(
   const bqrsInfo = await cliServer.bqrsInfo(bqrsPath);
   if (bqrsInfo["result-sets"].length !== 1) {
     void showAndLogExceptionWithTelemetry(
-      extLogger,
+      logger,
       telemetryListener,
       redactableError`Expected exactly one result set, got ${
         bqrsInfo["result-sets"].length

--- a/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
+++ b/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
@@ -4,7 +4,6 @@ import {
 } from "../../common/interface-types";
 import { telemetryListener } from "../../common/vscode/telemetry";
 import { showAndLogExceptionWithTelemetry } from "../../common/logging/notifications";
-import { extLogger } from "../../common/logging/vscode/loggers";
 import { App } from "../../common/app";
 import { redactableError } from "../../common/errors";
 import { Method } from "../method";
@@ -112,7 +111,7 @@ export class MethodModelingViewProvider extends AbstractWebviewViewProvider<
 
       case "unhandledError":
         void showAndLogExceptionWithTelemetry(
-          extLogger,
+          this.app.logger,
           telemetryListener,
           redactableError(
             msg.error,

--- a/extensions/ql-vscode/src/model-editor/model-editor-module.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-module.ts
@@ -200,6 +200,7 @@ export class ModelEditorModule extends DisposableObject {
 
           const success = await setUpPack(
             this.cliServer,
+            this.app.logger,
             queryDir,
             language,
             this.modelConfig,

--- a/extensions/ql-vscode/src/model-editor/model-editor-queries-setup.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-queries-setup.ts
@@ -8,6 +8,7 @@ import { ModelConfig } from "../config";
 import { Mode } from "./shared/mode";
 import { resolveQueriesFromPacks } from "../local-queries";
 import { modeTag } from "./mode-tag";
+import { NotificationLogger } from "../common/logging";
 
 export const syntheticQueryPackName = "codeql/model-editor-queries";
 
@@ -26,6 +27,7 @@ export const syntheticQueryPackName = "codeql/model-editor-queries";
  * are present in codeql/java-queries or in our own query pack. They just need to resolve the query.
  *
  * @param cliServer The CodeQL CLI server to use.
+ * @param logger The logger to use.
  * @param queryDir The directory to set up.
  * @param language The language to use for the queries.
  * @param modelConfig The model config to use.
@@ -33,6 +35,7 @@ export const syntheticQueryPackName = "codeql/model-editor-queries";
  */
 export async function setUpPack(
   cliServer: CodeQLCliServer,
+  logger: NotificationLogger,
   queryDir: string,
   language: QueryLanguage,
   modelConfig: ModelConfig,
@@ -64,6 +67,7 @@ export async function setUpPack(
   } else {
     // If we can't resolve the query, we need to write them to desk ourselves.
     const externalApiQuerySuccess = await prepareModelEditorQueries(
+      logger,
       queryDir,
       language,
     );

--- a/extensions/ql-vscode/src/model-editor/model-editor-queries.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-queries.ts
@@ -1,7 +1,9 @@
 import { QueryRunner } from "../query-server";
 import { getOnDiskWorkspaceFolders } from "../common/vscode/workspace-folders";
-import { extLogger } from "../common/logging/vscode";
-import { showAndLogExceptionWithTelemetry } from "../common/logging";
+import {
+  NotificationLogger,
+  showAndLogExceptionWithTelemetry,
+} from "../common/logging";
 import { CancellationToken } from "vscode";
 import { CodeQLCliServer } from "../codeql-cli/cli";
 import { DatabaseItem } from "../databases/local-databases";
@@ -24,6 +26,7 @@ import {
 type RunQueryOptions = {
   cliServer: CodeQLCliServer;
   queryRunner: QueryRunner;
+  logger: NotificationLogger;
   databaseItem: DatabaseItem;
   language: QueryLanguage;
   queryStorageDir: string;
@@ -34,6 +37,7 @@ type RunQueryOptions = {
 };
 
 export async function prepareModelEditorQueries(
+  logger: NotificationLogger,
   queryDir: string,
   language: QueryLanguage,
 ): Promise<boolean> {
@@ -41,7 +45,7 @@ export async function prepareModelEditorQueries(
   const query = fetchExternalApiQueries[language];
   if (!query) {
     void showAndLogExceptionWithTelemetry(
-      extLogger,
+      logger,
       telemetryListener,
       redactableError`No bundled model editor query found for language ${language}`,
     );
@@ -70,6 +74,7 @@ export async function runModelEditorQueries(
   {
     cliServer,
     queryRunner,
+    logger,
     databaseItem,
     language,
     queryStorageDir,
@@ -110,7 +115,7 @@ export async function runModelEditorQueries(
   );
   if (!queryPath) {
     void showAndLogExceptionWithTelemetry(
-      extLogger,
+      logger,
       telemetryListener,
       redactableError`The ${mode} model editor query could not be found. Try re-opening the model editor. If that doesn't work, try upgrading the CodeQL libraries.`,
     );
@@ -147,6 +152,7 @@ export async function runModelEditorQueries(
 
   const bqrsChunk = await readQueryResults({
     cliServer,
+    logger,
     bqrsPath: completedQuery.outputDir.bqrsPath,
   });
   if (!bqrsChunk) {
@@ -164,17 +170,19 @@ export async function runModelEditorQueries(
 
 type GetResultsOptions = {
   cliServer: Pick<CodeQLCliServer, "bqrsInfo" | "bqrsDecode">;
+  logger: NotificationLogger;
   bqrsPath: string;
 };
 
 export async function readQueryResults({
   cliServer,
+  logger,
   bqrsPath,
 }: GetResultsOptions) {
   const bqrsInfo = await cliServer.bqrsInfo(bqrsPath);
   if (bqrsInfo["result-sets"].length !== 1) {
     void showAndLogExceptionWithTelemetry(
-      extLogger,
+      logger,
       telemetryListener,
       redactableError`Expected exactly one result set, got ${bqrsInfo["result-sets"].length}`,
     );

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -437,6 +437,7 @@ export class ModelEditorView extends AbstractWebview<
       const queryResult = await runModelEditorQueries(mode, {
         cliServer: this.cliServer,
         queryRunner: this.queryRunner,
+        logger: this.app.logger,
         databaseItem: this.databaseItem,
         language: this.language,
         queryStorageDir: this.queryStorageDir,
@@ -502,6 +503,7 @@ export class ModelEditorView extends AbstractWebview<
           await runFlowModelQueries({
             cliServer: this.cliServer,
             queryRunner: this.queryRunner,
+            logger: this.app.logger,
             queryStorageDir: this.queryStorageDir,
             databaseItem: addedDatabase ?? this.databaseItem,
             language: this.language,

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/external-api-usage-query.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/external-api-usage-query.test.ts
@@ -65,6 +65,7 @@ describe("runModelEditorQueries", () => {
         }),
         logger: createMockLogger(),
       }),
+      logger: createMockLogger(),
       databaseItem: mockedObject<DatabaseItem>({
         databaseUri: mockedUri("/a/b/c/src.zip"),
         contents: {
@@ -131,6 +132,7 @@ describe("runModelEditorQueries", () => {
         }),
         logger: createMockLogger(),
       }),
+      logger: createMockLogger(),
       databaseItem: mockedObject<DatabaseItem>({
         databaseUri: mockedUri("/a/b/c/src.zip"),
         contents: {
@@ -180,6 +182,7 @@ describe("readQueryResults", () => {
       bqrsInfo: jest.fn(),
       bqrsDecode: jest.fn(),
     },
+    logger: createMockLogger(),
     bqrsPath: "/tmp/results.bqrs",
   };
 

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/model-editor-queries.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/model-editor-queries.test.ts
@@ -9,6 +9,7 @@ import { Mode } from "../../../../src/model-editor/shared/mode";
 import { mockedObject } from "../../utils/mocking.helpers";
 import { CodeQLCliServer } from "../../../../src/codeql-cli/cli";
 import { ModelConfig } from "../../../../src/config";
+import { createMockLogger } from "../../../__mocks__/loggerMock";
 
 describe("setUpPack", () => {
   let queryDir: string;
@@ -33,11 +34,12 @@ describe("setUpPack", () => {
         packInstall: jest.fn(),
         resolveQueriesInSuite: jest.fn().mockResolvedValue([]),
       });
+      const logger = createMockLogger();
       const modelConfig = mockedObject<ModelConfig>({
         llmGeneration: false,
       });
 
-      await setUpPack(cliServer, queryDir, language, modelConfig);
+      await setUpPack(cliServer, logger, queryDir, language, modelConfig);
 
       const queryFiles = await readdir(queryDir);
       expect(queryFiles).toEqual(
@@ -90,11 +92,12 @@ describe("setUpPack", () => {
           .fn()
           .mockResolvedValue(["/a/b/c/ApplicationModeEndpoints.ql"]),
       });
+      const logger = createMockLogger();
       const modelConfig = mockedObject<ModelConfig>({
         llmGeneration: false,
       });
 
-      await setUpPack(cliServer, queryDir, language, modelConfig);
+      await setUpPack(cliServer, logger, queryDir, language, modelConfig);
 
       const queryFiles = await readdir(queryDir);
       expect(queryFiles.sort()).toEqual(["codeql-pack.yml"].sort());


### PR DESCRIPTION
We shouldn't be directly using the `extLogger` if we have access to the app logger (either directly or by passing it in as a parameter). This removes all imports of `extLogger` from the model editor directory.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
