### PR TITLE
Allow multiple file URIs to be passed into prepareRemoteQueryRun

### DIFF
--- a/extensions/ql-vscode/src/variant-analysis/run-remote-query.ts
+++ b/extensions/ql-vscode/src/variant-analysis/run-remote-query.ts
@@ -274,11 +274,19 @@ interface PreparedRemoteQuery {
 export async function prepareRemoteQueryRun(
   cliServer: CodeQLCliServer,
   credentials: Credentials,
-  uri: Uri,
+  uris: Uri[],
   progress: ProgressCallback,
   token: CancellationToken,
   dbManager: DbManager,
 ): Promise<PreparedRemoteQuery> {
+  if (uris.length !== 1) {
+    // For now we only support a single file, but we're aiming
+    // to support multiple files in the near future.
+    throw Error("Exactly one query file must be selected.");
+  }
+
+  const uri = uris[0];
+
   if (!uri.fsPath.endsWith(".ql")) {
     throw new UserCancellationException("Not a CodeQL query file.");
   }

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -220,7 +220,7 @@ export class VariantAnalysisManager
   private async runVariantAnalysisCommand(uri: Uri): Promise<void> {
     return withProgress(
       async (progress, token) => {
-        await this.runVariantAnalysis(uri, progress, token);
+        await this.runVariantAnalysis([uri], progress, token);
       },
       {
         title: "Run Variant Analysis",
@@ -230,7 +230,7 @@ export class VariantAnalysisManager
   }
 
   public async runVariantAnalysis(
-    uri: Uri,
+    uris: Uri[],
     progress: ProgressCallback,
     token: CancellationToken,
   ): Promise<void> {
@@ -254,7 +254,7 @@ export class VariantAnalysisManager
     } = await prepareRemoteQueryRun(
       this.cliServer,
       this.app.credentials,
-      uri,
+      uris,
       progress,
       token,
       this.dbManager,

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
@@ -100,7 +100,7 @@ describe("Variant Analysis Manager", () => {
       const fileUri = getFile("data-remote-qlpack/in-pack.ql");
 
       await variantAnalysisManager.runVariantAnalysis(
-        fileUri,
+        [fileUri],
         progress,
         cancellationTokenSource.token,
       );
@@ -121,7 +121,7 @@ describe("Variant Analysis Manager", () => {
       const fileUri = getFile("data-remote-no-qlpack/in-pack.ql");
 
       await variantAnalysisManager.runVariantAnalysis(
-        fileUri,
+        [fileUri],
         progress,
         cancellationTokenSource.token,
       );
@@ -142,7 +142,7 @@ describe("Variant Analysis Manager", () => {
       const fileUri = getFile("data-remote-qlpack-nested/subfolder/in-pack.ql");
 
       await variantAnalysisManager.runVariantAnalysis(
-        fileUri,
+        [fileUri],
         progress,
         cancellationTokenSource.token,
       );
@@ -163,7 +163,7 @@ describe("Variant Analysis Manager", () => {
       const fileUri = getFile("data-remote-no-qlpack/in-pack.ql");
 
       const promise = variantAnalysisManager.runVariantAnalysis(
-        fileUri,
+        [fileUri],
         progress,
         cancellationTokenSource.token,
       );
@@ -313,7 +313,7 @@ describe("Variant Analysis Manager", () => {
     }) {
       const fileUri = getFile(queryPath);
       await variantAnalysisManager.runVariantAnalysis(
-        fileUri,
+        [fileUri],
         progress,
         cancellationTokenSource.token,
       );


### PR DESCRIPTION
This is a small change to set us up for future support for multiple queries.

I've stuck with the original name for now to avoid confusion/conflicts, but in the future we should consider renaming the variables to something more useful e.g. `queryFileUris`.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
