### PR TITLE
Remove unnecessary namespace imports

### DIFF
--- a/extensions/ql-vscode/.eslintrc.js
+++ b/extensions/ql-vscode/.eslintrc.js
@@ -66,7 +66,6 @@ const baseConfig = {
     "github/no-then": "off",
     "react/jsx-key": ["error", { checkFragmentShorthand: true }],
     "import/no-cycle": "off",
-    "import/no-namespace": "off",
     // Never allow extensions in import paths, except for JSON files where they are required.
     "import/extensions": ["error", "never", { json: "always" }],
   },
@@ -147,6 +146,8 @@ module.exports = {
       },
       rules: {
         ...baseConfig.rules,
+        // We want to allow mocking of functions in modules, so we need to allow namespace imports.
+        "import/no-namespace": "off",
         "@typescript-eslint/ban-types": [
           "error",
           {

--- a/extensions/ql-vscode/.eslintrc.js
+++ b/extensions/ql-vscode/.eslintrc.js
@@ -182,5 +182,17 @@ module.exports = {
         "@typescript-eslint/no-var-requires": "off",
       },
     },
+    {
+      files: [".storybook/**/*.tsx"],
+      parserOptions: {
+        project: resolve(__dirname, ".storybook/tsconfig.json"),
+      },
+      rules: {
+        ...baseConfig.rules,
+        // Storybook doesn't use the automatic JSX runtime in the addon yet, so we need to allow
+        // `React` to be imported.
+        "import/no-namespace": ["error", { ignore: ["react"] }],
+      },
+    },
   ],
 };

--- a/extensions/ql-vscode/.storybook/tsconfig.json
+++ b/extensions/ql-vscode/.storybook/tsconfig.json
@@ -5,7 +5,7 @@
     "target": "es6",
     "outDir": "out",
     "lib": ["ES2021", "dom"],
-    "jsx": "react-jsx",
+    "jsx": "react",
     "sourceMap": true,
     "rootDir": "..",
     "strict": true,

--- a/extensions/ql-vscode/.storybook/tsconfig.json
+++ b/extensions/ql-vscode/.storybook/tsconfig.json
@@ -5,7 +5,7 @@
     "target": "es6",
     "outDir": "out",
     "lib": ["ES2021", "dom"],
-    "jsx": "react",
+    "jsx": "react-jsx",
     "sourceMap": true,
     "rootDir": "..",
     "strict": true,

--- a/extensions/ql-vscode/.storybook/vscode-theme-addon/ThemeSelector.tsx
+++ b/extensions/ql-vscode/.storybook/vscode-theme-addon/ThemeSelector.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { FunctionComponent, useCallback } from "react";
 
 import { useGlobals } from "@storybook/manager-api";

--- a/extensions/ql-vscode/.storybook/vscode-theme-addon/ThemeSelector.tsx
+++ b/extensions/ql-vscode/.storybook/vscode-theme-addon/ThemeSelector.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import { FunctionComponent, useCallback } from "react";
 
 import { useGlobals } from "@storybook/manager-api";

--- a/extensions/ql-vscode/.storybook/vscode-theme-addon/manager.tsx
+++ b/extensions/ql-vscode/.storybook/vscode-theme-addon/manager.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { addons, types } from "@storybook/manager-api";
 import { ThemeSelector } from "./ThemeSelector";
 

--- a/extensions/ql-vscode/.storybook/vscode-theme-addon/manager.tsx
+++ b/extensions/ql-vscode/.storybook/vscode-theme-addon/manager.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import { addons, types } from "@storybook/manager-api";
 import { ThemeSelector } from "./ThemeSelector";
 

--- a/extensions/ql-vscode/gulpfile.ts/deploy.ts
+++ b/extensions/ql-vscode/gulpfile.ts/deploy.ts
@@ -9,7 +9,7 @@ import {
 } from "fs-extra";
 import { resolve, join } from "path";
 import { isDevBuild } from "./dev";
