### PR TITLE
Improve handling of unknown QL pack roots for multi-query MRVAs

### DIFF
--- a/extensions/ql-vscode/src/common/files.ts
+++ b/extensions/ql-vscode/src/common/files.ts
@@ -1,5 +1,5 @@
 import { pathExists, stat, readdir, opendir } from "fs-extra";
-import { isAbsolute, join, relative, resolve } from "path";
+import { isAbsolute, join, relative, resolve, sep } from "path";
 import { tmpdir as osTmpdir } from "os";
 
 /**
@@ -131,4 +131,31 @@ export function isIOError(e: any): e is IOError {
 // This function is a wrapper around `os.tmpdir()` to make it easier to mock in tests.
 export function tmpdir(): string {
   return osTmpdir();
+}
+
+/**
+ * Finds the common parent directory of an arbitrary number of paths. If the paths are absolute,
+ * the result is also absolute. If the paths are relative, the result is relative.
+ * @param paths The array of paths.
+ * @returns The common parent directory of the paths.
+ */
+export function findCommonParentDir(...paths: string[]): string {
+  // Split each path into its components
+  const pathParts = paths.map((path) => path.split(sep));
+
+  let commonDir = "";
+  // Iterate over the components of the first path and checks if the same
+  // component exists at the same position in all the other paths. If it does,
+  // add the component to the common directory. If it doesn't, stop the
+  // iteration and returns the common directory found so far.
+  for (let i = 0; i < pathParts[0].length; i++) {
+    const part = pathParts[0][i];
+    if (pathParts.every((parts) => parts[i] === part)) {
+      commonDir = `${commonDir}${part}${sep}`;
+    } else {
+      break;
+    }
+  }
+
+  return commonDir;
 }

