### PR TITLE
Stream CLI server command stderr instead of buffering

### DIFF
--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -362,8 +362,8 @@ export class CodeQLCliServer implements Disposable {
     silent?: boolean,
   ): Promise<string> {
     const stderrBuffers: Buffer[] = [];
-    // The array of fragments of stderr of this line. To be used for logging.
-    let currentLineStderrBuffers: Buffer[] = [];
+    // The current buffer of stderr of a single line. To be used for logging.
+    let currentLineStderrBuffer: Buffer = Buffer.alloc(0);
     if (this.commandInProcess) {
       throw new Error("runCodeQlCliInternal called while cli was running");
     }
@@ -423,28 +423,34 @@ export class CodeQLCliServer implements Disposable {
             stderrBuffers.push(newData);
 
             if (!silent) {
-              currentLineStderrBuffers.push(newData);
+              currentLineStderrBuffer = Buffer.concat([
+                currentLineStderrBuffer,
+                newData,
+              ]);
 
               // Print the stderr to the logger as it comes in. We need to ensure that
               // we don't split messages on the same line, so we buffer the stderr and
               // split it on EOLs.
-              let currentLineBuffer = Buffer.concat(currentLineStderrBuffers);
               const eolBuffer = Buffer.from(EOL);
-              if (currentLineBuffer.includes(eolBuffer)) {
-                while (currentLineBuffer.includes(eolBuffer)) {
-                  const line = currentLineBuffer.subarray(
-                    0,
-                    currentLineBuffer.indexOf(eolBuffer),
-                  );
 
-                  void this.logger.log(line.toString("utf-8"));
+              let hasCreatedSubarray = false;
 
-                  currentLineBuffer = currentLineBuffer.subarray(
-                    currentLineBuffer.indexOf(eolBuffer) + eolBuffer.length,
-                  );
-                }
+              let eolIndex;
+              while (
+                (eolIndex = currentLineStderrBuffer.indexOf(eolBuffer)) !== -1
+              ) {
+                const line = currentLineStderrBuffer.subarray(0, eolIndex);
+                void this.logger.log(line.toString("utf-8"));
+                currentLineStderrBuffer = currentLineStderrBuffer.subarray(
+                  eolIndex + eolBuffer.length,
+                );
+                hasCreatedSubarray = true;
+              }
 
-                currentLineStderrBuffers = [currentLineBuffer];
+              // We have created a subarray, which means that the complete original buffer is now referenced
+              // by the subarray. We need to create a new buffer to avoid memory leaks.
+              if (hasCreatedSubarray) {
+                currentLineStderrBuffer = Buffer.from(currentLineStderrBuffer);
               }
             }
           });
@@ -461,10 +467,8 @@ export class CodeQLCliServer implements Disposable {
         // Make sure we remove the terminator;
         const data = fullBuffer.toString("utf8", 0, fullBuffer.length - 1);
         if (!silent) {
-          void this.logger.log(
-            Buffer.concat(currentLineStderrBuffers).toString("utf8"),
-          );
-          currentLineStderrBuffers = [];
+          void this.logger.log(currentLineStderrBuffer.toString("utf8"));
+          currentLineStderrBuffer = Buffer.alloc(0);
           void this.logger.log("CLI command succeeded.");
         }
         return data;
@@ -484,10 +488,8 @@ export class CodeQLCliServer implements Disposable {
         cliError.stack += getErrorStack(err);
         throw cliError;
       } finally {
-        if (!silent && currentLineStderrBuffers.length > 0) {
-          void this.logger.log(
-            Buffer.concat(currentLineStderrBuffers).toString("utf8"),
-          );
+        if (!silent && currentLineStderrBuffer.length > 0) {
+          void this.logger.log(currentLineStderrBuffer.toString("utf8"));
         }
         // Remove the listeners we set up.
         process.stdout.removeAllListeners("data");


### PR DESCRIPTION
This streams the CLI server command stderr instead of buffering it and only printing it when the CLI command has completed. This helps users to know that something is actually happening for long-running commands. The full stderr will still be completed in an error when the command fails.

I think an easy way to test this is running a variant analysis. While the query is compiling, output should be streamed to the extension log output.

Closes https://github.com/github/vscode-codeql/issues/1459

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
