### PR TITLE
Add feature flag for Python model editor

### DIFF
--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -716,6 +716,7 @@ const LLM_GENERATION_DEV_ENDPOINT = new Setting(
   MODEL_SETTING,
 );
 const EXTENSIONS_DIRECTORY = new Setting("extensionsDirectory", MODEL_SETTING);
+const ENABLE_PYTHON = new Setting("enablePython", MODEL_SETTING);
 const ENABLE_ACCESS_PATH_SUGGESTIONS = new Setting(
   "enableAccessPathSuggestions",
   MODEL_SETTING,
@@ -725,6 +726,7 @@ export interface ModelConfig {
   flowGeneration: boolean;
   llmGeneration: boolean;
   getExtensionsDirectory(languageId: string): string | undefined;
+  enablePython: boolean;
   enableAccessPathSuggestions: boolean;
 }
 
@@ -761,6 +763,10 @@ export class ModelConfigListener extends ConfigListener implements ModelConfig {
     return EXTENSIONS_DIRECTORY.getValue<string>({
       languageId,
     });
+  }
+
+  public get enablePython(): boolean {
+    return !!ENABLE_PYTHON.getValue<boolean>();
   }
 
   public get enableAccessPathSuggestions(): boolean {

--- a/extensions/ql-vscode/src/model-editor/model-editor-module.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-module.ts
@@ -143,7 +143,10 @@ export class ModelEditorModule extends DisposableObject {
 
       const language = db.language;
 
-      if (!isQueryLanguage(language) || !isSupportedLanguage(language)) {
+      if (
+        !isQueryLanguage(language) ||
+        !isSupportedLanguage(language, this.modelConfig)
+      ) {
         void showAndLogErrorMessage(
           this.app.logger,
           `The CodeQL Model Editor is not supported for ${language} databases.`,

--- a/extensions/ql-vscode/src/model-editor/supported-languages.ts
+++ b/extensions/ql-vscode/src/model-editor/supported-languages.ts
@@ -1,4 +1,5 @@
 import { QueryLanguage } from "../common/query-language";
+import type { ModelConfig } from "../config";
 import { isCanary } from "../config";
 
 /**
@@ -10,7 +11,10 @@ export const SUPPORTED_LANGUAGES: QueryLanguage[] = [
   QueryLanguage.CSharp,
 ];
 
-export function isSupportedLanguage(language: QueryLanguage) {
+export function isSupportedLanguage(
+  language: QueryLanguage,
+  modelConfig: ModelConfig,
+) {
   if (SUPPORTED_LANGUAGES.includes(language)) {
     return true;
   }
@@ -18,6 +22,11 @@ export function isSupportedLanguage(language: QueryLanguage) {
   if (language === QueryLanguage.Ruby) {
     // Ruby is only enabled when in canary mode
     return isCanary();
+  }
+
+  if (language === QueryLanguage.Python) {
+    // Python is only enabled when the config setting is set
+    return modelConfig.enablePython;
   }
 
   return false;


### PR DESCRIPTION
This makes Python available in the model editor if you have `"codeQL.model.enablePython": true` in your (user or workspace) settings ⚙ (heavily inspired by the previous Ruby implementation from https://github.com/github/vscode-codeql/pull/3017/commits/b023431626c1cfe99d85ce194868f9a7de0d1f2a)

Note that Python won't actually work in the model editor yet, since we haven't implemented it. But we can do the necessary development work behind this flag without affecting existing users 🏴 

## Checklist

N/A

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
