### PR TITLE
Small usability improvements to database picker

### DIFF
--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -828,6 +828,12 @@ export class DatabaseUI extends DisposableObject {
   }
 
   private async promptForDatabase(): Promise<void> {
+    // If there aren't any existing databases,
+    // don't bother asking the user if they want to pick one.
+    if (this.databaseManager.databaseItems.length === 0) {
+      return this.importNewDatabase();
+    }
+
     const quickPickItems: DatabaseSelectionQuickPickItem[] = [
       {
         label: "$(database) Existing database",

--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -877,7 +877,7 @@ export class DatabaseUI extends DisposableObject {
       }));
 
     const selectedDatabase = await window.showQuickPick(dbItems, {
-      placeHolder: "Select a database",
+      placeHolder: "Select an existing database from your workspace...",
       ignoreFocusOut: true,
     });
 
@@ -919,7 +919,8 @@ export class DatabaseUI extends DisposableObject {
     ];
     const selectedImportOption =
       await window.showQuickPick<DatabaseImportQuickPickItems>(importOptions, {
-        placeHolder: "Import a database from...",
+        placeHolder:
+          "Import a new database from the cloud or your local machine...",
         ignoreFocusOut: true,
       });
     if (!selectedImportOption) {

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/databases/local-databases-ui.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/databases/local-databases-ui.test.ts
@@ -30,13 +30,13 @@ describe("local-databases-ui", () => {
   // these two should be deleted
   const db4 = createDatabase(
     storageDir,
-    "db2-notimported-with-db-info",
+    "db4-notimported-with-db-info",
     QueryLanguage.Cpp,
     ".dbinfo",
   );
   const db5 = createDatabase(
     storageDir,
-    "db2-notimported-with-codeql-database.yml",
+    "db5-notimported-with-codeql-database.yml",
     QueryLanguage.Cpp,
     "codeql-database.yml",
   );

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/databases/local-databases-ui.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/databases/local-databases-ui.test.ts
@@ -246,6 +246,29 @@ describe("local-databases-ui", () => {
         expect(showQuickPickSpy).toHaveBeenCalledTimes(2);
         expect(handleChooseDatabaseGithubSpy).toHaveBeenCalledTimes(1);
       });
+
+      it("should skip straight to prompting to import a database if there are no existing databases", async () => {
+        databaseManager.databaseItems = [];
+
+        const showQuickPickSpy = jest
+          .spyOn(window, "showQuickPick")
+          .mockResolvedValueOnce(
+            mockedQuickPickItem(
+              mockedObject<DatabaseImportQuickPickItems>({
+                importType: "github",
+              }),
+            ),
+          );
+
+        const handleChooseDatabaseGithubSpy = jest
+          .spyOn(databaseUI as any, "handleChooseDatabaseGithub")
+          .mockResolvedValue(undefined);
+
+        await databaseUI.getDatabaseItem(progress, token);
+
+        expect(showQuickPickSpy).toHaveBeenCalledTimes(1);
+        expect(handleChooseDatabaseGithubSpy).toHaveBeenCalledTimes(1);
+      });
     });
   });
 


### PR DESCRIPTION
These are some small improvements to the flow when you try to run a query and don't have a database selected.

If you don't have any existing databases then we won't bother asking you if you want to use one of those and skip straight to importing a new database.

Also changes a few progress and placeholder messages to be a little clearer (in my opinion. feel free to disagree)

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
