### PR TITLE
Run separate CLI server for test discovery

### DIFF
--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -246,6 +246,7 @@ export class CodeQLCliServer implements Disposable {
     private distributionProvider: DistributionProvider,
     private cliConfig: CliConfig,
     public readonly logger: Logger,
+    private readonly name = "CodeQL Cli Server",
   ) {
     this.commandQueue = [];
     this.commandInProcess = false;
@@ -260,6 +261,27 @@ export class CodeQLCliServer implements Disposable {
         this.restartCliServer();
       });
     }
+  }
+
+  /**
+   * Creates a clone of this CLI server with the same configuration. This is useful
+   * for creating a separate CLI server for running some commands in a different
+   * process to avoid blocking the main CLI server.
+   *
+   * To ensure that the CLI server is only used for its intended purpose, the
+   * generic `AvailableMethods` parameter should be set to the union of the
+   * methods that the CLI server will be used for.
+   */
+  public createClone<AvailableMethods extends keyof CodeQLCliServer>(
+    name: string,
+  ): Pick<CodeQLCliServer, AvailableMethods> & Disposable {
+    return new CodeQLCliServer(
+      this.app,
+      this.distributionProvider,
+      this.cliConfig,
+      this.logger,
+      name,
+    );
   }
 
   dispose(): void {
@@ -340,7 +362,7 @@ export class CodeQLCliServer implements Disposable {
 
     return spawnServer(
       codeQlPath,
-      "CodeQL CLI Server",
+      this.name,
       ["execute", "cli-server"],
       args,
       this.logger,

--- a/extensions/ql-vscode/src/query-testing/qltest-discovery.ts
+++ b/extensions/ql-vscode/src/query-testing/qltest-discovery.ts
@@ -26,7 +26,7 @@ export class QLTestDiscovery extends Discovery {
 
   constructor(
     private readonly workspaceFolder: WorkspaceFolder,
-    private readonly cliServer: CodeQLCliServer,
+    private readonly cliServer: Pick<CodeQLCliServer, "resolveTests">,
   ) {
     super("QL Test Discovery", extLogger);
 

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-testing/test-runner-helpers.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-testing/test-runner-helpers.ts
@@ -39,7 +39,10 @@ export function createMockCliServerForTestRun() {
     cliServer: mockedObject<CodeQLCliServer>({
       runTests: runTestsSpy,
       resolveQlpacks: resolveQlpacksSpy,
-      resolveTests: resolveTestsSpy,
+      createClone: () =>
+        mockedObject<CodeQLCliServer>({
+          resolveTests: resolveTestsSpy,
+        }),
     }),
     runTestsSpy,
   };

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-testing/test-runner.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-testing/test-runner.test.ts
@@ -33,8 +33,6 @@ describe("test-runner", () => {
   const renameDatabaseItemSpy = jest.fn();
   const setCurrentDatabaseItemSpy = jest.fn();
   let runTestsSpy: jest.Mock<any, any>;
-  const resolveTestsSpy = jest.fn();
-  const resolveQlpacksSpy = jest.fn();
 
   const preTestDatabaseItem = new DatabaseItemImpl(
     Uri.file("/path/to/test/dir/dir.testproj"),
@@ -58,8 +56,6 @@ describe("test-runner", () => {
     removeDatabaseItemSpy.mockResolvedValue(undefined);
     renameDatabaseItemSpy.mockResolvedValue(undefined);
     setCurrentDatabaseItemSpy.mockResolvedValue(undefined);
-    resolveQlpacksSpy.mockResolvedValue({});
-    resolveTestsSpy.mockResolvedValue([]);
     fakeDatabaseManager = mockedObject<DatabaseManager>(
       {
         openDatabase: openDatabaseSpy,


### PR DESCRIPTION
This is a workaround for the fact that the `resolveTests` command can take a long time to run for large workspaces. We don't want to block other CLI commands from running while this is happening, so we'll create a separate CLI server just for this.

I haven't yet tested how this behaves when the CLI is being updated, but I first wanted to validate that this is something we want to do.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
