### PR TITLE
Don't add database source archive folders by default

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,15 +2,14 @@
 
 ## [UNRELEASED]
 
+- When adding a CodeQL database, we no longer add the database source folder to the workspace by default (since this caused bugs in single-folder workspaces). [#3047](https://github.com/github/vscode-codeql/pull/3047)
+  - You can manually add individual database source folders to the workspace with the "Add Database Source to Workspace" right-click command in the databases view.
+  - To restore the old behavior of adding all database source folders by default, set the `codeQL.addingDatabases.addDatabaseSourceToWorkspace` setting to `true`.
 - The "Sort by Language" action in the databases view now sorts by name within each language. [#3055](https://github.com/github/vscode-codeql/pull/3055)
 
 ## 1.9.4 - 6 November 2023
 
 No user facing changes.
-- When downloading a database, we no longer add the database source folder to the workspace by default (since this caused bugs in single-folder workspaces). [#3047](https://github.com/github/vscode-codeql/pull/3047)
-- When adding a CodeQL database, we no longer add the database source folder to the workspace by default (since this caused bugs in single-folder workspaces). [#3047](https://github.com/github/vscode-codeql/pull/3047)
-  - You can manually add individual database source folders to the workspace with the "Add Database Source to Workspace" right-click command in the databases view.
-  - To restore the old behavior of adding all database source folders by default, set the `codeQL.addingDatabases.addDatabaseSourceToWorkspace` setting to `true`.
 
 ## 1.9.3 - 26 October 2023
 

--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -5,6 +5,7 @@
 - When adding a CodeQL database, we no longer add the database source folder to the workspace by default (since this caused bugs in single-folder workspaces). [#3047](https://github.com/github/vscode-codeql/pull/3047)
   - You can manually add individual database source folders to the workspace with the "Add Database Source to Workspace" right-click command in the databases view.
   - To restore the old behavior of adding all database source folders by default, set the `codeQL.addingDatabases.addDatabaseSourceToWorkspace` setting to `true`.
+- Rename the `codeQL.databaseDownload.allowHttp` setting to `codeQL.addingDatabases.allowHttp`, so that database-related settings are grouped together in the Settings UI. [#3047](https://github.com/github/vscode-codeql/pull/3047)
 - The "Sort by Language" action in the databases view now sorts by name within each language. [#3055](https://github.com/github/vscode-codeql/pull/3055)
 
 ## 1.9.4 - 6 November 2023

--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -7,6 +7,10 @@
 ## 1.9.4 - 6 November 2023
 
 No user facing changes.
+- When downloading a database, we no longer add the database source folder to the workspace by default (since this caused bugs in single-folder workspaces). [#3047](https://github.com/github/vscode-codeql/pull/3047)
+- When adding a CodeQL database, we no longer add the database source folder to the workspace by default (since this caused bugs in single-folder workspaces). [#3047](https://github.com/github/vscode-codeql/pull/3047)
+  - You can manually add individual database source folders to the workspace with the "Add Database Source to Workspace" right-click command in the databases view.
+  - To restore the old behavior of adding all database source folders by default, set the `codeQL.addingDatabases.addDatabaseSourceToWorkspace` setting to `true`.
 
 ## 1.9.3 - 26 October 2023
 

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -372,18 +372,18 @@
       },
       {
         "type": "object",
-        "title": "Downloading databases",
+        "title": "Adding databases",
         "order": 6,
         "properties": {
-          "codeQL.databaseDownload.allowHttp": {
+          "codeQL.addingDatabases.allowHttp": {
             "type": "boolean",
             "default": false,
             "description": "Allow databases to be downloaded via HTTP. Warning: enabling this option will allow downloading from insecure servers."
           },
-          "codeQL.databaseDownload.addDatabaseSourceToWorkspace": {
+          "codeQL.addingDatabases.addDatabaseSourceToWorkspace": {
             "type": "boolean",
             "default": false,
-            "markdownDescription": "When downloading a database, automatically add the database's source folder as a workspace folder. Warning: enabling this option in a single-folder workspace will cause the workspace to reload as a [multi-root workspace](https://code.visualstudio.com/docs/editor/multi-root-workspaces). This may cause query history and database lists to be reset."
+            "markdownDescription": "When adding a CodeQL database, automatically add the database's source folder as a workspace folder. Warning: enabling this option in a single-folder workspace will cause the workspace to reload as a [multi-root workspace](https://code.visualstudio.com/docs/editor/multi-root-workspaces). This may cause query history and database lists to be reset."
           }
         }
       },

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -378,7 +378,12 @@
           "codeQL.databaseDownload.allowHttp": {
             "type": "boolean",
             "default": false,
-            "description": "Allow database to be downloaded via HTTP. Warning: enabling this option will allow downloading from insecure servers."
+            "description": "Allow databases to be downloaded via HTTP. Warning: enabling this option will allow downloading from insecure servers."
+          },
+          "codeQL.databaseDownload.addDatabaseSourceToWorkspace": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "When downloading a database, automatically add the database's source folder as a workspace folder. Warning: enabling this option in a single-folder workspace will cause the workspace to reload as a [multi-root workspace](https://code.visualstudio.com/docs/editor/multi-root-workspaces). This may cause query history and database lists to be reset."
           }
         }
       },

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -380,6 +380,11 @@
             "default": false,
             "description": "Allow databases to be downloaded via HTTP. Warning: enabling this option will allow downloading from insecure servers."
           },
+          "codeQL.databaseDownload.allowHttp": {
+            "type": "boolean",
+            "markdownDeprecationMessage": "**Deprecated**: Please use `#codeQL.addingDatabases.allowHttp#` instead.",
+            "deprecationMessage": "Deprecated: Please use codeQL.addingDatabases.allowHttp instead."
+          },
           "codeQL.addingDatabases.addDatabaseSourceToWorkspace": {
             "type": "boolean",
             "default": false,

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -641,9 +641,9 @@ export function isCodespacesTemplate() {
   return !!CODESPACES_TEMPLATE.getValue<boolean>();
 }
 
-const DATABASE_DOWNLOAD_SETTING = new Setting("addingDatabases", ROOT_SETTING);
+const ADDING_DATABASES_SETTING = new Setting("addingDatabases", ROOT_SETTING);
 
-const ALLOW_HTTP_SETTING = new Setting("allowHttp", DATABASE_DOWNLOAD_SETTING);
+const ALLOW_HTTP_SETTING = new Setting("allowHttp", ADDING_DATABASES_SETTING);
 
 export function allowHttp(): boolean {
   return ALLOW_HTTP_SETTING.getValue<boolean>() || false;
@@ -651,7 +651,7 @@ export function allowHttp(): boolean {
 
 const ADD_DATABASE_SOURCE_TO_WORKSPACE_SETTING = new Setting(
   "addDatabaseSourceToWorkspace",
-  DATABASE_DOWNLOAD_SETTING,
+  ADDING_DATABASES_SETTING,
 );
 
 export function addDatabaseSourceToWorkspace(): boolean {

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -649,6 +649,15 @@ export function allowHttp(): boolean {
   return ALLOW_HTTP_SETTING.getValue<boolean>() || false;
 }
 
+const ADD_DATABASE_SOURCE_TO_WORKSPACE_SETTING = new Setting(
+  "addDatabaseSourceToWorkspace",
+  DATABASE_DOWNLOAD_SETTING,
+);
+
+export function addDatabaseSourceToWorkspace(): boolean {
+  return ADD_DATABASE_SOURCE_TO_WORKSPACE_SETTING.getValue<boolean>() || false;
+}
+
 /**
  * Parent setting for all settings related to the "Create Query" command.
  */

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -641,7 +641,7 @@ export function isCodespacesTemplate() {
   return !!CODESPACES_TEMPLATE.getValue<boolean>();
 }
 
-const DATABASE_DOWNLOAD_SETTING = new Setting("databaseDownload", ROOT_SETTING);
+const DATABASE_DOWNLOAD_SETTING = new Setting("addingDatabases", ROOT_SETTING);
 
 const ALLOW_HTTP_SETTING = new Setting("allowHttp", DATABASE_DOWNLOAD_SETTING);
 

--- a/extensions/ql-vscode/src/databases/database-fetcher.ts
+++ b/extensions/ql-vscode/src/databases/database-fetcher.ts
@@ -29,7 +29,7 @@ import {
 } from "../common/github-url-identifier-helper";
 import { Credentials } from "../common/authentication";
 import { AppCommandManager } from "../common/commands";
-import { allowHttp } from "../config";
+import { addDatabaseSourceToWorkspace, allowHttp } from "../config";
 import { showAndLogInformationMessage } from "../common/logging";
 import { AppOctokit } from "../common/octokit";
 import { getLanguageDisplayName } from "../common/query-language";
@@ -99,7 +99,7 @@ export async function promptImportGithubDatabase(
   cli?: CodeQLCliServer,
   language?: string,
   makeSelected = true,
-  addSourceArchiveFolder = true,
+  addSourceArchiveFolder = addDatabaseSourceToWorkspace(),
 ): Promise<DatabaseItem | undefined> {
   const githubRepo = await askForGitHubRepo(progress);
   if (!githubRepo) {
@@ -178,7 +178,7 @@ export async function downloadGitHubDatabase(
   cli?: CodeQLCliServer,
   language?: string,
   makeSelected = true,
-  addSourceArchiveFolder = true,
+  addSourceArchiveFolder = addDatabaseSourceToWorkspace(),
 ): Promise<DatabaseItem | undefined> {
   const nwo = getNwoFromGitHubUrl(githubRepo) || githubRepo;
   if (!isValidGitHubNwo(nwo)) {
@@ -295,7 +295,7 @@ async function databaseArchiveFetcher(
   progress: ProgressCallback,
   cli?: CodeQLCliServer,
   makeSelected = true,
-  addSourceArchiveFolder = true,
+  addSourceArchiveFolder = addDatabaseSourceToWorkspace(),
 ): Promise<DatabaseItem> {
   progress({
     message: "Getting database",
@@ -476,7 +476,7 @@ async function checkForFailingResponse(
     return response;
   }
 
-  // An error downloading the database. Attempt to extract the resaon behind it.
+  // An error downloading the database. Attempt to extract the reason behind it.
   const text = await response.text();
   let msg: string;
   try {

--- a/extensions/ql-vscode/src/databases/local-databases/database-manager.ts
+++ b/extensions/ql-vscode/src/databases/local-databases/database-manager.ts
@@ -7,6 +7,7 @@ import { QueryRunner } from "../../query-server";
 import * as cli from "../../codeql-cli/cli";
 import { ProgressCallback, withProgress } from "../../common/vscode/progress";
 import {
+  addDatabaseSourceToWorkspace,
   getAutogenerateQlPacks,
   isCodespacesTemplate,
   setAutogenerateQlPacks,
@@ -135,7 +136,7 @@ export class DatabaseManager extends DisposableObject {
     displayName?: string,
     {
       isTutorialDatabase = false,
-      addSourceArchiveFolder = true,
+      addSourceArchiveFolder = addDatabaseSourceToWorkspace(),
     }: OpenDatabaseOptions = {},
   ): Promise<DatabaseItem> {
     const databaseItem = await this.createDatabaseItem(uri, displayName);
@@ -158,7 +159,7 @@ export class DatabaseManager extends DisposableObject {
     databaseItem: DatabaseItemImpl,
     makeSelected: boolean,
     isTutorialDatabase?: boolean,
-    addSourceArchiveFolder = true,
+    addSourceArchiveFolder = addDatabaseSourceToWorkspace(),
   ): Promise<DatabaseItem> {
     const existingItem = this.findDatabaseItem(databaseItem.databaseUri);
     if (existingItem !== undefined) {

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -688,7 +688,6 @@ export class ModelEditorView extends AbstractWebview<
       this.cliServer,
       this.databaseItem.language,
       makeSelected,
-      false,
     );
     if (!addedDatabase) {
       void this.app.logger.log("No database chosen");

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -688,6 +688,7 @@ export class ModelEditorView extends AbstractWebview<
       this.cliServer,
       this.databaseItem.language,
       makeSelected,
+      false,
     );
     if (!addedDatabase) {
       void this.app.logger.log("No database chosen");

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-queries/local-databases.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-queries/local-databases.test.ts
@@ -729,7 +729,7 @@ describe("local databases", () => {
       expect(setCurrentDatabaseItemSpy).toBeCalledTimes(1);
     });
 
-    it("should not add database source archive folder when `codeQL.databaseDownload.addDatabaseSourceToWorkspace` is `false`", async () => {
+    it("should not add database source archive folder when `codeQL.addingDatabases.addDatabaseSourceToWorkspace` is `false`", async () => {
       jest.spyOn(config, "addDatabaseSourceToWorkspace").mockReturnValue(false);
 
       await databaseManager.openDatabase(mockDbItem.databaseUri);
@@ -737,7 +737,7 @@ describe("local databases", () => {
       expect(addDatabaseSourceArchiveFolderSpy).toBeCalledTimes(0);
     });
 
-    it("should add database source archive folder when `codeQL.databaseDownload.addDatabaseSourceToWorkspace` is `true`", async () => {
+    it("should add database source archive folder when `codeQL.addingDatabases.addDatabaseSourceToWorkspace` is `true`", async () => {
       jest.spyOn(config, "addDatabaseSourceToWorkspace").mockReturnValue(true);
 
       await databaseManager.openDatabase(mockDbItem.databaseUri);

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-queries/local-databases.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-queries/local-databases.test.ts
@@ -729,7 +729,17 @@ describe("local databases", () => {
       expect(setCurrentDatabaseItemSpy).toBeCalledTimes(1);
     });
 
-    it("should add database source archive folder", async () => {
+    it("should not add database source archive folder when `codeQL.databaseDownload.addDatabaseSourceToWorkspace` is `false`", async () => {
+      jest.spyOn(config, "addDatabaseSourceToWorkspace").mockReturnValue(false);
+
+      await databaseManager.openDatabase(mockDbItem.databaseUri);
+
+      expect(addDatabaseSourceArchiveFolderSpy).toBeCalledTimes(0);
+    });
+
+    it("should add database source archive folder when `codeQL.databaseDownload.addDatabaseSourceToWorkspace` is `true`", async () => {
+      jest.spyOn(config, "addDatabaseSourceToWorkspace").mockReturnValue(true);
+
       await databaseManager.openDatabase(mockDbItem.databaseUri);
 
       expect(addDatabaseSourceArchiveFolderSpy).toBeCalledTimes(1);


### PR DESCRIPTION
No longer add the database source folder to the workspace by default (since this caused bugs in single-folder workspaces). If users want to keep the old behaviour of auto-adding DB source folders, they can set the `addDatabaseSourceToWorkspace` setting to `true`.

See internal linked issue for more details.


## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
  - https://github.com/github/codeql/pull/14668