### PR TITLE
Use bind instead of thisArg parameter in MultiFileSystemWatcher

### DIFF
--- a/extensions/ql-vscode/src/common/vscode/multi-file-system-watcher.ts
+++ b/extensions/ql-vscode/src/common/vscode/multi-file-system-watcher.ts
@@ -20,7 +20,7 @@ class WatcherCollection extends DisposableObject {
    */
   public addWatcher(
     pattern: GlobPattern,
-    listener: (e: Uri) => any,
+    listener: (e: Uri) => void,
     thisArgs: any,
   ): void {
     const watcher = workspace.createFileSystemWatcher(pattern);

--- a/extensions/ql-vscode/src/common/vscode/multi-file-system-watcher.ts
+++ b/extensions/ql-vscode/src/common/vscode/multi-file-system-watcher.ts
@@ -18,15 +18,11 @@ class WatcherCollection extends DisposableObject {
    *   deleted.
    * @param thisArgs The `this` argument for the event listener.
    */
-  public addWatcher(
-    pattern: GlobPattern,
-    listener: (e: Uri) => void,
-    thisArgs: any,
-  ): void {
+  public addWatcher(pattern: GlobPattern, listener: (e: Uri) => void): void {
     const watcher = workspace.createFileSystemWatcher(pattern);
-    this.push(watcher.onDidCreate(listener, thisArgs));
-    this.push(watcher.onDidChange(listener, thisArgs));
-    this.push(watcher.onDidDelete(listener, thisArgs));
+    this.push(watcher.onDidCreate(listener));
+    this.push(watcher.onDidChange(listener));
+    this.push(watcher.onDidDelete(listener));
   }
 }
 
@@ -54,7 +50,7 @@ export class MultiFileSystemWatcher extends DisposableObject {
    * @param pattern The pattern to watch.
    */
   public addWatch(pattern: GlobPattern): void {
-    this.watchers.addWatcher(pattern, this.handleDidChange, this);
+    this.watchers.addWatcher(pattern, this.handleDidChange.bind(this));
   }
 
   /**


### PR DESCRIPTION
This PR:
- Changes the type of `listener` from `(Uri) => any` to `(Uri) => void`, because I believe these listeners are not expected to return anything and any return value is ignored anyway.
- Removes the `thisArgs` parameter and instead uses `bind` before passing in the listener function.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
