### PR TITLE
Don't select a model editor row when you click the suggest box

### DIFF
--- a/extensions/ql-vscode/src/view/common/SuggestBox/SuggestBox.tsx
+++ b/extensions/ql-vscode/src/view/common/SuggestBox/SuggestBox.tsx
@@ -106,6 +106,10 @@ export type SuggestBoxProps<
   ) => ReactNode;
 };
 
+const stopClickPropagation = (e: React.MouseEvent) => {
+  e.stopPropagation();
+};
+
 export const SuggestBox = <
   T extends Option<T>,
   D extends Diagnostic = Diagnostic,
@@ -196,7 +200,16 @@ export const SuggestBox = <
   }, [disabled]);
 
   return (
-    <>
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={stopClickPropagation}
+      onKeyDown={(event) => {
+        if (event.key === "Enter") {
+          event.stopPropagation();
+        }
+      }}
+    >
       {renderInputComponent(
         getReferenceProps({
           ref: refs.setReference,
@@ -270,6 +283,6 @@ export const SuggestBox = <
           )}
         </FloatingPortal>
       )}
-    </>
+    </div>
   );
 };

--- a/extensions/ql-vscode/src/view/common/SuggestBox/SuggestBox.tsx
+++ b/extensions/ql-vscode/src/view/common/SuggestBox/SuggestBox.tsx
@@ -200,16 +200,9 @@ export const SuggestBox = <
   }, [disabled]);
 
   return (
-    <div
-      role="button"
-      tabIndex={0}
-      onClick={stopClickPropagation}
-      onKeyDown={(event) => {
-        if (event.key === "Enter") {
-          event.stopPropagation();
-        }
-      }}
-    >
+    // Disabled because the div is used to stop click propagation, it's not a button
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+    <div onClick={stopClickPropagation}>
       {renderInputComponent(
         getReferenceProps({
           ref: refs.setReference,


### PR DESCRIPTION
When a user clicks inside a suggest box in the model editor, we don't want that to count as (de)selecting a model editor row. I've tried to do something similar to the `stopPropagation` from [here](https://github.com/github/vscode-codeql/pull/3156/commits/c8d31278a383edc63cedec4115243197668370c6), but I got various accessibility warnings so I'm not convinced this is correct... 😬

Specifically, I just wanted to add `<div onClick={stopClickPropagation}>` but that triggered these warnings: 🤔 
> Visible, non-interactive elements with click handlers must have at least one keyboard listener.eslint [jsx-a11y/click-events-have-key-events](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/click-events-have-key-events.md)
> Avoid non-native interactive elements. If using native HTML is not possible, add an appropriate role and support for tabbing, mouse, keyboard, and touch inputs to an interactive content element.eslint [jsx-a11y/no-static-element-interactions](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/no-static-element-interactions.md)

~❓ Anyone aware of a better approach here? Maybe trying to add the `onClick` handler to 
 `ModelInputSuggestBox` and `ModelOutputSuggestBox` instead of the generic SuggestBox component?~

EDIT: Koen suggested just disabling the warnings in this case, since we're not planning for this to be a clickable component with user interactions, literally just a way to stop the click propagation. Updated in latest commit.


## Checklist

N/A—nothing user-facing yet

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
