### PR TITLE
Add prototype implementation for codeQL.runVariantAnalysisPublishedPack

### DIFF
--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -121,6 +121,16 @@ type GenerateExtensiblePredicateMetadataResult = {
   }>;
 };
 
+type PackDownloadResult = {
+  // There are other properties in this object, but they are
+  // not relevant for its use in the extension, so we omit them.
+  packs: Array<{
+    name: string;
+    version: string;
+  }>;
+  packDir: string;
+};
+
 /**
  * The expected output of `codeql resolve qlref`.
  */
@@ -1383,7 +1393,7 @@ export class CodeQLCliServer implements Disposable {
    * Downloads a specified pack.
    * @param packs The `<package-scope/name[@version]>` of the packs to download.
    */
-  async packDownload(packs: string[]) {
+  async packDownload(packs: string[]): Promise<PackDownloadResult> {
     return this.runJsonCodeQlCliCommandWithAuthentication(
       ["pack", "download"],
       packs,

--- a/extensions/ql-vscode/src/codeql-cli/query-language.ts
+++ b/extensions/ql-vscode/src/codeql-cli/query-language.ts
@@ -63,7 +63,7 @@ export async function askForLanguage(
     .sort((a, b) => a.label.localeCompare(b.label));
 
   const selectedItem = await window.showQuickPick(items, {
-    placeHolder: "Select target language for your query",
+    placeHolder: "Select target query language",
     ignoreFocusOut: true,
   });
   if (!selectedItem) {

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -87,6 +87,7 @@ import type { QueryTreeViewItem } from "../queries-panel/query-tree-view-item";
 import { RequestError } from "@octokit/request-error";
 import { handleRequestError } from "./custom-errors";
 import { createMultiSelectionCommand } from "../common/vscode/selection-commands";
+import { askForLanguage } from "../codeql-cli/query-language";
 
 const maxRetryCount = 3;
 
@@ -214,7 +215,51 @@ export class VariantAnalysisManager
   }
 
   private async runVariantAnalysisFromPublishedPack(): Promise<void> {
-    throw new Error("Command not yet implemented");
+    const language = await askForLanguage(this.cliServer);
+
+    const packName = `codeql/${language}-queries`;
+    const packDownloadResult = await this.cliServer.packDownload([packName]);
+    const downloadedPack = packDownloadResult.packs[0];
+
+    const packDir = `${packDownloadResult.packDir}/${downloadedPack.name}/${downloadedPack.version}`;
+
+    const suitePath = `${packDir}/codeql-suites/${language}-code-scanning.qls`;
+    const resolvedQueries = await this.cliServer.resolveQueries(suitePath);
+
+    const problemQueries =
+      await this.filterToOnlyProblemQueries(resolvedQueries);
+
+    if (problemQueries.length === 0) {
+      void this.app.logger.showErrorMessage(
+        `Unable to trigger variant analysis. No problem queries found in published query pack: ${packName}.`,
+      );
+    }
+
+    return withProgress((progress, token) =>
+      this.runVariantAnalysis(
+        problemQueries.map((q) => Uri.file(q)),
+        progress,
+        token,
+      ),
+    );
+  }
+
+  private async filterToOnlyProblemQueries(
+    queries: string[],
+  ): Promise<string[]> {
+    const problemQueries: string[] = [];
+    for (const query of queries) {
+      const queryMetadata = await this.cliServer.resolveMetadata(query);
+      if (
+        queryMetadata.kind === "problem" ||
+        queryMetadata.kind === "path-problem"
+      ) {
+        problemQueries.push(query);
+      } else {
+        void this.app.logger.log(`Skipping non-problem query ${query}`);
+      }
+    }
+    return problemQueries;
   }
 
   private async runVariantAnalysisCommand(uri: Uri): Promise<void> {

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -221,9 +221,17 @@ export class VariantAnalysisManager
     const packDownloadResult = await this.cliServer.packDownload([packName]);
     const downloadedPack = packDownloadResult.packs[0];
 
-    const packDir = `${packDownloadResult.packDir}/${downloadedPack.name}/${downloadedPack.version}`;
+    const packDir = join(
+      packDownloadResult.packDir,
+      downloadedPack.name,
+      downloadedPack.version,
+    );
 
-    const suitePath = `${packDir}/codeql-suites/${language}-code-scanning.qls`;
+    const suitePath = join(
+      packDir,
+      "codeql-suites",
+      `${language}-code-scanning.qls`,
+    );
     const resolvedQueries = await this.cliServer.resolveQueries(suitePath);
 
     const problemQueries =

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -241,6 +241,7 @@ export class VariantAnalysisManager
       void this.app.logger.showErrorMessage(
         `Unable to trigger variant analysis. No problem queries found in published query pack: ${packName}.`,
       );
+      return;
     }
 
     return withProgress((progress, token) =>


### PR DESCRIPTION
Implements the `codeQL.runVariantAnalysisPublishedPack` command. This can likely still be considered a prototype implementation, but it seems to work quite well. Of course right now it fails saying you can't run multiple queries, but that will be fixed in the future.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
