### PR TITLE
Remove all dependency cycles

### DIFF
--- a/extensions/ql-vscode/.eslintrc.js
+++ b/extensions/ql-vscode/.eslintrc.js
@@ -67,7 +67,7 @@ const baseConfig = {
     "github/array-foreach": "off",
     "github/no-then": "off",
     "react/jsx-key": ["error", { checkFragmentShorthand: true }],
-    "import/no-cycle": "off",
+    "import/no-cycle": "error",
     // Never allow extensions in import paths, except for JSON files where they are required.
     "import/extensions": ["error", "never", { json: "always" }],
   },

--- a/extensions/ql-vscode/src/codeql-cli/cli-command.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli-command.ts
@@ -1,0 +1,50 @@
+import { execFile } from "child_process";
+import { promisify } from "util";
+
+import type { BaseLogger } from "../common/logging";
+import type { ProgressReporter } from "../common/logging/vscode";
+import { getChildProcessErrorMessage } from "../common/helpers-pure";
+
+/**
+ * Flags to pass to all cli commands.
+ */
+export const LOGGING_FLAGS = ["-v", "--log-to-stderr"];
+
+/**
+ * Runs a CodeQL CLI command without invoking the CLI server, returning the output as a string.
+ * @param codeQlPath The path to the CLI.
+ * @param command The `codeql` command to be run, provided as an array of command/subcommand names.
+ * @param commandArgs The arguments to pass to the `codeql` command.
+ * @param description Description of the action being run, to be shown in log and error messages.
+ * @param logger Logger to write command log messages, e.g. to an output channel.
+ * @param progressReporter Used to output progress messages, e.g. to the status bar.
+ * @returns The contents of the command's stdout, if the command succeeded.
+ */
+export async function runCodeQlCliCommand(
+  codeQlPath: string,
+  command: string[],
+  commandArgs: string[],
+  description: string,
+  logger: BaseLogger,
+  progressReporter?: ProgressReporter,
+): Promise<string> {
+  // Add logging arguments first, in case commandArgs contains positional parameters.
+  const args = command.concat(LOGGING_FLAGS).concat(commandArgs);
+  const argsString = args.join(" ");
+  try {
+    if (progressReporter !== undefined) {
+      progressReporter.report({ message: description });
+    }
+    void logger.log(
+      `${description} using CodeQL CLI: ${codeQlPath} ${argsString}...`,
+    );
+    const result = await promisify(execFile)(codeQlPath, args);
+    void logger.log(result.stderr);
+    void logger.log("CLI command succeeded.");
+    return result.stdout;
+  } catch (err) {
+    throw new Error(
+      `${description} failed: ${getChildProcessErrorMessage(err)}`,
+    );
+  }
+}

--- a/extensions/ql-vscode/src/codeql-cli/cli-version.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli-version.ts
@@ -1,6 +1,6 @@
 import type { SemVer } from "semver";
 import { parse } from "semver";
-import { runCodeQlCliCommand } from "./cli";
+import { runCodeQlCliCommand } from "./cli-command";
 import type { Logger } from "../common/logging";
 import { getErrorMessage } from "../common/helpers-pure";
 

--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -1,14 +1,13 @@
 import { EOL } from "os";
 import { spawn } from "child-process-promise";
 import type { ChildProcessWithoutNullStreams } from "child_process";
-import { execFile, spawn as spawnChildProcess } from "child_process";
+import { spawn as spawnChildProcess } from "child_process";
 import { readFile } from "fs-extra";
 import { delimiter, dirname, join } from "path";
 import type { Log } from "sarif";
 import { SemVer } from "semver";
 import type { Readable } from "stream";
 import tk from "tree-kill";
