### PR TITLE
Move query language to the QlPackDetails

### DIFF
--- a/extensions/ql-vscode/src/variant-analysis/ql-pack-details.ts
+++ b/extensions/ql-vscode/src/variant-analysis/ql-pack-details.ts
@@ -1,3 +1,5 @@
+import type { QueryLanguage } from "../common/query-language";
+
 /**
  * Details about the original QL pack that is used for triggering
  * a variant analysis.
@@ -12,4 +14,6 @@ export interface QlPackDetails {
   // The path to the QL pack file (a qlpack.yml or codeql-pack.yml) or undefined if
   // it doesn't exist.
   qlPackFilePath: string | undefined;
+
+  language: QueryLanguage;
 }

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -88,7 +88,7 @@ import type { QueryTreeViewItem } from "../queries-panel/query-tree-view-item";
 import { RequestError } from "@octokit/request-error";
 import { handleRequestError } from "./custom-errors";
 import { createMultiSelectionCommand } from "../common/vscode/selection-commands";
-import { askForLanguage } from "../codeql-cli/query-language";
+import { askForLanguage, findLanguage } from "../codeql-cli/query-language";
 import type { QlPackDetails } from "./ql-pack-details";
 import { findPackRoot, getQlPackFilePath } from "../common/ql";
 
@@ -278,6 +278,7 @@ export class VariantAnalysisManager
         queryFile: problemQueries[0],
         qlPackRootPath: packDir,
         qlPackFilePath,
+        language,
       };
 
       await this.runVariantAnalysis(
@@ -315,10 +316,21 @@ export class VariantAnalysisManager
     // Build up details to pass to the functions that run the variant analysis.
     const qlPackRootPath = await findPackRoot(uri.fsPath);
     const qlPackFilePath = await getQlPackFilePath(qlPackRootPath);
+
+    // Open popup to ask for language if not already hardcoded
+    const language = qlPackFilePath
+      ? await askForLanguage(this.cliServer)
+      : await findLanguage(this.cliServer, uri);
+
+    if (!language) {
+      throw new UserCancellationException("Could not determine query language");
+    }
+
     const qlPackDetails: QlPackDetails = {
       queryFile: uri.fsPath,
       qlPackRootPath,
       qlPackFilePath,
+      language,
     };
 
     return withProgress(
@@ -353,7 +365,6 @@ export class VariantAnalysisManager
       queryMetadata,
       controllerRepo,
       queryStartTime,
-      language,
     } = await prepareRemoteQueryRun(
       this.cliServer,
       this.app.credentials,
@@ -364,6 +375,7 @@ export class VariantAnalysisManager
     );
 
     const queryName = getQueryName(queryMetadata, queryFile);
+    const language = qlPackDetails.language;
     const variantAnalysisLanguage = parseVariantAnalysisQueryLanguage(language);
     if (variantAnalysisLanguage === undefined) {
       throw new UserCancellationException(

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -319,8 +319,8 @@ export class VariantAnalysisManager
 
     // Open popup to ask for language if not already hardcoded
     const language = qlPackFilePath
-      ? await askForLanguage(this.cliServer)
-      : await findLanguage(this.cliServer, uri);
+      ? await findLanguage(this.cliServer, uri)
+      : await askForLanguage(this.cliServer);
 
     if (!language) {
       throw new UserCancellationException("Could not determine query language");

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
@@ -108,6 +108,7 @@ describe("Variant Analysis Manager", () => {
         queryFile: filePath,
         qlPackRootPath,
         qlPackFilePath,
+        language: QueryLanguage.Javascript,
       };
 
       await variantAnalysisManager.runVariantAnalysis(
@@ -135,6 +136,7 @@ describe("Variant Analysis Manager", () => {
         queryFile: filePath,
         qlPackRootPath,
         qlPackFilePath: undefined,
+        language: QueryLanguage.Javascript,
       };
 
       await variantAnalysisManager.runVariantAnalysis(
@@ -167,6 +169,7 @@ describe("Variant Analysis Manager", () => {
         queryFile: filePath,
         qlPackRootPath,
         qlPackFilePath,
+        language: QueryLanguage.Javascript,
       };
 
       await variantAnalysisManager.runVariantAnalysis(
@@ -194,6 +197,7 @@ describe("Variant Analysis Manager", () => {
         queryFile: filePath,
         qlPackRootPath,
         qlPackFilePath: undefined,
+        language: QueryLanguage.Javascript,
       };
 
       const promise = variantAnalysisManager.runVariantAnalysis(
@@ -369,6 +373,7 @@ describe("Variant Analysis Manager", () => {
         queryFile: filePath,
         qlPackRootPath: getFileOrDir(qlPackRootPath),
         qlPackFilePath: qlPackFilePath && getFileOrDir(qlPackFilePath),
+        language: QueryLanguage.Javascript,
       };
 
       await variantAnalysisManager.runVariantAnalysis(

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-submission-integration.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-submission-integration.test.ts
@@ -86,6 +86,14 @@ describe("Variant Analysis Submission Integration", () => {
     it("shows the error message", async () => {
       await showQlDocument("query.ql");
 
+      // Select target language for your query
+      quickPickSpy.mockResolvedValueOnce(
+        mockedQuickPickItem({
+          label: "JavaScript",
+          language: "javascript",
+        }),
+      );
+
       await commandManager.execute("codeQL.runVariantAnalysis");
 
       expect(showErrorMessageSpy).toHaveBeenCalledWith(


### PR DESCRIPTION
Similar to https://github.com/github/vscode-codeql/pull/3267, this PR moves the query language out of `generateQueryPack`.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
