### PR TITLE
Add a consistency check for the model editor

### DIFF
--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -712,12 +712,17 @@ const LLM_GENERATION_DEV_ENDPOINT = new Setting(
 );
 const EXTENSIONS_DIRECTORY = new Setting("extensionsDirectory", MODEL_SETTING);
 const ENABLE_RUBY = new Setting("enableRuby", MODEL_SETTING);
+const ENABLE_CONSISTENCY_CHECK = new Setting(
+  "enableConsistencyCheck",
+  MODEL_SETTING,
+);
 
 export interface ModelConfig {
   flowGeneration: boolean;
   llmGeneration: boolean;
   getExtensionsDirectory(languageId: string): string | undefined;
   enableRuby: boolean;
+  enableConsistencyCheck: boolean;
 }
 
 export class ModelConfigListener extends ConfigListener implements ModelConfig {
@@ -757,6 +762,10 @@ export class ModelConfigListener extends ConfigListener implements ModelConfig {
 
   public get enableRuby(): boolean {
     return !!ENABLE_RUBY.getValue<boolean>();
+  }
+
+  public get enableConsistencyCheck(): boolean {
+    return !!ENABLE_CONSISTENCY_CHECK.getValue<boolean>();
   }
 }
 

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -712,17 +712,12 @@ const LLM_GENERATION_DEV_ENDPOINT = new Setting(
 );
 const EXTENSIONS_DIRECTORY = new Setting("extensionsDirectory", MODEL_SETTING);
 const ENABLE_RUBY = new Setting("enableRuby", MODEL_SETTING);
-const ENABLE_CONSISTENCY_CHECK = new Setting(
-  "enableConsistencyCheck",
-  MODEL_SETTING,
-);
 
 export interface ModelConfig {
   flowGeneration: boolean;
   llmGeneration: boolean;
   getExtensionsDirectory(languageId: string): string | undefined;
   enableRuby: boolean;
-  enableConsistencyCheck: boolean;
 }
 
 export class ModelConfigListener extends ConfigListener implements ModelConfig {
@@ -762,10 +757,6 @@ export class ModelConfigListener extends ConfigListener implements ModelConfig {
 
   public get enableRuby(): boolean {
     return !!ENABLE_RUBY.getValue<boolean>();
-  }
-
-  public get enableConsistencyCheck(): boolean {
-    return !!ENABLE_CONSISTENCY_CHECK.getValue<boolean>();
   }
 }
 

--- a/extensions/ql-vscode/src/model-editor/consistency-check.ts
+++ b/extensions/ql-vscode/src/model-editor/consistency-check.ts
@@ -4,11 +4,7 @@ import { BaseLogger } from "../common/logging";
 
 interface Notifier {
   missingMethod(signature: string): void;
-  inconsistentSupported(
-    signature: string,
-    expectedSupported: boolean,
-    actualSupported: boolean,
-  ): void;
+  inconsistentSupported(signature: string, expectedSupported: boolean): void;
 }
 
 export function checkConsistency(
@@ -48,11 +44,7 @@ function checkMethodConsistency(
   );
 
   if (method.supported !== expectSupported) {
-    notifier.inconsistentSupported(
-      method.signature,
-      expectSupported,
-      method.supported,
-    );
+    notifier.inconsistentSupported(method.signature, expectSupported);
   }
 }
 
@@ -65,13 +57,13 @@ export class DefaultNotifier implements Notifier {
     );
   }
 
-  inconsistentSupported(
-    signature: string,
-    expectedSupported: boolean,
-    actualSupported: boolean,
-  ) {
+  inconsistentSupported(signature: string, expectedSupported: boolean) {
+    const expectedMessage = expectedSupported
+      ? `Expected method to be supported, but it is not.`
+      : `Expected method to not be supported, but it is.`;
+
     void this.logger.log(
-      `Model editor query consistency check: Inconsistent supported flag for method ${signature}. Expected supported: ${expectedSupported}, actual supported: ${actualSupported}.`,
+      `Model editor query consistency check: Inconsistent supported flag for method ${signature}. ${expectedMessage}`,
     );
   }
 }

--- a/extensions/ql-vscode/src/model-editor/consistency-check.ts
+++ b/extensions/ql-vscode/src/model-editor/consistency-check.ts
@@ -58,7 +58,7 @@ export class DefaultNotifier implements Notifier {
 
   missingMethod(signature: string) {
     void this.logger.log(
-      `Consistency check: Missing method ${signature} for method that is modeled`,
+      `Model editor query consistency check: Missing method ${signature} for method that is modeled.`,
     );
   }
 
@@ -68,7 +68,7 @@ export class DefaultNotifier implements Notifier {
     actualSupported: boolean,
   ) {
     void this.logger.log(
-      `Consistency check: Inconsistent supported flag for method ${signature}. Expected supported: ${expectedSupported}, actual supported: ${actualSupported}`,
+      `Model editor query consistency check: Inconsistent supported flag for method ${signature}. Expected supported: ${expectedSupported}, actual supported: ${actualSupported}.`,
     );
   }
 }

--- a/extensions/ql-vscode/src/model-editor/consistency-check.ts
+++ b/extensions/ql-vscode/src/model-editor/consistency-check.ts
@@ -1,0 +1,74 @@
+import { Method } from "./method";
+import { ModeledMethod } from "./modeled-method";
+import { BaseLogger } from "../common/logging";
+
+interface Notifier {
+  missingMethod(signature: string): void;
+  inconsistentSupported(
+    signature: string,
+    expectedSupported: boolean,
+    actualSupported: boolean,
+  ): void;
+}
+
+export function checkConsistency(
+  methods: readonly Method[],
+  modeledMethods: Readonly<Record<string, readonly ModeledMethod[]>>,
+  notifier: Notifier,
+) {
+  const methodsBySignature = methods.reduce(
+    (acc, method) => {
+      acc[method.signature] = method;
+      return acc;
+    },
+    {} as Record<string, Method>,
+  );
+
+  for (const signature in modeledMethods) {
+    const method = methodsBySignature[signature];
+    if (!method) {
+      notifier.missingMethod(signature);
+      continue;
+    }
+
+    const modeledMethodsForSignature = modeledMethods[signature];
+
+    checkMethodConsistency(method, modeledMethodsForSignature, notifier);
+  }
+}
+
+function checkMethodConsistency(
+  method: Method,
+  modeledMethods: readonly ModeledMethod[],
+  notifier: Notifier,
+) {
+  const expectSupported = modeledMethods.some((m) => m.type !== "none");
+
+  if (method.supported !== expectSupported) {
+    notifier.inconsistentSupported(
+      method.signature,
+      expectSupported,
+      method.supported,
+    );
+  }
+}
+
+export class DefaultNotifier implements Notifier {
+  constructor(private readonly logger: BaseLogger) {}
+
+  missingMethod(signature: string) {
+    void this.logger.log(
+      `Consistency check: Missing method ${signature} for method that is modeled`,
+    );
+  }
+
+  inconsistentSupported(
+    signature: string,
+    expectedSupported: boolean,
+    actualSupported: boolean,
+  ) {
+    void this.logger.log(
+      `Consistency check: Inconsistent supported flag for method ${signature}. Expected supported: ${expectedSupported}, actual supported: ${actualSupported}`,
+    );
+  }
+}

--- a/extensions/ql-vscode/src/model-editor/consistency-check.ts
+++ b/extensions/ql-vscode/src/model-editor/consistency-check.ts
@@ -42,7 +42,10 @@ function checkMethodConsistency(
   modeledMethods: readonly ModeledMethod[],
   notifier: Notifier,
 ) {
-  const expectSupported = modeledMethods.some((m) => m.type !== "none");
+  // Type models are currently not shown as `supported` since they do not give any model information.
+  const expectSupported = modeledMethods.some(
+    (m) => m.type !== "none" && m.type !== "type",
+  );
 
   if (method.supported !== expectSupported) {
     notifier.inconsistentSupported(

--- a/extensions/ql-vscode/src/model-editor/model-editor-module.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-module.ts
@@ -103,10 +103,6 @@ export class ModelEditorModule extends DisposableObject {
 
     this.push(
       this.modelingEvents.onMethodsChanged((event) => {
-        if (!this.modelConfig.enableConsistencyCheck) {
-          return;
-        }
-
         const modeledMethods = this.modelingStore.getModeledMethods(
           event.databaseItem,
         );

--- a/extensions/ql-vscode/src/model-editor/model-editor-module.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-module.ts
@@ -24,6 +24,7 @@ import { ModelingEvents } from "./modeling-events";
 import { getModelsAsDataLanguage } from "./languages";
 import { INITIAL_MODE } from "./shared/mode";
 import { isSupportedLanguage } from "./supported-languages";
+import { DefaultNotifier, checkConsistency } from "./consistency-check";
 
 export class ModelEditorModule extends DisposableObject {
   private readonly queryStorageDir: string;
@@ -97,6 +98,24 @@ export class ModelEditorModule extends DisposableObject {
     this.push(
       this.modelingEvents.onSelectedMethodChanged(async (event) => {
         await this.showMethod(event.databaseItem, event.method, event.usage);
+      }),
+    );
+
+    this.push(
+      this.modelingEvents.onMethodsChanged((event) => {
+        if (!this.modelConfig.enableConsistencyCheck) {
+          return;
+        }
+
+        const modeledMethods = this.modelingStore.getModeledMethods(
+          event.databaseItem,
+        );
+
+        checkConsistency(
+          event.methods,
+          modeledMethods,
+          new DefaultNotifier(this.app.logger),
+        );
       }),
     );
   }

--- a/extensions/ql-vscode/src/model-editor/modeling-events.ts
+++ b/extensions/ql-vscode/src/model-editor/modeling-events.ts
@@ -9,6 +9,7 @@ import { Mode } from "./shared/mode";
 interface MethodsChangedEvent {
   readonly methods: readonly Method[];
   readonly dbUri: string;
+  readonly databaseItem: DatabaseItem;
   readonly isActiveDb: boolean;
 }
 
@@ -166,10 +167,12 @@ export class ModelingEvents extends DisposableObject {
   public fireMethodsChangedEvent(
     methods: Method[],
     dbUri: string,
+    databaseItem: DatabaseItem,
     isActiveDb: boolean,
   ) {
     this.onMethodsChangedEventEmitter.fire({
       methods,
+      databaseItem,
       dbUri,
       isActiveDb,
     });

--- a/extensions/ql-vscode/src/model-editor/modeling-store.ts
+++ b/extensions/ql-vscode/src/model-editor/modeling-store.ts
@@ -155,6 +155,7 @@ export class ModelingStore extends DisposableObject {
     this.modelingEvents.fireMethodsChangedEvent(
       methods,
       dbUri,
+      dbItem,
       dbUri === this.activeDb,
     );
   }

--- a/extensions/ql-vscode/test/unit-tests/model-editor/consistency-check.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/model-editor/consistency-check.test.ts
@@ -52,7 +52,6 @@ describe("checkConsistency", () => {
     expect(notifier.inconsistentSupported).toHaveBeenCalledWith(
       "Microsoft.CodeAnalysis.CSharp.SyntaxFactory.SeparatedList`1(System.Collections.Generic.IEnumerable<TNode>)",
       true,
-      false,
     );
     expect(notifier.missingMethod).not.toHaveBeenCalled();
   });

--- a/extensions/ql-vscode/test/unit-tests/model-editor/consistency-check.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/model-editor/consistency-check.test.ts
@@ -1,0 +1,83 @@
+import { checkConsistency } from "../../../src/model-editor/consistency-check";
+import { createSourceModeledMethod } from "../../factories/model-editor/modeled-method-factories";
+import { createMethod } from "../../factories/model-editor/method-factories";
+
+describe("checkConsistency", () => {
+  const notifier = {
+    missingMethod: jest.fn(),
+    inconsistentSupported: jest.fn(),
+  };
+
+  beforeEach(() => {
+    notifier.missingMethod.mockReset();
+    notifier.inconsistentSupported.mockReset();
+  });
+
+  it("should call missingMethod when method is missing", () => {
+    checkConsistency(
+      [],
+      {
+        "Microsoft.CodeAnalysis.CSharp.SyntaxFactory.SeparatedList`1(System.Collections.Generic.IEnumerable<TNode>)":
+          [createSourceModeledMethod()],
+      },
+      notifier,
+    );
+
+    expect(notifier.missingMethod).toHaveBeenCalledWith(
+      "Microsoft.CodeAnalysis.CSharp.SyntaxFactory.SeparatedList`1(System.Collections.Generic.IEnumerable<TNode>)",
+    );
+    expect(notifier.inconsistentSupported).not.toHaveBeenCalled();
+  });
+
+  it("should call inconsistentSupported when support is inconsistent", () => {
+    checkConsistency(
+      [
+        createMethod({
+          signature:
+            "Microsoft.CodeAnalysis.CSharp.SyntaxFactory.SeparatedList`1(System.Collections.Generic.IEnumerable<TNode>)",
+          packageName: "Microsoft.CodeAnalysis.CSharp",
+          typeName: "SyntaxFactory",
+          methodName: "SeparatedList`1",
+          methodParameters: "(System.Collections.Generic.IEnumerable<TNode>)",
+          supported: false,
+        }),
+      ],
+      {
+        "Microsoft.CodeAnalysis.CSharp.SyntaxFactory.SeparatedList`1(System.Collections.Generic.IEnumerable<TNode>)":
+          [createSourceModeledMethod({})],
+      },
+      notifier,
+    );
+
+    expect(notifier.inconsistentSupported).toHaveBeenCalledWith(
+      "Microsoft.CodeAnalysis.CSharp.SyntaxFactory.SeparatedList`1(System.Collections.Generic.IEnumerable<TNode>)",
+      true,
+      false,
+    );
+    expect(notifier.missingMethod).not.toHaveBeenCalled();
+  });
+
+  it("should call no methods when consistent", () => {
+    checkConsistency(
+      [
+        createMethod({
+          signature:
+            "Microsoft.CodeAnalysis.CSharp.SyntaxFactory.SeparatedList<TNode>(System.Collections.Generic.IEnumerable<TNode>)",
+          packageName: "Microsoft.CodeAnalysis.CSharp",
+          typeName: "SyntaxFactory",
+          methodName: "SeparatedList<TNode>",
+          methodParameters: "(System.Collections.Generic.IEnumerable<TNode>)",
+          supported: true,
+        }),
+      ],
+      {
+        "Microsoft.CodeAnalysis.CSharp.SyntaxFactory.SeparatedList<TNode>(System.Collections.Generic.IEnumerable<TNode>)":
+          [createSourceModeledMethod({})],
+      },
+      notifier,
+    );
+
+    expect(notifier.missingMethod).not.toHaveBeenCalled();
+    expect(notifier.inconsistentSupported).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
This adds an internal consistency check for the model editor. This catches cases where the model editor thinks something is supported, but the model editor queries return that it it not supported.

This would for example have caught https://github.com/github/codeql/pull/15089 without needing to manually check the query.

![Screenshot 2023-12-14 at 12 09 40](https://github.com/github/vscode-codeql/assets/1112623/903964d7-05f2-42af-a48a-cf7f3b5c8649)

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
