### PR TITLE
Functions for running "access path suggestions" queries

### DIFF
--- a/extensions/ql-vscode/src/model-editor/suggestion-queries.ts
+++ b/extensions/ql-vscode/src/model-editor/suggestion-queries.ts
@@ -1,0 +1,180 @@
+import type { CodeQLCliServer } from "../codeql-cli/cli";
+import type { Mode } from "./shared/mode";
+import { resolveQueriesFromPacks } from "../local-queries";
+import { modeTag } from "./mode-tag";
+import { getOnDiskWorkspaceFolders } from "../common/vscode/workspace-folders";
+import type { NotificationLogger } from "../common/logging";
+import { showAndLogExceptionWithTelemetry } from "../common/logging";
+import { telemetryListener } from "../common/vscode/telemetry";
+import { redactableError } from "../common/errors";
+import { runQuery } from "../local-queries/run-query";
+import type { QueryRunner } from "../query-server";
+import type { DatabaseItem } from "../databases/local-databases";
+import type { ProgressCallback } from "../common/vscode/progress";
+import type { CancellationToken } from "vscode";
+import type { DecodedBqrsChunk } from "../common/bqrs-cli-types";
+import type {
+  AccessPathSuggestionRow,
+  AccessPathSuggestionRows,
+} from "./suggestions";
+
+type RunQueryOptions = {
+  parseResults: (
+    results: DecodedBqrsChunk,
+  ) => AccessPathSuggestionRow[] | Promise<AccessPathSuggestionRow[]>;
+
+  cliServer: CodeQLCliServer;
+  queryRunner: QueryRunner;
+  logger: NotificationLogger;
+  databaseItem: DatabaseItem;
+  queryStorageDir: string;
+
+  progress: ProgressCallback;
+  token: CancellationToken;
+};
+
+const maxStep = 2000;
+
+export async function runSuggestionsQuery(
+  mode: Mode,
+  {
+    parseResults,
+    cliServer,
+    queryRunner,
+    logger,
+    databaseItem,
+    queryStorageDir,
+    progress,
+    token,
+  }: RunQueryOptions,
+): Promise<AccessPathSuggestionRows | undefined> {
+  progress({
+    message: "Resolving QL packs",
+    step: 1,
+    maxStep,
+  });
+  const additionalPacks = getOnDiskWorkspaceFolders();
+  const extensionPacks = Object.keys(
+    await cliServer.resolveQlpacks(additionalPacks, true),
+  );
+
+  progress({
+    message: "Resolving query",
+    step: 2,
+    maxStep,
+  });
+
+  const queryPath = await resolveSuggestionsQuery(
+    cliServer,
+    databaseItem.language,
+    mode,
+  );
+  if (!queryPath) {
+    void showAndLogExceptionWithTelemetry(
+      logger,
+      telemetryListener,
+      redactableError`The ${mode} access path suggestions query could not be found. Try re-opening the model editor. If that doesn't work, try upgrading the CodeQL libraries.`,
+    );
+    return undefined;
+  }
+
+  // Run the actual query
+  const completedQuery = await runQuery({
+    queryRunner,
+    databaseItem,
+    queryPath,
+    queryStorageDir,
+    additionalPacks,
+    extensionPacks,
+    progress: (update) =>
+      progress({
+        step: update.step + 500,
+        maxStep,
+        message: update.message,
+      }),
+    token,
+  });
+
+  if (!completedQuery) {
+    return undefined;
+  }
+
+  // Read the results and convert to internal representation
+  progress({
+    message: "Decoding results",
+    step: 1600,
+    maxStep,
+  });
+
+  const bqrs = await cliServer.bqrsDecodeAll(completedQuery.outputDir.bqrsPath);
+
+  progress({
+    message: "Finalizing results",
+    step: 1950,
+    maxStep,
+  });
+
+  const inputChunk = bqrs["input"];
+  const outputChunk = bqrs["output"];
+
+  if (!inputChunk && !outputChunk) {
+    void logger.log(
+      `No results found for ${mode} access path suggestions query`,
+    );
+    return undefined;
+  }
+
+  const inputSuggestions = inputChunk ? await parseResults(inputChunk) : [];
+  const outputSuggestions = outputChunk ? await parseResults(outputChunk) : [];
+
+  return {
+    input: inputSuggestions,
+    output: outputSuggestions,
+  };
+}
+
+/**
+ * Resolve the query path to the model editor access path suggestions query. All queries are tagged like this:
+ * modeleditor access-path-suggestions <mode>
+ * Example: modeleditor access-path-suggestions framework-mode
+ *
+ * @param cliServer The CodeQL CLI server to use.
+ * @param language The language of the query pack to use.
+ * @param mode The mode to resolve the query for.
+ * @param additionalPackNames Additional pack names to search.
+ * @param additionalPackPaths Additional pack paths to search.
+ */
+async function resolveSuggestionsQuery(
+  cliServer: CodeQLCliServer,
+  language: string,
+  mode: Mode,
+  additionalPackNames: string[] = [],
+  additionalPackPaths: string[] = [],
+): Promise<string | undefined> {
+  const packsToSearch = [`codeql/${language}-queries`, ...additionalPackNames];
+
+  const queries = await resolveQueriesFromPacks(
+    cliServer,
+    packsToSearch,
+    {
+      kind: "table",
+      "tags contain all": [
+        "modeleditor",
+        "access-path-suggestions",
+        modeTag(mode),
+      ],
+    },
+    additionalPackPaths,
+  );
+  if (queries.length > 1) {
+    throw new Error(
+      `Found multiple suggestions queries for ${mode}. Can't continue`,
+    );
+  }
+
+  if (queries.length === 0) {
+    return undefined;
+  }
+
+  return queries[0];
+}

