### PR TITLE
Make query constraints for access paths query configurable

### DIFF
--- a/extensions/ql-vscode/src/model-editor/languages/models-as-data.ts
+++ b/extensions/ql-vscode/src/model-editor/languages/models-as-data.ts
@@ -44,6 +44,7 @@ type ModelsAsDataLanguageModelGeneration = {
 };
 
 type ModelsAsDataLanguageAccessPathSuggestions = {
+  queryConstraints: (mode: Mode) => QueryConstraints;
   parseResults: (
     // The results of a single predicate of the query.
     bqrs: DecodedBqrsChunk,

--- a/extensions/ql-vscode/src/model-editor/languages/ruby/index.ts
+++ b/extensions/ql-vscode/src/model-editor/languages/ruby/index.ts
@@ -12,6 +12,7 @@ import {
   rubyPath,
 } from "./access-paths";
 import { parseAccessPathSuggestionsResults } from "./suggestions";
+import { modeTag } from "../../mode-tag";
 
 export const ruby: ModelsAsDataLanguage = {
   availableModes: [Mode.Framework],
@@ -170,6 +171,10 @@ export const ruby: ModelsAsDataLanguage = {
     parseResults: parseGenerateModelResults,
   },
   accessPathSuggestions: {
+    queryConstraints: (mode) => ({
+      kind: "table",
+      "tags contain all": ["modeleditor", "access-paths", modeTag(mode)],
+    }),
     parseResults: parseAccessPathSuggestionsResults,
   },
   getArgumentOptions: (method) => {

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -529,6 +529,7 @@ export class ModelEditorView extends AbstractWebview<
             modelsAsDataLanguage,
             this.app.logger,
           ),
+        queryConstraints: accessPathSuggestions.queryConstraints(mode),
         cliServer: this.cliServer,
         queryRunner: this.queryRunner,
         queryStorageDir: this.queryStorageDir,

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/suggestion-queries.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/suggestion-queries.test.ts
@@ -1,3 +1,5 @@
+import { load } from "js-yaml";
+import { readFile } from "fs-extra";
 import { createMockLogger } from "../../../__mocks__/loggerMock";
 import type { DatabaseItem } from "../../../../src/databases/local-databases";
 import { DatabaseKind } from "../../../../src/databases/local-databases";
@@ -138,15 +140,21 @@ describe("runSuggestionsQuery", () => {
       .mockResolvedValueOnce(mockInputSuggestions)
       .mockResolvedValueOnce(mockOutputSuggestions);
 
+    const resolveQueriesInSuite = jest
+      .fn()
+      .mockResolvedValue(["/a/b/c/FrameworkModeAccessPathSuggestions.ql"]);
+
     const options = {
       parseResults,
+      queryConstraints: {
+        kind: "table",
+        "tags all": ["modeleditor", "access-paths", "ruby", "foo"],
+      },
       cliServer: mockedObject<CodeQLCliServer>({
         resolveQlpacks: jest.fn().mockResolvedValue({
           "my/extensions": "/a/b/c/",
         }),
-        resolveQueriesInSuite: jest
-          .fn()
-          .mockResolvedValue(["/a/b/c/FrameworkModeAccessPathSuggestions.ql"]),
+        resolveQueriesInSuite,
         packPacklist: jest
           .fn()
           .mockResolvedValue([
@@ -205,6 +213,20 @@ describe("runSuggestionsQuery", () => {
       undefined,
       undefined,
     );
+    expect(options.cliServer.resolveQueriesInSuite).toHaveBeenCalledTimes(1);
+
+    expect(
+      load(await readFile(resolveQueriesInSuite.mock.calls[0][0], "utf-8")),
+    ).toEqual([
+      {
+        from: "codeql/ruby-queries",
+        include: {
+          kind: "table",
+          "tags all": ["modeleditor", "access-paths", "ruby", "foo"],
+        },
+        queries: ".",
+      },
+    ]);
 
     expect(options.parseResults).toHaveBeenCalledTimes(2);
 


### PR DESCRIPTION
This makes the query constraints for the access paths query configurable since these can differ between the languages. It also updates the query constraint for the Ruby query from the `access-path-suggestions` tag to `access-paths`, since that is [how the query was merged into CodeQL `main`](https://github.com/github/codeql/pull/15503/files#diff-891818fe6372315cfd5d569d6ec1dc4cdbd9614fab0306a14f8d98afeb72e2fdR6).

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
