### PR TITLE
Recompile view when shared files change

### DIFF
--- a/extensions/ql-vscode/gulpfile.ts/view.ts
+++ b/extensions/ql-vscode/gulpfile.ts/view.ts
@@ -28,7 +28,7 @@ export function compileViewEsbuild() {
 }
 
 export function watchViewEsbuild() {
-  watch(["src/view/**/*.{ts,tsx}"], compileViewEsbuild);
+  watch(["src/**/*.{ts,tsx}"], compileViewEsbuild);
 }
 
 export function checkViewTypeScript() {
@@ -38,5 +38,5 @@ export function checkViewTypeScript() {
 }
 
 export function watchViewCheckTypeScript() {
-  watch(["src/view/**/*.{ts,tsx}"], checkViewTypeScript);
+  watch(["src/**/*.{ts,tsx}"], checkViewTypeScript);
 }


### PR DESCRIPTION
When you change a file not in the view directory, but which is imported by the view directory (for example `src/model-editor/languages/languages.ts`, the view would not be recompiled while these do have an impact on the compiled output. This is very surprising behavior and not what we would expect: I expect a change to any file to immediately be visible in the view as well, without having to re-run `npm run build` or `npm run watch`. This fixes it by watching for all changes in the `src` directory.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
