### PR TITLE
Fix tests with `workspaceContains:.git` activation event

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -39,7 +39,8 @@
     "onWebviewPanel:resultsView",
     "onWebviewPanel:codeQL.variantAnalysis",
     "onWebviewPanel:codeQL.dataFlowPaths",
-    "onFileSystem:codeql-zip-archive"
+    "onFileSystem:codeql-zip-archive",
+    "workspaceContains:.git"
   ],
   "main": "./out/extension",
   "files": [

--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -241,15 +241,11 @@ export class CodeQLCliServer implements Disposable {
     if (this.distributionProvider.onDidChangeDistribution) {
       this.distributionProvider.onDidChangeDistribution(() => {
         this.restartCliServer();
-        this._version = undefined;
-        this._supportedLanguages = undefined;
       });
     }
     if (this.cliConfig.onDidChangeConfiguration) {
       this.cliConfig.onDidChangeConfiguration(() => {
         this.restartCliServer();
-        this._version = undefined;
-        this._supportedLanguages = undefined;
       });
     }
   }
@@ -290,6 +286,8 @@ export class CodeQLCliServer implements Disposable {
     const callback = (): void => {
       try {
         this.killProcessIfRunning();
+        this._version = undefined;
+        this._supportedLanguages = undefined;
       } finally {
         this.runNext();
       }

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -119,6 +119,14 @@ export interface DistributionConfig {
   ownerName?: string;
   repositoryName?: string;
   onDidChangeConfiguration?: Event<void>;
+
+  /**
+   * This forces an update of the distribution, even if the settings haven't changed.
+   *
+   * This should only be used when the distribution has been updated outside of the extension
+   * and only in tests. It should not be called in production code.
+   */
+  forceUpdateConfiguration(): void;
 }
 
 // Query server configuration
@@ -273,6 +281,10 @@ export class DistributionConfigListener
       newPath,
       ConfigurationTarget.Global,
     );
+  }
+
+  public forceUpdateConfiguration() {
+    this._onDidChangeConfiguration.fire(undefined);
   }
 
   protected handleDidChangeConfiguration(e: ConfigurationChangeEvent): void {

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/databases/database-fetcher.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/databases/database-fetcher.test.ts
@@ -15,7 +15,7 @@ import {
   storagePath,
 } from "../../global.helper";
 import { createMockCommandManager } from "../../../__mocks__/commandsMock";
-import { ensureDir, remove } from "fs-extra";
+import { remove } from "fs-extra";
 
 /**
  * Run various integration tests for databases
@@ -43,7 +43,6 @@ describe("database-fetcher", () => {
   afterEach(async () => {
     await cleanDatabases(databaseManager);
     await remove(storagePath);
-    await ensureDir(storagePath);
   });
 
   describe("importArchiveDatabase", () => {

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/databases/database-fetcher.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/databases/database-fetcher.test.ts
@@ -15,6 +15,7 @@ import {
   storagePath,
 } from "../../global.helper";
 import { createMockCommandManager } from "../../../__mocks__/commandsMock";
+import { ensureDir, remove } from "fs-extra";
 
 /**
  * Run various integration tests for databases
@@ -41,6 +42,8 @@ describe("database-fetcher", () => {
 
   afterEach(async () => {
     await cleanDatabases(databaseManager);
+    await remove(storagePath);
+    await ensureDir(storagePath);
   });
 
   describe("importArchiveDatabase", () => {

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/jest.setup.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/jest.setup.ts
@@ -39,15 +39,11 @@ beforeAll(async () => {
     const cliVersion = await extension.cliServer.getVersion();
 
     if (cliVersion.compare(process.env.CLI_VERSION) !== 0) {
-      // This calls the private `updateConfiguration` method in the `ConfigListener`
       // It seems like the CUSTOM_CODEQL_PATH_SETTING.updateValue() call in
       // `beforeAllAction` doesn't fire the event that the config has changed.
+      // `forceUpdateConfiguration` will fire the event manually.
       // This is a hacky workaround.
-      (
-        extension.distributionManager.config as unknown as {
-          updateConfiguration: () => void;
-        }
-      ).updateConfiguration();
+      extension.distributionManager.config.forceUpdateConfiguration();
     }
   }
 });

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/model-editor/modeled-method-fs.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/model-editor/modeled-method-fs.test.ts
@@ -53,20 +53,6 @@ describe("modeled-method-fs", () => {
   let workspacePath: string;
   let cli: CodeQLCliServer;
 
-  beforeAll(async () => {
-    const extension = await getActivatedExtension();
-    cli = extension.cliServer;
-
-    // All transitive dependencies must be available for resolve extensions to succeed.
-    const packUsingExtensionsPath = join(
-      __dirname,
-      "../../..",
-      "data-extensions",
-      "pack-using-extensions",
-    );
-    await cli.packInstall(packUsingExtensionsPath);
-  });
-
   beforeEach(async () => {
     // On windows, make sure to use a temp directory that isn't an alias and therefore won't be canonicalised by CodeQL.
     // See https://github.com/github/vscode-codeql/pull/2605 for more context.
@@ -92,6 +78,15 @@ describe("modeled-method-fs", () => {
 
     const extension = await getActivatedExtension();
     cli = extension.cliServer;
+
+    // All transitive dependencies must be available for resolve extensions to succeed.
+    const packUsingExtensionsPath = join(
+      __dirname,
+      "../../..",
+      "data-extensions",
+      "pack-using-extensions",
+    );
+    await cli.packInstall(packUsingExtensionsPath);
   });
 
   afterEach(() => {


### PR DESCRIPTION
It seems like changes to the CLI path setting are not picked up by the extension when it is already activated. This is probably because the `workspace.onDidChangeConfiguration` event is not fired when the update is made programmatically.

This fixes it by manually firing the event so that all listeners (CLI server, query server, IDE server) can pick up the change.

Some other small changes to the tests were necessary to make everything work (mostly with retries), but this should now work properly.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
