### PR TITLE
CodeQL model editor: user should be able to stop modeling before the main editor view is open

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Avoid showing a popup when hovering over source elements in database source files. [#3125](https://github.com/github/vscode-codeql/pull/3125)
 - Add comparison of alerts when comparing query results. This allows viewing path explanations for differences in alerts. [#3113](https://github.com/github/vscode-codeql/pull/3113)
 - Fix a bug where the CodeQL CLI and variant analysis results were corrupted after extraction in VS Code Insiders. [#3151](https://github.com/github/vscode-codeql/pull/3151) & [#3152](https://github.com/github/vscode-codeql/pull/3152)
+- Add option to cancel opening the model editor. [#3189](https://github.com/github/vscode-codeql/pull/3189)
 
 ## 1.11.0 - 13 December 2023
 

--- a/extensions/ql-vscode/src/model-editor/model-editor-queries.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-queries.ts
@@ -7,7 +7,10 @@ import {
 import { CancellationToken } from "vscode";
 import { CodeQLCliServer } from "../codeql-cli/cli";
 import { DatabaseItem } from "../databases/local-databases";
-import { ProgressCallback } from "../common/vscode/progress";
+import {
+  ProgressCallback,
+  UserCancellationException,
+} from "../common/vscode/progress";
 import { redactableError } from "../common/errors";
 import { telemetryListener } from "../common/vscode/telemetry";
 import { join } from "path";
@@ -89,6 +92,13 @@ export async function runModelEditorQueries(
   // For a reference of what this should do in the future, see the previous implementation in
   // https://github.com/github/vscode-codeql/blob/089d3566ef0bc67d9b7cc66e8fd6740b31c1c0b0/extensions/ql-vscode/src/data-extensions-editor/external-api-usage-query.ts#L33-L72
 
+  if (token.isCancellationRequested) {
+    throw new UserCancellationException(
+      "Run model editor queries cancelled.",
+      true,
+    );
+  }
+
   progress({
     message: "Resolving QL packs",
     step: 1,
@@ -98,6 +108,13 @@ export async function runModelEditorQueries(
   const extensionPacks = Object.keys(
     await cliServer.resolveQlpacks(additionalPacks, true),
   );
+
+  if (token.isCancellationRequested) {
+    throw new UserCancellationException(
+      "Run model editor queries cancelled.",
+      true,
+    );
+  }
 
   progress({
     message: "Resolving query",
@@ -143,6 +160,13 @@ export async function runModelEditorQueries(
     return;
   }
 
+  if (token.isCancellationRequested) {
+    throw new UserCancellationException(
+      "Run model editor queries cancelled.",
+      true,
+    );
+  }
+
   // Read the results and covert to internal representation
   progress({
     message: "Decoding results",
@@ -157,6 +181,13 @@ export async function runModelEditorQueries(
   });
   if (!bqrsChunk) {
     return;
+  }
+
+  if (token.isCancellationRequested) {
+    throw new UserCancellationException(
+      "Run model editor queries cancelled.",
+      true,
+    );
   }
 
   progress({

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -466,6 +466,13 @@ export class ModelEditorView extends AbstractWebview<
 
       this.modelingStore.setMethods(this.databaseItem, queryResult);
     } catch (err) {
+      if (
+        getErrorMessage(err).match(/The request \(.*\) has been cancelled/i)
+      ) {
+        this.panel?.dispose();
+        return;
+      }
+
       void showAndLogExceptionWithTelemetry(
         this.app.logger,
         this.app.telemetry,

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -52,6 +52,8 @@ import { ModelingStore } from "./modeling-store";
 import { ModelingEvents } from "./modeling-events";
 import { getModelsAsDataLanguage, ModelsAsDataLanguage } from "./languages";
 import { runGenerateQueries } from "./generate";
+import { ResponseError } from "vscode-jsonrpc";
+import { LSPErrorCodes } from "vscode-languageclient";
 
 export class ModelEditorView extends AbstractWebview<
   ToModelEditorMessage,
@@ -467,7 +469,8 @@ export class ModelEditorView extends AbstractWebview<
       this.modelingStore.setMethods(this.databaseItem, queryResult);
     } catch (err) {
       if (
-        getErrorMessage(err).match(/The request \(.*\) has been cancelled/i)
+        err instanceof ResponseError &&
+        err.code === LSPErrorCodes.RequestCancelled
       ) {
         this.panel?.dispose();
         return;

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/extension-pack-picker.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/extension-pack-picker.test.ts
@@ -1,4 +1,9 @@
-import { Uri, workspace, WorkspaceFolder } from "vscode";
+import {
+  CancellationTokenSource,
+  Uri,
+  workspace,
+  WorkspaceFolder,
+} from "vscode";
 import { dump as dumpYaml, load as loadYaml } from "js-yaml";
 import { outputFile, readFile } from "fs-extra";
 import { join } from "path";
@@ -24,6 +29,7 @@ describe("pickExtensionPack", () => {
   };
 
   const progress = jest.fn();
+  const token = new CancellationTokenSource().token;
   let workspaceFoldersSpy: jest.SpyInstance;
   let additionalPacks: string[];
   let workspaceFolder: WorkspaceFolder;
@@ -79,6 +85,7 @@ describe("pickExtensionPack", () => {
         modelConfig,
         logger,
         progress,
+        token,
         maxStep,
       ),
     ).toEqual(autoExtensionPack);
@@ -136,6 +143,7 @@ describe("pickExtensionPack", () => {
         modelConfig,
         logger,
         progress,
+        token,
         maxStep,
       ),
     ).toEqual({
@@ -190,6 +198,7 @@ describe("pickExtensionPack", () => {
         modelConfig,
         logger,
         progress,
+        token,
         maxStep,
       ),
     ).toEqual({
@@ -234,6 +243,7 @@ describe("pickExtensionPack", () => {
         modelConfig,
         logger,
         progress,
+        token,
         maxStep,
       ),
     ).toEqual(undefined);
@@ -260,6 +270,7 @@ describe("pickExtensionPack", () => {
         modelConfig,
         logger,
         progress,
+        token,
         maxStep,
       ),
     ).toEqual(undefined);
@@ -288,6 +299,7 @@ describe("pickExtensionPack", () => {
         modelConfig,
         logger,
         progress,
+        token,
         maxStep,
       ),
     ).toEqual(undefined);
@@ -326,6 +338,7 @@ describe("pickExtensionPack", () => {
         modelConfig,
         logger,
         progress,
+        token,
         maxStep,
       ),
     ).toEqual(undefined);
@@ -364,6 +377,7 @@ describe("pickExtensionPack", () => {
         modelConfig,
         logger,
         progress,
+        token,
         maxStep,
       ),
     ).toEqual(undefined);
@@ -405,6 +419,7 @@ describe("pickExtensionPack", () => {
         modelConfig,
         logger,
         progress,
+        token,
         maxStep,
       ),
     ).toEqual(undefined);
@@ -463,6 +478,7 @@ describe("pickExtensionPack", () => {
         modelConfig,
         logger,
         progress,
+        token,
         maxStep,
       ),
     ).toEqual(extensionPack);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Opening the model editor takes a while. This PR gives the user the option to cancel the progress and not open the editor.

When cancelling the open process the user effectively cancels a query run. This results in an error message and a telemetry event.
![Screenshot 2024-01-04 at 11 53 31](https://github.com/github/vscode-codeql/assets/29482385/21df20ad-3e37-4029-bb12-03cb417f66d7)

From my investigation I deduct that this behaviour stems from the query server in https://github.com/github/vscode-codeql/blob/nora/make-model-editor-open-cancellable/extensions/ql-vscode/src/query-server/run-queries.ts#L69

I would be happy for feedback on how to resolve this issue.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
