### PR TITLE
Detect existing query packs when creating skeleton query

### DIFF
--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -1244,11 +1244,13 @@ export class CodeQLCliServer implements Disposable {
    * @param additionalPacks A list of directories to search for qlpacks.
    * @param extensionPacksOnly Whether to only search for extension packs. If true, only extension packs will
    *    be returned. If false, all packs will be returned.
+   * @param kind Whether to only search for qlpacks with a certain kind.
    * @returns A dictionary mapping qlpack name to the directory it comes from
    */
   async resolveQlpacks(
     additionalPacks: string[],
     extensionPacksOnly = false,
+    kind?: "query" | "library" | "all",
   ): Promise<QlpacksInfo> {
     const args = this.getAdditionalPacksArg(additionalPacks);
     if (extensionPacksOnly) {
@@ -1259,6 +1261,8 @@ export class CodeQLCliServer implements Disposable {
         return {};
       }
       args.push("--kind", "extension", "--no-recursive");
+    } else if (kind) {
+      args.push("--kind", kind);
     }
 
     return this.runJsonCodeQlCliCommand<QlpacksInfo>(

--- a/extensions/ql-vscode/src/databases/local-databases/database-manager.ts
+++ b/extensions/ql-vscode/src/databases/local-databases/database-manager.ts
@@ -274,10 +274,9 @@ export class DatabaseManager extends DisposableObject {
 
     try {
       const qlPackGenerator = new QlPackGenerator(
-        folderName,
         databaseItem.language,
         this.cli,
-        firstWorkspaceFolder,
+        join(firstWorkspaceFolder, folderName),
       );
       await qlPackGenerator.generate();
     } catch (e: unknown) {

--- a/extensions/ql-vscode/src/local-queries/qlpack-generator.ts
+++ b/extensions/ql-vscode/src/local-queries/qlpack-generator.ts
@@ -13,20 +13,16 @@ export class QlPackGenerator {
   private readonly folderUri: Uri;
 
   constructor(
-    private readonly folderName: string,
     private readonly queryLanguage: QueryLanguage,
     private readonly cliServer: CodeQLCliServer,
-    private readonly storagePath: string | undefined,
+    private readonly storagePath: string,
   ) {
-    if (this.storagePath === undefined) {
-      throw new Error("Workspace storage path is undefined");
-    }
     this.qlpackName = `getting-started/codeql-extra-queries-${this.queryLanguage}`;
     this.qlpackVersion = "1.0.0";
     this.header = "# This is an automatically generated file.\n\n";
 
     this.qlpackFileName = "codeql-pack.yml";
-    this.folderUri = Uri.file(join(this.storagePath, this.folderName));
+    this.folderUri = Uri.file(this.storagePath);
   }
 
   public async generate() {

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/qlpack-generator.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/qlpack-generator.test.ts
@@ -9,7 +9,6 @@ import * as tmp from "tmp";
 import { mockedObject } from "../utils/mocking.helpers";
 
 describe("QlPackGenerator", () => {
-  let packFolderName: string;
   let packFolderPath: string;
   let qlPackYamlFilePath: string;
   let exampleQlFilePath: string;
@@ -22,8 +21,9 @@ describe("QlPackGenerator", () => {
     dir = tmp.dirSync();
 
     language = "ruby";
-    packFolderName = `test-ql-pack-${language}`;
-    packFolderPath = Uri.file(join(dir.name, packFolderName)).fsPath;
+    packFolderPath = Uri.file(
+      join(dir.name, `test-ql-pack-${language}`),
+    ).fsPath;
 
     qlPackYamlFilePath = join(packFolderPath, "codeql-pack.yml");
     exampleQlFilePath = join(packFolderPath, "example.ql");
@@ -34,10 +34,9 @@ describe("QlPackGenerator", () => {
     });
 
     generator = new QlPackGenerator(
-      packFolderName,
       language as QueryLanguage,
       mockCli,
-      dir.name,
+      packFolderPath,
     );
   });
 


### PR DESCRIPTION
This will change the skeleton query wizard to detect existing query packs when creating a skeleton query. This allows the user to create a query in an existing query pack that is not named
`codeql-custom-queries-{language}`.

See the linked internal issues for the scenarios this covers.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
