### PR TITLE
Remove cases from ResultsApp that seem to be impossible

### DIFF
--- a/extensions/ql-vscode/src/view/results/ResultsApp.tsx
+++ b/extensions/ql-vscode/src/view/results/ResultsApp.tsx
@@ -79,31 +79,29 @@ export function ResultsApp() {
 
   const updateStateWithNewResultsInfo = useCallback(
     (resultsInfo: ResultsInfo): void => {
-      setState(() => {
-        let results: Results | null = null;
-        let statusText = "";
-        try {
-          const resultSets = getResultSets(resultsInfo);
-          results = {
-            resultSets,
-            database: resultsInfo.database,
-            sortStates: getSortStates(resultsInfo),
-          };
-        } catch (e) {
-          const errorMessage = getErrorMessage(e);
-
-          statusText = `Error loading results: ${errorMessage}`;
-        }
-
-        return {
-          displayedResults: {
-            resultsInfo,
-            results,
-            errorMessage: statusText,
-          },
-          nextResultsInfo: null,
-          isExpectingResultsUpdate: false,
+      let results: Results | null = null;
+      let statusText = "";
+      try {
+        const resultSets = getResultSets(resultsInfo);
+        results = {
+          resultSets,
+          database: resultsInfo.database,
+          sortStates: getSortStates(resultsInfo),
         };
+      } catch (e) {
+        const errorMessage = getErrorMessage(e);
+
+        statusText = `Error loading results: ${errorMessage}`;
+      }
+
+      setState({
+        displayedResults: {
+          resultsInfo,
+          results,
+          errorMessage: statusText,
+        },
+        nextResultsInfo: null,
+        isExpectingResultsUpdate: false,
       });
     },
     [],

--- a/extensions/ql-vscode/src/view/results/ResultsApp.tsx
+++ b/extensions/ql-vscode/src/view/results/ResultsApp.tsx
@@ -79,31 +79,7 @@ export function ResultsApp() {
 
   const updateStateWithNewResultsInfo = useCallback(
     (resultsInfo: ResultsInfo): void => {
-      setState((prevState) => {
-        if (resultsInfo === null && prevState.isExpectingResultsUpdate) {
-          // Display loading message
-          return {
-            ...prevState,
-            displayedResults: {
-              resultsInfo: null,
-              results: null,
-              errorMessage: "Loading results…",
-            },
-            nextResultsInfo: resultsInfo,
-          };
-        } else if (resultsInfo === null) {
-          // No results to display
-          return {
-            ...prevState,
-            displayedResults: {
-              resultsInfo: null,
-              results: null,
-              errorMessage: "No results to display",
-            },
-            nextResultsInfo: resultsInfo,
-          };
-        }
-
+      setState(() => {
         let results: Results | null = null;
         let statusText = "";
         try {


### PR DESCRIPTION
I think these cases for `resultsInfo === null` are impossible. The only two places where `updateStateWithNewResultsInfo` is called both pass a non-null object for `resultsInfo`.

I tried adding logging/exceptions/breakpoints into these cases and trying to hit them and I couldn't. I've also tried testing this branch and everything seems to still work perfectly fine.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
