### PR TITLE
Remove missed feature flag reference from package.json

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -424,11 +424,6 @@
         "title": "GitHub Databases",
         "order": 8,
         "properties": {
-          "codeQL.githubDatabase.enable": {
-            "type": "boolean",
-            "default": false,
-            "markdownDescription": "Enable automatic detection of GitHub databases."
-          },
           "codeQL.githubDatabase.download": {
             "type": "string",
             "default": "ask",


### PR DESCRIPTION
This setting has been removed, so it should not be referenced in `package.json` anymore.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
