### PR TITLE
Refactor compare view

### DIFF
--- a/extensions/ql-vscode/src/common/bqrs-cli-types.ts
+++ b/extensions/ql-vscode/src/common/bqrs-cli-types.ts
@@ -21,7 +21,7 @@ type ColumnKind =
   | typeof ColumnKindCode.DATE
   | typeof ColumnKindCode.ENTITY;
 
-export interface Column {
+interface Column {
   name?: string;
   kind: ColumnKind;
 }
@@ -112,7 +112,7 @@ export type BqrsKind =
   | "Date"
   | "Entity";
 
-interface BqrsColumn {
+export interface BqrsColumn {
   name?: string;
   kind: BqrsKind;
 }

--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -3,8 +3,8 @@ import {
   RawResultSet,
   ResultRow,
   ResultSetSchema,
-  Column,
   ResolvableLocationValue,
+  BqrsColumn,
 } from "../common/bqrs-cli-types";
 import {
   VariantAnalysis,
@@ -353,7 +353,7 @@ export interface SetComparisonsMessage {
       time: string;
     };
   };
-  readonly columns: readonly Column[];
+  readonly columns: readonly BqrsColumn[];
   readonly commonResultSetNames: string[];
   readonly currentResultSetName: string;
   readonly rows: QueryCompareResult | undefined;

--- a/extensions/ql-vscode/src/compare/compare-view.ts
+++ b/extensions/ql-vscode/src/compare/compare-view.ts
@@ -88,7 +88,7 @@ export class CompareView extends AbstractWebview<
       currentResultSetDisplayName,
       fromResultSet,
       toResultSet,
-    } = await this.findCommonResultSetNames(
+    } = await this.findResultSetsToCompare(
       this.comparePair,
       selectedResultSetName,
     );
@@ -190,7 +190,7 @@ export class CompareView extends AbstractWebview<
     }
   }
 
