### PR TITLE
Add progress ring in 'stop evaluation' button

### DIFF
--- a/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
@@ -3,6 +3,7 @@ import type { ToModelEditorMessage } from "../../common/interface-types";
 import {
   VSCodeButton,
   VSCodeCheckbox,
+  VSCodeProgressRing,
   VSCodeTag,
 } from "@vscode/webview-ui-toolkit/react";
 import { styled } from "styled-components";
@@ -74,6 +75,12 @@ const ButtonsContainer = styled.div`
   margin-top: 1rem;
 `;
 
+const ProgressRing = styled(VSCodeProgressRing)`
+  width: 16px;
+  height: 16px;
+  margin-right: 5px;
+`;
+
 const ModelEvaluation = ({
   viewState,
   modeledMethods,
@@ -112,6 +119,7 @@ const ModelEvaluation = ({
   } else {
     return (
       <VSCodeButton onClick={onStopEvaluation} appearance="secondary">
+        <ProgressRing />
         Stop evaluation
       </VSCodeButton>
     );


### PR DESCRIPTION
Adds a progress ring in to the "Stop evaluation" button to match the "designs".

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
