### PR TITLE
Add support for Ruby keyword arguments

### DIFF
--- a/extensions/ql-vscode/src/model-editor/languages/ruby/index.ts
+++ b/extensions/ql-vscode/src/model-editor/languages/ruby/index.ts
@@ -160,10 +160,19 @@ export const ruby: ModelsAsDataLanguage = {
   },
   getArgumentOptions: (method) => {
     const argumentsList = getArgumentsList(method.methodParameters).map(
-      (argument, index): MethodArgument => ({
-        path: `Argument[${index}]`,
-        label: `Argument[${index}]: ${argument}`,
-      }),
+      (argument, index): MethodArgument => {
+        if (argument.endsWith(":")) {
+          return {
+            path: `Argument[${argument}]`,
+            label: `Argument[${argument}]`,
+          };
+        }
+
+        return {
+          path: `Argument[${index}]`,
+          label: `Argument[${index}]: ${argument}`,
+        };
+      },
     );
 
     return {


### PR DESCRIPTION
This adds support for `Argument[key:]` for Ruby. These are used for keyword arguments (in e.g. `def method(key:)`.

[The query will return](https://github.com/hmac/codeql/commit/5cfe71f91b51de1ca61b0c46091f99e0fdc6bc34) keyword arguments as `key:`.

Based on https://github.com/github/vscode-codeql/pull/3052

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