--- a/extensions/ql-vscode/src/model-editor/suggestions.ts
+++ b/extensions/ql-vscode/src/model-editor/suggestions.ts
@@ -25,6 +25,11 @@ export type AccessPathSuggestionRow = {
   details: string;
 };
 
+export type AccessPathSuggestionRows = {
+  input: AccessPathSuggestionRow[];
+  output: AccessPathSuggestionRow[];
+};
+
 export type AccessPathOption = {
   label: string;
   value: string;

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/suggestion-queries.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/suggestion-queries.test.ts
@@ -1,0 +1,88 @@
+import { createMockLogger } from "../../../__mocks__/loggerMock";
+import type { DatabaseItem } from "../../../../src/databases/local-databases";
+import { DatabaseKind } from "../../../../src/databases/local-databases";
+import { file } from "tmp-promise";
+import { QueryResultType } from "../../../../src/query-server/messages";
+import { QueryLanguage } from "../../../../src/common/query-language";
+import { mockedObject, mockedUri } from "../../utils/mocking.helpers";
+import { Mode } from "../../../../src/model-editor/shared/mode";
+import { join } from "path";
+import type { CodeQLCliServer } from "../../../../src/codeql-cli/cli";
+import type { QueryRunner } from "../../../../src/query-server";
+import { QueryOutputDir } from "../../../../src/local-queries/query-output-dir";
+import { runSuggestionsQuery } from "../../../../src/model-editor/suggestion-queries";
+
+describe("runSuggestionsQuery", () => {
+  it("should run query", async () => {
+    const language = QueryLanguage.Ruby;
+    const outputDir = new QueryOutputDir(join((await file()).path, "1"));
+
+    const options = {
+      parseResults: jest.fn().mockResolvedValue([]),
+      cliServer: mockedObject<CodeQLCliServer>({
+        resolveQlpacks: jest.fn().mockResolvedValue({
+          "my/extensions": "/a/b/c/",
+        }),
+        resolveQueriesInSuite: jest
+          .fn()
+          .mockResolvedValue(["/a/b/c/FrameworkModeAccessPathSuggestions.ql"]),
+        packPacklist: jest
+          .fn()
+          .mockResolvedValue([
+            "/a/b/c/qlpack.yml",
+            "/a/b/c/qlpack.lock.yml",
+            "/a/b/c/qlpack2.yml",
+          ]),
+        bqrsDecodeAll: jest.fn().mockResolvedValue([]),
+      }),
+      queryRunner: mockedObject<QueryRunner>({
+        createQueryRun: jest.fn().mockReturnValue({
+          evaluate: jest.fn().mockResolvedValue({
+            resultType: QueryResultType.SUCCESS,
+            outputDir,
+          }),
+          outputDir,
+        }),
+        logger: createMockLogger(),
+      }),
+      logger: createMockLogger(),
+      databaseItem: mockedObject<DatabaseItem>({
+        databaseUri: mockedUri("/a/b/c/src.zip"),
+        contents: {
+          kind: DatabaseKind.Database,
+          name: "foo",
+          datasetUri: mockedUri(),
+        },
+        language,
+      }),
+      queryStorageDir: "/tmp/queries",
+      progress: jest.fn(),
+      token: {
+        isCancellationRequested: false,
+        onCancellationRequested: jest.fn(),
+      },
+    };
+
+    const result = await runSuggestionsQuery(Mode.Framework, options);
+
+    expect(result).not.toBeUndefined;
+
+    expect(options.cliServer.resolveQlpacks).toHaveBeenCalledTimes(1);
+    expect(options.cliServer.resolveQlpacks).toHaveBeenCalledWith([], true);
+    expect(options.queryRunner.createQueryRun).toHaveBeenCalledWith(
+      "/a/b/c/src.zip",
+      {
+        queryPath: expect.stringMatching(/\S*AccessPathSuggestions\.ql/),
+        quickEvalPosition: undefined,
+        quickEvalCountOnly: false,
+      },
+      false,
+      [],
+      ["my/extensions"],
+      {},
+      "/tmp/queries",
+      undefined,
+      undefined,
+    );
+  });
+});


### PR DESCRIPTION
This PR adds functions for running "suggestion queries" (i.e. CodeQL queries that populate the autocomplete suggestions in the model editor). These queries currently live on a [branch](https://github.com/github/codeql/compare/koesie10/access-path-suggestions) from @koesie10's hackathon branch, so it's possible that the exact names and tags will change in future.

See internal issue for more details and context! ✨ 


## Checklist

N/A - only used in tests for now

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
