### PR TITLE
Stop variant analysis from published pack if no language selected

### DIFF
--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -223,6 +223,9 @@ export class VariantAnalysisManager
       });
 
       const language = await askForLanguage(this.cliServer);
+      if (!language) {
+        return;
+      }
 
       progress({
         maxStep: 8,


### PR DESCRIPTION
Tiny change to stop processing a variant analysis using a published back if the user doesn't select a language.

## Checklist
N/A - the functionality being changed is behind an unveiled feature flag:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
