### PR TITLE
Update method modeling panel language when new db opened

### DIFF
--- a/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
+++ b/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
@@ -208,13 +208,15 @@ export class MethodModelingViewProvider extends AbstractWebviewViewProvider<
     );
 
     this.push(
-      this.modelingEvents.onDbOpened(async (e) => {
+      this.modelingEvents.onDbOpened(async (databaseItem) => {
+        this.databaseItem = databaseItem;
+
         await this.postMessage({
           t: "setInModelingMode",
           inModelingMode: true,
         });
 
-        this.language = tryGetQueryLanguage(e.language);
+        this.language = tryGetQueryLanguage(databaseItem.language);
         await this.setViewState();
       }),
     );

--- a/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
+++ b/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
@@ -208,11 +208,14 @@ export class MethodModelingViewProvider extends AbstractWebviewViewProvider<
     );
 
     this.push(
-      this.modelingEvents.onDbOpened(async () => {
+      this.modelingEvents.onDbOpened(async (e) => {
         await this.postMessage({
           t: "setInModelingMode",
           inModelingMode: true,
         });
+
+        this.language = tryGetQueryLanguage(e.language);
+        await this.setViewState();
       }),
     );
 

--- a/extensions/ql-vscode/src/model-editor/modeling-events.ts
+++ b/extensions/ql-vscode/src/model-editor/modeling-events.ts
@@ -50,7 +50,7 @@ interface InProgressMethodsChangedEvent {
 
 export class ModelingEvents extends DisposableObject {
   public readonly onActiveDbChanged: AppEvent<void>;
-  public readonly onDbOpened: AppEvent<string>;
+  public readonly onDbOpened: AppEvent<DatabaseItem>;
   public readonly onDbClosed: AppEvent<string>;
   public readonly onMethodsChanged: AppEvent<MethodsChangedEvent>;
   public readonly onHideModeledMethodsChanged: AppEvent<HideModeledMethodsChangedEvent>;
@@ -61,7 +61,7 @@ export class ModelingEvents extends DisposableObject {
   public readonly onInProgressMethodsChanged: AppEvent<InProgressMethodsChangedEvent>;
 
   private readonly onActiveDbChangedEventEmitter: AppEventEmitter<void>;
-  private readonly onDbOpenedEventEmitter: AppEventEmitter<string>;
+  private readonly onDbOpenedEventEmitter: AppEventEmitter<DatabaseItem>;
   private readonly onDbClosedEventEmitter: AppEventEmitter<string>;
   private readonly onMethodsChangedEventEmitter: AppEventEmitter<MethodsChangedEvent>;
   private readonly onHideModeledMethodsChangedEventEmitter: AppEventEmitter<HideModeledMethodsChangedEvent>;
@@ -79,7 +79,9 @@ export class ModelingEvents extends DisposableObject {
     );
     this.onActiveDbChanged = this.onActiveDbChangedEventEmitter.event;
 
-    this.onDbOpenedEventEmitter = this.push(app.createEventEmitter<string>());
+    this.onDbOpenedEventEmitter = this.push(
+      app.createEventEmitter<DatabaseItem>(),
+    );
     this.onDbOpened = this.onDbOpenedEventEmitter.event;
 
     this.onDbClosedEventEmitter = this.push(app.createEventEmitter<string>());
@@ -130,8 +132,8 @@ export class ModelingEvents extends DisposableObject {
     this.onActiveDbChangedEventEmitter.fire();
   }
 
-  public fireDbOpenedEvent(dbUri: string) {
-    this.onDbOpenedEventEmitter.fire(dbUri);
+  public fireDbOpenedEvent(databaseItem: DatabaseItem) {
+    this.onDbOpenedEventEmitter.fire(databaseItem);
   }
 
   public fireDbClosedEvent(dbUri: string) {

--- a/extensions/ql-vscode/src/model-editor/modeling-store.ts
+++ b/extensions/ql-vscode/src/model-editor/modeling-store.ts
@@ -64,7 +64,7 @@ export class ModelingStore extends DisposableObject {
       inProgressMethods: new Set(),
     });
 
-    this.modelingEvents.fireDbOpenedEvent(dbUri);
+    this.modelingEvents.fireDbOpenedEvent(databaseItem);
   }
 
   public setActiveDb(databaseItem: DatabaseItem) {


### PR DESCRIPTION
Now that we check [viewState?.language](https://github.com/github/vscode-codeql/blob/6685883ebfdf67782845ccc5da453c9d002a0055/extensions/ql-vscode/src/view/method-modeling/MethodModelingView.tsx#L83) before showing the "Not in modeling mode" screen,  we need to make sure that `language` is set when opening a new DB. 

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
