### PR TITLE
Fix loading message for compare view

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Remove support for CodeQL CLI versions older than 2.11.6. [#3087](https://github.com/github/vscode-codeql/pull/3087)
 - Preserve focus on results viewer when showing a location in a file. [#3088](https://github.com/github/vscode-codeql/pull/3088)
 - The `dataflowtracking` and `tainttracking` snippets expand to the new module-based interface. [#3091](https://github.com/github/vscode-codeql/pull/3091)
+- The compare view will now show a loading message while the results are loading. [#3107](https://github.com/github/vscode-codeql/pull/3107)
 
 ## 1.10.0 - 16 November 2023
 

--- a/extensions/ql-vscode/src/view/compare/Compare.tsx
+++ b/extensions/ql-vscode/src/view/compare/Compare.tsx
@@ -11,23 +11,14 @@ import CompareTable from "./CompareTable";
 
 import "../results/resultsView.css";
 
-const emptyComparison: SetComparisonsMessage = {
-  t: "setComparisons",
-  stats: {},
-  result: undefined,
-  commonResultSetNames: [],
-  currentResultSetName: "",
-  databaseUri: "",
-  message: "Empty comparison",
-};
-
 export function Compare(_: Record<string, never>): JSX.Element {
-  const [comparison, setComparison] =
-    useState<SetComparisonsMessage>(emptyComparison);
+  const [comparison, setComparison] = useState<SetComparisonsMessage | null>(
+    null,
+  );
 
-  const message = comparison.message || "Empty comparison";
+  const message = comparison?.message || "Empty comparison";
   const hasRows =
-    comparison.result &&
+    comparison?.result &&
     (comparison.result.to.length || comparison.result.from.length);
 
   useEffect(() => {
@@ -50,6 +41,7 @@ export function Compare(_: Record<string, never>): JSX.Element {
       window.removeEventListener("message", listener);
     };
   }, []);
+
   if (!comparison) {
     return <div>Waiting for results to load.</div>;
   }


### PR DESCRIPTION
The loading message for the compare view was never shown because the `comparison` was never `undefined`/`null`. This changes the comparison to be `null` on load to make sure that we explicitly handle this case rather than relying on an empty comparison message. This helps when there is a large number of results and loading them takes a while.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
