### PR TITLE
Add processed by auto model state to method modeling panel

### DIFF
--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -615,6 +615,11 @@ interface SetInProgressMessage {
   inProgress: boolean;
 }
 
+interface SetProcessedByAutoModelMessage {
+  t: "setProcessedByAutoModel";
+  processedByAutoModel: boolean;
+}
+
 interface RevealMethodMessage {
   t: "revealMethod";
   methodSignature: string;
@@ -686,6 +691,7 @@ interface SetSelectedMethodMessage {
   modeledMethods: ModeledMethod[];
   isModified: boolean;
   isInProgress: boolean;
+  processedByAutoModel: boolean;
 }
 
 export type ToMethodModelingMessage =
@@ -695,4 +701,5 @@ export type ToMethodModelingMessage =
   | SetMethodModifiedMessage
   | SetSelectedMethodMessage
   | SetInModelingModeMessage
-  | SetInProgressMessage;
+  | SetInProgressMessage
+  | SetProcessedByAutoModelMessage;

--- a/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
+++ b/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
@@ -82,6 +82,7 @@ export class MethodModelingViewProvider extends AbstractWebviewViewProvider<
           modeledMethods: selectedMethod.modeledMethods,
           isModified: selectedMethod.isModified,
           isInProgress: selectedMethod.isInProgress,
+          processedByAutoModel: selectedMethod.processedByAutoModel,
         });
       }
 
@@ -200,6 +201,7 @@ export class MethodModelingViewProvider extends AbstractWebviewViewProvider<
             modeledMethods: e.modeledMethods,
             isModified: e.isModified,
             isInProgress: e.isInProgress,
+            processedByAutoModel: e.processedByAutoModel,
           });
         }
       }),
