### PR TITLE
Do not use the CLI server to determine query pack language

### DIFF
--- a/extensions/ql-vscode/scripts/generate-schemas.ts
+++ b/extensions/ql-vscode/scripts/generate-schemas.ts
@@ -7,6 +7,16 @@ const extensionDirectory = resolve(__dirname, "..");
 
 const schemas = [
   {
+    path: join(extensionDirectory, "src", "packaging", "qlpack-file.ts"),
+    type: "QlPackFile",
+    schemaPath: join(
+      extensionDirectory,
+      "src",
+      "packaging",
+      "qlpack-file.schema.json",
+    ),
+  },
+  {
     path: join(
       extensionDirectory,
       "src",

--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -721,29 +721,6 @@ export class CodeQLCliServer implements Disposable {
   }
 
   /**
-   * Resolve the library path and dbscheme for a query.
-   * @param workspaces The current open workspaces
-   * @param queryPath The path to the query
-   */
-  async resolveLibraryPath(
-    workspaces: string[],
-    queryPath: string,
-    silent = false,
-  ): Promise<QuerySetup> {
-    const subcommandArgs = [
-      "--query",
-      queryPath,
-      ...this.getAdditionalPacksArg(workspaces),
-    ];
-    return await this.runJsonCodeQlCliCommand<QuerySetup>(
-      ["resolve", "library-path"],
-      subcommandArgs,
-      "Resolving library paths",
-      { silent },
-    );
-  }
-
-  /**
    * Resolves the language for a query.
    * @param queryUri The URI of the query
    */

--- a/extensions/ql-vscode/src/common/discovery.ts
+++ b/extensions/ql-vscode/src/common/discovery.ts
@@ -1,6 +1,6 @@
 import { DisposableObject } from "./disposable-object";
 import { getErrorMessage } from "./helpers-pure";
-import { Logger } from "./logging";
+import { BaseLogger } from "./logging";
 
 /**
  * Base class for "discovery" operations, which scan the file system to find specific kinds of
@@ -13,7 +13,7 @@ export abstract class Discovery extends DisposableObject {
 
   constructor(
     protected readonly name: string,
-    private readonly logger: Logger,
+    protected readonly logger: BaseLogger,
   ) {
     super();
   }

--- a/extensions/ql-vscode/src/common/qlpack-language.ts
+++ b/extensions/ql-vscode/src/common/qlpack-language.ts
@@ -1,7 +1,5 @@
-import { load } from "js-yaml";
-import { readFile } from "fs-extra";
-import { QlPackFile } from "../packaging/qlpack-file";
 import { QueryLanguage } from "./query-language";
+import { loadQlpackFile } from "../packaging/qlpack-file-loader";
 
 /**
  * @param qlpackPath The path to the `qlpack.yml` or `codeql-pack.yml` file.
@@ -11,11 +9,9 @@ import { QueryLanguage } from "./query-language";
 export async function getQlPackLanguage(
   qlpackPath: string,
 ): Promise<QueryLanguage | undefined> {
-  const qlPack = load(await readFile(qlpackPath, "utf8")) as
-    | QlPackFile
-    | undefined;
+  const qlPack = await loadQlpackFile(qlpackPath);
   const dependencies = qlPack?.dependencies;
-  if (!dependencies || typeof dependencies !== "object") {
+  if (!dependencies) {
     return;
   }
 

--- a/extensions/ql-vscode/src/common/qlpack-language.ts
+++ b/extensions/ql-vscode/src/common/qlpack-language.ts
@@ -1,0 +1,30 @@
+import { load } from "js-yaml";
+import { readFile } from "fs-extra";
+import { QlPackFile } from "../packaging/qlpack-file";
+import { QueryLanguage } from "./query-language";
+
+/**
+ * @param qlpackPath The path to the `qlpack.yml` or `codeql-pack.yml` file.
+ * @return the language of the given qlpack file, or undefined if the file is
+ * not a valid qlpack file or does not contain exactly one language.
+ */
+export async function getQlPackLanguage(
+  qlpackPath: string,
+): Promise<QueryLanguage | undefined> {
+  const qlPack = load(await readFile(qlpackPath, "utf8")) as
+    | QlPackFile
+    | undefined;
+  const dependencies = qlPack?.dependencies;
+  if (!dependencies || typeof dependencies !== "object") {
+    return;
+  }
+
+  const matchingLanguages = Object.values(QueryLanguage).filter(
+    (language) => `codeql/${language}-all` in dependencies,
+  );
+  if (matchingLanguages.length !== 1) {
+    return undefined;
+  }
+
+  return matchingLanguages[0];
+}

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -799,11 +799,7 @@ async function activateWithInstalledDistribution(
   );
   ctx.subscriptions.push(databaseUI);
 
-  const queriesModule = QueriesModule.initialize(
-    app,
-    languageContext,
-    cliServer,
-  );
+  const queriesModule = QueriesModule.initialize(app, languageContext);
 
   void extLogger.log("Initializing evaluator log viewer.");
   const evalLogViewer = new EvalLogViewer();

--- a/extensions/ql-vscode/src/model-editor/extension-pack-metadata.schema.json
+++ b/extensions/ql-vscode/src/model-editor/extension-pack-metadata.schema.json
@@ -6,16 +6,23 @@
       "type": "object",
       "properties": {
         "name": {
-          "type": "string"
+          "type": ["string", "null"]
         },
         "version": {
-          "type": "string"
+          "type": ["string", "null"]
         },
         "extensionTargets": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "dataExtensions": {
           "anyOf": [
@@ -27,29 +34,46 @@
             },
             {
               "type": "string"
+            },
+            {
+              "type": "null"
             }
           ]
         },
         "dependencies": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "dbscheme": {
-          "type": "string"
+          "type": ["string", "null"]
         },
         "library": {
-          "type": "boolean"
+          "type": ["boolean", "null"]
         },
         "defaultSuite": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/SuiteInstruction"
-          }
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/SuiteInstruction"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "defaultSuiteFile": {
-          "type": "string"
+          "type": ["string", "null"]
         }
       },
       "required": ["dataExtensions", "extensionTargets", "name", "version"]

