### PR TITLE
Move QL pack root path to the QlPackDetails

### DIFF
--- a/extensions/ql-vscode/src/variant-analysis/ql-pack-details.ts
+++ b/extensions/ql-vscode/src/variant-analysis/ql-pack-details.ts
@@ -4,4 +4,8 @@
  */
 export interface QlPackDetails {
   queryFile: string;
+
+  // The path to the QL pack that is used for triggering a variant analysis.
+  // If there is no query pack, this is the same as the directory of the query files.
+  qlPackRootPath: string;
 }

--- a/extensions/ql-vscode/src/variant-analysis/run-remote-query.ts
+++ b/extensions/ql-vscode/src/variant-analysis/run-remote-query.ts
@@ -65,7 +65,7 @@ async function generateQueryPack(
 ): Promise<GeneratedQueryPack> {
   const queryFile = qlPackDetails.queryFile;
 
-  const originalPackRoot = await findPackRoot(queryFile);
+  const originalPackRoot = qlPackDetails.qlPackRootPath;
   const packRelativePath = relative(originalPackRoot, queryFile);
   const workspaceFolders = getOnDiskWorkspaceFolders();
   const extensionPacks = await getExtensionPacksToInject(
@@ -262,7 +262,7 @@ async function copyExistingQueryPack(
   await fixPackFile(queryPackDir, packRelativePath);
 }
 
-async function findPackRoot(queryFile: string): Promise<string> {
+export async function findPackRoot(queryFile: string): Promise<string> {
   // recursively find the directory containing qlpack.yml or codeql-pack.yml
   let dir = dirname(queryFile);
   while (!(await getQlPackFilePath(dir))) {

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -42,7 +42,11 @@ import type {
   LoadResultsOptions,
   VariantAnalysisResultsManager,
 } from "./variant-analysis-results-manager";
-import { getQueryName, prepareRemoteQueryRun } from "./run-remote-query";
+import {
+  findPackRoot,
+  getQueryName,
+  prepareRemoteQueryRun,
+} from "./run-remote-query";
 import {
   mapVariantAnalysis,
   mapVariantAnalysisRepositoryTask,
@@ -273,6 +277,7 @@ export class VariantAnalysisManager
       // for multiple queries.
       const qlPackDetails: QlPackDetails = {
         queryFile: problemQueries[0],
+        qlPackRootPath: packDir,
       };
 
       await this.runVariantAnalysis(
@@ -308,8 +313,10 @@ export class VariantAnalysisManager
 
   private async runVariantAnalysisCommand(uri: Uri): Promise<void> {
     // Build up details to pass to the functions that run the variant analysis.
+    const qlPackRootPath = await findPackRoot(uri.fsPath);
     const qlPackDetails: QlPackDetails = {
       queryFile: uri.fsPath,
+      qlPackRootPath,
     };
 
     return withProgress(

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
@@ -101,9 +101,10 @@ describe("Variant Analysis Manager", () => {
     });
 
     it("should run a variant analysis that is part of a qlpack", async () => {
-      const filePath = getFile("data-remote-qlpack/in-pack.ql");
+      const filePath = getFileOrDir("data-remote-qlpack/in-pack.ql");
       const qlPackDetails: QlPackDetails = {
         queryFile: filePath,
+        qlPackRootPath: join(baseDir, "data-remote-qlpack"),
       };
 
       await variantAnalysisManager.runVariantAnalysis(
@@ -125,9 +126,10 @@ describe("Variant Analysis Manager", () => {
     });
 
     it("should run a remote query that is not part of a qlpack", async () => {
-      const filePath = getFile("data-remote-no-qlpack/in-pack.ql");
+      const filePath = getFileOrDir("data-remote-no-qlpack/in-pack.ql");
       const qlPackDetails: QlPackDetails = {
         queryFile: filePath,
+        qlPackRootPath: join(baseDir, "data-remote-no-qlpack"),
       };
 
       await variantAnalysisManager.runVariantAnalysis(
@@ -149,11 +151,12 @@ describe("Variant Analysis Manager", () => {
     });
 
     it("should run a remote query that is nested inside a qlpack", async () => {
-      const filePath = getFile(
+      const filePath = getFileOrDir(
         "data-remote-qlpack-nested/subfolder/in-pack.ql",
       );
       const qlPackDetails: QlPackDetails = {
         queryFile: filePath,
+        qlPackRootPath: join(baseDir, "data-remote-qlpack-nested"),
       };
 
       await variantAnalysisManager.runVariantAnalysis(
@@ -175,9 +178,10 @@ describe("Variant Analysis Manager", () => {
     });
 
     it("should cancel a run before uploading", async () => {
-      const filePath = getFile("data-remote-no-qlpack/in-pack.ql");
+      const filePath = getFileOrDir("data-remote-no-qlpack/in-pack.ql");
       const qlPackDetails: QlPackDetails = {
         queryFile: filePath,
+        qlPackRootPath: join(baseDir, "data-remote-no-qlpack"),
       };
 
       const promise = variantAnalysisManager.runVariantAnalysis(
@@ -218,6 +222,7 @@ describe("Variant Analysis Manager", () => {
       it("should run a remote query that is part of a qlpack", async () => {
         await doVariantAnalysisTest({
           queryPath: "data-remote-qlpack/in-pack.ql",
+          qlPackRootPath: "data-remote-qlpack",
           expectedPackName: "github/remote-query-pack",
           filesThatExist: ["in-pack.ql", "lib.qll"],
           filesThatDoNotExist: [],
@@ -228,6 +233,7 @@ describe("Variant Analysis Manager", () => {
       it("should run a remote query that is not part of a qlpack", async () => {
         await doVariantAnalysisTest({
           queryPath: "data-remote-no-qlpack/in-pack.ql",
+          qlPackRootPath: "data-remote-no-qlpack",
           expectedPackName: "codeql-remote/query",
           filesThatExist: ["in-pack.ql"],
           filesThatDoNotExist: ["lib.qll", "not-in-pack.ql"],
@@ -238,6 +244,7 @@ describe("Variant Analysis Manager", () => {
       it("should run a remote query that is nested inside a qlpack", async () => {
         await doVariantAnalysisTest({
           queryPath: "data-remote-qlpack-nested/subfolder/in-pack.ql",
+          qlPackRootPath: "data-remote-qlpack-nested",
           expectedPackName: "github/remote-query-pack",
           filesThatExist: ["subfolder/in-pack.ql", "otherfolder/lib.qll"],
           filesThatDoNotExist: ["subfolder/not-in-pack.ql"],
@@ -255,6 +262,7 @@ describe("Variant Analysis Manager", () => {
         await cli.setUseExtensionPacks(true);
         await doVariantAnalysisTest({
           queryPath: "data-remote-qlpack-nested/subfolder/in-pack.ql",
+          qlPackRootPath: "data-remote-qlpack-nested",
           expectedPackName: "github/remote-query-pack",
           filesThatExist: [
             "subfolder/in-pack.ql",
@@ -299,12 +307,11 @@ describe("Variant Analysis Manager", () => {
           ? ["Telemetry/ExtractorInformation.ql"]
           : [];
 
+      const qlPackRootPath = join(process.env.TEST_CODEQL_PATH, "java/ql/src");
+      const queryPath = join(qlPackRootPath, queryToRun);
       await doVariantAnalysisTest({
-        queryPath: join(
-          process.env.TEST_CODEQL_PATH,
-          "java/ql/src",
-          queryToRun,
-        ),
+        queryPath,
+        qlPackRootPath,
         expectedPackName: "codeql/java-queries",
         filesThatExist: [queryToRun, ...extraQueries],
         filesThatDoNotExist: [],
@@ -317,6 +324,7 @@ describe("Variant Analysis Manager", () => {
 
     async function doVariantAnalysisTest({
       queryPath,
+      qlPackRootPath,
       expectedPackName,
       filesThatExist,
       qlxFilesThatExist,
@@ -328,6 +336,7 @@ describe("Variant Analysis Manager", () => {
       checkVersion = true,
     }: {
       queryPath: string;
+      qlPackRootPath: string;
       expectedPackName: string;
       filesThatExist: string[];
       qlxFilesThatExist: string[];
@@ -335,9 +344,10 @@ describe("Variant Analysis Manager", () => {
       dependenciesToCheck?: string[];
       checkVersion?: boolean;
     }) {
-      const filePath = getFile(queryPath);
+      const filePath = getFileOrDir(queryPath);
       const qlPackDetails: QlPackDetails = {
         queryFile: filePath,
+        qlPackRootPath: getFileOrDir(qlPackRootPath),
       };
 
       await variantAnalysisManager.runVariantAnalysis(
@@ -416,11 +426,11 @@ describe("Variant Analysis Manager", () => {
       );
     }
 
-    function getFile(file: string): string {
-      if (isAbsolute(file)) {
-        return file;
+    function getFileOrDir(path: string): string {
+      if (isAbsolute(path)) {
+        return path;
       } else {
-        return join(baseDir, file);
+        return join(baseDir, path);
       }
     }
   });


### PR DESCRIPTION
Continues the work started in https://github.com/github/vscode-codeql/pull/3260 and https://github.com/github/vscode-codeql/pull/3262, and now moves the QL pack root path retrieval out of `generateQueryPack`.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
