### PR TITLE
Provide types for all react refs

### DIFF
--- a/extensions/ql-vscode/src/view/results/AlertTable.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTable.tsx
@@ -40,7 +40,7 @@ export function AlertTable({
     undefined,
   );
 
-  const selectedItemRef = useRef<any>();
+  const selectedItemRef = useRef<HTMLTableRowElement>(null);
   useScrollIntoView(selectedItem, selectedItemRef);
 
   /**

--- a/extensions/ql-vscode/src/view/results/AlertTablePathNodeRow.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTablePathNodeRow.tsx
@@ -16,7 +16,7 @@ interface Props {
   pathIndex: number;
   resultIndex: number;
   selectedItem: undefined | ResultKey;
-  selectedItemRef: React.RefObject<any>;
+  selectedItemRef: React.RefObject<HTMLTableRowElement>;
   databaseUri: string;
   sourceLocationPrefix: string;
   updateSelectionCallback: (

--- a/extensions/ql-vscode/src/view/results/AlertTablePathRow.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTablePathRow.tsx
@@ -17,7 +17,7 @@ interface Props {
   resultIndex: number;
   currentPathExpanded: boolean;
   selectedItem: undefined | ResultKey;
-  selectedItemRef: React.RefObject<any>;
+  selectedItemRef: React.RefObject<HTMLTableRowElement>;
   databaseUri: string;
   sourceLocationPrefix: string;
   updateSelectionCallback: (

--- a/extensions/ql-vscode/src/view/results/AlertTableResultRow.tsx
+++ b/extensions/ql-vscode/src/view/results/AlertTableResultRow.tsx
@@ -18,7 +18,7 @@ interface Props {
   resultIndex: number;
   expanded: Set<string>;
   selectedItem: undefined | ResultKey;
-  selectedItemRef: React.RefObject<any>;
+  selectedItemRef: React.RefObject<HTMLTableRowElement>;
   databaseUri: string;
   sourceLocationPrefix: string;
   updateSelectionCallback: (

--- a/extensions/ql-vscode/src/view/results/RawTable.tsx
+++ b/extensions/ql-vscode/src/view/results/RawTable.tsx
@@ -38,7 +38,7 @@ export function RawTable({
 }: RawTableProps) {
   const [selectedItem, setSelectedItem] = useState<TableItem | undefined>();
 
-  const selectedItemRef = useRef<any>();
+  const selectedItemRef = useRef<HTMLTableCellElement>(null);
   useScrollIntoView(selectedItem, selectedItemRef);
 
   const setSelection = useCallback((row: number, column: number): void => {

--- a/extensions/ql-vscode/src/view/results/RawTableRow.tsx
+++ b/extensions/ql-vscode/src/view/results/RawTableRow.tsx
@@ -8,7 +8,7 @@ interface Props {
   databaseUri: string;
   className?: string;
   selectedColumn?: number;
-  selectedItemRef?: React.Ref<any>;
+  selectedItemRef?: React.Ref<HTMLTableCellElement>;
   onSelected?: (row: number, column: number) => void;
 }
 

--- a/extensions/ql-vscode/src/view/results/useScrollIntoView.tsx
+++ b/extensions/ql-vscode/src/view/results/useScrollIntoView.tsx
@@ -3,10 +3,10 @@ import { useEffect } from "react";
 
 export function useScrollIntoView<T>(
   selectedElement: T | undefined,
-  selectedElementRef: RefObject<any>,
+  selectedElementRef: RefObject<HTMLElement>,
 ) {
   useEffect(() => {
-    const element = selectedElementRef.current as HTMLElement | undefined;
+    const element = selectedElementRef.current;
     if (!element) {
       return;
     }


### PR DESCRIPTION
Everywhere we create or consume a React ref, give it a proper type instead of using `Ref<any>`.

To make this work I switched to passing `null` as the initial value instead of leaving it blank. I believe this doesn't change the behaviour of the components in any way.

Leaving the initial value empty was leading to a computed type of `Thing | undefined` and that was causing problems when trying to pass it to `ref={ref}` on an element. The ref type already expects `null` to be a possible value, so using that instead of `undefined` makes everything happy.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
