### PR TITLE
Add sentToLLM to ModelingStore

### DIFF
--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -543,8 +543,8 @@ interface SetInProgressMethodsMessage {
   methods: string[];
 }
 
-interface SetSentToLLMMethodsMessage {
-  t: "setSentToLLMMethods";
+interface SetProcessedByAutoModelMethodsMessage {
+  t: "setProcessedByAutoModelMethods";
   methods: string[];
 }
 
@@ -631,7 +631,7 @@ export type ToModelEditorMessage =
   | SetModeledMethodsMessage
   | SetModifiedMethodsMessage
   | SetInProgressMethodsMessage
-  | SetSentToLLMMethodsMessage
+  | SetProcessedByAutoModelMethodsMessage
   | RevealMethodMessage
   | SetAccessPathSuggestionsMessage;
 

--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -543,6 +543,11 @@ interface SetInProgressMethodsMessage {
   methods: string[];
 }
 
+interface SetSentToLLMMethodsMessage {
+  t: "setSentToLLMMethods";
+  methods: string[];
+}
+
 interface SwitchModeMessage {
   t: "switchMode";
   mode: Mode;
@@ -626,6 +631,7 @@ export type ToModelEditorMessage =
   | SetModeledMethodsMessage
   | SetModifiedMethodsMessage
   | SetInProgressMethodsMessage
+  | SetSentToLLMMethodsMessage
   | RevealMethodMessage
   | SetAccessPathSuggestionsMessage;
 

--- a/extensions/ql-vscode/src/model-editor/auto-modeler.ts
+++ b/extensions/ql-vscode/src/model-editor/auto-modeler.ts
@@ -161,7 +161,7 @@ export class AutoModeler {
           );
 
           // Let the UI know which methods have been sent to the LLM
-          this.modelingStore.addSentToLLMMethods(
+          this.modelingStore.addProcessedByAutoModelMethods(
             this.databaseItem,
             candidateSignatures,
           );

--- a/extensions/ql-vscode/src/model-editor/auto-modeler.ts
+++ b/extensions/ql-vscode/src/model-editor/auto-modeler.ts
@@ -159,6 +159,12 @@ export class AutoModeler {
             this.databaseItem,
             candidateSignatures,
           );
+
+          // Let the UI know which methods have been sent to the LLM
+          this.modelingStore.addSentToLLMMethods(
+            this.databaseItem,
+            candidateSignatures,
+          );
         }
       } finally {
         // Clear out in progress methods in case anything went wrong

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -836,6 +836,17 @@ export class ModelEditorView extends AbstractWebview<
     );
 
     this.push(
+      this.modelingEvents.onSentToLLMMethodsChanged(async (event) => {
+        if (event.dbUri === this.databaseItem.databaseUri.toString()) {
+          await this.postMessage({
+            t: "setSentToLLMMethods",
+            methods: Array.from(event.methods),
+          });
+        }
+      }),
+    );
+
+    this.push(
       this.modelingEvents.onRevealInModelEditor(async (event) => {
         if (event.dbUri === this.databaseItem.databaseUri.toString()) {
           await this.revealMethod(event.method);

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -836,14 +836,16 @@ export class ModelEditorView extends AbstractWebview<
     );
 
     this.push(
-      this.modelingEvents.onSentToLLMMethodsChanged(async (event) => {
-        if (event.dbUri === this.databaseItem.databaseUri.toString()) {
-          await this.postMessage({
-            t: "setSentToLLMMethods",
-            methods: Array.from(event.methods),
-          });
-        }
-      }),
+      this.modelingEvents.onProcessedByAutoModelMethodsChanged(
+        async (event) => {
+          if (event.dbUri === this.databaseItem.databaseUri.toString()) {
+            await this.postMessage({
+              t: "setProcessedByAutoModelMethods",
+              methods: Array.from(event.methods),
+            });
+          }
+        },
+      ),
     );
 
     this.push(

--- a/extensions/ql-vscode/src/model-editor/modeling-events.ts
+++ b/extensions/ql-vscode/src/model-editor/modeling-events.ts
@@ -42,7 +42,7 @@ interface SelectedMethodChangedEvent {
   readonly modeledMethods: readonly ModeledMethod[];
   readonly isModified: boolean;
   readonly isInProgress: boolean;
-  readonly hasBeenSentToLLM: boolean;
+  readonly processedByAutoModel: boolean;
 }
 
 interface InProgressMethodsChangedEvent {
@@ -50,7 +50,7 @@ interface InProgressMethodsChangedEvent {
   readonly methods: ReadonlySet<string>;
 }
 
-interface SentToLLMMethodsChangedEvent {
+interface ProcessedByAutoModelMethodsChangedEvent {
   readonly dbUri: string;
   readonly methods: ReadonlySet<string>;
 }
@@ -75,7 +75,7 @@ export class ModelingEvents extends DisposableObject {
   public readonly onModifiedMethodsChanged: AppEvent<ModifiedMethodsChangedEvent>;
   public readonly onSelectedMethodChanged: AppEvent<SelectedMethodChangedEvent>;
   public readonly onInProgressMethodsChanged: AppEvent<InProgressMethodsChangedEvent>;
-  public readonly onSentToLLMMethodsChanged: AppEvent<SentToLLMMethodsChangedEvent>;
+  public readonly onProcessedByAutoModelMethodsChanged: AppEvent<ProcessedByAutoModelMethodsChangedEvent>;
   public readonly onRevealInModelEditor: AppEvent<RevealInModelEditorEvent>;
   public readonly onFocusModelEditor: AppEvent<FocusModelEditorEvent>;
 
@@ -89,7 +89,7 @@ export class ModelingEvents extends DisposableObject {
   private readonly onModifiedMethodsChangedEventEmitter: AppEventEmitter<ModifiedMethodsChangedEvent>;
   private readonly onSelectedMethodChangedEventEmitter: AppEventEmitter<SelectedMethodChangedEvent>;
   private readonly onInProgressMethodsChangedEventEmitter: AppEventEmitter<InProgressMethodsChangedEvent>;
-  private readonly onSentToLLMMethodsChangedEventEmitter: AppEventEmitter<SentToLLMMethodsChangedEvent>;
+  private readonly onProcessedByAutoModelMethodsChangedEventEmitter: AppEventEmitter<ProcessedByAutoModelMethodsChangedEvent>;
   private readonly onRevealInModelEditorEventEmitter: AppEventEmitter<RevealInModelEditorEvent>;
   private readonly onFocusModelEditorEventEmitter: AppEventEmitter<FocusModelEditorEvent>;
 
@@ -149,11 +149,11 @@ export class ModelingEvents extends DisposableObject {
     this.onInProgressMethodsChanged =
       this.onInProgressMethodsChangedEventEmitter.event;
 
-    this.onSentToLLMMethodsChangedEventEmitter = this.push(
-      app.createEventEmitter<SentToLLMMethodsChangedEvent>(),
+    this.onProcessedByAutoModelMethodsChangedEventEmitter = this.push(
+      app.createEventEmitter<ProcessedByAutoModelMethodsChangedEvent>(),
     );
-    this.onSentToLLMMethodsChanged =
-      this.onSentToLLMMethodsChangedEventEmitter.event;
+    this.onProcessedByAutoModelMethodsChanged =
+      this.onProcessedByAutoModelMethodsChangedEventEmitter.event;
 
     this.onRevealInModelEditorEventEmitter = this.push(
       app.createEventEmitter<RevealInModelEditorEvent>(),
@@ -240,7 +240,7 @@ export class ModelingEvents extends DisposableObject {
     modeledMethods: ModeledMethod[],
     isModified: boolean,
     isInProgress: boolean,
-    hasBeenSentToLLM: boolean,
+    processedByAutoModel: boolean,
   ) {
     this.onSelectedMethodChangedEventEmitter.fire({
       databaseItem,
@@ -249,7 +249,7 @@ export class ModelingEvents extends DisposableObject {
       modeledMethods,
       isModified,
       isInProgress,
-      hasBeenSentToLLM,
+      processedByAutoModel,
     });
   }
 
@@ -263,11 +263,11 @@ export class ModelingEvents extends DisposableObject {
     });
   }
 
-  public fireSentToLLMMethodsChangedEvent(
+  public fireProcessedByAutoModelMethodsChangedEvent(
     dbUri: string,
     methods: ReadonlySet<string>,
   ) {
-    this.onSentToLLMMethodsChangedEventEmitter.fire({
+    this.onProcessedByAutoModelMethodsChangedEventEmitter.fire({
       dbUri,
       methods,
     });

--- a/extensions/ql-vscode/src/model-editor/modeling-events.ts
+++ b/extensions/ql-vscode/src/model-editor/modeling-events.ts
@@ -42,9 +42,15 @@ interface SelectedMethodChangedEvent {
   readonly modeledMethods: readonly ModeledMethod[];
   readonly isModified: boolean;
   readonly isInProgress: boolean;
+  readonly hasBeenSentToLLM: boolean;
 }
 
 interface InProgressMethodsChangedEvent {
+  readonly dbUri: string;
+  readonly methods: ReadonlySet<string>;
+}
+
+interface SentToLLMMethodsChangedEvent {
   readonly dbUri: string;
   readonly methods: ReadonlySet<string>;
 }
@@ -69,6 +75,7 @@ export class ModelingEvents extends DisposableObject {
   public readonly onModifiedMethodsChanged: AppEvent<ModifiedMethodsChangedEvent>;
   public readonly onSelectedMethodChanged: AppEvent<SelectedMethodChangedEvent>;
   public readonly onInProgressMethodsChanged: AppEvent<InProgressMethodsChangedEvent>;
+  public readonly onSentToLLMMethodsChanged: AppEvent<SentToLLMMethodsChangedEvent>;
   public readonly onRevealInModelEditor: AppEvent<RevealInModelEditorEvent>;
   public readonly onFocusModelEditor: AppEvent<FocusModelEditorEvent>;
 
@@ -82,6 +89,7 @@ export class ModelingEvents extends DisposableObject {
   private readonly onModifiedMethodsChangedEventEmitter: AppEventEmitter<ModifiedMethodsChangedEvent>;
   private readonly onSelectedMethodChangedEventEmitter: AppEventEmitter<SelectedMethodChangedEvent>;
   private readonly onInProgressMethodsChangedEventEmitter: AppEventEmitter<InProgressMethodsChangedEvent>;
+  private readonly onSentToLLMMethodsChangedEventEmitter: AppEventEmitter<SentToLLMMethodsChangedEvent>;
   private readonly onRevealInModelEditorEventEmitter: AppEventEmitter<RevealInModelEditorEvent>;
   private readonly onFocusModelEditorEventEmitter: AppEventEmitter<FocusModelEditorEvent>;
 
@@ -140,6 +148,12 @@ export class ModelingEvents extends DisposableObject {
     );
     this.onInProgressMethodsChanged =
       this.onInProgressMethodsChangedEventEmitter.event;
+
+    this.onSentToLLMMethodsChangedEventEmitter = this.push(
+      app.createEventEmitter<SentToLLMMethodsChangedEvent>(),
+    );
+    this.onSentToLLMMethodsChanged =
+      this.onSentToLLMMethodsChangedEventEmitter.event;
 
     this.onRevealInModelEditorEventEmitter = this.push(
       app.createEventEmitter<RevealInModelEditorEvent>(),
@@ -226,6 +240,7 @@ export class ModelingEvents extends DisposableObject {
     modeledMethods: ModeledMethod[],
     isModified: boolean,
     isInProgress: boolean,
+    hasBeenSentToLLM: boolean,
   ) {
     this.onSelectedMethodChangedEventEmitter.fire({
       databaseItem,
@@ -234,6 +249,7 @@ export class ModelingEvents extends DisposableObject {
       modeledMethods,
       isModified,
       isInProgress,
+      hasBeenSentToLLM,
     });
   }
 
@@ -242,6 +258,16 @@ export class ModelingEvents extends DisposableObject {
     methods: ReadonlySet<string>,
   ) {
     this.onInProgressMethodsChangedEventEmitter.fire({
+      dbUri,
+      methods,
+    });
+  }
+
+  public fireSentToLLMMethodsChangedEvent(
+    dbUri: string,
+    methods: ReadonlySet<string>,
+  ) {
+    this.onSentToLLMMethodsChangedEventEmitter.fire({
       dbUri,
       methods,
     });

--- a/extensions/ql-vscode/src/model-editor/modeling-store.ts
+++ b/extensions/ql-vscode/src/model-editor/modeling-store.ts
@@ -14,6 +14,7 @@ interface InternalDbModelingState {
   modeledMethods: Record<string, ModeledMethod[]>;
   modifiedMethodSignatures: Set<string>;
   inProgressMethods: Set<string>;
+  sentToLLMMethods: Set<string>;
   selectedMethod: Method | undefined;
   selectedUsage: Usage | undefined;
 }
@@ -26,6 +27,7 @@ interface DbModelingState {
   readonly modeledMethods: Readonly<Record<string, readonly ModeledMethod[]>>;
   readonly modifiedMethodSignatures: ReadonlySet<string>;
   readonly inProgressMethods: ReadonlySet<string>;
+  readonly sentToLLMMethods: ReadonlySet<string>;
   readonly selectedMethod: Method | undefined;
   readonly selectedUsage: Usage | undefined;
 }
@@ -37,6 +39,7 @@ interface SelectedMethodDetails {
   readonly modeledMethods: readonly ModeledMethod[];
   readonly isModified: boolean;
   readonly isInProgress: boolean;
+  readonly hasBeenSentToLLM: boolean;
 }
 
 export class ModelingStore extends DisposableObject {
@@ -59,6 +62,7 @@ export class ModelingStore extends DisposableObject {
       mode,
       modeledMethods: {},
       modifiedMethodSignatures: new Set(),
+      sentToLLMMethods: new Set(),
       selectedMethod: undefined,
       selectedUsage: undefined,
       inProgressMethods: new Set(),
@@ -301,6 +305,7 @@ export class ModelingStore extends DisposableObject {
     const modeledMethods = dbState.modeledMethods[method.signature] ?? [];
     const isModified = dbState.modifiedMethodSignatures.has(method.signature);
     const isInProgress = dbState.inProgressMethods.has(method.signature);
+    const hasBeenSentToLLM = dbState.sentToLLMMethods.has(method.signature);
     this.modelingEvents.fireSelectedMethodChangedEvent(
       dbItem,
       method,
@@ -308,6 +313,7 @@ export class ModelingStore extends DisposableObject {
       modeledMethods,
       isModified,
       isInProgress,
+      hasBeenSentToLLM,
     );
   }
 
@@ -336,6 +342,15 @@ export class ModelingStore extends DisposableObject {
     });
   }
 
+  public addSentToLLMMethods(dbItem: DatabaseItem, sentToLLMMethods: string[]) {
+    this.changeSentToLLMMethods(dbItem, (state) => {
+      state.sentToLLMMethods = new Set([
+        ...state.sentToLLMMethods,
+        ...sentToLLMMethods,
+      ]);
+    });
+  }
+
   public getSelectedMethodDetails(): SelectedMethodDetails | undefined {
     const dbState = this.getInternalStateForActiveDb();
     if (!dbState) {
@@ -356,6 +371,7 @@ export class ModelingStore extends DisposableObject {
         selectedMethod.signature,
       ),
       isInProgress: dbState.inProgressMethods.has(selectedMethod.signature),
+      hasBeenSentToLLM: dbState.sentToLLMMethods.has(selectedMethod.signature),
     };
   }
 
@@ -410,6 +426,20 @@ export class ModelingStore extends DisposableObject {
     this.modelingEvents.fireInProgressMethodsChangedEvent(
       dbItem.databaseUri.toString(),
       state.inProgressMethods,
+    );
+  }
+
+  private changeSentToLLMMethods(
+    dbItem: DatabaseItem,
+    updateState: (state: InternalDbModelingState) => void,
+  ) {
+    const state = this.getState(dbItem);
+
+    updateState(state);
+
+    this.modelingEvents.fireSentToLLMMethodsChangedEvent(
+      dbItem.databaseUri.toString(),
+      state.sentToLLMMethods,
     );
   }
 }

--- a/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
@@ -148,6 +148,10 @@ export function ModelEditor({
             setInProgressMethods(new Set(msg.methods));
             break;
           }
+          case "setSentToLLMMethods": {
+            // TODO: set state
+            break;
+          }
           case "revealMethod":
             setRevealedMethodSignature(msg.methodSignature);
             break;

--- a/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
@@ -148,7 +148,7 @@ export function ModelEditor({
             setInProgressMethods(new Set(msg.methods));
             break;
           }
-          case "setSentToLLMMethods": {
+          case "setProcessedByAutoModelMethods": {
             // TODO: set state
             break;
           }

--- a/extensions/ql-vscode/test/__mocks__/model-editor/modelingEventsMock.ts
+++ b/extensions/ql-vscode/test/__mocks__/model-editor/modelingEventsMock.ts
@@ -10,6 +10,7 @@ export function createMockModelingEvents({
   onModeledMethodsChanged = jest.fn(),
   onModifiedMethodsChanged = jest.fn(),
   onInProgressMethodsChanged = jest.fn(),
+  onProcessedByAutoModelMethodsChanged = jest.fn(),
   onRevealInModelEditor = jest.fn(),
   onFocusModelEditor = jest.fn(),
 }: {
@@ -21,6 +22,7 @@ export function createMockModelingEvents({
   onModeledMethodsChanged?: ModelingEvents["onModeledMethodsChanged"];
   onModifiedMethodsChanged?: ModelingEvents["onModifiedMethodsChanged"];
   onInProgressMethodsChanged?: ModelingEvents["onInProgressMethodsChanged"];
+  onProcessedByAutoModelMethodsChanged?: ModelingEvents["onProcessedByAutoModelMethodsChanged"];
   onRevealInModelEditor?: ModelingEvents["onRevealInModelEditor"];
   onFocusModelEditor?: ModelingEvents["onFocusModelEditor"];
 } = {}): ModelingEvents {
@@ -33,6 +35,7 @@ export function createMockModelingEvents({
     onModeledMethodsChanged,
     onModifiedMethodsChanged,
     onInProgressMethodsChanged,
+    onProcessedByAutoModelMethodsChanged,
     onRevealInModelEditor,
     onFocusModelEditor,
   });


### PR DESCRIPTION
This PR adds a new `sentToLLMMethods: Set<string>` field to `ModelingStore` along with all the associated events and plumbing.

Note: very open to suggestions for the naming of fields/methods. Naming is hard 😢 

The intention here is to very simply track which methods have been sent to the LLM in the current modeling session (i.e. it'll be reset if the model editor is closed and reopened). This state can be used along with the set of modeled methods to identify the set of positive and negative predictions from the LLM.

Methods are added to `sentToLLMMethods` whenever we successfully receive a response from the LLM. We add all methods from that batch, regardless of the modelings included in the LLM response. Currently there's no way to remove methods from `sentToLLMMethods` because we want the state to persist for the remainder of the session, but there's no reason a way of removing methods from this set couldn't be added.

UI changes for positive and negative LLM predictions will come in future PRs. Here we're just laying the groundwork.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
