### PR TITLE
Update provenance when inputs change

### DIFF
--- a/extensions/ql-vscode/src/model-editor/modeled-method.ts
+++ b/extensions/ql-vscode/src/model-editor/modeled-method.ts
@@ -130,7 +130,7 @@ export function isModelAccepted(
 /**
  * Calculates the new provenance for a modeled method based on the current provenance.
  * @param modeledMethod The modeled method if there is one.
- * @returns The new provencance
+ * @returns The new provenance.
  */
 export function calculateNewProvenance(
   modeledMethod: ModeledMethod | undefined,

--- a/extensions/ql-vscode/src/model-editor/modeled-method.ts
+++ b/extensions/ql-vscode/src/model-editor/modeled-method.ts
@@ -127,23 +127,37 @@ export function isModelAccepted(
   );
 }
 
+/**
+ * Calculates the new provenance for a modeled method based on the current provenance.
+ * @param modeledMethod The modeled method if there is one.
+ * @returns The new provencance
+ */
 export function calculateNewProvenance(
   modeledMethod: ModeledMethod | undefined,
 ) {
   if (!modeledMethod || !modeledMethodSupportsProvenance(modeledMethod)) {
+    // If nothing has been modeled or the modeled method does not support
+    // provenance, we assume that the user has entered it manually.
     return "manual";
   }
 
   switch (modeledMethod.provenance) {
     case "df-generated":
-      return "df-generated";
+      // If the method has been generated and there has been a change, we assume
+      // that the user has manually edited it.
+      return "df-manual";
     case "df-manual":
+      // If the method has had manual edits, we want the provenance to stay the same.
       return "df-manual";
     case "ai-generated":
+      // If the method has been generated and there has been a change, we assume
+      // that the user has manually edited it.
       return "ai-manual";
     case "ai-manual":
+      // If the method has had manual edits, we want the provenance to stay the same.
       return "ai-manual";
     default:
+      // The method has been modeled manually.
       return "manual";
   }
 }

--- a/extensions/ql-vscode/src/model-editor/modeled-method.ts
+++ b/extensions/ql-vscode/src/model-editor/modeled-method.ts
@@ -126,3 +126,24 @@ export function isModelAccepted(
     modeledMethod.provenance !== "ai-generated"
   );
 }
+
+export function calculateNewProvenance(
+  modeledMethod: ModeledMethod | undefined,
+) {
+  if (!modeledMethod || !modeledMethodSupportsProvenance(modeledMethod)) {
+    return "manual";
+  }
+
+  switch (modeledMethod.provenance) {
+    case "df-generated":
+      return "df-generated";
+    case "df-manual":
+      return "df-manual";
+    case "ai-generated":
+      return "ai-manual";
+    case "ai-manual":
+      return "ai-manual";
+    default:
+      return "manual";
+  }
+}

--- a/extensions/ql-vscode/src/view/model-editor/ModelInputDropdown.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelInputDropdown.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { ChangeEvent, useCallback, useMemo } from "react";
 import {
   ModeledMethod,
+  calculateNewProvenance,
   isModelAccepted,
   modeledMethodSupportsInput,
 } from "../../model-editor/modeled-method";
