### PR TITLE
CodeQL model editor: Make "add" and "delete" buttons more intuitive

### DIFF
--- a/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
@@ -269,7 +269,7 @@ const ModelableMethodRow = forwardRef<HTMLElement | undefined, MethodRowProps>(
                 </DataGridCell>
                 {viewState.showMultipleModels && (
                   <DataGridCell>
-                    {index === modeledMethods.length - 1 ? (
+                    {index === 0 ? (
                       <CodiconRow
                         appearance="icon"
                         aria-label="Add new model"

--- a/extensions/ql-vscode/src/view/model-editor/__tests__/MethodRow.spec.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/__tests__/MethodRow.spec.tsx
@@ -350,7 +350,7 @@ describe(MethodRow.name, () => {
     expect(removeButton?.getElementsByTagName("input")[0]).toBeEnabled();
   });
 
-  it("shows add model button on last row and remove model button on all other rows", async () => {
+  it("shows add model button on first row and remove model button on all other rows", async () => {
     render({
       modeledMethods: [
         { ...modeledMethod, type: "source" },
@@ -401,7 +401,7 @@ describe(MethodRow.name, () => {
     ]);
   });
 
-  it("can delete the first modeled method", async () => {
+  it("cannot delete the first modeled method (but delete second instead)", async () => {
     render({
       modeledMethods: [
         { ...modeledMethod, type: "source" },
@@ -420,7 +420,7 @@ describe(MethodRow.name, () => {
 
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange).toHaveBeenCalledWith(method.signature, [
-      { ...modeledMethod, type: "sink" },
+      { ...modeledMethod, type: "source" },
       { ...modeledMethod, type: "none" },
       { ...modeledMethod, type: "summary" },
     ]);
@@ -441,7 +441,7 @@ describe(MethodRow.name, () => {
     });
 
     onChange.mockReset();
-    await userEvent.click(screen.getAllByLabelText("Remove model")[2]);
+    await userEvent.click(screen.getAllByLabelText("Remove model")[1]);
 
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange).toHaveBeenCalledWith(method.signature, [


### PR DESCRIPTION
A minor UI suggestion for adding multiple models in the model editor. Previously, you'd click the last row of the model editor to add a new row, and then all other rows would become deletable, except that new empty one. We decided that it's slightly more helpful to have the first row remaining fixed (and undeletable).

![image](https://github.com/github/vscode-codeql/assets/42641846/34b9da6a-84b7-48da-8e24-4b996ec54a32)


## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
   - I don't think a changelog item is necessary here
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
   - See internal linked issue 
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
   - No update needed (I checked the [docs + screenshot](https://github.com/github/codeql/blob/main/docs/codeql/codeql-for-visual-studio-code/using-the-codeql-model-editor.rst#modeling-methods-with-multiple-potential-flows))