-import { promisify } from "util";
 import type { CancellationToken, Disposable, Uri } from "vscode";
 
 import type {
@@ -21,7 +20,6 @@ import type { DistributionProvider } from "./distribution";
 import { FindDistributionResultKind } from "./distribution";
 import {
   assertNever,
-  getChildProcessErrorMessage,
   getErrorMessage,
   getErrorStack,
 } from "../common/helpers-pure";
@@ -35,6 +33,7 @@ import type { App } from "../common/app";
 import { QueryLanguage } from "../common/query-language";
 import { LINE_ENDINGS, splitStreamAtSeparators } from "../common/split-stream";
 import type { Position } from "../query-server/messages";
+import { LOGGING_FLAGS } from "./cli-command";
 
 /**
  * The version of the SARIF format that we are using.
@@ -45,11 +44,6 @@ const SARIF_FORMAT = "sarifv2.1.0";
  * The string used to specify CSV format.
  */
 const CSV_FORMAT = "csv";
-
-/**
- * Flags to pass to all cli commands.
- */
-const LOGGING_FLAGS = ["-v", "--log-to-stderr"];
 
 /**
  * The expected output of `codeql resolve queries --format bylanguage`.
@@ -1630,45 +1624,6 @@ export function spawnServer(
   }
   void logger.log(`${name} started on PID: ${child.pid}`);
   return child;
-}
-
-/**
- * Runs a CodeQL CLI command without invoking the CLI server, returning the output as a string.
- * @param codeQlPath The path to the CLI.
- * @param command The `codeql` command to be run, provided as an array of command/subcommand names.
- * @param commandArgs The arguments to pass to the `codeql` command.
- * @param description Description of the action being run, to be shown in log and error messages.
- * @param logger Logger to write command log messages, e.g. to an output channel.
- * @param progressReporter Used to output progress messages, e.g. to the status bar.
- * @returns The contents of the command's stdout, if the command succeeded.
- */
-export async function runCodeQlCliCommand(
-  codeQlPath: string,
-  command: string[],
-  commandArgs: string[],
-  description: string,
-  logger: Logger,
-  progressReporter?: ProgressReporter,
-): Promise<string> {
-  // Add logging arguments first, in case commandArgs contains positional parameters.
-  const args = command.concat(LOGGING_FLAGS).concat(commandArgs);
-  const argsString = args.join(" ");
-  try {
-    if (progressReporter !== undefined) {
-      progressReporter.report({ message: description });
-    }
-    void logger.log(
-      `${description} using CodeQL CLI: ${codeQlPath} ${argsString}...`,
-    );
-    const result = await promisify(execFile)(codeQlPath, args);
-    void logger.log(result.stderr);
-    void logger.log("CLI command succeeded.");
-    return result.stdout;
-  } catch (err) {
-    throw new Error(
-      `${description} failed: ${getChildProcessErrorMessage(err)}`,
-    );
-  }
 }
 
 /**

--- a/extensions/ql-vscode/src/debugger/debugger-ui.ts
+++ b/extensions/ql-vscode/src/debugger/debugger-ui.ts
@@ -11,10 +11,10 @@ import { DisposableObject } from "../common/disposable-object";
 import type { CoreQueryResults } from "../query-server";
 import {
   getQuickEvalContext,
-  QueryOutputDir,
   saveBeforeStart,
   validateQueryUri,
 } from "../run-queries-shared";
+import { QueryOutputDir } from "../local-queries/query-output-dir";
 import type { QLResolvedDebugConfiguration } from "./debug-configuration";
 import type {
   AnyProtocolMessage,

--- a/extensions/ql-vscode/src/language-support/ast-viewer/ast-builder.ts
+++ b/extensions/ql-vscode/src/language-support/ast-viewer/ast-builder.ts
@@ -7,7 +7,7 @@ import type {
 import type { DatabaseItem } from "../../databases/local-databases";
 import type { ChildAstItem, AstItem } from "./ast-viewer";
 import type { Uri } from "vscode";
-import type { QueryOutputDir } from "../../run-queries-shared";
+import type { QueryOutputDir } from "../../local-queries/query-output-dir";
 import { fileRangeFromURI } from "../contextual/file-range-from-uri";
 import { mapUrlValue } from "../../common/bqrs-raw-results-mapper";
 

--- a/extensions/ql-vscode/src/language-support/contextual/location-finder.ts
+++ b/extensions/ql-vscode/src/language-support/contextual/location-finder.ts
@@ -21,7 +21,7 @@ import {
 } from "./query-resolver";
 import type { CancellationToken, LocationLink } from "vscode";
 import { Uri } from "vscode";
-import type { QueryOutputDir } from "../../run-queries-shared";
+import type { QueryOutputDir } from "../../local-queries/query-output-dir";
 import type { QueryRunner } from "../../query-server";
 import { QueryResultType } from "../../query-server/messages";
 import { fileRangeFromURI } from "./file-range-from-uri";

--- a/extensions/ql-vscode/src/local-queries/local-queries.ts
+++ b/extensions/ql-vscode/src/local-queries/local-queries.ts
@@ -29,7 +29,8 @@ import type {
   DatabaseItem,
   DatabaseManager,
 } from "../databases/local-databases";
-import type { QueryOutputDir, SelectedQuery } from "../run-queries-shared";
+import type { SelectedQuery } from "../run-queries-shared";
+import type { QueryOutputDir } from "./query-output-dir";
 import {
   createInitialQueryInfo,
   createTimestampFile,

--- a/extensions/ql-vscode/src/local-queries/local-query-run.ts
+++ b/extensions/ql-vscode/src/local-queries/local-query-run.ts
@@ -9,9 +9,9 @@ import type { QueryHistoryManager } from "../query-history/query-history-manager
 import type { DatabaseItem } from "../databases/local-databases";
 import type {
   EvaluatorLogPaths,
-  QueryOutputDir,
   QueryWithResults,
 } from "../run-queries-shared";
+import type { QueryOutputDir } from "./query-output-dir";
 import {
   generateEvalLogSummaries,
   logEndSummary,

--- a/extensions/ql-vscode/src/local-queries/query-output-dir.ts
+++ b/extensions/ql-vscode/src/local-queries/query-output-dir.ts
@@ -1,0 +1,75 @@
+import { join } from "path";
+
+function findQueryLogFile(resultPath: string): string {
+  return join(resultPath, "query.log");
+}
+
+function findQueryEvalLogFile(resultPath: string): string {
+  return join(resultPath, "evaluator-log.jsonl");
+}
+
+function findQueryEvalLogSummaryFile(resultPath: string): string {
+  return join(resultPath, "evaluator-log.summary");
+}
+
+function findJsonQueryEvalLogSummaryFile(resultPath: string): string {
+  return join(resultPath, "evaluator-log.summary.jsonl");
+}
+
+function findQueryEvalLogSummarySymbolsFile(resultPath: string): string {
+  return join(resultPath, "evaluator-log.summary.symbols.json");
+}
+
+function findQueryEvalLogEndSummaryFile(resultPath: string): string {
+  return join(resultPath, "evaluator-log-end.summary");
+}
+
+/**
+ * Provides paths to the files that can be generated in the output directory for a query evaluation.
+ */
+export class QueryOutputDir {
+  constructor(public readonly querySaveDir: string) {}
+
+  get dilPath() {
+    return join(this.querySaveDir, "results.dil");
+  }
+
+  /**
+   * Get the path that the compiled query is if it exists. Note that it only exists when using the legacy query server.
+   */
+  get compileQueryPath() {
+    return join(this.querySaveDir, "compiledQuery.qlo");
+  }
+
+  get csvPath() {
+    return join(this.querySaveDir, "results.csv");
+  }
+
+  get logPath() {
+    return findQueryLogFile(this.querySaveDir);
+  }
+
+  get evalLogPath() {
+    return findQueryEvalLogFile(this.querySaveDir);
+  }
+
+  get evalLogSummaryPath() {
+    return findQueryEvalLogSummaryFile(this.querySaveDir);
+  }
+
+  get jsonEvalLogSummaryPath() {
+    return findJsonQueryEvalLogSummaryFile(this.querySaveDir);
+  }
+
+  get evalLogSummarySymbolsPath() {
+    return findQueryEvalLogSummarySymbolsFile(this.querySaveDir);
+  }
+
+  get evalLogEndSummaryPath() {
+    return findQueryEvalLogEndSummaryFile(this.querySaveDir);
+  }
+
+  get bqrsPath() {
+    return join(this.querySaveDir, "results.bqrs");
+  }
+}

--- a/extensions/ql-vscode/src/query-history/store/query-history-domain-mapper.ts
+++ b/extensions/ql-vscode/src/query-history/store/query-history-domain-mapper.ts
@@ -2,9 +2,7 @@ import { assertNever } from "../../common/helpers-pure";
 import type { QueryHistoryInfo } from "../query-history-info";
 import { mapLocalQueryInfoToDto } from "./query-history-local-query-domain-mapper";
 import type { QueryHistoryItemDto } from "./query-history-dto";
-import { QueryLanguageDto } from "./query-history-dto";
 import { mapQueryHistoryVariantAnalysisToDto } from "./query-history-variant-analysis-domain-mapper";
-import { QueryLanguage } from "../../common/query-language";
 
 export function mapQueryHistoryToDto(
   queries: QueryHistoryInfo[],
@@ -18,29 +16,4 @@ export function mapQueryHistoryToDto(
       assertNever(q);
     }
   });
