### PR TITLE
Differentiate between suggestions and accepted models

### DIFF
--- a/extensions/ql-vscode/src/model-editor/modeled-method.ts
+++ b/extensions/ql-vscode/src/model-editor/modeled-method.ts
@@ -122,6 +122,7 @@ export function isModelAccepted(
   return (
     modelingStatus !== "unsaved" ||
     modeledMethod.type === "none" ||
+    !modeledMethodSupportsProvenance(modeledMethod) ||
     modeledMethod.provenance !== "ai-generated"
   );
 }

--- a/extensions/ql-vscode/src/model-editor/modeled-method.ts
+++ b/extensions/ql-vscode/src/model-editor/modeled-method.ts
@@ -1,4 +1,5 @@
 import { MethodSignature } from "./method";
+import { ModelingStatus } from "./shared/modeling-status";
 
 export type ModeledMethodType =
   | "none"
@@ -107,5 +108,20 @@ export function modeledMethodSupportsProvenance(
     modeledMethod.type === "sink" ||
     modeledMethod.type === "summary" ||
     modeledMethod.type === "neutral"
+  );
+}
+
+export function isModelAccepted(
+  modeledMethod: ModeledMethod | undefined,
+  modelingStatus: ModelingStatus,
+): boolean {
+  if (!modeledMethod) {
+    return true;
+  }
+
+  return (
+    modelingStatus !== "unsaved" ||
+    modeledMethod.type === "none" ||
+    modeledMethod.provenance !== "ai-generated"
   );
 }

--- a/extensions/ql-vscode/src/stories/method-modeling/MethodModeling.stories.tsx
+++ b/extensions/ql-vscode/src/stories/method-modeling/MethodModeling.stories.tsx
@@ -52,8 +52,8 @@ MultipleModelingsUnmodeled.args = {
   language,
   method,
   modeledMethods: [],
-  showMultipleModels: true,
   modelingStatus: "saved",
+  showMultipleModels: true,
 };
 
 export const MultipleModelingsModeledSingle = Template.bind({});
@@ -61,8 +61,8 @@ MultipleModelingsModeledSingle.args = {
   language,
   method,
   modeledMethods: [createSinkModeledMethod(method)],
-  showMultipleModels: true,
   modelingStatus: "saved",
+  showMultipleModels: true,
 };
 
 export const MultipleModelingsModeledMultiple = Template.bind({});
@@ -78,8 +78,8 @@ MultipleModelingsModeledMultiple.args = {
       kind: "remote",
     }),
   ],
-  showMultipleModels: true,
   modelingStatus: "saved",
+  showMultipleModels: true,
 };
 
 export const MultipleModelingsValidationFailedNeutral = Template.bind({});
@@ -90,8 +90,8 @@ MultipleModelingsValidationFailedNeutral.args = {
     createSinkModeledMethod(method),
     createNeutralModeledMethod(method),
   ],
-  showMultipleModels: true,
   modelingStatus: "unsaved",
+  showMultipleModels: true,
 };
 
 export const MultipleModelingsValidationFailedDuplicate = Template.bind({});
@@ -107,6 +107,6 @@ MultipleModelingsValidationFailedDuplicate.args = {
     }),
     createSinkModeledMethod(method),
   ],
-  showMultipleModels: true,
   modelingStatus: "unsaved",
+  showMultipleModels: true,
 };

--- a/extensions/ql-vscode/src/stories/method-modeling/MethodModelingInputs.stories.tsx
+++ b/extensions/ql-vscode/src/stories/method-modeling/MethodModelingInputs.stories.tsx
@@ -60,3 +60,13 @@ ModelingInProgress.args = {
   modeledMethod,
   isModelingInProgress: true,
 };
+
+const generatedModeledMethod = createSinkModeledMethod({
+  provenance: "ai-generated",
+});
+export const ModelingNotAccepted = Template.bind({});
+ModelingNotAccepted.args = {
+  method,
+  modeledMethod: generatedModeledMethod,
+  modelingStatus: "unsaved",
+};

