### PR TITLE
Remove ownerName and repositoryName from DistributionConfig

### DIFF
--- a/extensions/ql-vscode/src/codeql-cli/distribution.ts
+++ b/extensions/ql-vscode/src/codeql-cli/distribution.ts
@@ -512,9 +512,7 @@ class ExtensionSpecificDistributionManager {
   }
 
   private get distributionOwnerName(): string {
-    if (this.config.ownerName) {
-      return this.config.ownerName;
-    } else if (this.config.channel === "nightly") {
+    if (this.config.channel === "nightly") {
       return NIGHTLY_DISTRIBUTION_OWNER_NAME;
     } else {
       return DEFAULT_DISTRIBUTION_OWNER_NAME;
@@ -522,9 +520,7 @@ class ExtensionSpecificDistributionManager {
   }
 
   private get distributionRepositoryName(): string {
-    if (this.config.repositoryName) {
-      return this.config.repositoryName;
-    } else if (this.config.channel === "nightly") {
+    if (this.config.channel === "nightly") {
       return NIGHTLY_DISTRIBUTION_REPOSITORY_NAME;
     } else {
       return DEFAULT_DISTRIBUTION_REPOSITORY_NAME;

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -119,8 +119,6 @@ export interface DistributionConfig {
   updateCustomCodeQlPath: (newPath: string | undefined) => Promise<void>;
   includePrerelease: boolean;
   personalAccessToken?: string;
-  ownerName?: string;
-  repositoryName?: string;
   channel: CLIChannel;
   onDidChangeConfiguration?: Event<void>;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

As far as I can tell, these fields do not work. They aren't linked up to read values from the config, and setting `"codeQL.cli.repositoryName": "foo"` in your config does nothing.

This reason for this is because the only way these values are accessed is through the `DistributionConfigListener` class, which implements the `DistributionConfig` interface. That class does not define these fields and therefore they get their default value of `undefined`. The reason we didn't notice this earlier is because the field is allowed to be `undefined`. If you change the type to `string | null` then it produces an error.

Looking back in the history, I believe the intention was to fully remove these in https://github.com/github/vscode-codeql/pull/174 (see the comments on the linked internal issues) but for whatever reason that PR didn't remove all references and instead only marked them as maybe undefined. I'm a little confused by that, but I think that removing these final references does not change behaviour and is in the spirit of that earlier change.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
