### PR TITLE
Extract creation of method argument options to languages

### DIFF
--- a/extensions/ql-vscode/src/model-editor/languages/models-as-data.ts
+++ b/extensions/ql-vscode/src/model-editor/languages/models-as-data.ts
@@ -1,4 +1,4 @@
-import { MethodDefinition } from "../method";
+import { MethodArgument, MethodDefinition } from "../method";
 import {
   ModeledMethod,
   NeutralModeledMethod,
@@ -45,6 +45,11 @@ export type ModelsAsDataLanguagePredicates = {
   neutral?: ModelsAsDataLanguagePredicate<NeutralModeledMethod>;
 };
 
+export type MethodArgumentOptions = {
+  options: MethodArgument[];
+  defaultArgumentPath: string;
+};
+
 export type ModelsAsDataLanguage = {
   /**
    * The modes that are available for this language. If not specified, all
@@ -54,4 +59,9 @@ export type ModelsAsDataLanguage = {
   createMethodSignature: (method: MethodDefinition) => string;
   predicates: ModelsAsDataLanguagePredicates;
   modelGeneration?: ModelsAsDataLanguageModelGeneration;
+  /**
+   * Returns the list of valid arguments that can be selected for the given method.
+   * @param method The method to get the valid arguments for.
+   */
+  getArgumentOptions: (method: MethodDefinition) => MethodArgumentOptions;
 };

--- a/extensions/ql-vscode/src/model-editor/languages/ruby/index.ts
+++ b/extensions/ql-vscode/src/model-editor/languages/ruby/index.ts
@@ -2,6 +2,7 @@ import { ModelsAsDataLanguage } from "../models-as-data";
 import { sharedExtensiblePredicates, sharedKinds } from "../shared";
 import { Mode } from "../../shared/mode";
 import { parseGenerateModelResults } from "./generate";
+import { getArgumentsList, MethodArgument } from "../../method";
 
 function parseRubyMethodFromPath(path: string): string {
   const match = path.match(/Method\[([^\]]+)].*/);
@@ -156,5 +157,26 @@ export const ruby: ModelsAsDataLanguage = {
       "query path": "queries/modeling/GenerateModel.ql",
     },
     parseResults: parseGenerateModelResults,
+  },
+  getArgumentOptions: (method) => {
+    const argumentsList = getArgumentsList(method.methodParameters).map(
+      (argument, index): MethodArgument => ({
+        path: `Argument[${index}]`,
+        label: `Argument[${index}]: ${argument}`,
+      }),
+    );
+
+    return {
+      options: [
+        {
+          path: "Argument[self]",
+          label: "Argument[self]",
+        },
+        ...argumentsList,
+      ],
+      // If there are no arguments, we will default to "Argument[self]"
+      defaultArgumentPath:
+        argumentsList.length > 0 ? argumentsList[0].path : "Argument[self]",
+    };
   },
 };

--- a/extensions/ql-vscode/src/model-editor/languages/static/index.ts
+++ b/extensions/ql-vscode/src/model-editor/languages/static/index.ts
@@ -3,6 +3,7 @@ import { Provenance } from "../../modeled-method";
 import { DataTuple } from "../../model-extension-file";
 import { sharedExtensiblePredicates, sharedKinds } from "../shared";
 import { filterFlowModelQueries, parseFlowModelResults } from "./generate";
+import { getArgumentsList, MethodArgument } from "../../method";
 
 function readRowToMethod(row: DataTuple[]): string {
   return `${row[0]}.${row[1]}#${row[3]}${row[4]}`;
@@ -144,5 +145,26 @@ export const staticLanguage: ModelsAsDataLanguage = {
     },
     filterQueries: filterFlowModelQueries,
     parseResults: parseFlowModelResults,
+  },
+  getArgumentOptions: (method) => {
+    const argumentsList = getArgumentsList(method.methodParameters).map(
+      (argument, index): MethodArgument => ({
+        path: `Argument[${index}]`,
+        label: `Argument[${index}]: ${argument}`,
+      }),
+    );
+
+    return {
+      options: [
+        {
+          path: "Argument[this]",
+          label: "Argument[this]",
+        },
+        ...argumentsList,
+      ],
+      // If there are no arguments, we will default to "Argument[this]"
+      defaultArgumentPath:
+        argumentsList.length > 0 ? argumentsList[0].path : "Argument[this]",
+    };
   },
 };

--- a/extensions/ql-vscode/src/model-editor/method.ts
+++ b/extensions/ql-vscode/src/model-editor/method.ts
@@ -61,6 +61,11 @@ export interface Method extends MethodSignature {
   readonly usages: readonly Usage[];
 }
 
