### PR TITLE
Use unknown instead of any in type functions

### DIFF
--- a/extensions/ql-vscode/src/common/errors.ts
+++ b/extensions/ql-vscode/src/common/errors.ts
@@ -84,12 +84,13 @@ export interface ErrorLike {
   stack?: string;
 }
 
-function isErrorLike(error: any): error is ErrorLike {
-  if (
+function isErrorLike(error: unknown): error is ErrorLike {
+  return (
+    error !== undefined &&
+    error !== null &&
+    typeof error === "object" &&
+    "message" in error &&
     typeof error.message === "string" &&
-    (error.stack === undefined || typeof error.stack === "string")
-  ) {
-    return true;
-  }
-  return false;
+    (!("stack" in error) || typeof error.stack === "string")
+  );
 }

--- a/extensions/ql-vscode/src/common/files.ts
+++ b/extensions/ql-vscode/src/common/files.ts
@@ -124,8 +124,14 @@ export interface IOError {
   readonly code: string;
 }
 
-export function isIOError(e: any): e is IOError {
-  return e.code !== undefined && typeof e.code === "string";
+export function isIOError(e: unknown): e is IOError {
+  return (
+    e !== undefined &&
+    e !== null &&
+    typeof e === "object" &&
+    "code" in e &&
+    typeof e.code === "string"
+  );
 }
 
 // This function is a wrapper around `os.tmpdir()` to make it easier to mock in tests.

--- a/extensions/ql-vscode/src/local-queries/local-queries.ts
+++ b/extensions/ql-vscode/src/local-queries/local-queries.ts
@@ -600,6 +600,11 @@ export class LocalQueries extends DisposableObject {
   }
 }
 
-function isTabInputText(input: any): input is TabInputText {
-  return input?.uri !== undefined;
+function isTabInputText(input: unknown): input is TabInputText {
+  return (
+    input !== null &&
+    typeof input === "object" &&
+    "uri" in input &&
+    input?.uri !== undefined
+  );
 }


### PR DESCRIPTION
When checking if an object is a certain type, we should use `unknown` instead of `any`. The only difference this makes to the implementation is we need to add some extra `obj !== null` and `typeof obj === "object"` checks, but this makes it safer anyway since before if some of these were passed a `null` value they would throw an error when trying to access fields on it.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
