### PR TITLE
Move QL pack file path to the QlPackDetails

### DIFF
--- a/extensions/ql-vscode/src/variant-analysis/ql-pack-details.ts
+++ b/extensions/ql-vscode/src/variant-analysis/ql-pack-details.ts
@@ -8,4 +8,8 @@ export interface QlPackDetails {
   // The path to the QL pack that is used for triggering a variant analysis.
   // If there is no query pack, this is the same as the directory of the query files.
   qlPackRootPath: string;
+
+  // The path to the QL pack file (a qlpack.yml or codeql-pack.yml) or undefined if
+  // it doesn't exist.
+  qlPackFilePath: string | undefined;
 }

--- a/extensions/ql-vscode/src/variant-analysis/run-remote-query.ts
+++ b/extensions/ql-vscode/src/variant-analysis/run-remote-query.ts
@@ -73,8 +73,7 @@ async function generateQueryPack(
     workspaceFolders,
   );
 
-  const mustSynthesizePack =
-    (await getQlPackFilePath(originalPackRoot)) === undefined;
+  const mustSynthesizePack = qlPackDetails.qlPackFilePath === undefined;
   const cliSupportsMrvaPackCreate =
     await cliServer.cliConstraints.supportsMrvaPackCreate();
 

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -90,7 +90,7 @@ import { handleRequestError } from "./custom-errors";
 import { createMultiSelectionCommand } from "../common/vscode/selection-commands";
 import { askForLanguage } from "../codeql-cli/query-language";
 import type { QlPackDetails } from "./ql-pack-details";
-import { findPackRoot } from "../common/ql";
+import { findPackRoot, getQlPackFilePath } from "../common/ql";
 
 const maxRetryCount = 3;
 
@@ -269,12 +269,15 @@ export class VariantAnalysisManager
         return;
       }
 
