### PR TITLE
Give more types to CachedOperation to avoid use of any

### DIFF
--- a/extensions/ql-vscode/src/language-support/contextual/cached-operation.ts
+++ b/extensions/ql-vscode/src/language-support/contextual/cached-operation.ts
@@ -1,10 +1,10 @@
 import { asError } from "../../common/helpers-pure";
 
 /**
- * A cached mapping from strings to value of type U.
+ * A cached mapping from args of type [string, S] to a value of type Promise<U>.
  */
-export class CachedOperation<U> {
-  private readonly operation: (t: string, ...args: any[]) => Promise<U>;
+export class CachedOperation<S extends unknown[], U> {
+  private readonly operation: (t: string, ...args: S) => Promise<U>;
   private readonly cached: Map<string, U>;
   private readonly lru: string[];
   private readonly inProgressCallbacks: Map<
@@ -13,7 +13,7 @@ export class CachedOperation<U> {
   >;
 
   constructor(
-    operation: (t: string, ...args: any[]) => Promise<U>,
+    operation: (t: string, ...args: S) => Promise<U>,
     private cacheSize = 100,
   ) {
     this.operation = operation;
@@ -25,7 +25,7 @@ export class CachedOperation<U> {
     this.cached = new Map<string, U>();
   }
 
-  async get(t: string, ...args: any[]): Promise<U> {
+  async get(t: string, ...args: S): Promise<U> {
     // Try and retrieve from the cache
     const fromCache = this.cached.get(t);
     if (fromCache !== undefined) {

--- a/extensions/ql-vscode/src/language-support/contextual/cached-operation.ts
+++ b/extensions/ql-vscode/src/language-support/contextual/cached-operation.ts
@@ -1,7 +1,7 @@
 import { asError } from "../../common/helpers-pure";
 
 /**
- * A cached mapping from args of type [string, S] to a value of type Promise<U>.
+ * A cached mapping from strings to a value of type U.
  */
 export class CachedOperation<S extends unknown[], U> {
   private readonly operation: (t: string, ...args: S) => Promise<U>;

--- a/extensions/ql-vscode/src/language-support/contextual/template-provider.ts
+++ b/extensions/ql-vscode/src/language-support/contextual/template-provider.ts
@@ -50,7 +50,7 @@ import { MultiCancellationToken } from "../../common/vscode/multi-cancellation-t
  */
 
 export class TemplateQueryDefinitionProvider implements DefinitionProvider {
-  private cache: CachedOperation<LocationLink[]>;
+  private cache: CachedOperation<[CancellationToken], LocationLink[]>;
 
   constructor(
     private cli: CodeQLCliServer,
@@ -58,9 +58,7 @@ export class TemplateQueryDefinitionProvider implements DefinitionProvider {
     private dbm: DatabaseManager,
     private queryStorageDir: string,
   ) {
-    this.cache = new CachedOperation<LocationLink[]>(
-      this.getDefinitions.bind(this),
-    );
+    this.cache = new CachedOperation(this.getDefinitions.bind(this));
   }
 
   async provideDefinition(
@@ -112,7 +110,7 @@ export class TemplateQueryDefinitionProvider implements DefinitionProvider {
  * or from a selected identifier.
  */
 export class TemplateQueryReferenceProvider implements ReferenceProvider {
-  private cache: CachedOperation<FullLocationLink[]>;
+  private cache: CachedOperation<[CancellationToken], FullLocationLink[]>;
 
   constructor(
     private cli: CodeQLCliServer,
@@ -120,9 +118,7 @@ export class TemplateQueryReferenceProvider implements ReferenceProvider {
     private dbm: DatabaseManager,
     private queryStorageDir: string,
   ) {
-    this.cache = new CachedOperation<FullLocationLink[]>(
-      this.getReferences.bind(this),
-    );
+    this.cache = new CachedOperation(this.getReferences.bind(this));
   }
 
   async provideReferences(
@@ -185,7 +181,10 @@ export class TemplateQueryReferenceProvider implements ReferenceProvider {
  * source-language files.
  */
 export class TemplatePrintAstProvider {
-  private cache: CachedOperation<CoreCompletedQuery>;
+  private cache: CachedOperation<
+    [ProgressCallback, CancellationToken],
+    CoreCompletedQuery
+  >;
 
   constructor(
     private cli: CodeQLCliServer,
@@ -193,9 +192,7 @@ export class TemplatePrintAstProvider {
     private dbm: DatabaseManager,
     private queryStorageDir: string,
   ) {
-    this.cache = new CachedOperation<CoreCompletedQuery>(
-      this.getAst.bind(this),
-    );
+    this.cache = new CachedOperation(this.getAst.bind(this));
   }
 
   async provideAst(
@@ -283,15 +280,16 @@ export class TemplatePrintAstProvider {
  * source-language files.
  */
 export class TemplatePrintCfgProvider {
-  private cache: CachedOperation<[Uri, Record<string, string>] | undefined>;
+  private cache: CachedOperation<
+    [number, number],
+    [Uri, Record<string, string>]
+  >;
 
   constructor(
     private cli: CodeQLCliServer,
     private dbm: DatabaseManager,
   ) {
-    this.cache = new CachedOperation<[Uri, Record<string, string>] | undefined>(
-      this.getCfgUri.bind(this),
-    );
+    this.cache = new CachedOperation(this.getCfgUri.bind(this));
   }
 
   async provideCfgUri(


### PR DESCRIPTION
This PR removes the uses of `any` in `CachedOperation`. Unfortunately just replacing the use of `any` with `unknown` is not enough, but we can make it work if we add a type parameter for the function arguments.

I've made it work by having two type arguments. One for the arguments and another for the return type. Hopefully this isn't too cumbersome. I did manage to remove one set of explicit type args from `template-provider.ts` so now we only specify them once when declaring the variable and have them inferred when actually constructing the `CachedOperation` object.

I wanted to do it with one argument so you could do `CachedOperation<typeof this.getDefinitions>`, but sadly I couldn't get this to work. The issue I hit was that the async function didn't like a return type of `ReturnType<T>` and claimed it wasn't a `Promise`. It's possible we could get this to work with one type arg, but the effort didn't seem worth it to me.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
