### PR TITLE
Add access path suggestions to MaD model for Ruby

### DIFF
--- a/extensions/ql-vscode/src/model-editor/languages/ruby/index.ts
+++ b/extensions/ql-vscode/src/model-editor/languages/ruby/index.ts
@@ -11,6 +11,7 @@ import {
   rubyMethodSignature,
   rubyPath,
 } from "./access-paths";
+import { parseAccessPathSuggestionsResults } from "./suggestions";
 
 export const ruby: ModelsAsDataLanguage = {
   availableModes: [Mode.Framework],
@@ -167,6 +168,9 @@ export const ruby: ModelsAsDataLanguage = {
       "query path": "queries/modeling/GenerateModel.ql",
     },
     parseResults: parseGenerateModelResults,
+  },
+  accessPathSuggestions: {
+    parseResults: parseAccessPathSuggestionsResults,
   },
   getArgumentOptions: (method) => {
     const argumentsList = getArgumentsList(method.methodParameters).map(

--- a/extensions/ql-vscode/src/model-editor/languages/ruby/suggestions.ts
+++ b/extensions/ql-vscode/src/model-editor/languages/ruby/suggestions.ts
@@ -1,0 +1,56 @@
+import type { BaseLogger } from "../../../common/logging";
+import type { DecodedBqrsChunk } from "../../../common/bqrs-cli-types";
+import type { ModelsAsDataLanguage } from "../models-as-data";
+import type { AccessPathSuggestionRow } from "../../suggestions";
+import { isDefinitionType } from "../../suggestions";
+import { parseRubyMethodFromPath, rubyMethodSignature } from "./access-paths";
+
+export function parseAccessPathSuggestionsResults(
+  bqrs: DecodedBqrsChunk,
+  _modelsAsDataLanguage: ModelsAsDataLanguage,
+  logger: BaseLogger,
+): AccessPathSuggestionRow[] {
+  return bqrs.tuples
+    .map((tuple, index): AccessPathSuggestionRow | null => {
+      const row = tuple.filter(
+        (value): value is string => typeof value === "string",
+      );
+
+      if (row.length !== 5) {
+        void logger.log(
+          `Skipping result ${index} because it has the wrong length`,
+        );
+        return null;
+      }
+
+      const type = row[0];
+      const methodName = parseRubyMethodFromPath(row[1]);
+      const value = row[2];
+      const details = row[3];
+      const definitionType = row[4];
+
+      if (!isDefinitionType(definitionType)) {
+        void logger.log(
+          `Skipping result ${index} because it has an invalid definition type`,
+        );
+        return null;
+      }
+
+      return {
+        method: {
+          packageName: "",
+          typeName: type,
+          methodName,
+          methodParameters: "",
+          signature: rubyMethodSignature(type, methodName),
+        },
+        value,
+        details,
+        definitionType,
+      };
+    })
+    .filter(
+      (suggestion): suggestion is AccessPathSuggestionRow =>
+        suggestion !== null,
+    );
+}

--- a/extensions/ql-vscode/src/model-editor/suggestions.ts
+++ b/extensions/ql-vscode/src/model-editor/suggestions.ts
@@ -37,3 +37,11 @@ export type AccessPathOption = {
   details?: string;
   followup?: AccessPathOption[];
 };
+
+export function isDefinitionType(
+  value: string,
+): value is AccessPathSuggestionDefinitionType {
+  return Object.values(AccessPathSuggestionDefinitionType).includes(
+    value as AccessPathSuggestionDefinitionType,
+  );
+}

--- a/extensions/ql-vscode/test/unit-tests/model-editor/languages/ruby/suggestions.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/model-editor/languages/ruby/suggestions.test.ts
@@ -1,0 +1,63 @@
+import type { DecodedBqrsChunk } from "../../../../../src/common/bqrs-cli-types";
+import { ruby } from "../../../../../src/model-editor/languages/ruby";
+import { createMockLogger } from "../../../../__mocks__/loggerMock";
+import { parseAccessPathSuggestionsResults } from "../../../../../src/model-editor/languages/ruby/suggestions";
+
+describe("parseAccessPathSuggestionsResults", () => {
+  it("should parse the results", async () => {
+    const bqrsChunk: DecodedBqrsChunk = {
+      columns: [
+        {
+          name: "type",
+          kind: "String",
+        },
+        {
+          name: "path",
+          kind: "String",
+        },
+        {
+          name: "value",
+          kind: "String",
+        },
+        {
+          name: "details",
+          kind: "String",
+        },
+        {
+          name: "defType",
+          kind: "String",
+        },
+      ],
+      tuples: [
+        [
+          "Correctness",
+          "Method[assert!]",
+          "Argument[self]",
+          "self in assert!",
+          "parameter",
+        ],
+      ],
+    };
+
+    const result = parseAccessPathSuggestionsResults(
+      bqrsChunk,
+      ruby,
+      createMockLogger(),
+    );
+
+    expect(result).toEqual([
+      {
+        method: {
+          packageName: "",
+          typeName: "Correctness",
+          methodName: "assert!",
+          methodParameters: "",
+          signature: "Correctness#assert!",
+        },
+        value: "Argument[self]",
+        details: "self in assert!",
+        definitionType: "parameter",
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
Following on from https://github.com/github/vscode-codeql/pull/3295, this PR adds `accessPathSuggestions` to the Ruby MaD language model, so that we can display autocomplete suggestions for Ruby in the model editor. (I'll hook up the model editor webview in a later PR 🪝 )

See internal linked issue for more context! 🔗 

## Checklist

N/A—still feature-flagged for internal use

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
