### PR TITLE
Tidy up auto-modeling rate limit error message

### DIFF
--- a/extensions/ql-vscode/src/model-editor/auto-modeler.ts
+++ b/extensions/ql-vscode/src/model-editor/auto-modeler.ts
@@ -223,7 +223,7 @@ export class AutoModeler {
         void showAndLogExceptionWithTelemetry(
           this.app.logger,
           this.app.telemetry,
-          redactableError(e)`Rate limit hit, please try again soon.`,
+          redactableError`Rate limit hit, please try again soon.`,
         );
         return null;
       } else {


### PR DESCRIPTION
I don't think we need to record the error/stack trace at all so I've removed it completely. We have metrics in the backend service around it.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