@@ -53,6 +54,7 @@ export const ModelInputDropdown = ({
 
       onChange({
         ...modeledMethod,
+        provenance: calculateNewProvenance(modeledMethod),
         input: target.value,
       });
     },

--- a/extensions/ql-vscode/src/view/model-editor/ModelKindDropdown.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelKindDropdown.tsx
@@ -5,6 +5,7 @@ import {
   ModeledMethodKind,
   modeledMethodSupportsKind,
   isModelAccepted,
+  calculateNewProvenance,
 } from "../../model-editor/modeled-method";
 import { getModelsAsDataLanguage } from "../../model-editor/languages";
 import { QueryLanguage } from "../../common/query-language";
@@ -52,6 +53,7 @@ export const ModelKindDropdown = ({
 
       onChange({
         ...modeledMethod,
+        provenance: calculateNewProvenance(modeledMethod),
         kind,
       });
     },

--- a/extensions/ql-vscode/src/view/model-editor/ModelOutputDropdown.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelOutputDropdown.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { ChangeEvent, useCallback, useMemo } from "react";
 import {
   ModeledMethod,
+  calculateNewProvenance,
   isModelAccepted,
   modeledMethodSupportsOutput,
 } from "../../model-editor/modeled-method";
@@ -54,6 +55,7 @@ export const ModelOutputDropdown = ({
 
       onChange({
         ...modeledMethod,
+        provenance: calculateNewProvenance(modeledMethod),
         output: target.value,
       });
     },

--- a/extensions/ql-vscode/src/view/model-editor/ModelTypeDropdown.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelTypeDropdown.tsx
@@ -1,11 +1,10 @@
 import * as React from "react";
 import { ChangeEvent, useCallback } from "react";
 import {
+  calculateNewProvenance,
   isModelAccepted,
   ModeledMethod,
-  modeledMethodSupportsProvenance,
   ModeledMethodType,
-  Provenance,
 } from "../../model-editor/modeled-method";
 import { Method } from "../../model-editor/method";
 import { createEmptyModeledMethod } from "../../model-editor/modeled-method-empty";
@@ -43,15 +42,6 @@ export const ModelTypeDropdown = ({
     (e: ChangeEvent<HTMLSelectElement>) => {
       const modelsAsDataLanguage = getModelsAsDataLanguage(language);
 
-      let newProvenance: Provenance = "manual";
-      if (modeledMethod && modeledMethodSupportsProvenance(modeledMethod)) {
-        if (modeledMethod.provenance === "df-generated") {
-          newProvenance = "df-manual";
-        } else if (modeledMethod.provenance === "ai-generated") {
-          newProvenance = "ai-manual";
-        }
-      }
-
       const emptyModeledMethod = createEmptyModeledMethod(
         e.target.value as ModeledMethodType,
         method,
@@ -67,7 +57,8 @@ export const ModelTypeDropdown = ({
         updatedModeledMethod.output = "ReturnValue";
       }
       if ("provenance" in updatedModeledMethod) {
-        updatedModeledMethod.provenance = newProvenance;
+        console.log("** model-type-dropdown modeled method", modeledMethod);
+        updatedModeledMethod.provenance = calculateNewProvenance(modeledMethod);
       }
       if ("kind" in updatedModeledMethod) {
         updatedModeledMethod.kind = "value";

--- a/extensions/ql-vscode/src/view/model-editor/ModelTypeDropdown.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelTypeDropdown.tsx
@@ -57,7 +57,6 @@ export const ModelTypeDropdown = ({
         updatedModeledMethod.output = "ReturnValue";
       }
       if ("provenance" in updatedModeledMethod) {
-        console.log("** model-type-dropdown modeled method", modeledMethod);
         updatedModeledMethod.provenance = calculateNewProvenance(modeledMethod);
       }
       if ("kind" in updatedModeledMethod) {

--- a/extensions/ql-vscode/src/view/model-editor/__tests__/MethodRow.spec.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/__tests__/MethodRow.spec.tsx
@@ -27,7 +27,7 @@ describe(MethodRow.name, () => {
     input: "Argument[0]",
     output: "ReturnValue",
     kind: "taint",
-    provenance: "df-generated",
+    provenance: "manual",
   };
   const onChange = jest.fn();
 
@@ -107,6 +107,32 @@ describe(MethodRow.name, () => {
       {
         ...modeledMethod,
         kind: "value",
+      },
+    ]);
+  });
+
+  it("changes the provenance when the kind is changed", async () => {
+    const modeledMethodWithGeneratedProvenance: ModeledMethod = {
+      ...modeledMethod,
+      provenance: "df-generated",
+    };
+    render({ modeledMethods: [modeledMethodWithGeneratedProvenance] });
+
+    onChange.mockReset();
+
+    expect(screen.getByRole("combobox", { name: "Kind" })).toHaveValue("taint");
+
+    await userEvent.selectOptions(
+      screen.getByRole("combobox", { name: "Kind" }),
+      "value",
+    );
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(method.signature, [
+      {
+        ...modeledMethod,
+        kind: "value",
+        provenance: "df-manual",
       },
     ]);
   });


### PR DESCRIPTION
Change the provenance from `ai-generated`/`df-generated` to `ai-manual`/`df-manual` whenever any input changes. Also make sure the provenance remains correct after several updates. 

See internal linked issue for discussion/details on the decision.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
