### PR TITLE
Add a CLI test for MRVA with multiple queries

### DIFF
--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
@@ -343,6 +343,22 @@ describe("Variant Analysis Manager", () => {
       });
     });
 
+    it("should run multiple queries that are part of the same pack", async () => {
+      await doVariantAnalysisTest({
+        queryPaths: [
+          "data-qlpack-multiple-queries/query1.ql",
+          "data-qlpack-multiple-queries/query2.ql",
+        ],
+        qlPackRootPath: "data-qlpack-multiple-queries",
+        qlPackFilePath: "data-qlpack-multiple-queries/codeql-pack.yml",
+        expectedPackName: "github/remote-query-pack",
+        filesThatExist: ["query1.ql", "query2.ql"],
+        filesThatDoNotExist: [],
+        qlxFilesThatExist: ["query1.qlx", "query2.qlx"],
+        dependenciesToCheck: ["codeql/javascript-all"],
+      });
+    });
+
     async function doVariantAnalysisTest({
       queryPaths,
       qlPackRootPath,

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
@@ -236,7 +236,7 @@ describe("Variant Analysis Manager", () => {
 
       it("should run a remote query that is part of a qlpack", async () => {
         await doVariantAnalysisTest({
-          queryPath: "data-remote-qlpack/in-pack.ql",
+          queryPaths: ["data-remote-qlpack/in-pack.ql"],
           qlPackRootPath: "data-remote-qlpack",
           qlPackFilePath: "data-remote-qlpack/qlpack.yml",
           expectedPackName: "github/remote-query-pack",
@@ -248,7 +248,7 @@ describe("Variant Analysis Manager", () => {
 
       it("should run a remote query that is not part of a qlpack", async () => {
         await doVariantAnalysisTest({
-          queryPath: "data-remote-no-qlpack/in-pack.ql",
+          queryPaths: ["data-remote-no-qlpack/in-pack.ql"],
           qlPackRootPath: "data-remote-no-qlpack",
           qlPackFilePath: undefined,
           expectedPackName: "codeql-remote/query",
@@ -260,7 +260,7 @@ describe("Variant Analysis Manager", () => {
 
       it("should run a remote query that is nested inside a qlpack", async () => {
         await doVariantAnalysisTest({
-          queryPath: "data-remote-qlpack-nested/subfolder/in-pack.ql",
+          queryPaths: ["data-remote-qlpack-nested/subfolder/in-pack.ql"],
           qlPackRootPath: "data-remote-qlpack-nested",
           qlPackFilePath: "data-remote-qlpack-nested/codeql-pack.yml",
           expectedPackName: "github/remote-query-pack",
@@ -279,7 +279,7 @@ describe("Variant Analysis Manager", () => {
         }
         await cli.setUseExtensionPacks(true);
         await doVariantAnalysisTest({
-          queryPath: "data-remote-qlpack-nested/subfolder/in-pack.ql",
+          queryPaths: ["data-remote-qlpack-nested/subfolder/in-pack.ql"],
           qlPackRootPath: "data-remote-qlpack-nested",
           qlPackFilePath: "data-remote-qlpack-nested/codeql-pack.yml",
           expectedPackName: "github/remote-query-pack",
@@ -330,7 +330,7 @@ describe("Variant Analysis Manager", () => {
       const queryPath = join(qlPackRootPath, queryToRun);
       const qlPackFilePath = join(qlPackRootPath, "qlpack.yml");
       await doVariantAnalysisTest({
-        queryPath,
+        queryPaths: [queryPath],
         qlPackRootPath,
         qlPackFilePath,
         expectedPackName: "codeql/java-queries",
@@ -344,7 +344,7 @@ describe("Variant Analysis Manager", () => {
     });
 
     async function doVariantAnalysisTest({
-      queryPath,
+      queryPaths,
       qlPackRootPath,
       qlPackFilePath,
       expectedPackName,
@@ -357,7 +357,7 @@ describe("Variant Analysis Manager", () => {
       dependenciesToCheck = ["codeql/javascript-all"],
       checkVersion = true,
     }: {
-      queryPath: string;
+      queryPaths: string[];
       qlPackRootPath: string;
       qlPackFilePath: string | undefined;
       expectedPackName: string;
@@ -367,9 +367,9 @@ describe("Variant Analysis Manager", () => {
       dependenciesToCheck?: string[];
       checkVersion?: boolean;
     }) {
-      const filePath = getFileOrDir(queryPath);
+      const filePaths = queryPaths.map(getFileOrDir);
       const qlPackDetails: QlPackDetails = {
-        queryFiles: [filePath],
+        queryFiles: filePaths,
         qlPackRootPath: getFileOrDir(qlPackRootPath),
         qlPackFilePath: qlPackFilePath && getFileOrDir(qlPackFilePath),
         language: QueryLanguage.Javascript,
@@ -385,7 +385,7 @@ describe("Variant Analysis Manager", () => {
       expect(executeCommandSpy).toHaveBeenCalledWith(
         "codeQL.monitorNewVariantAnalysis",
         expect.objectContaining({
-          query: expect.objectContaining({ filePath }),
+          query: expect.objectContaining({ filePath: filePaths[0] }),
         }),
       );
 


### PR DESCRIPTION
This PR adds a simple test for running MRVA with two queries. This was actually quite easy because we can re-use the `doVariantAnalysisTest` method with only very small changes.

There are more edge cases of course, but I think they're mostly covered by the no-workspace integration tests. In the CLI tests which are even slower to run, I hope it's ok to just run a single MRVA with two queries and that shows that the process works.

There is already a test for running queries from a published pack, so we don't need to add anything more for that.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
