### PR TITLE
Switch to styled-components for compare components

### DIFF
--- a/extensions/ql-vscode/src/view/compare/Compare.tsx
+++ b/extensions/ql-vscode/src/view/compare/Compare.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { useState, useEffect } from "react";
+import { styled } from "styled-components";
 
 import {
   ToCompareViewMessage,
@@ -20,6 +21,18 @@ const emptyComparison: SetComparisonsMessage = {
   databaseUri: "",
   message: "Empty comparison",
 };
+
+const Header = styled.div`
+  display: flex;
+`;
+
+const HeaderTitle = styled.div`
+  margin: 0 1.5rem;
+`;
+
+const Message = styled.div`
+  padding: 1.5rem;
+`;
 
 export function Compare(_: Record<string, never>): JSX.Element {
   const [comparison, setComparison] =
@@ -57,8 +70,8 @@ export function Compare(_: Record<string, never>): JSX.Element {
   try {
     return (
       <>
-        <div className="vscode-codeql__compare-header">
-          <div className="vscode-codeql__compare-header-item">Comparing:</div>
+        <Header>
+          <HeaderTitle>Comparing:</HeaderTitle>
           <CompareSelector
             availableResultSets={comparison.commonResultSetNames}
             currentResultSetName={comparison.currentResultSetName}
@@ -66,11 +79,11 @@ export function Compare(_: Record<string, never>): JSX.Element {
               vscode.postMessage({ t: "changeCompare", newResultSetName })
             }
           />
-        </div>
+        </Header>
         {hasRows ? (
           <CompareTable comparison={comparison}></CompareTable>
         ) : (
-          <div className="vscode-codeql__compare-message">{message}</div>
+          <Message>{message}</Message>
         )}
       </>
     );

--- a/extensions/ql-vscode/src/view/compare/CompareTable.tsx
+++ b/extensions/ql-vscode/src/view/compare/CompareTable.tsx
@@ -20,6 +20,15 @@ const OpenButton = styled(TextButton)`
   padding: 0;
 `;
 
+const Table = styled.table`
+  margin: 20px 0;
+  width: 100%;
+
+  & > tbody {
+    vertical-align: top;
+  }
+`;
+
 export default function CompareTable(props: Props) {
   const comparison = props.comparison;
   const result = props.comparison.result!;
@@ -50,7 +59,7 @@ export default function CompareTable(props: Props) {
   }
 
   return (
-    <table className="vscode-codeql__compare-body">
+    <Table>
       <thead>
         <tr>
           <td>
@@ -97,6 +106,6 @@ export default function CompareTable(props: Props) {
           </td>
         </tr>
       </tbody>
-    </table>
+    </Table>
   );
 }

--- a/extensions/ql-vscode/src/view/results/resultsView.css
+++ b/extensions/ql-vscode/src/view/results/resultsView.css
@@ -168,27 +168,6 @@ td.vscode-codeql__path-index-cell {
   opacity: 0.6;
 }
 
-.vscode-codeql__compare-header {
-  display: flex;
-}
-
-.vscode-codeql__compare-header-item {
-  margin: 0 1.5rem;
-}
-
-.vscode-codeql__compare-message {
-  padding: 1.5rem;
-}
-
-.vscode-codeql__compare-body {
-  margin: 20px 0;
-  width: 100%;
-}
-
-.vscode-codeql__compare-body > tbody {
-  vertical-align: top;
-}
-
 .vscode-codeql__empty-query-message {
   height: 300px;
   display: flex;


### PR DESCRIPTION
This switches all compare view components to use `styled-components` rather than separate CSS to make it easier to modify and ensure more locality.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
