### PR TITLE
Remove workspaceContains:.git activation event

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -39,8 +39,7 @@
     "onWebviewPanel:resultsView",
     "onWebviewPanel:codeQL.variantAnalysis",
     "onWebviewPanel:codeQL.dataFlowPaths",
-    "onFileSystem:codeql-zip-archive",
-    "workspaceContains:.git"
+    "onFileSystem:codeql-zip-archive"
   ],
   "main": "./out/extension",
   "files": [


### PR DESCRIPTION
This removes the `workspaceContains:.git` activation event since it seems to be conflicting with running CLI tests. When this is present, the extension is activated before the Jest setup script is ran and the incorrect version is retrieved from the CLI.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