-}
-
-export function mapQueryLanguageToDto(
-  language: QueryLanguage,
-): QueryLanguageDto {
-  switch (language) {
-    case QueryLanguage.CSharp:
-      return QueryLanguageDto.CSharp;
-    case QueryLanguage.Cpp:
-      return QueryLanguageDto.Cpp;
-    case QueryLanguage.Go:
-      return QueryLanguageDto.Go;
-    case QueryLanguage.Java:
-      return QueryLanguageDto.Java;
-    case QueryLanguage.Javascript:
-      return QueryLanguageDto.Javascript;
-    case QueryLanguage.Python:
-      return QueryLanguageDto.Python;
-    case QueryLanguage.Ruby:
-      return QueryLanguageDto.Ruby;
-    case QueryLanguage.Swift:
-      return QueryLanguageDto.Swift;
-    default:
-      assertNever(language);
-  }
 }

--- a/extensions/ql-vscode/src/query-history/store/query-history-dto-mapper.ts
+++ b/extensions/ql-vscode/src/query-history/store/query-history-dto-mapper.ts
@@ -1,10 +1,7 @@
 import type { QueryHistoryInfo } from "../query-history-info";
 import type { QueryHistoryItemDto } from "./query-history-dto";
-import { QueryLanguageDto } from "./query-history-dto";
 import { mapQueryHistoryVariantAnalysisToDomainModel } from "./query-history-variant-analysis-dto-mapper";
 import { mapLocalQueryItemToDomainModel } from "./query-history-local-query-dto-mapper";