@@ -243,6 +245,21 @@ export class MethodModelingViewProvider extends AbstractWebviewViewProvider<
             await this.postMessage({
               t: "setInProgress",
               inProgress,
+            });
+          }
+        }
+      }),
+    );
+
+    this.push(
+      this.modelingEvents.onProcessedByAutoModelMethodsChanged(async (e) => {
+        if (this.method && this.databaseItem) {
+          const dbUri = this.databaseItem.databaseUri.toString();
+          if (e.dbUri === dbUri) {
+            const processedByAutoModel = e.methods.has(this.method.signature);
+            await this.postMessage({
+              t: "setProcessedByAutoModel",
+              processedByAutoModel,
             });
           }
         }

--- a/extensions/ql-vscode/src/model-editor/modeled-method.ts
+++ b/extensions/ql-vscode/src/model-editor/modeled-method.ts
@@ -114,7 +114,7 @@ export function modeledMethodSupportsProvenance(
 export function isModelPending(
   modeledMethod: ModeledMethod | undefined,
   modelingStatus: ModelingStatus,
-  processedByAutoModel?: boolean,
+  processedByAutoModel: boolean,
 ): boolean {
   if (
     (!modeledMethod || modeledMethod.type === "none") &&

--- a/extensions/ql-vscode/src/view/method-modeling/MethodModeling.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/MethodModeling.tsx
@@ -54,6 +54,7 @@ export type MethodModelingProps = {
   method: Method;
   modeledMethods: ModeledMethod[];
   isModelingInProgress: boolean;
+  isProcessedByAutoModel: boolean;
   onChange: (methodSignature: string, modeledMethods: ModeledMethod[]) => void;
 };
 
@@ -63,6 +64,7 @@ export const MethodModeling = ({
   modeledMethods,
   method,
   isModelingInProgress,
+  isProcessedByAutoModel,
   onChange,
 }: MethodModelingProps): React.JSX.Element => {
   return (
@@ -81,6 +83,7 @@ export const MethodModeling = ({
         method={method}
         modeledMethods={modeledMethods}
         isModelingInProgress={isModelingInProgress}
+        isProcessedByAutoModel={isProcessedByAutoModel}
         modelingStatus={modelingStatus}
         onChange={onChange}
       />

--- a/extensions/ql-vscode/src/view/method-modeling/MethodModelingView.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/MethodModelingView.tsx
@@ -33,6 +33,9 @@ export function MethodModelingView({
   const [isModelingInProgress, setIsModelingInProgress] =
     useState<boolean>(false);
 
+  const [isProcessedByAutoModel, setIsProcessedByAutoModel] =
+    useState<boolean>(false);
+
   const modelingStatus = useMemo(
     () => getModelingStatus(modeledMethods, isMethodModified),
     [modeledMethods, isMethodModified],
@@ -62,9 +65,14 @@ export function MethodModelingView({
             setMethod(msg.method);
             setModeledMethods(msg.modeledMethods);
             setIsMethodModified(msg.isModified);
+            setIsModelingInProgress(msg.isInProgress);
+            setIsProcessedByAutoModel(msg.processedByAutoModel);
             break;
           case "setInProgress":
             setIsModelingInProgress(msg.inProgress);
+            break;
+          case "setProcessedByAutoModel":
+            setIsProcessedByAutoModel(msg.processedByAutoModel);
             break;
           default:
             assertNever(msg);
@@ -112,6 +120,7 @@ export function MethodModelingView({
       method={method}
       modeledMethods={modeledMethods}
       isModelingInProgress={isModelingInProgress}
+      isProcessedByAutoModel={isProcessedByAutoModel}
       onChange={onChange}
     />
   );

--- a/extensions/ql-vscode/src/view/method-modeling/MultipleModeledMethodsPanel.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/MultipleModeledMethodsPanel.tsx
@@ -172,7 +172,11 @@ export const MultipleModeledMethodsPanel = ({
           language={language}
           method={method}
           modeledMethod={undefined}
-          modelPending={false}
+          modelPending={isModelPending(
+            modeledMethods[selectedIndex],
+            modelingStatus,
+            isProcessedByAutoModel,
+          )}
           isModelingInProgress={isModelingInProgress}
           onChange={handleChange}
         />

--- a/extensions/ql-vscode/src/view/method-modeling/MultipleModeledMethodsPanel.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/MultipleModeledMethodsPanel.tsx
@@ -23,6 +23,7 @@ export type MultipleModeledMethodsPanelProps = {
   modeledMethods: ModeledMethod[];
   modelingStatus: ModelingStatus;
   isModelingInProgress: boolean;
+  isProcessedByAutoModel: boolean;
   onChange: (methodSignature: string, modeledMethods: ModeledMethod[]) => void;
 };
 
@@ -64,6 +65,7 @@ export const MultipleModeledMethodsPanel = ({
   modeledMethods,
   modelingStatus,
   isModelingInProgress,
+  isProcessedByAutoModel,
   onChange,
 }: MultipleModeledMethodsPanelProps) => {
   const [selectedIndex, setSelectedIndex] = useState<number>(0);
@@ -160,6 +162,7 @@ export const MultipleModeledMethodsPanel = ({
           modelPending={isModelPending(
             modeledMethods[selectedIndex],
             modelingStatus,
+            isProcessedByAutoModel,
           )}
           isModelingInProgress={isModelingInProgress}
           onChange={handleChange}

--- a/extensions/ql-vscode/src/view/method-modeling/__tests__/MethodModeling.spec.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/__tests__/MethodModeling.spec.tsx
@@ -13,6 +13,7 @@ describe(MethodModeling.name, () => {
     const method = createMethod();
     const modeledMethod = createSinkModeledMethod();
     const isModelingInProgress = false;
+    const isProcessedByAutoModel = false;
     const onChange = jest.fn();
 
     render({
@@ -21,6 +22,7 @@ describe(MethodModeling.name, () => {
       method,
       modeledMethods: [modeledMethod],
       isModelingInProgress,
+      isProcessedByAutoModel,
       onChange,
     });
 

--- a/extensions/ql-vscode/src/view/method-modeling/__tests__/MultipleModeledMethodsPanel.spec.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/__tests__/MultipleModeledMethodsPanel.spec.tsx
@@ -18,6 +18,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
   const language = QueryLanguage.Java;
   const method = createMethod();
   const isModelingInProgress = false;
+  const isProcessedByAutoModel = false;
   const modelingStatus = "unmodeled";
   const onChange = jest.fn<void, [string, ModeledMethod[]]>();
 
@@ -31,6 +32,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         modeledMethods,
         modelingStatus,
         isModelingInProgress,
+        isProcessedByAutoModel,
         onChange,
       });
 
@@ -49,6 +51,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         modeledMethods,
         modelingStatus,
         isModelingInProgress,
+        isProcessedByAutoModel,
         onChange,
       });
 
@@ -71,6 +74,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         modeledMethods,
         modelingStatus,
         isModelingInProgress,
+        isProcessedByAutoModel,
         onChange,
       });
 
@@ -102,6 +106,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         modeledMethods,
         modelingStatus,
         isModelingInProgress,
+        isProcessedByAutoModel,
         onChange,
       });
 
@@ -120,6 +125,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         modeledMethods,
         modelingStatus,
         isModelingInProgress,
+        isProcessedByAutoModel,
         onChange,
       });
 
@@ -141,6 +147,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         modeledMethods,
         modelingStatus,
         isModelingInProgress,
+        isProcessedByAutoModel,
         onChange,
       });
 
@@ -158,6 +165,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         modeledMethods,
         modelingStatus,
         isModelingInProgress,
+        isProcessedByAutoModel,
         onChange,
       });
 
@@ -184,6 +192,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         modeledMethods,
         modelingStatus,
         isModelingInProgress,
+        isProcessedByAutoModel,
         onChange,
       });
 
@@ -197,6 +206,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
             onChange.mock.calls[onChange.mock.calls.length - 1][1]
           }
           isModelingInProgress={isModelingInProgress}
+          isProcessedByAutoModel={isProcessedByAutoModel}
           modelingStatus={modelingStatus}
           onChange={onChange}
         />,
@@ -222,6 +232,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        isProcessedByAutoModel,
         modelingStatus,
         onChange,
       });
@@ -240,6 +251,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        isProcessedByAutoModel,
         modelingStatus,
         onChange,
       });
@@ -255,6 +267,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        isProcessedByAutoModel,
         modelingStatus,
         onChange,
       });
@@ -275,6 +288,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        isProcessedByAutoModel,
         modelingStatus,
         onChange,
       });
