### PR TITLE
Send telemetry for `addDatabaseSourceToWorkspace` setting

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [UNRELEASED]
 
+- Enable collection of telemetry for the `codeQL.addingDatabases.addDatabaseSourceToWorkspace` setting. [#3238](https://github.com/github/vscode-codeql/pull/3238)
 - In the CodeQL model editor, you can now select individual method rows and save changes to only the selected rows, instead of having to save the entire library model. [#3156](https://github.com/github/vscode-codeql/pull/3156)
 - If you run a query without having selected a database, we show a more intuitive prompt to help you select a database. [#3214](https://github.com/github/vscode-codeql/pull/3214)
 - The UI for browsing and running CodeQL tests has moved to use VS Code's built-in test UI. This makes the CodeQL test UI more consistent with the test UIs for other languages.

--- a/extensions/ql-vscode/src/common/vscode/telemetry.ts
+++ b/extensions/ql-vscode/src/common/vscode/telemetry.ts
@@ -212,6 +212,21 @@ export class ExtensionTelemetryListener
     this.reporter.sendTelemetryErrorEvent("error", properties, {});
   }
 
+  sendConfigInformation(config: Record<string, string>): void {
+    if (!this.reporter) {
+      return;
+    }
+
+    this.reporter.sendTelemetryEvent(
+      "config",
+      {
+        ...config,
+        cliVersion: this.cliVersionStr,
+      },
+      {},
+    );
+  }
+
   /**
    * Displays a popup asking the user if they want to enable telemetry
    * for this extension.

--- a/extensions/ql-vscode/src/common/vscode/telemetry.ts
+++ b/extensions/ql-vscode/src/common/vscode/telemetry.ts
@@ -221,6 +221,7 @@ export class ExtensionTelemetryListener
       "config",
       {
         ...config,
+        isCanary: isCanary().toString(),
         cliVersion: this.cliVersionStr,
       },
       {},

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -653,7 +653,7 @@ export function allowHttp(): boolean {
   );
 }
 
-const ADD_DATABASE_SOURCE_TO_WORKSPACE_SETTING = new Setting(
+export const ADD_DATABASE_SOURCE_TO_WORKSPACE_SETTING = new Setting(
   "addDatabaseSourceToWorkspace",
   ADDING_DATABASES_SETTING,
 );

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -23,6 +23,8 @@ import {
 } from "./common/vscode/archive-filesystem-provider";
 import { CliVersionConstraint, CodeQLCliServer } from "./codeql-cli/cli";
 import {
+  ADD_DATABASE_SOURCE_TO_WORKSPACE_SETTING,
+  addDatabaseSourceToWorkspace,
   CliConfigListener,
   DistributionConfigListener,
   GitHubDatabaseConfigListener,
@@ -302,6 +304,14 @@ const codeQlVersionRange = DEFAULT_DISTRIBUTION_VERSION_RANGE;
 // before silently being refused to upgrade.
 const MIN_VERSION = "1.82.0";
 
+function sendConfigTelemetryData() {
+  const config: Record<string, string> = {};
+  config[ADD_DATABASE_SOURCE_TO_WORKSPACE_SETTING.qualifiedName] =
+    addDatabaseSourceToWorkspace().toString();
+
+  telemetryListener?.sendConfigInformation(config);
+}
+
 /**
  * Returns the CodeQLExtensionInterface, or an empty object if the interface is not
  * available after activation is complete. This will happen if there is no cli
@@ -328,6 +338,8 @@ export async function activate(
   install();
 
   const app = new ExtensionApp(ctx);
+
+  sendConfigTelemetryData();
 
   const quickEvalCodeLensProvider = new QuickEvalCodeLensProvider();
   languages.registerCodeLensProvider(

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/telemetry.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/telemetry.test.ts
@@ -450,7 +450,7 @@ describe("telemetry reporting", () => {
     expect(showInformationMessageSpy).toBeCalledTimes(1);
   });
 
-  it("should send a ui-interaction telementry event", async () => {
+  it("should send a ui-interaction telemetry event", async () => {
     await telemetryListener.initialize();
 
     telemetryListener.sendUIInteraction("test");
@@ -467,7 +467,7 @@ describe("telemetry reporting", () => {
     expect(sendTelemetryErrorEventSpy).not.toBeCalled();
   });
 
-  it("should send a ui-interaction telementry event with a cli version", async () => {
+  it("should send a ui-interaction telemetry event with a cli version", async () => {
     await telemetryListener.initialize();
 
     telemetryListener.cliVersion = new SemVer("1.2.3");
@@ -485,7 +485,7 @@ describe("telemetry reporting", () => {
     expect(sendTelemetryErrorEventSpy).not.toBeCalled();
   });
 
-  it("should send an error telementry event", async () => {
+  it("should send an error telemetry event", async () => {
     await telemetryListener.initialize();
 
     telemetryListener.sendError(redactableError`test`);
@@ -503,7 +503,7 @@ describe("telemetry reporting", () => {
     );
   });
 
-  it("should send an error telementry event with a cli version", async () => {
+  it("should send an error telemetry event with a cli version", async () => {
     await telemetryListener.initialize();
     telemetryListener.cliVersion = new SemVer("1.2.3");
 
@@ -541,6 +541,26 @@ describe("telemetry reporting", () => {
       },
       {},
     );
+  });
+
+  it("should send config telemetry event", async () => {
+    await telemetryListener.initialize();
+
+    telemetryListener.sendConfigInformation({
+      testKey: "testValue",
+      testKey2: "42",
+    });
+
+    expect(sendTelemetryEventSpy).toHaveBeenCalledWith(
+      "config",
+      {
+        testKey: "testValue",
+        testKey2: "42",
+        cliVersion: "not-set",
+      },
+      {},
+    );
+    expect(sendTelemetryErrorEventSpy).not.toHaveBeenCalled();
   });
 
   async function enableTelemetry(section: string, value: boolean | undefined) {

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/telemetry.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/telemetry.test.ts
@@ -556,6 +556,7 @@ describe("telemetry reporting", () => {
       {
         testKey: "testValue",
         testKey2: "42",
+        isCanary: "false",
         cliVersion: "not-set",
       },
       {},


### PR DESCRIPTION
We'd like to know if users are re-enabling the old behaviour of [auto-adding database sources](https://github.com/github/vscode-codeql/pull/3047) to the workspace. In future, this same approach could be extended to other settings. 

See internal linked issue for more info and an example Kusto query! 🔗 

## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
  - https://github.com/github/codeql/pull/15333
