### PR TITLE
Add `accessPathSuggestions` to "models as data" model

### DIFF
--- a/extensions/ql-vscode/src/model-editor/languages/models-as-data.ts
+++ b/extensions/ql-vscode/src/model-editor/languages/models-as-data.ts
@@ -10,8 +10,12 @@ import type {
 import type { DataTuple } from "../model-extension-file";
 import type { Mode } from "../shared/mode";
 import type { QueryConstraints } from "../../local-queries/query-constraints";
-import type { DecodedBqrs } from "../../common/bqrs-cli-types";
+import type {
+  DecodedBqrs,
+  DecodedBqrsChunk,
+} from "../../common/bqrs-cli-types";
 import type { BaseLogger } from "../../common/logging";
+import type { AccessPathSuggestionRow } from "../suggestions";
 
 type GenerateMethodDefinition<T> = (method: T) => DataTuple[];
 type ReadModeledMethod = (row: DataTuple[]) => ModeledMethod;
@@ -39,6 +43,18 @@ type ModelsAsDataLanguageModelGeneration = {
   ) => ModeledMethod[];
 };
 
+type ModelsAsDataLanguageAccessPathSuggestions = {
+  parseResults: (
+    // The results of a single predicate of the query.
+    bqrs: DecodedBqrsChunk,
+    // The language-specific predicate that was used to generate the results. This is passed to allow
+    // sharing of code between different languages.
+    modelsAsDataLanguage: ModelsAsDataLanguage,
+    // The logger to use for logging.
+    logger: BaseLogger,
+  ) => AccessPathSuggestionRow[];
+};
+
 export type ModelsAsDataLanguagePredicates = {
   source?: ModelsAsDataLanguagePredicate<SourceModeledMethod>;
   sink?: ModelsAsDataLanguagePredicate<SinkModeledMethod>;
@@ -61,6 +77,7 @@ export type ModelsAsDataLanguage = {
   createMethodSignature: (method: MethodDefinition) => string;
   predicates: ModelsAsDataLanguagePredicates;
   modelGeneration?: ModelsAsDataLanguageModelGeneration;
+  accessPathSuggestions?: ModelsAsDataLanguageAccessPathSuggestions;
   /**
    * Returns the list of valid arguments that can be selected for the given method.
    * @param method The method to get the valid arguments for.


### PR DESCRIPTION
Store the access path suggestions in the MaD model, so that we can pass those suggestions on to the webview. (I'll hook up the webview side in a later PR.)

See internal issue for more info + the bigger picture 🖼️ 

## Checklist

N/A - no user-facing changes

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
