### PR TITLE
Prevent duplicate query packs when creating a query

### DIFF
--- a/extensions/ql-vscode/src/local-queries/qlpack-generator.ts
+++ b/extensions/ql-vscode/src/local-queries/qlpack-generator.ts
@@ -1,12 +1,14 @@
 import { mkdir, writeFile } from "fs-extra";
 import { dump } from "js-yaml";
-import { join } from "path";
+import { dirname, join } from "path";
 import { Uri } from "vscode";
 import { CodeQLCliServer } from "../codeql-cli/cli";
 import { QueryLanguage } from "../common/query-language";
+import { getOnDiskWorkspaceFolders } from "../common/vscode/workspace-folders";
+import { basename } from "../common/path";
 
 export class QlPackGenerator {
-  private readonly qlpackName: string;
+  private qlpackName: string | undefined;
   private readonly qlpackVersion: string;
   private readonly header: string;
   private readonly qlpackFileName: string;
@@ -16,8 +18,8 @@ export class QlPackGenerator {
     private readonly queryLanguage: QueryLanguage,
     private readonly cliServer: CodeQLCliServer,
     private readonly storagePath: string,
+    private readonly includeFolderNameInQlpackName: boolean = false,
   ) {
-    this.qlpackName = `getting-started/codeql-extra-queries-${this.queryLanguage}`;
     this.qlpackVersion = "1.0.0";
     this.header = "# This is an automatically generated file.\n\n";
 
@@ -26,6 +28,8 @@ export class QlPackGenerator {
   }
 
   public async generate() {
+    this.qlpackName = await this.determineQlpackName();
+
     // create QL pack folder and add to workspace
     await this.createWorkspaceFolder();
 
@@ -37,6 +41,37 @@ export class QlPackGenerator {
 
     // create codeql-pack.lock.yml
     await this.createCodeqlPackLockYaml();
+  }
+
+  private async determineQlpackName(): Promise<string> {
+    let qlpackBaseName = `getting-started/codeql-extra-queries-${this.queryLanguage}`;
+    if (this.includeFolderNameInQlpackName) {
+      const folderBasename = basename(dirname(this.folderUri.fsPath));
+      if (
+        folderBasename.includes("codeql") ||
+        folderBasename.includes("queries")
+      ) {
+        // If the user has already included "codeql" or "queries" in the folder name, don't include it twice
+        qlpackBaseName = `getting-started/${folderBasename}-${this.queryLanguage}`;
+      } else {
+        qlpackBaseName = `getting-started/codeql-extra-queries-${folderBasename}-${this.queryLanguage}`;
+      }
+    }
+
+    const existingQlPacks = await this.cliServer.resolveQlpacks(
+      getOnDiskWorkspaceFolders(),
+    );
+    const existingQlPackNames = Object.keys(existingQlPacks);
+
+    let qlpackName = qlpackBaseName;
+    let i = 0;
+    while (existingQlPackNames.includes(qlpackName)) {
+      i++;
+
+      qlpackName = `${qlpackBaseName}-${i}`;
+    }
+
+    return qlpackName;
   }
 
   private async createWorkspaceFolder() {


### PR DESCRIPTION
This prevents the creation of duplicate query pack names when creating a query in the following ways:
- When you have selected a folder, the query pack name will include the name of the folder. This should prevent duplicate query pack names when creating queries in different folders. - When the folder name includes `codeql` or `queries`, we will not add `codeql-extra-queries-` since that would be redundant.
- After generating the query pack name, we will resolve all qlpacks and check if one with this name already exists. If it does, we will start adding an index to the name until we find a unique name.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
