### PR TITLE
Parse new access paths query BQRS output

### DIFF
--- a/extensions/ql-vscode/test/unit-tests/model-editor/languages/ruby/suggestions.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/model-editor/languages/ruby/suggestions.test.ts
@@ -20,8 +20,8 @@ describe("parseAccessPathSuggestionsResults", () => {
           kind: "String",
         },
         {
-          name: "details",
-          kind: "String",
+          name: "node",
+          kind: "Entity",
         },
         {
           name: "defType",
@@ -33,7 +33,9 @@ describe("parseAccessPathSuggestionsResults", () => {
           "Correctness",
           "Method[assert!]",
           "Argument[self]",
-          "self in assert!",
+          {
+            label: "self in assert!",
+          },
           "parameter",
         ],
       ],
@@ -59,5 +61,54 @@ describe("parseAccessPathSuggestionsResults", () => {
         definitionType: "parameter",
       },
     ]);
+  });
+
+  it("should not parse an incorrect result format", async () => {
+    const bqrsChunk: DecodedBqrsChunk = {
+      columns: [
+        {
+          name: "type",
+          kind: "String",
+        },
+        {
+          name: "path",
+          kind: "String",
+        },
+        {
+          name: "value",
+          kind: "String",
+        },
+        {
+          name: "details",
+          kind: "String",
+        },
+        {
+          name: "defType",
+          kind: "String",
+        },
+      ],
+      tuples: [
+        [
+          "Correctness",
+          "Method[assert!]",
+          "Argument[self]",
+          "self in assert!",
+          "parameter",
+        ],
+        ["Correctness", "Method[assert!]", "Argument[self]", "parameter"],
+      ],
+    };
+
+    const logger = createMockLogger();
+    expect(parseAccessPathSuggestionsResults(bqrsChunk, ruby, logger)).toEqual(
+      [],
+    );
+    expect(logger.log).toHaveBeenCalledTimes(2);
+    expect(logger.log).toHaveBeenCalledWith(
+      "Skipping result 0 because it has the wrong format",
+    );
+    expect(logger.log).toHaveBeenCalledWith(
+      "Skipping result 1 because it has the wrong format",
+    );
   });
 });

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/suggestion-queries.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/suggestion-queries.test.ts
@@ -29,8 +29,8 @@ describe("runSuggestionsQuery", () => {
           kind: "String",
         },
         {
-          name: "details",
-          kind: "String",
+          name: "node",
+          kind: "Entity",
         },
         {
           name: "defType",
@@ -42,7 +42,9 @@ describe("runSuggestionsQuery", () => {
           "Correctness",
           "Method[assert!]",
           "Argument[self]",
-          "self in assert!",
+          {
+            label: "self in assert!",
+          },
           "parameter",
         ],
       ],
@@ -62,8 +64,8 @@ describe("runSuggestionsQuery", () => {
           kind: "String",
         },
         {
-          name: "details",
-          kind: "String",
+          name: "node",
+          kind: "Entity",
         },
         {
           name: "defType",
@@ -75,14 +77,18 @@ describe("runSuggestionsQuery", () => {
           "Correctness",
           "Method[assert!]",
           "ReturnValue",
-          "call to puts",
+          {
+            label: "call to puts",
+          },
           "return",
         ],
         [
           "Correctness",
           "Method[assert!]",
           "Argument[self]",
-          "self in assert!",
+          {
+            label: "self in assert!",
+          },
           "parameter",
         ],
       ],


### PR DESCRIPTION
This parses the new access paths query BQRS output introduced in https://github.com/github/codeql/pull/15503. Somewhat dependent on https://github.com/github/vscode-codeql/pull/3318 for resolving the correct query.

The only difference in the output format is the fourth column (`details`), which was a string before, but has now been renamed to `node` and is an `Entity`. The same information is available in `node.label`, so that's the only change this makes (in addition to validating this new format).

To test this, you can use the `github/codeql` repository on `main` or update a submodule in another workspace to `main`.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
