### PR TITLE
Add stubs of commands for multi-query support

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -550,6 +550,10 @@
         "title": "CodeQL: Run Variant Analysis"
       },
       {
+        "command": "codeQL.runVariantAnalysisPublishedPack",
+        "title": "CodeQL: Run Variant Analysis against published pack"
+      },
+      {
         "command": "codeQL.exportSelectedVariantAnalysisResults",
         "title": "CodeQL: Export Variant Analysis Results"
       },
@@ -1409,6 +1413,10 @@
         {
           "command": "codeQL.runVariantAnalysisContextExplorer",
           "when": "false"
+        },
+        {
+          "command": "codeQL.runVariantAnalysisPublishedPack",
+          "when": "config.codeQL.canary && config.codeQL.variantAnalysis.multiQuery"
         },
         {
           "command": "codeQL.runVariantAnalysisContextEditor",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -546,6 +546,10 @@
         "title": "CodeQL: Run Variant Analysis"
       },
       {
+        "command": "codeQL.runVariantAnalysisContextExplorer",
+        "title": "CodeQL: Run Variant Analysis"
+      },
+      {
         "command": "codeQL.exportSelectedVariantAnalysisResults",
         "title": "CodeQL: Export Variant Analysis Results"
       },
@@ -1322,6 +1326,11 @@
           "when": "resourceScheme != codeql-zip-archive"
         },
         {
+          "command": "codeQL.runVariantAnalysisContextExplorer",
+          "group": "9_qlCommands",
+          "when": "resourceExtname == .ql && config.codeQL.canary && config.codeQL.variantAnalysis.multiQuery"
+        },
+        {
           "command": "codeQL.openReferencedFileContextExplorer",
           "group": "9_qlCommands",
           "when": "resourceExtname == .qlref"
@@ -1396,6 +1405,10 @@
         {
           "command": "codeQL.runVariantAnalysis",
           "when": "editorLangId == ql && resourceExtname == .ql"
+        },
+        {
+          "command": "codeQL.runVariantAnalysisContextExplorer",
+          "when": "false"
         },
         {
           "command": "codeQL.runVariantAnalysisContextEditor",

--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -277,6 +277,7 @@ export type VariantAnalysisCommands = {
   ) => Promise<void>;
   "codeQL.runVariantAnalysis": (uri?: Uri) => Promise<void>;
   "codeQL.runVariantAnalysisContextEditor": (uri?: Uri) => Promise<void>;
+  "codeQL.runVariantAnalysisContextExplorer": ExplorerSelectionCommandFunction<Uri>;
   "codeQLQueries.runVariantAnalysisContextMenu": TreeViewContextSingleSelectionCommandFunction<QueryTreeViewItem>;
 };
 

--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -279,6 +279,7 @@ export type VariantAnalysisCommands = {
   "codeQL.runVariantAnalysisContextEditor": (uri?: Uri) => Promise<void>;
   "codeQL.runVariantAnalysisContextExplorer": ExplorerSelectionCommandFunction<Uri>;
   "codeQLQueries.runVariantAnalysisContextMenu": TreeViewContextSingleSelectionCommandFunction<QueryTreeViewItem>;
+  "codeQL.runVariantAnalysisPublishedPack": () => Promise<void>;
 };
 
 export type DatabasePanelCommands = {

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -175,6 +175,8 @@ export class VariantAnalysisManager
       ),
       "codeQLQueries.runVariantAnalysisContextMenu":
         this.runVariantAnalysisFromQueriesPanel.bind(this),
+      "codeQL.runVariantAnalysisPublishedPack":
+        this.runVariantAnalysisFromPublishedPack.bind(this),
     };
   }
 
@@ -212,6 +214,10 @@ export class VariantAnalysisManager
         Uri.file(queryTreeViewItem.path),
       );
     }
+  }
+
+  private async runVariantAnalysisFromPublishedPack(): Promise<void> {
+    throw new Error("Command not yet implemented");
   }
 
   public async runVariantAnalysis(

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -86,6 +86,7 @@ import {
 import type { QueryTreeViewItem } from "../queries-panel/query-tree-view-item";
 import { RequestError } from "@octokit/request-error";
 import { handleRequestError } from "./custom-errors";
+import { createMultiSelectionCommand } from "../common/vscode/selection-commands";
 
 const maxRetryCount = 3;
 
@@ -167,9 +168,11 @@ export class VariantAnalysisManager
       "codeQL.openVariantAnalysisView": this.showView.bind(this),
       "codeQL.runVariantAnalysis":
         this.runVariantAnalysisFromCommand.bind(this),
-      // Since we are tracking extension usage through commands, this command mirrors the "codeQL.runVariantAnalysis" command
       "codeQL.runVariantAnalysisContextEditor":
         this.runVariantAnalysisFromCommand.bind(this),
+      "codeQL.runVariantAnalysisContextExplorer": createMultiSelectionCommand(
+        this.runVariantAnalysisFromExplorer.bind(this),
+      ),
       "codeQLQueries.runVariantAnalysisContextMenu":
         this.runVariantAnalysisFromQueriesPanel.bind(this),
     };
@@ -192,6 +195,13 @@ export class VariantAnalysisManager
         cancellable: true,
       },
     );
+  }
+
+  private async runVariantAnalysisFromExplorer(fileURIs: Uri[]): Promise<void> {
+    if (fileURIs.length !== 1) {
+      throw new Error("Can only run a single query at a time");
+    }
+    return this.runVariantAnalysisFromCommand(fileURIs[0]);
   }
 
   private async runVariantAnalysisFromQueriesPanel(


### PR DESCRIPTION
This PR adds stubs of commands for `codeQL.runVariantAnalysisContextExplorer` and `codeQL.runVariantAnalysisPublishedPack`. Both of these are currently behind the canary flag and a new `codeQL.variantAnalysis.multiQuery`. We're not trying to fully implement these commands in this PR, but just add the boilerplate that we can extend later.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
