### PR TITLE
Use object for pack generation details

### DIFF
--- a/extensions/ql-vscode/src/variant-analysis/ql-pack-details.ts
+++ b/extensions/ql-vscode/src/variant-analysis/ql-pack-details.ts
@@ -1,0 +1,7 @@
+/**
+ * Details about the original QL pack that is used for triggering
+ * a variant analysis.
+ */
+export interface QlPackDetails {
+  queryFile: string;
+}

--- a/extensions/ql-vscode/src/variant-analysis/run-remote-query.ts
+++ b/extensions/ql-vscode/src/variant-analysis/run-remote-query.ts
@@ -39,6 +39,7 @@ import { tryGetQueryMetadata } from "../codeql-cli/query-metadata";
 import { askForLanguage, findLanguage } from "../codeql-cli/query-language";
 import type { QlPackFile } from "../packaging/qlpack-file";
 import { expandShortPaths } from "../common/short-paths";
+import type { QlPackDetails } from "./ql-pack-details";
 
 /**
  * Well-known names for the query pack used by the server.
@@ -59,9 +60,11 @@ interface GeneratedQueryPack {
  */
 async function generateQueryPack(
   cliServer: CodeQLCliServer,
-  queryFile: string,
+  qlPackDetails: QlPackDetails,
   tmpDir: RemoteQueryTempDir,
 ): Promise<GeneratedQueryPack> {
+  const queryFile = qlPackDetails.queryFile;
+
   const originalPackRoot = await findPackRoot(queryFile);
   const packRelativePath = relative(originalPackRoot, queryFile);
   const workspaceFolders = getOnDiskWorkspaceFolders();
@@ -381,8 +384,12 @@ export async function prepareRemoteQueryRun(
 
   let pack: GeneratedQueryPack;
 
+  const qlPackDetails: QlPackDetails = {
+    queryFile,
+  };
+
   try {
-    pack = await generateQueryPack(cliServer, queryFile, tempDir);
+    pack = await generateQueryPack(cliServer, qlPackDetails, tempDir);
   } finally {
     await tempDir.remoteQueryDir.cleanup();
   }


### PR DESCRIPTION
The `generateQueryPack` function in `run-remote-query.ts` currently has logic to calculate a few things like the QL pack root, paths to the query files, the language, etc. In order to add multi-query support, a few of these calculations need to be moved further up the stack and then passed in to `generateQueryPack` as arguments. 

In this PR, we're introducing a new type (`QlPackDetails`) in the `/variant-analysis` domain to hold such information so that a single object can be passed in to `generateQueryPack` and using that to include the `queryFile`. In follow up PRs, we'll also need to move the language, and other related information. We'll also transition from a singular `queryFile` to multiple ones.

I'm not 100% convinced on the `QlPackDetails` name, so open to suggestions! We can also rename this once it has been fleshed out a bit more.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
