### PR TITLE
Enable noUnusedParameters for the view code

### DIFF
--- a/extensions/ql-vscode/src/view/common/DeterminateProgressRing.tsx
+++ b/extensions/ql-vscode/src/view/common/DeterminateProgressRing.tsx
@@ -3,7 +3,6 @@ import { styled } from "styled-components";
 
 type Props = {
   percent: number;
-  label?: string;
 };
 
 const Circle = styled.div`
@@ -33,10 +32,7 @@ const progressSegments = 44;
 // See https://github.com/microsoft/fast/blob/21c210f2164c5cf285cade1a328460c67e4b97e6/packages/web-components/fast-foundation/src/progress-ring/progress-ring.template.ts
 // Once the determinate progress ring is available in the VSCode webview UI toolkit, we should use that instead
 
-export const DeterminateProgressRing = ({
-  percent,
-  label = "Loading...",
-}: Props) => (
+export const DeterminateProgressRing = ({ percent }: Props) => (
   <Circle
     role="progressbar"
     aria-valuemin={0}

--- a/extensions/ql-vscode/src/view/model-editor/LibraryRow.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/LibraryRow.tsx
@@ -226,7 +226,6 @@ export const LibraryRow = ({
         <>
           <SectionDivider />
           <ModeledMethodDataGrid
-            packageName={title}
             methods={methods}
             modeledMethodsMap={modeledMethodsMap}
             modifiedSignatures={modifiedSignatures}

--- a/extensions/ql-vscode/src/view/model-editor/ModeledMethodDataGrid.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModeledMethodDataGrid.tsx
@@ -79,24 +79,22 @@ export const ModeledMethodDataGrid = ({
               <ScreenReaderOnly>Add or remove models</ScreenReaderOnly>
             </DataGridCell>
           )}
-          {methodsWithModelability.map(
-            ({ method, methodCanBeModeled }, index) => {
-              const modeledMethods = modeledMethodsMap[method.signature] ?? [];
-              return (
-                <MethodRow
-                  key={method.signature}
-                  method={method}
-                  methodCanBeModeled={methodCanBeModeled}
-                  modeledMethods={modeledMethods}
-                  methodIsUnsaved={modifiedSignatures.has(method.signature)}
-                  modelingInProgress={inProgressMethods.has(method.signature)}
-                  viewState={viewState}
-                  revealedMethodSignature={revealedMethodSignature}
-                  onChange={onChange}
-                />
-              );
-            },
-          )}
+          {methodsWithModelability.map(({ method, methodCanBeModeled }) => {
+            const modeledMethods = modeledMethodsMap[method.signature] ?? [];
+            return (
+              <MethodRow
+                key={method.signature}
+                method={method}
+                methodCanBeModeled={methodCanBeModeled}
+                modeledMethods={modeledMethods}
+                methodIsUnsaved={modifiedSignatures.has(method.signature)}
+                modelingInProgress={inProgressMethods.has(method.signature)}
+                viewState={viewState}
+                revealedMethodSignature={revealedMethodSignature}
+                onChange={onChange}
+              />
+            );
+          })}
         </>
       )}
       <HiddenMethodsRow

--- a/extensions/ql-vscode/src/view/model-editor/ModeledMethodDataGrid.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModeledMethodDataGrid.tsx
@@ -15,7 +15,6 @@ export const MULTIPLE_MODELS_GRID_TEMPLATE_COLUMNS =
   "0.5fr 0.125fr 0.125fr 0.125fr 0.125fr max-content";
 
 export type ModeledMethodDataGridProps = {
-  packageName: string;
   methods: Method[];
   modeledMethodsMap: Record<string, ModeledMethod[]>;
   modifiedSignatures: Set<string>;
@@ -27,7 +26,6 @@ export type ModeledMethodDataGridProps = {
 };
 
 export const ModeledMethodDataGrid = ({
-  packageName,
   methods,
   modeledMethodsMap,
   modifiedSignatures,

--- a/extensions/ql-vscode/src/view/model-editor/__tests__/ModeledMethodDataGrid.spec.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/__tests__/ModeledMethodDataGrid.spec.tsx
@@ -45,7 +45,6 @@ describe(ModeledMethodDataGrid.name, () => {
   const render = (props: Partial<ModeledMethodDataGridProps> = {}) =>
     reactRender(
       <ModeledMethodDataGrid
-        packageName="sql2o"
         methods={[method1, method2, method3]}
         modeledMethodsMap={{
           [method1.signature]: [

--- a/extensions/ql-vscode/src/view/results/Graph.tsx
+++ b/extensions/ql-vscode/src/view/results/Graph.tsx
@@ -47,9 +47,7 @@ export function Graph({ graphData, databaseUri }: GraphProps) {
             d.attributes["xlink:href"] = "#";
             d.attributes["href"] = "#";
             loc.uri = `file://${loc.uri}`;
-            select(this).on("click", function (e) {
-              jumpToLocation(loc, databaseUri);
-            });
+            select(this).on("click", () => jumpToLocation(loc, databaseUri));
           }
         }
         if ("fill" in d.attributes) {

--- a/extensions/ql-vscode/src/view/results/locations/ClickableLocation.tsx
+++ b/extensions/ql-vscode/src/view/results/locations/ClickableLocation.tsx
@@ -9,7 +9,6 @@ interface Props {
   loc: ResolvableLocationValue;
   label: string;
   databaseUri: string;
-  title?: string;
   onClick?: () => void;
 }
 
@@ -24,7 +23,6 @@ export function ClickableLocation({
   loc,
   label,
   databaseUri,
-  title,
   onClick: onClick,
 }: Props): JSX.Element {
   const handleClick = useCallback(

--- a/extensions/ql-vscode/src/view/results/locations/Location.tsx
+++ b/extensions/ql-vscode/src/view/results/locations/Location.tsx
@@ -48,7 +48,6 @@ export function Location({
       loc={resolvableLoc}
       label={displayLabel}
       databaseUri={databaseUri}
-      title={title}
       onClick={onClick}
     />
   );

--- a/extensions/ql-vscode/src/view/tsconfig.json
+++ b/extensions/ql-vscode/src/view/tsconfig.json
@@ -10,6 +10,7 @@
     "rootDir": "../..",
     "strict": true,
     "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
This PR enables the `noUnusedParameters` option in `src/view/tsconfig.json` and fixes all of the resulting errors.

With this option enabled it finds unused parameters to function components, e.g. it would detect
```typescript
const MyComponent = ({ myUnusedProp }: Props) => {
  return (
    <span>Hello World!</span>
  );
}
```

However it doesn't appear to detect when there is a field defined on the `Props` type that is never referenced anywhere. So if we removed `myUnusedProp` from the function parameters but left the `Props` type definition as
```typescript
interface Props {
  myUnusedProp: string;
}
```
then it would not cause a linting error.

For this PR I've also removed the field from the props types, but long term we should look into if we can catch these automatically as well. There may well be more unused props in our codebase.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
