### PR TITLE
Rename variant analysis mapping functions

### DIFF
--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -43,9 +43,9 @@ import type {
 } from "./variant-analysis-results-manager";
 import { getQueryName, prepareRemoteQueryRun } from "./run-remote-query";
 import {
-  processVariantAnalysis,
-  processVariantAnalysisRepositoryTask,
-} from "./variant-analysis-processor";
+  mapVariantAnalysis,
+  mapVariantAnalysisRepositoryTask,
+} from "./variant-analysis-mapper";
 import PQueue from "p-queue";
 import { createTimestampFile, saveBeforeStart } from "../run-queries-shared";
 import { readFile, remove, pathExists } from "fs-extra";
@@ -279,7 +279,7 @@ export class VariantAnalysisManager
       throw e;
     }
 
-    const processedVariantAnalysis = processVariantAnalysis(
+    const processedVariantAnalysis = mapVariantAnalysis(
       variantAnalysisSubmission,
       variantAnalysisResponse,
     );
@@ -619,7 +619,7 @@ export class VariantAnalysisManager
         scannedRepo.repository.id,
       );
 
-      repoTask = processVariantAnalysisRepositoryTask(repoTaskResponse);
+      repoTask = mapVariantAnalysisRepositoryTask(repoTaskResponse);
     } catch (e) {
       repoState.downloadStatus =
         VariantAnalysisScannedRepositoryDownloadStatus.Failed;

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-mapper.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-mapper.ts
@@ -23,11 +23,11 @@ import {
   VariantAnalysisRepoStatus,
 } from "./shared/variant-analysis";
 
-export function processVariantAnalysis(
+export function mapVariantAnalysis(
   submission: VariantAnalysisSubmission,
   response: ApiVariantAnalysis,
 ): VariantAnalysis {
-  return processUpdatedVariantAnalysis(
+  return mapUpdatedVariantAnalysis(
     {
       query: {
         name: submission.query.name,
@@ -43,7 +43,7 @@ export function processVariantAnalysis(
   );
 }
 
-export function processUpdatedVariantAnalysis(
+export function mapUpdatedVariantAnalysis(
   previousVariantAnalysis: Pick<
     VariantAnalysis,
     "query" | "databases" | "executionStartTime"
@@ -54,13 +54,13 @@ export function processUpdatedVariantAnalysis(
   let skippedRepos: VariantAnalysisSkippedRepositories = {};
 
   if (response.scanned_repositories) {
-    scannedRepos = processScannedRepositories(
+    scannedRepos = mapScannedRepositories(
       response.scanned_repositories as ApiVariantAnalysisScannedRepository[],
     );
   }
 
   if (response.skipped_repositories) {
-    skippedRepos = processSkippedRepositories(
+    skippedRepos = mapSkippedRepositories(
       response.skipped_repositories as ApiVariantAnalysisSkippedRepositories,
     );
   }
@@ -77,7 +77,7 @@ export function processUpdatedVariantAnalysis(
     executionStartTime: previousVariantAnalysis.executionStartTime,
     createdAt: response.created_at,
     updatedAt: response.updated_at,
-    status: processApiStatus(response.status),
+    status: mapApiStatus(response.status),
     completedAt: response.completed_at,
     actionsWorkflowRunId: response.actions_workflow_run_id,
     scannedRepos,
@@ -85,15 +85,13 @@ export function processUpdatedVariantAnalysis(
   };
 
   if (response.failure_reason) {
-    variantAnalysis.failureReason = processFailureReason(
-      response.failure_reason,
-    );
+    variantAnalysis.failureReason = mapFailureReason(response.failure_reason);
   }
 
   return variantAnalysis;
 }
 
-export function processVariantAnalysisRepositoryTask(
+export function mapVariantAnalysisRepositoryTask(
   response: ApiVariantAnalysisRepoTask,
 ): VariantAnalysisRepositoryTask {
   return {
@@ -102,7 +100,7 @@ export function processVariantAnalysisRepositoryTask(
       fullName: response.repository.full_name,
       private: response.repository.private,
     },
-    analysisStatus: processApiRepoStatus(response.analysis_status),
+    analysisStatus: mapApiRepoStatus(response.analysis_status),
     resultCount: response.result_count,
     artifactSizeInBytes: response.artifact_size_in_bytes,
     failureMessage: response.failure_message,
@@ -112,7 +110,7 @@ export function processVariantAnalysisRepositoryTask(
   };
 }
 
-export function processScannedRepository(
+export function mapScannedRepository(
   scannedRepo: ApiVariantAnalysisScannedRepository,
 ): VariantAnalysisScannedRepository {
   return {
@@ -123,33 +121,31 @@ export function processScannedRepository(
       stargazersCount: scannedRepo.repository.stargazers_count,
       updatedAt: scannedRepo.repository.updated_at,
     },
-    analysisStatus: processApiRepoStatus(scannedRepo.analysis_status),
+    analysisStatus: mapApiRepoStatus(scannedRepo.analysis_status),
     resultCount: scannedRepo.result_count,
     artifactSizeInBytes: scannedRepo.artifact_size_in_bytes,
     failureMessage: scannedRepo.failure_message,
   };
 }
 
-function processScannedRepositories(
+function mapScannedRepositories(
   scannedRepos: ApiVariantAnalysisScannedRepository[],
 ): VariantAnalysisScannedRepository[] {
-  return scannedRepos.map((scannedRepo) =>
-    processScannedRepository(scannedRepo),
-  );
+  return scannedRepos.map((scannedRepo) => mapScannedRepository(scannedRepo));
 }
 
-function processSkippedRepositories(
+function mapSkippedRepositories(
   skippedRepos: ApiVariantAnalysisSkippedRepositories,
 ): VariantAnalysisSkippedRepositories {
   return {
-    accessMismatchRepos: processRepoGroup(skippedRepos.access_mismatch_repos),
-    notFoundRepos: processNotFoundRepoGroup(skippedRepos.not_found_repos),
-    noCodeqlDbRepos: processRepoGroup(skippedRepos.no_codeql_db_repos),
-    overLimitRepos: processRepoGroup(skippedRepos.over_limit_repos),
+    accessMismatchRepos: mapRepoGroup(skippedRepos.access_mismatch_repos),
+    notFoundRepos: mapNotFoundRepoGroup(skippedRepos.not_found_repos),
+    noCodeqlDbRepos: mapRepoGroup(skippedRepos.no_codeql_db_repos),
+    overLimitRepos: mapRepoGroup(skippedRepos.over_limit_repos),
   };
 }
 
-function processRepoGroup(
+function mapRepoGroup(
   repoGroup: ApiVariantAnalysisSkippedRepositoryGroup | undefined,
 ): VariantAnalysisSkippedRepositoryGroup | undefined {
   if (!repoGroup) {
@@ -172,7 +168,7 @@ function processRepoGroup(
   };
 }
 
-function processNotFoundRepoGroup(
+function mapNotFoundRepoGroup(
   repoGroup: ApiVariantAnalysisNotFoundRepositoryGroup | undefined,
 ): VariantAnalysisSkippedRepositoryGroup | undefined {
   if (!repoGroup) {
@@ -191,7 +187,7 @@ function processNotFoundRepoGroup(
   };
 }
 
-function processApiRepoStatus(
+function mapApiRepoStatus(
   analysisStatus: ApiVariantAnalysisRepoStatus,
 ): VariantAnalysisRepoStatus {
   switch (analysisStatus) {
@@ -210,9 +206,7 @@ function processApiRepoStatus(
   }
 }
 
-function processApiStatus(
-  status: ApiVariantAnalysisStatus,
-): VariantAnalysisStatus {
+function mapApiStatus(status: ApiVariantAnalysisStatus): VariantAnalysisStatus {
   if (status === "succeeded") {
     return VariantAnalysisStatus.Succeeded;
   } else if (status === "in_progress") {
@@ -226,7 +220,7 @@ function processApiStatus(
   }
 }
 
-export function processFailureReason(
+export function mapFailureReason(
   failureReason: ApiVariantAnalysisFailureReason,
 ): VariantAnalysisFailureReason {
   switch (failureReason) {

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-monitor.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-monitor.ts
@@ -11,7 +11,7 @@ import {
   repoHasDownloadableArtifact,
 } from "./shared/variant-analysis";
 import type { VariantAnalysis as ApiVariantAnalysis } from "./gh-api/variant-analysis";
-import { processUpdatedVariantAnalysis } from "./variant-analysis-processor";
+import { mapUpdatedVariantAnalysis } from "./variant-analysis-mapper";
 import { DisposableObject } from "../common/disposable-object";
 import { sleep } from "../common/time";
 import { getErrorMessage } from "../common/helpers-pure";
@@ -119,7 +119,7 @@ export class VariantAnalysisMonitor extends DisposableObject {
         continue;
       }
 
-      variantAnalysis = processUpdatedVariantAnalysis(
+      variantAnalysis = mapUpdatedVariantAnalysis(
         variantAnalysis,
         variantAnalysisSummary,
       );

--- a/extensions/ql-vscode/test/unit-tests/variant-analysis/variant-analysis-mapper.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/variant-analysis/variant-analysis-mapper.test.ts
@@ -3,10 +3,10 @@ import type { VariantAnalysisScannedRepository as ApiVariantAnalysisScannedRepos
 import type { VariantAnalysisScannedRepository } from "../../../src/variant-analysis/shared/variant-analysis";
 import { VariantAnalysisRepoStatus } from "../../../src/variant-analysis/shared/variant-analysis";
 import {
-  processScannedRepository,
-  processVariantAnalysis,
-  processVariantAnalysisRepositoryTask,
-} from "../../../src/variant-analysis/variant-analysis-processor";
+  mapScannedRepository,
+  mapVariantAnalysis,
+  mapVariantAnalysisRepositoryTask,
+} from "../../../src/variant-analysis/variant-analysis-mapper";
 import {
   createMockScannedRepo,
   createMockScannedRepos,
@@ -17,7 +17,7 @@ import { createMockSubmission } from "../../factories/variant-analysis/shared/va
 import { createMockVariantAnalysisRepoTask } from "../../factories/variant-analysis/gh-api/variant-analysis-repo-task";
 import { QueryLanguage } from "../../../src/common/query-language";
 
-describe(processVariantAnalysis.name, () => {
+describe(mapVariantAnalysis.name, () => {
   const scannedRepos = createMockScannedRepos();
   const skippedRepos = createMockSkippedRepos();
   const mockApiResponse = createMockApiResponse(
@@ -27,8 +27,8 @@ describe(processVariantAnalysis.name, () => {
   );
   const mockSubmission = createMockSubmission();
 
-  it("should process an API response and return a variant analysis", () => {
-    const result = processVariantAnalysis(mockSubmission, mockApiResponse);
+  it("should map an API response and return a variant analysis", () => {
+    const result = mapVariantAnalysis(mockSubmission, mockApiResponse);
 
     const {
       access_mismatch_repos,
@@ -173,11 +173,11 @@ describe(processVariantAnalysis.name, () => {
   }
 });
 
-describe(processVariantAnalysisRepositoryTask.name, () => {
+describe(mapVariantAnalysisRepositoryTask.name, () => {
   const mockApiResponse = createMockVariantAnalysisRepoTask();
 
   it("should return the correct result", () => {
-    expect(processVariantAnalysisRepositoryTask(mockApiResponse)).toEqual({
+    expect(mapVariantAnalysisRepositoryTask(mockApiResponse)).toEqual({
       repository: {
         id: mockApiResponse.repository.id,
         fullName: mockApiResponse.repository.full_name,
@@ -194,7 +194,7 @@ describe(processVariantAnalysisRepositoryTask.name, () => {
   });
 });
 
-describe(processScannedRepository.name, () => {
+describe(mapScannedRepository.name, () => {
   const mockApiResponse = createMockScannedRepo(
     faker.word.sample(),
     faker.datatype.boolean(),
@@ -202,7 +202,7 @@ describe(processScannedRepository.name, () => {
   );
 
   it("should return the correct result", () => {
-    expect(processScannedRepository(mockApiResponse)).toEqual({
+    expect(mapScannedRepository(mockApiResponse)).toEqual({
       repository: {
         id: mockApiResponse.repository.id,
         fullName: mockApiResponse.repository.full_name,

--- a/extensions/ql-vscode/test/vscode-tests/activated-extension/variant-analysis/variant-analysis-monitor.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/activated-extension/variant-analysis/variant-analysis-monitor.test.ts
@@ -14,10 +14,10 @@ import type { VariantAnalysis } from "../../../../src/variant-analysis/shared/va
 import { VariantAnalysisStatus } from "../../../../src/variant-analysis/shared/variant-analysis";
 import { createMockScannedRepos } from "../../../factories/variant-analysis/gh-api/scanned-repositories";
 import {
-  processFailureReason,
-  processScannedRepository,
-  processUpdatedVariantAnalysis,
-} from "../../../../src/variant-analysis/variant-analysis-processor";
+  mapFailureReason,
+  mapScannedRepository,
+  mapUpdatedVariantAnalysis,
+} from "../../../../src/variant-analysis/variant-analysis-mapper";
 import { createMockVariantAnalysis } from "../../../factories/variant-analysis/shared/variant-analysis";
 import { createMockApp } from "../../../__mocks__/appMock";
 import { createMockCommandManager } from "../../../__mocks__/commandsMock";
@@ -88,7 +88,7 @@ describe("Variant Analysis Monitor", () => {
       expect(onVariantAnalysisChangeSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           status: VariantAnalysisStatus.Failed,
-          failureReason: processFailureReason(
+          failureReason: mapFailureReason(
             mockFailedApiResponse.failure_reason as VariantAnalysisFailureReason,
           ),
         }),
@@ -127,8 +127,8 @@ describe("Variant Analysis Monitor", () => {
           expect(mockEecuteCommand).toHaveBeenNthCalledWith(
             index + 1,
             "codeQL.autoDownloadVariantAnalysisResult",
-            processScannedRepository(succeededRepo),
-            processUpdatedVariantAnalysis(variantAnalysis, mockApiResponse),
+            mapScannedRepository(succeededRepo),
+            mapUpdatedVariantAnalysis(variantAnalysis, mockApiResponse),
           );
         });
       });


### PR DESCRIPTION
Renaming mapping functions around variant analysis objects to `mapXXX` (from `processXXX`).

Whenever I read `processXXX` it makes me think it's actually processing the variant analysis submission etc. when in fact it just maps from one object to another.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
