### PR TITLE
Rename `getQlPackPath` to `getQlPackFilePath`

### DIFF
--- a/extensions/ql-vscode/src/common/ql.ts
+++ b/extensions/ql-vscode/src/common/ql.ts
@@ -8,7 +8,13 @@ export const QLPACK_LOCK_FILENAMES = [
 ];
 export const FALLBACK_QLPACK_FILENAME = QLPACK_FILENAMES[0];
 
-export async function getQlPackPath(
+/**
+ * Gets the path to the QL pack file (a qlpack.yml or
+ * codeql-pack.yml).
+ * @param packRoot The root of the pack.
+ * @returns The path to the qlpack file, or undefined if it doesn't exist.
+ */
+export async function getQlPackFilePath(
   packRoot: string,
 ): Promise<string | undefined> {
   for (const filename of QLPACK_FILENAMES) {

--- a/extensions/ql-vscode/src/databases/qlpack.ts
+++ b/extensions/ql-vscode/src/databases/qlpack.ts
@@ -3,7 +3,7 @@ import { glob } from "glob";
 import { basename } from "path";
 import { load } from "js-yaml";
 import { readFile } from "fs-extra";
-import { getQlPackPath } from "../common/ql";
+import { getQlPackFilePath } from "../common/ql";
 import type { CodeQLCliServer, QlpacksInfo } from "../codeql-cli/cli";
 import { extLogger } from "../common/logging/vscode";
 import { getOnDiskWorkspaceFolders } from "../common/vscode/workspace-folders";
@@ -31,7 +31,7 @@ async function findDbschemePack(
 ): Promise<{ name: string; isLibraryPack: boolean }> {
   for (const { packDir, packName } of packs) {
     if (packDir !== undefined) {
-      const qlpackPath = await getQlPackPath(packDir);
+      const qlpackPath = await getQlPackFilePath(packDir);
 
       if (qlpackPath !== undefined) {
         const qlpack = load(await readFile(qlpackPath, "utf8")) as {

--- a/extensions/ql-vscode/src/local-queries/quick-query.ts
+++ b/extensions/ql-vscode/src/local-queries/quick-query.ts
@@ -11,7 +11,7 @@ import { getPrimaryDbscheme, getQlPackForDbscheme } from "../databases/qlpack";
 import type { ProgressCallback } from "../common/vscode/progress";
 import { UserCancellationException } from "../common/vscode/progress";
 import { getErrorMessage } from "../common/helpers-pure";
-import { FALLBACK_QLPACK_FILENAME, getQlPackPath } from "../common/ql";
+import { FALLBACK_QLPACK_FILENAME, getQlPackFilePath } from "../common/ql";
 import type { App } from "../common/app";
 import type { ExtensionApp } from "../common/vscode/vscode-app";
 
@@ -119,7 +119,7 @@ export async function displayQuickQuery(
     const dbscheme = await getPrimaryDbscheme(datasetFolder);
     const qlpack = (await getQlPackForDbscheme(cliServer, dbscheme))
       .dbschemePack;
-    const qlPackFile = await getQlPackPath(queriesDir);
+    const qlPackFile = await getQlPackFilePath(queriesDir);
     const qlFile = join(queriesDir, QUICK_QUERY_QUERY_NAME);
     const shouldRewrite = await checkShouldRewrite(qlPackFile, qlpack);
 

--- a/extensions/ql-vscode/src/local-queries/skeleton-query-wizard.ts
+++ b/extensions/ql-vscode/src/local-queries/skeleton-query-wizard.ts
@@ -36,7 +36,7 @@ import { redactableError } from "../common/errors";
 import type { App } from "../common/app";
 import type { QueryTreeViewItem } from "../queries-panel/query-tree-view-item";
 import { containsPath, pathsEqual } from "../common/files";
-import { getQlPackPath } from "../common/ql";
+import { getQlPackFilePath } from "../common/ql";
 import { getQlPackLanguage } from "../common/qlpack-language";
 
 type QueryLanguagesToDatabaseMap = Record<string, string>;
@@ -111,7 +111,7 @@ export class SkeletonQueryWizard {
 
       // Try to detect if there is already a qlpack in this location. We will assume that
       // the user hasn't changed the language of the qlpack.
-      const qlPackPath = await getQlPackPath(this.qlPackStoragePath);
+      const qlPackPath = await getQlPackFilePath(this.qlPackStoragePath);
 
       // If we are creating or using a qlpack in the user's selected folder, we will also
       // create the query in that folder
@@ -248,7 +248,7 @@ export class SkeletonQueryWizard {
 
     const matchingQueryPackPath = matchingQueryPacks[0];
 
-    const qlPackPath = await getQlPackPath(matchingQueryPackPath);
+    const qlPackPath = await getQlPackFilePath(matchingQueryPackPath);
     if (!qlPackPath) {
       return undefined;
     }

--- a/extensions/ql-vscode/src/model-editor/extension-pack-picker.ts
+++ b/extensions/ql-vscode/src/model-editor/extension-pack-picker.ts
@@ -9,7 +9,7 @@ import { getOnDiskWorkspaceFolders } from "../common/vscode/workspace-folders";
 import type { ProgressCallback } from "../common/vscode/progress";
 import { UserCancellationException } from "../common/vscode/progress";
 import type { DatabaseItem } from "../databases/local-databases";
-import { getQlPackPath, QLPACK_FILENAMES } from "../common/ql";
+import { getQlPackFilePath, QLPACK_FILENAMES } from "../common/ql";
 import { getErrorMessage } from "../common/helpers-pure";
 import type { ExtensionPack } from "./shared/extension-pack";
 import type { NotificationLogger } from "../common/logging";
@@ -208,7 +208,7 @@ async function readExtensionPack(
   path: string,
   language: string,
 ): Promise<ExtensionPack> {
-  const qlpackPath = await getQlPackPath(path);
+  const qlpackPath = await getQlPackFilePath(path);
   if (!qlpackPath) {
     throw new Error(
       `Could not find any of ${QLPACK_FILENAMES.join(", ")} in ${path}`,

--- a/extensions/ql-vscode/src/variant-analysis/run-remote-query.ts
+++ b/extensions/ql-vscode/src/variant-analysis/run-remote-query.ts
@@ -29,7 +29,7 @@ import {
 import type { Repository } from "./shared/repository";
 import type { DbManager } from "../databases/db-manager";
 import {
-  getQlPackPath,
+  getQlPackFilePath,
   FALLBACK_QLPACK_FILENAME,
   QLPACK_FILENAMES,
   QLPACK_LOCK_FILENAMES,
@@ -74,7 +74,7 @@ async function generateQueryPack(
   );
 
   const mustSynthesizePack =
-    (await getQlPackPath(originalPackRoot)) === undefined;
+    (await getQlPackFilePath(originalPackRoot)) === undefined;
   const cliSupportsMrvaPackCreate =
     await cliServer.cliConstraints.supportsMrvaPackCreate();
 
@@ -265,7 +265,7 @@ async function copyExistingQueryPack(
 async function findPackRoot(queryFile: string): Promise<string> {
   // recursively find the directory containing qlpack.yml or codeql-pack.yml
   let dir = dirname(queryFile);
-  while (!(await getQlPackPath(dir))) {
+  while (!(await getQlPackFilePath(dir))) {
     dir = dirname(dir);
     if (isFileSystemRoot(dir)) {
       // there is no qlpack.yml or codeql-pack.yml in this directory or any parent directory.
@@ -440,7 +440,7 @@ async function fixPackFile(
   queryPackDir: string,
   packRelativePath: string,
 ): Promise<void> {
-  const packPath = await getQlPackPath(queryPackDir);
+  const packPath = await getQlPackFilePath(queryPackDir);
 
   // This should not happen since we create the pack ourselves.
   if (!packPath) {
@@ -490,7 +490,7 @@ async function addExtensionPacksAsDependencies(
   queryPackDir: string,
   extensionPacks: string[],
 ): Promise<void> {
-  const qlpackFile = await getQlPackPath(queryPackDir);
+  const qlpackFile = await getQlPackFilePath(queryPackDir);
   if (!qlpackFile) {
     throw new Error(
       `Could not find ${QLPACK_FILENAMES.join(

--- a/extensions/ql-vscode/test/unit-tests/common/ql.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/common/ql.test.ts
@@ -2,9 +2,9 @@ import { join } from "path";
 import { dirSync } from "tmp-promise";
 import type { DirResult } from "tmp";
 import { writeFile } from "fs-extra";
-import { getQlPackPath } from "../../../src/common/ql";
+import { getQlPackFilePath } from "../../../src/common/ql";
 
-describe("getQlPackPath", () => {
+describe("getQlPackFilePath", () => {
   let tmpDir: DirResult;
 
   beforeEach(() => {
@@ -22,14 +22,14 @@ describe("getQlPackPath", () => {
   it("should find a qlpack.yml when it exists", async () => {
     await writeFile(join(tmpDir.name, "qlpack.yml"), "name: test");
 
-    const result = await getQlPackPath(tmpDir.name);
+    const result = await getQlPackFilePath(tmpDir.name);
     expect(result).toEqual(join(tmpDir.name, "qlpack.yml"));
   });
 
   it("should find a codeql-pack.yml when it exists", async () => {
     await writeFile(join(tmpDir.name, "codeql-pack.yml"), "name: test");
 
-    const result = await getQlPackPath(tmpDir.name);
+    const result = await getQlPackFilePath(tmpDir.name);
     expect(result).toEqual(join(tmpDir.name, "codeql-pack.yml"));
   });
 
@@ -37,12 +37,12 @@ describe("getQlPackPath", () => {
     await writeFile(join(tmpDir.name, "qlpack.yml"), "name: test");
     await writeFile(join(tmpDir.name, "codeql-pack.yml"), "name: test");
 
-    const result = await getQlPackPath(tmpDir.name);
+    const result = await getQlPackFilePath(tmpDir.name);
     expect(result).toEqual(join(tmpDir.name, "qlpack.yml"));
   });
 
   it("should find nothing when it doesn't exist", async () => {
-    const result = await getQlPackPath(tmpDir.name);
+    const result = await getQlPackFilePath(tmpDir.name);
     expect(result).toEqual(undefined);
   });
 });


### PR DESCRIPTION
I think this makes it clearer what this function does.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
