### PR TITLE
Send access path suggestions to the model editor view

### DIFF
--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -24,6 +24,7 @@ import type {
   Row,
   UrlValueResolvable,
 } from "./raw-result-types";
+import type { AccessPathSuggestionOptions } from "../model-editor/suggestions";
 
 /**
  * This module contains types and code that are shared between
@@ -614,13 +615,19 @@ interface RevealMethodMessage {
   methodSignature: string;
 }
 
+interface SetAccessPathSuggestionsMessage {
+  t: "setAccessPathSuggestions";
+  accessPathSuggestions: AccessPathSuggestionOptions;
+}
+
 export type ToModelEditorMessage =
   | SetExtensionPackStateMessage
   | SetMethodsMessage
   | SetModeledMethodsMessage
   | SetModifiedMethodsMessage
   | SetInProgressMethodsMessage
-  | RevealMethodMessage;
+  | RevealMethodMessage
+  | SetAccessPathSuggestionsMessage;
 
 export type FromModelEditorMessage =
   | CommonFromViewMessages

--- a/extensions/ql-vscode/src/model-editor/suggestions.ts
+++ b/extensions/ql-vscode/src/model-editor/suggestions.ts
@@ -38,6 +38,11 @@ export type AccessPathOption = {
   followup?: AccessPathOption[];
 };
 
+export type AccessPathSuggestionOptions = {
+  input: Record<string, AccessPathOption[]>;
+  output: Record<string, AccessPathOption[]>;
+};
+
 export function isDefinitionType(
   value: string,
 ): value is AccessPathSuggestionDefinitionType {

--- a/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
@@ -145,7 +145,9 @@ export function ModelEditor({
           }
           case "revealMethod":
             setRevealedMethodSignature(msg.methodSignature);
-
+            break;
+          case "setAccessPathSuggestions":
+            // TODO
             break;
           default:
             assertNever(msg);


### PR DESCRIPTION
If you have the relevant feature flag enabled, the model editor will now generate and load access path suggestions on start-up. 

I haven't yet added logic to the webview to actually _use_ those suggestions, but they will eventually be used to display autocomplete suggestions! 

See internal linked issue for more info 🔍 

## Checklist

N/A 

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
