### PR TITLE
Move Ruby access paths functions to separate file

### DIFF
--- a/extensions/ql-vscode/src/model-editor/languages/ruby/access-paths.ts
+++ b/extensions/ql-vscode/src/model-editor/languages/ruby/access-paths.ts
@@ -1,0 +1,41 @@
+export function parseRubyMethodFromPath(path: string): string {
+  const match = path.match(/Method\[([^\]]+)].*/);
+  if (match) {
+    return match[1];
+  } else {
+    return "";
+  }
+}
+
+export function parseRubyAccessPath(path: string): {
+  methodName: string;
+  path: string;
+} {
+  const match = path.match(/Method\[([^\]]+)]\.(.*)/);
+  if (match) {
+    return { methodName: match[1], path: match[2] };
+  } else {
+    return { methodName: "", path: "" };
+  }
+}
+
+export function rubyMethodSignature(typeName: string, methodName: string) {
+  return `${typeName}#${methodName}`;
+}
+
+export function rubyMethodPath(methodName: string) {
+  if (methodName === "") {
+    return "";
+  }
+
+  return `Method[${methodName}]`;
+}
+
+export function rubyPath(methodName: string, path: string) {
+  const methodPath = rubyMethodPath(methodName);
+  if (methodPath === "") {
+    return path;
+  }
+
+  return `${methodPath}.${path}`;
+}

--- a/extensions/ql-vscode/src/model-editor/languages/ruby/index.ts
+++ b/extensions/ql-vscode/src/model-editor/languages/ruby/index.ts
@@ -4,48 +4,13 @@ import { Mode } from "../../shared/mode";
 import { parseGenerateModelResults } from "./generate";
 import type { MethodArgument } from "../../method";
 import { getArgumentsList } from "../../method";
-
-function parseRubyMethodFromPath(path: string): string {
-  const match = path.match(/Method\[([^\]]+)].*/);
-  if (match) {
-    return match[1];
-  } else {
-    return "";
-  }
-}
-
-function parseRubyAccessPath(path: string): {
-  methodName: string;
-  path: string;
-} {
-  const match = path.match(/Method\[([^\]]+)]\.(.*)/);
-  if (match) {
-    return { methodName: match[1], path: match[2] };
-  } else {
-    return { methodName: "", path: "" };
-  }
-}
-
-function rubyMethodSignature(typeName: string, methodName: string) {
-  return `${typeName}#${methodName}`;
-}
-
-function rubyMethodPath(methodName: string) {
-  if (methodName === "") {
-    return "";
-  }
-
-  return `Method[${methodName}]`;
-}
-
-function rubyPath(methodName: string, path: string) {
-  const methodPath = rubyMethodPath(methodName);
-  if (methodPath === "") {
-    return path;
-  }
-
-  return `${methodPath}.${path}`;
-}
+import {
+  parseRubyAccessPath,
+  parseRubyMethodFromPath,
+  rubyMethodPath,
+  rubyMethodSignature,
+  rubyPath,
+} from "./access-paths";
 
 export const ruby: ModelsAsDataLanguage = {
   availableModes: [Mode.Framework],


### PR DESCRIPTION
This moves all functions for parsing and formatting Ruby access paths to a separate file so they can be re-used in the future. It also makes the `ruby/index.ts` file easier to read.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
