### PR TITLE
Change @typescript-eslint/no-unused-vars "args" option to "after-used"

### DIFF
--- a/extensions/ql-vscode/.eslintrc.js
+++ b/extensions/ql-vscode/.eslintrc.js
@@ -35,7 +35,7 @@ const baseConfig = {
       "warn",
       {
         vars: "all",
-        args: "none",
+        args: "after-used",
         ignoreRestSiblings: false,
       },
     ],

--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -334,7 +334,7 @@ export class CodeQLCliServer implements Disposable {
       ["execute", "cli-server"],
       args,
       this.logger,
-      (_data) => {
+      () => {
         /**/
       },
     );
@@ -495,9 +495,7 @@ export class CodeQLCliServer implements Disposable {
     try {
       if (cancellationToken !== undefined) {
         cancellationRegistration = cancellationToken.onCancellationRequested(
-          (_e) => {
-            tk(child.pid || 0);
-          },
+          () => tk(child.pid || 0),
         );
       }
       if (logger !== undefined) {

--- a/extensions/ql-vscode/src/common/vscode/abstract-webview-view-provider.ts
+++ b/extensions/ql-vscode/src/common/vscode/abstract-webview-view-provider.ts
@@ -22,11 +22,7 @@ export abstract class AbstractWebviewViewProvider<
    * This is called when a view first becomes visible. This may happen when the view is
    * first loaded or when the user hides and then shows a view again.
    */
-  public resolveWebviewView(
-    webviewView: vscode.WebviewView,
-    _context: vscode.WebviewViewResolveContext,
-    _token: vscode.CancellationToken,
-  ) {
+  public resolveWebviewView(webviewView: vscode.WebviewView) {
     webviewView.webview.options = {
       enableScripts: true,
       localResourceRoots: [Uri.file(this.app.extensionPath)],

--- a/extensions/ql-vscode/src/common/vscode/archive-filesystem-provider.ts
+++ b/extensions/ql-vscode/src/common/vscode/archive-filesystem-provider.ts
@@ -238,27 +238,19 @@ export class ArchiveFileSystemProvider implements vscode.FileSystemProvider {
 
   // write operations, all disabled
 
-  writeFile(
-    _uri: vscode.Uri,
-    _content: Uint8Array,
-    _options: { create: boolean; overwrite: boolean },
-  ): void {
+  writeFile(): void {
     throw this.readOnlyError;
   }
 
-  rename(
-    _oldUri: vscode.Uri,
-    _newUri: vscode.Uri,
-    _options: { overwrite: boolean },
-  ): void {
+  rename(): void {
     throw this.readOnlyError;
   }
 
-  delete(_uri: vscode.Uri): void {
+  delete(): void {
     throw this.readOnlyError;
   }
 
-  createDirectory(_uri: vscode.Uri): void {
+  createDirectory(): void {
     throw this.readOnlyError;
   }
 
@@ -314,7 +306,7 @@ export class ArchiveFileSystemProvider implements vscode.FileSystemProvider {
   readonly onDidChangeFile: vscode.Event<vscode.FileChangeEvent[]> =
     this._emitter.event;
 
-  watch(_resource: vscode.Uri): vscode.Disposable {
+  watch(): vscode.Disposable {
     // ignore, fires for all changes...
     return new vscode.Disposable(() => {
       /**/

--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -180,7 +180,7 @@ class DatabaseTreeDataProvider
     }
   }
 
-  public getParent(_element: DatabaseItem): ProviderResult<DatabaseItem> {
+  public getParent(): ProviderResult<DatabaseItem> {
     return null;
   }
 

--- a/extensions/ql-vscode/src/databases/local-databases/database-manager.ts
+++ b/extensions/ql-vscode/src/databases/local-databases/database-manager.ts
@@ -56,7 +56,7 @@ function eventFired<T>(
   event: vscode.Event<T>,
   timeoutMs = 1000,
 ): Promise<T | undefined> {
-  return new Promise((res, _rej) => {
+  return new Promise((res) => {
     const timeout = setTimeout(() => {
       void extLogger.log(
         `Waiting for event ${event} timed out after ${timeoutMs}ms`,

--- a/extensions/ql-vscode/src/databases/ui/db-selection-decoration-provider.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-selection-decoration-provider.ts
@@ -1,5 +1,4 @@
 import {
-  CancellationToken,
   FileDecoration,
   FileDecorationProvider,
   ProviderResult,
@@ -8,10 +7,7 @@ import {
 import { SELECTED_DB_ITEM_RESOURCE_URI } from "./db-tree-view-item";
 
 export class DbSelectionDecorationProvider implements FileDecorationProvider {
-  provideFileDecoration(
-    uri: Uri,
-    _token: CancellationToken,
-  ): ProviderResult<FileDecoration> {
+  provideFileDecoration(uri: Uri): ProviderResult<FileDecoration> {
     if (uri.toString(true) === SELECTED_DB_ITEM_RESOURCE_URI) {
       return {
         badge: "✓",

--- a/extensions/ql-vscode/src/debugger/debug-configuration.ts
+++ b/extensions/ql-vscode/src/debugger/debug-configuration.ts
@@ -1,5 +1,4 @@
 import {
-  CancellationToken,
   DebugConfiguration,
   DebugConfigurationProvider,
   WorkspaceFolder,
@@ -59,7 +58,6 @@ export class QLDebugConfigurationProvider
   public resolveDebugConfiguration(
     _folder: WorkspaceFolder | undefined,
     debugConfiguration: DebugConfiguration,
-    _token?: CancellationToken,
   ): DebugConfiguration {
     const qlConfiguration = <QLDebugConfiguration>debugConfiguration;
 
@@ -78,7 +76,6 @@ export class QLDebugConfigurationProvider
   public async resolveDebugConfigurationWithSubstitutedVariables(
     _folder: WorkspaceFolder | undefined,
     debugConfiguration: DebugConfiguration,
-    _token?: CancellationToken,
   ): Promise<DebugConfiguration | null> {
     try {
       const qlConfiguration = debugConfiguration as QLDebugConfiguration;

--- a/extensions/ql-vscode/src/debugger/debugger-factory.ts
+++ b/extensions/ql-vscode/src/debugger/debugger-factory.ts
@@ -2,10 +2,8 @@ import {
   debug,
   DebugAdapterDescriptor,
   DebugAdapterDescriptorFactory,
-  DebugAdapterExecutable,
   DebugAdapterInlineImplementation,
   DebugConfigurationProviderTriggerKind,
-  DebugSession,
   ProviderResult,
 } from "vscode";
 import { isCanary } from "../config";
@@ -36,10 +34,7 @@ export class QLDebugAdapterDescriptorFactory
     );
   }
 
-  public createDebugAdapterDescriptor(
-    _session: DebugSession,
-    _executable: DebugAdapterExecutable | undefined,
-  ): ProviderResult<DebugAdapterDescriptor> {
+  public createDebugAdapterDescriptor(): ProviderResult<DebugAdapterDescriptor> {
     if (!isCanary()) {
       throw new Error("The CodeQL debugger feature is not available yet.");
     }

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -760,7 +760,7 @@ async function activateWithInstalledDistribution(
     const fsWatcher = workspace.createFileSystemWatcher(glob);
     ctx.subscriptions.push(fsWatcher);
 
-    const clearPackCache = async (_uri: Uri) => {
+    const clearPackCache = async () => {
       await qs.clearPackCache();
     };
 

--- a/extensions/ql-vscode/src/language-support/contextual/template-provider.ts
+++ b/extensions/ql-vscode/src/language-support/contextual/template-provider.ts
@@ -97,7 +97,7 @@ export class TemplateQueryDefinitionProvider implements DefinitionProvider {
           this.queryStorageDir,
           progress,
           multiToken,
-          (src, _dest) => src === uriString,
+          (src) => src === uriString,
         );
       },
       {
@@ -171,7 +171,7 @@ export class TemplateQueryReferenceProvider implements ReferenceProvider {
           this.queryStorageDir,
           progress,
           multiToken,
-          (src, _dest) => src === uriString,
+          (src) => src === uriString,
         );
       },
       {

--- a/extensions/ql-vscode/src/language-support/ide-server.ts
+++ b/extensions/ql-vscode/src/language-support/ide-server.ts
@@ -60,7 +60,7 @@ export class CodeQLLanguageClient extends LanguageClient {
 async function spawnIdeServer(config: QueryServerConfig): Promise<StreamInfo> {
   return window.withProgress(
     { title: "CodeQL language server", location: ProgressLocation.Window },
-    async (progressReporter, _) => {
+    async (progressReporter) => {
       const args = ["--check-errors", "ON_CHANGE"];
       if (shouldDebugIdeServer()) {
         args.push(

--- a/extensions/ql-vscode/src/local-queries/skeleton-query-wizard.ts
+++ b/extensions/ql-vscode/src/local-queries/skeleton-query-wizard.ts
@@ -329,11 +329,11 @@ export class SkeletonQueryWizard {
     const folderUri = Uri.file(this.queryStoragePath);
     const files = await workspace.fs.readDirectory(folderUri);
     // If the example.ql file doesn't exist yet, use that name
-    if (!files.some(([filename, _fileType]) => filename === this.fileName)) {
+    if (!files.some(([filename]) => filename === this.fileName)) {
       return this.fileName;
     }
 
-    const qlFiles = files.filter(([filename, _fileType]) =>
+    const qlFiles = files.filter(([filename]) =>
       filename.match(/^example[0-9]*\.ql$/),
     );
 

--- a/extensions/ql-vscode/src/log-insights/summary-language-support.ts
+++ b/extensions/ql-vscode/src/log-insights/summary-language-support.ts
@@ -4,9 +4,7 @@ import {
   Position,
   Selection,
   TextDocument,
-  TextEditor,
   TextEditorRevealType,
-  TextEditorSelectionChangeEvent,
   ViewColumn,
   window,
   workspace,
@@ -168,15 +166,11 @@ export class SummaryLanguageSupport extends DisposableObject {
     );
   }
 
-  handleDidChangeActiveTextEditor = async (
-    _editor: TextEditor | undefined,
-  ): Promise<void> => {
+  handleDidChangeActiveTextEditor = async (): Promise<void> => {
     await this.updateContext();
   };
 
-  handleDidChangeTextEditorSelection = async (
-    _e: TextEditorSelectionChangeEvent,
-  ): Promise<void> => {
+  handleDidChangeTextEditorSelection = async (): Promise<void> => {
     await this.updateContext();
   };
 

--- a/extensions/ql-vscode/src/model-editor/modeling-store.ts
+++ b/extensions/ql-vscode/src/model-editor/modeling-store.ts
@@ -211,8 +211,8 @@ export class ModelingStore extends DisposableObject {
         ...methods,
         // Keep all methods that are already modeled in some form in the state
         ...Object.fromEntries(
-          Object.entries(state.modeledMethods).filter(([_, value]) =>
-            value.some((m) => m.type !== "none"),
+          Object.entries(state.modeledMethods).filter((entry) =>
+            entry[1].some((m) => m.type !== "none"),
           ),
         ),
       };

--- a/extensions/ql-vscode/src/model-editor/modeling-store.ts
+++ b/extensions/ql-vscode/src/model-editor/modeling-store.ts
@@ -211,8 +211,8 @@ export class ModelingStore extends DisposableObject {
         ...methods,
         // Keep all methods that are already modeled in some form in the state
         ...Object.fromEntries(
-          Object.entries(state.modeledMethods).filter((entry) =>
-            entry[1].some((m) => m.type !== "none"),
+          Object.entries(state.modeledMethods).filter(([, value]) =>
+            value.some((m) => m.type !== "none"),
           ),
         ),
       };

--- a/extensions/ql-vscode/src/query-history/history-tree-data-provider.ts
+++ b/extensions/ql-vscode/src/query-history/history-tree-data-provider.ts
@@ -182,7 +182,7 @@ export class HistoryTreeDataProvider
           });
   }
 
-  getParent(_element: QueryHistoryInfo): ProviderResult<QueryHistoryInfo> {
+  getParent(): ProviderResult<QueryHistoryInfo> {
     return null;
   }
 

--- a/extensions/ql-vscode/src/query-history/query-history-manager.ts
+++ b/extensions/ql-vscode/src/query-history/query-history-manager.ts
@@ -179,7 +179,7 @@ export class QueryHistoryManager extends DisposableObject {
     // Lazily update the tree view selection due to limitations of TreeView API (see
     // `updateTreeViewSelectionIfVisible` doc for details)
     this.push(
-      this.treeView.onDidChangeVisibility(async (_ev) =>
+      this.treeView.onDidChangeVisibility(async () =>
         this.updateTreeViewSelectionIfVisible(),
       ),
     );

--- a/extensions/ql-vscode/src/query-server/legacy/query-server-client.ts
+++ b/extensions/ql-vscode/src/query-server/legacy/query-server-client.ts
@@ -118,7 +118,7 @@ export class QueryServerClient extends DisposableObject {
   /** Starts a new query server process, sending progress messages to the status bar. */
   async startQueryServer(): Promise<void> {
     // Use an arrow function to preserve the value of `this`.
-    return this.withProgressReporting((progress, _) =>
+    return this.withProgressReporting((progress) =>
       this.startQueryServerImpl(progress),
     );
   }

--- a/extensions/ql-vscode/src/query-server/query-server-client.ts
+++ b/extensions/ql-vscode/src/query-server/query-server-client.ts
@@ -160,7 +160,7 @@ export class QueryServerClient extends DisposableObject {
   /** Starts a new query server process, sending progress messages to the status bar. */
   async startQueryServer(): Promise<void> {
     // Use an arrow function to preserve the value of `this`.
-    return this.withProgressReporting((progress, _) =>
+    return this.withProgressReporting((progress) =>
       this.startQueryServerImpl(progress),
     );
   }

--- a/extensions/ql-vscode/src/query-testing/test-ui.ts
+++ b/extensions/ql-vscode/src/query-testing/test-ui.ts
@@ -1,23 +1,9 @@
-import {
-  TestHub,
-  TestController,
-  TestAdapter,
-  TestRunStartedEvent,
-  TestRunFinishedEvent,
-  TestEvent,
-  TestSuiteEvent,
-} from "vscode-test-adapter-api";
+import { TestHub, TestController, TestAdapter } from "vscode-test-adapter-api";
 import { TestTreeNode } from "./test-tree-node";
 import { DisposableObject } from "../common/disposable-object";
 import { QLTestAdapter } from "./test-adapter";
 import { App } from "../common/app";
 import { TestManagerBase } from "./test-manager-base";
-
-type VSCodeTestEvent =
-  | TestRunStartedEvent
-  | TestRunFinishedEvent
-  | TestSuiteEvent
-  | TestEvent;
 
 /**
  * Test event listener. Currently unused, but left in to keep the plumbing hooked up for future use.
@@ -29,7 +15,7 @@ class QLTestListener extends DisposableObject {
     this.push(adapter.testStates(this.onTestStatesEvent, this));
   }
 
-  private onTestStatesEvent(_e: VSCodeTestEvent): void {
+  private onTestStatesEvent(): void {
     /**/
   }
 }

--- a/extensions/ql-vscode/src/stories/common/ResponsiveContainer.stories.tsx
+++ b/extensions/ql-vscode/src/stories/common/ResponsiveContainer.stories.tsx
@@ -9,7 +9,7 @@ export default {
   component: ResponsiveContainerComponent,
 } as Meta<typeof ResponsiveContainerComponent>;
 
-const Template: StoryFn<typeof ResponsiveContainerComponent> = (args) => (
+const Template: StoryFn<typeof ResponsiveContainerComponent> = () => (
   <ResponsiveContainerComponent>
     <span>Hello</span>
   </ResponsiveContainerComponent>

--- a/extensions/ql-vscode/src/stories/model-editor/InProgressDropdown.stories.tsx
+++ b/extensions/ql-vscode/src/stories/model-editor/InProgressDropdown.stories.tsx
@@ -9,7 +9,7 @@ export default {
   component: InProgressDropdownComponent,
 } as Meta<typeof InProgressDropdownComponent>;
 
-const Template: StoryFn<typeof InProgressDropdownComponent> = (args) => (
+const Template: StoryFn<typeof InProgressDropdownComponent> = () => (
   <InProgressDropdownComponent />
 );
 

--- a/extensions/ql-vscode/src/stories/variant-analysis/VariantAnalysisAnalyzedRepos.stories.tsx
+++ b/extensions/ql-vscode/src/stories/variant-analysis/VariantAnalysisAnalyzedRepos.stories.tsx
@@ -129,7 +129,7 @@ Example.args = {
 faker.seed(42);
 const uniqueStore = {};
 
-const manyScannedRepos = Array.from({ length: 1000 }, (_, i) => {
+const manyScannedRepos = Array.from({ length: 1000 }, () => {
   const mockedScannedRepo = createMockScannedRepo();
 
   return {
@@ -195,7 +195,7 @@ ManyResultsPerformanceExample.args = {
   repositoryResults: performanceNumbers.map((resultCount) => ({
     variantAnalysisId: 1,
     repositoryId: resultCount,
-    interpretedResults: Array.from({ length: resultCount }, (_, i) => ({
+    interpretedResults: Array.from({ length: resultCount }, () => ({
       ...mockAnalysisAlert,
     })),
   })),

--- a/extensions/ql-vscode/src/stories/variant-analysis/VariantAnalysisHeader.stories.tsx
+++ b/extensions/ql-vscode/src/stories/variant-analysis/VariantAnalysisHeader.stories.tsx
@@ -101,7 +101,7 @@ Succeeded.args = {
   variantAnalysis: {
     ...createMockVariantAnalysis({
       status: VariantAnalysisStatus.Succeeded,
-      scannedRepos: Array.from({ length: 1000 }, (_) => ({
+      scannedRepos: Array.from({ length: 1000 }, () => ({
         ...createMockScannedRepo(),
         analysisStatus: VariantAnalysisRepoStatus.Succeeded,
         resultCount: 100,

--- a/extensions/ql-vscode/src/view/compare/Compare.tsx
+++ b/extensions/ql-vscode/src/view/compare/Compare.tsx
@@ -22,7 +22,7 @@ const emptyComparison: SetComparisonsMessage = {
   message: "Empty comparison",
 };
 
-export function Compare(_: Record<string, never>): JSX.Element {
+export function Compare(): JSX.Element {
   const [comparison, setComparison] =
     useState<SetComparisonsMessage>(emptyComparison);
 

--- a/extensions/ql-vscode/test/unit-tests/packages/commands/CommandManager.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/packages/commands/CommandManager.test.ts
@@ -33,12 +33,14 @@ describe("CommandManager", () => {
     commandManager.register(
       "codeQL.openVariantAnalysisLogs",
       // @ts-expect-error wrong function parameter type should give a type error
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       async (variantAnalysisId: string): Promise<number> => 10,
     );
 
     commandManager.register(
       "codeQL.openVariantAnalysisLogs",
       // @ts-expect-error wrong function return type should give a type error
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       async (variantAnalysisId: number): Promise<string> => "hello",
     );
 

--- a/extensions/ql-vscode/test/vscode-tests/activated-extension/variant-analysis/variant-analysis-results-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/activated-extension/variant-analysis/variant-analysis-results-manager.test.ts
@@ -3,7 +3,7 @@ import * as fs from "fs-extra";
 import { join, resolve } from "path";
 import { Readable } from "stream";
 import * as fetchModule from "node-fetch";
-import { RequestInfo, RequestInit, Response } from "node-fetch";
+import { RequestInfo, Response } from "node-fetch";
 
 import { VariantAnalysisResultsManager } from "../../../../src/variant-analysis/variant-analysis-results-manager";
 import { CodeQLCliServer } from "../../../../src/codeql-cli/cli";
@@ -101,7 +101,7 @@ describe(VariantAnalysisResultsManager.name, () => {
 
         getVariantAnalysisRepoResultStub = jest
           .spyOn(fetchModule, "default")
-          .mockImplementation((url: RequestInfo, _init?: RequestInit) => {
+          .mockImplementation((url: RequestInfo) => {
             if (url === dummyRepoTask.artifactUrl) {
               return Promise.resolve(new Response(Readable.from(fileContents)));
             }
@@ -158,7 +158,7 @@ describe(VariantAnalysisResultsManager.name, () => {
         }
 
         getVariantAnalysisRepoResultStub.mockImplementation(
-          (url: RequestInfo, _init?: RequestInit) => {
+          (url: RequestInfo) => {
             if (url === dummyRepoTask.artifactUrl) {
               const response = new Response(Readable.from(generateInParts()));
               response.headers.set(

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/debugger/debug-controller.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/debugger/debug-controller.ts
@@ -288,7 +288,7 @@ class DebugController
     }
   }
 
-  private handleDidTerminateDebugSession(_session: DebugSession): void {
+  private handleDidTerminateDebugSession(): void {
     this.handleEvent({
       kind: "terminated",
     });
@@ -319,7 +319,7 @@ class DebugController
         return Promise.resolve(event);
       } else {
         // No event available yet, so we need to wait.
-        return new Promise((resolve, _reject) => {
+        return new Promise((resolve) => {
           this.resolver = resolve;
         });
       }

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/legacy-query.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/legacy-query.test.ts
@@ -211,7 +211,7 @@ describeWithCodeQL()("using the legacy query server", () => {
 
       try {
         await compilationSucceeded.done();
-        const callbackId = qs.registerCallback((_res) => {
+        const callbackId = qs.registerCallback(() => {
           void evaluationSucceeded.resolve();
         });
         const queryToRun: messages.QueryToRun = {

--- a/extensions/ql-vscode/test/vscode-tests/global.helper.ts
+++ b/extensions/ql-vscode/test/vscode-tests/global.helper.ts
@@ -41,7 +41,7 @@ export async function ensureTestDatabase(
     uri.toString(true),
     databaseManager,
     storagePath,
-    (_p) => {
+    () => {
       /**/
     },
     cli,

--- a/extensions/ql-vscode/test/vscode-tests/test-config.ts
+++ b/extensions/ql-vscode/test/vscode-tests/test-config.ts
@@ -83,11 +83,7 @@ class DefaultConfiguration implements WorkspaceConfiguration {
     return getIn(this.values, this.getKey(section, key)) !== undefined;
   }
 
-  public update(
-    _section: string | undefined,
-    _key: string,
-    _value: unknown,
-  ): void {
+  public update(): void {
     throw new Error("Cannot update default configuration");
   }
 
@@ -228,7 +224,7 @@ export const beforeEachAction = async () => {
           has(key: string) {
             return configuration.has(section, key);
           },
-          inspect(_key: string) {
+          inspect() {
             throw new Error("inspect is not supported in tests");
           },
           async update(


### PR DESCRIPTION
This PR changes the `args` option for the `@typescript-eslint/no-unused-vars` eslint rule to `after-used` instead of `none`. ([docs](https://eslint.org/docs/latest/rules/no-unused-vars#args))

The place where this comes up a lot is when implementing a subclass, or when passing a function as a parameter to something else. As in, places where you are implementing an existing function interface instead of defining it yourself.

Previously we were ignoring all unused arguments so long as they started with a `_` character. After this PR we'll raise a linting error for all such arguments that come after the last argument that is actually used. You can still use the underscore to ignore earlier arguments, because otherwise there isn't really a way to satisfy the rule.

One could argue that we should leave these unused arguments in because they act as documentation to future developers, so they know that that argument exists for them to use if needed. However I'm not sure this justifies the extra cruft from the unused code. If a developer wants to know the full interface of a function they are implementing, then it is advised for them to look directly at the type of the interface they are implementing.

This PR is based on https://github.com/github/vscode-codeql/pull/3060 because that PR also makes the same changes, although only a subset of the changes. I'll leave both PRs open because https://github.com/github/vscode-codeql/pull/3060 is much smaller and also likely to be less controversial. There are two places in this PR where the rule didn't behave 100% perfectly. I'll put comments on those locations in the code.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
