### PR TITLE
Introduce VsCodeWindow to provide types for the fields we're reading/writing

### DIFF
--- a/extensions/ql-vscode/src/view/common/CodePaths/__tests__/CodePaths.spec.tsx
+++ b/extensions/ql-vscode/src/view/common/CodePaths/__tests__/CodePaths.spec.tsx
@@ -29,7 +29,7 @@ describe(CodePaths.name, () => {
 
     await userEvent.click(screen.getByText("Show paths"));
 
-    expect((window as any).vsCodeApi.postMessage).toHaveBeenCalledWith({
+    expect(window.vsCodeApi.postMessage).toHaveBeenCalledWith({
       t: "showDataFlowPaths",
       dataFlowPaths: {
         codeFlows: createMockCodeFlows(),

--- a/extensions/ql-vscode/src/view/jest.setup.ts
+++ b/extensions/ql-vscode/src/view/jest.setup.ts
@@ -16,14 +16,12 @@ Object.defineProperty(window, "matchMedia", {
 });
 
 // Used by Primer React
-(window as any).CSS = {
-  supports: jest.fn().mockResolvedValue(false),
-};
+window.CSS.supports = jest.fn().mockResolvedValue(false);
 
 // Store this on the window so we can mock it
-(window as any).vsCodeApi = {
+window.vsCodeApi = {
   postMessage: jest.fn(),
   setState: jest.fn(),
 };
 
-(window as any).acquireVsCodeApi = () => (window as any).vsCodeApi;
+window.acquireVsCodeApi = () => window.vsCodeApi;

--- a/extensions/ql-vscode/src/view/variant-analysis/__tests__/RepoRow.spec.tsx
+++ b/extensions/ql-vscode/src/view/variant-analysis/__tests__/RepoRow.spec.tsx
@@ -355,7 +355,7 @@ describe(RepoRow.name, () => {
       );
     });
 
-    expect((window as any).vsCodeApi.postMessage).toHaveBeenCalledWith({
+    expect(window.vsCodeApi.postMessage).toHaveBeenCalledWith({
       t: "requestRepositoryResults",
       repositoryFullName: "octodemo/hello-world-1",
     });

--- a/extensions/ql-vscode/src/view/vscode-window.ts
+++ b/extensions/ql-vscode/src/view/vscode-window.ts
@@ -1,0 +1,11 @@
+import type { VsCodeApi } from "./vscode-api";
+
+declare global {
+  interface Window {
+    CSS: {
+      supports: () => Promise<boolean>;
+    };
+    vsCodeApi: VsCodeApi;
+    acquireVsCodeApi: () => VsCodeApi;
+  }
+}


### PR DESCRIPTION
There are a few places where we are reading/writing extra fields to the `window` object. I believe these fields which are provided by VS Code, but sometimes in the tests we are mocking them ourselves.

Instead of using `window as any` we can define the type that we expect it to take using `declare`. This is telling the typescript compiler that a variable exists with this given name and type and it will just believe us.

Since this is just telling the compiler what type things are, it shouldn't change anything at runtime. Therefore hopefully if this compiles then it's safe 🤞🏼 

We already do this in `extensions/ql-vscode/.storybook/preview.ts`, though I couldn't see a way for us to share this code and avoid duplication. Although `preview.ts` can import code from `src` (as evidenced by `VsCodeApi`) it doesn't do so automatically and hence this `declare global` doesn't get picked up. I'm not too concerned about it though 🤷🏼 

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
