### PR TITLE
Minor tidy-up for `local-databases` tests

### DIFF
--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-queries/local-databases.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-queries/local-databases.test.ts
@@ -634,7 +634,7 @@ describe("local databases", () => {
         await (databaseManager as any).createSkeletonPacks(mockDbItem);
 
         expect(generateSpy).not.toBeCalled();
-        expect(setAutogenerateQlPacksSpy).toHaveBeenCalledWith("never", 1);
+        expect(setAutogenerateQlPacksSpy).toHaveBeenCalledWith("never");
       });
 
       it("should create the skeleton QL pack for the user", async () => {

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-queries/local-databases.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-queries/local-databases.test.ts
@@ -20,7 +20,7 @@ import {
 import { testDisposeHandler } from "../../test-dispose-handler";
 import { QueryRunner } from "../../../../src/query-server/query-runner";
 import * as dialog from "../../../../src/common/vscode/dialog";
-import { Setting } from "../../../../src/config";
+import * as config from "../../../../src/config";
 import { QlPackGenerator } from "../../../../src/local-queries/qlpack-generator";
 import { mockedObject } from "../../utils/mocking.helpers";
 import { createMockApp } from "../../../__mocks__/appMock";
@@ -626,12 +626,15 @@ describe("local databases", () => {
         showNeverAskAgainDialogSpy = jest
           .spyOn(dialog, "showNeverAskAgainDialog")
           .mockResolvedValue("No, and never ask me again");
-        const updateValueSpy = jest.spyOn(Setting.prototype, "updateValue");
+        const setAutogenerateQlPacksSpy = jest.spyOn(
+          config,
+          "setAutogenerateQlPacks",
+        );
 
         await (databaseManager as any).createSkeletonPacks(mockDbItem);
 
         expect(generateSpy).not.toBeCalled();
-        expect(updateValueSpy).toHaveBeenCalledWith("never", 2);
+        expect(setAutogenerateQlPacksSpy).toHaveBeenCalledWith("never", 2);
       });
 
       it("should create the skeleton QL pack for the user", async () => {
@@ -735,7 +738,7 @@ describe("local databases", () => {
     describe("when codeQL.codespacesTemplate is set to true", () => {
       describe("when we add the tutorial database to the codespace", () => {
         it("should not offer to create a skeleton QL pack", async () => {
-          jest.spyOn(Setting.prototype, "getValue").mockReturnValue(true);
+          jest.spyOn(config, "isCodespacesTemplate").mockReturnValue(true);
 
           const isTutorialDatabase = true;
           const makeSelected = true;
@@ -754,7 +757,7 @@ describe("local databases", () => {
 
       describe("when we add a new database that isn't the tutorial one", () => {
         it("should create a skeleton QL pack", async () => {
-          jest.spyOn(Setting.prototype, "getValue").mockReturnValue(true);
+          jest.spyOn(config, "isCodespacesTemplate").mockReturnValue(true);
 
           await databaseManager.openDatabase(mockDbItem.databaseUri);
 
@@ -763,18 +766,9 @@ describe("local databases", () => {
       });
     });
 
-    describe("when codeQL.codespacesTemplate is set to false", () => {
+    describe("when codeQL.codespacesTemplate is set to false or not defined", () => {
       it("should not create a skeleton QL pack", async () => {
-        jest.spyOn(Setting.prototype, "getValue").mockReturnValue(false);
-
-        await databaseManager.openDatabase(mockDbItem.databaseUri);
-        expect(createSkeletonPacksSpy).toBeCalledTimes(0);
-      });
-    });
-
-    describe("when codeQL.codespacesTemplate is not set", () => {
-      it("should not create a skeleton QL pack", async () => {
-        jest.spyOn(Setting.prototype, "getValue").mockReturnValue(undefined);
+        jest.spyOn(config, "isCodespacesTemplate").mockReturnValue(false);
 
         await databaseManager.openDatabase(mockDbItem.databaseUri);
         expect(createSkeletonPacksSpy).toBeCalledTimes(0);

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-queries/local-databases.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-queries/local-databases.test.ts
@@ -634,7 +634,7 @@ describe("local databases", () => {
         await (databaseManager as any).createSkeletonPacks(mockDbItem);
 
         expect(generateSpy).not.toBeCalled();
-        expect(setAutogenerateQlPacksSpy).toHaveBeenCalledWith("never", 2);
+        expect(setAutogenerateQlPacksSpy).toHaveBeenCalledWith("never", 1);
       });
 
       it("should create the skeleton QL pack for the user", async () => {

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/databases/local-databases-ui.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/databases/local-databases-ui.test.ts
@@ -17,19 +17,19 @@ import { QueryLanguage } from "../../../../src/common/query-language";
 describe("local-databases-ui", () => {
   describe("fixDbUri", () => {
     const fixDbUri = (DatabaseUI.prototype as any).fixDbUri;
-    it("should choose current directory direcory normally", async () => {
+    it("should choose current directory normally", async () => {
       const dir = dirSync().name;
       const uri = await fixDbUri(Uri.file(dir));
       expect(uri.toString()).toBe(Uri.file(dir).toString());
     });
 
-    it("should choose parent direcory when file is selected", async () => {
+    it("should choose parent directory when file is selected", async () => {
       const file = fileSync().name;
       const uri = await fixDbUri(Uri.file(file));
       expect(uri.toString()).toBe(Uri.file(dirname(file)).toString());
     });
 
-    it("should choose parent direcory when db-* is selected", async () => {
+    it("should choose parent directory when db-* is selected", async () => {
       const dir = dirSync().name;
       const dbDir = join(dir, "db-javascript");
       await mkdirs(dbDir);
@@ -38,7 +38,7 @@ describe("local-databases-ui", () => {
       expect(uri.toString()).toBe(Uri.file(dir).toString());
     });
 
-    it("should choose parent's parent direcory when file selected is in db-*", async () => {
+    it("should choose parent's parent directory when file selected is in db-*", async () => {
       const dir = dirSync().name;
       const dbDir = join(dir, "db-javascript");
       const file = join(dbDir, "nested");


### PR DESCRIPTION
A few bits of clean-up, noticed in https://github.com/github/vscode-codeql/pull/3047.

## Checklist

N/A

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