-import type * as packageJsonType from "../package.json";
+import type packageJsonType from "../package.json";
 
 export interface DeployedPackage {
   distPath: string;

--- a/extensions/ql-vscode/gulpfile.ts/textmate.ts
+++ b/extensions/ql-vscode/gulpfile.ts/textmate.ts
@@ -2,7 +2,7 @@ import { dest, src } from "gulp";
 import { load } from "js-yaml";
 import { obj } from "through2";
 import PluginError from "plugin-error";
-import * as Vinyl from "vinyl";
+import Vinyl from "vinyl";
 
 /**
  * Replaces all rule references with the match pattern of the referenced rule.

--- a/extensions/ql-vscode/gulpfile.ts/view.ts
+++ b/extensions/ql-vscode/gulpfile.ts/view.ts
@@ -3,7 +3,7 @@ import esbuild from "gulp-esbuild";
 import { createProject } from "gulp-typescript";
 import { goodReporter } from "./typescript";
 
-import * as chromiumVersion from "./chromium-version.json";
+import chromiumVersion from "./chromium-version.json";
 
 const tsProject = createProject("src/view/tsconfig.json");
 

--- a/extensions/ql-vscode/src/codeql-cli/cli-version.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli-version.ts
@@ -1,4 +1,4 @@
-import * as semver from "semver";
+import { parse, SemVer } from "semver";
 import { runCodeQlCliCommand } from "./cli";
 import { Logger } from "../common/logging";
 import { getErrorMessage } from "../common/helpers-pure";
@@ -9,7 +9,7 @@ import { getErrorMessage } from "../common/helpers-pure";
 export async function getCodeQlCliVersion(
   codeQlPath: string,
   logger: Logger,
-): Promise<semver.SemVer | undefined> {
+): Promise<SemVer | undefined> {
   try {
     const output: string = await runCodeQlCliCommand(
       codeQlPath,
@@ -18,7 +18,7 @@ export async function getCodeQlCliVersion(
       "Checking CodeQL version",
       logger,
     );
-    return semver.parse(output.trim()) || undefined;
+    return parse(output.trim()) || undefined;
   } catch (e) {
     // Failed to run the version command. This might happen if the cli version is _really_ old, or it is corrupted.
     // Either way, we can't determine compatibility.

--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -56,16 +56,6 @@ const CSV_FORMAT = "csv";
 const LOGGING_FLAGS = ["-v", "--log-to-stderr"];
 
 /**
- * The expected output of `codeql resolve library-path`.
- */
-export interface QuerySetup {
-  libraryPath: string[];
-  dbscheme: string;
-  relativeName?: string;
-  compilationCache?: string;
-}
-
-/**
  * The expected output of `codeql resolve queries --format bylanguage`.
  */
 export interface QueryInfoByLanguage {
@@ -92,7 +82,7 @@ export interface DbInfo {
 /**
  * The expected output of `codeql resolve upgrades`.
  */
-export interface UpgradesInfo {
+interface UpgradesInfo {
   scripts: string[];
   finalDbscheme: string;
   matchesTarget?: boolean;
@@ -106,33 +96,33 @@ export type QlpacksInfo = { [name: string]: string[] };
 /**
  * The expected output of `codeql resolve languages`.
  */
-export type LanguagesInfo = { [name: string]: string[] };
+type LanguagesInfo = { [name: string]: string[] };
 
 /** Information about an ML model, as resolved by `codeql resolve ml-models`. */
-export type MlModelInfo = {
+type MlModelInfo = {
   checksum: string;
   path: string;
 };
 
 /** The expected output of `codeql resolve ml-models`. */
-export type MlModelsInfo = { models: MlModelInfo[] };
+type MlModelsInfo = { models: MlModelInfo[] };
 
 /** Information about a data extension predicate, as resolved by `codeql resolve extensions`. */
-export type DataExtensionResult = {
+type DataExtensionResult = {
   predicate: string;
   file: string;
   index: number;
 };
 
 /** The expected output of `codeql resolve extensions`. */
-export type ResolveExtensionsResult = {
+type ResolveExtensionsResult = {
   models: MlModelInfo[];
   data: {
     [path: string]: DataExtensionResult[];
   };
 };
 
-export type GenerateExtensiblePredicateMetadataResult = {
+type GenerateExtensiblePredicateMetadataResult = {
   // There are other properties in this object, but they are
   // not relevant for its use in the extension, so we omit them.
   extensible_predicates: Array<{
@@ -144,7 +134,7 @@ export type GenerateExtensiblePredicateMetadataResult = {
 /**
  * The expected output of `codeql resolve qlref`.
  */
-export type QlrefInfo = { resolvedPath: string };
+type QlrefInfo = { resolvedPath: string };
 
 // `codeql bqrs interpret` requires both of these to be present or
 // both absent.
@@ -156,17 +146,17 @@ export interface SourceInfo {
 /**
  * The expected output of `codeql resolve queries`.
  */
-export type ResolvedQueries = string[];
+type ResolvedQueries = string[];
 
 /**
  * The expected output of `codeql resolve tests`.
  */
-export type ResolvedTests = string[];
+type ResolvedTests = string[];
 
 /**
  * A compilation message for a test message (either an error or a warning)
  */
-export interface CompilationMessage {
+interface CompilationMessage {
   /**
    * The text of the message
    */
@@ -209,7 +199,7 @@ interface BqrsDecodeOptions {
   entities?: string[];
 }
 
-export type OnLineCallback = (
+type OnLineCallback = (
   line: string,
 ) => Promise<string | undefined> | string | undefined;
 
@@ -1714,7 +1704,7 @@ export function shouldDebugQueryServer() {
   return isEnvTrue("QUERY_SERVER_JAVA_DEBUG");
 }
 
-export function shouldDebugCliServer() {
+function shouldDebugCliServer() {
   return isEnvTrue("CLI_SERVER_JAVA_DEBUG");
 }
 

--- a/extensions/ql-vscode/src/codeql-cli/distribution.ts
+++ b/extensions/ql-vscode/src/codeql-cli/distribution.ts
@@ -1,8 +1,8 @@
-import { pathExists, mkdtemp, createWriteStream, remove } from "fs-extra";
+import { createWriteStream, mkdtemp, pathExists, remove } from "fs-extra";
 import { tmpdir } from "os";
 import { delimiter, dirname, join } from "path";
-import * as semver from "semver";
-import { ExtensionContext, Event } from "vscode";
+import { Range, satisfies, SemVer } from "semver";
+import { Event, ExtensionContext } from "vscode";
 import { DistributionConfig } from "../config";
 import { extLogger } from "../common/logging/vscode";
 import { getCodeQlCliVersion } from "./cli-version";
@@ -50,8 +50,7 @@ const NIGHTLY_DISTRIBUTION_REPOSITORY_NWO = "dsp-testing/codeql-cli-nightlies";
  *
  * This applies to both extension-managed and CLI distributions.
  */
-export const DEFAULT_DISTRIBUTION_VERSION_RANGE: semver.Range =
-  new semver.Range("2.x");
+export const DEFAULT_DISTRIBUTION_VERSION_RANGE: Range = new Range("2.x");
 
 export interface DistributionProvider {
   getCodeQlPathWithoutVersionCheck(): Promise<string | undefined>;
@@ -62,7 +61,7 @@ export interface DistributionProvider {
 export class DistributionManager implements DistributionProvider {
   constructor(
     public readonly config: DistributionConfig,
-    private readonly versionRange: semver.Range,
+    private readonly versionRange: Range,
     extensionContext: ExtensionContext,
   ) {
     this._onDidChangeDistribution = config.onDidChangeConfiguration;
@@ -121,7 +120,7 @@ export class DistributionManager implements DistributionProvider {
       distribution.kind !== DistributionKind.ExtensionManaged ||
       this.config.includePrerelease;
 
-    if (!semver.satisfies(version, this.versionRange, { includePrerelease })) {
+    if (!satisfies(version, this.versionRange, { includePrerelease })) {
       return {
         distribution,
         kind: FindDistributionResultKind.IncompatibleDistribution,
@@ -278,7 +277,7 @@ export class DistributionManager implements DistributionProvider {
 class ExtensionSpecificDistributionManager {
   constructor(
     private readonly config: DistributionConfig,
-    private readonly versionRange: semver.Range,
+    private readonly versionRange: Range,
     private readonly extensionContext: ExtensionContext,
   ) {
     /**/
@@ -601,7 +600,7 @@ interface DistributionResult {
 
 interface CompatibleDistributionResult extends DistributionResult {
   kind: FindDistributionResultKind.CompatibleDistribution;
-  version: semver.SemVer;
+  version: SemVer;
 }
 
 interface UnknownCompatibilityDistributionResult extends DistributionResult {
@@ -610,7 +609,7 @@ interface UnknownCompatibilityDistributionResult extends DistributionResult {
 
 interface IncompatibleDistributionResult extends DistributionResult {
   kind: FindDistributionResultKind.IncompatibleDistribution;
-  version: semver.SemVer;
+  version: SemVer;
 }
 
 interface NoDistributionResult {

--- a/extensions/ql-vscode/src/common/authentication.ts
+++ b/extensions/ql-vscode/src/common/authentication.ts
@@ -1,4 +1,4 @@
-import * as Octokit from "@octokit/rest";
+import { Octokit } from "@octokit/rest";
 
 /**
  * An interface providing methods for obtaining access tokens
@@ -12,7 +12,7 @@ export interface Credentials {
    *
    * @returns An instance of Octokit.
    */
-  getOctokit(): Promise<Octokit.Octokit>;
+  getOctokit(): Promise<Octokit>;
 
   /**
    * Returns an OAuth access token.

--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -1,4 +1,4 @@
-import * as sarif from "sarif";
+import { Log, Result } from "sarif";
 import {
   VariantAnalysis,
   VariantAnalysisScannedRepositoryResult,
@@ -76,7 +76,7 @@ export type SarifInterpretationData = {
    * they appear in the sarif file.
    */
   sortState?: InterpretedResultsSortState;
-} & sarif.Log;
+} & Log;
 
 export type GraphInterpretationData = {
   t: "GraphInterpretationData";
@@ -393,8 +393,8 @@ export type RawQueryCompareResult = {
 export type InterpretedQueryCompareResult = {
   kind: "interpreted";
   sourceLocationPrefix: string;
-  from: sarif.Result[];
-  to: sarif.Result[];
+  from: Result[];
+  to: Result[];
 };
 
 /**

--- a/extensions/ql-vscode/src/common/octokit.ts
+++ b/extensions/ql-vscode/src/common/octokit.ts
@@ -1,8 +1,8 @@
-import * as Octokit from "@octokit/rest";
+import { Octokit } from "@octokit/rest";
 import { retry } from "@octokit/plugin-retry";
 import fetch from "node-fetch";
 
-export const AppOctokit = Octokit.Octokit.defaults({
+export const AppOctokit = Octokit.defaults({
   request: {
     fetch,
   },

--- a/extensions/ql-vscode/src/common/sarif-parser.ts
+++ b/extensions/ql-vscode/src/common/sarif-parser.ts
@@ -1,14 +1,14 @@
-import * as Sarif from "sarif";
+import { Log, Tool } from "sarif";
 import { createReadStream } from "fs-extra";
 import { connectTo } from "stream-json/Assembler";
 import { getErrorMessage } from "./helpers-pure";
 import { withParser } from "stream-json/filters/Pick";
 
-const DUMMY_TOOL: Sarif.Tool = { driver: { name: "" } };
+const DUMMY_TOOL: Tool = { driver: { name: "" } };
 
 export async function sarifParser(
   interpretedResultsPath: string,
-): Promise<Sarif.Log> {
+): Promise<Log> {
   try {
     // Parse the SARIF file into token streams, filtering out only the results array.
     const pipeline = createReadStream(interpretedResultsPath).pipe(
@@ -38,7 +38,7 @@ export async function sarifParser(
       });
 
       asm.on("done", (asm) => {
-        const log: Sarif.Log = {
+        const log: Log = {
           version: "2.1.0",
           runs: [
             {

--- a/extensions/ql-vscode/src/common/sarif-utils.ts
+++ b/extensions/ql-vscode/src/common/sarif-utils.ts
@@ -1,4 +1,4 @@
-import * as Sarif from "sarif";
+import { Location, Region } from "sarif";
 import type { HighlightedRegion } from "../variant-analysis/shared/analysis-result";
 import { UrlValueResolvable } from "./raw-result-types";
 import { isEmptyPath } from "./bqrs-utils";
@@ -103,7 +103,7 @@ export function getPathRelativeToSourceLocationPrefix(
  * @param sourceLocationPrefix a file path (usually a full path) to the database containing the source location.
  */
 export function parseSarifLocation(
-  loc: Sarif.Location,
+  loc: Location,
   sourceLocationPrefix: string,
 ): ParsedSarifLocation {
   const physicalLocation = loc.physicalLocation;
@@ -153,7 +153,7 @@ export function parseSarifLocation(
   }
 }
 
-export function parseSarifRegion(region: Sarif.Region): {
+export function parseSarifRegion(region: Region): {
   startLine: number;
   endLine: number;
   startColumn: number;

--- a/extensions/ql-vscode/src/common/vscode/abstract-webview-view-provider.ts
+++ b/extensions/ql-vscode/src/common/vscode/abstract-webview-view-provider.ts
@@ -1,6 +1,11 @@
-import * as vscode from "vscode";
-import { Uri, WebviewViewProvider } from "vscode";
-import { WebviewKind, WebviewMessage, getHtmlForWebview } from "./webview-html";
+import {
+  CancellationToken,
+  Uri,
+  WebviewView,
+  WebviewViewProvider,
+  WebviewViewResolveContext,
+} from "vscode";
+import { getHtmlForWebview, WebviewKind, WebviewMessage } from "./webview-html";
 import { Disposable } from "../disposable-object";
 import { App } from "../app";
 import { DeepReadonly } from "../readonly";
@@ -10,7 +15,7 @@ export abstract class AbstractWebviewViewProvider<
   FromMessage extends WebviewMessage,
 > implements WebviewViewProvider
 {
-  protected webviewView: vscode.WebviewView | undefined = undefined;
+  protected webviewView: WebviewView | undefined = undefined;
   private disposables: Disposable[] = [];
 
   constructor(
@@ -23,9 +28,9 @@ export abstract class AbstractWebviewViewProvider<
    * first loaded or when the user hides and then shows a view again.
    */
   public resolveWebviewView(
-    webviewView: vscode.WebviewView,
-    _context: vscode.WebviewViewResolveContext,
-    _token: vscode.CancellationToken,
+    webviewView: WebviewView,
+    _context: WebviewViewResolveContext,
+    _token: CancellationToken,
   ) {
     webviewView.webview.options = {
       enableScripts: true,

--- a/extensions/ql-vscode/src/common/vscode/authentication.ts
+++ b/extensions/ql-vscode/src/common/vscode/authentication.ts
@@ -1,5 +1,5 @@
-import * as vscode from "vscode";
-import * as Octokit from "@octokit/rest";
+import { authentication } from "vscode";
+import { Octokit } from "@octokit/rest";
 import { Credentials } from "../authentication";
 import { AppOctokit } from "../octokit";
 
@@ -18,14 +18,14 @@ export class VSCodeCredentials implements Credentials {
   /**
    * A specific octokit to return, otherwise a new authenticated octokit will be created when needed.
    */
-  private octokit: Octokit.Octokit | undefined;
+  private octokit: Octokit | undefined;
 
   /**
    * Creates or returns an instance of Octokit.
    *
    * @returns An instance of Octokit.
    */
-  async getOctokit(): Promise<Octokit.Octokit> {
+  async getOctokit(): Promise<Octokit> {
     if (this.octokit) {
       return this.octokit;
     }
@@ -38,7 +38,7 @@ export class VSCodeCredentials implements Credentials {
   }
 
   async getAccessToken(): Promise<string> {
-    const session = await vscode.authentication.getSession(
+    const session = await authentication.getSession(
       GITHUB_AUTH_PROVIDER_ID,
       SCOPES,
       { createIfNone: true },
@@ -48,7 +48,7 @@ export class VSCodeCredentials implements Credentials {
   }
 
   async getExistingAccessToken(): Promise<string | undefined> {
-    const session = await vscode.authentication.getSession(
+    const session = await authentication.getSession(
       GITHUB_AUTH_PROVIDER_ID,
       SCOPES,
       { createIfNone: false },

--- a/extensions/ql-vscode/src/common/vscode/telemetry.ts
+++ b/extensions/ql-vscode/src/common/vscode/telemetry.ts
@@ -14,7 +14,7 @@ import {
   isIntegrationTestMode,
   isCanary,
 } from "../../config";
-import * as appInsights from "applicationinsights";
+import { TelemetryClient } from "applicationinsights";
 import { extLogger } from "../logging/vscode";
 import { UserCancellationException } from "./progress";
 import { showBinaryChoiceWithUrlDialog } from "./dialog";
@@ -129,8 +129,7 @@ export class ExtensionTelemetryListener
     );
     this.push(this.reporter);
 
-    const client = (this.reporter as any)
-      .appInsightsClient as appInsights.TelemetryClient;
+    const client = (this.reporter as any).appInsightsClient as TelemetryClient;
     if (client) {
       // add a telemetry processor to delete unwanted properties
       client.addTelemetryProcessor((envelope: any) => {

--- a/extensions/ql-vscode/src/common/vscode/vscode-app.ts
+++ b/extensions/ql-vscode/src/common/vscode/vscode-app.ts
@@ -1,4 +1,4 @@
-import * as vscode from "vscode";
+import { ExtensionContext, ExtensionMode } from "vscode";
 import { VSCodeCredentials } from "./authentication";
 import { Disposable } from "../disposable-object";
 import { App, AppMode, EnvironmentContext } from "../app";
@@ -18,9 +18,7 @@ export class ExtensionApp implements App {
   public readonly commands: AppCommandManager;
   public readonly queryServerCommands: QueryServerCommandManager;
 
-  public constructor(
-    public readonly extensionContext: vscode.ExtensionContext,
-  ) {
+  public constructor(public readonly extensionContext: ExtensionContext) {
     this.credentials = new VSCodeCredentials();
     this.commands = createVSCodeCommandManager();
     this.queryServerCommands = createVSCodeCommandManager(queryServerLogger);
@@ -49,9 +47,9 @@ export class ExtensionApp implements App {
 
   public get mode(): AppMode {
     switch (this.extensionContext.extensionMode) {
-      case vscode.ExtensionMode.Development:
+      case ExtensionMode.Development:
         return AppMode.Development;
-      case vscode.ExtensionMode.Test:
+      case ExtensionMode.Test:
         return AppMode.Test;
       default:
         return AppMode.Production;

--- a/extensions/ql-vscode/src/compare/interpreted-results.ts
+++ b/extensions/ql-vscode/src/compare/interpreted-results.ts
@@ -1,5 +1,5 @@
 import { Uri } from "vscode";
-import * as sarif from "sarif";
+import { Log } from "sarif";
 import { pathExists } from "fs-extra";
 import { sarifParser } from "../common/sarif-parser";
 import { CompletedLocalQueryInfo } from "../query-results";
@@ -11,7 +11,7 @@ import { sarifDiff } from "./sarif-diff";
 
 async function getInterpretedResults(
   interpretedResultsPath: string,
-): Promise<sarif.Log | undefined> {
+): Promise<Log | undefined> {
   if (!(await pathExists(interpretedResultsPath))) {
     return undefined;
   }

--- a/extensions/ql-vscode/src/compare/sarif-diff.ts
+++ b/extensions/ql-vscode/src/compare/sarif-diff.ts
@@ -1,4 +1,4 @@
-import * as sarif from "sarif";
+import { Result } from "sarif";
 
 /**
  * Compare the alerts of two queries. Use deep equality to determine if
@@ -16,10 +16,7 @@ import * as sarif from "sarif";
  *  1. If either query is empty
  *  2. If the queries are 100% disjoint
  */
-export function sarifDiff(
-  fromResults: sarif.Result[],
-  toResults: sarif.Result[],
-) {
+export function sarifDiff(fromResults: Result[], toResults: Result[]) {
   if (!fromResults.length) {
     throw new Error("CodeQL Compare: Source query has no results.");
   }

--- a/extensions/ql-vscode/src/databases/database-fetcher.ts
+++ b/extensions/ql-vscode/src/databases/database-fetcher.ts
@@ -12,7 +12,7 @@ import {
   readdir,
 } from "fs-extra";
 import { basename, join } from "path";
-import * as Octokit from "@octokit/rest";
+import { Octokit } from "@octokit/rest";
 
 import { DatabaseManager, DatabaseItem } from "./local-databases";
 import { tmpDir } from "../tmp-dir";
@@ -230,7 +230,7 @@ export async function downloadGitHubDatabaseFromUrl(
   commitOid: string | null,
   owner: string,
   name: string,
-  octokit: Octokit.Octokit,
+  octokit: Octokit,
   progress: ProgressCallback,
   databaseManager: DatabaseManager,
   storagePath: string,
@@ -568,7 +568,7 @@ export async function findDirWithFile(
 
 export async function convertGithubNwoToDatabaseUrl(
   nwo: string,
-  octokit: Octokit.Octokit,
+  octokit: Octokit,
   progress: ProgressCallback,
   language?: string,
 ): Promise<

--- a/extensions/ql-vscode/src/databases/local-databases/database-contents.ts
+++ b/extensions/ql-vscode/src/databases/local-databases/database-contents.ts
@@ -1,4 +1,4 @@
-import vscode from "vscode";
+import { Uri } from "vscode";
 
 /**
  * The layout of the database.
@@ -18,13 +18,13 @@ export interface DatabaseContents {
    */
   name: string;
   /** The URI of the QL dataset within the database. */
-  datasetUri: vscode.Uri;
+  datasetUri: Uri;
   /** The URI of the source archive within the database, if one exists. */
-  sourceArchiveUri?: vscode.Uri;
+  sourceArchiveUri?: Uri;
   /** The URI of the CodeQL database scheme within the database, if exactly one exists. */
-  dbSchemeUri?: vscode.Uri;
+  dbSchemeUri?: Uri;
 }
 
 export interface DatabaseContentsWithDbScheme extends DatabaseContents {
-  dbSchemeUri: vscode.Uri; // Always present
+  dbSchemeUri: Uri; // Always present
 }

--- a/extensions/ql-vscode/src/databases/local-databases/database-item.ts
+++ b/extensions/ql-vscode/src/databases/local-databases/database-item.ts
@@ -1,5 +1,5 @@
-import vscode from "vscode";
-import * as cli from "../../codeql-cli/cli";
+import { Uri } from "vscode";
+import { CodeQLCliServer } from "../../codeql-cli/cli";
 import { DatabaseContents } from "./database-contents";
 import { DatabaseOptions } from "./database-options";
 import { DatabaseOrigin } from "./database-origin";
@@ -7,14 +7,14 @@ import { DatabaseOrigin } from "./database-origin";
 /** An item in the list of available databases */
 export interface DatabaseItem {
   /** The URI of the database */
-  readonly databaseUri: vscode.Uri;
+  readonly databaseUri: Uri;
   /** The name of the database to be displayed in the UI */
   name: string;
 
   /** The primary language of the database or empty string if unknown */
   readonly language: string;
   /** The URI of the database's source archive, or `undefined` if no source archive is to be used. */
-  readonly sourceArchive: vscode.Uri | undefined;
+  readonly sourceArchive: Uri | undefined;
   /**
    * The contents of the database.
    * Will be `undefined` if the database is invalid. Can be updated by calling `refresh()`.
@@ -39,7 +39,7 @@ export interface DatabaseItem {
    *
    * @param file Filename within the source archive. May be `undefined` to return a dummy file path.
    */
-  resolveSourceFile(file: string | undefined): vscode.Uri;
+  resolveSourceFile(file: string | undefined): Uri;
 
   /**
    * Holds if the database item has a `.dbinfo` or `codeql-database.yml` file.
@@ -49,18 +49,18 @@ export interface DatabaseItem {
   /**
    * Returns `sourceLocationPrefix` of exported database.
    */
-  getSourceLocationPrefix(server: cli.CodeQLCliServer): Promise<string>;
+  getSourceLocationPrefix(server: CodeQLCliServer): Promise<string>;
 
   /**
    * Returns dataset folder of exported database.
    */
-  getDatasetFolder(server: cli.CodeQLCliServer): Promise<string>;
+  getDatasetFolder(server: CodeQLCliServer): Promise<string>;
 
   /**
    * Returns the root uri of the virtual filesystem for this database's source archive,
    * as displayed in the filesystem explorer.
    */
-  getSourceArchiveExplorerUri(): vscode.Uri;
+  getSourceArchiveExplorerUri(): Uri;
 
   /**
    * Returns true if the database's source archive is in the workspace.
@@ -70,7 +70,7 @@ export interface DatabaseItem {
   /**
    * Holds if `uri` belongs to this database's source archive.
    */
-  belongsToSourceArchiveExplorerUri(uri: vscode.Uri): boolean;
+  belongsToSourceArchiveExplorerUri(uri: Uri): boolean;
 
   /**
    * Whether the database may be affected by test execution for the given path.

--- a/extensions/ql-vscode/src/databases/local-databases/database-manager.ts
+++ b/extensions/ql-vscode/src/databases/local-databases/database-manager.ts
@@ -4,7 +4,7 @@ import { extLogger } from "../../common/logging/vscode";
 import { DisposableObject } from "../../common/disposable-object";
 import { App } from "../../common/app";
 import { QueryRunner } from "../../query-server";
-import * as cli from "../../codeql-cli/cli";
+import { CodeQLCliServer } from "../../codeql-cli/cli";
 import { ProgressCallback, withProgress } from "../../common/vscode/progress";
 import {
   addDatabaseSourceToWorkspace,
@@ -105,7 +105,7 @@ export class DatabaseManager extends DisposableObject {
     private readonly ctx: ExtensionContext,
     private readonly app: App,
     private readonly qs: QueryRunner,
-    private readonly cli: cli.CodeQLCliServer,
+    private readonly cli: CodeQLCliServer,
     private readonly languageContext: LanguageContextStore,
     public logger: Logger,
   ) {

--- a/extensions/ql-vscode/src/databases/local-databases/database-resolver.ts
+++ b/extensions/ql-vscode/src/databases/local-databases/database-resolver.ts
@@ -1,4 +1,4 @@
-import vscode from "vscode";
+import { Uri } from "vscode";
 import { pathExists } from "fs-extra";
 import { basename, join, resolve } from "path";
 import {
@@ -16,7 +16,7 @@ import { extLogger } from "../../common/logging/vscode";
 
 export class DatabaseResolver {
   public static async resolveDatabaseContents(
-    uri: vscode.Uri,
+    uri: Uri,
   ): Promise<DatabaseContentsWithDbScheme> {
     if (uri.scheme !== "file") {
       throw new Error(
@@ -51,7 +51,7 @@ export class DatabaseResolver {
         `Database '${databasePath}' contains multiple CodeQL dbschemes under '${dbPath}'.`,
       );
     } else {
-      const dbSchemeUri = vscode.Uri.file(resolve(dbPath, dbSchemeFiles[0]));
+      const dbSchemeUri = Uri.file(resolve(dbPath, dbSchemeFiles[0]));
       return {
         ...contents,
         dbSchemeUri,
@@ -83,7 +83,7 @@ export class DatabaseResolver {
  */
 class InvalidDatabaseError extends Error {}
 
-async function findDataset(parentDirectory: string): Promise<vscode.Uri> {
+async function findDataset(parentDirectory: string): Promise<Uri> {
   /*
    * Look directly in the root
    */
@@ -113,7 +113,7 @@ async function findDataset(parentDirectory: string): Promise<vscode.Uri> {
     );
   }
 
-  return vscode.Uri.file(dbAbsolutePath);
+  return Uri.file(dbAbsolutePath);
 }
 
 /** Gets the relative paths of all `.dbscheme` files in the given directory. */
@@ -124,7 +124,7 @@ async function getDbSchemeFiles(dbDirectory: string): Promise<string[]> {
 // exported for testing
 export async function findSourceArchive(
   databasePath: string,
-): Promise<vscode.Uri | undefined> {
+): Promise<Uri | undefined> {
   const relativePaths = ["src", "output/src_archive"];
 
   for (const relativePath of relativePaths) {
@@ -135,7 +135,7 @@ export async function findSourceArchive(
     if (await pathExists(zipPath)) {
       return encodeArchiveBasePath(zipPath);
     } else if (await pathExists(basePath)) {
-      return vscode.Uri.file(basePath);
+      return Uri.file(basePath);
     }
   }
 

--- a/extensions/ql-vscode/src/databases/ui/db-tree-view-item.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-tree-view-item.ts
@@ -1,4 +1,10 @@
-import * as vscode from "vscode";
+import {
+  ThemeColor,
+  ThemeIcon,
+  TreeItem,
+  TreeItemCollapsibleState,
+  Uri,
+} from "vscode";
 import {
   DbItem,
   isSelectableDbItem,
@@ -16,16 +22,16 @@ export const SELECTED_DB_ITEM_RESOURCE_URI = "codeql://databases?selected=true";
  * Represents an item in the database tree view. This item could be
  * representing an actual database item or a warning.
  */
-export class DbTreeViewItem extends vscode.TreeItem {
+export class DbTreeViewItem extends TreeItem {
   constructor(
     // iconPath and tooltip must have those names because
     // they are part of the vscode.TreeItem interface
 
     public readonly dbItem: DbItem | undefined,
-    public readonly iconPath: vscode.ThemeIcon | undefined,
+    public readonly iconPath: ThemeIcon | undefined,
     public readonly label: string,
     public readonly tooltip: string | undefined,
-    public readonly collapsibleState: vscode.TreeItemCollapsibleState,
+    public readonly collapsibleState: TreeItemCollapsibleState,
     public readonly children: DbTreeViewItem[],
   ) {
     super(label, collapsibleState);
@@ -40,7 +46,7 @@ export class DbTreeViewItem extends vscode.TreeItem {
 
   public setAsSelected(): void {
     // Define the resource id to drive the UI to render this item as selected.
-    this.resourceUri = vscode.Uri.parse(SELECTED_DB_ITEM_RESOURCE_URI);
+    this.resourceUri = Uri.parse(SELECTED_DB_ITEM_RESOURCE_URI);
   }
 
   public setAsUnselected(): void {
@@ -59,13 +65,10 @@ export function createDbTreeViewItemError(
 ): DbTreeViewItem {
   return new DbTreeViewItem(
     undefined,
-    new vscode.ThemeIcon(
-      "error",
-      new vscode.ThemeColor("problemsErrorIcon.foreground"),
-    ),
+    new ThemeIcon("error", new ThemeColor("problemsErrorIcon.foreground")),
     label,
     tooltip,
-    vscode.TreeItemCollapsibleState.None,
+    TreeItemCollapsibleState.None,
     [],
   );
 }
@@ -93,10 +96,10 @@ export function createDbTreeViewItemSystemDefinedList(
 ): DbTreeViewItem {
   return new DbTreeViewItem(
     dbItem,
-    new vscode.ThemeIcon("github"),
+    new ThemeIcon("github"),
     label,
     tooltip,
-    vscode.TreeItemCollapsibleState.None,
+    TreeItemCollapsibleState.None,
     [],
   );
 }
@@ -122,10 +125,10 @@ export function createDbTreeViewItemOwner(
 ): DbTreeViewItem {
   return new DbTreeViewItem(
     dbItem,
-    new vscode.ThemeIcon("organization"),
+    new ThemeIcon("organization"),
     ownerName,
     undefined,
-    vscode.TreeItemCollapsibleState.None,
+    TreeItemCollapsibleState.None,
     [],
   );
 }
@@ -136,18 +139,16 @@ export function createDbTreeViewItemRepo(
 ): DbTreeViewItem {
   return new DbTreeViewItem(
     dbItem,
-    new vscode.ThemeIcon("cloud"),
+    new ThemeIcon("cloud"),
     repoName,
     undefined,
-    vscode.TreeItemCollapsibleState.None,
+    TreeItemCollapsibleState.None,
     [],
   );
 }
 
-function getCollapsibleState(
-  expanded: boolean,
-): vscode.TreeItemCollapsibleState {
+function getCollapsibleState(expanded: boolean): TreeItemCollapsibleState {
   return expanded
-    ? vscode.TreeItemCollapsibleState.Expanded
-    : vscode.TreeItemCollapsibleState.Collapsed;
+    ? TreeItemCollapsibleState.Expanded
+    : TreeItemCollapsibleState.Collapsed;
 }

--- a/extensions/ql-vscode/src/debugger/debug-configuration.ts
+++ b/extensions/ql-vscode/src/debugger/debug-configuration.ts
@@ -7,7 +7,7 @@ import {
 import { getOnDiskWorkspaceFolders } from "../common/vscode/workspace-folders";
 import { LocalQueries } from "../local-queries";
 import { getQuickEvalContext, validateQueryPath } from "../run-queries-shared";
-import * as CodeQLProtocol from "./debug-protocol";
+import { LaunchConfig } from "./debug-protocol";
 import { getErrorMessage } from "../common/helpers-pure";
 import { showAndLogErrorMessage } from "../common/logging";
 import { extLogger } from "../common/logging/vscode";
@@ -36,8 +36,7 @@ export type QLDebugConfiguration = DebugConfiguration & QLDebugArgs;
  * A CodeQL debug configuration after all variables and defaults have been resolved. This is what
  * is passed to the debug adapter via the `launch` request.
  */
-export type QLResolvedDebugConfiguration = DebugConfiguration &
-  CodeQLProtocol.LaunchConfig;
+export type QLResolvedDebugConfiguration = DebugConfiguration & LaunchConfig;
 
 /** If the specified value is a single element, then turn it into an array containing that element. */
 function makeArray<T extends Exclude<any, any[]>>(value: T | T[]): T[] {

--- a/extensions/ql-vscode/src/debugger/debug-session.ts
+++ b/extensions/ql-vscode/src/debugger/debug-session.ts
@@ -16,6 +16,7 @@ import { BaseLogger, LogOptions } from "../common/logging";
 import { queryServerLogger } from "../common/logging/vscode";
 import { QueryResultType } from "../query-server/messages";
 import { CoreQueryResults, CoreQueryRun, QueryRunner } from "../query-server";
+// eslint-disable-next-line import/no-namespace -- There are two different debug protocols, so we should make a distinction.
 import * as CodeQLProtocol from "./debug-protocol";
 import { QuickEvalContext } from "../run-queries-shared";
 import { getErrorMessage } from "../common/helpers-pure";

--- a/extensions/ql-vscode/src/debugger/debugger-ui.ts
+++ b/extensions/ql-vscode/src/debugger/debugger-ui.ts
@@ -18,7 +18,12 @@ import {
   validateQueryUri,
 } from "../run-queries-shared";
 import { QLResolvedDebugConfiguration } from "./debug-configuration";
-import * as CodeQLProtocol from "./debug-protocol";
+import {
+  AnyProtocolMessage,
+  EvaluationCompletedEvent,
+  EvaluationStartedEvent,
+  QuickEvalRequest,
+} from "./debug-protocol";
 import { App } from "../common/app";
 import { LocalQueryRun, LocalQueries } from "../local-queries";
 
@@ -46,7 +51,7 @@ class QLDebugAdapterTracker
     this.configuration = <QLResolvedDebugConfiguration>session.configuration;
   }
 
-  public onDidSendMessage(message: CodeQLProtocol.AnyProtocolMessage): void {
+  public onDidSendMessage(message: AnyProtocolMessage): void {
     if (message.type === "event") {
       switch (message.event) {
         case "codeql-evaluation-started":
@@ -77,7 +82,7 @@ class QLDebugAdapterTracker
     // Since we're not going through VS Code's launch path, we need to save dirty files ourselves.
     await saveBeforeStart();
 
-    const args: CodeQLProtocol.QuickEvalRequest["arguments"] = {
+    const args: QuickEvalRequest["arguments"] = {
       quickEvalContext: await getQuickEvalContext(undefined, false),
     };
     await this.session.customRequest("codeql-quickeval", args);
@@ -102,7 +107,7 @@ class QLDebugAdapterTracker
 
   /** Updates the UI to track the currently executing query. */
   private async onEvaluationStarted(
-    body: CodeQLProtocol.EvaluationStartedEvent["body"],
+    body: EvaluationStartedEvent["body"],
   ): Promise<void> {
     const dbUri = Uri.file(this.configuration.database);
     const dbItem = await this.dbm.createOrOpenDatabaseItem(dbUri, {
@@ -128,7 +133,7 @@ class QLDebugAdapterTracker
 
   /** Update the UI after a query has finished evaluating. */
   private async onEvaluationCompleted(
-    body: CodeQLProtocol.EvaluationCompletedEvent["body"],
+    body: EvaluationCompletedEvent["body"],
   ): Promise<void> {
     if (this.localQueryRun !== undefined) {
       const results: CoreQueryResults = body;

--- a/extensions/ql-vscode/src/language-support/contextual/file-range-from-uri.ts
+++ b/extensions/ql-vscode/src/language-support/contextual/file-range-from-uri.ts
@@ -1,8 +1,8 @@
-import * as vscode from "vscode";
+import { Location, Range } from "vscode";
 
 import {
-  BqrsUrlValue,
   BqrsLineColumnLocation,
+  BqrsUrlValue,
 } from "../../common/bqrs-cli-types";
 import { isEmptyPath } from "../../common/bqrs-utils";
 import { DatabaseItem } from "../../databases/local-databases";
@@ -10,7 +10,7 @@ import { DatabaseItem } from "../../databases/local-databases";
 export function fileRangeFromURI(
   uri: BqrsUrlValue | undefined,
   db: DatabaseItem,
-): vscode.Location | undefined {
+): Location | undefined {
   if (!uri || typeof uri === "string") {
     return undefined;
   } else if ("startOffset" in uri) {
@@ -20,7 +20,7 @@ export function fileRangeFromURI(
     if (isEmptyPath(loc.uri)) {
       return undefined;
     }
-    const range = new vscode.Range(
+    const range = new Range(
       Math.max(0, (loc.startLine || 0) - 1),
       Math.max(0, (loc.startColumn || 0) - 1),
       Math.max(0, (loc.endLine || 0) - 1),
@@ -28,7 +28,7 @@ export function fileRangeFromURI(
     );
     try {
       if (uri.uri.startsWith("file:")) {
-        return new vscode.Location(db.resolveSourceFile(uri.uri), range);
+        return new Location(db.resolveSourceFile(uri.uri), range);
       }
       return undefined;
     } catch (e) {

--- a/extensions/ql-vscode/src/model-editor/auto-model-codeml-queries.ts
+++ b/extensions/ql-vscode/src/model-editor/auto-model-codeml-queries.ts
@@ -2,7 +2,7 @@ import { CodeQLCliServer, SourceInfo } from "../codeql-cli/cli";
 import { CoreCompletedQuery, QueryRunner } from "../query-server";
 import { DatabaseItem } from "../databases/local-databases";
 import { ProgressCallback } from "../common/vscode/progress";
-import * as Sarif from "sarif";
+import { Log } from "sarif";
 import { Mode } from "./shared/mode";
 import { getOnDiskWorkspaceFolders } from "../common/vscode/workspace-folders";
 import { interpretResultsSarif } from "../query-results";
@@ -30,7 +30,7 @@ type AutoModelQueriesOptions = {
 };
 
 export type AutoModelQueriesResult = {
-  candidates: Sarif.Log;
+  candidates: Log;
 };
 
 export async function runAutoModelQueries({
@@ -212,7 +212,7 @@ async function interpretAutomodelResults(
   completedQuery: CoreCompletedQuery,
   metadata: QueryMetadata,
   sourceInfo: SourceInfo | undefined,
-): Promise<Sarif.Log> {
+): Promise<Log> {
   const interpretedResultsPath = join(
     completedQuery.outputDir.querySaveDir,
     "results.sarif",

--- a/extensions/ql-vscode/src/model-editor/auto-model.ts
+++ b/extensions/ql-vscode/src/model-editor/auto-model.ts
@@ -2,7 +2,7 @@ import { AutomodelMode, ModelRequest } from "./auto-model-api";
 import { Mode } from "./shared/mode";
 import { AutoModelQueriesResult } from "./auto-model-codeml-queries";
 import { assertNever } from "../common/helpers-pure";
-import * as Sarif from "sarif";
+import { Log } from "sarif";
 import { gzipEncode } from "../common/zlib";
 import { Method, MethodSignature } from "./method";
 import { ModeledMethod } from "./modeled-method";
@@ -57,7 +57,7 @@ export function getCandidates(
  * @param log SARIF log to encode
  * @returns base64-encoded GZIP-compressed SARIF log
  */
-export async function encodeSarif(log: Sarif.Log): Promise<string> {
+export async function encodeSarif(log: Log): Promise<string> {
   const json = JSON.stringify(log);
   const buffer = Buffer.from(json, "utf-8");
   const compressed = await gzipEncode(buffer);

--- a/extensions/ql-vscode/src/model-editor/extension-pack-picker.ts
+++ b/extensions/ql-vscode/src/model-editor/extension-pack-picker.ts
@@ -20,7 +20,7 @@ import {
 import { autoPickExtensionsDirectory } from "./extensions-workspace-folder";
 
 import { ExtensionPackMetadata } from "./extension-pack-metadata";
-import * as extensionPackMetadataSchemaJson from "./extension-pack-metadata.schema.json";
+import extensionPackMetadataSchemaJson from "./extension-pack-metadata.schema.json";
 
 const ajv = new Ajv({ allErrors: true });
 const extensionPackValidate = ajv.compile(extensionPackMetadataSchemaJson);

--- a/extensions/ql-vscode/src/model-editor/yaml.ts
+++ b/extensions/ql-vscode/src/model-editor/yaml.ts
@@ -14,12 +14,12 @@ import {
   ModelsAsDataLanguagePredicate,
   ModelsAsDataLanguagePredicates,
 } from "./languages";
-
-import * as modelExtensionFileSchema from "./model-extension-file.schema.json";
 import { Mode } from "./shared/mode";
 import { assertNever } from "../common/helpers-pure";
 import { ModelExtensionFile } from "./model-extension-file";
 import { QueryLanguage } from "../common/query-language";
+
+import modelExtensionFileSchema from "./model-extension-file.schema.json";
 
 const ajv = new Ajv({ allErrors: true, allowUnionTypes: true });
 const modelExtensionFileSchemaValidate = ajv.compile(modelExtensionFileSchema);

--- a/extensions/ql-vscode/src/packaging/qlpack-file-loader.ts
+++ b/extensions/ql-vscode/src/packaging/qlpack-file-loader.ts
@@ -1,8 +1,9 @@
 import Ajv from "ajv";
-import * as qlpackFileSchemaJson from "./qlpack-file.schema.json";
 import { QlPackFile } from "./qlpack-file";
 import { load } from "js-yaml";
 import { readFile } from "fs-extra";
+
+import qlpackFileSchemaJson from "./qlpack-file.schema.json";
 
 const ajv = new Ajv({ allErrors: true });
 const qlpackFileValidate = ajv.compile(qlpackFileSchemaJson);

--- a/extensions/ql-vscode/src/queries-panel/query-tree-view-item.ts
+++ b/extensions/ql-vscode/src/queries-panel/query-tree-view-item.ts
@@ -1,6 +1,6 @@
-import * as vscode from "vscode";
+import { TreeItem, TreeItemCollapsibleState, Uri } from "vscode";
 
-export class QueryTreeViewItem extends vscode.TreeItem {
+export class QueryTreeViewItem extends TreeItem {
   constructor(
     name: string,
     public readonly path: string,
@@ -17,7 +17,7 @@ export function createQueryTreeFolderItem(
 ): QueryTreeViewItem {
   const item = new QueryTreeViewItem(name, path, children);
   item.tooltip = path;
-  item.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
+  item.collapsibleState = TreeItemCollapsibleState.Collapsed;
   item.contextValue = "queryFolder";
   return item;
 }
@@ -30,12 +30,12 @@ export function createQueryTreeFileItem(
   const item = new QueryTreeViewItem(name, path, []);
   item.tooltip = path;
   item.description = language;
-  item.collapsibleState = vscode.TreeItemCollapsibleState.None;
+  item.collapsibleState = TreeItemCollapsibleState.None;
   item.contextValue = "queryFile";
   item.command = {
     title: "Open",
     command: "vscode.open",
-    arguments: [vscode.Uri.file(path)],
+    arguments: [Uri.file(path)],
   };
   return item;
 }

--- a/extensions/ql-vscode/src/query-results.ts
+++ b/extensions/ql-vscode/src/query-results.ts
@@ -1,7 +1,7 @@
 import { CancellationTokenSource, env } from "vscode";
 
-import * as messages from "./query-server/messages-shared";
-import * as cli from "./codeql-cli/cli";
+import { Position } from "./query-server/messages-shared";
+import { CodeQLCliServer, SourceInfo } from "./codeql-cli/cli";
 import { pathExists } from "fs-extra";
 import { basename } from "path";
 import {
@@ -41,7 +41,7 @@ export interface InitialQueryInfo {
   readonly isQuickQuery: boolean;
   readonly isQuickEval: boolean;
   readonly isQuickEvalCount?: boolean; // Missing is false for backwards compatibility
-  readonly quickEvalPosition?: messages.Position;
+  readonly quickEvalPosition?: Position;
   readonly queryPath: string;
   readonly databaseInfo: DatabaseInfo;
   readonly start: Date;
@@ -86,7 +86,7 @@ export class CompletedQueryInfo implements QueryWithResults {
   }
 
   async updateSortState(
-    server: cli.CodeQLCliServer,
+    server: CodeQLCliServer,
     resultSetName: string,
     sortState?: RawResultsSortState,
   ): Promise<void> {
@@ -121,10 +121,10 @@ export class CompletedQueryInfo implements QueryWithResults {
  * Call cli command to interpret SARIF results.
  */
 export async function interpretResultsSarif(
-  cli: cli.CodeQLCliServer,
+  cli: CodeQLCliServer,
   metadata: QueryMetadata | undefined,
   resultsPaths: ResultsPaths,
-  sourceInfo?: cli.SourceInfo,
+  sourceInfo?: SourceInfo,
   args?: string[],
 ): Promise<SarifInterpretationData> {
   const { resultsPath, interpretedResultsPath } = resultsPaths;
@@ -147,10 +147,10 @@ export async function interpretResultsSarif(
  * Call cli command to interpret graph results.
  */
 export async function interpretGraphResults(
-  cliServer: cli.CodeQLCliServer,
+  cliServer: CodeQLCliServer,
   metadata: QueryMetadata | undefined,
   resultsPaths: ResultsPaths,
-  sourceInfo?: cli.SourceInfo,
+  sourceInfo?: SourceInfo,
 ): Promise<GraphInterpretationData> {
   const { resultsPath, interpretedResultsPath } = resultsPaths;
   if (await pathExists(interpretedResultsPath)) {

--- a/extensions/ql-vscode/src/query-server/messages.ts
+++ b/extensions/ql-vscode/src/query-server/messages.ts
@@ -45,7 +45,7 @@ export interface TrimCacheParams {
 /**
  * The result of trimming or clearing the cache.
  */
-export interface ClearCacheResult {
+interface ClearCacheResult {
   /**
    * A user friendly message saying what was or would be
    * deleted.
@@ -92,19 +92,19 @@ export namespace QueryResultType {
   export const DBSCHEME_NO_UPGRADE = 6;
 }
 
-export interface RegisterDatabasesParams {
+interface RegisterDatabasesParams {
   databases: string[];
 }
 
-export interface DeregisterDatabasesParams {
+interface DeregisterDatabasesParams {
   databases: string[];
 }
 
-export type RegisterDatabasesResult = {
+type RegisterDatabasesResult = {
   registeredDatabases: string[];
 };
 
-export type DeregisterDatabasesResult = {
+type DeregisterDatabasesResult = {
   registeredDatabases: string[];
 };
 
@@ -130,22 +130,22 @@ export interface RunQueryParams {
   extensionPacks?: string[];
 }
 
-export interface RunQueryResult {
+interface RunQueryResult {
   resultType: QueryResultType;
   message?: string;
   expectedDbschemeName?: string;
   evaluationTime: number;
 }
 
-export interface UpgradeParams {
+interface UpgradeParams {
   db: string;
   additionalPacks: string[];
 }
 
-export type UpgradeResult = Record<string, unknown>;
+type UpgradeResult = Record<string, unknown>;
 
-export type ClearPackCacheParams = Record<string, unknown>;
-export type ClearPackCacheResult = Record<string, unknown>;
+type ClearPackCacheParams = Record<string, unknown>;
+type ClearPackCacheResult = Record<string, unknown>;
 
 /**
  * A position within a QL file.
@@ -156,9 +156,7 @@ export type Position = shared.Position;
  * The way of compiling the query, as a normal query
  * or a subset of it. Note that precisely one of the two options should be set.
  */
-export type CompilationTarget = shared.CompilationTarget;
-
-export type QuickEvalOptions = shared.QuickEvalOptions;
+type CompilationTarget = shared.CompilationTarget;
 
 export type WithProgressId<T> = shared.WithProgressId<T>;
 export type ProgressMessage = shared.ProgressMessage;

--- a/extensions/ql-vscode/src/query-server/messages.ts
+++ b/extensions/ql-vscode/src/query-server/messages.ts
@@ -15,6 +15,7 @@
  */
 
 import { RequestType } from "vscode-jsonrpc";
+// eslint-disable-next-line import/no-namespace -- these names are intentionally the same
 import * as shared from "./messages-shared";
 
 /**

--- a/extensions/ql-vscode/src/query-server/query-server-client.ts
+++ b/extensions/ql-vscode/src/query-server/query-server-client.ts
@@ -3,7 +3,11 @@ import { ensureFile } from "fs-extra";
 import { DisposableObject, DisposeHandler } from "../common/disposable-object";
 import { CancellationToken } from "vscode";
 import { createMessageConnection, RequestType } from "vscode-jsonrpc/node";
-import * as cli from "../codeql-cli/cli";
+import {
+  CodeQLCliServer,
+  shouldDebugQueryServer,
+  spawnServer,
+} from "../codeql-cli/cli";
 import { QueryServerConfig } from "../config";
 import { BaseLogger, Logger, showAndLogErrorMessage } from "../common/logging";
 import { extLogger, ProgressReporter } from "../common/logging/vscode";
@@ -62,7 +66,7 @@ export class QueryServerClient extends DisposableObject {
   constructor(
     app: App,
     readonly config: QueryServerConfig,
-    readonly cliServer: cli.CodeQLCliServer,
+    readonly cliServer: CodeQLCliServer,
     readonly opts: ServerOpts,
     withProgressReporting: WithProgressReporting,
   ) {
@@ -198,13 +202,13 @@ export class QueryServerClient extends DisposableObject {
       args.push("--debug", "--tuple-counting");
     }
 
-    if (cli.shouldDebugQueryServer()) {
+    if (shouldDebugQueryServer()) {
       args.push(
         "-J=-agentlib:jdwp=transport=dt_socket,address=localhost:9010,server=y,suspend=y,quiet=y",
       );
     }
 
-    const child = cli.spawnServer(
+    const child = spawnServer(
       this.config.codeQlPath,
       "CodeQL query server",
       ["execute", "query-server2"],

--- a/extensions/ql-vscode/src/query-server/run-queries.ts
+++ b/extensions/ql-vscode/src/query-server/run-queries.ts
@@ -1,8 +1,8 @@
 import { CancellationToken } from "vscode";
 import { ProgressCallback } from "../common/vscode/progress";
-import * as messages from "./messages";
+import { runQuery, RunQueryParams } from "./messages";
 import { QueryOutputDir } from "../run-queries-shared";
-import * as qsClient from "./query-server-client";
+import { QueryServerClient } from "./query-server-client";
 import { CoreQueryResults, CoreQueryTarget } from "./query-runner";
 import { BaseLogger } from "../common/logging";
 
@@ -21,7 +21,7 @@ import { BaseLogger } from "../common/logging";
  */
 
 export async function compileAndRunQueryAgainstDatabaseCore(
-  qs: qsClient.QueryServerClient,
+  qs: QueryServerClient,
   dbPath: string,
   query: CoreQueryTarget,
   generateEvalLog: boolean,
@@ -45,7 +45,7 @@ export async function compileAndRunQueryAgainstDatabaseCore(
       : { query: {} };
 
   const evalLogPath = generateEvalLog ? outputDir.evalLogPath : undefined;
-  const queryToRun: messages.RunQueryParams = {
+  const queryToRun: RunQueryParams = {
     db: dbPath,
     additionalPacks,
     externalInputs: {},
@@ -65,12 +65,7 @@ export async function compileAndRunQueryAgainstDatabaseCore(
   // in parallel, each query's log messages are interleaved. Fixing this
   // properly will require a change in the query server.
   qs.activeQueryLogger = logger;
-  const result = await qs.sendRequest(
-    messages.runQuery,
-    queryToRun,
-    token,
-    progress,
-  );
+  const result = await qs.sendRequest(runQuery, queryToRun, token, progress);
 
   return {
     resultType: result.resultType,

--- a/extensions/ql-vscode/src/query-server/server-process.ts
+++ b/extensions/ql-vscode/src/query-server/server-process.ts
@@ -1,16 +1,16 @@
 import { Logger } from "../common/logging";
-import * as cp from "child_process";
+import { ChildProcess } from "child_process";
 import { Disposable } from "vscode";
 import { MessageConnection } from "vscode-jsonrpc";
 
 /** A running query server process and its associated message connection. */
 export class ServerProcess implements Disposable {
-  child: cp.ChildProcess;
+  child: ChildProcess;
   connection: MessageConnection;
   logger: Logger;
 
   constructor(
-    child: cp.ChildProcess,
+    child: ChildProcess,
     connection: MessageConnection,
     private name: string,
     logger: Logger,

--- a/extensions/ql-vscode/src/query-testing/test-adapter.ts
+++ b/extensions/ql-vscode/src/query-testing/test-adapter.ts
@@ -1,20 +1,24 @@
 import { extname } from "path";
-import * as vscode from "vscode";
+import {
+  CancellationTokenSource,
+  Event,
+  EventEmitter,
+  WorkspaceFolder,
+} from "vscode";
 import {
   TestAdapter,
-  TestLoadStartedEvent,
-  TestLoadFinishedEvent,
-  TestRunStartedEvent,
-  TestRunFinishedEvent,
-  TestSuiteEvent,
   TestEvent,
-  TestSuiteInfo,
-  TestInfo,
   TestHub,
+  TestInfo,
+  TestLoadFinishedEvent,
+  TestLoadStartedEvent,
+  TestRunFinishedEvent,
+  TestRunStartedEvent,
+  TestSuiteEvent,
+  TestSuiteInfo,
 } from "vscode-test-adapter-api";
 import { TestAdapterRegistrar } from "vscode-test-adapter-util";
 import { QLTestDiscovery } from "./qltest-discovery";
-import { Event, EventEmitter, CancellationTokenSource } from "vscode";
 import { DisposableObject } from "../common/disposable-object";
 import { CodeQLCliServer, TestCompleted } from "../codeql-cli/cli";
 import { testLogger } from "../common/logging/vscode";
@@ -95,10 +99,10 @@ export class QLTestAdapter extends DisposableObject implements TestAdapter {
     >(),
   );
   private readonly _autorun = this.push(new EventEmitter<void>());
-  private runningTask?: vscode.CancellationTokenSource = undefined;
+  private runningTask?: CancellationTokenSource = undefined;
 
   constructor(
-    public readonly workspaceFolder: vscode.WorkspaceFolder,
+    public readonly workspaceFolder: WorkspaceFolder,
     private readonly testRunner: TestRunner,
     cliServer: CodeQLCliServer,
   ) {

--- a/extensions/ql-vscode/src/run-queries-shared.ts
+++ b/extensions/ql-vscode/src/run-queries-shared.ts
@@ -1,4 +1,4 @@
-import * as messages from "./query-server/messages-shared";
+import { Position } from "./query-server/messages-shared";
 import { DatabaseInfo, QueryMetadata } from "./common/interface-types";
 import { join, parse, dirname, basename } from "path";
 import { Range, TextEditor, Uri, window, workspace } from "vscode";
@@ -132,7 +132,7 @@ export class QueryEvaluationInfo extends QueryOutputDir {
     querySaveDir: string,
     public readonly dbItemPath: string,
     public readonly databaseHasMetadataFile: boolean,
-    public readonly quickEvalPosition?: messages.Position,
+    public readonly quickEvalPosition?: Position,
     public readonly metadata?: QueryMetadata,
   ) {
     super(querySaveDir);
@@ -414,7 +414,7 @@ export function validateQueryPath(
 }
 
 export interface QuickEvalContext {
-  quickEvalPosition: messages.Position;
+  quickEvalPosition: Position;
   quickEvalText: string;
   quickEvalCount: boolean;
 }
@@ -466,7 +466,7 @@ export interface SelectedQuery {
 async function getSelectedPosition(
   editor: TextEditor,
   range?: Range,
-): Promise<messages.Position> {
+): Promise<Position> {
   const selectedRange = range || editor.selection;
   const pos = selectedRange.start;
   const posEnd = selectedRange.end;

--- a/extensions/ql-vscode/src/stories/common/icon/Codicon.stories.tsx
+++ b/extensions/ql-vscode/src/stories/common/icon/Codicon.stories.tsx
@@ -4,6 +4,7 @@ import { Codicon as CodiconComponent } from "../../../view/common";
 
 // To regenerate the icons, use the following command from the `extensions/ql-vscode` directory:
 // jq -R '[inputs | [splits(", *")] as $row | $row[0]]' < node_modules/@vscode/codicons/dist/codicon.csv > src/stories/common/icon/vscode-icons.json
+// eslint-disable-next-line import/no-namespace -- This is an array in a JSON file, so we can't use named imports
 import * as icons from "./vscode-icons.json";
 
 export default {

--- a/extensions/ql-vscode/src/stories/variant-analysis/RepoRow.stories.tsx
+++ b/extensions/ql-vscode/src/stories/variant-analysis/RepoRow.stories.tsx
@@ -11,7 +11,8 @@ import {
 } from "../../variant-analysis/shared/analysis-result";
 import { createMockRepositoryWithMetadata } from "../../../test/factories/variant-analysis/shared/repository";
 
-import * as analysesResults from "../data/analysesResultsMessage.json";
+import { analysesResults } from "../data/analysesResultsMessage.json";
+// eslint-disable-next-line import/no-namespace -- We need the full JSON object, so we can't use named imports
 import * as rawResults from "../data/rawResults.json";
 import { RepoRow, RepoRowProps } from "../../view/variant-analysis/RepoRow";
 
@@ -120,7 +121,7 @@ InterpretedResults.args = {
   ...Pending.args,
   status: VariantAnalysisRepoStatus.Succeeded,
   resultCount: 198,
-  interpretedResults: analysesResults.analysesResults.find(
+  interpretedResults: analysesResults.find(
     (v) => v.nwo === "facebook/create-react-app",
   )?.interpretedResults as AnalysisAlert[],
 };

--- a/extensions/ql-vscode/src/stories/variant-analysis/VariantAnalysisAnalyzedRepos.stories.tsx
+++ b/extensions/ql-vscode/src/stories/variant-analysis/VariantAnalysisAnalyzedRepos.stories.tsx
@@ -14,7 +14,7 @@ import { createMockVariantAnalysis } from "../../../test/factories/variant-analy
 import { createMockRepositoryWithMetadata } from "../../../test/factories/variant-analysis/shared/repository";
 import { createMockScannedRepo } from "../../../test/factories/variant-analysis/shared/scanned-repositories";
 
-import * as analysesResults from "../data/analysesResultsMessage.json";
+import { analysesResults } from "../data/analysesResultsMessage.json";
 
 export default {
   title: "Variant Analysis/Analyzed Repos",
@@ -35,7 +35,7 @@ const Template: StoryFn<typeof VariantAnalysisAnalyzedRepos> = (args) => (
 const interpretedResultsForRepo = (
   nwo: string,
 ): AnalysisAlert[] | undefined => {
-  return analysesResults.analysesResults.find((v) => v.nwo === nwo)
+  return analysesResults.find((v) => v.nwo === nwo)
     ?.interpretedResults as AnalysisAlert[];
 };
 

--- a/extensions/ql-vscode/src/variant-analysis/run-remote-query.ts
+++ b/extensions/ql-vscode/src/variant-analysis/run-remote-query.ts
@@ -6,7 +6,7 @@ import { dir, tmpName } from "tmp-promise";
 import { tmpDir } from "../tmp-dir";
 import { getOnDiskWorkspaceFolders } from "../common/vscode/workspace-folders";
 import { Credentials } from "../common/authentication";
-import * as cli from "../codeql-cli/cli";
+import { CodeQLCliServer } from "../codeql-cli/cli";
 import { extLogger } from "../common/logging/vscode";
 import {
   getActionBranch,
@@ -57,7 +57,7 @@ interface GeneratedQueryPack {
  * @returns the entire qlpack as a base64 string.
  */
 async function generateQueryPack(
-  cliServer: cli.CodeQLCliServer,
+  cliServer: CodeQLCliServer,
   queryFile: string,
   queryPackDir: string,
 ): Promise<GeneratedQueryPack> {
@@ -169,7 +169,7 @@ async function createNewQueryPack(
 }
 
 async function copyExistingQueryPack(
-  cliServer: cli.CodeQLCliServer,
+  cliServer: CodeQLCliServer,
   originalPackRoot: string,
   queryFile: string,
   queryPackDir: string,
@@ -273,7 +273,7 @@ interface PreparedRemoteQuery {
 }
 
 export async function prepareRemoteQueryRun(
-  cliServer: cli.CodeQLCliServer,
+  cliServer: CodeQLCliServer,
   credentials: Credentials,
   uri: Uri | undefined,
   progress: ProgressCallback,
@@ -391,7 +391,7 @@ async function fixPackFile(
 }
 
 async function injectExtensionPacks(
-  cliServer: cli.CodeQLCliServer,
+  cliServer: CodeQLCliServer,
   queryPackDir: string,
   workspaceFolders: string[],
 ) {

--- a/extensions/ql-vscode/src/variant-analysis/sarif-processing.ts
+++ b/extensions/ql-vscode/src/variant-analysis/sarif-processing.ts
@@ -1,21 +1,28 @@
-import * as sarif from "sarif";
 import {
-  SarifLink,
+  Log,
+  PhysicalLocation,
+  Region,
+  ReportingDescriptor,
+  Result,
+  Run,
+} from "sarif";
+import {
   parseHighlightedLine,
   parseSarifPlainTextMessage,
   parseSarifRegion,
+  SarifLink,
 } from "../common/sarif-utils";
 
 import {
   AnalysisAlert,
-  CodeFlow,
   AnalysisMessage,
+  AnalysisMessageLocationTokenLocation,
   AnalysisMessageToken,
-  ResultSeverity,
-  ThreadFlow,
+  CodeFlow,
   CodeSnippet,
   HighlightedRegion,
-  AnalysisMessageLocationTokenLocation,
+  ResultSeverity,
+  ThreadFlow,
 } from "./shared/analysis-result";
 
 // A line of more than 8k characters is probably generated.
@@ -26,7 +33,7 @@ const CODE_SNIPPET_HIGHLIGHTED_REGION_MINIMUM_RATIO = 0.01;
 const defaultSeverity = "Warning";
 
 export function extractAnalysisAlerts(
-  sarifLog: sarif.Log,
+  sarifLog: Log,
   fileLinkPrefix: string,
 ): {
   alerts: AnalysisAlert[];
@@ -50,8 +57,8 @@ export function extractAnalysisAlerts(
 }
 
 function extractResultAlerts(
-  run: sarif.Run,
-  result: sarif.Result,
+  run: Run,
+  result: Result,
   fileLinkPrefix: string,
 ): AnalysisAlert[] {
   const alerts: AnalysisAlert[] = [];
@@ -93,7 +100,7 @@ function extractResultAlerts(
 }
 
 function getShortDescription(
-  rule: sarif.ReportingDescriptor | undefined,
+  rule: ReportingDescriptor | undefined,
   message: AnalysisMessage,
 ): string {
   if (rule?.shortDescription?.text) {
@@ -104,9 +111,9 @@ function getShortDescription(
 }
 
 export function tryGetSeverity(
-  sarifRun: sarif.Run,
-  result: sarif.Result,
-  rule: sarif.ReportingDescriptor | undefined,
+  sarifRun: Run,
+  result: Result,
+  rule: ReportingDescriptor | undefined,
 ): ResultSeverity | undefined {
   if (!sarifRun || !result || !rule) {
     return undefined;
@@ -130,9 +137,9 @@ export function tryGetSeverity(
 }
 
 export function tryGetRule(
-  sarifRun: sarif.Run,
-  result: sarif.Result,
-): sarif.ReportingDescriptor | undefined {
+  sarifRun: Run,
+  result: Result,
+): ReportingDescriptor | undefined {
   if (!sarifRun || !result) {
     return undefined;
   }
@@ -171,7 +178,7 @@ export function tryGetRule(
 }
 
 export function tryGetFilePath(
-  physicalLocation: sarif.PhysicalLocation,
+  physicalLocation: PhysicalLocation,
 ): string | undefined {
   const filePath = physicalLocation.artifactLocation?.uri;
   // We expect the location uri value to be a relative file path, with no scheme.
@@ -188,8 +195,8 @@ export function tryGetFilePath(
 }
 
 function getCodeSnippet(
-  contextRegion?: sarif.Region,
-  region?: sarif.Region,
+  contextRegion?: Region,
+  region?: Region,
 ): CodeSnippet | undefined {
   const actualRegion = contextRegion ?? region;
 
@@ -234,7 +241,7 @@ function getCodeSnippet(
   };
 }
 
-function getHighlightedRegion(region: sarif.Region): HighlightedRegion {
+function getHighlightedRegion(region: Region): HighlightedRegion {
   const { startLine, startColumn, endLine, endColumn } =
     parseSarifRegion(region);
 
@@ -249,10 +256,7 @@ function getHighlightedRegion(region: sarif.Region): HighlightedRegion {
   };
 }
 
-function getCodeFlows(
-  result: sarif.Result,
-  fileLinkPrefix: string,
-): CodeFlow[] {
+function getCodeFlows(result: Result, fileLinkPrefix: string): CodeFlow[] {
   const codeFlows = [];
 
   if (result.codeFlows) {
@@ -292,10 +296,7 @@ function getCodeFlows(
   return codeFlows;
 }
 
-function getMessage(
-  result: sarif.Result,
-  fileLinkPrefix: string,
-): AnalysisMessage {
+function getMessage(result: Result, fileLinkPrefix: string): AnalysisMessage {
   const tokens: AnalysisMessageToken[] = [];
 
   const messageText = result.message!.text!;
@@ -323,7 +324,7 @@ function getMessage(
 
 function getRelatedLocation(
   messagePart: SarifLink,
-  result: sarif.Result,
+  result: Result,
   fileLinkPrefix: string,
 ): AnalysisMessageLocationTokenLocation | undefined {
   const relatedLocation = result.relatedLocations!.find(

--- a/extensions/ql-vscode/src/view/compare/InterpretedCompareResultTable.tsx
+++ b/extensions/ql-vscode/src/view/compare/InterpretedCompareResultTable.tsx
@@ -1,8 +1,8 @@
-import * as sarif from "sarif";
+import { Result } from "sarif";
 import { AlertTable } from "../results/AlertTable";
 
 type Props = {
-  results: sarif.Result[];
+  results: Result[];
   databaseUri: string;
   sourceLocationPrefix: string;
 };

--- a/extensions/ql-vscode/src/view/results/AlertTablePathNodeRow.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTablePathNodeRow.tsx
@@ -1,21 +1,26 @@
-import * as Sarif from "sarif";
-import * as Keys from "./result-keys";
+import { ThreadFlowLocation } from "sarif";
+import {
+  equalsNotUndefined,
+  PathNode,
+  Result as ResultKeysResult,
+  ResultKey,
+} from "./result-keys";
 import { SarifLocation } from "./locations/SarifLocation";
 import { selectableZebraStripe } from "./result-table-utils";
 import { useCallback, useMemo } from "react";
 import { VerticalRule } from "../common/VerticalRule";
 
 interface Props {
-  step: Sarif.ThreadFlowLocation;
+  step: ThreadFlowLocation;
   pathNodeIndex: number;
   pathIndex: number;
   resultIndex: number;
-  selectedItem: undefined | Keys.ResultKey;
+  selectedItem: undefined | ResultKey;
   selectedItemRef: React.RefObject<any>;
   databaseUri: string;
   sourceLocationPrefix: string;
   updateSelectionCallback: (
-    resultKey: Keys.PathNode | Keys.Result | undefined,
+    resultKey: PathNode | ResultKeysResult | undefined,
   ) => void;
 }
 
@@ -32,7 +37,7 @@ export function AlertTablePathNodeRow(props: Props) {
     updateSelectionCallback,
   } = props;
 
-  const pathNodeKey: Keys.PathNode = useMemo(
+  const pathNodeKey: PathNode = useMemo(
     () => ({
       resultIndex,
       pathIndex,
@@ -45,7 +50,7 @@ export function AlertTablePathNodeRow(props: Props) {
     [pathNodeKey, updateSelectionCallback],
   );
 
-  const isSelected = Keys.equalsNotUndefined(selectedItem, pathNodeKey);
+  const isSelected = equalsNotUndefined(selectedItem, pathNodeKey);
   const stepIndex = pathNodeIndex + 1; // Convert to 1-based
   const zebraIndex = resultIndex + stepIndex;
   return (

--- a/extensions/ql-vscode/src/view/results/AlertTablePathRow.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTablePathRow.tsx
@@ -1,5 +1,10 @@
-import * as Sarif from "sarif";
-import * as Keys from "./result-keys";
+import { ThreadFlow } from "sarif";
+import {
+  equalsNotUndefined,
+  PathNode,
+  Result as ResultKeysResult,
+  ResultKey,
+} from "./result-keys";
 import { selectableZebraStripe } from "./result-table-utils";
 import { AlertTablePathNodeRow } from "./AlertTablePathNodeRow";
 import { AlertTableDropdownIndicatorCell } from "./AlertTableDropdownIndicatorCell";
@@ -7,18 +12,18 @@ import { useCallback, useMemo } from "react";
 import { VerticalRule } from "../common/VerticalRule";
 
 interface Props {
-  path: Sarif.ThreadFlow;
+  path: ThreadFlow;
   pathIndex: number;
   resultIndex: number;
   currentPathExpanded: boolean;
-  selectedItem: undefined | Keys.ResultKey;
+  selectedItem: undefined | ResultKey;
   selectedItemRef: React.RefObject<any>;
   databaseUri: string;
   sourceLocationPrefix: string;
   updateSelectionCallback: (
-    resultKey: Keys.PathNode | Keys.Result | undefined,
+    resultKey: PathNode | ResultKeysResult | undefined,
   ) => void;
-  toggleExpanded: (e: React.MouseEvent, keys: Keys.ResultKey[]) => void;
+  toggleExpanded: (e: React.MouseEvent, keys: ResultKey[]) => void;
 }
 
 export function AlertTablePathRow(props: Props) {
@@ -41,10 +46,7 @@ export function AlertTablePathRow(props: Props) {
     [pathKey, toggleExpanded],
   );
 
-  const isPathSpecificallySelected = Keys.equalsNotUndefined(
-    pathKey,
-    selectedItem,
-  );
+  const isPathSpecificallySelected = equalsNotUndefined(pathKey, selectedItem);
 
   return (
     <>

--- a/extensions/ql-vscode/src/view/results/AlertTableResultRow.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTableResultRow.tsx
@@ -1,5 +1,11 @@
-import * as Sarif from "sarif";
-import * as Keys from "./result-keys";
+import { Result } from "sarif";
+import {
+  getAllPaths,
+  keyToString,
+  PathNode,
+  Result as ResultKeysResult,
+  ResultKey,
+} from "./result-keys";
 import { info, listUnordered } from "./octicons";
 import { selectableZebraStripe } from "./result-table-utils";
 import { AlertTableDropdownIndicatorCell } from "./AlertTableDropdownIndicatorCell";
@@ -9,17 +15,17 @@ import { SarifMessageWithLocations } from "./locations/SarifMessageWithLocations
 import { AlertTablePathRow } from "./AlertTablePathRow";
 
 interface Props {
-  result: Sarif.Result;
+  result: Result;
   resultIndex: number;
   expanded: Set<string>;
-  selectedItem: undefined | Keys.ResultKey;
+  selectedItem: undefined | ResultKey;
   selectedItemRef: React.RefObject<any>;
   databaseUri: string;
   sourceLocationPrefix: string;
   updateSelectionCallback: (
-    resultKey: Keys.PathNode | Keys.Result | undefined,
+    resultKey: PathNode | ResultKeysResult | undefined,
   ) => void;
-  toggleExpanded: (e: React.MouseEvent, keys: Keys.ResultKey[]) => void;
+  toggleExpanded: (e: React.MouseEvent, keys: ResultKey[]) => void;
 }
 
 export function AlertTableResultRow(props: Props) {
@@ -35,7 +41,7 @@ export function AlertTableResultRow(props: Props) {
     toggleExpanded,
   } = props;
 
-  const resultKey: Keys.Result = useMemo(
+  const resultKey: ResultKeysResult = useMemo(
     () => ({ resultIndex }),
     [resultIndex],
   );
@@ -47,7 +53,7 @@ export function AlertTableResultRow(props: Props) {
   const handleDropdownClick = useCallback(
     (e: React.MouseEvent) => {
       const indices =
-        Keys.getAllPaths(result).length === 1
+        getAllPaths(result).length === 1
           ? [resultKey, { ...resultKey, pathIndex: 0 }]
           : /* if there's exactly one path, auto-expand
              * the path when expanding the result */
@@ -75,7 +81,7 @@ export function AlertTableResultRow(props: Props) {
       />
     );
 
-  const currentResultExpanded = expanded.has(Keys.keyToString(resultKey));
+  const currentResultExpanded = expanded.has(keyToString(resultKey));
   return (
     <>
       <tr
@@ -110,14 +116,14 @@ export function AlertTableResultRow(props: Props) {
       </tr>
       {currentResultExpanded &&
         result.codeFlows &&
-        Keys.getAllPaths(result).map((path, pathIndex) => (
+        getAllPaths(result).map((path, pathIndex) => (
           <AlertTablePathRow
             key={`${resultIndex}-${pathIndex}`}
             {...props}
             path={path}
             pathIndex={pathIndex}
             currentPathExpanded={expanded.has(
-              Keys.keyToString({ resultIndex, pathIndex }),
+              keyToString({ resultIndex, pathIndex }),
             )}
           />
         ))}

--- a/extensions/ql-vscode/src/view/results/__tests__/results.spec.tsx
+++ b/extensions/ql-vscode/src/view/results/__tests__/results.spec.tsx
@@ -5,12 +5,12 @@ import {
   IntoResultsViewMsg,
   SortDirection,
 } from "../../../common/interface-types";
-import * as fs from "fs-extra";
+import { readJSONSync } from "fs-extra";
 import { resolve } from "path";
 import { postMessage } from "../../common/post-message";
 import { ColumnKind } from "../../../common/raw-result-types";
 
-const exampleSarif = fs.readJSONSync(
+const exampleSarif = readJSONSync(
   resolve(__dirname, "../../../../test/data/sarif/validSarif.sarif"),
 );
 

--- a/extensions/ql-vscode/src/view/results/locations/SarifLocation.tsx
+++ b/extensions/ql-vscode/src/view/results/locations/SarifLocation.tsx
@@ -1,4 +1,4 @@
-import * as Sarif from "sarif";
+import { Location as SarifLogLocation } from "sarif";
 import { parseSarifLocation } from "../../../common/sarif-utils";
 import { basename } from "../../../common/path";
 import { useMemo } from "react";
@@ -6,7 +6,7 @@ import { Location } from "./Location";
 
 interface Props {
   text?: string;
-  loc?: Sarif.Location;
+  loc?: SarifLogLocation;
   sourceLocationPrefix: string;
   databaseUri: string;
   onClick: () => void;

--- a/extensions/ql-vscode/src/view/results/locations/SarifMessageWithLocations.tsx
+++ b/extensions/ql-vscode/src/view/results/locations/SarifMessageWithLocations.tsx
@@ -1,10 +1,10 @@
-import * as Sarif from "sarif";
+import { Location as SarifLogLocation } from "sarif";
 import { parseSarifPlainTextMessage } from "../../../common/sarif-utils";
 import { SarifLocation } from "./SarifLocation";
 
 interface Props {
   msg: string;
-  relatedLocations: Sarif.Location[];
+  relatedLocations: SarifLogLocation[];
   sourceLocationPrefix: string;
   databaseUri: string;
   onClick: () => void;
@@ -20,7 +20,7 @@ export function SarifMessageWithLocations({
   databaseUri,
   onClick,
 }: Props) {
-  const relatedLocationsById: Map<number, Sarif.Location> = new Map();
+  const relatedLocationsById: Map<number, SarifLogLocation> = new Map();
   for (const loc of relatedLocations) {
     if (loc.id !== undefined) {
       relatedLocationsById.set(loc.id, loc);

--- a/extensions/ql-vscode/src/view/results/result-keys.ts
+++ b/extensions/ql-vscode/src/view/results/result-keys.ts
@@ -21,7 +21,7 @@ export interface Result extends ResultKeyBase {
 /**
  * Identifies one of the paths associated with a result.
  */
-export interface Path extends ResultKeyBase {
+interface Path extends ResultKeyBase {
   pathIndex: number;
   pathNodeIndex?: undefined;
 }

--- a/extensions/ql-vscode/src/view/results/result-keys.ts
+++ b/extensions/ql-vscode/src/view/results/result-keys.ts
@@ -1,4 +1,4 @@
-import * as sarif from "sarif";
+import { Location, Result as SarifResult, ThreadFlow } from "sarif";
 
 /**
  * Identifies a result, a path, or one of the nodes on a path.
@@ -40,9 +40,9 @@ export type ResultKey = Result | Path | PathNode;
  * Looks up a specific result in a result set.
  */
 export function getResult(
-  results: sarif.Result[],
+  results: SarifResult[],
   key: Result | Path | PathNode,
-): sarif.Result | undefined {
+): SarifResult | undefined {
   return results[key.resultIndex];
 }
 
@@ -50,9 +50,9 @@ export function getResult(
  * Looks up a specific path in a result set.
  */
 export function getPath(
-  results: sarif.Result[],
+  results: SarifResult[],
   key: Path | PathNode,
-): sarif.ThreadFlow | undefined {
+): ThreadFlow | undefined {
   const result = getResult(results, key);
   if (result === undefined) {
     return undefined;
@@ -76,9 +76,9 @@ export function getPath(
  * Looks up a specific path node in a result set.
  */
 export function getPathNode(
-  results: sarif.Result[],
+  results: SarifResult[],
   key: PathNode,
-): sarif.Location | undefined {
+): Location | undefined {
   const path = getPath(results, key);
   if (path === undefined) {
     return undefined;
@@ -108,7 +108,7 @@ export function equalsNotUndefined(
  *
  * Path nodes indices are relative to this flattened list.
  */
-export function getAllPaths(result: sarif.Result): sarif.ThreadFlow[] {
+export function getAllPaths(result: SarifResult): ThreadFlow[] {
   if (result.codeFlows === undefined) {
     return [];
   }

--- a/extensions/ql-vscode/test/common/logging/output-channel-logger.test.ts
+++ b/extensions/ql-vscode/test/common/logging/output-channel-logger.test.ts
@@ -1,6 +1,6 @@
 import { readdirSync, readFileSync } from "fs-extra";
 import { join } from "path";
-import * as tmp from "tmp";
+import { DirResult, dirSync } from "tmp";
 import { BaseLogger, Logger, TeeLogger } from "../../../src/common/logging";
 import { OutputChannelLogger } from "../../../src/common/logging/vscode";
 
@@ -29,14 +29,14 @@ jest.mock(
 );
 
 describe("OutputChannelLogger tests", function () {
-  const tempFolders: Record<string, tmp.DirResult> = {};
+  const tempFolders: Record<string, DirResult> = {};
   let logger: any;
 
   beforeEach(async () => {
-    tempFolders.globalStoragePath = tmp.dirSync({
+    tempFolders.globalStoragePath = dirSync({
       prefix: "logging-tests-global",
     });
-    tempFolders.storagePath = tmp.dirSync({
+    tempFolders.storagePath = dirSync({
       prefix: "logging-tests-workspace",
     });
     logger = new OutputChannelLogger("test-logger");

--- a/extensions/ql-vscode/test/factories/authentication.ts
+++ b/extensions/ql-vscode/test/factories/authentication.ts
@@ -1,10 +1,10 @@
-import * as Octokit from "@octokit/rest";
+import { Octokit } from "@octokit/rest";
 import { RequestInterface } from "@octokit/types/dist-types/RequestInterface";
 
 import { Credentials } from "../../src/common/authentication";
 import { AppOctokit } from "../../src/common/octokit";
 
-function makeTestOctokit(octokit: Octokit.Octokit): Credentials {
+function makeTestOctokit(octokit: Octokit): Credentials {
   return {
     getOctokit: async () => octokit,
     getAccessToken: async () => {

--- a/extensions/ql-vscode/test/factories/extension-context.ts
+++ b/extensions/ql-vscode/test/factories/extension-context.ts
@@ -1,4 +1,4 @@
-import * as vscode from "vscode";
+import { ExtensionContext, Memento, Uri } from "vscode";
 import { createMockMemento } from "../mock-memento";
 
 /**
@@ -12,13 +12,13 @@ export function createMockExtensionContext({
   extensionPath?: string;
   workspaceStoragePath?: string;
   globalStoragePath?: string;
-  workspaceState?: vscode.Memento;
-}): vscode.ExtensionContext {
+  workspaceState?: Memento;
+}): ExtensionContext {
   return {
     extensionPath,
-    globalStorageUri: vscode.Uri.file(globalStoragePath),
-    storageUri: vscode.Uri.file(workspaceStoragePath),
+    globalStorageUri: Uri.file(globalStoragePath),
+    storageUri: Uri.file(workspaceStoragePath),
     workspaceState: createMockMemento(),
     subscriptions: [],
-  } as any as vscode.ExtensionContext;
+  } as any as ExtensionContext;
 }

--- a/extensions/ql-vscode/test/unit-tests/codeql-cli/distribution/releases-api-consumer.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/codeql-cli/distribution/releases-api-consumer.test.ts
@@ -1,4 +1,4 @@
-import * as fetch from "node-fetch";
+import { Response } from "node-fetch";
 import { Range } from "semver";
 
 import {
@@ -73,10 +73,10 @@ describe("Releases API consumer", () => {
     ];
 
     class MockReleasesApiConsumer extends ReleasesApiConsumer {
-      protected async makeApiCall(apiPath: string): Promise<fetch.Response> {
+      protected async makeApiCall(apiPath: string): Promise<Response> {
         if (apiPath === `/repos/${repositoryNwo}/releases`) {
           return Promise.resolve(
-            new fetch.Response(JSON.stringify(sampleReleaseResponse)),
+            new Response(JSON.stringify(sampleReleaseResponse)),
           );
         }
         return Promise.reject(new Error(`Unknown API path: ${apiPath}`));
@@ -181,7 +181,7 @@ describe("Releases API consumer", () => {
     ];
 
     class MockReleasesApiConsumer extends ReleasesApiConsumer {
-      protected async makeApiCall(apiPath: string): Promise<fetch.Response> {
+      protected async makeApiCall(apiPath: string): Promise<Response> {
         if (apiPath === `/repos/${repositoryNwo}/releases`) {
           const responseBody: GithubRelease[] = [
             {
@@ -194,9 +194,7 @@ describe("Releases API consumer", () => {
             },
           ];
 
-          return Promise.resolve(
-            new fetch.Response(JSON.stringify(responseBody)),
-          );
+          return Promise.resolve(new Response(JSON.stringify(responseBody)));
         }
         return Promise.reject(new Error(`Unknown API path: ${apiPath}`));
       }

--- a/extensions/ql-vscode/test/unit-tests/common/files.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/common/files.test.ts
@@ -8,8 +8,7 @@ import {
   readDirFullPaths,
   walkDirectory,
 } from "../../../src/common/files";
-import { DirResult } from "tmp";
-import * as tmp from "tmp";
+import { DirResult, dirSync } from "tmp";
 import { ensureDirSync, symlinkSync, writeFileSync } from "fs-extra";
 
 describe("files", () => {
@@ -360,7 +359,7 @@ describe("walkDirectory", () => {
   let dir2: string;
 
   beforeEach(() => {
-    tmpDir = tmp.dirSync({ unsafeCleanup: true });
+    tmpDir = dirSync({ unsafeCleanup: true });
     dir = join(tmpDir.name, "dir");
     ensureDirSync(dir);
     dir2 = join(tmpDir.name, "dir2");

--- a/extensions/ql-vscode/test/unit-tests/common/sarif-utils.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/common/sarif-utils.test.ts
@@ -1,4 +1,4 @@
-import * as Sarif from "sarif";
+import { Location } from "sarif";
 
 import {
   getPathRelativeToSourceLocationPrefix,
@@ -109,7 +109,7 @@ describe("parsing sarif", () => {
     });
 
     it("should parse a sarif location with no region and no file protocol", () => {
-      const location: Sarif.Location = {
+      const location: Location = {
         physicalLocation: {
           artifactLocation: {
             uri: "abc?x=test",
@@ -124,7 +124,7 @@ describe("parsing sarif", () => {
     });
 
     it("should parse a sarif location with no region and file protocol", () => {
-      const location: Sarif.Location = {
+      const location: Location = {
         physicalLocation: {
           artifactLocation: {
             uri: "file:/abc%3Fx%3Dtest",
@@ -139,7 +139,7 @@ describe("parsing sarif", () => {
     });
 
     it("should parse a sarif location with a region and file protocol", () => {
-      const location: Sarif.Location = {
+      const location: Location = {
         physicalLocation: {
           artifactLocation: {
             uri: "file:abc%3Fx%3Dtest",

--- a/extensions/ql-vscode/test/unit-tests/databases/local-databases/db-contents-heuristics.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/local-databases/db-contents-heuristics.test.ts
@@ -1,4 +1,4 @@
-import * as tmp from "tmp";
+import { DirResult, dirSync } from "tmp";
 import { join } from "path";
 import { mkdirSync, writeFileSync } from "fs-extra";
 import {
@@ -7,9 +7,9 @@ import {
 } from "../../../../src/databases/local-databases/db-contents-heuristics";
 
 describe("isLikelyDatabaseRoot", () => {
-  let dir: tmp.DirResult;
+  let dir: DirResult;
   beforeEach(() => {
-    dir = tmp.dirSync({
+    dir = dirSync({
       unsafeCleanup: true,
     });
   });
@@ -54,9 +54,9 @@ describe("isLikelyDatabaseRoot", () => {
 });
 
 describe("isLikelyDbLanguageFolder", () => {
-  let dir: tmp.DirResult;
+  let dir: DirResult;
   beforeEach(() => {
-    dir = tmp.dirSync({
+    dir = dirSync({
       unsafeCleanup: true,
     });
   });

--- a/extensions/ql-vscode/test/unit-tests/local-queries/query-contents.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/local-queries/query-contents.test.ts
@@ -1,4 +1,4 @@
-import * as tmp from "tmp";
+import { DirResult, dirSync } from "tmp";
 import { dump } from "js-yaml";
 import { writeFileSync } from "fs-extra";
 import { join } from "path";
@@ -6,11 +6,11 @@ import { QueryLanguage } from "../../../src/common/query-language";
 import { getInitialQueryContents } from "../../../src/local-queries/query-contents";
 
 describe("getInitialQueryContents", () => {
-  let dir: tmp.DirResult;
+  let dir: DirResult;
   let language: QueryLanguage;
 
   beforeEach(() => {
-    dir = tmp.dirSync({
+    dir = dirSync({
       unsafeCleanup: true,
     });
     language = QueryLanguage.Cpp;

--- a/extensions/ql-vscode/test/unit-tests/model-editor/auto-model.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/model-editor/auto-model.test.ts
@@ -6,13 +6,13 @@ import {
 import { Mode } from "../../../src/model-editor/shared/mode";
 import { AutomodelMode } from "../../../src/model-editor/auto-model-api";
 import { AutoModelQueriesResult } from "../../../src/model-editor/auto-model-codeml-queries";
-import * as sarif from "sarif";
+import { Log } from "sarif";
 import { gzipDecode } from "../../../src/common/zlib";
 import { Method } from "../../../src/model-editor/method";
 import { ModeledMethod } from "../../../src/model-editor/modeled-method";
 
 describe("createAutoModelRequest", () => {
-  const createSarifLog = (queryId: string): sarif.Log => {
+  const createSarifLog = (queryId: string): Log => {
     return {
       version: "2.1.0",
       $schema: "http://json.schemastore.org/sarif-2.1.0-rtm.4",

--- a/extensions/ql-vscode/test/unit-tests/sarif-processing.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/sarif-processing.test.ts
@@ -1,4 +1,4 @@
-import * as sarif from "sarif";
+import { Log, PhysicalLocation, ReportingDescriptor, Result, Run } from "sarif";
 import {
   extractAnalysisAlerts,
   tryGetFilePath,
@@ -17,11 +17,11 @@ describe("SARIF processing", () => {
         const result = {
           message: "msg",
           // Rule is missing here.
-        } as sarif.Result;
+        } as Result;
 
         const sarifRun = {
           results: [result],
-        } as sarif.Run;
+        } as Run;
 
         const rule = tryGetRule(sarifRun, result);
 
@@ -34,7 +34,7 @@ describe("SARIF processing", () => {
           rule: {
             id: "NonExistentRule",
           },
-        } as sarif.Result;
+        } as Result;
 
         const sarifRun = {
           results: [result],
@@ -51,7 +51,7 @@ describe("SARIF processing", () => {
               ],
             },
           },
-        } as sarif.Run;
+        } as Run;
 
         const rule = tryGetRule(sarifRun, result);
 
@@ -64,7 +64,7 @@ describe("SARIF processing", () => {
           rule: {
             id: "B",
           },
-        } as sarif.Result;
+        } as Result;
 
         const sarifRun = {
           results: [result],
@@ -78,7 +78,7 @@ describe("SARIF processing", () => {
               ],
             },
           },
-        } as sarif.Run;
+        } as Run;
 
         const rule = tryGetRule(sarifRun, result);
 
@@ -97,7 +97,7 @@ describe("SARIF processing", () => {
               index: 1,
             },
           },
-        } as sarif.Result;
+        } as Result;
 
         const sarifRun = {
           results: [result],
@@ -127,7 +127,7 @@ describe("SARIF processing", () => {
               },
             ],
           },
-        } as sarif.Run;
+        } as Run;
 
         const rule = tryGetRule(sarifRun, result);
 
@@ -143,7 +143,7 @@ describe("SARIF processing", () => {
               // The tool component index should be set here.
             },
           },
-        } as sarif.Result;
+        } as Result;
 
         const sarifRun = {
           results: [result],
@@ -173,7 +173,7 @@ describe("SARIF processing", () => {
               },
             ],
           },
-        } as sarif.Run;
+        } as Run;
 
         const rule = tryGetRule(sarifRun, result);
 
@@ -189,14 +189,14 @@ describe("SARIF processing", () => {
               index: 1,
             },
           },
-        } as sarif.Result;
+        } as Result;
 
         const sarifRun = {
           results: [result],
           tool: {
             // Extensions should be set here.
           },
-        } as sarif.Run;
+        } as Run;
 
         const rule = tryGetRule(sarifRun, result);
 
@@ -212,7 +212,7 @@ describe("SARIF processing", () => {
               index: 1,
             },
           },
-        } as sarif.Result;
+        } as Result;
 
         const sarifRun = {
           results: [result],
@@ -232,7 +232,7 @@ describe("SARIF processing", () => {
               // There should be one more extension here (index 1).
             ],
           },
-        } as sarif.Run;
+        } as Run;
 
         const rule = tryGetRule(sarifRun, result);
 
@@ -249,7 +249,7 @@ describe("SARIF processing", () => {
               index: 1,
             },
           },
-        } as sarif.Result;
+        } as Result;
 
         const sarifRun = {
           results: [result],
@@ -279,7 +279,7 @@ describe("SARIF processing", () => {
               },
             ],
           },
-        } as sarif.Run;
+        } as Run;
 
         const rule = tryGetRule(sarifRun, result);
 
@@ -291,7 +291,7 @@ describe("SARIF processing", () => {
 
   describe("tryGetFilePath", () => {
     it("should return value when uri is a file path", () => {
-      const physicalLocation: sarif.PhysicalLocation = {
+      const physicalLocation: PhysicalLocation = {
         artifactLocation: {
           uri: "foo/bar",
         },
@@ -300,7 +300,7 @@ describe("SARIF processing", () => {
     });
 
     it("should return undefined when uri has a file scheme", () => {
-      const physicalLocation: sarif.PhysicalLocation = {
+      const physicalLocation: PhysicalLocation = {
         artifactLocation: {
           uri: "file:/",
         },
@@ -309,7 +309,7 @@ describe("SARIF processing", () => {
     });
 
     it("should return undefined when uri is empty", () => {
-      const physicalLocation: sarif.PhysicalLocation = {
+      const physicalLocation: PhysicalLocation = {
         artifactLocation: {
           uri: "",
         },
@@ -318,7 +318,7 @@ describe("SARIF processing", () => {
     });
 
     it("should return undefined if artifact location uri is undefined", () => {
-      const physicalLocation: sarif.PhysicalLocation = {
+      const physicalLocation: PhysicalLocation = {
         artifactLocation: {
           uri: undefined,
         },
@@ -327,7 +327,7 @@ describe("SARIF processing", () => {
     });
 
     it("should return undefined if artifact location is undefined", () => {
-      const physicalLocation: sarif.PhysicalLocation = {
+      const physicalLocation: PhysicalLocation = {
         artifactLocation: undefined,
       };
       expect(tryGetFilePath(physicalLocation)).toBe(undefined);
@@ -338,14 +338,14 @@ describe("SARIF processing", () => {
     it("should return undefined if no rule set", () => {
       const result = {
         message: "msg",
-      } as sarif.Result;
+      } as Result;
 
       // The rule should be set here.
-      const rule: sarif.ReportingDescriptor | undefined = undefined;
+      const rule: ReportingDescriptor | undefined = undefined;
 
       const sarifRun = {
         results: [result],
-      } as sarif.Run;
+      } as Run;
 
       const severity = tryGetSeverity(sarifRun, result, rule);
       expect(severity).toBeUndefined();
@@ -357,14 +357,14 @@ describe("SARIF processing", () => {
         rule: {
           id: "A",
         },
-      } as sarif.Result;
+      } as Result;
 
       const rule = {
         id: "A",
         properties: {
           // Severity not set
         },
-      } as sarif.ReportingDescriptor;
+      } as ReportingDescriptor;
 
       const sarifRun = {
         results: [result],
@@ -373,7 +373,7 @@ describe("SARIF processing", () => {
             rules: [rule, result.rule],
           },
         },
-      } as sarif.Run;
+      } as Run;
 
       const severity = tryGetSeverity(sarifRun, result, rule);
       expect(severity).toBeUndefined();
@@ -392,14 +392,14 @@ describe("SARIF processing", () => {
           rule: {
             id: "A",
           },
-        } as sarif.Result;
+        } as Result;
 
         const rule = {
           id: "A",
           properties: {
             "problem.severity": sarifSeverity,
           },
-        } as sarif.ReportingDescriptor;
+        } as ReportingDescriptor;
 
         const sarifRun = {
           results: [result],
@@ -408,7 +408,7 @@ describe("SARIF processing", () => {
               rules: [rule, result.rule],
             },
           },
-        } as sarif.Run;
+        } as Run;
 
         const severity = tryGetSeverity(sarifRun, result, rule);
         expect(severity).toBe(parsedSeverity);
@@ -421,7 +421,7 @@ describe("SARIF processing", () => {
     it("should not return any results if no runs found in the SARIF", () => {
       const sarif = {
         // Runs are missing here.
-      } as sarif.Log;
+      } as Log;
 
       const result = extractAnalysisAlerts(sarif, fakefileLinkPrefix);
 
@@ -439,7 +439,7 @@ describe("SARIF processing", () => {
             // Results are missing here.
           },
         ],
-      } as sarif.Log;
+      } as Log;
 
       const result = extractAnalysisAlerts(sarif, fakefileLinkPrefix);
 
@@ -524,7 +524,7 @@ describe("SARIF processing", () => {
 
     it("should return results for all alerts", () => {
       const sarif = {
-        version: "0.0.1" as sarif.Log.version,
+        version: "0.0.1" as Log.version,
         runs: [
           {
             results: [
@@ -602,7 +602,7 @@ describe("SARIF processing", () => {
             ],
           },
         ],
-      } as sarif.Log;
+      } as Log;
 
       const result = extractAnalysisAlerts(sarif, fakefileLinkPrefix);
       expect(result).toBeTruthy();
@@ -770,7 +770,7 @@ describe("SARIF processing", () => {
     expect(array).toEqual([]);
   }
 
-  function buildValidSarifLog(): sarif.Log {
+  function buildValidSarifLog(): Log {
     return {
       version: "2.1.0",
       runs: [
@@ -805,7 +805,7 @@ describe("SARIF processing", () => {
           ],
         },
       ],
-    } as sarif.Log;
+    } as Log;
   }
 
   function getMessageText(message: AnalysisMessage) {

--- a/extensions/ql-vscode/test/vscode-tests/activated-extension/databases/db-panel.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/activated-extension/databases/db-panel.test.ts
@@ -1,7 +1,7 @@
 import { window } from "vscode";
 
 import { readJson } from "fs-extra";
-import * as path from "path";
+import { join } from "path";
 import {
   DbConfig,
   SelectedDbItemKind,
@@ -32,10 +32,7 @@ describe("Db panel UI commands", () => {
     storagePath =
       extension.ctx.storageUri?.fsPath || extension.ctx.globalStorageUri.fsPath;
 
-    dbConfigFilePath = path.join(
-      storagePath,
-      DbConfigStore.databaseConfigFileName,
-    );
+    dbConfigFilePath = join(storagePath, DbConfigStore.databaseConfigFileName);
   });
 
   it("should add new remote db list", async () => {

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/local-queries/skeleton-query-wizard.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/local-queries/skeleton-query-wizard.test.ts
@@ -4,7 +4,7 @@ import {
   SkeletonQueryWizard,
 } from "../../../../src/local-queries/skeleton-query-wizard";
 import { mockedObject, mockedQuickPickItem } from "../../utils/mocking.helpers";
-import * as tmp from "tmp";
+import { DirResult, dirSync } from "tmp";
 import {
   MessageItem,
   TextDocument,
@@ -48,7 +48,7 @@ describe("SkeletonQueryWizard", () => {
   let mockApp: App;
   let wizard: SkeletonQueryWizard;
   let mockDatabaseManager: DatabaseManager;
-  let dir: tmp.DirResult;
+  let dir: DirResult;
   let storagePath: string;
   let quickPickSpy: jest.SpiedFunction<typeof window.showQuickPick>;
   let showInputBoxSpy: jest.SpiedFunction<typeof window.showInputBox>;
@@ -104,7 +104,7 @@ describe("SkeletonQueryWizard", () => {
       databaseItems: [] as DatabaseItem[],
     });
 
-    dir = tmp.dirSync({
+    dir = dirSync({
       prefix: "skeleton_query_wizard_",
       unsafeCleanup: true,
     });
@@ -699,10 +699,10 @@ describe("SkeletonQueryWizard", () => {
     });
 
     describe("with folders and files", () => {
-      let queriesDir: tmp.DirResult;
+      let queriesDir: DirResult;
 
       beforeEach(async () => {
-        queriesDir = tmp.dirSync({
+        queriesDir = dirSync({
           prefix: "queries_",
           unsafeCleanup: true,
         });

--- a/extensions/ql-vscode/test/vscode-tests/jest.activated-extension.setup.ts
+++ b/extensions/ql-vscode/test/vscode-tests/jest.activated-extension.setup.ts
@@ -1,6 +1,6 @@
 import { env } from "vscode";
 import { beforeEachAction as testConfigBeforeEachAction } from "./test-config";
-import * as tmp from "tmp";
+import { DirResult, dirSync } from "tmp";
 import { realpathSync } from "fs-extra";
 import {
   getActivatedExtension,
@@ -15,11 +15,11 @@ if (process.env.CI) {
 }
 
 // create an extension storage location
-let removeStorage: tmp.DirResult["removeCallback"] | undefined;
+let removeStorage: DirResult["removeCallback"] | undefined;
 
 export async function beforeAllAction() {
   // Create the temp directory to be used as extension local storage.
-  const dir = tmp.dirSync({
+  const dir = dirSync({
     unsafeCleanup: true,
   });
   let storagePath = realpathSync(dir.name);

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/common/vscode/file-path-discovery.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/common/vscode/file-path-discovery.test.ts
@@ -9,7 +9,7 @@ import {
 import { FilePathDiscovery } from "../../../../../src/common/vscode/file-path-discovery";
 import { basename, dirname, join } from "path";
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
-import * as tmp from "tmp";
+import { dirSync } from "tmp";
 import { normalizePath } from "../../../../../src/common/files";
 import { extLogger } from "../../../../../src/common/logging/vscode/loggers";
 import { getErrorMessage } from "../../../../../src/common/helpers-pure";
@@ -83,7 +83,7 @@ describe("FilePathDiscovery", () => {
   let discovery: TestFilePathDiscovery;
 
   beforeEach(() => {
-    const t = tmp.dirSync({
+    const t = dirSync({
       unsafeCleanup: true,
     });
     tmpDir = normalizePath(t.name);

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-queries/determining-selected-query-test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-queries/determining-selected-query-test.ts
@@ -1,16 +1,15 @@
-import { resolve, join } from "path";
-import * as vscode from "vscode";
-import { Uri } from "vscode";
+import { join, resolve } from "path";
+import { TextDocument, Uri, window, workspace } from "vscode";
 import {
   getQuickEvalContext,
   validateQueryUri,
 } from "../../../../src/run-queries-shared";
 
-async function showQlDocument(name: string): Promise<vscode.TextDocument> {
-  const folderPath = vscode.workspace.workspaceFolders![0].uri.fsPath;
+async function showQlDocument(name: string): Promise<TextDocument> {
+  const folderPath = workspace.workspaceFolders![0].uri.fsPath;
   const documentPath = resolve(folderPath, name);
-  const document = await vscode.workspace.openTextDocument(documentPath);
-  await vscode.window.showTextDocument(document!);
+  const document = await workspace.openTextDocument(documentPath);
+  await window.showTextDocument(document!);
   return document;
 }
 

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-queries/local-databases.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-queries/local-databases.test.ts
@@ -1,4 +1,4 @@
-import * as tmp from "tmp";
+import { DirResult, dirSync } from "tmp";
 import { ensureDir, ensureFile, pathExists, writeFile } from "fs-extra";
 import { join } from "path";
 import { ExtensionContext, Uri, workspace } from "vscode";
@@ -48,11 +48,11 @@ describe("local databases", () => {
     typeof dialog.showNeverAskAgainDialog
   >;
 
-  let dir: tmp.DirResult;
+  let dir: DirResult;
   let extensionContextStoragePath: string;
 
   beforeEach(() => {
-    dir = tmp.dirSync({
+    dir = dirSync({
       unsafeCleanup: true,
     });
 

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/qlpack-generator.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/qlpack-generator.test.ts
@@ -5,7 +5,7 @@ import { QueryLanguage } from "../../../src/common/query-language";
 import { CodeQLCliServer } from "../../../src/codeql-cli/cli";
 import { Uri, workspace } from "vscode";
 import { getErrorMessage } from "../../../src/common/helpers-pure";
-import * as tmp from "tmp";
+import { DirResult, dirSync } from "tmp";
 import { mockedObject } from "../utils/mocking.helpers";
 import { ensureDir, readFile } from "fs-extra";
 import { load } from "js-yaml";
@@ -22,10 +22,10 @@ describe("QlPackGenerator", () => {
     typeof CodeQLCliServer.prototype.resolveQlpacks
   >;
   let mockCli: CodeQLCliServer;
-  let dir: tmp.DirResult;
+  let dir: DirResult;
 
   beforeEach(async () => {
-    dir = tmp.dirSync({
+    dir = dirSync({
       unsafeCleanup: true,
     });
 

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/queries-panel/query-discovery.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/queries-panel/query-discovery.test.ts
@@ -5,7 +5,7 @@ import {
 } from "../../../../src/queries-panel/query-discovery";
 import { createMockApp } from "../../../__mocks__/appMock";
 import { basename, dirname, join } from "path";
-import * as tmp from "tmp";
+import { dirSync } from "tmp";
 import {
   FileTreeDirectory,
   FileTreeLeaf,
@@ -31,7 +31,7 @@ describe("Query pack discovery", () => {
   let discovery: QueryDiscovery;
 
   beforeEach(() => {
-    const t = tmp.dirSync({
+    const t = dirSync({
       unsafeCleanup: true,
     });
     tmpDir = t.name;

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/queries-panel/query-pack-discovery.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/queries-panel/query-pack-discovery.test.ts
@@ -1,6 +1,6 @@
 import { Uri, workspace } from "vscode";
 import { QueryPackDiscovery } from "../../../../src/queries-panel/query-pack-discovery";
-import * as tmp from "tmp";
+import { dirSync } from "tmp";
 import { dirname, join } from "path";
 import { ensureDir, writeJSON } from "fs-extra";
 import { QueryLanguage } from "../../../../src/common/query-language";
@@ -14,7 +14,7 @@ describe("Query pack discovery", () => {
   let discovery: QueryPackDiscovery;
 
   beforeEach(() => {
-    const t = tmp.dirSync({
+    const t = dirSync({
       unsafeCleanup: true,
     });
     tmpDir = t.name;

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/query-testing/qltest-discovery.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/query-testing/qltest-discovery.test.ts
@@ -1,10 +1,9 @@
 import { Uri, WorkspaceFolder } from "vscode";
-import * as fs from "fs-extra";
+import { remove } from "fs-extra";
 import { join } from "path";
 
 import { QLTestDiscovery } from "../../../../src/query-testing/qltest-discovery";
-import { DirectoryResult } from "tmp-promise";
-import * as tmp from "tmp-promise";
+import { DirectoryResult, dir } from "tmp-promise";
 
 import "../../../matchers/toEqualPath";
 import { mockedObject } from "../../utils/mocking.helpers";
@@ -22,7 +21,7 @@ describe("qltest-discovery", () => {
     let qlTestDiscover: QLTestDiscovery;
 
     beforeEach(async () => {
-      directory = await tmp.dir({
+      directory = await dir({
         unsafeCleanup: true,
       });
 
@@ -83,7 +82,7 @@ describe("qltest-discovery", () => {
     });
 
     it("should avoid discovery if a folder does not exist", async () => {
-      await fs.remove(baseDir);
+      await remove(baseDir);
 
       await qlTestDiscover.refresh();
       const testDirectory = qlTestDiscover.testDirectory;

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/code-tour/code-tour.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/code-tour/code-tour.test.ts
@@ -1,5 +1,5 @@
 import { Uri, window, workspace, WorkspaceFolder } from "vscode";
-import * as tmp from "tmp";
+import { DirResult, dirSync } from "tmp";
 import { join } from "path";
 import { mkdir, writeFile } from "fs-extra";
 
@@ -8,13 +8,13 @@ import { Setting } from "../../../../src/config";
 import { createMockCommandManager } from "../../../__mocks__/commandsMock";
 
 describe("prepareCodeTour", () => {
-  let dir: tmp.DirResult;
+  let dir: DirResult;
   let showInformationMessageSpy: jest.SpiedFunction<
     typeof window.showInformationMessage
   >;
 
   beforeEach(() => {
-    dir = tmp.dirSync({
+    dir = dirSync({
       unsafeCleanup: true,
     });
 

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/codeql-cli/distribution.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/codeql-cli/distribution.test.ts
@@ -1,10 +1,9 @@
 import * as log from "../../../../src/common/logging/notifications";
 import { extLogger } from "../../../../src/common/logging/vscode";
-import * as fs from "fs-extra";
-import * as path from "path";
+import { writeFile } from "fs-extra";
+import { join } from "path";
 import * as os from "os";
-import * as tmp from "tmp-promise";
-import { DirectoryResult } from "tmp-promise";
+import { dir, DirectoryResult } from "tmp-promise";
 import {
   DistributionManager,
   getExecutableFromDirectory,
@@ -45,12 +44,12 @@ describe("Launcher path", () => {
 
     mockedOS.platform.mockReturnValue("win32");
 
-    directory = await tmp.dir({
+    directory = await dir({
       unsafeCleanup: true,
     });
 
-    pathToCmd = path.join(directory.path, "codeql.cmd");
-    pathToExe = path.join(directory.path, "codeql.exe");
+    pathToCmd = join(directory.path, "codeql.cmd");
+    pathToExe = join(directory.path, "codeql.exe");
   });
 
   afterEach(async () => {
@@ -58,7 +57,7 @@ describe("Launcher path", () => {
   });
 
   it("should not warn with proper launcher name", async () => {
-    await fs.writeFile(pathToExe, "");
+    await writeFile(pathToExe, "");
 
     const result = await getExecutableFromDirectory(directory.path);
 
@@ -70,7 +69,7 @@ describe("Launcher path", () => {
   });
 
   it("should warn when using a hard-coded deprecated launcher name", async () => {
-    await fs.writeFile(pathToCmd, "");
+    await writeFile(pathToCmd, "");
 
     const result = await getExecutableFromDirectory(directory.path);
 
@@ -102,7 +101,7 @@ describe("Launcher path", () => {
   });
 
   it("should not warn when deprecated launcher is used, but no new launcher is available", async function () {
-    await fs.writeFile(pathToCmd, "");
+    await writeFile(pathToCmd, "");
 
     const manager = new DistributionManager(
       { customCodeQlPath: pathToCmd } as any,
@@ -119,8 +118,8 @@ describe("Launcher path", () => {
   });
 
   it("should warn when deprecated launcher is used, and new launcher is available", async () => {
-    await fs.writeFile(pathToCmd, "");
-    await fs.writeFile(pathToExe, "");
+    await writeFile(pathToCmd, "");
+    await writeFile(pathToExe, "");
 
     const manager = new DistributionManager(
       { customCodeQlPath: pathToCmd } as any,

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/common/vscode/external-files.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/common/vscode/external-files.test.ts
@@ -1,22 +1,20 @@
-import * as vscode from "vscode";
+import { TextEditor, Uri, window } from "vscode";
 import { tryOpenExternalFile } from "../../../../../src/common/vscode/external-files";
 import { createMockCommandManager } from "../../../../__mocks__/commandsMock";
 import { mockedObject } from "../../../utils/mocking.helpers";
 
 describe("tryOpenExternalFile", () => {
-  let showTextDocumentSpy: jest.SpiedFunction<
-    typeof vscode.window.showTextDocument
-  >;
+  let showTextDocumentSpy: jest.SpiedFunction<typeof window.showTextDocument>;
   let showInformationMessageSpy: jest.SpiedFunction<
-    typeof vscode.window.showInformationMessage
+    typeof window.showInformationMessage
   >;
 
   beforeEach(() => {
     showTextDocumentSpy = jest
-      .spyOn(vscode.window, "showTextDocument")
-      .mockResolvedValue(mockedObject<vscode.TextEditor>({}));
+      .spyOn(window, "showTextDocument")
+      .mockResolvedValue(mockedObject<TextEditor>({}));
     showInformationMessageSpy = jest
-      .spyOn(vscode.window, "showInformationMessage")
+      .spyOn(window, "showInformationMessage")
       .mockResolvedValue(undefined);
   });
 
@@ -27,7 +25,7 @@ describe("tryOpenExternalFile", () => {
     await tryOpenExternalFile(commandManager, "xxx");
     expect(showTextDocumentSpy).toHaveBeenCalledTimes(1);
     expect(showTextDocumentSpy).toHaveBeenCalledWith(
-      vscode.Uri.file("xxx"),
+      Uri.file("xxx"),
       expect.anything(),
     );
     expect(executeCommand).not.toBeCalled();
@@ -45,7 +43,7 @@ describe("tryOpenExternalFile", () => {
       showInformationMessageSpy.mockResolvedValue({ title: "Yes" });
 
       await tryOpenExternalFile(commandManager, "xxx");
-      const uri = vscode.Uri.file("xxx");
+      const uri = Uri.file("xxx");
       expect(showTextDocumentSpy).toHaveBeenCalledTimes(1);
       expect(showTextDocumentSpy).toHaveBeenCalledWith(uri, expect.anything());
       expect(executeCommand).toHaveBeenCalledWith("revealFileInOS", uri);
@@ -59,7 +57,7 @@ describe("tryOpenExternalFile", () => {
       showInformationMessageSpy.mockResolvedValue({ title: "No" });
 
       await tryOpenExternalFile(commandManager, "xxx");
-      const uri = vscode.Uri.file("xxx");
+      const uri = Uri.file("xxx");
       expect(showTextDocumentSpy).toHaveBeenCalledTimes(1);
       expect(showTextDocumentSpy).toHaveBeenCalledWith(uri, expect.anything());
       expect(showInformationMessageSpy).toBeCalled();

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/databases/database-fetcher.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/databases/database-fetcher.test.ts
@@ -1,13 +1,13 @@
 import { join } from "path";
 import { createFileSync, mkdirSync } from "fs-extra";
-import * as tmp from "tmp";
+import { DirResult, dirSync } from "tmp";
 import { window } from "vscode";
 
 import {
   convertGithubNwoToDatabaseUrl,
   findDirWithFile,
 } from "../../../../src/databases/database-fetcher";
-import * as Octokit from "@octokit/rest";
+import { Octokit } from "@octokit/rest";
 import {
   mockedObject,
   mockedOctokitFunction,
@@ -26,7 +26,7 @@ describe("database-fetcher", () => {
       "codeScanning",
       "listCodeqlDatabases"
     >();
-    const octokit = mockedObject<Octokit.Octokit>({
+    const octokit = mockedObject<Octokit>({
       rest: {
         codeScanning: {
           listCodeqlDatabases: mockListCodeqlDatabases,
@@ -202,9 +202,9 @@ describe("database-fetcher", () => {
   });
 
   describe("findDirWithFile", () => {
-    let dir: tmp.DirResult;
+    let dir: DirResult;
     beforeEach(() => {
-      dir = tmp.dirSync({ unsafeCleanup: true });
+      dir = dirSync({ unsafeCleanup: true });
       createFile("a");
       createFile("b");
       createFile("c");

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/databases/github-databases/api.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/databases/github-databases/api.test.ts
@@ -6,7 +6,7 @@ import { GitHubDatabaseConfig } from "../../../../../src/config";
 import * as dialog from "../../../../../src/common/vscode/dialog";
 import { listDatabases } from "../../../../../src/databases/github-databases/api";
 import { Credentials } from "../../../../../src/common/authentication";
-import * as Octokit from "@octokit/rest";
+import { Octokit } from "@octokit/rest";
 import { AppOctokit } from "../../../../../src/common/octokit";
 import { RequestError } from "@octokit/request-error";
 
@@ -18,7 +18,7 @@ const appMockListCodeqlDatabases = mockedOctokitFunction<
   "codeScanning",
   "listCodeqlDatabases"
 >();
-const appOctokit = mockedObject<Octokit.Octokit>({
+const appOctokit = mockedObject<Octokit>({
   rest: {
     codeScanning: {
       listCodeqlDatabases: appMockListCodeqlDatabases,
@@ -41,7 +41,7 @@ describe("listDatabases", () => {
     "codeScanning",
     "listCodeqlDatabases"
   >();
-  const octokit = mockedObject<Octokit.Octokit>({
+  const octokit = mockedObject<Octokit>({
     rest: {
       codeScanning: {
         listCodeqlDatabases: mockListCodeqlDatabases,

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/language-support/contextual/query-resolver.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/language-support/contextual/query-resolver.test.ts
@@ -1,5 +1,5 @@
 import { load } from "js-yaml";
-import * as fs from "fs-extra";
+import { readFile } from "fs-extra";
 
 import { getErrorMessage } from "../../../../../src/common/helpers-pure";
 
@@ -109,7 +109,7 @@ describe("queryResolver", () => {
 
       const fileName = resolveQueriesInSuite.mock.calls[0][0];
 
-      expect(load(await fs.readFile(fileName, "utf-8"))).toEqual([
+      expect(load(await readFile(fileName, "utf-8"))).toEqual([
         {
           from: "my-qlpack",
           queries: ".",

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/local-queries/query-resolver.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/local-queries/query-resolver.test.ts
@@ -8,7 +8,7 @@ import * as qlpack from "../../../../src/databases/qlpack";
 import * as workspaceFolders from "../../../../src/common/vscode/workspace-folders";
 import * as log from "../../../../src/common/logging/notifications";
 import { load } from "js-yaml";
-import * as fs from "fs-extra";
+import { readFile } from "fs-extra";
 
 describe("qlpackOfDatabase", () => {
   let getQlPackForDbschemeSpy: jest.SpiedFunction<
@@ -87,7 +87,7 @@ describe("resolveQueries", () => {
 
     const fileName = resolveQueriesInSuite.mock.calls[0][0];
 
-    expect(load(await fs.readFile(fileName, "utf-8"))).toEqual([
+    expect(load(await readFile(fileName, "utf-8"))).toEqual([
       {
         from: "my-qlpack",
         queries: ".",

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/history-tree-data-provider.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/history-tree-data-provider.test.ts
@@ -1,5 +1,11 @@
 import { join } from "path";
-import * as vscode from "vscode";
+import {
+  ExtensionContext,
+  ThemeColor,
+  ThemeIcon,
+  Uri,
+  workspace,
+} from "vscode";
 
 import { extLogger } from "../../../../src/common/logging/vscode";
 import { QueryHistoryConfigListener } from "../../../../src/config";
@@ -165,7 +171,7 @@ describe("HistoryTreeDataProvider", () => {
       });
       expect(treeItem.label).toContain("query-file.ql");
       expect(treeItem.contextValue).toBe("rawResultsItem");
-      expect(treeItem.iconPath).toEqual(new vscode.ThemeIcon("database"));
+      expect(treeItem.iconPath).toEqual(new ThemeIcon("database"));
     });
 
     it("should get a tree item with interpreted results", async () => {
@@ -181,7 +187,7 @@ describe("HistoryTreeDataProvider", () => {
         mockQueryWithInterpretedResults,
       );
       expect(treeItem.contextValue).toBe("interpretedResultsItem");
-      expect(treeItem.iconPath).toEqual(new vscode.ThemeIcon("database"));
+      expect(treeItem.iconPath).toEqual(new ThemeIcon("database"));
     });
 
     it("should get a tree item that did not complete successfully", async () => {
@@ -195,7 +201,7 @@ describe("HistoryTreeDataProvider", () => {
 
       const treeItem = await historyTreeDataProvider.getTreeItem(mockQuery);
       expect(treeItem.iconPath).toEqual(
-        new vscode.ThemeIcon("error", new vscode.ThemeColor("errorForeground")),
+        new ThemeIcon("error", new ThemeColor("errorForeground")),
       );
     });
 
@@ -207,7 +213,7 @@ describe("HistoryTreeDataProvider", () => {
 
       const treeItem = await historyTreeDataProvider.getTreeItem(mockQuery);
       expect(treeItem.iconPath).toEqual(
-        new vscode.ThemeIcon("error", new vscode.ThemeColor("errorForeground")),
+        new ThemeIcon("error", new ThemeColor("errorForeground")),
       );
     });
 
@@ -497,9 +503,9 @@ describe("HistoryTreeDataProvider", () => {
       {} as EvalLogViewer,
       createMockQueryHistoryDirs(),
       {
-        globalStorageUri: vscode.Uri.file(mockExtensionLocation),
-        extensionPath: vscode.Uri.file("/x/y/z").fsPath,
-      } as vscode.ExtensionContext,
+        globalStorageUri: Uri.file(mockExtensionLocation),
+        extensionPath: Uri.file("/x/y/z").fsPath,
+      } as ExtensionContext,
       configListener,
       new HistoryItemLabelProvider({
         format: "",
@@ -510,7 +516,7 @@ describe("HistoryTreeDataProvider", () => {
       doCompareCallback,
     );
     (qhm.treeDataProvider as any).history = [...allHistory];
-    await vscode.workspace.saveAll();
+    await workspace.saveAll();
     await qhm.refreshTreeView();
     return qhm;
   }

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-manager.test.ts
@@ -1,5 +1,5 @@
 import { join } from "path";
-import * as vscode from "vscode";
+import { ExtensionContext, Uri, window, workspace } from "vscode";
 
 import { extLogger } from "../../../../src/common/logging/vscode";
 import { QueryHistoryManager } from "../../../../src/query-history/query-history-manager";
@@ -33,7 +33,7 @@ import { LanguageContextStore } from "../../../../src/language-context-store";
 describe("QueryHistoryManager", () => {
   const mockExtensionLocation = join(tmpDir.name, "mock-extension-location");
   let configListener: QueryHistoryConfigListener;
-  let showQuickPickSpy: jest.SpiedFunction<typeof vscode.window.showQuickPick>;
+  let showQuickPickSpy: jest.SpiedFunction<typeof window.showQuickPick>;
   let cancelVariantAnalysisSpy: jest.SpiedFunction<
     typeof variantAnalysisManagerStub.cancelVariantAnalysis
   >;
@@ -55,7 +55,7 @@ describe("QueryHistoryManager", () => {
 
   beforeEach(() => {
     showQuickPickSpy = jest
-      .spyOn(vscode.window, "showQuickPick")
+      .spyOn(window, "showQuickPick")
       .mockResolvedValue(undefined);
 
     executeCommand = jest.fn();
@@ -929,9 +929,9 @@ describe("QueryHistoryManager", () => {
       {} as EvalLogViewer,
       createMockQueryHistoryDirs(),
       {
-        globalStorageUri: vscode.Uri.file(mockExtensionLocation),
-        extensionPath: vscode.Uri.file("/x/y/z").fsPath,
-      } as vscode.ExtensionContext,
+        globalStorageUri: Uri.file(mockExtensionLocation),
+        extensionPath: Uri.file("/x/y/z").fsPath,
+      } as ExtensionContext,
       configListener,
       new HistoryItemLabelProvider({
         format: "",
@@ -942,7 +942,7 @@ describe("QueryHistoryManager", () => {
       doCompareCallback,
     );
     (qhm.treeDataProvider as any).history = [...allHistory];
-    await vscode.workspace.saveAll();
+    await workspace.saveAll();
     await qhm.refreshTreeView();
     return qhm;
   }

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-scrubber.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-scrubber.test.ts
@@ -1,6 +1,6 @@
 import { readdirSync, mkdirSync, writeFileSync } from "fs-extra";
 import { join } from "path";
-import * as vscode from "vscode";
+import { Disposable, ExtensionContext } from "vscode";
 
 import { extLogger } from "../../../../src/common/logging/vscode";
 import { registerQueryHistoryScrubber } from "../../../../src/query-history/query-history-scrubber";
@@ -21,7 +21,7 @@ const now = Date.now();
 const LESS_THAN_ONE_DAY = ONE_DAY_IN_MS - 1000;
 
 describe("query history scrubber", () => {
-  let deregister: vscode.Disposable | undefined;
+  let deregister: Disposable | undefined;
   let tmpDir: DirResult;
 
   beforeEach(() => {
@@ -160,7 +160,7 @@ describe("query history scrubber", () => {
     return `query-${timestamp}`;
   }
 
-  function createMockContext(): vscode.ExtensionContext {
+  function createMockContext(): ExtensionContext {
     return {
       globalState: {
         lastScrubTime: now,
@@ -177,13 +177,10 @@ describe("query history scrubber", () => {
           this.lastScrubTime = value;
         },
       },
-    } as any as vscode.ExtensionContext;
+    } as any as ExtensionContext;
   }
 
-  function registerScrubber(
-    dir: string,
-    ctx: vscode.ExtensionContext,
-  ): jest.Mock {
+  function registerScrubber(dir: string, ctx: ExtensionContext): jest.Mock {
     const onScrubberRun = jest.fn();
     deregister = registerQueryHistoryScrubber(
       ONE_HOUR_IN_MS,

--- a/extensions/ql-vscode/test/vscode-tests/utils/mocking.helpers.ts
+++ b/extensions/ql-vscode/test/vscode-tests/utils/mocking.helpers.ts
@@ -1,6 +1,6 @@
 import type { QuickPickItem, window, Uri } from "vscode";
 import { DatabaseItem } from "../../../src/databases/local-databases";
-import * as Octokit from "@octokit/rest";
+import { Octokit } from "@octokit/rest";
 
 export type DeepPartial<T> = T extends object
   ? {
@@ -84,11 +84,11 @@ export function mockedObject<T extends object>(
 }
 
 export function mockedOctokitFunction<
-  Namespace extends keyof Octokit.Octokit["rest"],
-  Name extends keyof Octokit.Octokit["rest"][Namespace],
->(): Octokit.Octokit["rest"][Namespace][Name] & jest.Mock {
+  Namespace extends keyof Octokit["rest"],
+  Name extends keyof Octokit["rest"][Namespace],
+>(): Octokit["rest"][Namespace][Name] & jest.Mock {
   const fn = jest.fn();
-  return fn as unknown as Octokit.Octokit["rest"][Namespace][Name] & jest.Mock;
+  return fn as unknown as Octokit["rest"][Namespace][Name] & jest.Mock;
 }
 
 export function mockDatabaseItem(


### PR DESCRIPTION
This removes all unnecessary namespace imports. The only namespace imports that are left are those that are needed for spying on functions in tests and for React in the `.storybook` directory because it doesn't support the automatic JSX runtime.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
