### PR TITLE
Tidy up uses of QueryPackDetails object fields

### DIFF
--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -389,11 +389,12 @@ export class VariantAnalysisManager
       firstQueryFile,
     );
     const queryName = getQueryName(queryMetadata, firstQueryFile);
-    const language = qlPackDetails.language;
-    const variantAnalysisLanguage = parseVariantAnalysisQueryLanguage(language);
+    const variantAnalysisLanguage = parseVariantAnalysisQueryLanguage(
+      qlPackDetails.language,
+    );
     if (variantAnalysisLanguage === undefined) {
       throw new UserCancellationException(
-        `Found unsupported language: ${language}`,
+        `Found unsupported language: ${qlPackDetails.language}`,
       );
     }
 


### PR DESCRIPTION
Mentioned in https://github.com/github/vscode-codeql/pull/3274#discussion_r1465149544

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
