### PR TITLE
Don't accidentally mix DTO and non-DTO types in query-history-store.test.ts

### DIFF
--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/store/query-history-store.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/store/query-history-store.test.ts
@@ -19,15 +19,6 @@ import { createMockVariantAnalysisHistoryItem } from "../../../../factories/quer
 import { nanoid } from "nanoid";
 
 describe("write and read", () => {
-  let infoSuccessRaw: LocalQueryInfo;
-  let infoSuccessInterpreted: LocalQueryInfo;
-  let infoEarlyFailure: LocalQueryInfo;
-  let infoLateFailure: LocalQueryInfo;
-  let infoInProgress: LocalQueryInfo;
-
-  let variantAnalysis1: VariantAnalysisHistoryItem;
-  let variantAnalysis2: VariantAnalysisHistoryItem;
-
   let allHistory: QueryHistoryInfo[];
   let expectedHistory: QueryHistoryInfo[];
   let queryPath: string;
@@ -36,23 +27,23 @@ describe("write and read", () => {
   beforeEach(() => {
     queryPath = join(Uri.file(tmpDir.name).fsPath, `query-${cnt++}`);
 
-    infoSuccessRaw = createMockFullQueryInfo(
+    const infoSuccessRaw = createMockFullQueryInfo(
       "a",
       createMockQueryWithResults(`${queryPath}-a`, false, "/a/b/c/a"),
     );
-    infoSuccessInterpreted = createMockFullQueryInfo(
+    const infoSuccessInterpreted = createMockFullQueryInfo(
       "b",
       createMockQueryWithResults(`${queryPath}-b`, true, "/a/b/c/b"),
     );
-    infoEarlyFailure = createMockFullQueryInfo("c", undefined, true);
-    infoLateFailure = createMockFullQueryInfo(
+    const infoEarlyFailure = createMockFullQueryInfo("c", undefined, true);
+    const infoLateFailure = createMockFullQueryInfo(
       "d",
       createMockQueryWithResults(`${queryPath}-c`, false, "/a/b/c/d"),
     );
-    infoInProgress = createMockFullQueryInfo("e");
+    const infoInProgress = createMockFullQueryInfo("e");
 
-    variantAnalysis1 = createMockVariantAnalysisHistoryItem({});
-    variantAnalysis2 = createMockVariantAnalysisHistoryItem({});
+    const variantAnalysis1 = createMockVariantAnalysisHistoryItem({});
+    const variantAnalysis2 = createMockVariantAnalysisHistoryItem({});
 
     allHistory = [
       infoSuccessRaw,


### PR DESCRIPTION
I hit some errors in https://github.com/github/vscode-codeql/actions/runs/7695850568/job/20969605471?pr=3287 and this made me realise that `query-history-store.test.ts` is being a bit naughty when writing test data. We're writing the query history file but the data being written is the internal query history types instead of the query history DTO types.

This PR introduces a `writeRawQueryHistory` method which accepts the correct `QueryHistoryDto` type and writes it to disk. Hopefully this will help avoid people making the same mistake in the future by discouraging direct use of `writeFileSync` and writing incorrect JSON.

When I merge this branch into the `robertbrignull/move_language_pack` branch then the `no-workspace` tests pass locally (where they don't before) so that convinces me this change is correct.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
