### PR TITLE
Avoid use of any in TelemetryListener

### DIFF
--- a/extensions/ql-vscode/src/common/vscode/telemetry.ts
+++ b/extensions/ql-vscode/src/common/vscode/telemetry.ts
@@ -128,7 +128,8 @@ export class ExtensionTelemetryListener
     );
     this.push(this.reporter);
 
-    const client = (this.reporter as any).appInsightsClient as TelemetryClient;
+    // The appInsightsClient field is private but we want to access it anyway
+    const client = this.reporter["appInsightsClient"] as TelemetryClient;
     if (client) {
       // add a telemetry processor to delete unwanted properties
       client.addTelemetryProcessor((envelope: any) => {

--- a/extensions/ql-vscode/src/common/vscode/telemetry.ts
+++ b/extensions/ql-vscode/src/common/vscode/telemetry.ts
@@ -20,6 +20,7 @@ import { showBinaryChoiceWithUrlDialog } from "./dialog";
 import type { RedactableError } from "../errors";
 import type { SemVer } from "semver";
 import type { AppTelemetry } from "../telemetry";
+import { EnvelopeTelemetry } from "applicationinsights/out/Declarations/Contracts";
 
 // Key is injected at build time through the APP_INSIGHTS_KEY environment variable.
 const key = "REPLACE-APP-INSIGHTS-KEY";
@@ -132,9 +133,9 @@ export class ExtensionTelemetryListener
     const client = this.reporter["appInsightsClient"] as TelemetryClient;
     if (client) {
       // add a telemetry processor to delete unwanted properties
-      client.addTelemetryProcessor((envelope: any) => {
+      client.addTelemetryProcessor((envelope: EnvelopeTelemetry) => {
         tagsToRemove.forEach((tag) => delete envelope.tags[tag]);
-        const baseDataProperties = (envelope.data as any)?.baseData?.properties;
+        const baseDataProperties = envelope.data.baseData?.properties;
         if (baseDataProperties) {
           baseDataPropertiesToRemove.forEach(
             (prop) => delete baseDataProperties[prop],

--- a/extensions/ql-vscode/src/common/vscode/telemetry.ts
+++ b/extensions/ql-vscode/src/common/vscode/telemetry.ts
@@ -20,7 +20,7 @@ import { showBinaryChoiceWithUrlDialog } from "./dialog";
 import type { RedactableError } from "../errors";
 import type { SemVer } from "semver";
 import type { AppTelemetry } from "../telemetry";
-import { EnvelopeTelemetry } from "applicationinsights/out/Declarations/Contracts";
+import type { EnvelopeTelemetry } from "applicationinsights/out/Declarations/Contracts";
 
 // Key is injected at build time through the APP_INSIGHTS_KEY environment variable.
 const key = "REPLACE-APP-INSIGHTS-KEY";


### PR DESCRIPTION
In this PR:
- Use string index notation to access the private field instead of casting to `any`. As far as I can tell this is the "intended way" to access private fields.
- Uses the `EnvelopeTelemetry` type since it exists, instead of `any`.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
