### PR TITLE
Add run-remote-query.ts to CLI tests workflow triggers

### DIFF
--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -11,6 +11,7 @@ on:
       - extensions/ql-vscode/src/language-support/**
       - extensions/ql-vscode/src/query-server/**
       - extensions/ql-vscode/supported_cli_versions.json
+      - extensions/ql-vscode/src/variant-analysis/run-remote-query.ts
 
 jobs:
   find-nightly:


### PR DESCRIPTION
`run-remote-query.ts` has logic that deals with different versions of the CLI so we should run the whole matrix of CLI tests when the file changes.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
