### PR TITLE
CodeQL model editor: Always show the "Generate" button for Ruby DBs

### DIFF
--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -395,7 +395,9 @@ export class ModelEditorView extends AbstractWebview<
     const modelsAsDataLanguage = getModelsAsDataLanguage(this.language);
 
     const showGenerateButton =
-      this.modelConfig.flowGeneration && !!modelsAsDataLanguage.modelGeneration;
+      (this.databaseItem.language === "ruby" ||
+        this.modelConfig.flowGeneration) &&
+      !!modelsAsDataLanguage.modelGeneration;
 
     const showLlmButton =
       this.databaseItem.language === "java" && this.modelConfig.llmGeneration;


### PR DESCRIPTION
Always show the "Generate" button in the Ruby model editor, even if the `flowGeneration` flag isn't set. This is because the "generation" functionality for Ruby is more important than in the static languages' case (for generating `Type` models).

See internal linked issue for more details! 🔍

## Checklist

N/A—this doesn't affect the Java/C# editor, and the Ruby one is still feature-flagged.

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
