### PR TITLE
Extract `RawCompareResultTable` component

### DIFF
--- a/extensions/ql-vscode/src/view/compare/CompareTable.tsx
+++ b/extensions/ql-vscode/src/view/compare/CompareTable.tsx
@@ -1,14 +1,11 @@
 import * as React from "react";
 
 import { SetComparisonsMessage } from "../../common/interface-types";
-import RawTableHeader from "../results/RawTableHeader";
 import { className } from "../results/result-table-utils";
-import { ResultRow } from "../../common/bqrs-cli-types";
-import RawTableRow from "../results/RawTableRow";
 import { vscode } from "../vscode-api";
-import { sendTelemetry } from "../common/telemetry";
 import TextButton from "../common/TextButton";
 import { styled } from "styled-components";
+import { RawCompareResultTable } from "./RawCompareResultTable";
 
 interface Props {
   comparison: SetComparisonsMessage;
@@ -29,24 +26,6 @@ export default function CompareTable(props: Props) {
       t: "openQuery",
       kind,
     });
-  }
-
-  function createRows(rows: ResultRow[], databaseUri: string) {
-    return (
-      <tbody>
-        {rows.map((row, rowIndex) => (
-          <RawTableRow
-            key={rowIndex}
-            rowIndex={rowIndex}
-            row={row}
-            databaseUri={databaseUri}
-            onSelected={() => {
-              sendTelemetry("comapre-view-result-clicked");
-            }}
-          />
-        ))}
-      </tbody>
-    );
   }
 
   return (
@@ -76,24 +55,22 @@ export default function CompareTable(props: Props) {
       <tbody>
         <tr>
           <td>
-            <table className={className}>
-              <RawTableHeader
-                columns={result.columns}
-                schemaName={comparison.currentResultSetName}
-                preventSort={true}
-              />
-              {createRows(result.from, comparison.databaseUri)}
-            </table>
+            <RawCompareResultTable
+              columns={result.columns}
+              schemaName={comparison.currentResultSetName}
+              rows={result.from}
+              databaseUri={comparison.databaseUri}
+              className={className}
+            />
           </td>
           <td>
-            <table className={className}>
-              <RawTableHeader
-                columns={result.columns}
-                schemaName={comparison.currentResultSetName}
-                preventSort={true}
-              />
-              {createRows(result.to, comparison.databaseUri)}
-            </table>
+            <RawCompareResultTable
+              columns={result.columns}
+              schemaName={comparison.currentResultSetName}
+              rows={result.to}
+              databaseUri={comparison.databaseUri}
+              className={className}
+            />
           </td>
         </tr>
       </tbody>

--- a/extensions/ql-vscode/src/view/compare/RawCompareResultTable.tsx
+++ b/extensions/ql-vscode/src/view/compare/RawCompareResultTable.tsx
@@ -1,0 +1,45 @@
+import * as React from "react";
+import { ResultRow } from "../../common/bqrs-cli-types";
+import { sendTelemetry } from "../common/telemetry";
+import RawTableHeader from "../results/RawTableHeader";
+import RawTableRow from "../results/RawTableRow";
+
+interface Props {
+  columns: ReadonlyArray<{ name?: string }>;
+  schemaName: string;
+  rows: ResultRow[];
+  databaseUri: string;
+
+  className?: string;
+}
+
+export function RawCompareResultTable({
+  columns,
+  schemaName,
+  rows,
+  databaseUri,
+  className,
+}: Props) {
+  return (
+    <table className={className}>
+      <RawTableHeader
+        columns={columns}
+        schemaName={schemaName}
+        preventSort={true}
+      />
+      <tbody>
+        {rows.map((row, rowIndex) => (
+          <RawTableRow
+            key={rowIndex}
+            rowIndex={rowIndex}
+            row={row}
+            databaseUri={databaseUri}
+            onSelected={() => {
+              sendTelemetry("comapre-view-result-clicked");
+            }}
+          />
+        ))}
+      </tbody>
+    </table>
+  );
+}


### PR DESCRIPTION
This extracts part of the `CompareTable` component to a new `RawCompareResultTable` to reduce duplication between the `from` and `to` columns.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
