### PR TITLE
Update outdated VS Code version docs

### DIFF
--- a/docs/node-version.md
+++ b/docs/node-version.md
@@ -23,4 +23,4 @@ npx ts-node scripts/update-node-version.ts
 
 Unit tests will use whatever version of Node.js is installed locally. In CI this will be the version specified in the workflow.
 
-Integration tests download a copy of VS Code and then will use whatever version of Node.js is provided by VS Code. Our integration tests are currently pinned to an older version of VS Code. See [VS Code version used in tests](./vscode-version.md#vs-code-version-used-in-tests) for more information.
+Integration tests download a copy of VS Code and then will use whatever version of Node.js is provided by VS Code. See [VS Code version used in tests](./vscode-version.md#vs-code-version-used-in-tests) for more information.

--- a/docs/vscode-version.md
+++ b/docs/vscode-version.md
@@ -50,6 +50,6 @@ npx update-browserslist-db@latest
 
 ## VS Code version used in tests
 
-Our integration tests are currently pinned to use an older version of VS Code due to <https://github.com/github/vscode-codeql/issues/2402>.
-This version is specified in [`jest-runner-vscode.config.base.js`](https://github.com/github/vscode-codeql/blob/d93f2b67c84e79737b0ce4bb74e31558b5f5166e/extensions/ql-vscode/test/vscode-tests/jest-runner-vscode.config.base.js#L17).
-Until this is resolved this will limit us updating our minimum supported version of VS Code.
+The integration tests use the latest stable version of VS Code. This is specified in
+the [`test/vscode-tests/jest-runner-vscode.config.base.js`](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/test/vscode-tests/jest-runner-vscode.config.base.js#L15)
+file. This shouldn't need to be updated unless there is a breaking change in VS Code that prevents the tests from running.


### PR DESCRIPTION
There were still references to a pinned version of VS Code used in the integration tests, but this was resolved in https://github.com/github/vscode-codeql/pull/2877.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
