### PR TITLE
Use semver range for `@types/node`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,12 @@ updates:
       day: "thursday" # Thursday is arbitrary
     labels:
       - "Update dependencies"
+    ignore:
+      # @types/node is related to the version of VS Code we're supporting and should
+      # not be updated to a newer version of Node automatically. However, patch versions
+      # are unrelated to the Node version, so we allow those.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/extensions/ql-vscode/package-lock.json
+++ b/extensions/ql-vscode/package-lock.json
@@ -79,7 +79,7 @@
         "@types/jest": "^29.0.2",
         "@types/js-yaml": "^4.0.6",
         "@types/nanoid": "^3.0.0",
-        "@types/node": "18.15.0",
+        "@types/node": "18.15.*",
         "@types/node-fetch": "^2.5.2",
         "@types/react": "^18.0.28",
         "@types/react-dom": "^18.0.11",
@@ -9425,9 +9425,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.15.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.0.tgz",
-      "integrity": "sha512-z6nr0TTEOBGkzLGmbypWOGnpSpSIBorEhC4L+4HeQ2iezKCi4f77kyslRwvHeNitymGQ+oFyIWGP96l/DPSV9w==",
+      "version": "18.15.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
+      "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==",
       "dev": true
     },
     "node_modules/@types/node-fetch": {

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1976,7 +1976,7 @@
     "@types/jest": "^29.0.2",
     "@types/js-yaml": "^4.0.6",
     "@types/nanoid": "^3.0.0",
-    "@types/node": "18.15.0",
+    "@types/node": "18.15.*",
     "@types/node-fetch": "^2.5.2",
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",

--- a/extensions/ql-vscode/scripts/update-node-version.ts
+++ b/extensions/ql-vscode/scripts/update-node-version.ts
@@ -49,9 +49,20 @@ async function updateNodeVersion() {
     "utf8",
   );
 
+  // The @types/node version needs to match the first two parts of the Node
+  // version, e.g. if the Node version is 18.17.3, the @types/node version
+  // should be 18.17.*. This corresponds with the documentation at
+  // https://github.com/definitelytyped/definitelytyped#how-do-definitely-typed-package-versions-relate-to-versions-of-the-corresponding-library
+  // "The patch version of the type declaration package is unrelated to the library patch version. This allows
+  // Definitely Typed to safely update type declarations for the same major/minor version of a library."
+  // 18.17.* is equivalent to >=18.17.0 <18.18.0
+  const typesNodeVersion = versionInformation.nodeVersion
+    .split(".")
+    .slice(0, 2)
+    .join(".");
+
   packageJson.engines.node = `^${versionInformation.nodeVersion}`;
-  packageJson.devDependencies["@types/node"] =
-    `${versionInformation.nodeVersion}`;
+  packageJson.devDependencies["@types/node"] = `${typesNodeVersion}.*`;
 
   await outputFile(
     join(extensionDirectory, "package.json"),
@@ -61,6 +72,11 @@ async function updateNodeVersion() {
   console.log("Updated package.json, now running npm install");
 
   execSync("npm install", { cwd: extensionDirectory, stdio: "inherit" });
+  // Always use the latest patch version of @types/node
+  execSync("npm upgrade @types/node", {
+    cwd: extensionDirectory,
+    stdio: "inherit",
+  });
 
   console.log("Node version updated successfully");
 }


### PR DESCRIPTION
According to the DefinitelyTyped documentation, the patch version of the type declaration package is unrelated to the library patch version. Therefore, we should use an [X-range](https://github.com/npm/node-semver?tab=readme-ov-file#x-ranges-12x-1x-12-) for `@types/node` to allow newer patch versions to be installed automatically.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
