### PR TITLE
CodeQL model editor: Don't highlight row when clicking inside text box

### DIFF
--- a/extensions/ql-vscode/src/view/model-editor/ModelTypeTextbox.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelTypeTextbox.tsx
@@ -15,6 +15,10 @@ type Props = {
   "aria-label"?: string;
 };
 
+const stopClickPropagation = (e: React.MouseEvent) => {
+  e.stopPropagation();
+};
+
 export const ModelTypeTextbox = ({
   modeledMethod,
   typeInfo,
@@ -48,5 +52,12 @@ export const ModelTypeTextbox = ({
     500,
   );
 
-  return <VSCodeTextField value={value} onInput={handleChange} {...props} />;
+  return (
+    <VSCodeTextField
+      value={value}
+      onInput={handleChange}
+      onClick={stopClickPropagation}
+      {...props}
+    />
+  );
 };


### PR DESCRIPTION
When you click the `Type` input boxes in the model editor (for Ruby), this shouldn't select/deselect the row: 

![image](https://github.com/github/vscode-codeql/assets/42641846/898dc370-bbfe-44f5-9df0-5b5405b2f82a)

(Inspired by https://github.com/github/vscode-codeql/pull/3156/commits/c8d31278a383edc63cedec4115243197668370c6, which disables (de)selection when you click a dropdown) 


## Checklist

N/A: Feature-flagged for internal use for now. 

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
