### PR TITLE
Remove use of any and make typing clearer in debugger code

### DIFF
--- a/extensions/ql-vscode/src/common/helpers-pure.ts
+++ b/extensions/ql-vscode/src/common/helpers-pure.ts
@@ -7,6 +7,18 @@
 
 import { RedactableError } from "./errors";
 
+// Matches any type that is not an array. This is useful to help avoid
+// nested arrays, or for cases like createSingleSelectionCommand to avoid T
+// accidentally getting instantiated as DatabaseItem[] instead of DatabaseItem.
+export type NotArray =
+  | string
+  | bigint
+  | number
+  | boolean
+  | (object & {
+      length?: never;
+    });
+
 /**
  * This error is used to indicate a runtime failure of an exhaustivity check enforced at compile time.
  */

--- a/extensions/ql-vscode/src/common/vscode/selection-commands.ts
+++ b/extensions/ql-vscode/src/common/vscode/selection-commands.ts
@@ -3,13 +3,9 @@ import type {
   TreeViewContextMultiSelectionCommandFunction,
   TreeViewContextSingleSelectionCommandFunction,
 } from "../commands";
+import type { NotArray } from "../helpers-pure";
 import type { NotificationLogger } from "../logging";
 import { showAndLogErrorMessage } from "../logging";
-
-// A hack to match types that are not an array, which is useful to help avoid
-// misusing createSingleSelectionCommand, e.g. where T accidentally gets instantiated
-// as DatabaseItem[] instead of DatabaseItem.
-type NotArray = object & { length?: never };
 
 // A way to get the type system to help assert that one type is a supertype of another.
 type CreateSupertypeOf<Super, Sub extends Super> = Sub;

--- a/extensions/ql-vscode/src/debugger/debug-configuration.ts
+++ b/extensions/ql-vscode/src/debugger/debug-configuration.ts
@@ -22,7 +22,7 @@ export interface QLDebugArgs {
   extensionPacks?: string[] | string;
   quickEval?: boolean;
   noDebug?: boolean;
-  additionalRunQueryArgs?: Record<string, any>;
+  additionalRunQueryArgs?: Record<string, unknown>;
 }
 
 /**
@@ -39,7 +39,7 @@ export type QLDebugConfiguration = DebugConfiguration & QLDebugArgs;
 export type QLResolvedDebugConfiguration = DebugConfiguration & LaunchConfig;
 
 /** If the specified value is a single element, then turn it into an array containing that element. */
-function makeArray<T extends Exclude<any, any[]>>(value: T | T[]): T[] {
+function makeArray<T extends Exclude<unknown, unknown[]>>(value: T | T[]): T[] {
   if (Array.isArray(value)) {
     return value;
   } else {

--- a/extensions/ql-vscode/src/debugger/debug-configuration.ts
+++ b/extensions/ql-vscode/src/debugger/debug-configuration.ts
@@ -8,6 +8,7 @@ import { getOnDiskWorkspaceFolders } from "../common/vscode/workspace-folders";
 import type { LocalQueries } from "../local-queries";
 import { getQuickEvalContext, validateQueryPath } from "../run-queries-shared";
 import type { LaunchConfig } from "./debug-protocol";
+import type { NotArray } from "../common/helpers-pure";
 import { getErrorMessage } from "../common/helpers-pure";
 import { showAndLogErrorMessage } from "../common/logging";
 import { extLogger } from "../common/logging/vscode";
@@ -39,7 +40,7 @@ export type QLDebugConfiguration = DebugConfiguration & QLDebugArgs;
 export type QLResolvedDebugConfiguration = DebugConfiguration & LaunchConfig;
 
 /** If the specified value is a single element, then turn it into an array containing that element. */
-function makeArray<T extends Exclude<unknown, unknown[]>>(value: T | T[]): T[] {
+function makeArray<T extends NotArray>(value: T | T[]): T[] {
   if (Array.isArray(value)) {
     return value;
   } else {

--- a/extensions/ql-vscode/src/debugger/debug-protocol.ts
+++ b/extensions/ql-vscode/src/debugger/debug-protocol.ts
@@ -71,7 +71,7 @@ export interface LaunchConfig {
   /** Run the query without debugging it. */
   noDebug: boolean;
   /** Undocumented: Additional arguments to be passed to the `runQuery` API on the query server. */
-  additionalRunQueryArgs: Record<string, any>;
+  additionalRunQueryArgs: Record<string, unknown>;
 }
 
 export interface LaunchRequest extends Request, DebugProtocol.LaunchRequest {


### PR DESCRIPTION
This aims to remove the use of `any` from `debug-configuration.ts` and `debug-protocol.ts`. The first commit does this by replacing instances of `any` with `unknown`, and this appears to work fine.

The second commit tries to improve type clarity by reusing the `NotArray` type. I'm not 100% sure but I think this is what `makeArray` is trying to achieve with `T extends Exclude<any, any[]>`. Using a named type there and reusing code instead of having two hacks for the same thing will hopefully make it easier to understand in the future.

As part of this I had to augment `NotArray` to handle other primitive types instead of just `object`, but I don't think this will have any negative effect on `selection-commands.ts`.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
