### PR TITLE
Remove GitHub database download feature flag

### DIFF
--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -762,8 +762,6 @@ export class ModelConfigListener extends ConfigListener implements ModelConfig {
 
 const GITHUB_DATABASE_SETTING = new Setting("githubDatabase", ROOT_SETTING);
 
-// Feature flag for the GitHub database downnload.
-const GITHUB_DATABASE_ENABLE = new Setting("enable", GITHUB_DATABASE_SETTING);
 const GITHUB_DATABASE_DOWNLOAD = new Setting(
   "download",
   GITHUB_DATABASE_SETTING,
@@ -778,7 +776,6 @@ const GitHubDatabaseUpdateValues = ["ask", "never"] as const;
 type GitHubDatabaseUpdate = (typeof GitHubDatabaseUpdateValues)[number];
 
 export interface GitHubDatabaseConfig {
-  enable: boolean;
   download: GitHubDatabaseDownload;
   update: GitHubDatabaseUpdate;
   setDownload(
@@ -800,10 +797,6 @@ export class GitHubDatabaseConfigListener
       [GITHUB_DATABASE_SETTING],
       e,
     );
-  }
-
-  public get enable() {
-    return !!GITHUB_DATABASE_ENABLE.getValue<boolean>();
   }
 
   public get download(): GitHubDatabaseDownload {

--- a/extensions/ql-vscode/src/databases/github-databases/github-databases-module.ts
+++ b/extensions/ql-vscode/src/databases/github-databases/github-databases-module.ts
@@ -60,10 +60,6 @@ export class GitHubDatabasesModule extends DisposableObject {
   }
 
   private async initialize(): Promise<void> {
-    if (!this.config.enable) {
-      return;
-    }
-
     // Start the check and downloading the database asynchronously. We don't want to block on this
     // in extension activation since this makes network requests and waits for user input.
     void this.promptGitHubRepositoryDownload().catch((e: unknown) => {


### PR DESCRIPTION
This removes the `codeQL.githubDatabase.enable` setting and always enables the GitHub database download feature.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
