### PR TITLE
Do not reregister watchers on every file change for qltests

### DIFF
--- a/extensions/ql-vscode/src/query-testing/qltest-discovery.ts
+++ b/extensions/ql-vscode/src/query-testing/qltest-discovery.ts
@@ -31,6 +31,15 @@ export class QLTestDiscovery extends Discovery {
     super("QL Test Discovery", extLogger);
 
     this.push(this.watcher.onDidChange(this.handleDidChange, this));
+
+    // Watch for changes to any `.ql` or `.qlref` file in any of the QL packs that contain tests.
+    this.watcher.addWatch(
+      new RelativePattern(this.workspaceFolder.uri.fsPath, "**/*.{ql,qlref}"),
+    );
+    // need to explicitly watch for changes to directories themselves.
+    this.watcher.addWatch(
+      new RelativePattern(this.workspaceFolder.uri.fsPath, "**/"),
+    );
   }
 
   /**
@@ -56,15 +65,6 @@ export class QLTestDiscovery extends Discovery {
   protected async discover() {
     this._testDirectory = await this.discoverTests();
 
-    this.watcher.clear();
-    // Watch for changes to any `.ql` or `.qlref` file in any of the QL packs that contain tests.
-    this.watcher.addWatch(
-      new RelativePattern(this.workspaceFolder.uri.fsPath, "**/*.{ql,qlref}"),
-    );
-    // need to explicitly watch for changes to directories themselves.
-    this.watcher.addWatch(
-      new RelativePattern(this.workspaceFolder.uri.fsPath, "**/"),
-    );
     this._onDidChangeTests.fire(undefined);
   }
 


### PR DESCRIPTION
During the qltest discovery, we were recreating the watchers for qltests on every file change. This was causing the watchers to be recreated on each change, while there were no functional changes to the watchers themselves.

This commit moves the creation of the watchers to the constructor of the QLTestDiscovery class, and removes the creation of the watchers from the discover() method. The behavior should be the same.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