--- a/extensions/ql-vscode/src/common/ql.ts
+++ b/extensions/ql-vscode/src/common/ql.ts
@@ -32,16 +32,16 @@ export async function getQlPackFilePath(
  * Recursively find the directory containing qlpack.yml or codeql-pack.yml. If
  * no such directory is found, the directory containing the query file is returned.
  * @param queryFile The query file to start from.
- * @returns The path to the pack root.
+ * @returns The path to the pack root or undefined if it doesn't exist.
  */
-export async function findPackRoot(queryFile: string): Promise<string> {
+export async function findPackRoot(
+  queryFile: string,
+): Promise<string | undefined> {
   let dir = dirname(queryFile);
   while (!(await getQlPackFilePath(dir))) {
     dir = dirname(dir);
     if (isFileSystemRoot(dir)) {
-      // there is no qlpack.yml or codeql-pack.yml in this directory or any parent directory.
-      // just use the query file's directory as the pack root.
-      return dirname(queryFile);
+      return undefined;
     }
   }
 

--- a/extensions/ql-vscode/src/variant-analysis/ql.ts
+++ b/extensions/ql-vscode/src/variant-analysis/ql.ts
@@ -1,0 +1,87 @@
+import { dirname } from "path";
+import { findCommonParentDir } from "../common/files";
+import { findPackRoot } from "../common/ql";
+
+/**
+ * This function finds the root directory of the QL pack that contains the provided query files.
+ * It handles several cases:
+ * - If no query files are provided, it throws an error.
+ * - If all query files are in the same QL pack, it returns the root directory of that pack.
+ * - If the query files are in different QL packs, it throws an error.
+ * - If some query files are in a QL pack and some aren't, it throws an error.
+ * - If none of the query files are in a QL pack, it returns the common parent directory of the query files. However,
+ *   if there are more than one query files and they're not in the same workspace folder, it throws an error.
+ *
+ * @param queryFiles - An array of file paths for the query files.
+ * @param workspaceFolders - An array of workspace folder paths.
+ * @returns The root directory of the QL pack that contains the query files, or the common parent directory of the query files.
+ */
+export async function findVariantAnalysisQlPackRoot(
+  queryFiles: string[],
+  workspaceFolders: string[],
+): Promise<string> {
+  if (queryFiles.length === 0) {
+    throw Error("No query files provided");
+  }
+
+  // Calculate the pack root for each query file
+  const packRoots: Array<string | undefined> = [];
+  for (const queryFile of queryFiles) {
+    const packRoot = await findPackRoot(queryFile);
+    packRoots.push(packRoot);
+  }
+
+  if (queryFiles.length === 1) {
+    return packRoots[0] ?? dirname(queryFiles[0]);
+  }
+
+  const uniquePackRoots = Array.from(new Set(packRoots));
+
+  if (uniquePackRoots.length > 1) {
+    if (uniquePackRoots.includes(undefined)) {
+      throw Error("Some queries are in a pack and some aren't");
+    } else {
+      throw Error("Some queries are in different packs");
+    }
+  }
+
+  if (uniquePackRoots[0] === undefined) {
+    return findQlPackRootForQueriesWithNoPack(queryFiles, workspaceFolders);
+  } else {
+    // All in the same pack, return that pack's root
+    return uniquePackRoots[0];
+  }
+}
+
+/**
+ * For queries that are not in a pack, a potential pack root is the
+ * common parent dir of all the queries. However, we only want to
+ * return this if all the queries are in the same workspace folder.
+ */
+function findQlPackRootForQueriesWithNoPack(
+  queryFiles: string[],
+  workspaceFolders: string[],
+): string {
+  const queryFileWorkspaceFolders = queryFiles.map((queryFile) =>
+    workspaceFolders.find((workspaceFolder) =>
+      queryFile.startsWith(workspaceFolder),
+    ),
+  );
+
+  // Check if any query file is not part of the workspace.
+  if (queryFileWorkspaceFolders.includes(undefined)) {
+    throw Error(
+      "Queries that are not part of a pack need to be part of the workspace",
+    );
+  }
+
+  // Check if query files are not in the same workspace folder.
+  if (new Set(queryFileWorkspaceFolders).size > 1) {
+    throw Error(
+      "Queries that are not part of a pack need to be in the same workspace folder",
+    );
+  }
+
+  // They're in the same workspace folder, so we can find a common parent dir.
+  return findCommonParentDir(...queryFiles);
+}

--- a/extensions/ql-vscode/src/variant-analysis/ql.ts
+++ b/extensions/ql-vscode/src/variant-analysis/ql.ts
@@ -64,6 +64,9 @@ function findQlPackRootForQueriesWithNoPack(
 ): string {
   const commonParentDir = findCommonParentDir(...queryFiles);
 
+  // Check that all queries are in a workspace folder (the same one),
+  // so that we don't return a pack root that's outside the workspace.
+  // This is to avoid accessing files outside the workspace folders.
   for (const workspaceFolder of workspaceFolders) {
     if (containsPath(workspaceFolder, commonParentDir)) {
       return commonParentDir;

--- a/extensions/ql-vscode/test/data/variant-analysis-query-packs/workspace1/dir1/query1.ql
+++ b/extensions/ql-vscode/test/data/variant-analysis-query-packs/workspace1/dir1/query1.ql
@@ -1,0 +1,1 @@
+select 42, 3.14159, "hello world", true

--- a/extensions/ql-vscode/test/data/variant-analysis-query-packs/workspace1/pack1/qlpack.yml
+++ b/extensions/ql-vscode/test/data/variant-analysis-query-packs/workspace1/pack1/qlpack.yml
@@ -1,0 +1,2 @@
+name: test-queries
+version: 0.0.0

--- a/extensions/ql-vscode/test/data/variant-analysis-query-packs/workspace1/pack1/query1.ql
+++ b/extensions/ql-vscode/test/data/variant-analysis-query-packs/workspace1/pack1/query1.ql
@@ -1,0 +1,1 @@
+select 42, 3.14159, "hello world", true

--- a/extensions/ql-vscode/test/data/variant-analysis-query-packs/workspace1/pack1/query2.ql
+++ b/extensions/ql-vscode/test/data/variant-analysis-query-packs/workspace1/pack1/query2.ql
@@ -1,0 +1,1 @@
+select 42, 3.14159, "hello world", true

--- a/extensions/ql-vscode/test/data/variant-analysis-query-packs/workspace1/pack2/qlpack.yml
+++ b/extensions/ql-vscode/test/data/variant-analysis-query-packs/workspace1/pack2/qlpack.yml
@@ -1,0 +1,2 @@
+name: test-queries
+version: 0.0.0

--- a/extensions/ql-vscode/test/data/variant-analysis-query-packs/workspace1/pack2/query1.ql
+++ b/extensions/ql-vscode/test/data/variant-analysis-query-packs/workspace1/pack2/query1.ql
@@ -1,0 +1,1 @@
+select 42, 3.14159, "hello world", true

--- a/extensions/ql-vscode/test/data/variant-analysis-query-packs/workspace1/query1.ql
+++ b/extensions/ql-vscode/test/data/variant-analysis-query-packs/workspace1/query1.ql
@@ -1,0 +1,1 @@
+select 42, 3.14159, "hello world", true

--- a/extensions/ql-vscode/test/data/variant-analysis-query-packs/workspace2/query1.ql
+++ b/extensions/ql-vscode/test/data/variant-analysis-query-packs/workspace2/query1.ql
@@ -1,0 +1,1 @@
+select 42, 3.14159, "hello world", true

--- a/extensions/ql-vscode/test/unit-tests/common/files.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/common/files.test.ts
@@ -2,6 +2,7 @@ import { join } from "path";
 
 import {
   containsPath,
+  findCommonParentDir,
   gatherQlFiles,
   getDirectoryNamesInsidePath,
   pathsEqual,
@@ -11,6 +12,7 @@ import {
 import type { DirResult } from "tmp";
 import { dirSync } from "tmp";
 import { ensureDirSync, symlinkSync, writeFileSync } from "fs-extra";
+import "../../matchers/toEqualPath";
 
 describe("files", () => {
   const dataDir = join(__dirname, "../../data");
@@ -62,9 +64,29 @@ describe("files", () => {
       const file4 = join(dataDir, "multiple-result-sets.ql");
       const file5 = join(dataDir, "query.ql");
 
+      const vaDir = join(dataDir, "variant-analysis-query-packs");
+      const file6 = join(vaDir, "workspace1", "dir1", "query1.ql");
+      const file7 = join(vaDir, "workspace1", "pack1", "query1.ql");
+      const file8 = join(vaDir, "workspace1", "pack1", "query2.ql");
+      const file9 = join(vaDir, "workspace1", "pack2", "query1.ql");
+      const file10 = join(vaDir, "workspace1", "query1.ql");
+      const file11 = join(vaDir, "workspace2", "query1.ql");
+
       const result = await gatherQlFiles([dataDir]);
       expect(result.sort()).toEqual([
-        [file1, file2, file3, file4, file5],
+        [
+          file1,
+          file2,
+          file3,
+          file4,
+          file5,
+          file6,
+          file7,
+          file8,
+          file9,
+          file10,
+          file11,
+        ],
         true,
       ]);
     });
@@ -88,10 +110,30 @@ describe("files", () => {
       const file4 = join(dataDir, "multiple-result-sets.ql");
       const file5 = join(dataDir, "query.ql");
 
+      const vaDir = join(dataDir, "variant-analysis-query-packs");
+      const file6 = join(vaDir, "workspace1", "dir1", "query1.ql");
+      const file7 = join(vaDir, "workspace1", "pack1", "query1.ql");
+      const file8 = join(vaDir, "workspace1", "pack1", "query2.ql");
+      const file9 = join(vaDir, "workspace1", "pack2", "query1.ql");
+      const file10 = join(vaDir, "workspace1", "query1.ql");
+      const file11 = join(vaDir, "workspace2", "query1.ql");
+
       const result = await gatherQlFiles([file1, dataDir, file3, file4, file5]);
       result[0].sort();
       expect(result.sort()).toEqual([
-        [file1, file2, file3, file4, file5],
+        [
+          file1,
+          file2,
+          file3,
+          file4,
+          file5,
+          file6,
+          file7,
+          file8,
+          file9,
+          file10,
+          file11,
+        ],
         true,
       ]);
     });
@@ -415,5 +457,43 @@ describe("walkDirectory", () => {
 
     // Only real files should be returned.
     expect(files.sort()).toEqual([file1, file2, file3, file4, file5, file6]);
+  });
+});
+
+describe("findCommonParentDir", () => {
+  it("should find the common parent dir for multiple paths with common parent", () => {
+    const paths = [
+      join("foo", "bar", "baz"),
+      join("foo", "bar", "qux"),
+      join("foo", "bar", "quux"),
+    ];
+
+    const commonDir = findCommonParentDir(...paths);
+
+    expect(commonDir).toEqualPath(join("foo", "bar"));
+  });
+
+  it("should return the root if paths have no common parent other than root", () => {
+    const paths = [
+      join("foo", "bar", "baz"),
+      join("qux", "quux", "corge"),
+      join("grault", "garply"),
+    ];
+
+    const commonDir = findCommonParentDir(...paths);
+
+    expect(commonDir).toEqualPath("");
+  });
+
+  it("should return empty string for relative paths with no common parent", () => {
+    const paths = [
+      join("foo", "bar", "baz"),
+      join("qux", "quux", "corge"),
+      join("grault", "garply"),
+    ];
+
+    const commonDir = findCommonParentDir(...paths);
+
+    expect(commonDir).toEqualPath("");
   });
 });

--- a/extensions/ql-vscode/test/unit-tests/variant-analysis/ql.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/variant-analysis/ql.test.ts
@@ -87,7 +87,7 @@ describe("findVariantAnalysisQlPackRoot", () => {
     await expect(
       findVariantAnalysisQlPackRoot(queryFiles, workspaceFolders),
     ).rejects.toThrow(
-      "Queries that are not part of a pack need to be in the same workspace folder",
+      "All queries must be within the workspace and within the same workspace root",
     );
   });
 
@@ -100,7 +100,7 @@ describe("findVariantAnalysisQlPackRoot", () => {
     await expect(
       findVariantAnalysisQlPackRoot(queryFiles, workspaceFolders),
     ).rejects.toThrow(
-      "Queries that are not part of a pack need to be part of the workspace",
+      "All queries must be within the workspace and within the same workspace root",
     );
   });
 

--- a/extensions/ql-vscode/test/unit-tests/variant-analysis/ql.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/variant-analysis/ql.test.ts
@@ -1,0 +1,134 @@
+import { join } from "path";
+import { findVariantAnalysisQlPackRoot } from "../../../src/variant-analysis/ql";
+import "../../matchers/toEqualPath";
+
+describe("findVariantAnalysisQlPackRoot", () => {
+  const testDataDir = join(
+    __dirname,
+    "../../data/variant-analysis-query-packs",
+  );
+
+  const workspaceFolders = [
+    getFullPath("workspace1"),
+    getFullPath("workspace2"),
+  ];
+
+  function getFullPath(relativePath: string) {
+    return join(testDataDir, relativePath);
+  }
+
+  it("should throw an error if no query files are provided", async () => {
+    await expect(
+      findVariantAnalysisQlPackRoot([], workspaceFolders),
+    ).rejects.toThrow("No query files provided");
+  });
+
+  it("should return the pack root of a single query in a pack", async () => {
+    const queryFiles = [getFullPath("workspace1/pack1/query1.ql")];
+
+    const packRoot = await findVariantAnalysisQlPackRoot(
+      queryFiles,
+      workspaceFolders,
+    );
+
+    expect(packRoot).toEqualPath(getFullPath("workspace1/pack1"));
+  });
+
+  it("should return the pack root of a single query not in a pack", async () => {
+    const queryFiles = [getFullPath("workspace1/query1.ql")];
+
+    const packRoot = await findVariantAnalysisQlPackRoot(
+      queryFiles,
+      workspaceFolders,
+    );
+
+    expect(packRoot).toEqualPath(getFullPath("workspace1"));
+  });
+
+  it("should return the pack root of a single query not in a pack or workspace", async () => {
+    const queryFiles = [getFullPath("dir1/query1.ql")];
+
+    const packRoot = await findVariantAnalysisQlPackRoot(
+      queryFiles,
+      workspaceFolders,
+    );
+
+    expect(packRoot).toEqualPath(getFullPath("dir1"));
+  });
+
+  it("should throw an error if some queries are in a pack and some are not", async () => {
+    const queryFiles = [
+      getFullPath("workspace1/pack1/query1.ql"),
+      getFullPath("workspace1/query1.ql"),
+    ];
+
+    await expect(
+      findVariantAnalysisQlPackRoot(queryFiles, workspaceFolders),
+    ).rejects.toThrow("Some queries are in a pack and some aren't");
+  });
+
+  it("should throw an error if queries are in different packs", async () => {
+    const queryFiles = [
+      getFullPath("workspace1/pack1/query1.ql"),
+      getFullPath("workspace1/pack2/query1.ql"),
+    ];
+
+    await expect(
+      findVariantAnalysisQlPackRoot(queryFiles, workspaceFolders),
+    ).rejects.toThrow("Some queries are in different packs");
+  });
+
+  it("should throw an error if query files are not in a pack and in different workspace folders", async () => {
+    const queryFiles = [
+      getFullPath("workspace1/query1.ql"),
+      getFullPath("workspace2/query1.ql"),
+    ];
+
+    await expect(
+      findVariantAnalysisQlPackRoot(queryFiles, workspaceFolders),
+    ).rejects.toThrow(
+      "Queries that are not part of a pack need to be in the same workspace folder",
+    );
+  });
+
+  it("should throw an error if query files are not part of any workspace folder", async () => {
+    const queryFiles = [
+      getFullPath("workspace3/query1.ql"),
+      getFullPath("workspace3/query2.ql"),
+    ];
+
+    await expect(
+      findVariantAnalysisQlPackRoot(queryFiles, workspaceFolders),
+    ).rejects.toThrow(
+      "Queries that are not part of a pack need to be part of the workspace",
+    );
+  });
+
+  it("should return the common parent directory if no queries are in a pack", async () => {
+    const queryFiles = [
+      getFullPath("workspace1/query1.ql"),
+      getFullPath("workspace1/dir1/query1.ql"),
+    ];
+
+    const result = await findVariantAnalysisQlPackRoot(
+      queryFiles,
+      workspaceFolders,
+    );
+
+    expect(result).toEqualPath(getFullPath("workspace1"));
+  });
+
+  it("should return the pack root if all query files are in the same pack", async () => {
+    const queryFiles = [
+      getFullPath("workspace1/pack1/query1.ql"),
+      getFullPath("workspace1/pack1/query2.ql"),
+    ];
+
+    const result = await findVariantAnalysisQlPackRoot(
+      queryFiles,
+      workspaceFolders,
+    );
+
+    expect(result).toEqualPath(getFullPath("workspace1/pack1"));
+  });
+});

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/packaging/packaging.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/packaging/packaging.test.ts
@@ -127,6 +127,9 @@ describe("Packaging commands", () => {
         expect.objectContaining({
           label: "semmle/targets-extension",
         }),
+        expect.objectContaining({
+          label: "test-queries",
+        }),
       ],
       expect.anything(),
     );


### PR DESCRIPTION
Add some logic to handle calculating QL pack roots for MRVA better.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
