### PR TITLE
Switch to `yauzl` in the archive filesystem provider

### DIFF
--- a/extensions/ql-vscode/package-lock.json
+++ b/extensions/ql-vscode/package-lock.json
@@ -44,6 +44,7 @@
         "vscode-languageclient": "^8.0.2",
         "vscode-test-adapter-api": "^1.7.0",
         "vscode-test-adapter-util": "^0.7.0",
+        "yauzl": "^2.10.0",
         "zip-a-folder": "^3.1.3"
       },
       "devDependencies": {
@@ -95,6 +96,7 @@
         "@types/vscode": "^1.82.0",
         "@types/webpack": "^5.28.0",
         "@types/webpack-env": "^1.18.0",
+        "@types/yauzl": "^2.10.3",
         "@typescript-eslint/eslint-plugin": "^6.2.1",
         "@typescript-eslint/parser": "^6.14.0",
         "@vscode/test-electron": "^2.2.0",
@@ -8080,6 +8082,15 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true
     },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "6.13.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.13.2.tgz",
@@ -15012,7 +15023,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
       "dependencies": {
         "pend": "~1.2.0"
       }
@@ -24673,8 +24683,7 @@
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
@@ -30756,7 +30765,6 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "dev": true,
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1946,6 +1946,7 @@
     "vscode-languageclient": "^8.0.2",
     "vscode-test-adapter-api": "^1.7.0",
     "vscode-test-adapter-util": "^0.7.0",
+    "yauzl": "^2.10.0",
     "zip-a-folder": "^3.1.3"
   },
   "devDependencies": {
@@ -1997,6 +1998,7 @@
     "@types/vscode": "^1.82.0",
     "@types/webpack": "^5.28.0",
     "@types/webpack-env": "^1.18.0",
+    "@types/yauzl": "^2.10.3",
     "@typescript-eslint/eslint-plugin": "^6.2.1",
     "@typescript-eslint/parser": "^6.14.0",
     "@vscode/test-electron": "^2.2.0",

--- a/extensions/ql-vscode/src/common/unzip.ts
+++ b/extensions/ql-vscode/src/common/unzip.ts
@@ -1,0 +1,84 @@
+import { Entry as ZipEntry, open, Options as ZipOptions, ZipFile } from "yauzl";
+import { Readable } from "stream";
+
+// We can't use promisify because it picks up the wrong overload.
+export function openZip(
+  path: string,
+  options: ZipOptions = {},
+): Promise<ZipFile> {
+  return new Promise((resolve, reject) => {
+    open(path, options, (err, zipFile) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+
+      resolve(zipFile);
+    });
+  });
+}
+
+export function excludeDirectories(entries: ZipEntry[]): ZipEntry[] {
+  return entries.filter((entry) => !/\/$/.test(entry.fileName));
+}
+
+export function readZipEntries(zipFile: ZipFile): Promise<ZipEntry[]> {
+  return new Promise((resolve, reject) => {
+    const files: ZipEntry[] = [];
+
+    zipFile.readEntry();
+    zipFile.on("entry", (entry: ZipEntry) => {
+      if (/\/$/.test(entry.fileName)) {
+        // Directory file names end with '/'
+        // We don't need to do anything for directories.
+      } else {
+        files.push(entry);
+      }
+
+      zipFile.readEntry();
+    });
+
+    zipFile.on("end", () => {
+      resolve(files);
+    });
+
+    zipFile.on("error", (err) => {
+      reject(err);
+    });
+  });
+}
+
+function openZipReadStream(
+  zipFile: ZipFile,
+  entry: ZipEntry,
+): Promise<Readable> {
+  return new Promise((resolve, reject) => {
+    zipFile.openReadStream(entry, (err, readStream) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+
+      resolve(readStream);
+    });
+  });
+}
+
+export async function openZipBuffer(
+  zipFile: ZipFile,
+  entry: ZipEntry,
+): Promise<Buffer> {
+  const readable = await openZipReadStream(zipFile, entry);
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    readable.on("data", (chunk) => {
+      chunks.push(chunk);
+    });
+    readable.on("error", (err) => {
+      reject(err);
+    });
+    readable.on("end", () => {
+      resolve(Buffer.concat(chunks));
+    });
+  });
+}

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/common/vscode/archive-filesystem-provider.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/common/vscode/archive-filesystem-provider.test.ts
@@ -47,11 +47,10 @@ describe("archive-filesystem-provider", () => {
       pathWithinSourceArchive: "folder1",
     });
     const files = await archiveProvider.readDirectory(uri);
-    expect(files).toEqual([
-      ["folder2", FileType.Directory],
-      ["textFile.txt", FileType.File],
-      ["textFile2.txt", FileType.File],
-    ]);
+    expect(files).toHaveLength(3);
+    expect(files).toContainEqual(["folder2", FileType.Directory]);
+    expect(files).toContainEqual(["textFile.txt", FileType.File]);
+    expect(files).toContainEqual(["textFile2.txt", FileType.File]);
   });
 
   it("should handle a missing directory", async () => {


### PR DESCRIPTION
This switches the archive filesystem provider to `yauzl` instead of `unzipper` in preparation for removing `unzipper`. There should be no changes in behavior (except when Node > 18.15.0, in which case `unzipper` might actually read corrupted ZIP files).

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
