### PR TITLE
Skip multi-query MRVAs from query history

### DIFF
--- a/extensions/ql-vscode/src/query-history/query-history-manager.ts
+++ b/extensions/ql-vscode/src/query-history/query-history-manager.ts
@@ -373,6 +373,11 @@ export class QueryHistoryManager extends DisposableObject {
     const variantAnalysisAddedSubscription =
       this.variantAnalysisManager.onVariantAnalysisAdded(
         async (variantAnalysis) => {
+          if (variantAnalysis.queries === undefined) {
+            // This is a variant analysis that contains multiple queries, which
+            // is not fully supported yet. So we ignore it from the query history.
+            return;
+          }
           this.addQuery({
             t: "variant-analysis",
             status: QueryStatus.InProgress,

--- a/extensions/ql-vscode/src/query-history/query-history-manager.ts
+++ b/extensions/ql-vscode/src/query-history/query-history-manager.ts
@@ -373,7 +373,7 @@ export class QueryHistoryManager extends DisposableObject {
     const variantAnalysisAddedSubscription =
       this.variantAnalysisManager.onVariantAnalysisAdded(
         async (variantAnalysis) => {
-          if (variantAnalysis.queries === undefined) {
+          if (variantAnalysis.queries !== undefined) {
             // This is a variant analysis that contains multiple queries, which
             // is not fully supported yet. So we ignore it from the query history.
             return;

--- a/extensions/ql-vscode/src/variant-analysis/shared/variant-analysis.ts
+++ b/extensions/ql-vscode/src/variant-analysis/shared/variant-analysis.ts
@@ -12,6 +12,7 @@ export interface VariantAnalysis {
     text: string;
     kind?: string;
   };
+  queries?: VariantAnalysisQueries;
   databases: {
     repositories?: string[];
     repositoryLists?: string[];
@@ -144,11 +145,20 @@ export interface VariantAnalysisSubmission {
     // Base64 encoded query pack.
     pack: string;
   };
+  queries?: VariantAnalysisQueries;
   databases: {
     repositories?: string[];
     repositoryLists?: string[];
     repositoryOwners?: string[];
   };
+}
+
+// Experimental information about the queries that are
+// going to be run as part of the variant analysis.
+// For now, this is just the query language, but it's
+// unclear what it will look like in the future.
+export interface VariantAnalysisQueries {
+  language: QueryLanguage;
 }
 
 export async function isVariantAnalysisComplete(

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -347,6 +347,13 @@ export class VariantAnalysisManager
 
     const queryText = await readFile(queryFile, "utf8");
 
+    const queries =
+      uris.length === 1
+        ? undefined
+        : {
+            language: variantAnalysisLanguage,
+          };
+
     const variantAnalysisSubmission: VariantAnalysisSubmission = {
       startTime: queryStartTime,
       actionRepoRef: actionBranch,
@@ -359,6 +366,7 @@ export class VariantAnalysisManager
         text: queryText,
         kind: queryMetadata?.kind,
       },
+      queries,
       databases: {
         repositories: repoSelection.repositories,
         repositoryLists: repoSelection.repositoryLists,

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-mapper.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-mapper.ts
@@ -36,6 +36,7 @@ export function mapVariantAnalysis(
         text: submission.query.text,
         kind: submission.query.kind,
       },
+      queries: submission.queries,
       databases: submission.databases,
       executionStartTime: submission.startTime,
     },
@@ -46,7 +47,7 @@ export function mapVariantAnalysis(
 export function mapUpdatedVariantAnalysis(
   previousVariantAnalysis: Pick<
     VariantAnalysis,
-    "query" | "databases" | "executionStartTime"
+    "query" | "queries" | "databases" | "executionStartTime"
   >,
   response: ApiVariantAnalysis,
 ): VariantAnalysis {
@@ -73,6 +74,7 @@ export function mapUpdatedVariantAnalysis(
       private: response.controller_repo.private,
     },
     query: previousVariantAnalysis.query,
+    queries: previousVariantAnalysis.queries,
     databases: previousVariantAnalysis.databases,
     executionStartTime: previousVariantAnalysis.executionStartTime,
     createdAt: response.created_at,


### PR DESCRIPTION
Add some data and logic to ensure that multi-query MRVAs are skipped from the query history for now. 

I've added a `queries` field to the `VariantAnalysis` entity with a single `language` field to help drive this, but in the future that will look very different. By changing the domain entity and not touching the query history, we're making it really easy for us to change how it looks, while the multi-query feature gets more fleshed out.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
