### PR TITLE
Change compare view default result set name

### DIFF
--- a/extensions/ql-vscode/src/compare/result-set-names.ts
+++ b/extensions/ql-vscode/src/compare/result-set-names.ts
@@ -1,4 +1,5 @@
 import { BQRSInfo } from "../common/bqrs-cli-types";
+import { getDefaultResultSetName } from "../common/interface-types";
 
 export async function findResultSetNames(
   fromSchemas: BQRSInfo,
@@ -30,7 +31,8 @@ export async function findResultSetNames(
     );
   }
 
-  const currentResultSetName = selectedResultSetName || commonResultSetNames[0];
+  const currentResultSetName =
+    selectedResultSetName ?? getDefaultResultSetName(commonResultSetNames);
   const fromResultSetName = currentResultSetName || defaultFromResultSetName!;
   const toResultSetName = currentResultSetName || defaultToResultSetName!;
 


### PR DESCRIPTION
This changes the default result set that is selected in the compare view to the same as the default result set in the results view. This will select `#select` by default for most queries, rather than the first result set, which could be `edges` or `nodes` for some queries. If `#select` doesn't exist, the behavior is the same as before.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