-import { QueryLanguage } from "../../common/query-language";
-import { assertNever } from "../../common/helpers-pure";
 
 export function mapQueryHistoryToDomainModel(
   queries: QueryHistoryItemDto[],
@@ -22,29 +19,4 @@ export function mapQueryHistoryToDomainModel(
       )}`,
     );
   });
-}
-
-export function mapQueryLanguageToDomainModel(
-  language: QueryLanguageDto,
-): QueryLanguage {
-  switch (language) {
-    case QueryLanguageDto.CSharp:
-      return QueryLanguage.CSharp;
-    case QueryLanguageDto.Cpp:
-      return QueryLanguage.Cpp;
-    case QueryLanguageDto.Go:
-      return QueryLanguage.Go;
-    case QueryLanguageDto.Java:
-      return QueryLanguage.Java;
-    case QueryLanguageDto.Javascript:
-      return QueryLanguage.Javascript;
-    case QueryLanguageDto.Python:
-      return QueryLanguage.Python;
-    case QueryLanguageDto.Ruby:
-      return QueryLanguage.Ruby;
-    case QueryLanguageDto.Swift:
-      return QueryLanguage.Swift;
-    default:
-      assertNever(language);
-  }
 }

--- a/extensions/ql-vscode/src/query-history/store/query-history-language-domain-mapper.ts
+++ b/extensions/ql-vscode/src/query-history/store/query-history-language-domain-mapper.ts
@@ -1,0 +1,28 @@
+import { assertNever } from "../../common/helpers-pure";
+import { QueryLanguageDto } from "./query-history-dto";
+import { QueryLanguage } from "../../common/query-language";
+
+export function mapQueryLanguageToDto(
+  language: QueryLanguage,
+): QueryLanguageDto {
+  switch (language) {
+    case QueryLanguage.CSharp:
+      return QueryLanguageDto.CSharp;
+    case QueryLanguage.Cpp:
+      return QueryLanguageDto.Cpp;
+    case QueryLanguage.Go:
+      return QueryLanguageDto.Go;
+    case QueryLanguage.Java:
+      return QueryLanguageDto.Java;
+    case QueryLanguage.Javascript:
+      return QueryLanguageDto.Javascript;
+    case QueryLanguage.Python:
+      return QueryLanguageDto.Python;
+    case QueryLanguage.Ruby:
+      return QueryLanguageDto.Ruby;
+    case QueryLanguage.Swift:
+      return QueryLanguageDto.Swift;
+    default:
+      assertNever(language);
+  }
+}

--- a/extensions/ql-vscode/src/query-history/store/query-history-language-dto-mapper.ts
+++ b/extensions/ql-vscode/src/query-history/store/query-history-language-dto-mapper.ts
@@ -1,0 +1,28 @@
+import { QueryLanguageDto } from "./query-history-dto";
+import { QueryLanguage } from "../../common/query-language";
+import { assertNever } from "../../common/helpers-pure";
+
+export function mapQueryLanguageToDomainModel(
+  language: QueryLanguageDto,
+): QueryLanguage {
+  switch (language) {
+    case QueryLanguageDto.CSharp:
+      return QueryLanguage.CSharp;
+    case QueryLanguageDto.Cpp:
+      return QueryLanguage.Cpp;
+    case QueryLanguageDto.Go:
+      return QueryLanguage.Go;
+    case QueryLanguageDto.Java:
+      return QueryLanguage.Java;
+    case QueryLanguageDto.Javascript:
+      return QueryLanguage.Javascript;
+    case QueryLanguageDto.Python:
+      return QueryLanguage.Python;
+    case QueryLanguageDto.Ruby:
+      return QueryLanguage.Ruby;
+    case QueryLanguageDto.Swift:
+      return QueryLanguage.Swift;
+    default:
+      assertNever(language);
+  }
+}

--- a/extensions/ql-vscode/src/query-history/store/query-history-local-query-domain-mapper.ts
+++ b/extensions/ql-vscode/src/query-history/store/query-history-local-query-domain-mapper.ts
@@ -17,7 +17,7 @@ import type {
   SortedResultSetInfo,
 } from "../../common/interface-types";
 import { SortDirection } from "../../common/interface-types";
-import { mapQueryLanguageToDto } from "./query-history-domain-mapper";
+import { mapQueryLanguageToDto } from "./query-history-language-domain-mapper";
 
 export function mapLocalQueryInfoToDto(
   query: LocalQueryInfo,

--- a/extensions/ql-vscode/src/query-history/store/query-history-local-query-dto-mapper.ts
+++ b/extensions/ql-vscode/src/query-history/store/query-history-local-query-dto-mapper.ts
@@ -18,7 +18,7 @@ import type {
   SortedResultSetInfo,
 } from "../../common/interface-types";
 import { SortDirection } from "../../common/interface-types";
-import { mapQueryLanguageToDomainModel } from "./query-history-dto-mapper";
+import { mapQueryLanguageToDomainModel } from "./query-history-language-dto-mapper";
 
 export function mapLocalQueryItemToDomainModel(
   localQuery: QueryHistoryLocalQueryDto,

--- a/extensions/ql-vscode/src/query-history/store/query-history-local-query-dto-mapper.ts
+++ b/extensions/ql-vscode/src/query-history/store/query-history-local-query-dto-mapper.ts
@@ -1,6 +1,8 @@
 import type { InitialQueryInfo } from "../../query-results";
 import { LocalQueryInfo, CompletedQueryInfo } from "../../query-results";
-import { QueryEvaluationInfo, QueryOutputDir } from "../../run-queries-shared";
+import { QueryEvaluationInfo } from "../../run-queries-shared";
+import { QueryOutputDir } from "../../local-queries/query-output-dir";
+import { SortDirectionDto } from "./query-history-local-query-dto";
 import type {
   CompletedQueryInfoDto,
   QueryEvaluationInfoDto,
@@ -10,7 +12,6 @@ import type {
   SortedResultSetInfoDto,
   RawResultsSortStateDto,
 } from "./query-history-local-query-dto";
-import { SortDirectionDto } from "./query-history-local-query-dto";
 import type {
   InterpretedResultsSortState,
   RawResultsSortState,

--- a/extensions/ql-vscode/src/query-history/store/query-history-variant-analysis-domain-mapper.ts
+++ b/extensions/ql-vscode/src/query-history/store/query-history-variant-analysis-domain-mapper.ts
@@ -27,7 +27,7 @@ import {
 import { assertNever } from "../../common/helpers-pure";
 import { QueryStatus } from "../query-status";
 import type { VariantAnalysisHistoryItem } from "../variant-analysis-history-item";
-import { mapQueryLanguageToDto } from "./query-history-domain-mapper";
+import { mapQueryLanguageToDto } from "./query-history-language-domain-mapper";
 
 export function mapQueryHistoryVariantAnalysisToDto(
   item: VariantAnalysisHistoryItem,

--- a/extensions/ql-vscode/src/query-history/store/query-history-variant-analysis-dto-mapper.ts
+++ b/extensions/ql-vscode/src/query-history/store/query-history-variant-analysis-dto-mapper.ts
@@ -27,7 +27,7 @@ import {
 import { assertNever } from "../../common/helpers-pure";
 import { QueryStatus } from "../query-status";
 import type { VariantAnalysisHistoryItem } from "../variant-analysis-history-item";
-import { mapQueryLanguageToDomainModel } from "./query-history-dto-mapper";
+import { mapQueryLanguageToDomainModel } from "./query-history-language-dto-mapper";
 
 export function mapQueryHistoryVariantAnalysisToDomainModel(
   item: QueryHistoryVariantAnalysisDto,

--- a/extensions/ql-vscode/src/query-results.ts
+++ b/extensions/ql-vscode/src/query-results.ts
@@ -19,9 +19,9 @@ import { QueryStatus } from "./query-history/query-status";
 import type {
   EvaluatorLogPaths,
   QueryEvaluationInfo,
-  QueryOutputDir,
   QueryWithResults,
 } from "./run-queries-shared";
+import type { QueryOutputDir } from "./local-queries/query-output-dir";
 import { sarifParser } from "./common/sarif-parser";
 
 /**

--- a/extensions/ql-vscode/src/query-server/query-runner.ts
+++ b/extensions/ql-vscode/src/query-server/query-runner.ts
@@ -1,10 +1,10 @@
-import type { CancellationToken } from "vscode";
-import vscode from "vscode";
+import { window } from "vscode";
+import type { CancellationToken, MessageItem } from "vscode";
 import type { CodeQLCliServer } from "../codeql-cli/cli";
 import type { ProgressCallback } from "../common/vscode/progress";
 import { UserCancellationException } from "../common/vscode/progress";
-import type { DatabaseItem } from "../databases/local-databases";
-import { QueryOutputDir } from "../run-queries-shared";
+import type { DatabaseItem } from "../databases/local-databases/database-item";
+import { QueryOutputDir } from "../local-queries/query-output-dir";
 import type {
   ClearCacheParams,
   Position,
@@ -178,11 +178,11 @@ export class QueryRunner {
   ): Promise<void> {
     const yesItem = { title: "Yes", isCloseAffordance: false };
     const noItem = { title: "No", isCloseAffordance: true };
-    const dialogOptions: vscode.MessageItem[] = [yesItem, noItem];
+    const dialogOptions: MessageItem[] = [yesItem, noItem];
 
     const message = `Should the database ${dbItem.databaseUri.fsPath} be destructively upgraded?\n\nThis should not be necessary to run queries
     as we will non-destructively update it anyway.`;
-    const chosenItem = await vscode.window.showInformationMessage(
+    const chosenItem = await window.showInformationMessage(
       message,
       { modal: true },
       ...dialogOptions,

--- a/extensions/ql-vscode/src/query-server/run-queries.ts
+++ b/extensions/ql-vscode/src/query-server/run-queries.ts
@@ -2,7 +2,7 @@ import type { CancellationToken } from "vscode";
 import type { ProgressCallback } from "../common/vscode/progress";
 import type { RunQueryParams } from "./messages";
 import { runQuery } from "./messages";
-import type { QueryOutputDir } from "../run-queries-shared";
+import type { QueryOutputDir } from "../local-queries/query-output-dir";
 import type { QueryServerClient } from "./query-server-client";
 import type { CoreQueryResults, CoreQueryTarget } from "./query-runner";
 import type { BaseLogger } from "../common/logging";

--- a/extensions/ql-vscode/src/run-queries-shared.ts
+++ b/extensions/ql-vscode/src/run-queries-shared.ts
@@ -15,7 +15,7 @@ import {
 } from "fs-extra";
 import type { InitialQueryInfo } from "./query-results";
 import { ensureMetadataIsComplete } from "./query-results";
-import { isQuickQueryPath } from "./local-queries";
+import { isQuickQueryPath } from "./local-queries/quick-query";
 import { nanoid } from "nanoid";
 import type { CodeQLCliServer } from "./codeql-cli/cli";
 import { SELECT_QUERY_NAME } from "./language-support";
@@ -30,6 +30,7 @@ import { extLogger } from "./common/logging/vscode";
 import { generateSummarySymbolsFile } from "./log-insights/summary-parser";
 import { getErrorMessage } from "./common/helpers-pure";
 import { createHash } from "crypto";
+import { QueryOutputDir } from "./local-queries/query-output-dir";
 
 /**
  * run-queries.ts
@@ -47,80 +48,6 @@ export interface EvaluatorLogPaths {
   endSummary: string | undefined;
   jsonSummary: string | undefined;
   summarySymbols: string | undefined;
-}
-
-function findQueryLogFile(resultPath: string): string {
-  return join(resultPath, "query.log");
-}
-
-function findQueryEvalLogFile(resultPath: string): string {
-  return join(resultPath, "evaluator-log.jsonl");
-}
-
-function findQueryEvalLogSummaryFile(resultPath: string): string {
-  return join(resultPath, "evaluator-log.summary");
-}
-
-function findJsonQueryEvalLogSummaryFile(resultPath: string): string {
-  return join(resultPath, "evaluator-log.summary.jsonl");
-}
-
-function findQueryEvalLogSummarySymbolsFile(resultPath: string): string {
-  return join(resultPath, "evaluator-log.summary.symbols.json");
-}
-
-function findQueryEvalLogEndSummaryFile(resultPath: string): string {
-  return join(resultPath, "evaluator-log-end.summary");
-}
-
-/**
- * Provides paths to the files that can be generated in the output directory for a query evaluation.
- */
-export class QueryOutputDir {
-  constructor(public readonly querySaveDir: string) {}
-
-  get dilPath() {
-    return join(this.querySaveDir, "results.dil");
-  }
-
-  /**
-   * Get the path that the compiled query is if it exists. Note that it only exists when using the legacy query server.
-   */
-  get compileQueryPath() {
-    return join(this.querySaveDir, "compiledQuery.qlo");
-  }
-
-  get csvPath() {
-    return join(this.querySaveDir, "results.csv");
-  }
-
-  get logPath() {
-    return findQueryLogFile(this.querySaveDir);
-  }
-
-  get evalLogPath() {
-    return findQueryEvalLogFile(this.querySaveDir);
-  }
-
-  get evalLogSummaryPath() {
-    return findQueryEvalLogSummaryFile(this.querySaveDir);
-  }
-
-  get jsonEvalLogSummaryPath() {
-    return findJsonQueryEvalLogSummaryFile(this.querySaveDir);
-  }
-
-  get evalLogSummarySymbolsPath() {
-    return findQueryEvalLogSummarySymbolsFile(this.querySaveDir);
-  }
-
-  get evalLogEndSummaryPath() {
-    return findQueryEvalLogEndSummaryFile(this.querySaveDir);
-  }
-
-  get bqrsPath() {
-    return join(this.querySaveDir, "results.bqrs");
-  }
 }
 
 export class QueryEvaluationInfo extends QueryOutputDir {

--- a/extensions/ql-vscode/src/view/results/AlertTable.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTable.tsx
@@ -6,7 +6,7 @@ import type {
 } from "./result-keys";
 import { getPath, getPathNode, getResult, keyToString } from "./result-keys";
 import { className, jumpToLocation } from "./result-table-utils";
-import { onNavigation } from "./ResultsApp";
+import { onNavigation } from "./navigation";
 import type { NavigateMsg } from "../../common/interface-types";
 import { NavigationDirection } from "../../common/interface-types";
 import { isNoLocation, parseSarifLocation } from "../../common/sarif-utils";

--- a/extensions/ql-vscode/src/view/results/RawTable.tsx
+++ b/extensions/ql-vscode/src/view/results/RawTable.tsx
@@ -10,7 +10,7 @@ import {
 } from "../../common/interface-types";
 import RawTableHeader from "./RawTableHeader";
 import RawTableRow from "./RawTableRow";
-import { onNavigation } from "./ResultsApp";
+import { onNavigation } from "./navigation";
 import { sendTelemetry } from "../common/telemetry";
 import { assertNever } from "../../common/helpers-pure";
 import { EmptyQueryResultsMessage } from "./EmptyQueryResultsMessage";

--- a/extensions/ql-vscode/src/view/results/ResultsApp.tsx
+++ b/extensions/ql-vscode/src/view/results/ResultsApp.tsx
@@ -8,15 +8,14 @@ import type {
   QueryMetadata,
   ResultsPaths,
   ParsedResultSets,
-  NavigateMsg,
   ResultSet,
 } from "../../common/interface-types";
 import {
   ALERTS_TABLE_NAME,
   GRAPH_TABLE_NAME,
 } from "../../common/interface-types";
-import { EventHandlers as EventHandlerList } from "./event-handler-list";
 import { ResultTables } from "./ResultTables";
+import { onNavigation } from "./navigation";
 
 import "./resultsView.css";
 import { useCallback, useEffect, useState } from "react";
@@ -63,11 +62,6 @@ interface ResultsViewState {
   nextResultsInfo: ResultsInfo | null;
   isExpectingResultsUpdate: boolean;
 }
-
-/**
- * Event handlers to be notified of navigation events coming from outside the webview.
- */
-export const onNavigation = new EventHandlerList<NavigateMsg>();
 
 /**
  * A minimal state container for displaying results.

--- a/extensions/ql-vscode/src/view/results/navigation.ts
+++ b/extensions/ql-vscode/src/view/results/navigation.ts
@@ -1,0 +1,7 @@
+import type { NavigateMsg } from "../../common/interface-types";
+import { EventHandlers as EventHandlerList } from "./event-handler-list";
+
+/**
+ * Event handlers to be notified of navigation events coming from outside the webview.
+ */
+export const onNavigation = new EventHandlerList<NavigateMsg>();

--- a/extensions/ql-vscode/test/factories/query-history/local-query-history-item.ts
+++ b/extensions/ql-vscode/test/factories/query-history/local-query-history-item.ts
@@ -5,7 +5,7 @@ import type {
   QueryEvaluationInfo,
   QueryWithResults,
 } from "../../../src/run-queries-shared";
-import { QueryOutputDir } from "../../../src/run-queries-shared";
+import { QueryOutputDir } from "../../../src/local-queries/query-output-dir";
 import type { CancellationTokenSource } from "vscode";
 import type { QueryMetadata } from "../../../src/common/interface-types";
 import type { QueryLanguage } from "../../../src/common/query-language";

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/debugger/debug-controller.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/debugger/debug-controller.ts
@@ -10,7 +10,7 @@ import type * as CodeQLProtocol from "../../../../src/debugger/debug-protocol";
 import { DisposableObject } from "../../../../src/common/disposable-object";
 import { QueryResultType } from "../../../../src/query-server/messages";
 import type { CoreCompletedQuery } from "../../../../src/query-server/query-runner";
-import { QueryOutputDir } from "../../../../src/run-queries-shared";
+import { QueryOutputDir } from "../../../../src/local-queries/query-output-dir";
 import type {
   QLDebugArgs,
   QLDebugConfiguration,

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/debugger/debugger.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/debugger/debugger.test.ts
@@ -10,7 +10,7 @@ import {
 import { describeWithCodeQL } from "../../cli";
 import { withDebugController } from "./debug-controller";
 import type { CodeQLCliServer } from "../../../../src/codeql-cli/cli";
-import type { QueryOutputDir } from "../../../../src/run-queries-shared";
+import type { QueryOutputDir } from "../../../../src/local-queries/query-output-dir";
 import { createVSCodeCommandManager } from "../../../../src/common/vscode/commands";
 import type { AllCommands } from "../../../../src/common/commands";
 import { getDataFolderFilePath } from "../utils";

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/language-support/ast-viewer/ast-builder.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/language-support/ast-viewer/ast-builder.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "fs-extra";
 
 import type { CodeQLCliServer } from "../../../../../src/codeql-cli/cli";
 import { Uri } from "vscode";
-import { QueryOutputDir } from "../../../../../src/run-queries-shared";
+import { QueryOutputDir } from "../../../../../src/local-queries/query-output-dir";
 import { mockDatabaseItem, mockedObject } from "../../../utils/mocking.helpers";
 import path from "path";
 import { AstBuilder } from "../../../../../src/language-support";

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/auto-model-codeml-queries.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/auto-model-codeml-queries.test.ts
@@ -17,7 +17,7 @@ import { join } from "path";
 import { pathExists, readFile } from "fs-extra";
 import { load as loadYaml } from "js-yaml";
 import { CancellationTokenSource } from "vscode-jsonrpc";
-import { QueryOutputDir } from "../../../../src/run-queries-shared";
+import { QueryOutputDir } from "../../../../src/local-queries/query-output-dir";
 import type { ModelExtensionFile } from "../../../../src/model-editor/model-extension-file";
 
 describe("runAutoModelQueries", () => {

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/external-api-usage-query.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/external-api-usage-query.test.ts
@@ -17,7 +17,7 @@ import { Mode } from "../../../../src/model-editor/shared/mode";
 import { join } from "path";
 import type { CodeQLCliServer } from "../../../../src/codeql-cli/cli";
 import type { QueryRunner } from "../../../../src/query-server";
-import { QueryOutputDir } from "../../../../src/run-queries-shared";
+import { QueryOutputDir } from "../../../../src/local-queries/query-output-dir";
 
 describe("runModelEditorQueries", () => {
   const language = Object.keys(fetchExternalApiQueries)[

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/generate.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/generate.test.ts
@@ -8,7 +8,7 @@ import type { CodeQLCliServer } from "../../../../src/codeql-cli/cli";
 import type { QueryRunner } from "../../../../src/query-server";
 import { join } from "path";
 import { CancellationTokenSource } from "vscode-jsonrpc";
-import { QueryOutputDir } from "../../../../src/run-queries-shared";
+import { QueryOutputDir } from "../../../../src/local-queries/query-output-dir";
 import { runGenerateQueries } from "../../../../src/model-editor/generate";
 import { ruby } from "../../../../src/model-editor/languages/ruby";
 

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/store/query-history-store.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/store/query-history-store.test.ts
@@ -7,10 +7,8 @@ import { writeFileSync, mkdirpSync, writeFile } from "fs-extra";
 import type { InitialQueryInfo } from "../../../../../src/query-results";
 import { LocalQueryInfo } from "../../../../../src/query-results";
 import type { QueryWithResults } from "../../../../../src/run-queries-shared";
-import {
-  QueryEvaluationInfo,
-  QueryOutputDir,
-} from "../../../../../src/run-queries-shared";
+import { QueryEvaluationInfo } from "../../../../../src/run-queries-shared";
+import { QueryOutputDir } from "../../../../../src/local-queries/query-output-dir";
 import type { DatabaseInfo } from "../../../../../src/common/interface-types";
 import type { CancellationTokenSource } from "vscode";
 import { Uri } from "vscode";

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-results.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-results.test.ts
@@ -13,15 +13,13 @@ import {
   interpretResultsSarif,
 } from "../../../src/query-results";
 import type { QueryWithResults } from "../../../src/run-queries-shared";
-import {
-  QueryEvaluationInfo,
-  QueryOutputDir,
-} from "../../../src/run-queries-shared";
+import { QueryEvaluationInfo } from "../../../src/run-queries-shared";
+import { QueryOutputDir } from "../../../src/local-queries/query-output-dir";
+import { SortDirection } from "../../../src/common/interface-types";
 import type {
   DatabaseInfo,
   SortedResultSetInfo,
 } from "../../../src/common/interface-types";
-import { SortDirection } from "../../../src/common/interface-types";
 import type { CodeQLCliServer, SourceInfo } from "../../../src/codeql-cli/cli";
 import type { CancellationTokenSource } from "vscode";
 import { Uri } from "vscode";


### PR DESCRIPTION
This removes all dependency/import cycles and enables the [`import/no-cycle` ESLint rule](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-cycle.md) to avoid introducing any new dependency cycles. There is no auto-fix available for this rule, so I've made these changes manually. They mostly involve moving around some classes/functions to remove the cycles.

It's easiest to review this commit-by-commit.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
