### PR TITLE
Remove fallback behavior for database unbundle

### DIFF
--- a/extensions/ql-vscode/src/databases/database-fetcher.ts
+++ b/extensions/ql-vscode/src/databases/database-fetcher.ts
@@ -1,6 +1,5 @@
 import fetch, { Response } from "node-fetch";
 import { zip } from "zip-a-folder";
-import { Open } from "unzipper";
 import { Uri, window, InputBoxOptions } from "vscode";
 import { CodeQLCliServer } from "../codeql-cli/cli";
 import {
@@ -46,7 +45,7 @@ export async function promptImportInternetDatabase(
   databaseManager: DatabaseManager,
   storagePath: string,
   progress: ProgressCallback,
-  cli?: CodeQLCliServer,
+  cli: CodeQLCliServer,
 ): Promise<DatabaseItem | undefined> {
   const databaseUrl = await window.showInputBox({
     prompt: "Enter URL of zipfile of database to download",
@@ -101,7 +100,7 @@ export async function promptImportGithubDatabase(
   storagePath: string,
   credentials: Credentials | undefined,
   progress: ProgressCallback,
-  cli?: CodeQLCliServer,
+  cli: CodeQLCliServer,
   language?: string,
   makeSelected = true,
   addSourceArchiveFolder = addDatabaseSourceToWorkspace(),
@@ -180,7 +179,7 @@ export async function downloadGitHubDatabase(
   storagePath: string,
   credentials: Credentials | undefined,
   progress: ProgressCallback,
-  cli?: CodeQLCliServer,
+  cli: CodeQLCliServer,
   language?: string,
   makeSelected = true,
   addSourceArchiveFolder = addDatabaseSourceToWorkspace(),
@@ -235,7 +234,7 @@ export async function downloadGitHubDatabaseFromUrl(
   progress: ProgressCallback,
   databaseManager: DatabaseManager,
   storagePath: string,
-  cli?: CodeQLCliServer,
+  cli: CodeQLCliServer,
   makeSelected = true,
   addSourceArchiveFolder = true,
 ): Promise<DatabaseItem | undefined> {
@@ -279,6 +278,7 @@ export async function downloadGitHubDatabaseFromUrl(
  * @param databaseUrl the file url of the archive to import
  * @param databaseManager the DatabaseManager
  * @param storagePath where to store the unzipped database.
+ * @param cli the CodeQL CLI server
  */
 export async function importArchiveDatabase(
   commandManager: AppCommandManager,
@@ -286,7 +286,7 @@ export async function importArchiveDatabase(
   databaseManager: DatabaseManager,
   storagePath: string,
   progress: ProgressCallback,
-  cli?: CodeQLCliServer,
+  cli: CodeQLCliServer,
 ): Promise<DatabaseItem | undefined> {
   try {
     const item = await databaseArchiveFetcher(
@@ -333,6 +333,7 @@ export async function importArchiveDatabase(
  * @param nameOverride a name for the database that overrides the default
  * @param origin the origin of the database
  * @param progress callback to send progress messages to
+ * @param cli the CodeQL CLI server
  * @param makeSelected make the new database selected in the databases panel (default: true)
  * @param addSourceArchiveFolder whether to add a workspace folder containing the source archive to the workspace
  */
@@ -344,7 +345,7 @@ async function databaseArchiveFetcher(
   nameOverride: string | undefined,
   origin: DatabaseOrigin,
   progress: ProgressCallback,
-  cli?: CodeQLCliServer,
+  cli: CodeQLCliServer,
   makeSelected = true,
   addSourceArchiveFolder = addDatabaseSourceToWorkspace(),
 ): Promise<DatabaseItem> {
@@ -443,34 +444,24 @@ function validateUrl(databaseUrl: string) {
 async function readAndUnzip(
   zipUrl: string,
   unzipPath: string,
-  cli?: CodeQLCliServer,
+  cli: CodeQLCliServer,
   progress?: ProgressCallback,
 ) {
-  // TODO: Providing progress as the file is unzipped is currently blocked
-  // on https://github.com/ZJONSSON/node-unzipper/issues/222
   const zipFile = Uri.parse(zipUrl).fsPath;
   progress?.({
     maxStep: 10,
     step: 9,
     message: `Unzipping into ${basename(unzipPath)}`,
   });
-  if (cli) {
-    // Use the `database unbundle` command if the installed cli version supports it
-    await cli.databaseUnbundle(zipFile, unzipPath);
-  } else {
-    // Must get the zip central directory since streaming the
-    // zip contents may not have correct local file headers.
-    // Instead, we can only rely on the central directory.
-    const directory = await Open.file(zipFile);
-    await directory.extract({ path: unzipPath });
-  }
+
+  await cli.databaseUnbundle(zipFile, unzipPath);
 }
 
 async function fetchAndUnzip(
   databaseUrl: string,
   requestHeaders: { [key: string]: string },
   unzipPath: string,
-  cli?: CodeQLCliServer,
+  cli: CodeQLCliServer,
   progress?: ProgressCallback,
 ) {
   // Although it is possible to download and stream directly to an unzipped directory,

--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -233,7 +233,7 @@ export class DatabaseUI extends DisposableObject {
     private app: App,
     private databaseManager: DatabaseManager,
     languageContext: LanguageContextStore,
-    private readonly queryServer: QueryRunner | undefined,
+    private readonly queryServer: QueryRunner,
     private readonly storagePath: string,
     readonly extensionPath: string,
   ) {
@@ -402,10 +402,7 @@ export class DatabaseUI extends DisposableObject {
         workspace.workspaceFolders[0].uri.fsPath,
         "tutorial-queries",
       );
-      const cli = this.queryServer?.cliServer;
-      if (!cli) {
-        throw new Error("No CLI server found");
-      }
+      const cli = this.queryServer.cliServer;
       await cli.packInstall(tutorialQueriesPath);
     }
   }
@@ -528,7 +525,7 @@ export class DatabaseUI extends DisposableObject {
           this.databaseManager,
           this.storagePath,
           progress,
-          this.queryServer?.cliServer,
+          this.queryServer.cliServer,
         );
       },
       {
@@ -548,7 +545,7 @@ export class DatabaseUI extends DisposableObject {
           this.storagePath,
           credentials,
           progress,
-          this.queryServer?.cliServer,
+          this.queryServer.cliServer,
         );
       },
       {
@@ -704,7 +701,7 @@ export class DatabaseUI extends DisposableObject {
               this.databaseManager,
               this.storagePath,
               progress,
-              this.queryServer?.cliServer,
+              this.queryServer.cliServer,
             );
           } else {
             await this.databaseManager.openDatabase(uri, {
@@ -836,7 +833,7 @@ export class DatabaseUI extends DisposableObject {
             this.databaseManager,
             this.storagePath,
             progress,
-            this.queryServer?.cliServer,
+            this.queryServer.cliServer,
           );
         }
       },

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/databases/database-fetcher.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/databases/database-fetcher.test.ts
@@ -36,6 +36,7 @@ describe("database-fetcher", () => {
 
     const extension = await getActivatedExtension();
     databaseManager = extension.databaseManager;
+    cli = extension.cliServer;
 
     await cleanDatabases(databaseManager);
   });

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/new-query.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/new-query.test.ts
@@ -135,7 +135,7 @@ describeWithCodeQL()("using the new query server", () => {
     // Unlike the old query sevre the new one wants a database and the empty direcrtory is not valid.
     const dbItem = await ensureTestDatabase(
       extension.databaseManager,
-      undefined,
+      cliServer,
     );
     db = dbItem.databaseUri.fsPath;
   });

--- a/extensions/ql-vscode/test/vscode-tests/global.helper.ts
+++ b/extensions/ql-vscode/test/vscode-tests/global.helper.ts
@@ -28,7 +28,7 @@ export let storagePath: string;
  */
 export async function ensureTestDatabase(
   databaseManager: DatabaseManager,
-  cli: CodeQLCliServer | undefined,
+  cli: CodeQLCliServer,
 ): Promise<DatabaseItem> {
   // Add a database, but make sure the database manager is empty first
   await cleanDatabases(databaseManager);


### PR DESCRIPTION
The CodeQL CLI always supports the `database unbundle` command since https://github.com/github/vscode-codeql/commit/140d369098b286a006322432777b88649832c954 so we can remove the fallback behavior.

There were some places which were not passing in the CodeQL CLI server, but these always have access to the CLI server, so this just passes them in.

The only change in behavior (in terms of the fallback behavior) is in the `new-query.test.ts` test.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
