### PR TITLE
Add test for "promptForDatabase"

### DIFF
--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -827,7 +827,7 @@ export class DatabaseUI extends DisposableObject {
     return this.databaseManager.currentDatabaseItem;
   }
 
-  public async promptForDatabase(): Promise<void> {
+  private async promptForDatabase(): Promise<void> {
     const quickPickItems: DatabaseSelectionQuickPickItem[] = [
       {
         label: "$(database) Existing database",
@@ -862,7 +862,7 @@ export class DatabaseUI extends DisposableObject {
     }
   }
 
-  public async selectExistingDatabase() {
+  private async selectExistingDatabase() {
     const dbItems: DatabaseQuickPickItem[] =
       this.databaseManager.databaseItems.map((dbItem) => ({
         label: dbItem.name,
@@ -884,7 +884,7 @@ export class DatabaseUI extends DisposableObject {
     );
   }
 
-  public async importNewDatabase() {
+  private async importNewDatabase() {
     const importOptions: DatabaseImportQuickPickItems[] = [
       {
         label: "$(github) GitHub",

--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -243,7 +243,7 @@ export interface DatabaseQuickPickItem extends QuickPickItem {
   databaseItem: DatabaseItem;
 }
 
-interface DatabaseImportQuickPickItems extends QuickPickItem {
+export interface DatabaseImportQuickPickItems extends QuickPickItem {
   importType: "URL" | "github" | "archive" | "folder";
 }
 

--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -235,7 +235,7 @@ async function chooseDatabaseDir(byFolder: boolean): Promise<Uri | undefined> {
   return getFirst(chosen);
 }
 
-interface DatabaseSelectionQuickPickItem extends QuickPickItem {
+export interface DatabaseSelectionQuickPickItem extends QuickPickItem {
   databaseKind: "new" | "existing";
 }
 
@@ -827,7 +827,7 @@ export class DatabaseUI extends DisposableObject {
     return this.databaseManager.currentDatabaseItem;
   }
 
-  private async promptForDatabase(): Promise<void> {
+  public async promptForDatabase(): Promise<void> {
     const quickPickItems: DatabaseSelectionQuickPickItem[] = [
       {
         label: "$(database) Existing database",
@@ -862,7 +862,7 @@ export class DatabaseUI extends DisposableObject {
     }
   }
 
-  private async selectExistingDatabase() {
+  public async selectExistingDatabase() {
     const dbItems: DatabaseQuickPickItem[] =
       this.databaseManager.databaseItems.map((dbItem) => ({
         label: dbItem.name,
@@ -884,7 +884,7 @@ export class DatabaseUI extends DisposableObject {
     );
   }
 
-  private async importNewDatabase() {
+  public async importNewDatabase() {
     const importOptions: DatabaseImportQuickPickItems[] = [
       {
         label: "$(github) GitHub",


### PR DESCRIPTION
Follow-up to https://github.com/github/vscode-codeql/pull/3214 to add a basic test of the new "Select database" prompt. 

I plan to open a new issue for more comprehensive tests and to improve the feature generally, so this is just a starting point and to get advice on whether this is a sensible way to test... 

(Example follow-up work: we could probably filter any existing DBs by language, check that we actually _have_ existing DBs, test those different cases...) 

## Checklist

N/A - test change only

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
