### PR TITLE
Add an integration test of runVariantAnalysisFromPublishedPack

### DIFF
--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -214,7 +214,7 @@ export class VariantAnalysisManager
     }
   }
 
-  private async runVariantAnalysisFromPublishedPack(): Promise<void> {
+  public async runVariantAnalysisFromPublishedPack(): Promise<void> {
     return withProgress(async (progress, token) => {
       progress({
         maxStep: 8,

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
@@ -388,4 +388,37 @@ describe("Variant Analysis Manager", () => {
       }
     }
   });
+
+  describe("runVariantAnalysisFromPublishedPack", () => {
+    it("should download pack for correct language and identify problem queries", async () => {
+      const showQuickPickSpy = jest
+        .spyOn(window, "showQuickPick")
+        .mockResolvedValue(
+          mockedQuickPickItem({
+            label: "JavaScript",
+            description: "javascript",
+            language: "javascript",
+          }),
+        );
+
+      const runVariantAnalysisMock = jest.fn();
+      variantAnalysisManager.runVariantAnalysis = runVariantAnalysisMock;
+
+      await variantAnalysisManager.runVariantAnalysisFromPublishedPack();
+
+      expect(showQuickPickSpy).toHaveBeenCalledTimes(1);
+      expect(runVariantAnalysisMock).toHaveBeenCalledTimes(1);
+
+      const queries: Uri[] = runVariantAnalysisMock.mock.calls[0][0];
+      // Should include queries. Just check that at least one known query exists.
+      // It doesn't particularly matter which query we check for.
+      expect(
+        queries.find((q) => q.fsPath.includes("CWE-201/PostMessageStar.ql")),
+      ).toBeDefined();
+      // Should not include non-problem queries.
+      expect(
+        queries.find((q) => q.fsPath.includes("LinesOfCode.ql")),
+      ).not.toBeDefined();
+    });
+  });
 });


### PR DESCRIPTION
Adds a single integration test that calls `runVariantAnalysisFromPublishedPack`.

We mock the quick pick result to choose javascript, and abort at the point where it calls into the regular variant analysis code, but otherwise this is running all of the code. Is this ok? I felt it wasn't worth running the shared variant analysis code since that's tested separately and it would require a lot more time and setup.

Because we're calling the real `codeql pack download` it means it downloads the real published query pack into the directory of the CodeQL CLI being used in the tests. So that means this test isn't fully isolated as it leaves behind a downloaded pack. I think that's probably fine since it's not leaving corrupted data and anything that should cause problems for other tests. The test will also still succeed if the pack is already downloaded.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
