### PR TITLE
Add new type parameters to functions where possible

### DIFF
--- a/extensions/ql-vscode/src/common/jsonl-reader.ts
+++ b/extensions/ql-vscode/src/common/jsonl-reader.ts
@@ -10,9 +10,9 @@ import { readFile } from "fs-extra";
  * @param path The path to the file.
  * @param handler Callback to be invoked for each top-level JSON object in order.
  */
-export async function readJsonlFile(
+export async function readJsonlFile<T>(
   path: string,
-  handler: (value: any) => Promise<void>,
+  handler: (value: T) => Promise<void>,
 ): Promise<void> {
   const logSummary = await readFile(path, "utf-8");
 
@@ -20,7 +20,7 @@ export async function readJsonlFile(
   const jsonSummaryObjects: string[] = logSummary.split(/\r?\n\r?\n/g);
 
   for (const obj of jsonSummaryObjects) {
-    const jsonObj = JSON.parse(obj);
+    const jsonObj = JSON.parse(obj) as T;
     await handler(jsonObj);
   }
 }

--- a/extensions/ql-vscode/src/common/memento.ts
+++ b/extensions/ql-vscode/src/common/memento.ts
@@ -40,5 +40,5 @@ export interface Memento {
    * @param key A string.
    * @param value A value. MUST not contain cyclic references.
    */
-  update(key: string, value: any): Thenable<void>;
+  update<T>(key: string, value: T | undefined): Thenable<void>;
 }

--- a/extensions/ql-vscode/src/common/vscode/commands.ts
+++ b/extensions/ql-vscode/src/common/vscode/commands.ts
@@ -40,13 +40,13 @@ export function createVSCodeCommandManager<
  * @param logger The logger to use for error reporting.
  * @param telemetry The telemetry listener to use for error reporting.
  */
-export function registerCommandWithErrorHandling(
+export function registerCommandWithErrorHandling<S extends unknown[], T>(
   commandId: string,
-  task: (...args: any[]) => Promise<any>,
+  task: (...args: S) => Promise<T>,
   logger: NotificationLogger = extLogger,
   telemetry: AppTelemetry | undefined = telemetryListener,
 ): Disposable {
-  return commands.registerCommand(commandId, async (...args: any[]) => {
+  return commands.registerCommand(commandId, async (...args: S) => {
     const startTime = Date.now();
     let error: Error | undefined;
 

--- a/extensions/ql-vscode/src/common/vscode/commands.ts
+++ b/extensions/ql-vscode/src/common/vscode/commands.ts
@@ -40,13 +40,15 @@ export function createVSCodeCommandManager<
  * @param logger The logger to use for error reporting.
  * @param telemetry The telemetry listener to use for error reporting.
  */
-export function registerCommandWithErrorHandling<S extends unknown[], T>(
+export function registerCommandWithErrorHandling<
+  T extends (...args: unknown[]) => Promise<unknown>,
+>(
   commandId: string,
-  task: (...args: S) => Promise<T>,
+  task: T,
   logger: NotificationLogger = extLogger,
   telemetry: AppTelemetry | undefined = telemetryListener,
 ): Disposable {
-  return commands.registerCommand(commandId, async (...args: S) => {
+  return commands.registerCommand(commandId, async (...args: Parameters<T>) => {
     const startTime = Date.now();
     let error: Error | undefined;
 

--- a/extensions/ql-vscode/src/log-insights/log-scanner.ts
+++ b/extensions/ql-vscode/src/log-insights/log-scanner.ts
@@ -103,7 +103,7 @@ export class EvaluationLogScannerSet {
       p.createScanner(problemReporter),
     );
 
-    await readJsonlFile(jsonSummaryLocation, async (obj) => {
+    await readJsonlFile<SummaryEvent>(jsonSummaryLocation, async (obj) => {
       scanners.forEach((scanner) => {
         scanner.onEvent(obj);
       });

--- a/extensions/ql-vscode/src/log-insights/log-summary-parser.ts
+++ b/extensions/ql-vscode/src/log-insights/log-summary-parser.ts
@@ -19,7 +19,7 @@ export async function parseViewerData(
 ): Promise<EvalLogData[]> {
   const viewerData: EvalLogData[] = [];
 
-  await readJsonlFile(jsonSummaryPath, async (jsonObj) => {
+  await readJsonlFile<EvalLogData>(jsonSummaryPath, async (jsonObj) => {
     // Only convert log items that have an RA and millis field
     if (jsonObj.ra !== undefined && jsonObj.millis !== undefined) {
       const newLogData: EvalLogData = {


### PR DESCRIPTION
These are a few functions that currently use `any` but could instead have a type parameter.

I think each of these cases increases our type safety a little bit. I can't see any downsides, unless I've missed an edge case.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
