### PR TITLE
Silence `resolve tests` command

### DIFF
--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -797,6 +797,11 @@ export class CodeQLCliServer implements Disposable {
       ["resolve", "tests", "--strict-test-discovery"],
       subcommandArgs,
       "Resolving tests",
+      {
+        // This happens as part of a background process, so we don't want to
+        // spam the log with messages.
+        silent: true,
+      },
     );
   }
 


### PR DESCRIPTION
This hides that the `resolve tests` command is run from the user, as it is run as part of a background process and spams the log.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