-  private async findCommonResultSetNames(
+  private async findResultSetsToCompare(
     { from, fromSchemas, to, toSchemas }: ComparePair,
     selectedResultSetName: string | undefined,
   ) {

--- a/extensions/ql-vscode/src/compare/compare-view.ts
+++ b/extensions/ql-vscode/src/compare/compare-view.ts
@@ -83,16 +83,16 @@ export class CompareView extends AbstractWebview<
     panel.reveal(undefined, true);
 
     await this.waitForPanelLoaded();
-    const [
+    const {
       commonResultSetNames,
-      currentResultSetName,
+      currentResultSetDisplayName,
       fromResultSet,
       toResultSet,
-    ] = await this.findCommonResultSetNames(
+    } = await this.findCommonResultSetNames(
       this.comparePair,
       selectedResultSetName,
     );
-    if (currentResultSetName) {
+    if (currentResultSetDisplayName) {
       let rows: QueryCompareResult | undefined;
       let message: string | undefined;
       try {
@@ -120,7 +120,7 @@ export class CompareView extends AbstractWebview<
         },
         columns: fromResultSet.columns,
         commonResultSetNames,
-        currentResultSetName,
+        currentResultSetName: currentResultSetDisplayName,
         rows,
         message,
         databaseUri: to.initialInfo.databaseInfo.databaseUri,
@@ -193,7 +193,7 @@ export class CompareView extends AbstractWebview<
   private async findCommonResultSetNames(
     { from, fromSchemas, to, toSchemas }: ComparePair,
     selectedResultSetName: string | undefined,
-  ): Promise<[string[], string, DecodedBqrsChunk, DecodedBqrsChunk]> {
+  ) {
     const {
       commonResultSetNames,
       currentResultSetDisplayName,
@@ -211,12 +211,12 @@ export class CompareView extends AbstractWebview<
       toResultSetName,
       to.completedQuery.query.resultsPaths.resultsPath,
     );
-    return [
+    return {
       commonResultSetNames,
       currentResultSetDisplayName,
       fromResultSet,
       toResultSet,
-    ];
+    };
   }
 
   private async changeTable(newResultSetName: string) {

--- a/extensions/ql-vscode/src/compare/compare-view.ts
+++ b/extensions/ql-vscode/src/compare/compare-view.ts
@@ -58,6 +58,17 @@ export class CompareView extends AbstractWebview<
     selectedResultSetName?: string,
   ) {
     this.comparePair = { from, to };
+
+    await this.showResultsInternal(selectedResultSetName);
+  }
+
+  private async showResultsInternal(selectedResultSetName?: string) {
+    if (!this.comparePair) {
+      return;
+    }
+
+    const { from, to } = this.comparePair;
+
     const panel = await this.getPanel();
     panel.reveal(undefined, true);
 
@@ -204,14 +215,7 @@ export class CompareView extends AbstractWebview<
   }
 
   private async changeTable(newResultSetName: string) {
-    if (!this.comparePair?.from || !this.comparePair.to) {
-      return;
-    }
-    await this.showResults(
-      this.comparePair.from,
-      this.comparePair.to,
-      newResultSetName,
-    );
+    await this.showResultsInternal(newResultSetName);
   }
 
   private async getResultSet(

--- a/extensions/ql-vscode/src/compare/result-set-names.ts
+++ b/extensions/ql-vscode/src/compare/result-set-names.ts
@@ -1,0 +1,55 @@
+import { CompletedLocalQueryInfo } from "../query-results";
+import { CodeQLCliServer } from "../codeql-cli/cli";
+
+export async function findResultSetNames(
+  cliServer: CodeQLCliServer,
+  from: CompletedLocalQueryInfo,
+  to: CompletedLocalQueryInfo,
+  selectedResultSetName: string | undefined,
+) {
+  const fromSchemas = await cliServer.bqrsInfo(
+    from.completedQuery.query.resultsPaths.resultsPath,
+  );
+  const toSchemas = await cliServer.bqrsInfo(
+    to.completedQuery.query.resultsPaths.resultsPath,
+  );
+  const fromSchemaNames = fromSchemas["result-sets"].map(
+    (schema) => schema.name,
+  );
+  const toSchemaNames = toSchemas["result-sets"].map((schema) => schema.name);
+  const commonResultSetNames = fromSchemaNames.filter((name) =>
+    toSchemaNames.includes(name),
+  );
+
+  // Fall back on the default result set names if there are no common ones.
+  const defaultFromResultSetName = fromSchemaNames.find((name) =>
+    name.startsWith("#"),
+  );
+  const defaultToResultSetName = toSchemaNames.find((name) =>
+    name.startsWith("#"),
+  );
+
+  if (
+    commonResultSetNames.length === 0 &&
+    !(defaultFromResultSetName || defaultToResultSetName)
+  ) {
+    throw new Error(
+      "No common result sets found between the two queries. Please check that the queries are compatible.",
+    );
+  }
+
+  const currentResultSetName = selectedResultSetName || commonResultSetNames[0];
+  const fromResultSetName = currentResultSetName || defaultFromResultSetName!;
+  const toResultSetName = currentResultSetName || defaultToResultSetName!;
+
+  return {
+    commonResultSetNames,
+    currentResultSetDisplayName:
+      currentResultSetName ||
+      `${defaultFromResultSetName} <-> ${defaultToResultSetName}`,
+    fromSchemas,
+    fromResultSetName,
+    toSchemas,
+    toResultSetName,
+  };
+}

--- a/extensions/ql-vscode/src/compare/result-set-names.ts
+++ b/extensions/ql-vscode/src/compare/result-set-names.ts
@@ -1,18 +1,10 @@
-import { CompletedLocalQueryInfo } from "../query-results";
-import { CodeQLCliServer } from "../codeql-cli/cli";
+import { BQRSInfo } from "../common/bqrs-cli-types";
 
 export async function findResultSetNames(
-  cliServer: CodeQLCliServer,
-  from: CompletedLocalQueryInfo,
-  to: CompletedLocalQueryInfo,
+  fromSchemas: BQRSInfo,
+  toSchemas: BQRSInfo,
   selectedResultSetName: string | undefined,
 ) {
-  const fromSchemas = await cliServer.bqrsInfo(
-    from.completedQuery.query.resultsPaths.resultsPath,
-  );
-  const toSchemas = await cliServer.bqrsInfo(
-    to.completedQuery.query.resultsPaths.resultsPath,
-  );
   const fromSchemaNames = fromSchemas["result-sets"].map(
     (schema) => schema.name,
   );
@@ -47,9 +39,7 @@ export async function findResultSetNames(
     currentResultSetDisplayName:
       currentResultSetName ||
       `${defaultFromResultSetName} <-> ${defaultToResultSetName}`,
-    fromSchemas,
     fromResultSetName,
-    toSchemas,
     toResultSetName,
   };
 }

--- a/extensions/ql-vscode/src/compare/resultsDiff.ts
+++ b/extensions/ql-vscode/src/compare/resultsDiff.ts
@@ -1,4 +1,4 @@
-import { RawResultSet } from "../common/bqrs-cli-types";
+import { DecodedBqrsChunk } from "../common/bqrs-cli-types";
 import { QueryCompareResult } from "../common/interface-types";
 
 /**
@@ -20,29 +20,29 @@ import { QueryCompareResult } from "../common/interface-types";
  *  3. If the queries are 100% disjoint
  */
 export default function resultsDiff(
-  fromResults: RawResultSet,
-  toResults: RawResultSet,
+  fromResults: DecodedBqrsChunk,
+  toResults: DecodedBqrsChunk,
 ): QueryCompareResult {
-  if (fromResults.schema.columns.length !== toResults.schema.columns.length) {
+  if (fromResults.columns.length !== toResults.columns.length) {
     throw new Error("CodeQL Compare: Columns do not match.");
   }
 
-  if (!fromResults.rows.length) {
+  if (!fromResults.tuples.length) {
     throw new Error("CodeQL Compare: Source query has no results.");
   }
 
-  if (!toResults.rows.length) {
+  if (!toResults.tuples.length) {
     throw new Error("CodeQL Compare: Target query has no results.");
   }
 
   const results = {
-    from: arrayDiff(fromResults.rows, toResults.rows),
-    to: arrayDiff(toResults.rows, fromResults.rows),
+    from: arrayDiff(fromResults.tuples, toResults.tuples),
+    to: arrayDiff(toResults.tuples, fromResults.tuples),
   };
 
   if (
-    fromResults.rows.length === results.from.length &&
-    toResults.rows.length === results.to.length
+    fromResults.tuples.length === results.from.length &&
+    toResults.tuples.length === results.to.length
   ) {
     throw new Error("CodeQL Compare: No overlap between the selected queries.");
   }

--- a/extensions/ql-vscode/src/stories/compare/CompareTable.stories.tsx
+++ b/extensions/ql-vscode/src/stories/compare/CompareTable.stories.tsx
@@ -32,8 +32,8 @@ CompareTable.args = {
       },
     },
     columns: [
-      { name: "a", kind: "e" },
-      { name: "b", kind: "e" },
+      { name: "a", kind: "Entity" },
+      { name: "b", kind: "Entity" },
     ],
     commonResultSetNames: ["edges", "nodes", "subpaths", "#select"],
     currentResultSetName: "edges",

--- a/extensions/ql-vscode/src/view/results/RawTableHeader.tsx
+++ b/extensions/ql-vscode/src/view/results/RawTableHeader.tsx
@@ -6,10 +6,11 @@ import {
   SortDirection,
 } from "../../common/interface-types";
 import { nextSortDirection } from "./result-table-utils";
-import { Column } from "../../common/bqrs-cli-types";
 
 interface Props {
-  readonly columns: readonly Column[];
+  readonly columns: ReadonlyArray<{
+    name?: string;
+  }>;
   readonly schemaName: string;
   readonly sortState?: RawResultsSortState;
   readonly preventSort?: boolean;


### PR DESCRIPTION
This makes a start on refactoring the compare view to be more maintainable and extensible. The main changes are:
- Extracting a `findResultSetNames` function from `findCommonResultSetNames`
- Renaming `findCommonResultSetNames` to `findResultSetsToCompare`
- Caching BQRS schemas instead of reading them when changing result sets

It's easiest to review this commit-by-commit.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
