### PR TITLE
Don't compare internal and dto types in variant-analysis-history.test.ts

### DIFF
--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/data/variant-analysis/workspace-query-history.json
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/data/variant-analysis/workspace-query-history.json
@@ -33,7 +33,7 @@
       "status": "Completed",
       "completed": true,
       "variantAnalysis": {
-        "id": 98574321397,
+        "id": 58993265664,
         "controllerRepo": {
           "id": 128321,
           "fullName": "github/codeql",


### PR DESCRIPTION
In `variant-analysis-history.test.ts` we are reading the raw query history DTO types from a file and then trying to compare them to the internal types from the query history manager. On `main` this happens to work because the types are the same, but the whole point of having these two types is that they don't have to be the same.

The "workspace-query-history.json" file is where the query history manager also loads its data from. However in the tests we never actually want it as this raw data and instead just want to make sure it's done the loading correctly.

Similar to https://github.com/github/vscode-codeql/pull/3290, I found this because of a test failure on https://github.com/github/vscode-codeql/actions/runs/7699342606/job/20983096500?pr=3287 where the internal types are changing but the DTO types are not.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
