### PR TITLE
Use correct types where possible instead of any

### DIFF
--- a/extensions/ql-vscode/scripts/add-fields-to-scenarios.ts
+++ b/extensions/ql-vscode/scripts/add-fields-to-scenarios.ts
@@ -15,6 +15,7 @@ import { pathExists, readJson, writeJson } from "fs-extra";
 import { resolve, relative } from "path";
 
 import type { Octokit } from "@octokit/core";
+import type { EndpointDefaults } from "@octokit/types";
 import type { RestEndpointMethodTypes } from "@octokit/rest";
 import { throttling } from "@octokit/plugin-throttling";
 
@@ -42,7 +43,7 @@ const octokit = new MyOctokit({
   throttle: {
     onRateLimit: (
       retryAfter: number,
-      options: any,
+      options: EndpointDefaults,
       octokit: Octokit,
     ): boolean => {
       octokit.log.warn(
@@ -53,7 +54,7 @@ const octokit = new MyOctokit({
     },
     onSecondaryRateLimit: (
       _retryAfter: number,
-      options: any,
+      options: EndpointDefaults,
       octokit: Octokit,
     ): void => {
       octokit.log.warn(

--- a/extensions/ql-vscode/scripts/source-map.ts
+++ b/extensions/ql-vscode/scripts/source-map.ts
@@ -243,7 +243,7 @@ type WorkflowRunListItem = {
 async function replaceAsync(
   str: string,
   regex: RegExp,
-  replacer: (substring: string, ...args: any[]) => Promise<string>,
+  replacer: (substring: string, ...args: string[]) => Promise<string>,
 ) {
   const promises: Array<Promise<string>> = [];
   str.replace(regex, (match, ...args) => {

--- a/extensions/ql-vscode/src/common/text-utils.ts
+++ b/extensions/ql-vscode/src/common/text-utils.ts
@@ -17,7 +17,7 @@ export function convertNonPrintableChars(label: string | undefined) {
      * If the label contains certain non-printable characters, loop through each
      * character and replace it with the cooresponding unicode control label.
      */
-    const convertedLabelArray: any[] = [];
+    const convertedLabelArray: string[] = [];
     for (let i = 0; i < label.length; i++) {
       const labelCheck = label.codePointAt(i)!;
       if (labelCheck <= CONTROL_CODE) {

--- a/extensions/ql-vscode/src/common/vscode/multi-cancellation-token.ts
+++ b/extensions/ql-vscode/src/common/vscode/multi-cancellation-token.ts
@@ -16,7 +16,7 @@ export class MultiCancellationToken implements CancellationToken {
     return this.tokens.some((t) => t.isCancellationRequested);
   }
 
-  onCancellationRequested<T>(listener: (e: T) => any): Disposable {
+  onCancellationRequested<T>(listener: (e: T) => void): Disposable {
     return new DisposableObject(
       ...this.tokens.map((t) => t.onCancellationRequested(listener)),
     );

--- a/extensions/ql-vscode/src/databases/code-search-api.ts
+++ b/extensions/ql-vscode/src/databases/code-search-api.ts
@@ -6,6 +6,7 @@ import type { BaseLogger } from "../common/logging";
 import { AppOctokit } from "../common/octokit";
 import type { ProgressCallback } from "../common/vscode/progress";
 import { UserCancellationException } from "../common/vscode/progress";
+import { EndpointDefaults } from "@octokit/types";
 
 export async function getCodeSearchRepositories(
   query: string,
@@ -54,14 +55,17 @@ async function provideOctokitWithThrottling(
   const octokit = new MyOctokit({
     auth,
     throttle: {
-      onRateLimit: (retryAfter: number, options: any): boolean => {
+      onRateLimit: (retryAfter: number, options: EndpointDefaults): boolean => {
         void logger.log(
           `Rate Limit detected for request ${options.method} ${options.url}. Retrying after ${retryAfter} seconds!`,
         );
 
         return true;
       },
-      onSecondaryRateLimit: (_retryAfter: number, options: any): void => {
+      onSecondaryRateLimit: (
+        _retryAfter: number,
+        options: EndpointDefaults,
+      ): void => {
         void logger.log(
           `Secondary Rate Limit detected for request ${options.method} ${options.url}`,
         );

--- a/extensions/ql-vscode/src/databases/code-search-api.ts
+++ b/extensions/ql-vscode/src/databases/code-search-api.ts
@@ -6,7 +6,7 @@ import type { BaseLogger } from "../common/logging";
 import { AppOctokit } from "../common/octokit";
 import type { ProgressCallback } from "../common/vscode/progress";
 import { UserCancellationException } from "../common/vscode/progress";
-import { EndpointDefaults } from "@octokit/types";
+import type { EndpointDefaults } from "@octokit/types";
 
 export async function getCodeSearchRepositories(
   query: string,

--- a/extensions/ql-vscode/src/databases/database-fetcher.ts
+++ b/extensions/ql-vscode/src/databases/database-fetcher.ts
@@ -590,7 +590,7 @@ export async function convertGithubNwoToDatabaseUrl(
       repo,
     });
 
-    const languages = response.data.map((db: any) => db.language);
+    const languages = response.data.map((db) => db.language);
 
     if (!language || !languages.includes(language)) {
       language = await promptForLanguage(languages, progress);

--- a/extensions/ql-vscode/src/local-queries/quick-query.ts
+++ b/extensions/ql-vscode/src/local-queries/quick-query.ts
@@ -14,7 +14,7 @@ import { getErrorMessage } from "../common/helpers-pure";
 import { FALLBACK_QLPACK_FILENAME, getQlPackFilePath } from "../common/ql";
 import type { App } from "../common/app";
 import type { ExtensionApp } from "../common/vscode/vscode-app";
-import { QlPackFile } from "../packaging/qlpack-file";
+import type { QlPackFile } from "../packaging/qlpack-file";
 
 const QUICK_QUERIES_DIR_NAME = "quick-queries";
 const QUICK_QUERY_QUERY_NAME = "quick-query.ql";

--- a/extensions/ql-vscode/src/local-queries/quick-query.ts
+++ b/extensions/ql-vscode/src/local-queries/quick-query.ts
@@ -14,6 +14,7 @@ import { getErrorMessage } from "../common/helpers-pure";
 import { FALLBACK_QLPACK_FILENAME, getQlPackFilePath } from "../common/ql";
 import type { App } from "../common/app";
 import type { ExtensionApp } from "../common/vscode/vscode-app";
+import { QlPackFile } from "../packaging/qlpack-file";
 
 const QUICK_QUERIES_DIR_NAME = "quick-queries";
 const QUICK_QUERY_QUERY_NAME = "quick-query.ql";
@@ -125,7 +126,7 @@ export async function displayQuickQuery(
 
     // Only rewrite the qlpack file if the database has changed
     if (shouldRewrite) {
-      const quickQueryQlpackYaml: any = {
+      const quickQueryQlpackYaml: QlPackFile = {
         name: "vscode/quick-query",
         version: "1.0.0",
         dependencies: {
@@ -175,6 +176,6 @@ async function checkShouldRewrite(
   if (!(await pathExists(qlPackFile))) {
     return true;
   }
-  const qlPackContents: any = load(await readFile(qlPackFile, "utf8"));
+  const qlPackContents = load(await readFile(qlPackFile, "utf8")) as QlPackFile;
   return !qlPackContents.dependencies?.[newDependency];
 }


### PR DESCRIPTION
This is all the cases I could find where we are using `any` but there exists some other type we can use instead that doesn't involve changing anything else. If everything still compiles then this should be safe to do so.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
