### PR TITLE
Fix some broken storybook stories

### DIFF
--- a/extensions/ql-vscode/src/stories/method-modeling/MethodModeling.stories.tsx
+++ b/extensions/ql-vscode/src/stories/method-modeling/MethodModeling.stories.tsx
@@ -5,6 +5,7 @@ import { Meta, StoryFn } from "@storybook/react";
 import { MethodModeling as MethodModelingComponent } from "../../view/method-modeling/MethodModeling";
 import { createMethod } from "../../../test/factories/model-editor/method-factories";
 import { createModeledMethod } from "../../../test/factories/model-editor/modeled-method-factories";
+import { QueryLanguage } from "../../common/query-language";
 export default {
   title: "Method Modeling/Method Modeling",
   component: MethodModelingComponent,
@@ -15,9 +16,11 @@ const Template: StoryFn<typeof MethodModelingComponent> = (args) => (
 );
 
 const method = createMethod();
+const language = QueryLanguage.Java;
 
 export const MethodUnmodeled = Template.bind({});
 MethodUnmodeled.args = {
+  language,
   method,
   modeledMethods: [],
   modelingStatus: "unmodeled",
@@ -25,6 +28,7 @@ MethodUnmodeled.args = {
 
 export const MethodModeled = Template.bind({});
 MethodModeled.args = {
+  language,
   method,
   modeledMethods: [],
   modelingStatus: "unsaved",
@@ -32,6 +36,7 @@ MethodModeled.args = {
 
 export const MethodSaved = Template.bind({});
 MethodSaved.args = {
+  language,
   method,
   modeledMethods: [],
   modelingStatus: "saved",
@@ -39,6 +44,7 @@ MethodSaved.args = {
 
 export const MultipleModelingsUnmodeled = Template.bind({});
 MultipleModelingsUnmodeled.args = {
+  language,
   method,
   modeledMethods: [],
   showMultipleModels: true,
@@ -47,6 +53,7 @@ MultipleModelingsUnmodeled.args = {
 
 export const MultipleModelingsModeledSingle = Template.bind({});
 MultipleModelingsModeledSingle.args = {
+  language,
   method,
   modeledMethods: [createModeledMethod(method)],
   showMultipleModels: true,
@@ -55,6 +62,7 @@ MultipleModelingsModeledSingle.args = {
 
 export const MultipleModelingsModeledMultiple = Template.bind({});
 MultipleModelingsModeledMultiple.args = {
+  language,
   method,
   modeledMethods: [
     createModeledMethod(method),
@@ -72,6 +80,7 @@ MultipleModelingsModeledMultiple.args = {
 
 export const MultipleModelingsValidationFailedNeutral = Template.bind({});
 MultipleModelingsValidationFailedNeutral.args = {
+  language,
   method,
   modeledMethods: [
     createModeledMethod(method),
@@ -86,6 +95,7 @@ MultipleModelingsValidationFailedNeutral.args = {
 
 export const MultipleModelingsValidationFailedDuplicate = Template.bind({});
 MultipleModelingsValidationFailedDuplicate.args = {
+  language,
   method,
   modeledMethods: [
     createModeledMethod(method),

--- a/extensions/ql-vscode/src/stories/method-modeling/MethodModelingInputs.stories.tsx
+++ b/extensions/ql-vscode/src/stories/method-modeling/MethodModelingInputs.stories.tsx
@@ -7,6 +7,7 @@ import { createMethod } from "../../../test/factories/model-editor/method-factor
 import { createModeledMethod } from "../../../test/factories/model-editor/modeled-method-factories";
 import { useState } from "react";
 import { ModeledMethod } from "../../model-editor/modeled-method";
+import { QueryLanguage } from "../../common/query-language";
 
 export default {
   title: "Method Modeling/Method Modeling Inputs",
@@ -32,6 +33,7 @@ const Template: StoryFn<typeof MethodModelingInputsComponent> = (args) => {
   return (
     <MethodModelingInputsComponent
       {...args}
+      language={QueryLanguage.Java}
       modeledMethod={m}
       onChange={onChange}
     />

--- a/extensions/ql-vscode/src/stories/method-modeling/MultipleModeledMethodsPanel.stories.tsx
+++ b/extensions/ql-vscode/src/stories/method-modeling/MultipleModeledMethodsPanel.stories.tsx
@@ -7,6 +7,7 @@ import { MultipleModeledMethodsPanel as MultipleModeledMethodsPanelComponent } f
 import { createMethod } from "../../../test/factories/model-editor/method-factories";
 import { createModeledMethod } from "../../../test/factories/model-editor/modeled-method-factories";
 import { ModeledMethod } from "../../model-editor/modeled-method";
+import { QueryLanguage } from "../../common/query-language";
 
 export default {
   title: "Method Modeling/Multiple Modeled Methods Panel",
@@ -42,21 +43,25 @@ const Template: StoryFn<typeof MultipleModeledMethodsPanelComponent> = (
 };
 
 const method = createMethod();
+const language = QueryLanguage.Java;
 
 export const Unmodeled = Template.bind({});
 Unmodeled.args = {
+  language,
   method,
   modeledMethods: [],
 };
 
 export const Single = Template.bind({});
 Single.args = {
+  language,
   method,
   modeledMethods: [createModeledMethod(method)],
 };
 
 export const Multiple = Template.bind({});
 Multiple.args = {
+  language,
   method,
   modeledMethods: [
     createModeledMethod(method),


### PR DESCRIPTION
A new `language` argument was added to a few modeling components recently but not passed in when building up components in the storybook. This was causing the stories to fail. 

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
