### PR TITLE
Add SARIF result comparison to compare view

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [UNRELEASED]
 
 - Avoid showing a popup when hovering over source elements in database source files. [#3125](https://github.com/github/vscode-codeql/pull/3125)
+- Add comparison of alerts when comparing query results. This allows viewing path explanations for differences in alerts. [#3113](https://github.com/github/vscode-codeql/pull/3113)
 
 ## 1.11.0 - 13 December 2023
 

--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -371,7 +371,9 @@ export interface SetComparisonsMessage {
   readonly message: string | undefined;
 }
 
-type QueryCompareResult = RawQueryCompareResult | InterpretedQueryCompareResult;
+export type QueryCompareResult =
+  | RawQueryCompareResult
+  | InterpretedQueryCompareResult;
 
 /**
  * from is the set of rows that have changes in the "from" query.
@@ -388,7 +390,7 @@ export type RawQueryCompareResult = {
  * from is the set of results that have changes in the "from" query.
  * to is the set of results that have changes in the "to" query.
  */
-type InterpretedQueryCompareResult = {
+export type InterpretedQueryCompareResult = {
   kind: "interpreted";
   sourceLocationPrefix: string;
   from: sarif.Result[];

--- a/extensions/ql-vscode/src/compare/compare-view.ts
+++ b/extensions/ql-vscode/src/compare/compare-view.ts
@@ -68,12 +68,12 @@ export class CompareView extends AbstractWebview<
     to: CompletedLocalQueryInfo,
     selectedResultSetName?: string,
   ) {
-    const fromSchemas = await this.cliServer.bqrsInfo(
-      from.completedQuery.query.resultsPaths.resultsPath,
-    );
-    const toSchemas = await this.cliServer.bqrsInfo(
-      to.completedQuery.query.resultsPaths.resultsPath,
-    );
+    const [fromSchemas, toSchemas] = await Promise.all([
+      this.cliServer.bqrsInfo(
+        from.completedQuery.query.resultsPaths.resultsPath,
+      ),
+      this.cliServer.bqrsInfo(to.completedQuery.query.resultsPaths.resultsPath),
+    ]);
 
     const [fromSchemaNames, toSchemaNames] = await Promise.all([
       getResultSetNames(
@@ -296,16 +296,18 @@ export class CompareView extends AbstractWebview<
     fromResultSetName: string,
     toResultSetName: string,
   ): Promise<RawQueryCompareResult> {
-    const fromResultSet = await this.getResultSet(
-      fromInfo.schemas,
-      fromResultSetName,
-      from.completedQuery.query.resultsPaths.resultsPath,
-    );
-    const toResultSet = await this.getResultSet(
-      toInfo.schemas,
-      toResultSetName,
-      to.completedQuery.query.resultsPaths.resultsPath,
-    );
+    const [fromResultSet, toResultSet] = await Promise.all([
+      this.getResultSet(
+        fromInfo.schemas,
+        fromResultSetName,
+        from.completedQuery.query.resultsPaths.resultsPath,
+      ),
+      this.getResultSet(
+        toInfo.schemas,
+        toResultSetName,
+        to.completedQuery.query.resultsPaths.resultsPath,
+      ),
+    ]);
 
     return resultsDiff(fromResultSet, toResultSet);
   }

--- a/extensions/ql-vscode/src/compare/interpreted-results.ts
+++ b/extensions/ql-vscode/src/compare/interpreted-results.ts
@@ -1,0 +1,74 @@
+import { Uri } from "vscode";
+import * as sarif from "sarif";
+import { pathExists } from "fs-extra";
+import { sarifParser } from "../common/sarif-parser";
+import { CompletedLocalQueryInfo } from "../query-results";
+import { DatabaseManager } from "../databases/local-databases";
+import { CodeQLCliServer } from "../codeql-cli/cli";
+import { InterpretedQueryCompareResult } from "../common/interface-types";
+
+import { sarifDiff } from "./sarif-diff";
+
+async function getInterpretedResults(
+  interpretedResultsPath: string,
+): Promise<sarif.Log | undefined> {
+  if (!(await pathExists(interpretedResultsPath))) {
+    return undefined;
+  }
+
+  return await sarifParser(interpretedResultsPath);
+}
+
+export async function compareInterpretedResults(
+  databaseManager: DatabaseManager,
+  cliServer: CodeQLCliServer,
+  fromQuery: CompletedLocalQueryInfo,
+  toQuery: CompletedLocalQueryInfo,
+): Promise<InterpretedQueryCompareResult> {
+  const fromResultSet = await getInterpretedResults(
+    fromQuery.completedQuery.query.resultsPaths.interpretedResultsPath,
+  );
+
+  const toResultSet = await getInterpretedResults(
+    toQuery.completedQuery.query.resultsPaths.interpretedResultsPath,
+  );
+
+  if (!fromResultSet || !toResultSet) {
+    throw new Error(
+      "Could not find interpreted results for one or both queries.",
+    );
+  }
+
+  const database = databaseManager.findDatabaseItem(
+    Uri.parse(toQuery.initialInfo.databaseInfo.databaseUri),
+  );
+  if (!database) {
+    throw new Error(
+      "Could not find database the queries. Please check that the database still exists.",
+    );
+  }
+
+  const sourceLocationPrefix = await database.getSourceLocationPrefix(
+    cliServer,
+  );
+
+  const fromResults = fromResultSet.runs[0].results;
+  const toResults = toResultSet.runs[0].results;
+
+  if (!fromResults) {
+    throw new Error("No results found in the 'from' query.");
+  }
+
+  if (!toResults) {
+    throw new Error("No results found in the 'to' query.");
+  }
+
+  const { from, to } = sarifDiff(fromResults, toResults);
+
+  return {
+    kind: "interpreted",
+    sourceLocationPrefix,
+    from,
+    to,
+  };
+}

--- a/extensions/ql-vscode/src/compare/result-set-names.ts
+++ b/extensions/ql-vscode/src/compare/result-set-names.ts
@@ -68,6 +68,7 @@ export async function findResultSetNames(
   const toResultSetName = currentResultSetName || defaultToResultSetName!;
 
   return {
+    currentResultSetName,
     currentResultSetDisplayName:
       currentResultSetName ||
       `${defaultFromResultSetName} <-> ${defaultToResultSetName}`,

--- a/extensions/ql-vscode/src/compare/result-set-names.ts
+++ b/extensions/ql-vscode/src/compare/result-set-names.ts
@@ -1,28 +1,49 @@
+import { pathExists } from "fs-extra";
 import { BqrsInfo } from "../common/bqrs-cli-types";
-import { getDefaultResultSetName } from "../common/interface-types";
+import {
+  ALERTS_TABLE_NAME,
+  getDefaultResultSetName,
+  QueryMetadata,
+} from "../common/interface-types";
 
-export async function findCommonResultSetNames(
-  fromSchemas: BqrsInfo,
-  toSchemas: BqrsInfo,
+export async function getResultSetNames(
+  schemas: BqrsInfo,
+  metadata: QueryMetadata | undefined,
+  interpretedResultsPath: string | undefined,
 ): Promise<string[]> {
-  const fromSchemaNames = fromSchemas["result-sets"].map(
-    (schema) => schema.name,
-  );
-  const toSchemaNames = toSchemas["result-sets"].map((schema) => schema.name);
+  const schemaNames = schemas["result-sets"].map((schema) => schema.name);
 
+  if (metadata?.kind !== "graph" && interpretedResultsPath) {
+    if (await pathExists(interpretedResultsPath)) {
+      schemaNames.push(ALERTS_TABLE_NAME);
+    }
+  }
+
+  return schemaNames;
+}
+
+export function findCommonResultSetNames(
+  fromSchemaNames: string[],
+  toSchemaNames: string[],
+): string[] {
   return fromSchemaNames.filter((name) => toSchemaNames.includes(name));
 }
 
+export type CompareQueryInfo = {
+  schemas: BqrsInfo;
+  schemaNames: string[];
+  metadata: QueryMetadata | undefined;
+  interpretedResultsPath: string;
+};
+
 export async function findResultSetNames(
-  fromSchemas: BqrsInfo,
-  toSchemas: BqrsInfo,
+  from: CompareQueryInfo,
+  to: CompareQueryInfo,
   commonResultSetNames: readonly string[],
   selectedResultSetName: string | undefined,
 ) {
-  const fromSchemaNames = fromSchemas["result-sets"].map(
-    (schema) => schema.name,
-  );
-  const toSchemaNames = toSchemas["result-sets"].map((schema) => schema.name);
+  const fromSchemaNames = from.schemaNames;
+  const toSchemaNames = to.schemaNames;
 
   // Fall back on the default result set names if there are no common ones.
   const defaultFromResultSetName = fromSchemaNames.find((name) =>

--- a/extensions/ql-vscode/src/compare/sarif-diff.ts
+++ b/extensions/ql-vscode/src/compare/sarif-diff.ts
@@ -1,0 +1,50 @@
+import * as sarif from "sarif";
+
+/**
+ * Compare the alerts of two queries. Use deep equality to determine if
+ * results have been added or removed across two invocations of a query.
+ *
+ * Assumptions:
+ *
+ * 1. Queries have the same sort order
+ * 2. Results are not changed or re-ordered, they are only added or removed
+ *
+ * @param fromResults the source query
+ * @param toResults the target query
+ *
+ * @throws Error when:
+ *  1. If either query is empty
+ *  2. If the queries are 100% disjoint
+ */
+export function sarifDiff(
+  fromResults: sarif.Result[],
+  toResults: sarif.Result[],
+) {
+  if (!fromResults.length) {
+    throw new Error("CodeQL Compare: Source query has no results.");
+  }
+
+  if (!toResults.length) {
+    throw new Error("CodeQL Compare: Target query has no results.");
+  }
+
+  const results = {
+    from: arrayDiff(fromResults, toResults),
+    to: arrayDiff(toResults, fromResults),
+  };
+
+  if (
+    fromResults.length === results.from.length &&
+    toResults.length === results.to.length
+  ) {
+    throw new Error("CodeQL Compare: No overlap between the selected queries.");
+  }
+
+  return results;
+}
+
+function arrayDiff<T>(source: readonly T[], toRemove: readonly T[]): T[] {
+  // Stringify the object so that we can compare hashes in the set
+  const rest = new Set(toRemove.map((item) => JSON.stringify(item)));
+  return source.filter((element) => !rest.has(JSON.stringify(element)));
+}


### PR DESCRIPTION
This adds diffing of SARIF results to the compare view. It naively compares the `JSON.stringify` of the SARIF results and doesn't do anything smart about differing paths etc.

It's easiest to review this commit-by-commit.

![Screenshot 2023-12-14 at 10 27 25](https://github.com/github/vscode-codeql/assets/1112623/ca669340-e15d-4c97-9448-a715ccc44c27)


## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
