### PR TITLE
Remove ambiguity from 'View logs' messages

### DIFF
--- a/extensions/ql-vscode/src/common/logging/vscode/output-channel-logger.ts
+++ b/extensions/ql-vscode/src/common/logging/vscode/output-channel-logger.ts
@@ -63,7 +63,7 @@ export class OutputChannelLogger
     message: string,
     show: (message: string, ...items: string[]) => Thenable<string | undefined>,
   ): Promise<void> {
-    const label = "Show Log";
+    const label = "View extension logs";
     const result = await show(message, label);
 
     if (result === label) {

--- a/extensions/ql-vscode/src/stories/common/Alert.stories.tsx
+++ b/extensions/ql-vscode/src/stories/common/Alert.stories.tsx
@@ -72,8 +72,8 @@ ErrorExample.args = {
     <>
       Request to
       https://api.github.com/repos/octodemo/Hello-World/code-scanning/codeql/queries
-      failed. <VSCodeLink>Check logs</VSCodeLink> and try running this query
-      again.
+      failed. <VSCodeLink>View actions logs</VSCodeLink> and try running this
+      query again.
     </>
   ),
 };
@@ -86,7 +86,7 @@ ErrorWithButtons.args = {
     "Request to https://api.github.com/repos/octodemo/Hello-World/code-scanning/codeql/queries failed. Try running this query again.",
   actions: (
     <>
-      <VSCodeButton appearance="secondary">View logs</VSCodeButton>
+      <VSCodeButton appearance="secondary">View actions logs</VSCodeButton>
       <VSCodeButton>Retry</VSCodeButton>
     </>
   ),

--- a/extensions/ql-vscode/src/view/variant-analysis/FailureReasonAlert.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/FailureReasonAlert.tsx
@@ -34,8 +34,8 @@ const getMessage = (failureReason: VariantAnalysisFailureReason): ReactNode => {
       return (
         <>
           The GitHub Actions workflow run has failed.{" "}
-          <VSCodeLink onClick={openLogs}>Check logs</VSCodeLink> and try running
-          this query again.
+          <VSCodeLink onClick={openLogs}>View actions logs</VSCodeLink> and try
+          running this query again.
         </>
       );
     case VariantAnalysisFailureReason.InternalError:

--- a/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisStatusStats.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/VariantAnalysisStatusStats.tsx
@@ -37,7 +37,7 @@ export const VariantAnalysisStatusStats = ({
         <span>{completedAt !== undefined ? formatDate(completedAt) : "-"}</span>
       )}
       {onViewLogsClick && (
-        <VSCodeLink onClick={onViewLogsClick}>View logs</VSCodeLink>
+        <VSCodeLink onClick={onViewLogsClick}>View actions logs</VSCodeLink>
       )}
     </Container>
   );

--- a/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisStats.spec.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisStats.spec.tsx
@@ -147,7 +147,7 @@ describe(VariantAnalysisStats.name, () => {
       completedAt: new Date(),
     });
 
-    await userEvent.click(screen.getByText("View logs"));
+    await userEvent.click(screen.getByText("View actions logs"));
     expect(onViewLogsClick).toHaveBeenCalledTimes(1);
   });
 

--- a/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisStatusStats.spec.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/__tests__/VariantAnalysisStatusStats.spec.tsx
@@ -54,7 +54,7 @@ describe(VariantAnalysisStatusStats.name, () => {
       onViewLogsClick: () => undefined,
     });
 
-    expect(screen.getByText("View logs")).toBeInTheDocument();
+    expect(screen.getByText("View actions logs")).toBeInTheDocument();
   });
 
   it("renders when there isn't a viewLogs links", () => {
@@ -63,6 +63,6 @@ describe(VariantAnalysisStatusStats.name, () => {
       onViewLogsClick: undefined,
     });
 
-    expect(screen.queryByText("View logs")).not.toBeInTheDocument();
+    expect(screen.queryByText("View actions logs")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

This PR removes ambiguity of our 'View logs' messages.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
