### PR TITLE
Use Uri to convert paths to platform specific fs paths

### DIFF
--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
@@ -1,5 +1,4 @@
-import type { Uri } from "vscode";
-import { CancellationTokenSource, commands, window } from "vscode";
+import { CancellationTokenSource, commands, window, Uri } from "vscode";
 import { extLogger } from "../../../../src/common/logging/vscode";
 import { setRemoteControllerRepo } from "../../../../src/config";
 import * as ghApiClient from "../../../../src/variant-analysis/gh-api/gh-api-client";
@@ -453,10 +452,11 @@ describe("Variant Analysis Manager", () => {
     }
 
     function getFileOrDir(path: string): string {
+      // Use `Uri.file(path).fsPath` to make sure the path is in the correct format for the OS (i.e. forward/backward slashes).
       if (isAbsolute(path)) {
-        return path;
+        return Uri.file(path).fsPath;
       } else {
-        return join(baseDir, path);
+        return Uri.file(join(baseDir, path)).fsPath;
       }
     }
   });


### PR DESCRIPTION
Aims to fix the CLI tests on windows. We believe they were broken in https://github.com/github/vscode-codeql/pull/3262 by the change to `getFile`. This PR adds back in the use of `Uri.file(...).fsPath` to convert the paths supplied by the test code (which always use forward slashes) to a platform-dependent file path.

Successful CLI test run: https://github.com/github/vscode-codeql/actions/runs/7639479147

There may well be other ways of achieving this, though I can't immediately find one that's clearly better. Stackoverflow is suggesting `somepath.split(path.sep).join(locale.sep)` though I'm not sure I like that more than using `Uri`. Since it's just for the CLI tests I don't think we need to be too worried about being perfect, so if this works it should be fine.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
