### PR TITLE
Add more information for consistency check errors

### DIFF
--- a/extensions/ql-vscode/test/unit-tests/model-editor/consistency-check.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/model-editor/consistency-check.test.ts
@@ -14,17 +14,20 @@ describe("checkConsistency", () => {
   });
 
   it("should call missingMethod when method is missing", () => {
+    const modeledMethods = [createSourceModeledMethod()];
+
     checkConsistency(
       [],
       {
         "Microsoft.CodeAnalysis.CSharp.SyntaxFactory.SeparatedList`1(System.Collections.Generic.IEnumerable<TNode>)":
-          [createSourceModeledMethod()],
+          modeledMethods,
       },
       notifier,
     );
 
     expect(notifier.missingMethod).toHaveBeenCalledWith(
       "Microsoft.CodeAnalysis.CSharp.SyntaxFactory.SeparatedList`1(System.Collections.Generic.IEnumerable<TNode>)",
+      modeledMethods,
     );
     expect(notifier.inconsistentSupported).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
It's useful to know which models are present for a certain method to compare the CodeQL queries against. This changes the messages to be like:

```
Model editor query consistency check: Missing method Liquid::Render!#new for method that is modeled as summary
```

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
