### PR TITLE
Fix missing `await` in `prepareModelEditorQueries`

### DIFF
--- a/extensions/ql-vscode/src/model-editor/model-editor-queries.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-queries.ts
@@ -55,10 +55,12 @@ export async function prepareModelEditorQueries(
     return false;
   }
   // Create the query file.
-  Object.values(Mode).map(async (mode) => {
-    const queryFile = join(queryDir, queryNameFromMode(mode));
-    await writeFile(queryFile, query[`${mode}ModeQuery`], "utf8");
-  });
+  await Promise.all(
+    Object.values(Mode).map(async (mode) => {
+      const queryFile = join(queryDir, queryNameFromMode(mode));
+      await writeFile(queryFile, query[`${mode}ModeQuery`], "utf8");
+    }),
+  );
 
   // Create any dependencies
   if (query.dependencies) {


### PR DESCRIPTION
This fixes a missing `await` in `prepareModelEditorQueries` that caused the function to potentially return before the query files were written.

This was discovered by looking at the error in https://github.com/github/vscode-codeql/pull/3197.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
