### PR TITLE
Move findPackRoot to ql.ts

### DIFF
--- a/extensions/ql-vscode/src/variant-analysis/run-remote-query.ts
+++ b/extensions/ql-vscode/src/variant-analysis/run-remote-query.ts
@@ -1,6 +1,6 @@
 import type { CancellationToken } from "vscode";
 import { Uri, window } from "vscode";
-import { relative, join, sep, dirname, parse, basename } from "path";
+import { relative, join, sep, basename } from "path";
 import { dump, load } from "js-yaml";
 import { copy, writeFile, readFile, mkdirp } from "fs-extra";
 import type { DirectoryResult } from "tmp-promise";
@@ -260,26 +260,6 @@ async function copyExistingQueryPack(
   void extLogger.log(`Copied ${copiedCount} files to ${queryPackDir}`);
 
   await fixPackFile(queryPackDir, packRelativePath);
-}
-
-export async function findPackRoot(queryFile: string): Promise<string> {
-  // recursively find the directory containing qlpack.yml or codeql-pack.yml
-  let dir = dirname(queryFile);
-  while (!(await getQlPackFilePath(dir))) {
-    dir = dirname(dir);
-    if (isFileSystemRoot(dir)) {
-      // there is no qlpack.yml or codeql-pack.yml in this directory or any parent directory.
-      // just use the query file's directory as the pack root.
-      return dirname(queryFile);
-    }
-  }
-
-  return dir;
-}
-
-function isFileSystemRoot(dir: string): boolean {
-  const pathObj = parse(dir);
-  return pathObj.root === dir && pathObj.base === "";
 }
 
 interface RemoteQueryTempDir {

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -42,11 +42,7 @@ import type {
   LoadResultsOptions,
   VariantAnalysisResultsManager,
 } from "./variant-analysis-results-manager";
-import {
-  findPackRoot,
-  getQueryName,
-  prepareRemoteQueryRun,
-} from "./run-remote-query";
+import { getQueryName, prepareRemoteQueryRun } from "./run-remote-query";
 import {
   mapVariantAnalysis,
   mapVariantAnalysisRepositoryTask,
@@ -94,6 +90,7 @@ import { handleRequestError } from "./custom-errors";
 import { createMultiSelectionCommand } from "../common/vscode/selection-commands";
 import { askForLanguage } from "../codeql-cli/query-language";
 import type { QlPackDetails } from "./ql-pack-details";
+import { findPackRoot } from "../common/ql";
 
 const maxRetryCount = 3;
 


### PR DESCRIPTION
ql.ts seems a better location for this function so I've moved it.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
