### PR TITLE
Fix queries always being created in qlpack root

### DIFF
--- a/extensions/ql-vscode/src/databases/local-databases/database-manager.ts
+++ b/extensions/ql-vscode/src/databases/local-databases/database-manager.ts
@@ -248,8 +248,10 @@ export class DatabaseManager extends DisposableObject {
     const firstWorkspaceFolder = getFirstWorkspaceFolder();
     const folderName = `codeql-custom-queries-${databaseItem.language}`;
 
+    const qlpackStoragePath = join(firstWorkspaceFolder, folderName);
+
     if (
-      existsSync(join(firstWorkspaceFolder, folderName)) ||
+      existsSync(qlpackStoragePath) ||
       isFolderAlreadyInWorkspace(folderName)
     ) {
       return;
@@ -276,7 +278,8 @@ export class DatabaseManager extends DisposableObject {
       const qlPackGenerator = new QlPackGenerator(
         databaseItem.language,
         this.cli,
-        join(firstWorkspaceFolder, folderName),
+        qlpackStoragePath,
+        qlpackStoragePath,
       );
       await qlPackGenerator.generate();
     } catch (e: unknown) {

--- a/extensions/ql-vscode/src/local-queries/qlpack-generator.ts
+++ b/extensions/ql-vscode/src/local-queries/qlpack-generator.ts
@@ -18,6 +18,7 @@ export class QlPackGenerator {
     private readonly queryLanguage: QueryLanguage,
     private readonly cliServer: CodeQLCliServer,
     private readonly storagePath: string,
+    private readonly queryStoragePath: string,
     private readonly includeFolderNameInQlpackName: boolean = false,
   ) {
     this.qlpackVersion = "1.0.0";
@@ -91,7 +92,7 @@ export class QlPackGenerator {
   }
 
   public async createExampleQlFile(fileName = "example.ql") {
-    const exampleQlFilePath = join(this.folderUri.fsPath, fileName);
+    const exampleQlFilePath = join(this.queryStoragePath, fileName);
 
     const exampleQl = `
 /**

--- a/extensions/ql-vscode/src/local-queries/skeleton-query-wizard.ts
+++ b/extensions/ql-vscode/src/local-queries/skeleton-query-wizard.ts
@@ -455,7 +455,10 @@ export class SkeletonQueryWizard {
 
   private createQlPackGenerator() {
     if (this.qlPackStoragePath === undefined) {
-      throw new Error("Query pack storage path is undefined");
+      throw new Error("QL pack storage path is undefined");
+    }
+    if (this.queryStoragePath === undefined) {
+      throw new Error("Query storage path is undefined");
     }
     if (this.language === undefined) {
       throw new Error("Language is undefined");
@@ -472,6 +475,7 @@ export class SkeletonQueryWizard {
       this.language,
       this.cliServer,
       this.qlPackStoragePath,
+      this.queryStoragePath,
       includeFolderNameInQlpackName,
     );
   }

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/qlpack-generator.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/qlpack-generator.test.ts
@@ -46,6 +46,7 @@ describe("QlPackGenerator", () => {
       language as QueryLanguage,
       mockCli,
       packFolderPath,
+      packFolderPath,
     );
   });
 
@@ -128,6 +129,7 @@ describe("QlPackGenerator", () => {
         language as QueryLanguage,
         mockCli,
         packFolderPath,
+        packFolderPath,
         true,
       );
     });
@@ -160,6 +162,7 @@ describe("QlPackGenerator", () => {
         generator = new QlPackGenerator(
           language as QueryLanguage,
           mockCli,
+          packFolderPath,
           packFolderPath,
           true,
         );
@@ -194,6 +197,7 @@ describe("QlPackGenerator", () => {
         generator = new QlPackGenerator(
           language as QueryLanguage,
           mockCli,
+          packFolderPath,
           packFolderPath,
           true,
         );


### PR DESCRIPTION
This passes through the query storage path to the qlpack generator so it's able to create the query in the correct selected folder.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
