### PR TITLE
Preserve focus on results viewer when showing location

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add a prompt to the "Quick query" command to encourage users in single-folder workspaces to use "Create query" instead. [#3082](https://github.com/github/vscode-codeql/pull/3082)
 - Remove support for CodeQL CLI versions older than 2.11.6. [#3087](https://github.com/github/vscode-codeql/pull/3087)
+- Preserve focus on results viewer when showing a location in a file. [#3088](https://github.com/github/vscode-codeql/pull/3088)
 
 ## 1.10.0 - 16 November 2023
 

--- a/extensions/ql-vscode/src/databases/local-databases/locations.ts
+++ b/extensions/ql-vscode/src/databases/local-databases/locations.ts
@@ -128,6 +128,8 @@ export async function showLocation(location?: Location) {
           // avoid preview mode so editor is sticky and will be added to navigation and search histories.
           preview: false,
           viewColumn: ViewColumn.One,
+          // Keep the focus on the results view so that the user can easily navigate to the next result.
+          preserveFocus: true,
         });
 
   const range = location.range;


### PR DESCRIPTION
This preserves the focus on the results viewer when showing a location to ensure that the user can navigate to the next result without having to click or change the focus to the results viewer first. This allows the user to quickly navigate through the results.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
