### PR TITLE
Remove `enableRuby` feature flag

### DIFF
--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -716,7 +716,6 @@ const LLM_GENERATION_DEV_ENDPOINT = new Setting(
   MODEL_SETTING,
 );
 const EXTENSIONS_DIRECTORY = new Setting("extensionsDirectory", MODEL_SETTING);
-const ENABLE_RUBY = new Setting("enableRuby", MODEL_SETTING);
 const ENABLE_ACCESS_PATH_SUGGESTIONS = new Setting(
   "enableAccessPathSuggestions",
   MODEL_SETTING,
@@ -726,7 +725,6 @@ export interface ModelConfig {
   flowGeneration: boolean;
   llmGeneration: boolean;
   getExtensionsDirectory(languageId: string): string | undefined;
-  enableRuby: boolean;
   enableAccessPathSuggestions: boolean;
 }
 
@@ -763,10 +761,6 @@ export class ModelConfigListener extends ConfigListener implements ModelConfig {
     return EXTENSIONS_DIRECTORY.getValue<string>({
       languageId,
     });
-  }
-
-  public get enableRuby(): boolean {
-    return !!ENABLE_RUBY.getValue<boolean>();
   }
 
   public get enableAccessPathSuggestions(): boolean {

--- a/extensions/ql-vscode/src/model-editor/model-editor-module.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-module.ts
@@ -143,10 +143,7 @@ export class ModelEditorModule extends DisposableObject {
 
       const language = db.language;
 
-      if (
-        !isQueryLanguage(language) ||
-        !isSupportedLanguage(language, this.modelConfig)
-      ) {
+      if (!isQueryLanguage(language) || !isSupportedLanguage(language)) {
         void showAndLogErrorMessage(
           this.app.logger,
           `The CodeQL Model Editor is not supported for ${language} databases.`,

--- a/extensions/ql-vscode/src/model-editor/supported-languages.ts
+++ b/extensions/ql-vscode/src/model-editor/supported-languages.ts
@@ -1,5 +1,5 @@
 import { QueryLanguage } from "../common/query-language";
-import type { ModelConfig } from "../config";
+import { isCanary } from "../config";
 
 /**
  * Languages that are always supported by the model editor. These languages
@@ -10,17 +10,14 @@ export const SUPPORTED_LANGUAGES: QueryLanguage[] = [
   QueryLanguage.CSharp,
 ];
 
-export function isSupportedLanguage(
-  language: QueryLanguage,
-  modelConfig: ModelConfig,
-) {
+export function isSupportedLanguage(language: QueryLanguage) {
   if (SUPPORTED_LANGUAGES.includes(language)) {
     return true;
   }
 
   if (language === QueryLanguage.Ruby) {
-    // Ruby is only enabled when the config setting is set
-    return modelConfig.enableRuby;
+    // Ruby is only enabled when in canary mode
+    return isCanary();
   }
 
   return false;


### PR DESCRIPTION
The model editor for Ruby will now be available behind the canary setting instead of being feature flagged separately.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
