### PR TITLE
Fix not being able to open command palette in suggest box

### DIFF
--- a/extensions/ql-vscode/src/view/common/SuggestBox/SuggestBox.tsx
+++ b/extensions/ql-vscode/src/view/common/SuggestBox/SuggestBox.tsx
@@ -243,6 +243,7 @@ export const SuggestBox = <
               context={context}
               initialFocus={-1}
               visuallyHiddenDismiss
+              returnFocus={false}
             >
               <ListContainer
                 {...getFloatingProps({

--- a/extensions/ql-vscode/src/view/common/SuggestBox/SuggestBox.tsx
+++ b/extensions/ql-vscode/src/view/common/SuggestBox/SuggestBox.tsx
@@ -243,6 +243,11 @@ export const SuggestBox = <
               context={context}
               initialFocus={-1}
               visuallyHiddenDismiss
+              // The default for returnFocus is true, but this doesn't work when opening
+              // the command palette in a VS Code webview. The focus is returned to the
+              // input element, but this closes the command palette immediately after opening
+              // it. By setting returnFocus to false, the focus is not immediately given to
+              // the input element, so the command palette stays open.
               returnFocus={false}
             >
               <ListContainer


### PR DESCRIPTION
This fixes not being able to open the command palette using Cmd/Ctrl+Shift+P when in a suggest box. Documentation about the `returnFocus` prop can be found here: [`returnFocus`](https://floating-ui.com/docs/floatingfocusmanager#returnfocus).

The problem seems to be that if you press Cmd/Ctrl+Shift+P, focus moves to the `body` element. Floating UI then tries to focus the suggest box again, which removes the focus from the command palette. By adding this prop and setting it to `false` (the default is `true`), Floating UI doesn't try to regain focus. This results in a somewhat worse experience when returning from the command palette, but is still preferable to not being able to open the command palette at all.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