@@ -312,6 +326,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        isProcessedByAutoModel,
         modelingStatus,
         onChange,
       });
@@ -324,6 +339,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
           method={method}
           modeledMethods={[modeledMethods[1]]}
           isModelingInProgress={isModelingInProgress}
+          isProcessedByAutoModel={isProcessedByAutoModel}
           modelingStatus={modelingStatus}
           onChange={onChange}
         />,
@@ -343,6 +359,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        isProcessedByAutoModel,
         modelingStatus,
         onChange,
       });
@@ -356,6 +373,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        isProcessedByAutoModel,
         modelingStatus,
         onChange,
       });
@@ -389,6 +407,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        isProcessedByAutoModel,
         modelingStatus,
         onChange,
       });
@@ -424,6 +443,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        isProcessedByAutoModel,
         modelingStatus,
         onChange,
       });
@@ -442,6 +462,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        isProcessedByAutoModel,
         modelingStatus,
         onChange,
       });
@@ -468,6 +489,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        isProcessedByAutoModel,
         modelingStatus,
         onChange,
       });
@@ -482,6 +504,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
             onChange.mock.calls[onChange.mock.calls.length - 1][1]
           }
           isModelingInProgress={isModelingInProgress}
+          isProcessedByAutoModel={isProcessedByAutoModel}
           modelingStatus={modelingStatus}
           onChange={onChange}
         />,
@@ -503,6 +526,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
             onChange.mock.calls[onChange.mock.calls.length - 1][1]
           }
           isModelingInProgress={isModelingInProgress}
+          isProcessedByAutoModel={isProcessedByAutoModel}
           modelingStatus={modelingStatus}
           onChange={onChange}
         />,
@@ -522,6 +546,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
             onChange.mock.calls[onChange.mock.calls.length - 1][1]
           }
           isModelingInProgress={isModelingInProgress}
+          isProcessedByAutoModel={isProcessedByAutoModel}
           modelingStatus={modelingStatus}
           onChange={onChange}
         />,
@@ -539,6 +564,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        isProcessedByAutoModel,
         modelingStatus,
         onChange,
       });
@@ -555,6 +581,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
             onChange.mock.calls[onChange.mock.calls.length - 1][1]
           }
           isModelingInProgress={isModelingInProgress}
+          isProcessedByAutoModel={isProcessedByAutoModel}
           modelingStatus={modelingStatus}
           onChange={onChange}
         />,
@@ -589,6 +616,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        isProcessedByAutoModel,
         modelingStatus,
         onChange,
       });
@@ -680,6 +708,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        isProcessedByAutoModel,
         modelingStatus,
         onChange,
       });
@@ -692,6 +721,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
           method={method}
           modeledMethods={modeledMethods.slice(0, 2)}
           isModelingInProgress={isModelingInProgress}
+          isProcessedByAutoModel={isProcessedByAutoModel}
           modelingStatus={modelingStatus}
           onChange={onChange}
         />,
@@ -706,6 +736,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        isProcessedByAutoModel,
         modelingStatus,
         onChange,
       });
@@ -720,6 +751,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
           method={method}
           modeledMethods={modeledMethods.slice(0, 2)}
           isModelingInProgress={isModelingInProgress}
+          isProcessedByAutoModel={isProcessedByAutoModel}
           modelingStatus={modelingStatus}
           onChange={onChange}
         />,
@@ -748,6 +780,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        isProcessedByAutoModel,
         modelingStatus,
         onChange,
       });
@@ -763,6 +796,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        isProcessedByAutoModel,
         modelingStatus,
         onChange,
       });
@@ -781,6 +815,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        isProcessedByAutoModel,
         modelingStatus,
         onChange,
       });
@@ -800,6 +835,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        isProcessedByAutoModel,
         modelingStatus,
         onChange,
       });
@@ -818,6 +854,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
           method={method}
           modeledMethods={modeledMethods.slice(0, 1)}
           isModelingInProgress={isModelingInProgress}
+          isProcessedByAutoModel={isProcessedByAutoModel}
           modelingStatus={modelingStatus}
           onChange={onChange}
         />,
@@ -857,6 +894,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        isProcessedByAutoModel,
         modelingStatus,
         onChange,
       });
@@ -870,6 +908,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
         method,
         modeledMethods,
         isModelingInProgress,
+        isProcessedByAutoModel,
         modelingStatus,
         onChange,
       });


### PR DESCRIPTION
This adds showing auto-model negative predictions in italics to the method modeling panel by adding the processed by LLM state to the panel.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
