### PR TITLE
Rename update Chromium version script to generate Chromium version

### DIFF
--- a/docs/vscode-version.md
+++ b/docs/vscode-version.md
@@ -36,7 +36,7 @@ This version should be the same as the version of Chromium that is bundled with 
 the version, run:
 
 ```bash
-npx ts-node scripts/update-chromium-version.ts
+npx ts-node scripts/generate-chromium-version.ts
 ```
 
 #### Troubleshooting

--- a/docs/vscode-version.md
+++ b/docs/vscode-version.md
@@ -27,16 +27,11 @@ Also consider what percentage of our users are using each VS Code version. This 
 To provide a good experience to users, it is recommented to update the `MIN_VERSION` in `extension.ts` first and release, and then update the `vscode` version in `package.json` and release again.
 By staggering this update across two releases it gives users on older VS Code versions a chance to upgrade before it silently refuses to upgrade them.
 
-When updating the minimum version in `package.json`, you should also follow the additional steps listed below.
-
-### Updating the Chromium target version
-
-For the webview code, we use [esbuild](https://esbuild.github.io/) to bundle the code. This requires a target version of Chromium to be specified.
-This version should be the same as the version of Chromium that is bundled with the new minimum VS Code version. To update
-the version, run:
+After updating the minimum version in `package.json`, make sure to also run the following command to update any generated
+files dependent on this version:
 
 ```bash
-npx ts-node scripts/generate-chromium-version.ts
+npm run generate
 ```
 
 #### Troubleshooting

--- a/docs/vscode-version.md
+++ b/docs/vscode-version.md
@@ -34,15 +34,6 @@ files dependent on this version:
 npm run generate
 ```
 
-#### Troubleshooting
-
-In case there's an error when specifying a version of Chromium, you may need to update the version of `caniuse-lite`
-in `package.json` to a newer version. You should be able to do so by running:
-
-```shell
-npx update-browserslist-db@latest
-```
-
 ## VS Code version used in tests
 
 Our integration tests are currently pinned to use an older version of VS Code due to <https://github.com/github/vscode-codeql/issues/2402>.

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1902,6 +1902,7 @@
     "lint:scenarios": "ts-node scripts/lint-scenarios.ts",
     "generate": "npm-run-all -p generate:*",
     "generate:schemas": "ts-node scripts/generate-schemas.ts",
+    "generate:chromium-version": "ts-node scripts/generate-chromium-version.ts",
     "check-types": "find . -type f -name \"tsconfig.json\" -not -path \"./node_modules/*\" | sed -r 's|/[^/]+$||' | sort | uniq | xargs -I {} sh -c \"echo Checking types in {} && cd {} && npx tsc --noEmit\"",
     "postinstall": "patch-package",
     "prepare": "cd ../.. && husky install"

--- a/extensions/ql-vscode/scripts/generate-chromium-version.ts
+++ b/extensions/ql-vscode/scripts/generate-chromium-version.ts
@@ -5,7 +5,7 @@ import { getVersionInformation } from "./util/vscode-versions";
 
 const extensionDirectory = resolve(__dirname, "..");
 
-async function updateChromiumVersion() {
+async function generateChromiumVersion() {
   const packageJson = await readJSON(
     resolve(extensionDirectory, "package.json"),
   );
@@ -36,7 +36,7 @@ async function updateChromiumVersion() {
   );
 }
 
-updateChromiumVersion().catch((e: unknown) => {
+generateChromiumVersion().catch((e: unknown) => {
   console.error(e);
   process.exit(2);
 });


### PR DESCRIPTION
This also adds the script as a script in the `package.json` with the naming such that `npm generate` will re-generate the Chromium version file. This will ensure that the CI checks fail when the Chromium version doesn't match the minimum supported VS Code version.

I've also updated the documentation for updating the VS Code version to simply run `npm run generate` which will run this script as well.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
