### PR TITLE
Remove unnecessary ModelKindDropdown input

### DIFF
--- a/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
@@ -263,7 +263,6 @@ const ModelableMethodRow = forwardRef<HTMLElement | undefined, MethodRowProps>(
                 <DataGridCell>
                   <ModelKindDropdown
                     language={viewState.language}
-                    method={method}
                     modeledMethod={modeledMethod}
                     onChange={modeledMethodChangedHandlers[index]}
                   />

--- a/extensions/ql-vscode/src/view/model-editor/ModelKindDropdown.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelKindDropdown.tsx
@@ -5,20 +5,17 @@ import type {
   ModeledMethodKind,
 } from "../../model-editor/modeled-method";
 import { Dropdown } from "../common/Dropdown";
-import { Method } from "../../model-editor/method";
 import { getModelsAsDataLanguage } from "../../model-editor/languages";
 import { QueryLanguage } from "../../common/query-language";
 
 type Props = {
   language: QueryLanguage;
-  method: Method;
   modeledMethod: ModeledMethod | undefined;
   onChange: (modeledMethod: ModeledMethod) => void;
 };
 
 export const ModelKindDropdown = ({
   language,
-  method,
   modeledMethod,
   onChange,
 }: Props) => {

--- a/extensions/ql-vscode/src/view/model-editor/__tests__/ModelKindDropdown.spec.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/__tests__/ModelKindDropdown.spec.tsx
@@ -2,13 +2,11 @@ import * as React from "react";
 import { render, screen } from "@testing-library/react";
 import { ModelKindDropdown } from "../ModelKindDropdown";
 import userEvent from "@testing-library/user-event";
-import { createMethod } from "../../../../test/factories/model-editor/method-factories";
 import { createModeledMethod } from "../../../../test/factories/model-editor/modeled-method-factories";
 import { QueryLanguage } from "../../../common/query-language";
 
 describe(ModelKindDropdown.name, () => {
   const onChange = jest.fn();
-  const method = createMethod();
 
   beforeEach(() => {
     onChange.mockReset();
@@ -23,7 +21,6 @@ describe(ModelKindDropdown.name, () => {
     render(
       <ModelKindDropdown
         language={QueryLanguage.Java}
-        method={method}
         modeledMethod={modeledMethod}
         onChange={onChange}
       />,
@@ -39,7 +36,6 @@ describe(ModelKindDropdown.name, () => {
   });
 
   it("resets the kind when changing the supported kinds", () => {
-    const method = createMethod();
     const modeledMethod = createModeledMethod({
       type: "source",
       kind: "local",
@@ -48,7 +44,6 @@ describe(ModelKindDropdown.name, () => {
     const { rerender } = render(
       <ModelKindDropdown
         language={QueryLanguage.Java}
-        method={method}
         modeledMethod={modeledMethod}
         onChange={onChange}
       />,
@@ -66,7 +61,6 @@ describe(ModelKindDropdown.name, () => {
     rerender(
       <ModelKindDropdown
         language={QueryLanguage.Java}
-        method={method}
         modeledMethod={updatedModeledMethod}
         onChange={onChange}
       />,
@@ -76,7 +70,6 @@ describe(ModelKindDropdown.name, () => {
   });
 
   it("sets the kind when value is undefined", () => {
-    const method = createMethod();
     const modeledMethod = createModeledMethod({
       type: "source",
     });
@@ -84,7 +77,6 @@ describe(ModelKindDropdown.name, () => {
     render(
       <ModelKindDropdown
         language={QueryLanguage.Java}
-        method={method}
         modeledMethod={modeledMethod}
         onChange={onChange}
       />,
@@ -99,7 +91,6 @@ describe(ModelKindDropdown.name, () => {
   });
 
   it("does not call onChange when unmodeled and the kind is valid", () => {
-    const method = createMethod();
     const modeledMethod = createModeledMethod({
       type: "none",
       kind: "",
@@ -108,7 +99,6 @@ describe(ModelKindDropdown.name, () => {
     render(
       <ModelKindDropdown
         language={QueryLanguage.Java}
-        method={method}
         modeledMethod={modeledMethod}
         onChange={onChange}
       />,
@@ -118,7 +108,6 @@ describe(ModelKindDropdown.name, () => {
   });
 
   it("calls onChange when unmodeled and the kind is valid", () => {
-    const method = createMethod();
     const modeledMethod = createModeledMethod({
       type: "none",
       kind: "local",
@@ -127,7 +116,6 @@ describe(ModelKindDropdown.name, () => {
     render(
       <ModelKindDropdown
         language={QueryLanguage.Java}
-        method={method}
         modeledMethod={modeledMethod}
         onChange={onChange}
       />,


### PR DESCRIPTION
I noticed that the `method` input was not used in the `ModelKindDropdown` so I got rid of it.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
