### PR TITLE
Enable ESLint `curly` rule

### DIFF
--- a/extensions/ql-vscode/.eslintrc.js
+++ b/extensions/ql-vscode/.eslintrc.js
@@ -50,6 +50,7 @@ const baseConfig = {
     "@typescript-eslint/no-throw-literal": "error",
     "no-useless-escape": 0,
     camelcase: "off",
+    curly: ["error", "all"],
     "escompat/no-regexp-lookbehind": "off",
     "etc/no-implicit-any-catch": "error",
     "filenames/match-regex": "off",

--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -637,9 +637,10 @@ export class CodeQLCliServer implements Disposable {
     } = {},
   ): Promise<OutputType> {
     let args: string[] = [];
-    if (addFormat)
+    if (addFormat) {
       // Add format argument first, in case commandArgs contains positional parameters.
       args = args.concat(["--format", "json"]);
+    }
     args = args.concat(commandArgs);
     const result = await this.runCodeQlCliCommand(command, args, description, {
       progressReporter,
@@ -941,8 +942,12 @@ export class CodeQLCliServer implements Disposable {
     name?: string,
   ): Promise<string> {
     const subcommandArgs = [];
-    if (target) subcommandArgs.push("--target", target);
-    if (name) subcommandArgs.push("--name", name);
+    if (target) {
+      subcommandArgs.push("--target", target);
+    }
+    if (name) {
+      subcommandArgs.push("--name", name);
+    }
     subcommandArgs.push(archivePath);
 
     return await this.runCodeQlCliCommand(
@@ -963,7 +968,9 @@ export class CodeQLCliServer implements Disposable {
     outputDirectory?: string,
   ): Promise<string> {
     const subcommandArgs = ["--format=markdown"];
-    if (outputDirectory) subcommandArgs.push("--output", outputDirectory);
+    if (outputDirectory) {
+      subcommandArgs.push("--output", outputDirectory);
+    }
     subcommandArgs.push(pathToQhelp);
 
     return await this.runCodeQlCliCommand(
@@ -1611,16 +1618,19 @@ export function spawnServer(
   });
   // Set up event listeners.
   child.on("close", async (code, signal) => {
-    if (code !== null)
+    if (code !== null) {
       void logger.log(`Child process exited with code ${code}`);
-    if (signal)
+    }
+    if (signal) {
       void logger.log(
         `Child process exited due to receipt of signal ${signal}`,
       );
+    }
     // If the process exited abnormally, log the last stdout message,
     // It may be from the jvm.
-    if (code !== 0 && lastStdout !== undefined)
+    if (code !== 0 && lastStdout !== undefined) {
       void logger.log(`Last stdout was "${lastStdout.toString()}"`);
+    }
   });
   child.stderr!.on("data", stderrListener);
   if (stdoutListener !== undefined) {

--- a/extensions/ql-vscode/src/common/sarif-utils.ts
+++ b/extensions/ql-vscode/src/common/sarif-utils.ts
@@ -107,11 +107,15 @@ export function parseSarifLocation(
   sourceLocationPrefix: string,
 ): ParsedSarifLocation {
   const physicalLocation = loc.physicalLocation;
-  if (physicalLocation === undefined) return { hint: "no physical location" };
-  if (physicalLocation.artifactLocation === undefined)
+  if (physicalLocation === undefined) {
+    return { hint: "no physical location" };
+  }
+  if (physicalLocation.artifactLocation === undefined) {
     return { hint: "no artifact location" };
-  if (physicalLocation.artifactLocation.uri === undefined)
+  }
+  if (physicalLocation.artifactLocation.uri === undefined) {
     return { hint: "artifact location has no uri" };
+  }
   if (isEmptyPath(physicalLocation.artifactLocation.uri)) {
     return { hint: "artifact location has empty uri" };
   }

--- a/extensions/ql-vscode/src/common/vscode/archive-filesystem-provider.ts
+++ b/extensions/ql-vscode/src/common/vscode/archive-filesystem-provider.ts
@@ -130,11 +130,14 @@ export function decodeSourceArchiveUri(uri: vscode.Uri): ZipFileReference {
     };
   }
   const match = sourceArchiveUriAuthorityPattern.exec(uri.authority);
-  if (match === null) throw new InvalidSourceArchiveUriError(uri);
+  if (match === null) {
+    throw new InvalidSourceArchiveUriError(uri);
+  }
   const zipPathStartIndex = parseInt(match[1]);
   const zipPathEndIndex = parseInt(match[2]);
-  if (isNaN(zipPathStartIndex) || isNaN(zipPathEndIndex))
+  if (isNaN(zipPathStartIndex) || isNaN(zipPathEndIndex)) {
     throw new InvalidSourceArchiveUriError(uri);
+  }
   return {
     pathWithinSourceArchive: uri.path.substring(zipPathEndIndex) || "/",
     sourceArchiveZipPath: uri.path.substring(
@@ -179,8 +182,9 @@ type Archive = {
 };
 
 async function parse_zip(zipPath: string): Promise<Archive> {
-  if (!(await pathExists(zipPath)))
+  if (!(await pathExists(zipPath))) {
     throw vscode.FileSystemError.FileNotFound(zipPath);
+  }
   const archive: Archive = {
     unzipped: await unzipper.Open.file(zipPath),
     dirMap: new Map(),

--- a/extensions/ql-vscode/src/databases/db-item-selection.ts
+++ b/extensions/ql-vscode/src/databases/db-item-selection.ts
@@ -9,11 +9,15 @@ export function getSelectedDbItem(dbItems: DbItem[]): DbItem | undefined {
     ) {
       for (const child of dbItem.children) {
         const selectedItem = extractSelected(child);
-        if (selectedItem) return selectedItem;
+        if (selectedItem) {
+          return selectedItem;
+        }
       }
     } else {
       const selectedItem = extractSelected(dbItem);
-      if (selectedItem) return selectedItem;
+      if (selectedItem) {
+        return selectedItem;
+      }
     }
   }
   return undefined;

--- a/extensions/ql-vscode/src/databases/local-databases/database-item-impl.ts
+++ b/extensions/ql-vscode/src/databases/local-databases/database-item-impl.ts
@@ -197,7 +197,9 @@ export class DatabaseItemImpl implements DatabaseItem {
    * Holds if `uri` belongs to this database's source archive.
    */
   public belongsToSourceArchiveExplorerUri(uri: vscode.Uri): boolean {
-    if (this.sourceArchive === undefined) return false;
+    if (this.sourceArchive === undefined) {
+      return false;
+    }
     return (
       uri.scheme === zipArchiveScheme &&
       decodeSourceArchiveUri(uri).sourceArchiveZipPath ===

--- a/extensions/ql-vscode/src/local-queries/results-view.ts
+++ b/extensions/ql-vscode/src/local-queries/results-view.ts
@@ -655,8 +655,9 @@ export class ResultsView extends AbstractWebview<
     const schema = resultSetSchemas.find(
       (resultSet) => resultSet.name === selectedTable,
     )!;
-    if (schema === undefined)
+    if (schema === undefined) {
       throw new Error(`Query result set '${selectedTable}' not found.`);
+    }
 
     const pageSize = PAGE_SIZE.getValue<number>();
     const chunk = await this.cliServer.bqrsDecode(
@@ -771,7 +772,9 @@ export class ResultsView extends AbstractWebview<
       );
     }
 
-    if (interp.data.t !== "SarifInterpretationData") return interp;
+    if (interp.data.t !== "SarifInterpretationData") {
+      return interp;
+    }
 
     if (interp.data.runs.length !== 1) {
       void this.logger.log(
@@ -887,7 +890,9 @@ export class ResultsView extends AbstractWebview<
   ): Promise<void> {
     const { data, sourceLocationPrefix } = interpretation;
 
-    if (data.t !== "SarifInterpretationData") return;
+    if (data.t !== "SarifInterpretationData") {
+      return;
+    }
 
     if (!data.runs || !data.runs[0].results) {
       void this.logger.log(

--- a/extensions/ql-vscode/src/query-history/query-history-manager.ts
+++ b/extensions/ql-vscode/src/query-history/query-history-manager.ts
@@ -556,7 +556,9 @@ export class QueryHistoryManager extends DisposableObject {
           item,
         )}. Are you sure?`,
       );
-      if (!response) return;
+      if (!response) {
+        return;
+      }
     }
 
     this.treeDataProvider.remove(item);
@@ -579,7 +581,9 @@ export class QueryHistoryManager extends DisposableObject {
 
     void showInformationMessageWithAction(message, "Go to workflow run").then(
       async (shouldOpenWorkflowRun) => {
-        if (!shouldOpenWorkflowRun) return;
+        if (!shouldOpenWorkflowRun) {
+          return;
+        }
         await env.openExternal(Uri.parse(workflowRunUrl));
       },
     );

--- a/extensions/ql-vscode/src/view/results/locations/NonClickableLocation.tsx
+++ b/extensions/ql-vscode/src/view/results/locations/NonClickableLocation.tsx
@@ -10,6 +10,8 @@ interface Props {
  * Designed to fit in with the other types of location components.
  */
 export function NonClickableLocation({ msg, locationHint }: Props) {
-  if (msg === undefined) return null;
+  if (msg === undefined) {
+    return null;
+  }
   return <span title={locationHint}>{msg}</span>;
 }

--- a/extensions/ql-vscode/src/view/results/result-keys.ts
+++ b/extensions/ql-vscode/src/view/results/result-keys.ts
@@ -54,13 +54,19 @@ export function getPath(
   key: Path | PathNode,
 ): sarif.ThreadFlow | undefined {
   const result = getResult(sarif, key);
-  if (result === undefined) return undefined;
+  if (result === undefined) {
+    return undefined;
+  }
   let index = -1;
-  if (result.codeFlows === undefined) return undefined;
+  if (result.codeFlows === undefined) {
+    return undefined;
+  }
   for (const codeFlows of result.codeFlows) {
     for (const threadFlow of codeFlows.threadFlows) {
       ++index;
-      if (index === key.pathIndex) return threadFlow;
+      if (index === key.pathIndex) {
+        return threadFlow;
+      }
     }
   }
   return undefined;
@@ -74,7 +80,9 @@ export function getPathNode(
   key: PathNode,
 ): sarif.Location | undefined {
   const path = getPath(sarif, key);
-  if (path === undefined) return undefined;
+  if (path === undefined) {
+    return undefined;
+  }
   return path.locations[key.pathNodeIndex]?.location;
 }
 
@@ -85,7 +93,9 @@ export function equalsNotUndefined(
   key1: Partial<PathNode> | undefined,
   key2: Partial<PathNode> | undefined,
 ): boolean {
-  if (key1 === undefined || key2 === undefined) return false;
+  if (key1 === undefined || key2 === undefined) {
+    return false;
+  }
   return (
     key1.resultIndex === key2.resultIndex &&
     key1.pathIndex === key2.pathIndex &&
@@ -99,7 +109,9 @@ export function equalsNotUndefined(
  * Path nodes indices are relative to this flattened list.
  */
 export function getAllPaths(result: sarif.Result): sarif.ThreadFlow[] {
-  if (result.codeFlows === undefined) return [];
+  if (result.codeFlows === undefined) {
+    return [];
+  }
   const paths = [];
   for (const codeFlow of result.codeFlows) {
     for (const threadFlow of codeFlow.threadFlows) {

--- a/extensions/ql-vscode/test/unit-tests/command-lint.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/command-lint.test.ts
@@ -85,8 +85,9 @@ describe("commands declared in package.json", () => {
   });
 
   menus.commandPalette.forEach((commandDecl: CmdDecl) => {
-    if (commandDecl.when === "false")
+    if (commandDecl.when === "false") {
       disabledInPalette.add(commandDecl.command);
+    }
   });
 
   it("should have commands appropriately prefixed", () => {

--- a/extensions/ql-vscode/test/unit-tests/variant-analysis/custom-errors.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/variant-analysis/custom-errors.test.ts
@@ -144,7 +144,9 @@ function mockRequestError(status: number, body: any): RequestError {
 // Copied from https://github.com/octokit/request.js/blob/c67f902350384846f88d91196e7066daadc08357/src/fetch-wrapper.ts#L166 to have a
 // somewhat realistic error message
 function toErrorMessage(data: any) {
-  if (typeof data === "string") return data;
+  if (typeof data === "string") {
+    return data;
+  }
 
   if ("message" in data) {
     if (Array.isArray(data.errors)) {

--- a/extensions/ql-vscode/test/vscode-tests/ensureCli.ts
+++ b/extensions/ql-vscode/test/vscode-tests/ensureCli.ts
@@ -140,10 +140,11 @@ export async function ensureCli(useCli: boolean) {
  */
 function getCliDownloadUrl(assetName: string) {
   if (CLI_VERSION === "nightly") {
-    if (!process.env.NIGHTLY_URL)
+    if (!process.env.NIGHTLY_URL) {
       throw new Error(
         "Nightly CLI was specified but no URL to download it from was given!",
       );
+    }
     return `${process.env.NIGHTLY_URL}/${assetName}`;
   }
   return `https://github.com/github/codeql-cli-binaries/releases/download/${CLI_VERSION}/${assetName}`;


### PR DESCRIPTION
This enables [the ESLint `curly` rule](https://eslint.org/docs/latest/rules/curly) with its options set to `all`. This enforces curly braces around all blocks, even single-line ones.

I've used `npm run lint -- --fix` to fix all occurrences.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
