### PR TITLE
Change dataflow and taint-tracking snippets to match the module-based API

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add a prompt to the "Quick query" command to encourage users in single-folder workspaces to use "Create query" instead. [#3082](https://github.com/github/vscode-codeql/pull/3082)
 - Remove support for CodeQL CLI versions older than 2.11.6. [#3087](https://github.com/github/vscode-codeql/pull/3087)
 - Preserve focus on results viewer when showing a location in a file. [#3088](https://github.com/github/vscode-codeql/pull/3088)
+- The `dataflowtracking` and `tainttracking` snippets expand to the new module-based interface. [#3091](https://github.com/github/vscode-codeql/pull/3091)
 
 ## 1.10.0 - 16 November 2023
 

--- a/extensions/ql-vscode/snippets.json
+++ b/extensions/ql-vscode/snippets.json
@@ -34,12 +34,12 @@
       "\tpredicate isSource(DataFlow::Node node) {",
       "\t\t${2:none()}",
       "\t}",
-      "\t",
+      "",
       "\tpredicate isSink(DataFlow::Node node) {",
       "\t\t${3:none()}",
       "\t}",
       "}",
-      "\t",
+      "",
       "module ${4:Flow} = DataFlow::Global<$1>;"
     ],
     "description": "Boilerplate for a dataflow tracking class"
@@ -51,12 +51,12 @@
       "\tpredicate isSource(DataFlow::Node node) {",
       "\t\t${2:none()}",
       "\t}",
-      "\t",
+      "",
       "\tpredicate isSink(DataFlow::Node node) {",
       "\t\t${3:none()}",
       "\t}",
       "}",
-      "\t",
+      "",
       "module ${4:Flow} = TaintTracking::Global<$1>;"
     ],
     "description": "Boilerplate for a taint tracking class"

--- a/extensions/ql-vscode/snippets.json
+++ b/extensions/ql-vscode/snippets.json
@@ -30,34 +30,34 @@
   "Dataflow Tracking Class": {
     "prefix": "dataflowtracking",
     "body": [
-      "class $1 extends DataFlow::Configuration {",
-      "\t$1() { this = \"$1\" }",
-      "\t",
-      "\toverride predicate isSource(DataFlow::Node node) {",
+      "module $1 implements DataFlow::ConfigSig {",
+      "\tpredicate isSource(DataFlow::Node node) {",
       "\t\t${2:none()}",
       "\t}",
       "\t",
-      "\toverride predicate isSink(DataFlow::Node node) {",
+      "\tpredicate isSink(DataFlow::Node node) {",
       "\t\t${3:none()}",
       "\t}",
-      "}"
+      "}",
+      "\t",
+      "module ${4:Flow} = DataFlow::Global<$1>;"
     ],
     "description": "Boilerplate for a dataflow tracking class"
   },
   "Taint Tracking Class": {
     "prefix": "tainttracking",
     "body": [
-      "class $1 extends TaintTracking::Configuration {",
-      "\t$1() { this = \"$1\" }",
-      "\t",
-      "\toverride predicate isSource(DataFlow::Node node) {",
+      "module $1 implements DataFlow::ConfigSig {",
+      "\tpredicate isSource(DataFlow::Node node) {",
       "\t\t${2:none()}",
       "\t}",
       "\t",
-      "\toverride predicate isSink(DataFlow::Node node) {",
+      "\tpredicate isSink(DataFlow::Node node) {",
       "\t\t${3:none()}",
       "\t}",
-      "}"
+      "}",
+      "\t",
+      "module ${4:Flow} = TaintTracking::Global<$1>;"
     ],
     "description": "Boilerplate for a taint tracking class"
   },


### PR DESCRIPTION
The snippets were expanding to the old class-based dataflow API which we don't want users to use anymore.

This PR updates those snippets to expand to the new module-based API:

<img width="320" alt="Screenshot 2023-11-24 at 17 57 17" src="https://github.com/github/vscode-codeql/assets/4527323/d27d6ae7-50ad-4713-ba8e-b39e27047282">

<img width="323" alt="Screenshot 2023-11-24 at 17 57 34" src="https://github.com/github/vscode-codeql/assets/4527323/c2adbf4c-1032-4902-90f8-efc8c5de9848">


## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
