### PR TITLE
Don't send methods to AutoModel more than once

### DIFF
--- a/extensions/ql-vscode/src/model-editor/auto-model.ts
+++ b/extensions/ql-vscode/src/model-editor/auto-model.ts
@@ -22,7 +22,13 @@ export function getCandidates(
   mode: Mode,
   methods: readonly Method[],
   modeledMethodsBySignature: Record<string, readonly ModeledMethod[]>,
+  processedByAutoModelMethods: Set<string>,
 ): MethodSignature[] {
+  // Filter out any methods already processed by auto-model
+  methods = methods.filter(
+    (m) => !processedByAutoModelMethods.has(m.signature),
+  );
+
   // Sort the same way as the UI so we send the first ones listed in the UI first
   const grouped = groupMethods(methods, mode);
   const sortedGroupNames = sortGroupNames(grouped);

--- a/extensions/ql-vscode/src/model-editor/auto-modeler.ts
+++ b/extensions/ql-vscode/src/model-editor/auto-modeler.ts
@@ -58,6 +58,7 @@ export class AutoModeler {
     packageName: string,
     methods: readonly Method[],
     modeledMethods: Record<string, readonly ModeledMethod[]>,
+    processedByAutoModelMethods: Set<string>,
     mode: Mode,
   ): Promise<void> {
     if (this.jobs.has(packageName)) {
@@ -72,6 +73,7 @@ export class AutoModeler {
         packageName,
         methods,
         modeledMethods,
+        processedByAutoModelMethods,
         mode,
         cancellationTokenSource,
       );
@@ -105,6 +107,7 @@ export class AutoModeler {
     packageName: string,
     methods: readonly Method[],
     modeledMethods: Record<string, readonly ModeledMethod[]>,
+    processedByAutoModelMethods: Set<string>,
     mode: Mode,
     cancellationTokenSource: CancellationTokenSource,
   ): Promise<void> {
@@ -114,7 +117,12 @@ export class AutoModeler {
 
     await withProgress(async (progress) => {
       // Fetch the candidates to send to the model
-      const allCandidateMethods = getCandidates(mode, methods, modeledMethods);
+      const allCandidateMethods = getCandidates(
+        mode,
+        methods,
+        modeledMethods,
+        processedByAutoModelMethods,
+      );
 
       // If there are no candidates, there is nothing to model and we just return
       if (allCandidateMethods.length === 0) {

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -656,7 +656,10 @@ export class ModelEditorView extends AbstractWebview<
       methodSignatures,
     );
     const processedByAutoModelMethods =
-      this.modelingStore.getProcessedByAutoModelMethods(this.databaseItem);
+      this.modelingStore.getProcessedByAutoModelMethods(
+        this.databaseItem,
+        methodSignatures,
+      );
     const mode = this.modelingStore.getMode(this.databaseItem);
     await this.autoModeler.startModeling(
       packageName,

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -655,11 +655,14 @@ export class ModelEditorView extends AbstractWebview<
       this.databaseItem,
       methodSignatures,
     );
+    const processedByAutoModelMethods =
+      this.modelingStore.getProcessedByAutoModelMethods(this.databaseItem);
     const mode = this.modelingStore.getMode(this.databaseItem);
     await this.autoModeler.startModeling(
       packageName,
       methods,
       modeledMethods,
+      processedByAutoModelMethods,
       mode,
     );
   }

--- a/extensions/ql-vscode/src/model-editor/modeling-store.ts
+++ b/extensions/ql-vscode/src/model-editor/modeling-store.ts
@@ -344,6 +344,20 @@ export class ModelingStore extends DisposableObject {
     });
   }
 
+  public getProcessedByAutoModelMethods(
+    dbItem: DatabaseItem,
+    methodSignatures?: string[],
+  ): Set<string> {
+    const processedByAutoModelMethods =
+      this.getState(dbItem).processedByAutoModelMethods;
+    if (!methodSignatures) {
+      return processedByAutoModelMethods;
+    }
+    return new Set(
+      Array.from(processedByAutoModelMethods).filter(methodSignatures.includes),
+    );
+  }
+
   public addProcessedByAutoModelMethods(
     dbItem: DatabaseItem,
     processedByAutoModelMethods: string[],

--- a/extensions/ql-vscode/src/model-editor/modeling-store.ts
+++ b/extensions/ql-vscode/src/model-editor/modeling-store.ts
@@ -354,7 +354,9 @@ export class ModelingStore extends DisposableObject {
       return processedByAutoModelMethods;
     }
     return new Set(
-      Array.from(processedByAutoModelMethods).filter(methodSignatures.includes),
+      Array.from(processedByAutoModelMethods).filter((x) =>
+        methodSignatures.includes(x),
+      ),
     );
   }
 

--- a/extensions/ql-vscode/test/unit-tests/model-editor/auto-model.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/model-editor/auto-model.test.ts
@@ -116,7 +116,12 @@ describe("getCandidates", () => {
         },
       ],
     };
-    const candidates = getCandidates(Mode.Application, methods, modeledMethods);
+    const candidates = getCandidates(
+      Mode.Application,
+      methods,
+      modeledMethods,
+      new Set(),
+    );
     expect(candidates.length).toEqual(0);
   });
 
@@ -136,7 +141,37 @@ describe("getCandidates", () => {
       },
     ];
     const modeledMethods = {};
-    const candidates = getCandidates(Mode.Application, methods, modeledMethods);
+    const candidates = getCandidates(
+      Mode.Application,
+      methods,
+      modeledMethods,
+      new Set(),
+    );
+    expect(candidates.length).toEqual(0);
+  });
+
+  it("doesn't return methods that are already processed by auto model", () => {
+    const methods: Method[] = [
+      {
+        library: "my.jar",
+        signature: "org.my.A#x()",
+        endpointType: EndpointType.Method,
+        packageName: "org.my",
+        typeName: "A",
+        methodName: "x",
+        methodParameters: "()",
+        supported: false,
+        supportedType: "none",
+        usages: [],
+      },
+    ];
+    const modeledMethods = {};
+    const candidates = getCandidates(
+      Mode.Application,
+      methods,
+      modeledMethods,
+      new Set(["org.my.A#x()"]),
+    );
     expect(candidates.length).toEqual(0);
   });
 
@@ -155,7 +190,12 @@ describe("getCandidates", () => {
       usages: [],
     });
     const modeledMethods = {};
-    const candidates = getCandidates(Mode.Application, methods, modeledMethods);
+    const candidates = getCandidates(
+      Mode.Application,
+      methods,
+      modeledMethods,
+      new Set(),
+    );
     expect(candidates.length).toEqual(1);
   });
 });


### PR DESCRIPTION
Once a method has been processed by AutoModel once, don't try to process it again. Pretty simple now we have `processedByAutoModelMethods` available.

The only problem I've noticed with this is that it can make the UI confusing when there's nothing to model. You'll press to "model with AI" button and it'll appear to do nothing. I'm going to open a separate PR to follow this one to try to address that.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
