### PR TITLE
Sort databases by name if their languages are the same

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [UNRELEASED]
 
+- The "Sort by Language" action in the databases view now sorts by name within each language. [#3055](https://github.com/github/vscode-codeql/pull/3055)
+
 ## 1.9.4 - 6 November 2023
 
 No user facing changes.

--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -158,9 +158,17 @@ class DatabaseTreeDataProvider
           case SortOrder.NameDesc:
             return db2.name.localeCompare(db1.name, env.language);
           case SortOrder.LanguageAsc:
-            return db1.language.localeCompare(db2.language, env.language);
+            return (
+              db1.language.localeCompare(db2.language, env.language) ||
+              // If the languages are the same, sort by name
+              db1.name.localeCompare(db2.name, env.language)
+            );
           case SortOrder.LanguageDesc:
-            return db2.language.localeCompare(db1.language, env.language);
+            return (
+              db2.language.localeCompare(db1.language, env.language) ||
+              // If the languages are the same, sort by name
+              db2.name.localeCompare(db1.name, env.language)
+            );
           case SortOrder.DateAddedAsc:
             return (db1.dateAdded || 0) - (db2.dateAdded || 0);
           case SortOrder.DateAddedDesc:


### PR DESCRIPTION
When databases in the DB panel have the same language, let's sort them by name within each language.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
