### PR TITLE
Discourage use of "Quick query" in single-folder workspaces

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [UNRELEASED]
 
+- Add a prompt to the "Quick query" command to encourage users in single-folder workspaces to use "Create query" instead. [#3082](https://github.com/github/vscode-codeql/pull/3082)
+
 ## 1.10.0 - 16 November 2023
 
 - Add new CodeQL views for managing databases and queries:

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -635,8 +635,8 @@
         "icon": "$(new-file)"
       },
       {
-        "command": "codeQL.createQueryFromPrompt",
-        "title": "CodeQL: Create query from prompt"
+        "command": "codeQLQuickQuery.createQuery",
+        "title": "Create query from prompt"
       },
       {
         "command": "codeQLVariantAnalysisRepositories.openConfigFile",
@@ -1351,7 +1351,7 @@
           "when": "false"
         },
         {
-          "command": "codeQL.createQueryFromPrompt",
+          "command": "codeQLQuickQuery.createQuery",
           "when": "false"
         },
         {

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -635,10 +635,6 @@
         "icon": "$(new-file)"
       },
       {
-        "command": "codeQLQuickQuery.createQuery",
-        "title": "Create query from prompt"
-      },
-      {
         "command": "codeQLVariantAnalysisRepositories.openConfigFile",
         "title": "Open database configuration file",
         "icon": "$(json)"
@@ -1348,10 +1344,6 @@
         },
         {
           "command": "codeQLQueries.createQuery",
-          "when": "false"
-        },
-        {
-          "command": "codeQLQuickQuery.createQuery",
           "when": "false"
         },
         {

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -635,6 +635,10 @@
         "icon": "$(new-file)"
       },
       {
+        "command": "codeQL.createQueryFromPrompt",
+        "title": "CodeQL: Create query from prompt"
+      },
+      {
         "command": "codeQLVariantAnalysisRepositories.openConfigFile",
         "title": "Open database configuration file",
         "icon": "$(json)"
@@ -1344,6 +1348,10 @@
         },
         {
           "command": "codeQLQueries.createQuery",
+          "when": "false"
+        },
+        {
+          "command": "codeQL.createQueryFromPrompt",
           "when": "false"
         },
         {

--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -146,7 +146,7 @@ export type LocalQueryCommands = {
   "codeQL.quickQuery": () => Promise<void>;
   "codeQL.getCurrentQuery": () => Promise<string>;
   "codeQL.createQuery": () => Promise<void>;
-  "codeQL.createQueryFromPrompt": () => Promise<void>;
+  "codeQLQuickQuery.createQuery": () => Promise<void>;
 };
 
 // Debugger commands

--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -146,6 +146,7 @@ export type LocalQueryCommands = {
   "codeQL.quickQuery": () => Promise<void>;
   "codeQL.getCurrentQuery": () => Promise<string>;
   "codeQL.createQuery": () => Promise<void>;
+  "codeQL.createQueryFromPrompt": () => Promise<void>;
 };
 
 // Debugger commands

--- a/extensions/ql-vscode/src/local-queries/local-queries.ts
+++ b/extensions/ql-vscode/src/local-queries/local-queries.ts
@@ -119,7 +119,7 @@ export class LocalQueries extends DisposableObject {
         return this.getCurrentQuery(true);
       },
       "codeQL.createQuery": this.createSkeletonQuery.bind(this),
-      "codeQL.createQueryFromPrompt": this.createSkeletonQuery.bind(this),
+      "codeQLQuickQuery.createQuery": this.createSkeletonQuery.bind(this),
     };
   }
 

--- a/extensions/ql-vscode/src/local-queries/local-queries.ts
+++ b/extensions/ql-vscode/src/local-queries/local-queries.ts
@@ -42,7 +42,6 @@ import { WebviewReveal } from "./webview";
 import { asError, getErrorMessage } from "../common/helpers-pure";
 import { CliVersionConstraint, CodeQLCliServer } from "../codeql-cli/cli";
 import { LocalQueryCommands } from "../common/commands";
-import { App } from "../common/app";
 import { DisposableObject } from "../common/disposable-object";
 import { SkeletonQueryWizard } from "./skeleton-query-wizard";
 import { LocalQueryRun } from "./local-query-run";
@@ -51,6 +50,7 @@ import { findLanguage } from "../codeql-cli/query-language";
 import type { QueryTreeViewItem } from "../queries-panel/query-tree-view-item";
 import { tryGetQueryLanguage } from "../common/query-language";
 import { LanguageContextStore } from "../language-context-store";
+import { ExtensionApp } from "../common/vscode/vscode-app";
 
 interface DatabaseQuickPickItem extends QuickPickItem {
   databaseItem: DatabaseItem;
@@ -66,7 +66,7 @@ export class LocalQueries extends DisposableObject {
   private selectedQueryTreeViewItems: readonly QueryTreeViewItem[] = [];
 
   public constructor(
-    private readonly app: App,
+    private readonly app: ExtensionApp,
     private readonly queryRunner: QueryRunner,
     private readonly queryHistoryManager: QueryHistoryManager,
     private readonly databaseManager: DatabaseManager,

--- a/extensions/ql-vscode/src/local-queries/local-queries.ts
+++ b/extensions/ql-vscode/src/local-queries/local-queries.ts
@@ -119,6 +119,7 @@ export class LocalQueries extends DisposableObject {
         return this.getCurrentQuery(true);
       },
       "codeQL.createQuery": this.createSkeletonQuery.bind(this),
+      "codeQL.createQueryFromPrompt": this.createSkeletonQuery.bind(this),
     };
   }
 

--- a/extensions/ql-vscode/src/local-queries/quick-query.ts
+++ b/extensions/ql-vscode/src/local-queries/quick-query.ts
@@ -96,7 +96,7 @@ export async function displayQuickQuery(
         updateQuickQueryDir(queriesDir, workspaceFolders.length, 0);
       }
       if (quickQueryPrompt === createQueryOption) {
-        await app.queryServerCommands.execute("codeQL.createQueryFromPrompt");
+        await app.queryServerCommands.execute("codeQLQuickQuery.createQuery");
       }
       return;
     }

