### PR TITLE
Fix Ruby method parsing for methods containing brackets

### DIFF
--- a/extensions/ql-vscode/src/model-editor/languages/ruby/access-paths.ts
+++ b/extensions/ql-vscode/src/model-editor/languages/ruby/access-paths.ts
@@ -1,5 +1,15 @@
+import { parseAccessPathTokens } from "../../shared/access-paths";
+
+const methodTokenRegex = /^Method\[(.+)]$/;
+
 export function parseRubyMethodFromPath(path: string): string {
-  const match = path.match(/Method\[([^\]]+)].*/);
+  const tokens = parseAccessPathTokens(path);
+
+  if (tokens.length === 0) {
+    return "";
+  }
+
+  const match = tokens[0].text.match(methodTokenRegex);
   if (match) {
     return match[1];
   } else {
@@ -11,9 +21,22 @@ export function parseRubyAccessPath(path: string): {
   methodName: string;
   path: string;
 } {
-  const match = path.match(/Method\[([^\]]+)]\.(.*)/);
+  const tokens = parseAccessPathTokens(path);
+
+  if (tokens.length === 0) {
+    return { methodName: "", path: "" };
+  }
+
+  const match = tokens[0].text.match(methodTokenRegex);
+
   if (match) {
-    return { methodName: match[1], path: match[2] };
+    return {
+      methodName: match[1],
+      path: tokens
+        .slice(1)
+        .map((token) => token.text)
+        .join("."),
+    };
   } else {
     return { methodName: "", path: "" };
   }


### PR DESCRIPTION
This fixes parsing of access paths for Ruby methods that contain square brackets, such as `Liquid::Context#[]`. The previous implementation would incorrectly stop capturing at the `]` character, resulting in a method name of `[` for an access path of `Method[[]].ReturnValue`. This fixes it by switching to the shared access path parsing code, which correctly handles square brackets.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
