### PR TITLE
Remove deprecated jest syntac

### DIFF
--- a/extensions/ql-vscode/test/common/logging/output-channel-logger.test.ts
+++ b/extensions/ql-vscode/test/common/logging/output-channel-logger.test.ts
@@ -54,12 +54,12 @@ describe("OutputChannelLogger tests", function () {
 
   it("should log to the output channel", async () => {
     await logger.log("xxx");
-    expect(mockOutputChannel.appendLine).toBeCalledWith("xxx");
-    expect(mockOutputChannel.append).not.toBeCalledWith("xxx");
+    expect(mockOutputChannel.appendLine).toHaveBeenCalledWith("xxx");
+    expect(mockOutputChannel.append).not.toHaveBeenCalledWith("xxx");
 
     await logger.log("yyy", { trailingNewline: false });
-    expect(mockOutputChannel.appendLine).not.toBeCalledWith("yyy");
-    expect(mockOutputChannel.append).toBeCalledWith("yyy");
+    expect(mockOutputChannel.appendLine).not.toHaveBeenCalledWith("yyy");
+    expect(mockOutputChannel.append).toHaveBeenCalledWith("yyy");
 
     const hucairz = createSideLogger(logger, "hucairz");
     await hucairz.log("zzz");

--- a/extensions/ql-vscode/test/unit-tests/common/disposable-object.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/common/disposable-object.test.ts
@@ -34,9 +34,9 @@ describe("DisposableObject and DisposeHandler", () => {
 
     disposableObject.dispose();
 
-    expect(disposable1.dispose).toBeCalled();
-    expect(disposable2.dispose).toBeCalled();
-    expect(disposable3.dispose).toBeCalled();
+    expect(disposable1.dispose).toHaveBeenCalled();
+    expect(disposable2.dispose).toHaveBeenCalled();
+    expect(disposable3.dispose).toHaveBeenCalled();
 
     // pushed items must be called in reverse order
     expect(disposable2.dispose.mock.invocationCallOrder[0]).toBeLessThan(
@@ -51,30 +51,30 @@ describe("DisposableObject and DisposeHandler", () => {
 
     disposableObject.dispose();
 
-    expect(disposable1.dispose).not.toBeCalled();
-    expect(disposable2.dispose).not.toBeCalled();
-    expect(disposable3.dispose).not.toBeCalled();
+    expect(disposable1.dispose).not.toHaveBeenCalled();
+    expect(disposable2.dispose).not.toHaveBeenCalled();
+    expect(disposable3.dispose).not.toHaveBeenCalled();
   });
 
   it("should dispose and stop tracking objects", () => {
     disposableObject.track(disposable1);
     disposableObject.disposeAndStopTracking(disposable1);
 
-    expect(disposable1.dispose).toBeCalled();
+    expect(disposable1.dispose).toHaveBeenCalled();
     disposable1.dispose.mockClear();
 
     disposableObject.dispose();
-    expect(disposable1.dispose).not.toBeCalled();
+    expect(disposable1.dispose).not.toHaveBeenCalled();
   });
 
   it("should avoid disposing an object that is not tracked", () => {
     disposableObject.push(disposable1);
     disposableObject.disposeAndStopTracking(disposable1);
 
-    expect(disposable1.dispose).not.toBeCalled();
+    expect(disposable1.dispose).not.toHaveBeenCalled();
 
     disposableObject.dispose();
-    expect(disposable1.dispose).toBeCalled();
+    expect(disposable1.dispose).toHaveBeenCalled();
   });
 
   it("ahould use a dispose handler", () => {
@@ -91,10 +91,10 @@ describe("DisposableObject and DisposeHandler", () => {
 
     disposableObject.dispose(handler);
 
-    expect(disposable1.dispose).toBeCalled();
-    expect(disposable2.dispose).not.toBeCalled();
-    expect(disposable3.dispose).toBeCalled();
-    expect(disposable4.dispose).not.toBeCalled();
+    expect(disposable1.dispose).toHaveBeenCalled();
+    expect(disposable2.dispose).not.toHaveBeenCalled();
+    expect(disposable3.dispose).toHaveBeenCalled();
+    expect(disposable4.dispose).not.toHaveBeenCalled();
 
     // now that disposableObject has been disposed, subsequent disposals are
     // no-ops
@@ -105,10 +105,10 @@ describe("DisposableObject and DisposeHandler", () => {
 
     disposableObject.dispose();
 
-    expect(disposable1.dispose).not.toBeCalled();
-    expect(disposable2.dispose).not.toBeCalled();
-    expect(disposable3.dispose).not.toBeCalled();
-    expect(disposable4.dispose).not.toBeCalled();
+    expect(disposable1.dispose).not.toHaveBeenCalled();
+    expect(disposable2.dispose).not.toHaveBeenCalled();
+    expect(disposable3.dispose).not.toHaveBeenCalled();
+    expect(disposable4.dispose).not.toHaveBeenCalled();
   });
 
   class MyDisposableObject extends DisposableObject {

--- a/extensions/ql-vscode/test/unit-tests/databases/config/db-config-store.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/config/db-config-store.test.ts
@@ -139,7 +139,7 @@ describe("db config store", () => {
       const configStore = new DbConfigStore(app, false);
       await configStore.initialize();
 
-      expect(executeCommand).toBeCalledWith(
+      expect(executeCommand).toHaveBeenCalledWith(
         "setContext",
         "codeQLVariantAnalysisRepositories.configError",
         true,
@@ -157,7 +157,7 @@ describe("db config store", () => {
       const configStore = new DbConfigStore(app, false);
       await configStore.initialize();
 
-      expect(executeCommand).toBeCalledWith(
+      expect(executeCommand).toHaveBeenCalledWith(
         "setContext",
         "codeQLVariantAnalysisRepositories.configError",
         false,

--- a/extensions/ql-vscode/test/vscode-tests/activated-extension/variant-analysis/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/activated-extension/variant-analysis/variant-analysis-manager.test.ts
@@ -610,7 +610,7 @@ describe("Variant Analysis Manager", () => {
     it("should return cancel if valid", async () => {
       await variantAnalysisManager.cancelVariantAnalysis(variantAnalysis.id);
 
-      expect(mockCancelVariantAnalysis).toBeCalledWith(
+      expect(mockCancelVariantAnalysis).toHaveBeenCalledWith(
         app.credentials,
         variantAnalysis,
       );

--- a/extensions/ql-vscode/test/vscode-tests/activated-extension/variant-analysis/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/activated-extension/variant-analysis/variant-analysis-manager.test.ts
@@ -96,7 +96,7 @@ describe("Variant Analysis Manager", () => {
 
         await variantAnalysisManager.rehydrateVariantAnalysis(variantAnalysis);
 
-        expect(stub).toBeCalledTimes(1);
+        expect(stub).toHaveBeenCalledTimes(1);
       });
     });
 
@@ -423,7 +423,7 @@ describe("Variant Analysis Manager", () => {
       );
 
       expect(variantAnalysisManager.downloadsQueueSize()).toBe(0);
-      expect(getResultsSpy).toBeCalledTimes(3);
+      expect(getResultsSpy).toHaveBeenCalledTimes(3);
     });
   });
 
@@ -451,7 +451,7 @@ describe("Variant Analysis Manager", () => {
 
       await variantAnalysisManager.removeVariantAnalysis(dummyVariantAnalysis);
 
-      expect(removeAnalysisResultsStub).toBeCalledTimes(1);
+      expect(removeAnalysisResultsStub).toHaveBeenCalledTimes(1);
       expect(variantAnalysisManager.variantAnalysesSize).toBe(0);
 
       await expect(
@@ -722,7 +722,7 @@ describe("Variant Analysis Manager", () => {
           variantAnalysis.id,
         );
 
-        expect(writeTextStub).toBeCalledTimes(1);
+        expect(writeTextStub).toHaveBeenCalledTimes(1);
       });
 
       it("should be valid JSON when put in object", async () => {

--- a/extensions/ql-vscode/test/vscode-tests/activated-extension/variant-analysis/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/activated-extension/variant-analysis/variant-analysis-manager.test.ts
@@ -656,7 +656,7 @@ describe("Variant Analysis Manager", () => {
           variantAnalysis.id,
         );
 
-        expect(writeTextStub).not.toBeCalled();
+        expect(writeTextStub).not.toHaveBeenCalled();
       });
     });
 
@@ -682,7 +682,7 @@ describe("Variant Analysis Manager", () => {
           variantAnalysis.id,
         );
 
-        expect(writeTextStub).not.toBeCalled();
+        expect(writeTextStub).not.toHaveBeenCalled();
       });
     });
 

--- a/extensions/ql-vscode/test/vscode-tests/activated-extension/variant-analysis/variant-analysis-monitor.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/activated-extension/variant-analysis/variant-analysis-monitor.test.ts
@@ -121,7 +121,7 @@ describe("Variant Analysis Monitor", () => {
         );
         await variantAnalysisMonitor.monitorVariantAnalysis(variantAnalysis);
 
-        expect(mockEecuteCommand).toBeCalledTimes(succeededRepos.length);
+        expect(mockEecuteCommand).toHaveBeenCalledTimes(succeededRepos.length);
 
         succeededRepos.forEach((succeededRepo, index) => {
           expect(mockEecuteCommand).toHaveBeenNthCalledWith(
@@ -197,8 +197,8 @@ describe("Variant Analysis Monitor", () => {
       it("should trigger a download extension command for each repo", async () => {
         await variantAnalysisMonitor.monitorVariantAnalysis(variantAnalysis);
 
-        expect(mockGetVariantAnalysis).toBeCalledTimes(4);
-        expect(mockEecuteCommand).toBeCalledTimes(5);
+        expect(mockGetVariantAnalysis).toHaveBeenCalledTimes(4);
+        expect(mockEecuteCommand).toHaveBeenCalledTimes(5);
       });
     });
 
@@ -261,7 +261,7 @@ describe("Variant Analysis Monitor", () => {
       it("should only trigger the warning once per error", async () => {
         await variantAnalysisMonitor.monitorVariantAnalysis(variantAnalysis);
 
-        expect(logger.showWarningMessage).toBeCalledTimes(4);
+        expect(logger.showWarningMessage).toHaveBeenCalledTimes(4);
         expect(logger.showWarningMessage).toHaveBeenNthCalledWith(
           1,
           expect.stringMatching(/No internet connection/),

--- a/extensions/ql-vscode/test/vscode-tests/activated-extension/variant-analysis/variant-analysis-monitor.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/activated-extension/variant-analysis/variant-analysis-monitor.test.ts
@@ -291,7 +291,7 @@ describe("Variant Analysis Monitor", () => {
       it("should not try to download any repos", async () => {
         await variantAnalysisMonitor.monitorVariantAnalysis(variantAnalysis);
 
-        expect(mockEecuteCommand).not.toBeCalled();
+        expect(mockEecuteCommand).not.toHaveBeenCalled();
       });
     });
 

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
@@ -113,8 +113,8 @@ describe("Variant Analysis Manager", () => {
         }),
       );
 
-      expect(mockGetRepositoryFromNwo).toBeCalledTimes(1);
-      expect(mockSubmitVariantAnalysis).toBeCalledTimes(1);
+      expect(mockGetRepositoryFromNwo).toHaveBeenCalledTimes(1);
+      expect(mockSubmitVariantAnalysis).toHaveBeenCalledTimes(1);
     });
 
     it("should run a remote query that is not part of a qlpack", async () => {
@@ -134,8 +134,8 @@ describe("Variant Analysis Manager", () => {
         }),
       );
 
-      expect(mockGetRepositoryFromNwo).toBeCalledTimes(1);
-      expect(mockSubmitVariantAnalysis).toBeCalledTimes(1);
+      expect(mockGetRepositoryFromNwo).toHaveBeenCalledTimes(1);
+      expect(mockSubmitVariantAnalysis).toHaveBeenCalledTimes(1);
     });
 
     it("should run a remote query that is nested inside a qlpack", async () => {
@@ -155,8 +155,8 @@ describe("Variant Analysis Manager", () => {
         }),
       );
 
-      expect(mockGetRepositoryFromNwo).toBeCalledTimes(1);
-      expect(mockSubmitVariantAnalysis).toBeCalledTimes(1);
+      expect(mockGetRepositoryFromNwo).toHaveBeenCalledTimes(1);
+      expect(mockSubmitVariantAnalysis).toHaveBeenCalledTimes(1);
     });
 
     it("should cancel a run before uploading", async () => {
@@ -318,7 +318,7 @@ describe("Variant Analysis Manager", () => {
         cancellationTokenSource.token,
       );
 
-      expect(mockSubmitVariantAnalysis).toBeCalledTimes(1);
+      expect(mockSubmitVariantAnalysis).toHaveBeenCalledTimes(1);
       expect(executeCommandSpy).toHaveBeenCalledWith(
         "codeQL.monitorNewVariantAnalysis",
         expect.objectContaining({

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
@@ -105,7 +105,7 @@ describe("Variant Analysis Manager", () => {
         cancellationTokenSource.token,
       );
 
-      expect(executeCommandSpy).toBeCalledWith(
+      expect(executeCommandSpy).toHaveBeenCalledWith(
         "codeQL.monitorNewVariantAnalysis",
         expect.objectContaining({
           id: mockApiResponse.id,
@@ -126,7 +126,7 @@ describe("Variant Analysis Manager", () => {
         cancellationTokenSource.token,
       );
 
-      expect(executeCommandSpy).toBeCalledWith(
+      expect(executeCommandSpy).toHaveBeenCalledWith(
         "codeQL.monitorNewVariantAnalysis",
         expect.objectContaining({
           id: mockApiResponse.id,
@@ -147,7 +147,7 @@ describe("Variant Analysis Manager", () => {
         cancellationTokenSource.token,
       );
 
-      expect(executeCommandSpy).toBeCalledWith(
+      expect(executeCommandSpy).toHaveBeenCalledWith(
         "codeQL.monitorNewVariantAnalysis",
         expect.objectContaining({
           id: mockApiResponse.id,
@@ -319,7 +319,7 @@ describe("Variant Analysis Manager", () => {
       );
 
       expect(mockSubmitVariantAnalysis).toBeCalledTimes(1);
-      expect(executeCommandSpy).toBeCalledWith(
+      expect(executeCommandSpy).toHaveBeenCalledWith(
         "codeQL.monitorNewVariantAnalysis",
         expect.objectContaining({
           query: expect.objectContaining({ filePath: fileUri.fsPath }),

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-queries/local-databases.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-queries/local-databases.test.ts
@@ -130,13 +130,13 @@ describe("local databases", () => {
     await (databaseManager as any).addDatabaseItem(mockDbItem);
 
     expect((databaseManager as any)._databaseItems).toEqual([mockDbItem]);
-    expect(updateSpy).toBeCalledWith("databaseList", [
+    expect(updateSpy).toHaveBeenCalledWith("databaseList", [
       {
         options: mockDbOptions(),
         uri: dbLocationUri(dir).toString(true),
       },
     ]);
-    expect(onDidChangeDatabaseItem).toBeCalledWith({
+    expect(onDidChangeDatabaseItem).toHaveBeenCalledWith({
       item: undefined,
       kind: DatabaseEventKind.Add,
     });
@@ -147,8 +147,8 @@ describe("local databases", () => {
     // now remove the item
     await databaseManager.removeDatabaseItem(mockDbItem);
     expect((databaseManager as any)._databaseItems).toEqual([]);
-    expect(updateSpy).toBeCalledWith("databaseList", []);
-    expect(onDidChangeDatabaseItem).toBeCalledWith({
+    expect(updateSpy).toHaveBeenCalledWith("databaseList", []);
+    expect(onDidChangeDatabaseItem).toHaveBeenCalledWith({
       item: undefined,
       kind: DatabaseEventKind.Remove,
     });
@@ -164,14 +164,14 @@ describe("local databases", () => {
       await databaseManager.renameDatabaseItem(mockDbItem, "new name");
 
       expect(mockDbItem.name).toBe("new name");
-      expect(updateSpy).toBeCalledWith("databaseList", [
+      expect(updateSpy).toHaveBeenCalledWith("databaseList", [
         {
           options: { ...mockDbOptions(), displayName: "new name" },
           uri: dbLocationUri(dir).toString(true),
         },
       ]);
 
-      expect(onDidChangeDatabaseItem).toBeCalledWith({
+      expect(onDidChangeDatabaseItem).toHaveBeenCalledWith({
         item: undefined,
         kind: DatabaseEventKind.Rename,
       });
@@ -187,7 +187,7 @@ describe("local databases", () => {
       await (databaseManager as any).addDatabaseItem(mockDbItem);
 
       expect(databaseManager.databaseItems).toEqual([mockDbItem]);
-      expect(updateSpy).toBeCalledWith("databaseList", [
+      expect(updateSpy).toHaveBeenCalledWith("databaseList", [
         {
           uri: dbLocationUri(dir).toString(true),
           options: mockDbOptions(),
@@ -198,7 +198,7 @@ describe("local databases", () => {
         item: undefined,
         kind: DatabaseEventKind.Add,
       };
-      expect(onDidChangeDatabaseItem).toBeCalledWith(mockEvent);
+      expect(onDidChangeDatabaseItem).toHaveBeenCalledWith(mockEvent);
     });
 
     it("should add a database item source archive", async () => {
@@ -234,9 +234,9 @@ describe("local databases", () => {
       await databaseManager.removeDatabaseItem(mockDbItem);
 
       expect(databaseManager.databaseItems).toEqual([]);
-      expect(updateSpy).toBeCalledWith("databaseList", []);
+      expect(updateSpy).toHaveBeenCalledWith("databaseList", []);
       // should remove the folder
-      expect(workspace.updateWorkspaceFolders).toBeCalledWith(0, 1);
+      expect(workspace.updateWorkspaceFolders).toHaveBeenCalledWith(0, 1);
 
       // should also delete the db contents
       await expect(pathExists(mockDbItem.databaseUri.fsPath)).resolves.toBe(
@@ -262,9 +262,9 @@ describe("local databases", () => {
       await databaseManager.removeDatabaseItem(mockDbItem);
 
       expect(databaseManager.databaseItems).toEqual([]);
-      expect(updateSpy).toBeCalledWith("databaseList", []);
+      expect(updateSpy).toHaveBeenCalledWith("databaseList", []);
       // should remove the folder
-      expect(workspace.updateWorkspaceFolders).toBeCalledWith(0, 1);
+      expect(workspace.updateWorkspaceFolders).toHaveBeenCalledWith(0, 1);
 
       // should NOT delete the db contents
       await expect(pathExists(mockDbItem.databaseUri.fsPath)).resolves.toBe(
@@ -279,12 +279,12 @@ describe("local databases", () => {
 
       await (databaseManager as any).addDatabaseItem(mockDbItem);
       // Should have registered this database
-      expect(registerSpy).toBeCalledWith(mockDbItem);
+      expect(registerSpy).toHaveBeenCalledWith(mockDbItem);
 
       await databaseManager.removeDatabaseItem(mockDbItem);
 
       // Should have deregistered this database
-      expect(deregisterSpy).toBeCalledWith(mockDbItem);
+      expect(deregisterSpy).toHaveBeenCalledWith(mockDbItem);
     });
   });
 

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-queries/local-databases.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-queries/local-databases.test.ts
@@ -628,7 +628,7 @@ describe("local databases", () => {
 
         await (databaseManager as any).createSkeletonPacks(mockDbItem);
 
-        expect(generateSpy).not.toBeCalled();
+        expect(generateSpy).not.toHaveBeenCalled();
       });
 
       it("should return early if the user escapes out of the dialog", async () => {
@@ -638,7 +638,7 @@ describe("local databases", () => {
 
         await (databaseManager as any).createSkeletonPacks(mockDbItem);
 
-        expect(generateSpy).not.toBeCalled();
+        expect(generateSpy).not.toHaveBeenCalled();
       });
 
       it("should return early and write choice to settings if user wants to never be asked again", async () => {
@@ -652,14 +652,14 @@ describe("local databases", () => {
 
         await (databaseManager as any).createSkeletonPacks(mockDbItem);
 
-        expect(generateSpy).not.toBeCalled();
+        expect(generateSpy).not.toHaveBeenCalled();
         expect(setAutogenerateQlPacksSpy).toHaveBeenCalledWith("never");
       });
 
       it("should create the skeleton QL pack for the user", async () => {
         await (databaseManager as any).createSkeletonPacks(mockDbItem);
 
-        expect(generateSpy).toBeCalled();
+        expect(generateSpy).toHaveBeenCalled();
       });
     });
 
@@ -694,7 +694,7 @@ describe("local databases", () => {
 
         await (databaseManager as any).createSkeletonPacks(mockDbItem);
 
-        expect(generateSpy).not.toBeCalled();
+        expect(generateSpy).not.toHaveBeenCalled();
       });
     });
   });

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-queries/local-databases.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-queries/local-databases.test.ts
@@ -618,7 +618,7 @@ describe("local databases", () => {
       it("should offer the user to set up a skeleton QL pack", async () => {
         await (databaseManager as any).createSkeletonPacks(mockDbItem);
 
-        expect(showNeverAskAgainDialogSpy).toBeCalledTimes(1);
+        expect(showNeverAskAgainDialogSpy).toHaveBeenCalledTimes(1);
       });
 
       it("should return early if the user refuses help", async () => {
@@ -742,7 +742,7 @@ describe("local databases", () => {
         mockDbItem.origin,
       );
 
-      expect(resolveDatabaseContentsSpy).toBeCalledTimes(2);
+      expect(resolveDatabaseContentsSpy).toHaveBeenCalledTimes(2);
     });
 
     it("should set the database as the currently selected one", async () => {
@@ -751,7 +751,7 @@ describe("local databases", () => {
         mockDbItem.origin,
       );
 
-      expect(setCurrentDatabaseItemSpy).toBeCalledTimes(1);
+      expect(setCurrentDatabaseItemSpy).toHaveBeenCalledTimes(1);
     });
 
     it("should not add database source archive folder when `codeQL.addingDatabases.addDatabaseSourceToWorkspace` is `false`", async () => {
@@ -762,7 +762,7 @@ describe("local databases", () => {
         mockDbItem.origin,
       );
 
-      expect(addDatabaseSourceArchiveFolderSpy).toBeCalledTimes(0);
+      expect(addDatabaseSourceArchiveFolderSpy).toHaveBeenCalledTimes(0);
     });
 
     it("should add database source archive folder when `codeQL.addingDatabases.addDatabaseSourceToWorkspace` is `true`", async () => {
@@ -773,7 +773,7 @@ describe("local databases", () => {
         mockDbItem.origin,
       );
 
-      expect(addDatabaseSourceArchiveFolderSpy).toBeCalledTimes(1);
+      expect(addDatabaseSourceArchiveFolderSpy).toHaveBeenCalledTimes(1);
     });
 
     describe("when codeQL.codespacesTemplate is set to true", () => {
@@ -793,7 +793,7 @@ describe("local databases", () => {
             { isTutorialDatabase },
           );
 
-          expect(createSkeletonPacksSpy).toBeCalledTimes(0);
+          expect(createSkeletonPacksSpy).toHaveBeenCalledTimes(0);
         });
       });
 
@@ -806,7 +806,7 @@ describe("local databases", () => {
             mockDbItem.origin,
           );
 
-          expect(createSkeletonPacksSpy).toBeCalledTimes(1);
+          expect(createSkeletonPacksSpy).toHaveBeenCalledTimes(1);
         });
       });
     });
@@ -819,7 +819,7 @@ describe("local databases", () => {
           mockDbItem.databaseUri,
           mockDbItem.origin,
         );
-        expect(createSkeletonPacksSpy).toBeCalledTimes(0);
+        expect(createSkeletonPacksSpy).toHaveBeenCalledTimes(0);
       });
     });
   });

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/queries-panel/query-tree-data-provider.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/queries-panel/query-tree-data-provider.test.ts
@@ -39,7 +39,7 @@ describe("QueryTreeDataProvider", () => {
       );
 
       expect(dataProvider.getChildren()).toEqual([]);
-      expect(executeCommand).toBeCalledWith(
+      expect(executeCommand).toHaveBeenCalledWith(
         "setContext",
         "codeQL.noQueries",
         true,
@@ -118,7 +118,7 @@ describe("QueryTreeDataProvider", () => {
       onDidChangeQueriesEmitter.fire();
 
       expect(dataProvider.getChildren().length).toEqual(2);
-      expect(executeCommand).toBeCalledWith(
+      expect(executeCommand).toHaveBeenCalledWith(
         "setContext",
         "codeQL.noQueries",
         false,

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/codeql-cli/distribution.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/codeql-cli/distribution.test.ts
@@ -114,8 +114,8 @@ describe("Launcher path", () => {
     expect(result).toBe(pathToCmd);
 
     // no warning or error message
-    expect(warnSpy).toBeCalledTimes(0);
-    expect(errorSpy).toBeCalledTimes(0);
+    expect(warnSpy).toHaveBeenCalledTimes(0);
+    expect(errorSpy).toHaveBeenCalledTimes(0);
   });
 
   it("should warn when deprecated launcher is used, and new launcher is available", async () => {
@@ -132,8 +132,8 @@ describe("Launcher path", () => {
     expect(result).toBe(pathToCmd);
 
     // has warning message
-    expect(warnSpy).toBeCalledTimes(1);
-    expect(errorSpy).toBeCalledTimes(0);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledTimes(0);
   });
 
   it("should warn when launcher path is incorrect", async () => {
@@ -147,7 +147,7 @@ describe("Launcher path", () => {
     expect(result).toBeUndefined();
 
     // no error message
-    expect(warnSpy).toBeCalledTimes(0);
-    expect(errorSpy).toBeCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledTimes(0);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/common/vscode/external-files.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/common/vscode/external-files.test.ts
@@ -29,7 +29,7 @@ describe("tryOpenExternalFile", () => {
       Uri.file("xxx"),
       expect.anything(),
     );
-    expect(executeCommand).not.toBeCalled();
+    expect(executeCommand).not.toHaveBeenCalled();
   });
 
   [
@@ -61,8 +61,8 @@ describe("tryOpenExternalFile", () => {
       const uri = Uri.file("xxx");
       expect(showTextDocumentSpy).toHaveBeenCalledTimes(1);
       expect(showTextDocumentSpy).toHaveBeenCalledWith(uri, expect.anything());
-      expect(showInformationMessageSpy).toBeCalled();
-      expect(executeCommand).not.toBeCalled();
+      expect(showInformationMessageSpy).toHaveBeenCalled();
+      expect(executeCommand).not.toHaveBeenCalled();
     });
   });
 });

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/common/vscode/progress.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/common/vscode/progress.test.ts
@@ -17,7 +17,7 @@ describe("helpers", () => {
     listener({ length: firstStep });
     listener({ length: secondStep });
 
-    expect(progressSpy).toBeCalledTimes(3);
+    expect(progressSpy).toHaveBeenCalledTimes(3);
     expect(progressSpy).toHaveBeenCalledWith({
       step: 0,
       maxStep: max,
@@ -50,7 +50,7 @@ describe("helpers", () => {
     // There are no listeners registered to this readable
     expect(mockReadable.on).not.toHaveBeenCalled();
 
-    expect(progressSpy).toBeCalledTimes(1);
+    expect(progressSpy).toHaveBeenCalledTimes(1);
     expect(progressSpy).toHaveBeenCalledWith({
       step: 1,
       maxStep: 2,

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/common/vscode/progress.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/common/vscode/progress.test.ts
@@ -18,17 +18,17 @@ describe("helpers", () => {
     listener({ length: secondStep });
 
     expect(progressSpy).toBeCalledTimes(3);
-    expect(progressSpy).toBeCalledWith({
+    expect(progressSpy).toHaveBeenCalledWith({
       step: 0,
       maxStep: max,
       message: "My prefix [0.0 MB of 4.0 MB]",
     });
-    expect(progressSpy).toBeCalledWith({
+    expect(progressSpy).toHaveBeenCalledWith({
       step: firstStep,
       maxStep: max,
       message: "My prefix [1.6 MB of 4.0 MB]",
     });
-    expect(progressSpy).toBeCalledWith({
+    expect(progressSpy).toHaveBeenCalledWith({
       step: firstStep + secondStep,
       maxStep: max,
       message: "My prefix [3.6 MB of 4.0 MB]",
@@ -51,7 +51,7 @@ describe("helpers", () => {
     expect(mockReadable.on).not.toHaveBeenCalled();
 
     expect(progressSpy).toBeCalledTimes(1);
-    expect(progressSpy).toBeCalledWith({
+    expect(progressSpy).toHaveBeenCalledWith({
       step: 1,
       maxStep: 2,
       message: "My prefix (Size unknown)",

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/common/vscode/progress.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/common/vscode/progress.test.ts
@@ -48,7 +48,7 @@ describe("helpers", () => {
     );
 
     // There are no listeners registered to this readable
-    expect(mockReadable.on).not.toBeCalled();
+    expect(mockReadable.on).not.toHaveBeenCalled();
 
     expect(progressSpy).toBeCalledTimes(1);
     expect(progressSpy).toBeCalledWith({

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/databases/database-fetcher.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/databases/database-fetcher.test.ts
@@ -145,7 +145,7 @@ describe("database-fetcher", () => {
       await expect(
         convertGithubNwoToDatabaseUrl(githubRepo, octokit, progressSpy),
       ).rejects.toThrow(/Unable to get database/);
-      expect(progressSpy).toBeCalledTimes(0);
+      expect(progressSpy).toHaveBeenCalledTimes(0);
     });
 
     // User has access to the repository, but there are no databases for any language.
@@ -159,7 +159,7 @@ describe("database-fetcher", () => {
       await expect(
         convertGithubNwoToDatabaseUrl(githubRepo, octokit, progressSpy),
       ).rejects.toThrow(/Unable to get database/);
-      expect(progressSpy).toBeCalledTimes(1);
+      expect(progressSpy).toHaveBeenCalledTimes(1);
     });
 
     describe("when language is already provided", () => {

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/language-support/ast-viewer/ast-builder.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/language-support/ast-viewer/ast-builder.test.ts
@@ -55,9 +55,9 @@ describe("AstBuilder", () => {
 
     const bqrsPath = path.normalize("/a/b/c/results.bqrs");
     const options = { entities: ["id", "url", "string"] };
-    expect(mockCli.bqrsDecode).toBeCalledWith(bqrsPath, "nodes", options);
-    expect(mockCli.bqrsDecode).toBeCalledWith(bqrsPath, "edges", options);
-    expect(mockCli.bqrsDecode).toBeCalledWith(
+    expect(mockCli.bqrsDecode).toHaveBeenCalledWith(bqrsPath, "nodes", options);
+    expect(mockCli.bqrsDecode).toHaveBeenCalledWith(bqrsPath, "edges", options);
+    expect(mockCli.bqrsDecode).toHaveBeenCalledWith(
       bqrsPath,
       "graphProperties",
       options,

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/language-support/ast-viewer/ast-viewer.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/language-support/ast-viewer/ast-viewer.test.ts
@@ -86,7 +86,7 @@ describe("AstViewer", () => {
     const mockEvent = createMockEvent(selectionRange, fileUri);
     (viewer as any).updateTreeSelection(mockEvent);
     if (expectedSelection) {
-      expect(revealMock).toBeCalledWith(expectedSelection);
+      expect(revealMock).toHaveBeenCalledWith(expectedSelection);
     } else {
       expect(revealMock).not.toHaveBeenCalled();
     }

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/language-support/ast-viewer/ast-viewer.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/language-support/ast-viewer/ast-viewer.test.ts
@@ -88,7 +88,7 @@ describe("AstViewer", () => {
     if (expectedSelection) {
       expect(revealMock).toBeCalledWith(expectedSelection);
     } else {
-      expect(revealMock).not.toBeCalled();
+      expect(revealMock).not.toHaveBeenCalled();
     }
   }
 

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/local-queries/query-resolver.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/local-queries/query-resolver.test.ts
@@ -49,7 +49,7 @@ describe("qlpackOfDatabase", () => {
       dbschemePack: "my-qlpack",
       dbschemePackIsLibraryPack: false,
     });
-    expect(getPrimaryDbschemeSpy).toBeCalledWith("/path/to/database");
+    expect(getPrimaryDbschemeSpy).toHaveBeenCalledWith("/path/to/database");
   });
 });
 

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-manager.test.ts
@@ -619,7 +619,7 @@ describe("QueryHistoryManager", () => {
         const inProgress1 = variantAnalysisHistory[1];
 
         await queryHistoryManager.handleCancel([inProgress1]);
-        expect(cancelVariantAnalysisSpy).toBeCalledWith(
+        expect(cancelVariantAnalysisSpy).toHaveBeenCalledWith(
           inProgress1.variantAnalysis.id,
         );
       });
@@ -632,10 +632,10 @@ describe("QueryHistoryManager", () => {
         const inProgress2 = variantAnalysisHistory[3];
 
         await queryHistoryManager.handleCancel([inProgress1, inProgress2]);
-        expect(cancelVariantAnalysisSpy).toBeCalledWith(
+        expect(cancelVariantAnalysisSpy).toHaveBeenCalledWith(
           inProgress1.variantAnalysis.id,
         );
-        expect(cancelVariantAnalysisSpy).toBeCalledWith(
+        expect(cancelVariantAnalysisSpy).toHaveBeenCalledWith(
           inProgress2.variantAnalysis.id,
         );
       });
@@ -675,7 +675,7 @@ describe("QueryHistoryManager", () => {
         const completedVariantAnalysis = variantAnalysisHistory[0];
 
         await queryHistoryManager.handleCancel([completedVariantAnalysis]);
-        expect(cancelVariantAnalysisSpy).not.toBeCalledWith(
+        expect(cancelVariantAnalysisSpy).not.toHaveBeenCalledWith(
           completedVariantAnalysis.variantAnalysis,
         );
       });
@@ -691,10 +691,10 @@ describe("QueryHistoryManager", () => {
           completedVariantAnalysis,
           failedVariantAnalysis,
         ]);
-        expect(cancelVariantAnalysisSpy).not.toBeCalledWith(
+        expect(cancelVariantAnalysisSpy).not.toHaveBeenCalledWith(
           completedVariantAnalysis.variantAnalysis.id,
         );
-        expect(cancelVariantAnalysisSpy).not.toBeCalledWith(
+        expect(cancelVariantAnalysisSpy).not.toHaveBeenCalledWith(
           failedVariantAnalysis.variantAnalysis.id,
         );
       });
@@ -718,9 +718,9 @@ describe("QueryHistoryManager", () => {
       const item = variantAnalysisHistory[1];
       await queryHistoryManager.handleCopyRepoList(item);
 
-      expect(variantAnalysisManagerStub.copyRepoListToClipboard).toBeCalledWith(
-        item.variantAnalysis.id,
-      );
+      expect(
+        variantAnalysisManagerStub.copyRepoListToClipboard,
+      ).toHaveBeenCalledWith(item.variantAnalysis.id);
     });
   });
 
@@ -739,7 +739,7 @@ describe("QueryHistoryManager", () => {
 
       const item = variantAnalysisHistory[1];
       await queryHistoryManager.handleExportResults(item);
-      expect(variantAnalysisManagerStub.exportResults).toBeCalledWith(
+      expect(variantAnalysisManagerStub.exportResults).toHaveBeenCalledWith(
         item.variantAnalysis.id,
       );
     });

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-manager.test.ts
@@ -608,8 +608,8 @@ describe("QueryHistoryManager", () => {
         const cancelSpy2 = jest.spyOn(inProgress2, "cancel");
 
         await queryHistoryManager.handleCancel([inProgress1, inProgress2]);
-        expect(cancelSpy1).toBeCalled();
-        expect(cancelSpy2).toBeCalled();
+        expect(cancelSpy1).toHaveBeenCalled();
+        expect(cancelSpy2).toHaveBeenCalled();
       });
 
       it("should cancel a single variant analysis", async () => {
@@ -708,7 +708,7 @@ describe("QueryHistoryManager", () => {
       const item = localQueryHistory[4];
       await queryHistoryManager.handleCopyRepoList(item);
 
-      expect(executeCommand).not.toBeCalled();
+      expect(executeCommand).not.toHaveBeenCalled();
     });
 
     it("should copy repo list for a single variant analysis", async () => {
@@ -731,7 +731,7 @@ describe("QueryHistoryManager", () => {
       const item = localQueryHistory[4];
       await queryHistoryManager.handleExportResults(item);
 
-      expect(variantAnalysisManagerStub.exportResults).not.toBeCalled();
+      expect(variantAnalysisManagerStub.exportResults).not.toHaveBeenCalled();
     });
 
     it("should export results for a single variant analysis", async () => {
@@ -801,7 +801,7 @@ describe("QueryHistoryManager", () => {
           queryHistoryManager as any
         ).findOtherQueryToCompare(thisQuery, [thisQuery, localQueryHistory[0]]);
         expect(otherQuery).toBe(localQueryHistory[0]);
-        expect(showQuickPickSpy).not.toBeCalled();
+        expect(showQuickPickSpy).not.toHaveBeenCalled();
       });
 
       it("should throw an error when a databases are not the same", async () => {
@@ -850,7 +850,7 @@ describe("QueryHistoryManager", () => {
         await queryHistoryManager.handleCompareWith(localQueryHistory[0], [
           localQueryHistory[0],
         ]);
-        expect(doCompareCallback).not.toBeCalled();
+        expect(doCompareCallback).not.toHaveBeenCalled();
       });
 
       it("should throw an error when a query is not successful", async () => {

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-manager.test.ts
@@ -594,7 +594,7 @@ describe("QueryHistoryManager", () => {
         const cancelSpy = jest.spyOn(inProgress1, "cancel");
 
         await queryHistoryManager.handleCancel([inProgress1]);
-        expect(cancelSpy).toBeCalledTimes(1);
+        expect(cancelSpy).toHaveBeenCalledTimes(1);
       });
 
       it("should cancel multiple local queries", async () => {
@@ -650,7 +650,7 @@ describe("QueryHistoryManager", () => {
         const cancelSpy = jest.spyOn(completed, "cancel");
 
         await queryHistoryManager.handleCancel([completed]);
-        expect(cancelSpy).not.toBeCalledTimes(1);
+        expect(cancelSpy).not.toHaveBeenCalledTimes(1);
       });
 
       it("should not cancel multiple local queries", async () => {
@@ -664,8 +664,8 @@ describe("QueryHistoryManager", () => {
         const cancelSpy2 = jest.spyOn(failed, "cancel");
 
         await queryHistoryManager.handleCancel([completed, failed]);
-        expect(cancelSpy).not.toBeCalledTimes(1);
-        expect(cancelSpy2).not.toBeCalledTimes(1);
+        expect(cancelSpy).not.toHaveBeenCalledTimes(1);
+        expect(cancelSpy2).not.toHaveBeenCalledTimes(1);
       });
 
       it("should not cancel a single variant analysis", async () => {

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/variant-analysis-history.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/variant-analysis-history.test.ts
@@ -119,7 +119,7 @@ describe("Variant Analyses and QueryHistoryManager", () => {
   it("should read query history that has variant analysis history items", async () => {
     await qhm.readQueryHistory();
 
-    expect(rehydrateVariantAnalysisStub).toBeCalledTimes(2);
+    expect(rehydrateVariantAnalysisStub).toHaveBeenCalledTimes(2);
     expect(rehydrateVariantAnalysisStub).toHaveBeenNthCalledWith(
       1,
       rawQueryHistory[0].variantAnalysis,
@@ -142,8 +142,8 @@ describe("Variant Analyses and QueryHistoryManager", () => {
 
     // Add it back to the history
     qhm.addQuery(rawQueryHistory[0]);
-    expect(removeVariantAnalysisStub).toBeCalledTimes(1);
-    expect(rehydrateVariantAnalysisStub).toBeCalledTimes(2);
+    expect(removeVariantAnalysisStub).toHaveBeenCalledTimes(1);
+    expect(rehydrateVariantAnalysisStub).toHaveBeenCalledTimes(2);
     expect(qhm.treeDataProvider.allHistory).toEqual([
       rawQueryHistory[1],
       rawQueryHistory[0],

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/variant-analysis-history.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/variant-analysis-history.test.ts
@@ -184,7 +184,9 @@ describe("Variant Analyses and QueryHistoryManager", () => {
     await qhm.readQueryHistory();
 
     await qhm.handleItemClicked(qhm.treeDataProvider.allHistory[0]);
-    expect(showViewStub).toBeCalledWith(rawQueryHistory[0].variantAnalysis.id);
+    expect(showViewStub).toHaveBeenCalledWith(
+      rawQueryHistory[0].variantAnalysis.id,
+    );
   });
 
   it("should get the query text", async () => {

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-results.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-results.test.ts
@@ -245,7 +245,7 @@ describe("query-results", () => {
           sourceInfo as SourceInfo,
         );
         // We do not re-interpret if we are reading from a SARIF file.
-        expect(spy).not.toBeCalled();
+        expect(spy).not.toHaveBeenCalled();
 
         expect(results).toHaveProperty("t", "SarifInterpretationData");
         expect(results).toHaveProperty("runs[0].results");
@@ -279,7 +279,7 @@ describe("query-results", () => {
         );
 
         // We do not attempt to re-interpret if we are reading from a SARIF file.
-        expect(spy).not.toBeCalled();
+        expect(spy).not.toHaveBeenCalled();
       },
       2 * 60 * 1000, // up to 2 minutes per test
     );
@@ -336,7 +336,7 @@ describe("query-results", () => {
           sourceInfo as SourceInfo,
         );
         // We do not re-interpret if we are reading from a SARIF file.
-        expect(spy).not.toBeCalled();
+        expect(spy).not.toHaveBeenCalled();
 
         expect(results).toHaveProperty("t", "SarifInterpretationData");
         expect(results).toHaveProperty("runs[0].results");
@@ -400,7 +400,7 @@ describe("query-results", () => {
         );
 
         // We do not attempt to re-interpret if we are reading from a SARIF file.
-        expect(spy).not.toBeCalled();
+        expect(spy).not.toHaveBeenCalled();
       },
       2 * 60 * 1000, // up to 2 minutes per test
     );

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-results.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-results.test.ts
@@ -130,7 +130,7 @@ describe("query-results", () => {
         queryPath,
         "sortedResults-cc8589f226adc134f87f2438e10075e0667571c72342068e2281e0b3b65e1092.bqrs",
       );
-      expect(spy).toBeCalledWith(
+      expect(spy).toHaveBeenCalledWith(
         expectedResultsPath,
         expectedSortedResultsPath,
         "a-result-set-name",
@@ -189,7 +189,7 @@ describe("query-results", () => {
         );
 
         expect(results).toEqual({ a: "1234", t: "SarifInterpretationData" });
-        expect(spy).toBeCalledWith(
+        expect(spy).toHaveBeenCalledWith(
           metadata,
           resultsPath,
           interpretedResultsPath,
@@ -214,7 +214,7 @@ describe("query-results", () => {
           sourceInfo as SourceInfo,
         );
         expect(results).toEqual({ a: "1234", t: "SarifInterpretationData" });
-        expect(spy).toBeCalledWith(
+        expect(spy).toHaveBeenCalledWith(
           { kind: "my-kind", id: "dummy-id", scored: undefined },
           resultsPath,
           interpretedResultsPath,

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-testing/test-adapter.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-testing/test-adapter.test.ts
@@ -95,8 +95,8 @@ describe("test-adapter", () => {
     const request = new TestRunRequest([rootItem]);
     await testManager.run(request, new CancellationTokenSource().token);
 
-    expect(enqueuedSpy).toBeCalledTimes(3);
-    expect(passedSpy).toBeCalledTimes(1);
+    expect(enqueuedSpy).toHaveBeenCalledTimes(3);
+    expect(passedSpy).toHaveBeenCalledTimes(1);
     expect(passedSpy).toHaveBeenCalledWith(childItems[0], 3000);
     expect(erroredSpy).toHaveBeenCalledTimes(1);
     expect(erroredSpy).toHaveBeenCalledWith(
@@ -121,7 +121,7 @@ describe("test-adapter", () => {
       ],
       11000,
     );
-    expect(failedSpy).toBeCalledTimes(1);
-    expect(endSpy).toBeCalledTimes(1);
+    expect(failedSpy).toHaveBeenCalledTimes(1);
+    expect(endSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-testing/test-runner.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-testing/test-runner.test.ts
@@ -94,7 +94,7 @@ describe("test-runner", () => {
       eventHandlerSpy,
     );
 
-    expect(eventHandlerSpy).toBeCalledTimes(3);
+    expect(eventHandlerSpy).toHaveBeenCalledTimes(3);
 
     expect(eventHandlerSpy).toHaveBeenNthCalledWith(1, {
       test: mockTestsInfo.dPath,
@@ -160,23 +160,23 @@ describe("test-runner", () => {
       setCurrentDatabaseItemSpy.mock.invocationCallOrder[0],
     ).toBeGreaterThan(openDatabaseSpy.mock.invocationCallOrder[0]);
 
-    expect(removeDatabaseItemSpy).toBeCalledTimes(1);
+    expect(removeDatabaseItemSpy).toHaveBeenCalledTimes(1);
     expect(removeDatabaseItemSpy).toHaveBeenCalledWith(preTestDatabaseItem);
 
-    expect(openDatabaseSpy).toBeCalledTimes(1);
+    expect(openDatabaseSpy).toHaveBeenCalledTimes(1);
     expect(openDatabaseSpy).toHaveBeenCalledWith(
       preTestDatabaseItem.databaseUri,
       preTestDatabaseItem.origin,
       false,
     );
 
-    expect(renameDatabaseItemSpy).toBeCalledTimes(1);
+    expect(renameDatabaseItemSpy).toHaveBeenCalledTimes(1);
     expect(renameDatabaseItemSpy).toHaveBeenCalledWith(
       postTestDatabaseItem,
       preTestDatabaseItem.name,
     );
 
-    expect(setCurrentDatabaseItemSpy).toBeCalledTimes(1);
+    expect(setCurrentDatabaseItemSpy).toHaveBeenCalledTimes(1);
     expect(setCurrentDatabaseItemSpy).toHaveBeenCalledWith(
       postTestDatabaseItem,
       true,

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-testing/test-runner.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-testing/test-runner.test.ts
@@ -161,23 +161,23 @@ describe("test-runner", () => {
     ).toBeGreaterThan(openDatabaseSpy.mock.invocationCallOrder[0]);
 
     expect(removeDatabaseItemSpy).toBeCalledTimes(1);
-    expect(removeDatabaseItemSpy).toBeCalledWith(preTestDatabaseItem);
+    expect(removeDatabaseItemSpy).toHaveBeenCalledWith(preTestDatabaseItem);
 
     expect(openDatabaseSpy).toBeCalledTimes(1);
-    expect(openDatabaseSpy).toBeCalledWith(
+    expect(openDatabaseSpy).toHaveBeenCalledWith(
       preTestDatabaseItem.databaseUri,
       preTestDatabaseItem.origin,
       false,
     );
 
     expect(renameDatabaseItemSpy).toBeCalledTimes(1);
-    expect(renameDatabaseItemSpy).toBeCalledWith(
+    expect(renameDatabaseItemSpy).toHaveBeenCalledWith(
       postTestDatabaseItem,
       preTestDatabaseItem.name,
     );
 
     expect(setCurrentDatabaseItemSpy).toBeCalledTimes(1);
-    expect(setCurrentDatabaseItemSpy).toBeCalledWith(
+    expect(setCurrentDatabaseItemSpy).toHaveBeenCalledWith(
       postTestDatabaseItem,
       true,
     );

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/telemetry.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/telemetry.test.ts
@@ -152,11 +152,11 @@ describe("telemetry reporting", () => {
     expect(telemetryListener._reporter).toBeDefined();
     expect(telemetryListener._reporter).not.toBe(firstReporter);
 
-    expect(disposeSpy).toBeCalledTimes(1);
+    expect(disposeSpy).toHaveBeenCalledTimes(1);
 
     // initializing a third time continues to dispose
     await telemetryListener.initialize();
-    expect(disposeSpy).toBeCalledTimes(2);
+    expect(disposeSpy).toHaveBeenCalledTimes(2);
   });
 
   it("should reinitialize reporter when extension setting changes", async () => {
@@ -170,13 +170,13 @@ describe("telemetry reporting", () => {
 
     expect(telemetryListener._reporter).toBeUndefined();
 
-    expect(disposeSpy).toBeCalledTimes(1);
+    expect(disposeSpy).toHaveBeenCalledTimes(1);
 
     // creates a new reporter, but does not dispose again
     await enableTelemetry("codeQL.telemetry", true);
 
     expect(telemetryListener._reporter).toBeDefined();
-    expect(disposeSpy).toBeCalledTimes(1);
+    expect(disposeSpy).toHaveBeenCalledTimes(1);
   });
 
   it("should set userOprIn to false when global setting changes", async () => {
@@ -361,7 +361,7 @@ describe("telemetry reporting", () => {
     await wait(500);
 
     // Dialog opened, user clicks "yes" and telemetry enabled
-    expect(showInformationMessageSpy).toBeCalledTimes(1);
+    expect(showInformationMessageSpy).toHaveBeenCalledTimes(1);
     expect(ENABLE_TELEMETRY.getValue()).toBe(true);
     expect(ctx.globalState.get("telemetry-request-viewed")).toBe(true);
   });
@@ -374,7 +374,7 @@ describe("telemetry reporting", () => {
     await telemetryListener.initialize();
 
     // Dialog opened, user clicks "no" and telemetry disabled
-    expect(showInformationMessageSpy).toBeCalledTimes(1);
+    expect(showInformationMessageSpy).toHaveBeenCalledTimes(1);
     expect(ENABLE_TELEMETRY.getValue()).toBe(false);
     expect(ctx.globalState.get("telemetry-request-viewed")).toBe(true);
   });
@@ -387,7 +387,7 @@ describe("telemetry reporting", () => {
     await enableTelemetry("codeQL.telemetry", false);
 
     // Dialog opened, and user closes without interacting with it
-    expect(showInformationMessageSpy).toBeCalledTimes(1);
+    expect(showInformationMessageSpy).toHaveBeenCalledTimes(1);
     expect(ENABLE_TELEMETRY.getValue()).toBe(false);
     // dialog was canceled, so should not have marked as viewed
     expect(ctx.globalState.get("telemetry-request-viewed")).toBe(false);
@@ -406,7 +406,7 @@ describe("telemetry reporting", () => {
 
     // Dialog opened, and user closes without interacting with it
     // Telemetry state should not have changed
-    expect(showInformationMessageSpy).toBeCalledTimes(1);
+    expect(showInformationMessageSpy).toHaveBeenCalledTimes(1);
     expect(ENABLE_TELEMETRY.getValue()).toBe(true);
     // dialog was canceled, so should not have marked as viewed
     expect(ctx.globalState.get("telemetry-request-viewed")).toBe(false);
@@ -447,7 +447,7 @@ describe("telemetry reporting", () => {
 
     // now, we should have to click through the telemetry requestor again
     expect(ctx.globalState.get("telemetry-request-viewed")).toBe(false);
-    expect(showInformationMessageSpy).toBeCalledTimes(1);
+    expect(showInformationMessageSpy).toHaveBeenCalledTimes(1);
   });
 
   it("should send a ui-interaction telementry event", async () => {

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/telemetry.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/telemetry.test.ts
@@ -162,7 +162,7 @@ describe("telemetry reporting", () => {
   it("should reinitialize reporter when extension setting changes", async () => {
     await telemetryListener.initialize();
 
-    expect(disposeSpy).not.toBeCalled();
+    expect(disposeSpy).not.toHaveBeenCalled();
     expect(telemetryListener._reporter).toBeDefined();
 
     // this disables the reporter
@@ -205,7 +205,7 @@ describe("telemetry reporting", () => {
       },
       { executionTime: 1234 },
     );
-    expect(sendTelemetryErrorEventSpy).not.toBeCalled();
+    expect(sendTelemetryErrorEventSpy).not.toHaveBeenCalled();
   });
 
   it("should send a command usage event with an error", async () => {
@@ -227,7 +227,7 @@ describe("telemetry reporting", () => {
       },
       { executionTime: 1234 },
     );
-    expect(sendTelemetryErrorEventSpy).not.toBeCalled();
+    expect(sendTelemetryErrorEventSpy).not.toHaveBeenCalled();
   });
 
   it("should send a command usage event with a cli version", async () => {
@@ -250,7 +250,7 @@ describe("telemetry reporting", () => {
       },
       { executionTime: 1234 },
     );
-    expect(sendTelemetryErrorEventSpy).not.toBeCalled();
+    expect(sendTelemetryErrorEventSpy).not.toHaveBeenCalled();
 
     // Verify that if the cli version is not set, then the telemetry falls back to "not-set"
     sendTelemetryEventSpy.mockClear();
@@ -272,7 +272,7 @@ describe("telemetry reporting", () => {
       },
       { executionTime: 5678 },
     );
-    expect(sendTelemetryErrorEventSpy).not.toBeCalled();
+    expect(sendTelemetryErrorEventSpy).not.toHaveBeenCalled();
   });
 
   it("should avoid sending an event when telemetry is disabled", async () => {
@@ -282,8 +282,8 @@ describe("telemetry reporting", () => {
     telemetryListener.sendCommandUsage("command-id", 1234, undefined);
     telemetryListener.sendCommandUsage("command-id", 1234, new Error());
 
-    expect(sendTelemetryEventSpy).not.toBeCalled();
-    expect(sendTelemetryErrorEventSpy).not.toBeCalled();
+    expect(sendTelemetryEventSpy).not.toHaveBeenCalled();
+    expect(sendTelemetryErrorEventSpy).not.toHaveBeenCalled();
   });
 
   it("should send an event when telemetry is re-enabled", async () => {
@@ -303,7 +303,7 @@ describe("telemetry reporting", () => {
       },
       { executionTime: 1234 },
     );
-    expect(sendTelemetryErrorEventSpy).not.toBeCalled();
+    expect(sendTelemetryErrorEventSpy).not.toHaveBeenCalled();
   });
 
   it("should filter undesired properties from telemetry payload", async () => {
@@ -426,7 +426,7 @@ describe("telemetry reporting", () => {
     await telemetryListener.initialize();
 
     // popup should not be shown even though we have initialized telemetry
-    expect(showInformationMessageSpy).not.toBeCalled();
+    expect(showInformationMessageSpy).not.toHaveBeenCalled();
   });
 
   // This test is failing because codeQL.canary is not a registered configuration.
@@ -464,7 +464,7 @@ describe("telemetry reporting", () => {
       },
       {},
     );
-    expect(sendTelemetryErrorEventSpy).not.toBeCalled();
+    expect(sendTelemetryErrorEventSpy).not.toHaveBeenCalled();
   });
 
   it("should send a ui-interaction telementry event with a cli version", async () => {
@@ -482,7 +482,7 @@ describe("telemetry reporting", () => {
       },
       {},
     );
-    expect(sendTelemetryErrorEventSpy).not.toBeCalled();
+    expect(sendTelemetryErrorEventSpy).not.toHaveBeenCalled();
   });
 
   it("should send an error telementry event", async () => {
@@ -490,7 +490,7 @@ describe("telemetry reporting", () => {
 
     telemetryListener.sendError(redactableError`test`);
 
-    expect(sendTelemetryEventSpy).not.toBeCalled();
+    expect(sendTelemetryEventSpy).not.toHaveBeenCalled();
     expect(sendTelemetryErrorEventSpy).toHaveBeenCalledWith(
       "error",
       {
@@ -509,7 +509,7 @@ describe("telemetry reporting", () => {
 
     telemetryListener.sendError(redactableError`test`);
 
-    expect(sendTelemetryEventSpy).not.toBeCalled();
+    expect(sendTelemetryEventSpy).not.toHaveBeenCalled();
     expect(sendTelemetryErrorEventSpy).toHaveBeenCalledWith(
       "error",
       {
@@ -529,7 +529,7 @@ describe("telemetry reporting", () => {
       redactableError`test message with secret information: ${42} and more ${"secret"} parts`,
     );
 
-    expect(sendTelemetryEventSpy).not.toBeCalled();
+    expect(sendTelemetryEventSpy).not.toHaveBeenCalled();
     expect(sendTelemetryErrorEventSpy).toHaveBeenCalledWith(
       "error",
       {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Replaces 3 methods we identified are deprecated with the successor. 

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
