### PR TITLE
Add types for complex access path suggestions

### DIFF
--- a/extensions/ql-vscode/src/model-editor/suggestions.ts
+++ b/extensions/ql-vscode/src/model-editor/suggestions.ts
@@ -1,0 +1,52 @@
+import type { MethodSignature } from "./method";
+
+export enum AccessPathSuggestionDefinitionType {
+  Array = "array",
+  Class = "class",
+  Enum = "enum",
+  EnumMember = "enum-member",
+  Field = "field",
+  Interface = "interface",
+  Key = "key",
+  Method = "method",
+  Misc = "misc",
+  Namespace = "namespace",
+  Parameter = "parameter",
+  Property = "property",
+  Structure = "structure",
+  Return = "return",
+  Variable = "variable",
+}
+
+export type AccessPathSuggestionRow = {
+  method: MethodSignature;
+  definitionType: AccessPathSuggestionDefinitionType;
+  value: string;
+  details: string;
+};
+
+export type AccessPathSuggestionRows = {
+  input: AccessPathSuggestionRow[];
+  output: AccessPathSuggestionRow[];
+};
+
+export type AccessPathOption = {
+  label: string;
+  value: string;
+  icon: string;
+  details?: string;
+  followup?: AccessPathOption[];
+};
+
+export type AccessPathSuggestionOptions = {
+  input: Record<string, AccessPathOption[]>;
+  output: Record<string, AccessPathOption[]>;
+};
+
+export function isDefinitionType(
+  value: string,
+): value is AccessPathSuggestionDefinitionType {
+  return Object.values(AccessPathSuggestionDefinitionType).includes(
+    value as AccessPathSuggestionDefinitionType,
+  );
+}


### PR DESCRIPTION
Adds a bunch of types that we'll need for showing complex access path suggestions in the model editor. See internal linked issue for more context. 

Note: these currently aren't used (and will probably break the `deadcode` CI check 🙃) 

## Checklist

N/A
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
