### PR TITLE
CodeQL model editor: Add support for free text input in type models

### DIFF
--- a/extensions/ql-vscode/src/view/common/useDebounceCallback.ts
+++ b/extensions/ql-vscode/src/view/common/useDebounceCallback.ts
@@ -1,0 +1,27 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Call the callback after the value has not changed for a certain amount of time.
+ * @param value
+ * @param callback
+ * @param delay
+ */
+export function useDebounceCallback<T>(
+  value: T,
+  callback: (value: T) => void,
+  delay?: number,
+) {
+  const callbackRef = useRef<(value: T) => void>(callback);
+
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => callbackRef.current(value), delay || 500);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [value, delay]);
+}

--- a/extensions/ql-vscode/src/view/model-editor/ModelInputDropdown.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelInputDropdown.tsx
@@ -68,7 +68,11 @@ export const ModelInputDropdown = ({
 
   if (modeledMethod?.type === "type") {
     return (
-      <ModelTypeTextbox modeledMethod={modeledMethod} onChange={onChange} />
+      <ModelTypeTextbox
+        modeledMethod={modeledMethod}
+        typeInfo="path"
+        onChange={onChange}
+      />
     );
   }
 

--- a/extensions/ql-vscode/src/view/model-editor/ModelInputDropdown.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelInputDropdown.tsx
@@ -72,6 +72,7 @@ export const ModelInputDropdown = ({
         modeledMethod={modeledMethod}
         typeInfo="path"
         onChange={onChange}
+        aria-label="Path"
       />
     );
   }

--- a/extensions/ql-vscode/src/view/model-editor/ModelInputDropdown.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelInputDropdown.tsx
@@ -7,11 +7,11 @@ import {
   modeledMethodSupportsInput,
 } from "../../model-editor/modeled-method";
 import type { Method } from "../../model-editor/method";
-import { ReadonlyDropdown } from "../common/ReadonlyDropdown";
 import type { QueryLanguage } from "../../common/query-language";
 import { getModelsAsDataLanguage } from "../../model-editor/languages";
 import type { ModelingStatus } from "../../model-editor/shared/modeling-status";
 import { InputDropdown } from "./InputDropdown";
+import { ModelTypeTextbox } from "./ModelTypeTextbox";
 
 type Props = {
   language: QueryLanguage;
@@ -67,7 +67,9 @@ export const ModelInputDropdown = ({
       : undefined;
 
   if (modeledMethod?.type === "type") {
-    return <ReadonlyDropdown value={modeledMethod.path} aria-label="Path" />;
+    return (
+      <ModelTypeTextbox modeledMethod={modeledMethod} onChange={onChange} />
+    );
   }
 
   const modelAccepted = isModelAccepted(modeledMethod, modelingStatus);

--- a/extensions/ql-vscode/src/view/model-editor/ModelOutputDropdown.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelOutputDropdown.tsx
@@ -73,6 +73,7 @@ export const ModelOutputDropdown = ({
         modeledMethod={modeledMethod}
         typeInfo="relatedTypeName"
         onChange={onChange}
+        aria-label="Related type name"
       />
     );
   }

--- a/extensions/ql-vscode/src/view/model-editor/ModelOutputDropdown.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelOutputDropdown.tsx
@@ -7,11 +7,11 @@ import {
   modeledMethodSupportsOutput,
 } from "../../model-editor/modeled-method";
 import type { Method } from "../../model-editor/method";
-import { ReadonlyDropdown } from "../common/ReadonlyDropdown";
 import { getModelsAsDataLanguage } from "../../model-editor/languages";
 import type { QueryLanguage } from "../../common/query-language";
 import type { ModelingStatus } from "../../model-editor/shared/modeling-status";
 import { InputDropdown } from "./InputDropdown";
+import { ModelTypeTextbox } from "./ModelTypeTextbox";
 
 type Props = {
   language: QueryLanguage;
@@ -69,9 +69,10 @@ export const ModelOutputDropdown = ({
 
   if (modeledMethod?.type === "type") {
     return (
-      <ReadonlyDropdown
-        value={modeledMethod.relatedTypeName}
-        aria-label="Related type name"
+      <ModelTypeTextbox
+        modeledMethod={modeledMethod}
+        typeInfo="relatedTypeName"
+        onChange={onChange}
       />
     );
   }

--- a/extensions/ql-vscode/src/view/model-editor/ModelTypeTextbox.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelTypeTextbox.tsx
@@ -1,11 +1,14 @@
 import type { ChangeEvent } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import type { ModeledMethod } from "../../model-editor/modeled-method";
+import type {
+  ModeledMethod,
+  TypeModeledMethod,
+} from "../../model-editor/modeled-method";
 import { VSCodeTextField } from "@vscode/webview-ui-toolkit/react";
 import { useDebounceCallback } from "../common/useDebounceCallback";
 
 type Props = {
-  modeledMethod: ModeledMethod | undefined;
+  modeledMethod: TypeModeledMethod;
   typeInfo: "path" | "relatedTypeName";
   onChange: (modeledMethod: ModeledMethod) => void;
 };
@@ -15,25 +18,14 @@ export const ModelTypeTextbox = ({
   typeInfo,
   onChange,
 }: Props): JSX.Element => {
-  const enabled = useMemo(
-    () => modeledMethod && modeledMethod.type === "type",
-    [modeledMethod],
-  );
+  const enabled = useMemo(() => modeledMethod, [modeledMethod]);
   const [value, setValue] = useState<string | undefined>(
-    modeledMethod && modeledMethod.type === "type"
-      ? typeInfo === "path"
-        ? modeledMethod.path
-        : modeledMethod.relatedTypeName
-      : undefined,
+    modeledMethod[typeInfo],
   );
 
   useEffect(() => {
-    if (modeledMethod && modeledMethod.type === "type") {
-      setValue(
-        typeInfo === "path"
-          ? modeledMethod.path
-          : modeledMethod.relatedTypeName,
-      );
+    if (modeledMethod) {
+      setValue(modeledMethod[typeInfo]);
     }
   }, [modeledMethod, typeInfo]);
 
@@ -48,7 +40,7 @@ export const ModelTypeTextbox = ({
   useDebounceCallback(
     value,
     (newValue: string | undefined) => {
-      if (!modeledMethod || modeledMethod.type !== "type") {
+      if (!modeledMethod) {
         return;
       }
 

--- a/extensions/ql-vscode/src/view/model-editor/ModelTypeTextbox.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelTypeTextbox.tsx
@@ -6,11 +6,13 @@ import { useDebounceCallback } from "../common/useDebounceCallback";
 
 type Props = {
   modeledMethod: ModeledMethod | undefined;
+  typeInfo: "path" | "relatedTypeName";
   onChange: (modeledMethod: ModeledMethod) => void;
 };
 
 export const ModelTypeTextbox = ({
   modeledMethod,
+  typeInfo,
   onChange,
 }: Props): JSX.Element => {
   const enabled = useMemo(
@@ -19,15 +21,21 @@ export const ModelTypeTextbox = ({
   );
   const [value, setValue] = useState<string | undefined>(
     modeledMethod && modeledMethod.type === "type"
-      ? modeledMethod.path
+      ? typeInfo === "path"
+        ? modeledMethod.path
+        : modeledMethod.relatedTypeName
       : undefined,
   );
 
   useEffect(() => {
     if (modeledMethod && modeledMethod.type === "type") {
-      setValue(modeledMethod.path);
+      setValue(
+        typeInfo === "path"
+          ? modeledMethod.path
+          : modeledMethod.relatedTypeName,
+      );
     }
-  }, [modeledMethod]);
+  }, [modeledMethod, typeInfo]);
 
   const handleChange = useCallback((e: ChangeEvent<HTMLSelectElement>) => {
     const target = e.target as HTMLSelectElement;
@@ -39,14 +47,14 @@ export const ModelTypeTextbox = ({
   // Not doing this results in a lot of lag when typing.
   useDebounceCallback(
     value,
-    (path: string | undefined) => {
+    (newValue: string | undefined) => {
       if (!modeledMethod || modeledMethod.type !== "type") {
         return;
       }
 
       onChange({
         ...modeledMethod,
-        path: path ?? "",
+        [typeInfo]: newValue ?? "",
       });
     },
     500,
@@ -56,7 +64,7 @@ export const ModelTypeTextbox = ({
     <VSCodeTextField
       value={value}
       onInput={handleChange}
-      aria-label="Path"
+      aria-label={typeInfo === "path" ? "Path" : "Related type name"}
       disabled={!enabled}
     />
   );

--- a/extensions/ql-vscode/src/view/model-editor/ModelTypeTextbox.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelTypeTextbox.tsx
@@ -1,0 +1,63 @@
+import type { ChangeEvent } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { ModeledMethod } from "../../model-editor/modeled-method";
+import { VSCodeTextField } from "@vscode/webview-ui-toolkit/react";
+import { useDebounceCallback } from "../common/useDebounceCallback";
+
+type Props = {
+  modeledMethod: ModeledMethod | undefined;
+  onChange: (modeledMethod: ModeledMethod) => void;
+};
+
+export const ModelTypeTextbox = ({
+  modeledMethod,
+  onChange,
+}: Props): JSX.Element => {
+  const enabled = useMemo(
+    () => modeledMethod && modeledMethod.type === "type",
+    [modeledMethod],
+  );
+  const [value, setValue] = useState<string | undefined>(
+    modeledMethod && modeledMethod.type === "type"
+      ? modeledMethod.path
+      : undefined,
+  );
+
+  useEffect(() => {
+    if (modeledMethod && modeledMethod.type === "type") {
+      setValue(modeledMethod.path);
+    }
+  }, [modeledMethod]);
+
+  const handleChange = useCallback((e: ChangeEvent<HTMLSelectElement>) => {
+    const target = e.target as HTMLSelectElement;
+
+    setValue(target.value);
+  }, []);
+
+  // Debounce the callback to avoid updating the model too often.
+  // Not doing this results in a lot of lag when typing.
+  useDebounceCallback(
+    value,
+    (path: string | undefined) => {
+      if (!modeledMethod || modeledMethod.type !== "type") {
+        return;
+      }
+
+      onChange({
+        ...modeledMethod,
+        path: path ?? "",
+      });
+    },
+    500,
+  );
+
+  return (
+    <VSCodeTextField
+      value={value}
+      onInput={handleChange}
+      aria-label="Path"
+      disabled={!enabled}
+    />
+  );
+};

--- a/extensions/ql-vscode/src/view/model-editor/ModelTypeTextbox.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelTypeTextbox.tsx
@@ -1,5 +1,5 @@
 import type { ChangeEvent } from "react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type {
   ModeledMethod,
   TypeModeledMethod,
@@ -11,22 +11,22 @@ type Props = {
   modeledMethod: TypeModeledMethod;
   typeInfo: "path" | "relatedTypeName";
   onChange: (modeledMethod: ModeledMethod) => void;
+
+  "aria-label"?: "Path" | "Related type name";
 };
 
 export const ModelTypeTextbox = ({
   modeledMethod,
   typeInfo,
   onChange,
+  ...props
 }: Props): JSX.Element => {
-  const enabled = useMemo(() => modeledMethod, [modeledMethod]);
   const [value, setValue] = useState<string | undefined>(
     modeledMethod[typeInfo],
   );
 
   useEffect(() => {
-    if (modeledMethod) {
-      setValue(modeledMethod[typeInfo]);
-    }
+    setValue(modeledMethod[typeInfo]);
   }, [modeledMethod, typeInfo]);
 
   const handleChange = useCallback((e: ChangeEvent<HTMLSelectElement>) => {
@@ -40,10 +40,6 @@ export const ModelTypeTextbox = ({
   useDebounceCallback(
     value,
     (newValue: string | undefined) => {
-      if (!modeledMethod) {
-        return;
-      }
-
       onChange({
         ...modeledMethod,
         [typeInfo]: newValue ?? "",
@@ -52,12 +48,5 @@ export const ModelTypeTextbox = ({
     500,
   );
 
-  return (
-    <VSCodeTextField
-      value={value}
-      onInput={handleChange}
-      aria-label={typeInfo === "path" ? "Path" : "Related type name"}
-      disabled={!enabled}
-    />
-  );
+  return <VSCodeTextField value={value} onInput={handleChange} {...props} />;
 };

--- a/extensions/ql-vscode/src/view/model-editor/ModelTypeTextbox.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelTypeTextbox.tsx
@@ -12,7 +12,7 @@ type Props = {
   typeInfo: "path" | "relatedTypeName";
   onChange: (modeledMethod: ModeledMethod) => void;
 
-  "aria-label"?: "Path" | "Related type name";
+  "aria-label"?: string;
 };
 
 export const ModelTypeTextbox = ({


### PR DESCRIPTION
For type models, it doesn't make sense to have an input and output column dropdown. We instead use the "input" column to store the `path` and the "output" column the `relatedTypeName`: 

![image](https://github.com/github/vscode-codeql/assets/42641846/0571d601-c63b-4fde-a08c-abfe6548e7cd)

These are now free text fields instead of dropdowns. Note: I haven't played around much with styling and different sized screens yet, but it looks like things resize in a sensible way 🤔 

See internal linked issue for more details! (Paired with @koesie10 🍐)



## Checklist

N/A: this is still feature-flagged for internal use.

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