--- a/extensions/ql-vscode/src/view/method-modeling/MethodModeling.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/MethodModeling.tsx
@@ -85,6 +85,7 @@ export const MethodModeling = ({
         modeledMethods={modeledMethods}
         showMultipleModels={showMultipleModels}
         isModelingInProgress={isModelingInProgress}
+        modelingStatus={modelingStatus}
         onChange={onChange}
       />
       <ReviewInEditorButton method={method} />

--- a/extensions/ql-vscode/src/view/method-modeling/MethodModelingInputs.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/MethodModelingInputs.tsx
@@ -8,6 +8,7 @@ import { ModelOutputDropdown } from "../model-editor/ModelOutputDropdown";
 import { ModelKindDropdown } from "../model-editor/ModelKindDropdown";
 import { InProgressDropdown } from "../model-editor/InProgressDropdown";
 import { QueryLanguage } from "../../common/query-language";
+import { ModelingStatus } from "../../model-editor/shared/modeling-status";
 
 const Container = styled.div`
   padding-top: 0.5rem;
@@ -27,6 +28,7 @@ export type MethodModelingInputsProps = {
   language: QueryLanguage;
   method: Method;
   modeledMethod: ModeledMethod | undefined;
+  modelingStatus: ModelingStatus;
   isModelingInProgress: boolean;
   onChange: (modeledMethod: ModeledMethod) => void;
 };
@@ -35,6 +37,7 @@ export const MethodModelingInputs = ({
   language,
   method,
   modeledMethod,
+  modelingStatus,
   isModelingInProgress,
   onChange,
 }: MethodModelingInputsProps): JSX.Element => {
@@ -42,6 +45,7 @@ export const MethodModelingInputs = ({
     language,
     method,
     modeledMethod,
+    modelingStatus,
     onChange,
   };
 

--- a/extensions/ql-vscode/src/view/method-modeling/ModeledMethodsPanel.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/ModeledMethodsPanel.tsx
@@ -7,11 +7,13 @@ import { styled } from "styled-components";
 import { MultipleModeledMethodsPanel } from "./MultipleModeledMethodsPanel";
 import { convertToLegacyModeledMethod } from "../../model-editor/shared/modeled-methods-legacy";
 import { QueryLanguage } from "../../common/query-language";
+import { ModelingStatus } from "../../model-editor/shared/modeling-status";
 
 export type ModeledMethodsPanelProps = {
   language: QueryLanguage;
   method: Method;
   modeledMethods: ModeledMethod[];
+  modelingStatus: ModelingStatus;
   isModelingInProgress: boolean;
   showMultipleModels: boolean;
   onChange: (methodSignature: string, modeledMethods: ModeledMethod[]) => void;
@@ -25,6 +27,7 @@ export const ModeledMethodsPanel = ({
   language,
   method,
   modeledMethods,
+  modelingStatus,
   isModelingInProgress,
   showMultipleModels,
   onChange,
@@ -42,6 +45,7 @@ export const ModeledMethodsPanel = ({
         language={language}
         method={method}
         modeledMethod={convertToLegacyModeledMethod(modeledMethods)}
+        modelingStatus={modelingStatus}
         isModelingInProgress={isModelingInProgress}
         onChange={handleSingleChange}
       />
@@ -53,6 +57,7 @@ export const ModeledMethodsPanel = ({
       language={language}
       method={method}
       modeledMethods={modeledMethods}
+      modelingStatus={modelingStatus}
       isModelingInProgress={isModelingInProgress}
       onChange={onChange}
     />

--- a/extensions/ql-vscode/src/view/method-modeling/MultipleModeledMethodsPanel.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/MultipleModeledMethodsPanel.tsx
@@ -15,11 +15,13 @@ import { ModeledMethodAlert } from "./ModeledMethodAlert";
 import { QueryLanguage } from "../../common/query-language";
 import { createEmptyModeledMethod } from "../../model-editor/modeled-method-empty";
 import { sendTelemetry } from "../common/telemetry";
+import { ModelingStatus } from "../../model-editor/shared/modeling-status";
 
 export type MultipleModeledMethodsPanelProps = {
   language: QueryLanguage;
   method: Method;
   modeledMethods: ModeledMethod[];
+  modelingStatus: ModelingStatus;
   isModelingInProgress: boolean;
   onChange: (methodSignature: string, modeledMethods: ModeledMethod[]) => void;
 };
@@ -60,6 +62,7 @@ export const MultipleModeledMethodsPanel = ({
   language,
   method,
   modeledMethods,
+  modelingStatus,
   isModelingInProgress,
   onChange,
 }: MultipleModeledMethodsPanelProps) => {
@@ -154,6 +157,7 @@ export const MultipleModeledMethodsPanel = ({
           language={language}
           method={method}
           modeledMethod={modeledMethods[selectedIndex]}
+          modelingStatus={modelingStatus}
           isModelingInProgress={isModelingInProgress}
           onChange={handleChange}
         />
@@ -162,6 +166,7 @@ export const MultipleModeledMethodsPanel = ({
           language={language}
           method={method}
           modeledMethod={undefined}
+          modelingStatus={modelingStatus}
           isModelingInProgress={isModelingInProgress}
           onChange={handleChange}
         />

--- a/extensions/ql-vscode/src/view/method-modeling/__tests__/MethodModelingInputs.spec.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/__tests__/MethodModelingInputs.spec.tsx
@@ -20,6 +20,7 @@ describe(MethodModelingInputs.name, () => {
   const language = QueryLanguage.Java;
   const method = createMethod();
   const modeledMethod = createSinkModeledMethod();
+  const modelingStatus = "unmodeled";
   const isModelingInProgress = false;
   const onChange = jest.fn();
 
@@ -28,6 +29,7 @@ describe(MethodModelingInputs.name, () => {
       language,
       method,
       modeledMethod,
+      modelingStatus,
       isModelingInProgress,
       onChange,
     });
@@ -54,6 +56,7 @@ describe(MethodModelingInputs.name, () => {
       language,
       method,
       modeledMethod,
+      modelingStatus,
       isModelingInProgress,
       onChange,
     });
@@ -76,6 +79,7 @@ describe(MethodModelingInputs.name, () => {
       language,
       method,
       modeledMethod,
+      modelingStatus,
       isModelingInProgress,
       onChange,
     });
@@ -90,6 +94,7 @@ describe(MethodModelingInputs.name, () => {
         language={language}
         method={method}
         modeledMethod={updatedModeledMethod}
+        modelingStatus={modelingStatus}
         isModelingInProgress={isModelingInProgress}
         onChange={onChange}
       />,
@@ -119,6 +124,7 @@ describe(MethodModelingInputs.name, () => {
       language,
       method,
       modeledMethod,
+      modelingStatus,
       isModelingInProgress: true,
       onChange,
     });

--- a/extensions/ql-vscode/src/view/method-modeling/__tests__/ModeledMethodsPanel.spec.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/__tests__/ModeledMethodsPanel.spec.tsx
@@ -15,6 +15,7 @@ describe(ModeledMethodsPanel.name, () => {
   const language = QueryLanguage.Java;
   const method = createMethod();
   const modeledMethods = [createSinkModeledMethod(), createSinkModeledMethod()];
+  const modelingStatus = "unmodeled";
   const isModelingInProgress = false;
   const onChange = jest.fn();
 
@@ -27,6 +28,7 @@ describe(ModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        modelingStatus,
         onChange,
         showMultipleModels,
       });
@@ -40,6 +42,7 @@ describe(ModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        modelingStatus,
         onChange,
         showMultipleModels,
       });
@@ -60,6 +63,7 @@ describe(ModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        modelingStatus,
         onChange,
         showMultipleModels,
       });
@@ -73,6 +77,7 @@ describe(ModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        modelingStatus,
         onChange,
         showMultipleModels,
       });

--- a/extensions/ql-vscode/src/view/method-modeling/__tests__/MultipleModeledMethodsPanel.spec.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/__tests__/MultipleModeledMethodsPanel.spec.tsx
@@ -21,6 +21,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
   const language = QueryLanguage.Java;
   const method = createMethod();
   const isModelingInProgress = false;
+  const modelingStatus = "unmodeled";
   const onChange = jest.fn<void, [string, ModeledMethod[]]>();
 
   describe("with no modeled methods", () => {
@@ -31,6 +32,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         language,
         method,
         modeledMethods,
+        modelingStatus,
         isModelingInProgress,
         onChange,
       });
@@ -48,6 +50,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         language,
         method,
         modeledMethods,
+        modelingStatus,
         isModelingInProgress,
         onChange,
       });
@@ -69,6 +72,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         language,
         method,
         modeledMethods,
+        modelingStatus,
         isModelingInProgress,
         onChange,
       });
@@ -99,6 +103,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         language,
         method,
         modeledMethods,
+        modelingStatus,
         isModelingInProgress,
         onChange,
       });
@@ -116,6 +121,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         language,
         method,
         modeledMethods,
+        modelingStatus,
         isModelingInProgress,
         onChange,
       });
@@ -136,6 +142,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         language,
         method,
         modeledMethods,
+        modelingStatus,
         isModelingInProgress,
         onChange,
       });
@@ -152,6 +159,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         language,
         method,
         modeledMethods,
+        modelingStatus,
         isModelingInProgress,
         onChange,
       });
@@ -176,6 +184,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         language,
         method,
         modeledMethods,
+        modelingStatus,
         isModelingInProgress,
         onChange,
       });
@@ -190,6 +199,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
             onChange.mock.calls[onChange.mock.calls.length - 1][1]
           }
           isModelingInProgress={isModelingInProgress}
+          modelingStatus={modelingStatus}
           onChange={onChange}
         />,
       );
@@ -214,6 +224,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        modelingStatus,
         onChange,
       });
 
@@ -231,6 +242,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        modelingStatus,
         onChange,
       });
 
@@ -245,6 +257,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        modelingStatus,
         onChange,
       });
 
@@ -264,6 +277,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        modelingStatus,
         onChange,
       });
 
@@ -300,6 +314,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        modelingStatus,
         onChange,
       });
 
@@ -311,6 +326,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
           method={method}
           modeledMethods={[modeledMethods[1]]}
           isModelingInProgress={isModelingInProgress}
+          modelingStatus={modelingStatus}
           onChange={onChange}
         />,
       );
@@ -329,6 +345,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        modelingStatus,
         onChange,
       });
 
@@ -341,6 +358,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        modelingStatus,
         onChange,
       });
 
@@ -372,6 +390,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        modelingStatus,
         onChange,
       });
 
@@ -405,6 +424,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        modelingStatus,
         onChange,
       });
 
@@ -422,6 +442,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        modelingStatus,
         onChange,
       });
 
@@ -446,6 +467,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        modelingStatus,
         onChange,
       });
 
@@ -459,6 +481,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
             onChange.mock.calls[onChange.mock.calls.length - 1][1]
           }
           isModelingInProgress={isModelingInProgress}
+          modelingStatus={modelingStatus}
           onChange={onChange}
         />,
       );
@@ -479,6 +502,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
             onChange.mock.calls[onChange.mock.calls.length - 1][1]
           }
           isModelingInProgress={isModelingInProgress}
+          modelingStatus={modelingStatus}
           onChange={onChange}
         />,
       );
@@ -497,6 +521,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
             onChange.mock.calls[onChange.mock.calls.length - 1][1]
           }
           isModelingInProgress={isModelingInProgress}
+          modelingStatus={modelingStatus}
           onChange={onChange}
         />,
       );
@@ -513,6 +538,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        modelingStatus,
         onChange,
       });
 
@@ -528,6 +554,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
             onChange.mock.calls[onChange.mock.calls.length - 1][1]
           }
           isModelingInProgress={isModelingInProgress}
+          modelingStatus={modelingStatus}
           onChange={onChange}
         />,
       );
@@ -561,6 +588,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        modelingStatus,
         onChange,
       });
 
@@ -651,6 +679,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        modelingStatus,
         onChange,
       });
 
@@ -662,6 +691,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
           method={method}
           modeledMethods={modeledMethods.slice(0, 2)}
           isModelingInProgress={isModelingInProgress}
+          modelingStatus={modelingStatus}
           onChange={onChange}
         />,
       );
@@ -675,6 +705,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        modelingStatus,
         onChange,
       });
 
@@ -688,6 +719,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
           method={method}
           modeledMethods={modeledMethods.slice(0, 2)}
           isModelingInProgress={isModelingInProgress}
+          modelingStatus={modelingStatus}
           onChange={onChange}
         />,
       );
@@ -715,6 +747,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        modelingStatus,
         onChange,
       });
 
@@ -729,6 +762,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        modelingStatus,
         onChange,
       });
 
@@ -746,6 +780,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        modelingStatus,
         onChange,
       });
 
@@ -764,6 +799,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        modelingStatus,
         onChange,
       });
 
@@ -781,6 +817,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
           method={method}
           modeledMethods={modeledMethods.slice(0, 1)}
           isModelingInProgress={isModelingInProgress}
+          modelingStatus={modelingStatus}
           onChange={onChange}
         />,
       );
@@ -818,6 +855,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        modelingStatus,
         onChange,
       });
 
@@ -830,6 +868,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        modelingStatus,
         onChange,
       });
 

--- a/extensions/ql-vscode/src/view/model-editor/InputDropdown.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/InputDropdown.tsx
@@ -1,0 +1,6 @@
+import { styled } from "styled-components";
+import { Dropdown } from "../common/Dropdown";
+
+export const InputDropdown = styled(Dropdown)<{ $accepted: boolean }>`
+  font-style: ${(props) => (props.$accepted ? "normal" : "italic")};
+`;

--- a/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
@@ -237,6 +237,7 @@ const ModelableMethodRow = forwardRef<HTMLElement | undefined, MethodRowProps>(
                     language={viewState.language}
                     method={method}
                     modeledMethod={modeledMethod}
+                    modelingStatus={modelingStatus}
                     onChange={modeledMethodChangedHandlers[index]}
                   />
                 </DataGridCell>
@@ -245,6 +246,7 @@ const ModelableMethodRow = forwardRef<HTMLElement | undefined, MethodRowProps>(
                     language={viewState.language}
                     method={method}
                     modeledMethod={modeledMethod}
+                    modelingStatus={modelingStatus}
                     onChange={modeledMethodChangedHandlers[index]}
                   />
                 </DataGridCell>
@@ -253,6 +255,7 @@ const ModelableMethodRow = forwardRef<HTMLElement | undefined, MethodRowProps>(
                     language={viewState.language}
                     method={method}
                     modeledMethod={modeledMethod}
+                    modelingStatus={modelingStatus}
                     onChange={modeledMethodChangedHandlers[index]}
                   />
                 </DataGridCell>
@@ -260,6 +263,7 @@ const ModelableMethodRow = forwardRef<HTMLElement | undefined, MethodRowProps>(
                   <ModelKindDropdown
                     language={viewState.language}
                     modeledMethod={modeledMethod}
+                    modelingStatus={modelingStatus}
                     onChange={modeledMethodChangedHandlers[index]}
                   />
                 </DataGridCell>

--- a/extensions/ql-vscode/src/view/model-editor/ModelInputDropdown.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelInputDropdown.tsx
@@ -9,11 +9,13 @@ import { Method } from "../../model-editor/method";
 import { ReadonlyDropdown } from "../common/ReadonlyDropdown";
 import { QueryLanguage } from "../../common/query-language";
 import { getModelsAsDataLanguage } from "../../model-editor/languages";
+import { ModelingStatus } from "../../model-editor/shared/modeling-status";
 
 type Props = {
   language: QueryLanguage;
   method: Method;
   modeledMethod: ModeledMethod | undefined;
+  modelingStatus: ModelingStatus;
   onChange: (modeledMethod: ModeledMethod) => void;
 };
 

--- a/extensions/ql-vscode/src/view/model-editor/ModelInputDropdown.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelInputDropdown.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 import { ChangeEvent, useCallback, useMemo } from "react";
-import { Dropdown } from "../common/Dropdown";
 import {
   ModeledMethod,
+  isModelAccepted,
   modeledMethodSupportsInput,
 } from "../../model-editor/modeled-method";
 import { Method } from "../../model-editor/method";
@@ -10,6 +10,7 @@ import { ReadonlyDropdown } from "../common/ReadonlyDropdown";
 import { QueryLanguage } from "../../common/query-language";
 import { getModelsAsDataLanguage } from "../../model-editor/languages";
 import { ModelingStatus } from "../../model-editor/shared/modeling-status";
+import { InputDropdown } from "./InputDropdown";
 
 type Props = {
   language: QueryLanguage;
@@ -23,6 +24,7 @@ export const ModelInputDropdown = ({
   language,
   method,
   modeledMethod,
+  modelingStatus,
   onChange,
 }: Props): JSX.Element => {
   const options = useMemo(() => {
@@ -66,11 +68,14 @@ export const ModelInputDropdown = ({
     return <ReadonlyDropdown value={modeledMethod.path} aria-label="Path" />;
   }
 
+  const modelAccepted = isModelAccepted(modeledMethod, modelingStatus);
+
   return (
-    <Dropdown
+    <InputDropdown
       value={value}
       options={options}
       disabled={!enabled}
+      $accepted={modelAccepted}
       onChange={handleChange}
       aria-label="Input"
     />

--- a/extensions/ql-vscode/src/view/model-editor/ModelKindDropdown.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelKindDropdown.tsx
@@ -1,14 +1,15 @@
 import * as React from "react";
 import { ChangeEvent, useCallback, useEffect, useMemo } from "react";
-import type {
+import {
   ModeledMethod,
   ModeledMethodKind,
+  modeledMethodSupportsKind,
+  isModelAccepted,
 } from "../../model-editor/modeled-method";
-import { modeledMethodSupportsKind } from "../../model-editor/modeled-method";
-import { Dropdown } from "../common/Dropdown";
 import { getModelsAsDataLanguage } from "../../model-editor/languages";
 import { QueryLanguage } from "../../common/query-language";
 import { ModelingStatus } from "../../model-editor/shared/modeling-status";
+import { InputDropdown } from "./InputDropdown";
 
 type Props = {
   language: QueryLanguage;
@@ -20,6 +21,7 @@ type Props = {
 export const ModelKindDropdown = ({
   language,
   modeledMethod,
+  modelingStatus,
   onChange,
 }: Props) => {
   const predicate = useMemo(() => {
@@ -83,11 +85,14 @@ export const ModelKindDropdown = ({
     }
   }, [modeledMethod, value, kinds, onChangeKind]);
 
+  const modelAccepted = isModelAccepted(modeledMethod, modelingStatus);
+
   return (
-    <Dropdown
+    <InputDropdown
       value={value}
       options={options}
       disabled={disabled}
+      $accepted={modelAccepted}
       onChange={handleChange}
       aria-label="Kind"
     />

--- a/extensions/ql-vscode/src/view/model-editor/ModelKindDropdown.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelKindDropdown.tsx
@@ -8,10 +8,12 @@ import { modeledMethodSupportsKind } from "../../model-editor/modeled-method";
 import { Dropdown } from "../common/Dropdown";
 import { getModelsAsDataLanguage } from "../../model-editor/languages";
 import { QueryLanguage } from "../../common/query-language";
+import { ModelingStatus } from "../../model-editor/shared/modeling-status";
 
 type Props = {
   language: QueryLanguage;
   modeledMethod: ModeledMethod | undefined;
+  modelingStatus: ModelingStatus;
   onChange: (modeledMethod: ModeledMethod) => void;
 };
 

--- a/extensions/ql-vscode/src/view/model-editor/ModelOutputDropdown.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelOutputDropdown.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 import { ChangeEvent, useCallback, useMemo } from "react";
-import { Dropdown } from "../common/Dropdown";
 import {
   ModeledMethod,
+  isModelAccepted,
   modeledMethodSupportsOutput,
 } from "../../model-editor/modeled-method";
 import { Method } from "../../model-editor/method";
@@ -10,6 +10,7 @@ import { ReadonlyDropdown } from "../common/ReadonlyDropdown";
 import { getModelsAsDataLanguage } from "../../model-editor/languages";
 import { QueryLanguage } from "../../common/query-language";
 import { ModelingStatus } from "../../model-editor/shared/modeling-status";
+import { InputDropdown } from "./InputDropdown";
 
 type Props = {
   language: QueryLanguage;
@@ -23,6 +24,7 @@ export const ModelOutputDropdown = ({
   language,
   method,
   modeledMethod,
+  modelingStatus,
   onChange,
 }: Props): JSX.Element => {
   const options = useMemo(() => {
@@ -72,11 +74,14 @@ export const ModelOutputDropdown = ({
     );
   }
 
+  const modelAccepted = isModelAccepted(modeledMethod, modelingStatus);
+
   return (
-    <Dropdown
+    <InputDropdown
       value={value}
       options={options}
       disabled={!enabled}
+      $accepted={modelAccepted}
       onChange={handleChange}
       aria-label="Output"
     />

--- a/extensions/ql-vscode/src/view/model-editor/ModelOutputDropdown.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelOutputDropdown.tsx
@@ -9,11 +9,13 @@ import { Method } from "../../model-editor/method";
 import { ReadonlyDropdown } from "../common/ReadonlyDropdown";
 import { getModelsAsDataLanguage } from "../../model-editor/languages";
 import { QueryLanguage } from "../../common/query-language";
+import { ModelingStatus } from "../../model-editor/shared/modeling-status";
 
 type Props = {
   language: QueryLanguage;
   method: Method;
   modeledMethod: ModeledMethod | undefined;
+  modelingStatus: ModelingStatus;
   onChange: (modeledMethod: ModeledMethod) => void;
 };
 

--- a/extensions/ql-vscode/src/view/model-editor/ModelTypeDropdown.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelTypeDropdown.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { ChangeEvent, useCallback } from "react";
-import { Dropdown } from "../common/Dropdown";
 import {
+  isModelAccepted,
   ModeledMethod,
   modeledMethodSupportsProvenance,
   ModeledMethodType,
@@ -14,6 +14,7 @@ import { ReadonlyDropdown } from "../common/ReadonlyDropdown";
 import { QueryLanguage } from "../../common/query-language";
 import { getModelsAsDataLanguage } from "../../model-editor/languages";
 import { ModelingStatus } from "../../model-editor/shared/modeling-status";
+import { InputDropdown } from "./InputDropdown";
 
 const options: Array<{ value: ModeledMethodType; label: string }> = [
   { value: "none", label: "Unmodeled" },
@@ -35,6 +36,7 @@ export const ModelTypeDropdown = ({
   language,
   method,
   modeledMethod,
+  modelingStatus,
   onChange,
 }: Props): JSX.Element => {
   const handleChange = useCallback(
@@ -90,10 +92,13 @@ export const ModelTypeDropdown = ({
     );
   }
 
+  const modelAccepted = isModelAccepted(modeledMethod, modelingStatus);
+
   return (
-    <Dropdown
+    <InputDropdown
       value={modeledMethod?.type ?? "none"}
       options={options}
+      $accepted={modelAccepted}
       onChange={handleChange}
       aria-label="Model type"
     />

--- a/extensions/ql-vscode/src/view/model-editor/ModelTypeDropdown.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelTypeDropdown.tsx
@@ -13,6 +13,7 @@ import { Mutable } from "../../common/mutable";
 import { ReadonlyDropdown } from "../common/ReadonlyDropdown";
 import { QueryLanguage } from "../../common/query-language";
 import { getModelsAsDataLanguage } from "../../model-editor/languages";
+import { ModelingStatus } from "../../model-editor/shared/modeling-status";
 
 const options: Array<{ value: ModeledMethodType; label: string }> = [
   { value: "none", label: "Unmodeled" },
@@ -26,6 +27,7 @@ type Props = {
   language: QueryLanguage;
   method: Method;
   modeledMethod: ModeledMethod | undefined;
+  modelingStatus: ModelingStatus;
   onChange: (modeledMethod: ModeledMethod) => void;
 };
 

--- a/extensions/ql-vscode/src/view/model-editor/__tests__/ModelKindDropdown.spec.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/__tests__/ModelKindDropdown.spec.tsx
@@ -25,6 +25,7 @@ describe(ModelKindDropdown.name, () => {
       <ModelKindDropdown
         language={QueryLanguage.Java}
         modeledMethod={modeledMethod}
+        modelingStatus="unsaved"
         onChange={onChange}
       />,
     );
@@ -47,6 +48,7 @@ describe(ModelKindDropdown.name, () => {
       <ModelKindDropdown
         language={QueryLanguage.Java}
         modeledMethod={modeledMethod}
+        modelingStatus="unsaved"
         onChange={onChange}
       />,
     );
@@ -63,6 +65,7 @@ describe(ModelKindDropdown.name, () => {
       <ModelKindDropdown
         language={QueryLanguage.Java}
         modeledMethod={updatedModeledMethod}
+        modelingStatus="unsaved"
         onChange={onChange}
       />,
     );
@@ -80,6 +83,7 @@ describe(ModelKindDropdown.name, () => {
       <ModelKindDropdown
         language={QueryLanguage.Java}
         modeledMethod={modeledMethod}
+        modelingStatus="unsaved"
         onChange={onChange}
       />,
     );
@@ -99,6 +103,7 @@ describe(ModelKindDropdown.name, () => {
       <ModelKindDropdown
         language={QueryLanguage.Java}
         modeledMethod={modeledMethod}
+        modelingStatus="unsaved"
         onChange={onChange}
       />,
     );


### PR DESCRIPTION
There are two commits in this PR:
- https://github.com/github/vscode-codeql/commit/0d3e626328768fc40bcad445ee03d399ecb37920 is doing a bunch of prop drilling so that the various input drop-downs have the modeling status available to them.
- https://github.com/github/vscode-codeql/commit/0078093e17a21c073c811d189256725d88e9c111 adds some logic that allows us to differentiate between models that were suggested by automodel but not necessarily accepted/committed, and ones that have.

This is not perfect as only changes to the Type change provenance at the moment. I'm chasing up to find if that's correct.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
