### PR TITLE
Allow using Tab to select the active option in the suggest box

### DIFF
--- a/extensions/ql-vscode/src/view/common/SuggestBox/SuggestBox.tsx
+++ b/extensions/ql-vscode/src/view/common/SuggestBox/SuggestBox.tsx
@@ -207,9 +207,9 @@ export const SuggestBox = <
           "aria-autocomplete": "list",
           "aria-label": ariaLabel,
           onKeyDown: (event) => {
-            // When the user presses the enter key, select the active item
+            // When the user presses the enter or tab key, select the active item
             if (
-              event.key === "Enter" &&
+              (event.key === "Enter" || event.key === "Tab") &&
               activeIndex !== null &&
               suggestionItems[activeIndex]
             ) {

--- a/extensions/ql-vscode/src/view/common/SuggestBox/__tests__/SuggestBox.test.tsx
+++ b/extensions/ql-vscode/src/view/common/SuggestBox/__tests__/SuggestBox.test.tsx
@@ -161,13 +161,57 @@ describe("SuggestBox", () => {
     expect(screen.getByRole("option")).toHaveTextContent("Parameter[1]");
   });
 
-  it("closes the options when selecting an option", async () => {
+  it("selects an option using Enter", async () => {
     render({
       value: "Argument[block].1",
     });
 
     await userEvent.click(screen.getByRole("combobox"));
     await userEvent.keyboard("{Enter}");
+
+    expect(onChange).toHaveBeenCalledWith("Argument[block].Parameter[1]");
+  });
+
+  it("selects an option using Tab", async () => {
+    render({
+      value: "Argument[block].1",
+    });
+
+    await userEvent.click(screen.getByRole("combobox"));
+    await userEvent.keyboard("{Enter}");
+
+    expect(onChange).toHaveBeenCalledWith("Argument[block].Parameter[1]");
+  });
+
+  it("does not select an option using Home", async () => {
+    render({
+      value: "Argument[block].1",
+    });
+
+    await userEvent.click(screen.getByRole("combobox"));
+    await userEvent.keyboard("{Home}");
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("closes the options when selecting an option using Enter", async () => {
+    render({
+      value: "Argument[block].1",
+    });
+
+    await userEvent.click(screen.getByRole("combobox"));
+    await userEvent.keyboard("{Enter}");
+
+    expect(screen.queryByRole("option")).not.toBeInTheDocument();
+  });
+
+  it("closes the options when selecting an option using Tab", async () => {
+    render({
+      value: "Argument[block].1",
+    });
+
+    await userEvent.click(screen.getByRole("combobox"));
+    await userEvent.keyboard("{Tab}");
 
     expect(screen.queryByRole("option")).not.toBeInTheDocument();
   });


### PR DESCRIPTION
This adds Tab as a key that will select the active item in the suggest box, as suggested in https://github.com/github/vscode-codeql/pull/3242#pullrequestreview-1839068752.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
