### PR TITLE
Wait for options to be shown and to be removed when pressing Tab

### DIFF
--- a/extensions/ql-vscode/src/view/common/SuggestBox/__tests__/SuggestBox.test.tsx
+++ b/extensions/ql-vscode/src/view/common/SuggestBox/__tests__/SuggestBox.test.tsx
@@ -1,4 +1,4 @@
-import { render as reactRender, screen } from "@testing-library/react";
+import { render as reactRender, screen, waitFor } from "@testing-library/react";
 import type { SuggestBoxProps } from "../SuggestBox";
 import { SuggestBox } from "../SuggestBox";
 import { userEvent } from "@testing-library/user-event";
@@ -219,7 +219,9 @@ describe("SuggestBox", () => {
 
     await userEvent.keyboard("{Tab}");
 
-    expect(screen.queryByRole("option")).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByRole("option")).not.toBeInTheDocument();
+    });
   });
 
   it("shows no suggestions with no matching followup options", async () => {

--- a/extensions/ql-vscode/src/view/common/SuggestBox/__tests__/SuggestBox.test.tsx
+++ b/extensions/ql-vscode/src/view/common/SuggestBox/__tests__/SuggestBox.test.tsx
@@ -200,6 +200,9 @@ describe("SuggestBox", () => {
     });
 
     await userEvent.click(screen.getByRole("combobox"));
+
+    expect(screen.getAllByRole("option")).not.toHaveLength(0);
+
     await userEvent.keyboard("{Enter}");
 
     expect(screen.queryByRole("option")).not.toBeInTheDocument();
@@ -211,6 +214,9 @@ describe("SuggestBox", () => {
     });
 
     await userEvent.click(screen.getByRole("combobox"));
+
+    expect(screen.getAllByRole("option")).not.toHaveLength(0);
+
     await userEvent.keyboard("{Tab}");
 
     expect(screen.queryByRole("option")).not.toBeInTheDocument();


### PR DESCRIPTION
This might fix the flaky test by adding some (conditional) waits for elements to appear and disappear.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
