### PR TITLE
Tidy up variant analysis commands

### DIFF
--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -275,8 +275,8 @@ export type VariantAnalysisCommands = {
   "codeQL.openVariantAnalysisView": (
     variantAnalysisId: number,
   ) => Promise<void>;
-  "codeQL.runVariantAnalysis": (uri?: Uri) => Promise<void>;
-  "codeQL.runVariantAnalysisContextEditor": (uri?: Uri) => Promise<void>;
+  "codeQL.runVariantAnalysis": () => Promise<void>;
+  "codeQL.runVariantAnalysisContextEditor": (uri: Uri) => Promise<void>;
   "codeQL.runVariantAnalysisContextExplorer": ExplorerSelectionCommandFunction<Uri>;
   "codeQLQueries.runVariantAnalysisContextMenu": TreeViewContextSingleSelectionCommandFunction<QueryTreeViewItem>;
   "codeQL.runVariantAnalysisPublishedPack": () => Promise<void>;

--- a/extensions/ql-vscode/src/variant-analysis/run-remote-query.ts
+++ b/extensions/ql-vscode/src/variant-analysis/run-remote-query.ts
@@ -274,12 +274,12 @@ interface PreparedRemoteQuery {
 export async function prepareRemoteQueryRun(
   cliServer: CodeQLCliServer,
   credentials: Credentials,
-  uri: Uri | undefined,
+  uri: Uri,
   progress: ProgressCallback,
   token: CancellationToken,
   dbManager: DbManager,
 ): Promise<PreparedRemoteQuery> {
-  if (!uri?.fsPath.endsWith(".ql")) {
+  if (!uri.fsPath.endsWith(".ql")) {
     throw new UserCancellationException("Not a CodeQL query file.");
   }
 


### PR DESCRIPTION
Paired with @robertbrignull.

The `codeQL.runVariantAnalysis` and `runVariantAnalysisContextEditor` commands were both calling the same underlying code, making types a bit hard to follow. This makes the commands and types more explicit early on
 
## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
