### PR TITLE
Improve user experience when no database is selected

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [UNRELEASED]
 
+- If you run a query without having selected a database, we show a more intuitive prompt to help you select a database. [#3214](https://github.com/github/vscode-codeql/pull/3214)
 - Add a prompt for downloading a GitHub database when opening a GitHub repository. [#3138](https://github.com/github/vscode-codeql/pull/3138)
 - Avoid showing a popup when hovering over source elements in database source files. [#3125](https://github.com/github/vscode-codeql/pull/3125)
 - Add comparison of alerts when comparing query results. This allows viewing path explanations for differences in alerts. [#3113](https://github.com/github/vscode-codeql/pull/3113)

--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -814,10 +814,10 @@ export class DatabaseUI extends DisposableObject {
    * notification if it tries to perform any long-running operations.
    */
   private async getDatabaseItemInternal(
-    progress: ProgressContext | undefined,
+    progressContext: ProgressContext | undefined,
   ): Promise<DatabaseItem | undefined> {
     if (this.databaseManager.currentDatabaseItem === undefined) {
-      progress?.progress({
+      progressContext?.progress({
         maxStep: 2,
         step: 1,
         message: "Choosing database",

--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -5,6 +5,7 @@ import type {
   ProviderResult,
   TreeDataProvider,
   CancellationToken,
+  QuickPickItem,
 } from "vscode";
 import {
   EventEmitter,
@@ -28,7 +29,11 @@ import type {
   ProgressCallback,
   ProgressContext,
 } from "../common/vscode/progress";
-import { withInheritedProgress, withProgress } from "../common/vscode/progress";
+import {
+  UserCancellationException,
+  withInheritedProgress,
+  withProgress,
+} from "../common/vscode/progress";
 import {
   isLikelyDatabaseRoot,
   isLikelyDbLanguageFolder,
@@ -52,7 +57,10 @@ import {
   createMultiSelectionCommand,
   createSingleSelectionCommand,
 } from "../common/vscode/selection-commands";
-import { tryGetQueryLanguage } from "../common/query-language";
+import {
+  getLanguageDisplayName,
+  tryGetQueryLanguage,
+} from "../common/query-language";
 import type { LanguageContextStore } from "../language-context-store";
 
 enum SortOrder {
@@ -225,6 +233,18 @@ async function chooseDatabaseDir(byFolder: boolean): Promise<Uri | undefined> {
     filters: byFolder ? {} : { Archives: ["zip"] },
   });
   return getFirst(chosen);
+}
+
+interface DatabaseSelectionQuickPickItem extends QuickPickItem {
+  databaseKind: "new" | "existing";
+}
+
+export interface DatabaseQuickPickItem extends QuickPickItem {
+  databaseItem: DatabaseItem;
+}
+
+interface DatabaseImportQuickPickItems extends QuickPickItem {
+  importType: "URL" | "github" | "archive" | "folder";
 }
 
 export class DatabaseUI extends DisposableObject {
@@ -797,10 +817,117 @@ export class DatabaseUI extends DisposableObject {
     progress: ProgressContext | undefined,
   ): Promise<DatabaseItem | undefined> {
     if (this.databaseManager.currentDatabaseItem === undefined) {
-      await this.chooseAndSetDatabase(false, progress);
+      progress?.progress({
+        maxStep: 2,
+        step: 1,
+        message: "Choosing database",
+      });
+      await this.promptForDatabase();
+    }
+    return this.databaseManager.currentDatabaseItem;
+  }
+
+  private async promptForDatabase(): Promise<void> {
+    const quickPickItems: DatabaseSelectionQuickPickItem[] = [
+      {
+        label: "$(database) Existing database",
+        detail: "Select an existing database from your workspace",
+        alwaysShow: true,
+        databaseKind: "existing",
+      },
+      {
+        label: "$(arrow-down) New database",
+        detail: "Import a new database from the cloud or your local machine",
+        alwaysShow: true,
+        databaseKind: "new",
+      },
+    ];
+    const selectedOption =
+      await window.showQuickPick<DatabaseSelectionQuickPickItem>(
+        quickPickItems,
+        {
+          placeHolder: "Select an option",
+          ignoreFocusOut: true,
+        },
+      );
+
+    if (!selectedOption) {
+      throw new UserCancellationException("No database selected", true);
     }
 
-    return this.databaseManager.currentDatabaseItem;
+    if (selectedOption.databaseKind === "existing") {
+      await this.selectExistingDatabase();
+    } else if (selectedOption.databaseKind === "new") {
+      await this.importNewDatabase();
+    }
+  }
+
+  private async selectExistingDatabase() {
+    const dbItems: DatabaseQuickPickItem[] =
+      this.databaseManager.databaseItems.map((dbItem) => ({
+        label: dbItem.name,
+        description: getLanguageDisplayName(dbItem.language),
+        databaseItem: dbItem,
+      }));
+
+    const selectedDatabase = await window.showQuickPick(dbItems, {
+      placeHolder: "Select a database",
+      ignoreFocusOut: true,
+    });
+
+    if (!selectedDatabase) {
+      throw new UserCancellationException("No database selected", true);
+    }
+
+    await this.databaseManager.setCurrentDatabaseItem(
+      selectedDatabase.databaseItem,
+    );
+  }
+
+  private async importNewDatabase() {
+    const importOptions: DatabaseImportQuickPickItems[] = [
+      {
+        label: "$(github) GitHub",
+        detail: "Import a database from a GitHub repository",
+        alwaysShow: true,
+        importType: "github",
+      },
+      {
+        label: "$(link) URL",
+        detail: "Import a database archive or folder from a remote URL",
+        alwaysShow: true,
+        importType: "URL",
+      },
+      {
+        label: "$(file-zip) Archive",
+        detail: "Import a database from a local ZIP archive",
+        alwaysShow: true,
+        importType: "archive",
+      },
+      {
+        label: "$(folder) Folder",
+        detail: "Import a database from a local folder",
+        alwaysShow: true,
+        importType: "folder",
+      },
+    ];
+    const selectedImportOption =
+      await window.showQuickPick<DatabaseImportQuickPickItems>(importOptions, {
+        placeHolder: "Import a database from...",
+        ignoreFocusOut: true,
+      });
+    if (!selectedImportOption) {
+      throw new UserCancellationException("No database selected", true);
+    }
+    if (selectedImportOption.importType === "github") {
+      await this.handleChooseDatabaseGithub();
+    } else if (selectedImportOption.importType === "URL") {
+      await this.handleChooseDatabaseInternet();
+    } else if (selectedImportOption.importType === "archive") {
+      await this.handleChooseDatabaseArchive();
+    } else if (selectedImportOption.importType === "folder") {
+      await this.handleChooseDatabaseFolder();
+    }
   }
 
   /**

--- a/extensions/ql-vscode/src/local-queries/local-queries.ts
+++ b/extensions/ql-vscode/src/local-queries/local-queries.ts
@@ -3,12 +3,7 @@ import type {
   ProgressUpdate,
 } from "../common/vscode/progress";
 import { withProgress } from "../common/vscode/progress";
-import type {
-  CancellationToken,
-  QuickPickItem,
-  Range,
-  TabInputText,
-} from "vscode";
+import type { CancellationToken, Range, TabInputText } from "vscode";
 import { CancellationTokenSource, Uri, window } from "vscode";
 import {
   TeeLogger,
@@ -23,7 +18,10 @@ import { getOnDiskWorkspaceFolders } from "../common/vscode/workspace-folders";
 import { displayQuickQuery } from "./quick-query";
 import type { CoreCompletedQuery, QueryRunner } from "../query-server";
 import type { QueryHistoryManager } from "../query-history/query-history-manager";
-import type { DatabaseUI } from "../databases/local-databases-ui";
+import type {
+  DatabaseQuickPickItem,
+  DatabaseUI,
+} from "../databases/local-databases-ui";
 import type { ResultsView } from "./results-view";
 import type {
   DatabaseItem,
@@ -54,10 +52,6 @@ import type { QueryTreeViewItem } from "../queries-panel/query-tree-view-item";
 import { tryGetQueryLanguage } from "../common/query-language";
 import type { LanguageContextStore } from "../language-context-store";
 import type { ExtensionApp } from "../common/vscode/vscode-app";
-
-interface DatabaseQuickPickItem extends QuickPickItem {
-  databaseItem: DatabaseItem;
-}
 
 export enum QuickEvalType {
   None,


### PR DESCRIPTION
Previously, if you ran a query without having a DB selected, the extension would pop up a file explorer window prompting you to select a database archive from your file system. This isn't the most common way to select a database so it was a fairly confusing pop-up. See internal issue for more info 🔍 

### Changes

New flow (inspired by designs from the internal issue, though I updated the wording slightly):
- Choose between an existing or new DB:
  ![image](https://github.com/github/vscode-codeql/assets/42641846/d242605a-608c-459f-a27a-4b8c1716a1f6)
- If you choose "existing", we list the DBs from your DB panel
  ![image](https://github.com/github/vscode-codeql/assets/42641846/49161766-94be-4e4c-97b2-ae10763bebf3)
- If you choose "new", we offer the different options for importing a DB:
  ![image](https://github.com/github/vscode-codeql/assets/42641846/38292cfa-3001-41f5-a2cc-553f6b2b525b)

In all cases, we select that DB and run the query against it 🎉 (Note: this also works in the same way for "[CodeQL: Debug Query](https://github.com/github/vscode-codeql/pull/2291)") 

### Notes

- Suggestions on wording and code structure very welcome as always! 👀 
- I haven't done anything particularly clever to decide which DBs to display. I just show all of them, without filtering/sorting by language for example. That might be a nice follow-up task, but this seems like a good improvement already 😅 


## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
  - No docs update needed
