### PR TITLE
Allow downloading multiple databases from GitHub

### DIFF
--- a/extensions/ql-vscode/src/databases/github-database-prompt.ts
+++ b/extensions/ql-vscode/src/databases/github-database-prompt.ts
@@ -3,10 +3,7 @@ import { RestEndpointMethodTypes } from "@octokit/plugin-rest-endpoint-methods";
 import { Octokit } from "@octokit/rest";
 import { showNeverAskAgainDialog } from "../common/vscode/dialog";
 import { getLanguageDisplayName } from "../common/query-language";
-import {
-  downloadGitHubDatabaseFromUrl,
-  promptForLanguage,
-} from "./database-fetcher";
+import { downloadGitHubDatabaseFromUrl } from "./database-fetcher";
 import { withProgress } from "../common/vscode/progress";
 import { DatabaseManager } from "./local-databases";
 import { CodeQLCliServer } from "../codeql-cli/cli";
@@ -77,38 +74,46 @@ export async function promptGitHubDatabaseDownload(
     return;
   }
 
-  const language = await promptForLanguage(languages, undefined);
-  if (!language) {
+  const selectedDatabases = await promptForDatabases(databases);
+  if (selectedDatabases.length === 0) {
     return;
   }
 
-  const database = databases.find((database) => database.language === language);
-  if (!database) {
-    return;
-  }
+  await Promise.all(
+    selectedDatabases.map((database) =>
+      withProgress(
+        async (progress) => {
+          await downloadGitHubDatabaseFromUrl(
+            database.url,
+            database.id,
+            database.created_at,
+            database.commit_oid ?? null,
+            owner,
+            repo,
+            octokit,
+            progress,
+            databaseManager,
+            storagePath,
+            cliServer,
+            true,
+            false,
+          );
 
-  await withProgress(async (progress) => {
-    await downloadGitHubDatabaseFromUrl(
-      database.url,
-      database.id,
-      database.created_at,
-      database.commit_oid ?? null,
-      owner,
-      repo,
-      octokit,
-      progress,
-      databaseManager,
-      storagePath,
-      cliServer,
-      true,
-      false,
-    );
-
-    await commandManager.execute("codeQLDatabases.focus");
-    void window.showInformationMessage(
-      `Downloaded ${getLanguageDisplayName(language)} database from GitHub.`,
-    );
-  });
+          await commandManager.execute("codeQLDatabases.focus");
+          void window.showInformationMessage(
+            `Downloaded ${getLanguageDisplayName(
+              database.language,
+            )} database from GitHub.`,
+          );
+        },
+        {
+          title: `Adding ${getLanguageDisplayName(
+            database.language,
+          )} database from GitHub`,
+        },
+      ),
+    ),
+  );
 }
 
 /**
@@ -134,4 +139,35 @@ function joinLanguages(languages: string[]): string {
   }
 
   return result;
+}
+
+async function promptForDatabases(
+  databases: CodeqlDatabase[],
+): Promise<CodeqlDatabase[]> {
+  if (databases.length === 1) {
+    return databases;
+  }
+
+  const items = databases
+    .map((database) => {
+      const bytesToDisplayMB = `${(database.size / (1024 * 1024)).toFixed(
+        1,
+      )} MB`;
+
+      return {
+        label: getLanguageDisplayName(database.language),
+        description: bytesToDisplayMB,
+        database,
+      };
+    })
+    .sort((a, b) => a.label.localeCompare(b.label));
+
+  const selectedItems = await window.showQuickPick(items, {
+    title: "Select databases to download",
+    placeHolder: "Databases found in this repository",
+    ignoreFocusOut: true,
+    canPickMany: true,
+  });
+
+  return selectedItems?.map((selectedItem) => selectedItem.database) ?? [];
 }


### PR DESCRIPTION
This adds the option to download multiple databases from GitHub in the initial GitHub database download prompt. The databases will be downloaded concurrently.

Unfortunately it doesn't seem possible to change the "OK" text in the quick pick to "Download", so I've left it as "OK" for now.

![Screenshot 2023-11-14 at 16 14 43](https://github.com/github/vscode-codeql/assets/1112623/45b38264-6e36-4b18-b07e-ba944ecc8293)

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