--- a/extensions/ql-vscode/src/local-queries/quick-query.ts
+++ b/extensions/ql-vscode/src/local-queries/quick-query.ts
@@ -96,7 +96,7 @@ export async function displayQuickQuery(
         updateQuickQueryDir(queriesDir, workspaceFolders.length, 0);
       }
       if (quickQueryPrompt === createQueryOption) {
-        await app.queryServerCommands.execute("codeQL.createQuery");
+        await app.queryServerCommands.execute("codeQL.createQueryFromPrompt");
       }
       return;
     }

--- a/extensions/ql-vscode/src/local-queries/quick-query.ts
+++ b/extensions/ql-vscode/src/local-queries/quick-query.ts
@@ -5,7 +5,6 @@ import { CancellationToken, window as Window, workspace, Uri } from "vscode";
 import { LSPErrorCodes, ResponseError } from "vscode-languageclient";
 import { CodeQLCliServer } from "../codeql-cli/cli";
 import { DatabaseUI } from "../databases/local-databases-ui";
-import { showBinaryChoiceDialog } from "../common/vscode/dialog";
 import { getInitialQueryContents } from "./query-contents";
 import { getPrimaryDbscheme, getQlPackForDbscheme } from "../databases/qlpack";
 import {
@@ -15,6 +14,7 @@ import {
 import { getErrorMessage } from "../common/helpers-pure";
 import { FALLBACK_QLPACK_FILENAME, getQlPackPath } from "../common/ql";
 import { App } from "../common/app";
+import { ExtensionApp } from "../common/vscode/vscode-app";
 
 const QUICK_QUERIES_DIR_NAME = "quick-queries";
 const QUICK_QUERY_QUERY_NAME = "quick-query.ql";
@@ -52,7 +52,7 @@ function findExistingQuickQueryEditor() {
  * Show a buffer the user can enter a simple query into.
  */
 export async function displayQuickQuery(
-  app: App,
+  app: ExtensionApp,
   cliServer: CodeQLCliServer,
   databaseUI: DatabaseUI,
   progress: ProgressCallback,
@@ -80,11 +80,23 @@ export async function displayQuickQuery(
     // being undefined) just let the user know that they're in for a
     // restart.
     if (workspace.workspaceFile === undefined) {
-      const makeMultiRoot = await showBinaryChoiceDialog(
-        "Quick query requires multiple folders in the workspace. Reload workspace as multi-folder workspace?",
+      const createQueryOption = 'Run "Create query"';
+      const quickQueryOption = 'Run "Quick query" anyway';
+      const quickQueryPrompt = await Window.showWarningMessage(
+        '"Quick query" requires reloading your workspace as a multi-root workspace, which may cause query history and databases to be lost.',
+        {
+          modal: true,
+          detail:
+            'The "Create query" command does not require reloading the workspace.',
+        },
+        createQueryOption,
+        quickQueryOption,
       );
-      if (makeMultiRoot) {
+      if (quickQueryPrompt === quickQueryOption) {
         updateQuickQueryDir(queriesDir, workspaceFolders.length, 0);
+      }
+      if (quickQueryPrompt === createQueryOption) {
+        await app.queryServerCommands.execute("codeQL.createQuery");
       }
       return;
     }

--- a/extensions/ql-vscode/test/unit-tests/command-lint.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/command-lint.test.ts
@@ -41,6 +41,7 @@ describe("commands declared in package.json", () => {
       command.match(/^codeQLLanguageSelection\./) ||
       command.match(/^codeQLDatabases\./) ||
       command.match(/^codeQLQueries\./) ||
+      command.match(/^codeQLQuickQuery\./) ||
       command.match(/^codeQLVariantAnalysisRepositories\./) ||
       command.match(/^codeQLQueryHistory\./) ||
       command.match(/^codeQLAstViewer\./) ||
@@ -114,7 +115,7 @@ describe("commands declared in package.json", () => {
       expect(disabledInPalette.has(command)).toBe(false);
     });
 
-    // Commands in contribContextMenuCmds may reasonbly be enabled or
+    // Commands in contribContextMenuCmds may reasonably be enabled or
     // disabled in the command palette; for example, codeQL.runQuery
     // is available there, since we heuristically figure out which
     // query to run, but codeQL.setCurrentDatabase is not.


### PR DESCRIPTION
The "Quick query" command creates a new workspace folder, which doesn't work well for users in single-folder workspaces. This PR adds a prompt for those people to encourage them to use the new "Create query" command instead:

![image](https://github.com/github/vscode-codeql/assets/42641846/6796b45e-74e5-4547-bce5-1406dc9080cc)

See internal linked issue for more details.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
   - N/A: No docs change needed 
