### PR TITLE
Remove disabled ESLint rules without linting errors

### DIFF
--- a/extensions/ql-vscode/.eslintrc.js
+++ b/extensions/ql-vscode/.eslintrc.js
@@ -31,7 +31,6 @@ const baseConfig = {
   ],
   rules: {
     "@typescript-eslint/await-thenable": "error",
-    "@typescript-eslint/no-use-before-define": 0,
     "@typescript-eslint/no-unused-vars": [
       "warn",
       {
@@ -40,9 +39,6 @@ const baseConfig = {
         ignoreRestSiblings: false,
       },
     ],
-    "@typescript-eslint/explicit-function-return-type": "off",
-    "@typescript-eslint/explicit-module-boundary-types": "off",
-    "@typescript-eslint/no-non-null-assertion": "off",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-floating-promises": ["error", { ignoreVoid: true }],
     "@typescript-eslint/no-invalid-this": "off",


### PR DESCRIPTION
This removes some ESLint rules that do not give any linting errors when removing the rule overrides from the config file. This could be because there are no instances of the rule being violated, or because the rule is already disabled by some other configuration.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