+export interface MethodArgument {
+  path: string;
+  label: string;
+}
+
 export function getArgumentsList(methodParameters: string): string[] {
   if (methodParameters === "()") {
     return [];

--- a/extensions/ql-vscode/src/view/method-modeling/MethodModelingInputs.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/MethodModelingInputs.tsx
@@ -39,6 +39,7 @@ export const MethodModelingInputs = ({
   onChange,
 }: MethodModelingInputsProps): JSX.Element => {
   const inputProps = {
+    language,
     method,
     modeledMethod,
     onChange,
@@ -82,7 +83,7 @@ export const MethodModelingInputs = ({
           {isModelingInProgress ? (
             <InProgressDropdown />
           ) : (
-            <ModelKindDropdown language={language} {...inputProps} />
+            <ModelKindDropdown {...inputProps} />
           )}
         </Input>
       </Container>

--- a/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
@@ -234,6 +234,7 @@ const ModelableMethodRow = forwardRef<HTMLElement | undefined, MethodRowProps>(
               <DataGridRow key={index} focused={focusedIndex === index}>
                 <DataGridCell>
                   <ModelTypeDropdown
+                    language={viewState.language}
                     method={method}
                     modeledMethod={modeledMethod}
                     onChange={modeledMethodChangedHandlers[index]}
@@ -241,6 +242,7 @@ const ModelableMethodRow = forwardRef<HTMLElement | undefined, MethodRowProps>(
                 </DataGridCell>
                 <DataGridCell>
                   <ModelInputDropdown
+                    language={viewState.language}
                     method={method}
                     modeledMethod={modeledMethod}
                     onChange={modeledMethodChangedHandlers[index]}
@@ -248,6 +250,7 @@ const ModelableMethodRow = forwardRef<HTMLElement | undefined, MethodRowProps>(
                 </DataGridCell>
                 <DataGridCell>
                   <ModelOutputDropdown
+                    language={viewState.language}
                     method={method}
                     modeledMethod={modeledMethod}
                     onChange={modeledMethodChangedHandlers[index]}

--- a/extensions/ql-vscode/src/view/model-editor/ModelInputDropdown.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelInputDropdown.tsx
@@ -5,34 +5,33 @@ import {
   ModeledMethod,
   modeledMethodSupportsInput,
 } from "../../model-editor/modeled-method";
-import { Method, getArgumentsList } from "../../model-editor/method";
+import { Method } from "../../model-editor/method";
+import { QueryLanguage } from "../../common/query-language";
+import { getModelsAsDataLanguage } from "../../model-editor/languages";
 
 type Props = {
+  language: QueryLanguage;
   method: Method;
   modeledMethod: ModeledMethod | undefined;
   onChange: (modeledMethod: ModeledMethod) => void;
 };
 
 export const ModelInputDropdown = ({
+  language,
   method,
   modeledMethod,
   onChange,
 }: Props): JSX.Element => {
-  const argumentsList = useMemo(
-    () => getArgumentsList(method.methodParameters),
-    [method.methodParameters],
-  );
+  const options = useMemo(() => {
+    const modelsAsDataLanguage = getModelsAsDataLanguage(language);
 
-  const options = useMemo(
-    () => [
-      { value: "Argument[this]", label: "Argument[this]" },
-      ...argumentsList.map((argument, index) => ({
-        value: `Argument[${index}]`,
-        label: `Argument[${index}]: ${argument}`,
-      })),
-    ],
-    [argumentsList],
-  );
+    return modelsAsDataLanguage
+      .getArgumentOptions(method)
+      .options.map((option) => ({
+        value: option.path,
+        label: option.label,
+      }));
+  }, [language, method]);
 
   const enabled = useMemo(
     () => modeledMethod && modeledMethodSupportsInput(modeledMethod),

--- a/extensions/ql-vscode/src/view/model-editor/ModelOutputDropdown.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelOutputDropdown.tsx
@@ -5,35 +5,34 @@ import {
   ModeledMethod,
   modeledMethodSupportsOutput,
 } from "../../model-editor/modeled-method";
-import { Method, getArgumentsList } from "../../model-editor/method";
+import { Method } from "../../model-editor/method";
+import { getModelsAsDataLanguage } from "../../model-editor/languages";
+import { QueryLanguage } from "../../common/query-language";
 
 type Props = {
+  language: QueryLanguage;
   method: Method;
   modeledMethod: ModeledMethod | undefined;
   onChange: (modeledMethod: ModeledMethod) => void;
 };
 
 export const ModelOutputDropdown = ({
+  language,
   method,
   modeledMethod,
   onChange,
 }: Props): JSX.Element => {
-  const argumentsList = useMemo(
-    () => getArgumentsList(method.methodParameters),
-    [method.methodParameters],
-  );
+  const options = useMemo(() => {
+    const modelsAsDataLanguage = getModelsAsDataLanguage(language);
 
-  const options = useMemo(
-    () => [
-      { value: "ReturnValue", label: "ReturnValue" },
-      { value: "Argument[this]", label: "Argument[this]" },
-      ...argumentsList.map((argument, index) => ({
-        value: `Argument[${index}]`,
-        label: `Argument[${index}]: ${argument}`,
-      })),
-    ],
-    [argumentsList],
-  );
+    const options = modelsAsDataLanguage
+      .getArgumentOptions(method)
+      .options.map((option) => ({
+        value: option.path,
+        label: option.label,
+      }));
+    return [{ value: "ReturnValue", label: "ReturnValue" }, ...options];
+  }, [language, method]);
 
   const enabled = useMemo(
     () => modeledMethod && modeledMethodSupportsOutput(modeledMethod),


### PR DESCRIPTION
This moves the creation of possible method argument options from the view to the languages. This allows differentiating between the languages, for example by using `Argument[self]` for Ruby instead of `Argument[this]`. Right now, this is the only difference, but in the future there will be more differences, like `Argument[block]` for Ruby and keyword arguments for Ruby.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