--- a/extensions/ql-vscode/src/model-editor/extension-pack-metadata.ts
+++ b/extensions/ql-vscode/src/model-editor/extension-pack-metadata.ts
@@ -1,7 +1,9 @@
 import { QlPackFile } from "../packaging/qlpack-file";
 
 export type ExtensionPackMetadata = QlPackFile & {
-  // Make both extensionTargets and dataExtensions required
+  // Make name, version, extensionTargets, and dataExtensions required
+  name: string;
+  version: string;
   extensionTargets: Record<string, string>;
   dataExtensions: string[] | string;
 };

--- a/extensions/ql-vscode/src/packaging/qlpack-file-loader.ts
+++ b/extensions/ql-vscode/src/packaging/qlpack-file-loader.ts
@@ -1,0 +1,28 @@
+import Ajv from "ajv";
+import * as qlpackFileSchemaJson from "./qlpack-file.schema.json";
+import { QlPackFile } from "./qlpack-file";
+import { load } from "js-yaml";
+import { readFile } from "fs-extra";
+
+const ajv = new Ajv({ allErrors: true });
+const qlpackFileValidate = ajv.compile(qlpackFileSchemaJson);
+
+export async function loadQlpackFile(path: string): Promise<QlPackFile> {
+  const qlPack = load(await readFile(path, "utf8")) as QlPackFile | undefined;
+
+  qlpackFileValidate(qlPack);
+
+  if (qlpackFileValidate.errors) {
+    throw new Error(
+      `Invalid extension pack YAML: ${qlpackFileValidate.errors
+        .map((error) => `${error.instancePath} ${error.message}`)
+        .join(", ")}`,
+    );
+  }
+
+  if (!qlPack) {
+    throw new Error(`Could not parse ${path}`);
+  }
+
+  return qlPack;
+}

