### PR TITLE
Remove more ESLint rule overrides

### DIFF
--- a/extensions/ql-vscode/.eslintrc.js
+++ b/extensions/ql-vscode/.eslintrc.js
@@ -47,7 +47,6 @@ const baseConfig = {
     "@typescript-eslint/no-throw-literal": "error",
     "@typescript-eslint/consistent-type-imports": "error",
     "import/consistent-type-specifier-style": ["error", "prefer-top-level"],
-    "no-useless-escape": 0,
     camelcase: "off",
     curly: ["error", "all"],
     "escompat/no-regexp-lookbehind": "off",

--- a/extensions/ql-vscode/.eslintrc.js
+++ b/extensions/ql-vscode/.eslintrc.js
@@ -53,7 +53,6 @@ const baseConfig = {
     "etc/no-implicit-any-catch": "error",
     "filenames/match-regex": "off",
     "filenames/match-regexp": "off",
-    "func-style": "off",
     "i18n-text/no-en": "off",
     "no-invalid-this": "off",
     "no-console": "off",

--- a/extensions/ql-vscode/.eslintrc.js
+++ b/extensions/ql-vscode/.eslintrc.js
@@ -47,7 +47,6 @@ const baseConfig = {
     "@typescript-eslint/no-throw-literal": "error",
     "@typescript-eslint/consistent-type-imports": "error",
     "import/consistent-type-specifier-style": ["error", "prefer-top-level"],
-    camelcase: "off",
     curly: ["error", "all"],
     "escompat/no-regexp-lookbehind": "off",
     "etc/no-implicit-any-catch": "error",

--- a/extensions/ql-vscode/.eslintrc.js
+++ b/extensions/ql-vscode/.eslintrc.js
@@ -51,7 +51,6 @@ const baseConfig = {
     "escompat/no-regexp-lookbehind": "off",
     "etc/no-implicit-any-catch": "error",
     "filenames/match-regex": "off",
-    "filenames/match-regexp": "off",
     "i18n-text/no-en": "off",
     "no-invalid-this": "off",
     "no-console": "off",

--- a/extensions/ql-vscode/.eslintrc.js
+++ b/extensions/ql-vscode/.eslintrc.js
@@ -57,7 +57,6 @@ const baseConfig = {
     "func-style": "off",
     "i18n-text/no-en": "off",
     "no-invalid-this": "off",
-    "no-fallthrough": "off",
     "no-console": "off",
     "no-shadow": "off",
     "github/array-foreach": "off",

--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -1532,7 +1532,7 @@ export class CodeQLCliServer implements Disposable {
     const distribution = await this.distributionProvider.getDistribution();
     switch (distribution.kind) {
       case FindDistributionResultKind.CompatibleDistribution:
-
+      // eslint-disable-next-line no-fallthrough -- Intentional fallthrough
       case FindDistributionResultKind.IncompatibleDistribution:
         return distribution.version;
 

--- a/extensions/ql-vscode/src/common/helpers-pure.ts
+++ b/extensions/ql-vscode/src/common/helpers-pure.ts
@@ -40,13 +40,13 @@ export const asyncFilter = async function <T>(
  * - `owner` is made up of alphanumeric characters, hyphens, underscores, or periods
  * - `repo` is made up of alphanumeric characters, hyphens, underscores, or periods
  */
-export const REPO_REGEX = /^[a-zA-Z0-9-_\.]+\/[a-zA-Z0-9-_\.]+$/;
+export const REPO_REGEX = /^[a-zA-Z0-9-_.]+\/[a-zA-Z0-9-_.]+$/;
 
 /**
  * This regex matches GiHub organization and user strings. These are made up for alphanumeric
  * characters, hyphens, underscores or periods.
  */
-export const OWNER_REGEX = /^[a-zA-Z0-9-_\.]+$/;
+export const OWNER_REGEX = /^[a-zA-Z0-9-_.]+$/;
 
 export function getErrorMessage(e: unknown): string {
   if (e instanceof RedactableError) {

--- a/extensions/ql-vscode/src/common/helpers-pure.ts
+++ b/extensions/ql-vscode/src/common/helpers-pure.ts
@@ -27,13 +27,13 @@ export function assertNever(value: never): never {
 /**
  * Use to perform array filters where the predicate is asynchronous.
  */
-export const asyncFilter = async function <T>(
+export async function asyncFilter<T>(
   arr: T[],
   predicate: (arg0: T) => Promise<boolean>,
 ) {
   const results = await Promise.all(arr.map(predicate));
   return arr.filter((_, index) => results[index]);
-};
+}
 
 /**
  * This regex matches strings of the form `owner/repo` where:

--- a/extensions/ql-vscode/src/common/sarif-utils.ts
+++ b/extensions/ql-vscode/src/common/sarif-utils.ts
@@ -47,7 +47,7 @@ export function parseSarifPlainTextMessage(
   // Technically we could have any uri in the target but we don't output that yet.
   // The possibility of escaping outside the link is not mentioned in the sarif spec but we always output sartif this way.
   const linkRegex =
-    /(?<=(?<!\\)(\\\\)*)\[(?<linkText>([^\\\]\[]|\\\\|\\\]|\\\[)*)\]\((?<linkTarget>[0-9]+)\)/g;
+    /(?<=(?<!\\)(\\\\)*)\[(?<linkText>([^\\\][]|\\\\|\\\]|\\\[)*)\]\((?<linkTarget>[0-9]+)\)/g;
   let result: RegExpExecArray | null;
   let curIndex = 0;
   while ((result = linkRegex.exec(message)) !== null) {

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -607,11 +607,11 @@ async function getDistributionDisplayingDistributionWarnings(
           case DistributionKind.ExtensionManaged:
             return 'Please update the CodeQL CLI by running the "CodeQL: Check for CLI Updates" command.';
           case DistributionKind.CustomPathConfig:
-            return `Please update the \"CodeQL CLI Executable Path\" setting to point to a CLI in the version range ${codeQlVersionRange}.`;
+            return `Please update the "CodeQL CLI Executable Path" setting to point to a CLI in the version range ${codeQlVersionRange}.`;
           case DistributionKind.PathEnvironmentVariable:
             return (
               `Please update the CodeQL CLI on your PATH to a version compatible with ${codeQlVersionRange}, or ` +
-              `set the \"CodeQL CLI Executable Path\" setting to the path of a CLI version compatible with ${codeQlVersionRange}.`
+              `set the "CodeQL CLI Executable Path" setting to the path of a CLI version compatible with ${codeQlVersionRange}.`
             );
         }
       })();

--- a/extensions/ql-vscode/src/language-support/language-support.ts
+++ b/extensions/ql-vscode/src/language-support/language-support.ts
@@ -18,7 +18,7 @@ export function install() {
   langConfig.wordPattern = new RegExp(langConfig.wordPattern);
   langConfig.onEnterRules = onEnterRules;
   langConfig.indentationRules = {
-    decreaseIndentPattern: /^((?!.*?\/\*).*\*\/)?\s*[\}\]].*$/,
+    decreaseIndentPattern: /^((?!.*?\/\*).*\*\/)?\s*[}\]].*$/,
     increaseIndentPattern: /^((?!\/\/).)*(\{[^}"'`]*|\([^)"'`]*|\[[^\]"'`]*)$/,
   };
   delete langConfig.autoClosingPairs;
@@ -31,18 +31,18 @@ export function install() {
 const onEnterRules: OnEnterRule[] = [
   {
     // e.g. /** | */
-    beforeText: /^\s*\/\*\*(?!\/)([^\*]|\*(?!\/))*$/,
+    beforeText: /^\s*\/\*\*(?!\/)([^*]|\*(?!\/))*$/,
     afterText: /^\s*\*\/$/,
     action: { indentAction: IndentAction.IndentOutdent, appendText: " * " },
   },
   {
     // e.g. /** ...|
-    beforeText: /^\s*\/\*\*(?!\/)([^\*]|\*(?!\/))*$/,
+    beforeText: /^\s*\/\*\*(?!\/)([^*]|\*(?!\/))*$/,
     action: { indentAction: IndentAction.None, appendText: " * " },
   },
   {
     // e.g.  * ...|
-    beforeText: /^(\t|[ ])*[ ]\*([ ]([^\*]|\*(?!\/))*)?$/,
+    beforeText: /^(\t|[ ])*[ ]\*([ ]([^*]|\*(?!\/))*)?$/,
     // oneLineAboveText: /^(\s*(\/\*\*|\*)).*/,
     action: { indentAction: IndentAction.None, appendText: "* " },
   },

--- a/extensions/ql-vscode/src/variant-analysis/export-results.ts
+++ b/extensions/ql-vscode/src/variant-analysis/export-results.ts
@@ -356,7 +356,7 @@ async function exportToLocalMarkdown(
   // This needs to use .then to ensure we aren't keeping the progress notification open. We shouldn't await the
   // "Open exported results" button click.
   void showInformationMessageWithAction(
-    `Variant analysis results exported to \"${exportedResultsPath}\".`,
+    `Variant analysis results exported to "${exportedResultsPath}".`,
     "Open exported results",
   ).then(async (shouldOpenExportedResults) => {
     if (!shouldOpenExportedResults) {

--- a/extensions/ql-vscode/test/matchers/toEqualPath.ts
+++ b/extensions/ql-vscode/test/matchers/toEqualPath.ts
@@ -2,6 +2,7 @@ import { expect } from "@jest/globals";
 import type { MatcherFunction } from "expect";
 import { pathsEqual } from "../../src/common/files";
 
+// eslint-disable-next-line func-style -- We need to set the type of this function
 const toEqualPath: MatcherFunction<[expectedPath: unknown]> = function (
   actual,
   expectedPath,


### PR DESCRIPTION
This removes some more ESLint rule overrides for rules for which there were very few violations. This simplifies our ESLint configuration. It's easiest to review this commit-by-commit.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
