### PR TITLE
Use Octokit REST for listing CodeQL databases

### DIFF
--- a/extensions/ql-vscode/package-lock.json
+++ b/extensions/ql-vscode/package-lock.json
@@ -4392,9 +4392,9 @@
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-19.0.0.tgz",
-      "integrity": "sha512-PclQ6JGMTE9iUStpzMkwLCISFn/wDeRjkZFIKALpvJQNBGwDoYYi2fFvuHwssoQ1rXI5mfh6jgTgWuddeUzfWw=="
+      "version": "19.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-19.0.2.tgz",
+      "integrity": "sha512-8li32fUDUeml/ACRp/njCWTsk5t17cfTM1jp9n08pBrqs5cDFJubtjsSnuz56r5Tad6jdEPJld7LxNp9dNcyjQ=="
     },
     "node_modules/@octokit/plugin-paginate-rest": {
       "version": "9.0.0",
@@ -35269,9 +35269,9 @@
       }
     },
     "@octokit/openapi-types": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-19.0.0.tgz",
-      "integrity": "sha512-PclQ6JGMTE9iUStpzMkwLCISFn/wDeRjkZFIKALpvJQNBGwDoYYi2fFvuHwssoQ1rXI5mfh6jgTgWuddeUzfWw=="
+      "version": "19.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-19.0.2.tgz",
+      "integrity": "sha512-8li32fUDUeml/ACRp/njCWTsk5t17cfTM1jp9n08pBrqs5cDFJubtjsSnuz56r5Tad6jdEPJld7LxNp9dNcyjQ=="
     },
     "@octokit/plugin-paginate-rest": {
       "version": "9.0.0",

--- a/extensions/ql-vscode/src/databases/database-fetcher.ts
+++ b/extensions/ql-vscode/src/databases/database-fetcher.ts
@@ -562,10 +562,10 @@ export async function convertGithubNwoToDatabaseUrl(
   try {
     const [owner, repo] = nwo.split("/");
 
-    const response = await octokit.request(
-      "GET /repos/:owner/:repo/code-scanning/codeql/databases",
-      { owner, repo },
-    );
+    const response = await octokit.rest.codeScanning.listCodeqlDatabases({
+      owner,
+      repo,
+    });
 
     const languages = response.data.map((db: any) => db.language);
 
@@ -584,12 +584,12 @@ export async function convertGithubNwoToDatabaseUrl(
     }
 
     return {
-      databaseUrl: `https://api.github.com/repos/${owner}/${repo}/code-scanning/codeql/databases/${language}`,
+      databaseUrl: databaseForLanguage.url,
       owner,
       name: repo,
       databaseId: databaseForLanguage.id,
       databaseCreatedAt: databaseForLanguage.created_at,
-      commitOid: databaseForLanguage.commit_oid,
+      commitOid: databaseForLanguage.commit_oid ?? null,
     };
   } catch (e) {
     void extLogger.log(`Error: ${getErrorMessage(e)}`);

--- a/extensions/ql-vscode/test/vscode-tests/utils/mocking.helpers.ts
+++ b/extensions/ql-vscode/test/vscode-tests/utils/mocking.helpers.ts
@@ -1,5 +1,6 @@
 import type { QuickPickItem, window, Uri } from "vscode";
 import { DatabaseItem } from "../../../src/databases/local-databases";
+import * as Octokit from "@octokit/rest";
 
 export type DeepPartial<T> = T extends object
   ? {
@@ -55,6 +56,14 @@ export function mockedObject<T extends object>(
       throw new Error(`Method ${String(prop)} not mocked`);
     },
   });
+}
+
+export function mockedOctokitFunction<
+  Namespace extends keyof Octokit.Octokit["rest"],
+  Name extends keyof Octokit.Octokit["rest"][Namespace],
+>(): Octokit.Octokit["rest"][Namespace][Name] & jest.Mock {
+  const fn = jest.fn();
+  return fn as unknown as Octokit.Octokit["rest"][Namespace][Name] & jest.Mock;
 }
 
 export function mockDatabaseItem(


### PR DESCRIPTION
This switches the request to the GitHub API for listing CodeQL databases from a custom request to the Octokit REST API. This allows us to be more type-safe without introducing our own types.

The update to `@octokit/openapi-types` was necessary to have access to the `commit_oid` field.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