+      const qlPackFilePath = await getQlPackFilePath(packDir);
+
       // Build up details to pass to the functions that run the variant analysis.
       // For now, only include the first problem query until we have support
       // for multiple queries.
       const qlPackDetails: QlPackDetails = {
         queryFile: problemQueries[0],
         qlPackRootPath: packDir,
+        qlPackFilePath,
       };
 
       await this.runVariantAnalysis(
@@ -311,9 +314,11 @@ export class VariantAnalysisManager
   private async runVariantAnalysisCommand(uri: Uri): Promise<void> {
     // Build up details to pass to the functions that run the variant analysis.
     const qlPackRootPath = await findPackRoot(uri.fsPath);
+    const qlPackFilePath = await getQlPackFilePath(qlPackRootPath);
     const qlPackDetails: QlPackDetails = {
       queryFile: uri.fsPath,
       qlPackRootPath,
+      qlPackFilePath,
     };
 
     return withProgress(

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
@@ -102,9 +102,12 @@ describe("Variant Analysis Manager", () => {
 
     it("should run a variant analysis that is part of a qlpack", async () => {
       const filePath = getFileOrDir("data-remote-qlpack/in-pack.ql");
+      const qlPackRootPath = getFileOrDir("data-remote-qlpack");
+      const qlPackFilePath = getFileOrDir("data-remote-qlpack/qlpack.yml");
       const qlPackDetails: QlPackDetails = {
         queryFile: filePath,
-        qlPackRootPath: join(baseDir, "data-remote-qlpack"),
+        qlPackRootPath,
+        qlPackFilePath,
       };
 
       await variantAnalysisManager.runVariantAnalysis(
@@ -127,9 +130,11 @@ describe("Variant Analysis Manager", () => {
 
     it("should run a remote query that is not part of a qlpack", async () => {
       const filePath = getFileOrDir("data-remote-no-qlpack/in-pack.ql");
+      const qlPackRootPath = getFileOrDir("data-remote-no-qlpack");
       const qlPackDetails: QlPackDetails = {
         queryFile: filePath,
-        qlPackRootPath: join(baseDir, "data-remote-no-qlpack"),
+        qlPackRootPath,
+        qlPackFilePath: undefined,
       };
 
       await variantAnalysisManager.runVariantAnalysis(
@@ -154,9 +159,14 @@ describe("Variant Analysis Manager", () => {
       const filePath = getFileOrDir(
         "data-remote-qlpack-nested/subfolder/in-pack.ql",
       );
+      const qlPackRootPath = getFileOrDir("data-remote-qlpack-nested");
+      const qlPackFilePath = getFileOrDir(
+        "data-remote-qlpack-nested/codeql-pack.yml",
+      );
       const qlPackDetails: QlPackDetails = {
         queryFile: filePath,
-        qlPackRootPath: join(baseDir, "data-remote-qlpack-nested"),
+        qlPackRootPath,
+        qlPackFilePath,
       };
 
       await variantAnalysisManager.runVariantAnalysis(
@@ -179,9 +189,11 @@ describe("Variant Analysis Manager", () => {
 
     it("should cancel a run before uploading", async () => {
       const filePath = getFileOrDir("data-remote-no-qlpack/in-pack.ql");
+      const qlPackRootPath = getFileOrDir("data-remote-no-qlpack");
       const qlPackDetails: QlPackDetails = {
         queryFile: filePath,
-        qlPackRootPath: join(baseDir, "data-remote-no-qlpack"),
+        qlPackRootPath,
+        qlPackFilePath: undefined,
       };
 
       const promise = variantAnalysisManager.runVariantAnalysis(
@@ -223,6 +235,7 @@ describe("Variant Analysis Manager", () => {
         await doVariantAnalysisTest({
           queryPath: "data-remote-qlpack/in-pack.ql",
           qlPackRootPath: "data-remote-qlpack",
+          qlPackFilePath: "data-remote-qlpack/qlpack.yml",
           expectedPackName: "github/remote-query-pack",
           filesThatExist: ["in-pack.ql", "lib.qll"],
           filesThatDoNotExist: [],
@@ -234,6 +247,7 @@ describe("Variant Analysis Manager", () => {
         await doVariantAnalysisTest({
           queryPath: "data-remote-no-qlpack/in-pack.ql",
           qlPackRootPath: "data-remote-no-qlpack",
+          qlPackFilePath: undefined,
           expectedPackName: "codeql-remote/query",
           filesThatExist: ["in-pack.ql"],
           filesThatDoNotExist: ["lib.qll", "not-in-pack.ql"],
@@ -245,6 +259,7 @@ describe("Variant Analysis Manager", () => {
         await doVariantAnalysisTest({
           queryPath: "data-remote-qlpack-nested/subfolder/in-pack.ql",
           qlPackRootPath: "data-remote-qlpack-nested",
+          qlPackFilePath: "data-remote-qlpack-nested/codeql-pack.yml",
           expectedPackName: "github/remote-query-pack",
           filesThatExist: ["subfolder/in-pack.ql", "otherfolder/lib.qll"],
           filesThatDoNotExist: ["subfolder/not-in-pack.ql"],
@@ -263,6 +278,7 @@ describe("Variant Analysis Manager", () => {
         await doVariantAnalysisTest({
           queryPath: "data-remote-qlpack-nested/subfolder/in-pack.ql",
           qlPackRootPath: "data-remote-qlpack-nested",
+          qlPackFilePath: "data-remote-qlpack-nested/codeql-pack.yml",
           expectedPackName: "github/remote-query-pack",
           filesThatExist: [
             "subfolder/in-pack.ql",
@@ -309,9 +325,11 @@ describe("Variant Analysis Manager", () => {
 
       const qlPackRootPath = join(process.env.TEST_CODEQL_PATH, "java/ql/src");
       const queryPath = join(qlPackRootPath, queryToRun);
+      const qlPackFilePath = join(qlPackRootPath, "qlpack.yml");
       await doVariantAnalysisTest({
         queryPath,
         qlPackRootPath,
+        qlPackFilePath,
         expectedPackName: "codeql/java-queries",
         filesThatExist: [queryToRun, ...extraQueries],
         filesThatDoNotExist: [],
@@ -325,6 +343,7 @@ describe("Variant Analysis Manager", () => {
     async function doVariantAnalysisTest({
       queryPath,
       qlPackRootPath,
+      qlPackFilePath,
       expectedPackName,
       filesThatExist,
       qlxFilesThatExist,
@@ -337,6 +356,7 @@ describe("Variant Analysis Manager", () => {
     }: {
       queryPath: string;
       qlPackRootPath: string;
+      qlPackFilePath: string | undefined;
       expectedPackName: string;
       filesThatExist: string[];
       qlxFilesThatExist: string[];
@@ -348,6 +368,7 @@ describe("Variant Analysis Manager", () => {
       const qlPackDetails: QlPackDetails = {
         queryFile: filePath,
         qlPackRootPath: getFileOrDir(qlPackRootPath),
+        qlPackFilePath: qlPackFilePath && getFileOrDir(qlPackFilePath),
       };
 
       await variantAnalysisManager.runVariantAnalysis(


### PR DESCRIPTION
Similar to https://github.com/github/vscode-codeql/pull/3267, this PR moves the QL pack file path out of `generateQueryPack`.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
