### PR TITLE
CodeQL model editor: Make `Type` a selectable model kind for Ruby

### DIFF
--- a/extensions/ql-vscode/src/view/model-editor/ModelTypeDropdown.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelTypeDropdown.tsx
@@ -1,5 +1,5 @@
 import type { ChangeEvent } from "react";
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import type {
   ModeledMethod,
   ModeledMethodType,
@@ -32,16 +32,20 @@ export const ModelTypeDropdown = ({
   modelingStatus,
   onChange,
 }: Props): JSX.Element => {
-  const options: Array<{ value: ModeledMethodType; label: string }> = [
-    { value: "none", label: "Unmodeled" },
-    { value: "source", label: "Source" },
-    { value: "sink", label: "Sink" },
-    { value: "summary", label: "Flow summary" },
-    { value: "neutral", label: "Neutral" },
-  ];
-  if (language === QueryLanguage.Ruby) {
-    options.push({ value: "type", label: "Type" });
-  }
+  const options = useMemo(() => {
+    const baseOptions: Array<{ value: ModeledMethodType; label: string }> = [
+      { value: "none", label: "Unmodeled" },
+      { value: "source", label: "Source" },
+      { value: "sink", label: "Sink" },
+      { value: "summary", label: "Flow summary" },
+      { value: "neutral", label: "Neutral" },
+    ];
+    if (language === QueryLanguage.Ruby) {
+      baseOptions.push({ value: "type", label: "Type" });
+    }
+
+    return baseOptions;
+  }, [language]);
 
   const handleChange = useCallback(
     (e: ChangeEvent<HTMLSelectElement>) => {

--- a/extensions/ql-vscode/src/view/model-editor/ModelTypeDropdown.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelTypeDropdown.tsx
@@ -12,18 +12,10 @@ import type { Method } from "../../model-editor/method";
 import { createEmptyModeledMethod } from "../../model-editor/modeled-method-empty";
 import type { Mutable } from "../../common/mutable";
 import { ReadonlyDropdown } from "../common/ReadonlyDropdown";
-import type { QueryLanguage } from "../../common/query-language";
+import { QueryLanguage } from "../../common/query-language";
 import { getModelsAsDataLanguage } from "../../model-editor/languages";
 import type { ModelingStatus } from "../../model-editor/shared/modeling-status";
 import { InputDropdown } from "./InputDropdown";
-
-const options: Array<{ value: ModeledMethodType; label: string }> = [
-  { value: "none", label: "Unmodeled" },
-  { value: "source", label: "Source" },
-  { value: "sink", label: "Sink" },
-  { value: "summary", label: "Flow summary" },
-  { value: "neutral", label: "Neutral" },
-];
 
 type Props = {
   language: QueryLanguage;
@@ -40,6 +32,17 @@ export const ModelTypeDropdown = ({
   modelingStatus,
   onChange,
 }: Props): JSX.Element => {
+  const options: Array<{ value: ModeledMethodType; label: string }> = [
+    { value: "none", label: "Unmodeled" },
+    { value: "source", label: "Source" },
+    { value: "sink", label: "Sink" },
+    { value: "summary", label: "Flow summary" },
+    { value: "neutral", label: "Neutral" },
+  ];
+  if (language === QueryLanguage.Ruby) {
+    options.push({ value: "type", label: "Type" });
+  }
+
   const handleChange = useCallback(
     (e: ChangeEvent<HTMLSelectElement>) => {
       const modelsAsDataLanguage = getModelsAsDataLanguage(language);

--- a/extensions/ql-vscode/src/view/model-editor/__tests__/ModelTypeDropdown.spec.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/__tests__/ModelTypeDropdown.spec.tsx
@@ -1,0 +1,77 @@
+import { userEvent } from "@testing-library/user-event";
+import { render, screen } from "@testing-library/react";
+import { createNoneModeledMethod } from "../../../../test/factories/model-editor/modeled-method-factories";
+import { QueryLanguage } from "../../../common/query-language";
+import { ModelTypeDropdown } from "../ModelTypeDropdown";
+import { createMethod } from "../../../../test/factories/model-editor/method-factories";
+
+describe(ModelTypeDropdown.name, () => {
+  const onChange = jest.fn();
+
+  beforeEach(() => {
+    onChange.mockReset();
+  });
+
+  it("allows changing the type", async () => {
+    const method = createMethod();
+    const modeledMethod = createNoneModeledMethod();
+
+    render(
+      <ModelTypeDropdown
+        language={QueryLanguage.Java}
+        modeledMethod={modeledMethod}
+        modelingStatus="unsaved"
+        onChange={onChange}
+        method={method}
+      />,
+    );
+
+    await userEvent.selectOptions(screen.getByRole("combobox"), "source");
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "source",
+      }),
+    );
+  });
+
+  it("allows changing the type to 'Type' for Ruby", async () => {
+    const method = createMethod();
+    const modeledMethod = createNoneModeledMethod();
+
+    render(
+      <ModelTypeDropdown
+        language={QueryLanguage.Ruby}
+        modeledMethod={modeledMethod}
+        modelingStatus="unsaved"
+        onChange={onChange}
+        method={method}
+      />,
+    );
+
+    await userEvent.selectOptions(screen.getByRole("combobox"), "type");
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "type",
+      }),
+    );
+  });
+
+  it("does not allow changing the type to 'Type' for Java", async () => {
+    const method = createMethod();
+    const modeledMethod = createNoneModeledMethod();
+
+    render(
+      <ModelTypeDropdown
+        language={QueryLanguage.Java}
+        modeledMethod={modeledMethod}
+        modelingStatus="unsaved"
+        onChange={onChange}
+        method={method}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("option", { name: "Type" }),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Currently type models in Ruby are read-only, and you can't manually select/define one. This PR adds it as a selectable type. (Based on https://github.com/github/vscode-codeql/pull/3217, which turns the input/output dropdowns into free text fields. See internal linked issue for more details)

![image](https://github.com/github/vscode-codeql/assets/42641846/7acb9f16-f182-4be4-aac4-54e513d25bc2)

Any suggestions on if/how to test this? 🤔 Maybe a view test in [MethodRow.spec.tsx](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/src/view/model-editor/__tests__/MethodRow.spec.tsx) or something?

## Checklist

N/A

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
