### PR TITLE
Don't try to parse output of `codeql pack add` as JSON

### DIFF
--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -1384,13 +1384,10 @@ export class CodeQLCliServer implements Disposable {
   async packAdd(dir: string, queryLanguage: QueryLanguage) {
     const args = ["--dir", dir];
     args.push(`codeql/${queryLanguage}-all`);
-    return this.runJsonCodeQlCliCommandWithAuthentication(
+    return this.runCodeQlCliCommand(
       ["pack", "add"],
       args,
       `Adding and installing ${queryLanguage} pack dependency.`,
-      {
-        addFormat: false,
-      },
     );
   }
 


### PR DESCRIPTION
Fixes https://github.com/github/vscode-codeql/issues/3219.

The `packAdd` command is only used in the "Create query" flow, where it was causing some confusing/useless log messages. This is because we were incorrectly expecting JSON output.

I've tested this by running "Create query" and checking that it still works, but _doesn't_ display the following error message 
> Could not create skeleton QL pack: Parsing output of Adding and installing java pack dependency. failed: Unexpected token 'P', "Package in"... is not valid JSON



## Checklist

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
  - I don't think this a changelog update it necessary? It just removes an errant log message 🤔  
- [x] Issues have been created for any UI or other user-facing changes made by this pull request.
- [x] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
