### PR TITLE
Revert "Bump actions/dependency-review-action from 3 to 4"

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -13,4 +13,4 @@ jobs:
       - name: 'Checkout Repository'
         uses: actions/checkout@v4
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@v3


### PR DESCRIPTION
Reverts github/vscode-codeql#3252

It looks like our workflow runner uses ubuntu-latest, which has node18 https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md