### PR TITLE
Avoid creating a multitoken when finding definitions

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [UNRELEASED]
 
+- Avoid showing a popup when hovering over source elements in database source files. [#3125](https://github.com/github/vscode-codeql/pull/3125)
+
 ## 1.11.0 - 13 December 2023
 
 - Add a new method modeling panel to classify methods as sources/sinks/summaries while in the context of the source code. [#3128](https://github.com/github/vscode-codeql/pull/3128)
@@ -19,7 +21,7 @@
 - Add new CodeQL views for managing databases and queries:
   1. A queries panel that shows all queries in your workspace. It allows you to view, create, and run queries in one place.
   2. A language selector, which allows you to quickly filter databases and queries by language.
-  
+
   For more information, see the [documentation](https://codeql.github.com/docs/codeql-for-visual-studio-code/analyzing-your-projects/#filtering-databases-and-queries-by-language).
 - When adding a CodeQL database, we no longer add the database source folder to the workspace by default (since this caused bugs in single-folder workspaces). [#3047](https://github.com/github/vscode-codeql/pull/3047)
   - You can manually add individual database source folders to the workspace with the "Add Database Source to Workspace" right-click command in the databases view.

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -1086,23 +1086,27 @@ async function activateWithInstalledDistribution(
   // Jump-to-definition and find-references
   void extLogger.log("Registering jump-to-definition handlers.");
 
-  languages.registerDefinitionProvider(
-    { scheme: zipArchiveScheme },
-    new TemplateQueryDefinitionProvider(
-      cliServer,
-      qs,
-      dbm,
-      contextualQueryStorageDir,
+  ctx.subscriptions.push(
+    languages.registerDefinitionProvider(
+      { scheme: zipArchiveScheme },
+      new TemplateQueryDefinitionProvider(
+        cliServer,
+        qs,
+        dbm,
+        contextualQueryStorageDir,
+      ),
     ),
   );
 
-  languages.registerReferenceProvider(
-    { scheme: zipArchiveScheme },
-    new TemplateQueryReferenceProvider(
-      cliServer,
-      qs,
-      dbm,
-      contextualQueryStorageDir,
+  ctx.subscriptions.push(
+    languages.registerReferenceProvider(
+      { scheme: zipArchiveScheme },
+      new TemplateQueryReferenceProvider(
+        cliServer,
+        qs,
+        dbm,
+        contextualQueryStorageDir,
+      ),
     ),
   );
 

--- a/extensions/ql-vscode/src/language-support/contextual/template-provider.ts
+++ b/extensions/ql-vscode/src/language-support/contextual/template-provider.ts
@@ -88,25 +88,18 @@ export class TemplateQueryDefinitionProvider implements DefinitionProvider {
     uriString: string,
     token: CancellationToken,
   ): Promise<LocationLink[]> {
-    return withProgress(
-      async (progress, tokenInner) => {
-        const multiToken = new MultiCancellationToken(token, tokenInner);
-        return getLocationsForUriString(
-          this.cli,
-          this.qs,
-          this.dbm,
-          uriString,
-          KeyType.DefinitionQuery,
-          this.queryStorageDir,
-          progress,
-          multiToken,
-          (src, _dest) => src === uriString,
-        );
-      },
-      {
-        cancellable: true,
-        title: "Finding definitions",
-      },
+    // Do not create a multitoken here. There will be no popup and users cannot click on anything to cancel this operation.
+    // This is because finding definitions can be triggered by a hover, which should not have a popup.
+    return getLocationsForUriString(
+      this.cli,
+      this.qs,
+      this.dbm,
+      uriString,
+      KeyType.DefinitionQuery,
+      this.queryStorageDir,
+      () => {}, // noop
+      token,
+      (src, _dest) => src === uriString,
     );
   }
 }
@@ -161,6 +154,7 @@ export class TemplateQueryReferenceProvider implements ReferenceProvider {
     uriString: string,
     token: CancellationToken,
   ): Promise<FullLocationLink[]> {
+    // Create a multitoken here. There will be a popup and users can click on it to cancel this operation.
     return withProgress(
       async (progress, tokenInner) => {
         const multiToken = new MultiCancellationToken(token, tokenInner);


### PR DESCRIPTION
This will avoid showing a query-server popup on hovers. When someone does CTRL+hover on source code in a database archive, the definitions provider is triggered. The first time this is run, there will be a query that is invoked in order to find definitions. This can be a long process.

Previously, this query brought up a popup window that could be cancelled. However, this is confusing users since the query is automatically cancelled when the mouse hovers away from the element.

The downside of this PR is that even when find definitions is explicitly invoked, (using F12), there will still be no hover.

I think this is an improvement, but I am happy to discuss if others disagree.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Replace this with a description of the changes your pull request makes.

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [n/a] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
