### PR TITLE
Fix MRVA integration test failure

### DIFF
--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -1737,6 +1737,9 @@ export class CliVersionConstraint {
    */
   public static CLI_VERSION_WITH_TRIM_CACHE = new SemVer("2.15.1");
 
+  public static CLI_VERSION_WITH_EXTENSIBLE_PREDICATE_METADATA_IN_QLX =
+    new SemVer("2.16.1");
+
   constructor(private readonly cli: CodeQLCliServer) {
     /**/
   }
@@ -1779,6 +1782,11 @@ export class CliVersionConstraint {
     );
   }
 
+  async supportsExtensiblePredicateMetadataInQlx() {
+    return this.isVersionAtLeast(
+      CliVersionConstraint.CLI_VERSION_WITH_EXTENSIBLE_PREDICATE_METADATA_IN_QLX,
+    );
+  }
   async supportsMrvaPackCreate(): Promise<boolean> {
     return (await this.cli.getFeatures()).mrvaPackCreate === true;
   }

--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -1785,9 +1785,9 @@ export class CliVersionConstraint {
 
   async preservesExtensiblePredicatesInMrvaPack() {
     // Negated, because we _stopped_ preserving these in 2.16.1.
-    return !this.isVersionAtLeast(
+    return !(await this.isVersionAtLeast(
       CliVersionConstraint.CLI_VERSION_WITHOUT_MRVA_EXTENSIBLE_PREDICATE_HACK,
-    );
+    ));
   }
 
   async supportsMrvaPackCreate(): Promise<boolean> {

--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -1737,8 +1737,9 @@ export class CliVersionConstraint {
    */
   public static CLI_VERSION_WITH_TRIM_CACHE = new SemVer("2.15.1");
 
-  public static CLI_VERSION_WITH_EXTENSIBLE_PREDICATE_METADATA_IN_QLX =
-    new SemVer("2.16.1");
+  public static CLI_VERSION_WITHOUT_MRVA_EXTENSIBLE_PREDICATE_HACK = new SemVer(
+    "2.16.1",
+  );
 
   constructor(private readonly cli: CodeQLCliServer) {
     /**/
@@ -1782,11 +1783,13 @@ export class CliVersionConstraint {
     );
   }
 
-  async supportsExtensiblePredicateMetadataInQlx() {
-    return this.isVersionAtLeast(
-      CliVersionConstraint.CLI_VERSION_WITH_EXTENSIBLE_PREDICATE_METADATA_IN_QLX,
+  async preservesExtensiblePredicatesInMrvaPack() {
+    // Negated, because we _stopped_ preserving these in 2.16.1.
+    return !this.isVersionAtLeast(
+      CliVersionConstraint.CLI_VERSION_WITHOUT_MRVA_EXTENSIBLE_PREDICATE_HACK,
     );
   }
+
   async supportsMrvaPackCreate(): Promise<boolean> {
     return (await this.cli.getFeatures()).mrvaPackCreate === true;
   }

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
@@ -279,7 +279,7 @@ describe("Variant Analysis Manager", () => {
       // We only need to preserve queries with extensible predicates if the CLI doesn't support
       // storing the necessary metadata in the compiled QLX.
       const needsExtraQueries =
-        !cli.cliConstraints.supportsExtensiblePredicateMetadataInQlx();
+        !(await cli.cliConstraints.supportsExtensiblePredicateMetadataInQlx());
 
       const extraQueries = needsExtraQueries
         ? ["Telemetry/ExtractorInformation.ql"]

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
@@ -276,14 +276,12 @@ describe("Variant Analysis Manager", () => {
       const queryToRun =
         "Security/CWE/CWE-020/ExternalAPIsUsedWithUntrustedData.ql";
 
-      // We only need to preserve queries with extensible predicates if the CLI doesn't support
-      // storing the necessary metadata in the compiled QLX.
-      const needsExtraQueries =
-        !(await cli.cliConstraints.supportsExtensiblePredicateMetadataInQlx());
-
-      const extraQueries = needsExtraQueries
-        ? ["Telemetry/ExtractorInformation.ql"]
-        : [];
+      // Recent versions of the CLI don't preserve queries with extensible predicates in MRVA packs,
+      // because all the necessary info is in the `.packinfo` file.
+      const extraQueries =
+        (await cli.cliConstraints.preservesExtensiblePredicatesInMrvaPack())
+          ? ["Telemetry/ExtractorInformation.ql"]
+          : [];
 
       await doVariantAnalysisTest({
         queryPath: join(

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
@@ -275,7 +275,15 @@ describe("Variant Analysis Manager", () => {
 
       const queryToRun =
         "Security/CWE/CWE-020/ExternalAPIsUsedWithUntrustedData.ql";
-      const extraQuery = "Telemetry/ExtractorInformation.ql";
+
+      // We only need to preserve queries with extensible predicates if the CLI doesn't support
+      // storing the necessary metadata in the compiled QLX.
+      const needsExtraQueries =
+        !cli.cliConstraints.supportsExtensiblePredicateMetadataInQlx();
+
+      const extraQueries = needsExtraQueries
+        ? ["Telemetry/ExtractorInformation.ql"]
+        : [];
 
       await doVariantAnalysisTest({
         queryPath: join(
@@ -284,7 +292,7 @@ describe("Variant Analysis Manager", () => {
           queryToRun,
         ),
         expectedPackName: "codeql/java-queries",
-        filesThatExist: [queryToRun, extraQuery],
+        filesThatExist: [queryToRun, ...extraQueries],
         filesThatDoNotExist: [],
         qlxFilesThatExist: [],
         dependenciesToCheck: ["codeql/java-all"],


### PR DESCRIPTION
Newer CLI versions preserve the metadata for extensible predicates in the compiled pack, so they no longer preserve queries that contain extensible predicates when creating a MRVA pack.

Fixes https://github.com/github/semmle-code/issues/48686
