### PR TITLE
Fix minor bugs with queries panel + language selector

### DIFF
--- a/extensions/ql-vscode/src/databases/local-databases/database-manager.ts
+++ b/extensions/ql-vscode/src/databases/local-databases/database-manager.ts
@@ -116,7 +116,7 @@ export class DatabaseManager extends DisposableObject {
       this.languageContext.onLanguageContextChanged(async () => {
         if (
           this.currentDatabaseItem !== undefined &&
-          !this.languageContext.isSelectedLanguage(
+          !this.languageContext.shouldInclude(
             tryGetQueryLanguage(this.currentDatabaseItem.language),
           )
         ) {

--- a/extensions/ql-vscode/src/local-queries/qlpack-generator.ts
+++ b/extensions/ql-vscode/src/local-queries/qlpack-generator.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from "fs-extra";
+import { mkdir, pathExists, writeFile } from "fs-extra";
 import { dump } from "js-yaml";
 import { dirname, join } from "path";
 import { Uri } from "vscode";
@@ -76,7 +76,10 @@ export class QlPackGenerator {
   }
 
   private async createWorkspaceFolder() {
-    await mkdir(this.folderUri.fsPath);
+    const folderExists = await pathExists(this.folderUri.fsPath);
+    if (!folderExists) {
+      await mkdir(this.folderUri.fsPath);
+    }
   }
 
   private async createQlPackYaml() {

--- a/extensions/ql-vscode/src/local-queries/qlpack-generator.ts
+++ b/extensions/ql-vscode/src/local-queries/qlpack-generator.ts
@@ -1,4 +1,4 @@
-import { mkdir, pathExists, writeFile } from "fs-extra";
+import { ensureDir, writeFile } from "fs-extra";
 import { dump } from "js-yaml";
 import { dirname, join } from "path";
 import { Uri } from "vscode";
@@ -76,10 +76,7 @@ export class QlPackGenerator {
   }
 
   private async createWorkspaceFolder() {
-    const folderExists = await pathExists(this.folderUri.fsPath);
-    if (!folderExists) {
-      await mkdir(this.folderUri.fsPath);
-    }
+    await ensureDir(this.folderUri.fsPath);
   }
 
   private async createQlPackYaml() {


### PR DESCRIPTION
Fixes a few small bugs:

- The currently selected DB getting deselected when you choose `All languages`: 

  https://github.com/github/code-scanning/assets/42641846/370b8c98-f7e9-4c03-9751-dd27b20fca9b

- When the custom queries folder exists (in my case it was empty), error `Could not create skeleton QL pack: EEXIST: file already exists, mkdir '...\codeql-custom-queries-cpp'`. 

See internal linked issue for more details!

## Checklist

N/A (still feature flagged)

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
