### PR TITLE
Add `processedByAutoModelMethods` state to React view

### DIFF
--- a/extensions/ql-vscode/src/view/model-editor/LibraryRow.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/LibraryRow.tsx
@@ -74,6 +74,7 @@ export type LibraryRowProps = {
   modifiedSignatures: Set<string>;
   selectedSignatures: Set<string>;
   inProgressMethods: Set<string>;
+  processedByAutoModelMethods: Set<string>;
   viewState: ModelEditorViewState;
   hideModeledMethods: boolean;
   revealedMethodSignature: string | null;
@@ -98,6 +99,7 @@ export const LibraryRow = ({
   modifiedSignatures,
   selectedSignatures,
   inProgressMethods,
+  processedByAutoModelMethods,
   viewState,
   hideModeledMethods,
   revealedMethodSignature,
@@ -237,6 +239,7 @@ export const LibraryRow = ({
             modifiedSignatures={modifiedSignatures}
             selectedSignatures={selectedSignatures}
             inProgressMethods={inProgressMethods}
+            processedByAutoModelMethods={processedByAutoModelMethods}
             viewState={viewState}
             hideModeledMethods={hideModeledMethods}
             revealedMethodSignature={revealedMethodSignature}

--- a/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
@@ -75,6 +75,7 @@ export type MethodRowProps = {
   methodIsUnsaved: boolean;
   methodIsSelected: boolean;
   modelingInProgress: boolean;
+  processedByAutoModel: boolean;
   viewState: ModelEditorViewState;
   revealedMethodSignature: string | null;
   inputAccessPathSuggestions?: AccessPathOption[];

--- a/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
@@ -103,6 +103,8 @@ export function ModelEditor({
   const [inProgressMethods, setInProgressMethods] = useState<Set<string>>(
     new Set(),
   );
+  const [processedByAutoModelMethods, setProcessedByAutoModelMethods] =
+    useState<Set<string>>(new Set());
 
   const [hideModeledMethods, setHideModeledMethods] = useState(
     initialHideModeledMethods,
@@ -149,7 +151,7 @@ export function ModelEditor({
             break;
           }
           case "setProcessedByAutoModelMethods": {
-            // TODO: set state
+            setProcessedByAutoModelMethods(new Set(msg.methods));
             break;
           }
           case "revealMethod":
@@ -392,6 +394,7 @@ export function ModelEditor({
           modifiedSignatures={modifiedSignatures}
           selectedSignatures={selectedSignatures}
           inProgressMethods={inProgressMethods}
+          processedByAutoModelMethods={processedByAutoModelMethods}
           viewState={viewState}
           hideModeledMethods={hideModeledMethods}
           revealedMethodSignature={revealedMethodSignature}

--- a/extensions/ql-vscode/src/view/model-editor/ModeledMethodDataGrid.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModeledMethodDataGrid.tsx
@@ -19,6 +19,7 @@ export type ModeledMethodDataGridProps = {
   modifiedSignatures: Set<string>;
   selectedSignatures: Set<string>;
   inProgressMethods: Set<string>;
+  processedByAutoModelMethods: Set<string>;
   viewState: ModelEditorViewState;
   hideModeledMethods: boolean;
   revealedMethodSignature: string | null;
@@ -33,6 +34,7 @@ export const ModeledMethodDataGrid = ({
   modifiedSignatures,
   selectedSignatures,
   inProgressMethods,
+  processedByAutoModelMethods,
   viewState,
   hideModeledMethods,
   revealedMethodSignature,
@@ -93,6 +95,9 @@ export const ModeledMethodDataGrid = ({
                 methodIsUnsaved={modifiedSignatures.has(method.signature)}
                 methodIsSelected={selectedSignatures.has(method.signature)}
                 modelingInProgress={inProgressMethods.has(method.signature)}
+                processedByAutoModel={processedByAutoModelMethods.has(
+                  method.signature,
+                )}
                 viewState={viewState}
                 revealedMethodSignature={revealedMethodSignature}
                 inputAccessPathSuggestions={inputAccessPathSuggestions}

--- a/extensions/ql-vscode/src/view/model-editor/ModeledMethodsList.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModeledMethodsList.tsx
@@ -16,6 +16,7 @@ export type ModeledMethodsListProps = {
   modifiedSignatures: Set<string>;
   selectedSignatures: Set<string>;
   inProgressMethods: Set<string>;
+  processedByAutoModelMethods: Set<string>;
   revealedMethodSignature: string | null;
   accessPathSuggestions?: AccessPathSuggestionOptions;
   viewState: ModelEditorViewState;
@@ -42,6 +43,7 @@ export const ModeledMethodsList = ({
   modifiedSignatures,
   selectedSignatures,
   inProgressMethods,
+  processedByAutoModelMethods,
   viewState,
   hideModeledMethods,
   revealedMethodSignature,
@@ -91,6 +93,7 @@ export const ModeledMethodsList = ({
           modifiedSignatures={modifiedSignatures}
           selectedSignatures={selectedSignatures}
           inProgressMethods={inProgressMethods}
+          processedByAutoModelMethods={processedByAutoModelMethods}
           viewState={viewState}
           hideModeledMethods={hideModeledMethods}
           revealedMethodSignature={revealedMethodSignature}

--- a/extensions/ql-vscode/src/view/model-editor/__tests__/LibraryRow.spec.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/__tests__/LibraryRow.spec.tsx
@@ -36,6 +36,7 @@ describe(LibraryRow.name, () => {
         modifiedSignatures={new Set([method.signature])}
         selectedSignatures={new Set()}
         inProgressMethods={new Set()}
+        processedByAutoModelMethods={new Set()}
         viewState={viewState}
         hideModeledMethods={false}
         revealedMethodSignature={null}

--- a/extensions/ql-vscode/src/view/model-editor/__tests__/MethodRow.spec.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/__tests__/MethodRow.spec.tsx
@@ -43,6 +43,7 @@ describe(MethodRow.name, () => {
         methodIsUnsaved={false}
         methodIsSelected={false}
         modelingInProgress={false}
+        processedByAutoModel={false}
         revealedMethodSignature={null}
         viewState={viewState}
         onChange={onChange}

--- a/extensions/ql-vscode/src/view/model-editor/__tests__/ModeledMethodDataGrid.spec.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/__tests__/ModeledMethodDataGrid.spec.tsx
@@ -58,6 +58,7 @@ describe(ModeledMethodDataGrid.name, () => {
         modifiedSignatures={new Set([method1.signature])}
         selectedSignatures={new Set()}
         inProgressMethods={new Set()}
+        processedByAutoModelMethods={new Set()}
         viewState={viewState}
         hideModeledMethods={false}
         revealedMethodSignature={null}

--- a/extensions/ql-vscode/src/view/model-editor/__tests__/ModeledMethodsList.spec.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/__tests__/ModeledMethodsList.spec.tsx
@@ -59,6 +59,7 @@ describe(ModeledMethodsList.name, () => {
         modifiedSignatures={new Set([method1.signature])}
         selectedSignatures={new Set()}
         inProgressMethods={new Set()}
+        processedByAutoModelMethods={new Set()}
         viewState={viewState}
         hideModeledMethods={false}
         revealedMethodSignature={null}


### PR DESCRIPTION
This adds the `processedByAutoModelMethods` state to the React view, and also passes the state down to `MethodRow` to ensure that the state is used.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