--- a/extensions/ql-vscode/src/packaging/qlpack-file-loader.ts
+++ b/extensions/ql-vscode/src/packaging/qlpack-file-loader.ts
@@ -8,7 +8,15 @@ const ajv = new Ajv({ allErrors: true });
 const qlpackFileValidate = ajv.compile(qlpackFileSchemaJson);
 
 export async function loadQlpackFile(path: string): Promise<QlPackFile> {
-  const qlPack = load(await readFile(path, "utf8")) as QlPackFile | undefined;
+  const qlpackFileText = await readFile(path, "utf8");
+
+  let qlPack = load(qlpackFileText) as QlPackFile | undefined;
+
+  if (qlPack === undefined || qlPack === null) {
+    // An empty file is not valid according to the schema since it's not an object,
+    // but it is equivalent to an empty object.
+    qlPack = {};
+  }
 
   qlpackFileValidate(qlPack);
 
@@ -18,10 +26,6 @@ export async function loadQlpackFile(path: string): Promise<QlPackFile> {
         .map((error) => `${error.instancePath} ${error.message}`)
         .join(", ")}`,
     );
-  }
-
-  if (!qlPack) {
-    throw new Error(`Could not parse ${path}`);
   }
 
   return qlPack;

--- a/extensions/ql-vscode/src/packaging/qlpack-file.schema.json
+++ b/extensions/ql-vscode/src/packaging/qlpack-file.schema.json
@@ -6,37 +6,58 @@
       "type": "object",
       "properties": {
         "name": {
-          "type": "string"
+          "type": ["string", "null"]
         },
         "version": {
-          "type": "string"
+          "type": ["string", "null"]
         },
         "dependencies": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "extensionTargets": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "dbscheme": {
-          "type": "string"
+          "type": ["string", "null"]
         },
         "library": {
-          "type": "boolean"
+          "type": ["boolean", "null"]
         },
         "defaultSuite": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/SuiteInstruction"
-          }
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/SuiteInstruction"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "defaultSuiteFile": {
-          "type": "string"
+          "type": ["string", "null"]
         },
         "dataExtensions": {
           "anyOf": [
@@ -48,6 +69,9 @@
             },
             {
               "type": "string"
+            },
+            {
+              "type": "null"
             }
           ]
         }

--- a/extensions/ql-vscode/src/packaging/qlpack-file.schema.json
+++ b/extensions/ql-vscode/src/packaging/qlpack-file.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$ref": "#/definitions/ExtensionPackMetadata",
+  "$ref": "#/definitions/QlPackFile",
   "definitions": {
-    "ExtensionPackMetadata": {
+    "QlPackFile": {
       "type": "object",
       "properties": {
         "name": {
@@ -11,26 +11,13 @@
         "version": {
           "type": "string"
         },
-        "extensionTargets": {
+        "dependencies": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
           }
         },
-        "dataExtensions": {
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            {
-              "type": "string"
-            }
-          ]
-        },
-        "dependencies": {
+        "extensionTargets": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
@@ -50,9 +37,22 @@
         },
         "defaultSuiteFile": {
           "type": "string"
+        },
+        "dataExtensions": {
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "type": "string"
+            }
+          ]
         }
       },
-      "required": ["dataExtensions", "extensionTargets", "name", "version"]
+      "description": "The qlpack pack file, either in qlpack.yml or in codeql-pack.yml."
     },
     "SuiteInstruction": {
       "type": "object",

--- a/extensions/ql-vscode/src/packaging/qlpack-file.ts
+++ b/extensions/ql-vscode/src/packaging/qlpack-file.ts
@@ -4,8 +4,8 @@ import { SuiteInstruction } from "./suite-instruction";
  * The qlpack pack file, either in qlpack.yml or in codeql-pack.yml.
  */
 export interface QlPackFile {
-  name: string;
-  version: string;
+  name?: string;
+  version?: string;
   dependencies?: Record<string, string>;
   extensionTargets?: Record<string, string>;
   dbscheme?: string;

--- a/extensions/ql-vscode/src/packaging/qlpack-file.ts
+++ b/extensions/ql-vscode/src/packaging/qlpack-file.ts
@@ -4,13 +4,13 @@ import { SuiteInstruction } from "./suite-instruction";
  * The qlpack pack file, either in qlpack.yml or in codeql-pack.yml.
  */
 export interface QlPackFile {
-  name?: string;
-  version?: string;
-  dependencies?: Record<string, string>;
-  extensionTargets?: Record<string, string>;
-  dbscheme?: string;
-  library?: boolean;
-  defaultSuite?: SuiteInstruction[];
-  defaultSuiteFile?: string;
-  dataExtensions?: string[] | string;
+  name?: string | null;
+  version?: string | null;
+  dependencies?: Record<string, string> | null;
+  extensionTargets?: Record<string, string> | null;
+  dbscheme?: string | null;
+  library?: boolean | null;
+  defaultSuite?: SuiteInstruction[] | null;
+  defaultSuiteFile?: string | null;
+  dataExtensions?: string[] | string | null;
 }

--- a/extensions/ql-vscode/src/queries-panel/queries-module.ts
+++ b/extensions/ql-vscode/src/queries-panel/queries-module.ts
@@ -1,4 +1,3 @@
-import { CodeQLCliServer } from "../codeql-cli/cli";
 import { extLogger } from "../common/logging/vscode";
 import { App } from "../common/app";
 import { DisposableObject } from "../common/disposable-object";
@@ -26,23 +25,18 @@ export class QueriesModule extends DisposableObject {
   public static initialize(
     app: App,
     languageContext: LanguageContextStore,
-    cliServer: CodeQLCliServer,
   ): QueriesModule {
     const queriesModule = new QueriesModule(app);
     app.subscriptions.push(queriesModule);
 
-    queriesModule.initialize(app, languageContext, cliServer);
+    queriesModule.initialize(app, languageContext);
     return queriesModule;
   }
 
-  private initialize(
-    app: App,
-    langauageContext: LanguageContextStore,
-    cliServer: CodeQLCliServer,
-  ): void {
+  private initialize(app: App, langauageContext: LanguageContextStore): void {
     void extLogger.log("Initializing queries panel.");
 
-    const queryPackDiscovery = new QueryPackDiscovery(cliServer);
+    const queryPackDiscovery = new QueryPackDiscovery();
     this.push(queryPackDiscovery);
     void queryPackDiscovery.initialRefresh();
 

--- a/extensions/ql-vscode/src/queries-panel/query-pack-discovery.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-pack-discovery.ts
@@ -1,14 +1,12 @@
 import { basename, dirname } from "path";
-import { CodeQLCliServer, QuerySetup } from "../codeql-cli/cli";
 import { Event } from "vscode";
-import { QueryLanguage, dbSchemeToLanguage } from "../common/query-language";
+import { QueryLanguage } from "../common/query-language";
 import { FALLBACK_QLPACK_FILENAME, QLPACK_FILENAMES } from "../common/ql";
 import { FilePathDiscovery } from "../common/vscode/file-path-discovery";
-import { getErrorMessage } from "../common/helpers-pure";
-import { extLogger } from "../common/logging/vscode";
-import { EOL } from "os";
 import { containsPath } from "../common/files";
-import { getOnDiskWorkspaceFolders } from "../common/vscode/workspace-folders";
+import { load } from "js-yaml";
+import { readFile } from "fs-extra";
+import { QlPackFile } from "../packaging/qlpack-file";
 
 interface QueryPack {
   path: string;
@@ -19,7 +17,7 @@ interface QueryPack {
  * Discovers all query packs in the workspace.
  */
 export class QueryPackDiscovery extends FilePathDiscovery<QueryPack> {
-  constructor(private readonly cliServer: CodeQLCliServer) {
+  constructor() {
     super("Query Pack Discovery", `**/{${QLPACK_FILENAMES.join(",")}}`);
   }
 
@@ -71,32 +69,32 @@ export class QueryPackDiscovery extends FilePathDiscovery<QueryPack> {
   }
 
   protected async getDataForPath(path: string): Promise<QueryPack> {
-    const language = await this.determinePackLanguage(path);
+    let language: QueryLanguage | undefined;
+    try {
+      language = await this.determinePackLanguage(path);
+    } catch (e) {
+      language = undefined;
+    }
     return { path, language };
   }
 
   private async determinePackLanguage(
     path: string,
   ): Promise<QueryLanguage | undefined> {
-    let packInfo: QuerySetup | undefined = undefined;
-    try {
-      packInfo = await this.cliServer.resolveLibraryPath(
-        getOnDiskWorkspaceFolders(),
-        path,
-        true,
-      );
-    } catch (err) {
-      void extLogger.log(
-        `Query pack discovery failed to determine language for query pack: ${path}${EOL}Reason: ${getErrorMessage(
-          err,
-        )}`,
-      );
+    const qlPack = load(await readFile(path, "utf8")) as QlPackFile | undefined;
+    const dependencies = qlPack?.dependencies;
+    if (!dependencies || typeof dependencies !== "object") {
+      return;
     }
-    if (packInfo?.dbscheme === undefined) {
+
+    const matchingLanguages = Object.values(QueryLanguage).filter(
+      (language) => `codeql/${language}-all` in dependencies,
+    );
+    if (matchingLanguages.length !== 1) {
       return undefined;
     }
-    const dbscheme = basename(packInfo.dbscheme);
-    return dbSchemeToLanguage[dbscheme];
+
+    return matchingLanguages[0];
   }
 
   protected pathIsRelevant(path: string): boolean {

--- a/extensions/ql-vscode/src/queries-panel/query-pack-discovery.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-pack-discovery.ts
@@ -5,6 +5,7 @@ import { FALLBACK_QLPACK_FILENAME, QLPACK_FILENAMES } from "../common/ql";
 import { FilePathDiscovery } from "../common/vscode/file-path-discovery";
 import { containsPath } from "../common/files";
 import { getQlPackLanguage } from "../common/qlpack-language";
+import { getErrorMessage } from "../common/helpers-pure";
 
 interface QueryPack {
   path: string;
@@ -70,7 +71,12 @@ export class QueryPackDiscovery extends FilePathDiscovery<QueryPack> {
     let language: QueryLanguage | undefined;
     try {
       language = await getQlPackLanguage(path);
-    } catch (e) {
+    } catch (err) {
+      void this.logger.log(
+        `Query pack discovery failed to determine language for query pack: ${path}\n\tReason: ${getErrorMessage(
+          err,
+        )}`,
+      );
       language = undefined;
     }
     return { path, language };

--- a/extensions/ql-vscode/test/unit-tests/common/qlpack-language.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/common/qlpack-language.test.ts
@@ -59,24 +59,22 @@ describe("getQlPackLanguage", () => {
     expect(result).toEqual(undefined);
   });
 
-  it("should find nothing when dependencies is a scalar", async () => {
+  it("should throw when dependencies is a scalar", async () => {
     await writeYAML(qlpackPath, {
       name: "test",
       dependencies: "codeql/java-all",
     });
 
-    const result = await getQlPackLanguage(qlpackPath);
-    expect(result).toEqual(undefined);
+    await expect(getQlPackLanguage(qlpackPath)).rejects.toBeDefined();
   });
 
-  it("should find nothing when dependencies is an array", async () => {
+  it("should throw when dependencies is an array", async () => {
     await writeYAML(qlpackPath, {
       name: "test",
       dependencies: ["codeql/java-all"],
     });
 
-    const result = await getQlPackLanguage(qlpackPath);
-    expect(result).toEqual(undefined);
+    await expect(getQlPackLanguage(qlpackPath)).rejects.toBeDefined();
   });
 
   it("should find nothing when there are no matching dependencies", async () => {

--- a/extensions/ql-vscode/test/unit-tests/common/qlpack-language.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/common/qlpack-language.test.ts
@@ -1,0 +1,125 @@
+import { join } from "path";
+import { dirSync } from "tmp-promise";
+import { DirResult } from "tmp";
+import { outputFile } from "fs-extra";
+import { dump } from "js-yaml";
+import { QueryLanguage } from "../../../src/common/query-language";
+import { getQlPackLanguage } from "../../../src/common/qlpack-language";
+
+describe("getQlPackLanguage", () => {
+  let tmpDir: DirResult;
+  let qlpackPath: string;
+
+  beforeEach(() => {
+    tmpDir = dirSync({
+      prefix: "queries_",
+      keep: false,
+      unsafeCleanup: true,
+    });
+
+    qlpackPath = join(tmpDir.name, "qlpack.yml");
+  });
+
+  afterEach(() => {
+    tmpDir.removeCallback();
+  });
+
+  it.each(Object.values(QueryLanguage))(
+    "should find a single language %s",
+    async (language) => {
+      await writeYAML(qlpackPath, {
+        name: "test",
+        dependencies: {
+          [`codeql/${language}-all`]: "^0.7.0",
+          "my-custom-pack/test": "${workspace}",
+        },
+      });
+
+      const result = await getQlPackLanguage(qlpackPath);
+      expect(result).toEqual(language);
+    },
+  );
+
+  it("should find nothing when there is no dependencies key", async () => {
+    await writeYAML(qlpackPath, {
+      name: "test",
+    });
+
+    const result = await getQlPackLanguage(qlpackPath);
+    expect(result).toEqual(undefined);
+  });
+
+  it("should find nothing when the dependencies are empty", async () => {
+    await writeYAML(qlpackPath, {
+      name: "test",
+      dependencies: {},
+    });
+
+    const result = await getQlPackLanguage(qlpackPath);
+    expect(result).toEqual(undefined);
+  });
+
+  it("should find nothing when dependencies is a scalar", async () => {
+    await writeYAML(qlpackPath, {
+      name: "test",
+      dependencies: "codeql/java-all",
+    });
+
+    const result = await getQlPackLanguage(qlpackPath);
+    expect(result).toEqual(undefined);
+  });
+
+  it("should find nothing when dependencies is an array", async () => {
+    await writeYAML(qlpackPath, {
+      name: "test",
+      dependencies: ["codeql/java-all"],
+    });
+
+    const result = await getQlPackLanguage(qlpackPath);
+    expect(result).toEqual(undefined);
+  });
+
+  it("should find nothing when there are no matching dependencies", async () => {
+    await writeYAML(qlpackPath, {
+      name: "test",
+      dependencies: {
+        "codeql/java-queries": "*",
+        "github/my-test-query-pack": "*",
+      },
+    });
+
+    const result = await getQlPackLanguage(qlpackPath);
+    expect(result).toEqual(undefined);
+  });
+
+  it("should find nothing when there are multiple matching dependencies", async () => {
+    await writeYAML(qlpackPath, {
+      name: "test",
+      dependencies: {
+        "codeql/java-all": "*",
+        "codeql/csharp-all": "*",
+      },
+    });
+
+    const result = await getQlPackLanguage(qlpackPath);
+    expect(result).toEqual(undefined);
+  });
+
+  it("should throw when the file does not exist", async () => {
+    await expect(getQlPackLanguage(qlpackPath)).rejects.toBeDefined();
+  });
+
+  it("should throw when reading a directory", async () => {
+    await expect(getQlPackLanguage(tmpDir.name)).rejects.toBeDefined();
+  });
+
+  it("should throw when the file is invalid YAML", async () => {
+    await outputFile(qlpackPath, `name: test\n  foo: bar`);
+
+    await expect(getQlPackLanguage(tmpDir.name)).rejects.toBeDefined();
+  });
+});
+
+async function writeYAML(path: string, yaml: unknown): Promise<void> {
+  await outputFile(path, dump(yaml), "utf-8");
+}


### PR DESCRIPTION
This removes the use of the CLI `codeql resolve library-path` command to detect the language of a query pack. Instead, it uses the `qlpack.yml` file to determine the language. This is slightly less correct since it only works for `codeql/${language}-all` dependencies, but it is much faster and more reliable. It also doesn't result in the CLI server restarting for invalid query packs (such as in the `github/codeql` repository or in any workspaces containing it). Query pack discovery on `github/codeql` now takes less than 3 seconds rather than more than 11 seconds, and it also doesn't slow down other extension operations using the CLI server anymore.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
