### PR TITLE
Moved logic to get standard pack for variant analysis

### DIFF
--- a/extensions/ql-vscode/src/variant-analysis/code-scanning-pack.ts
+++ b/extensions/ql-vscode/src/variant-analysis/code-scanning-pack.ts
@@ -1,0 +1,77 @@
+import { join } from "path";
+import type { App } from "../common/app";
+import type { QueryLanguage } from "../common/query-language";
+import type { CodeQLCliServer } from "../codeql-cli/cli";
+import type { QlPackDetails } from "./ql-pack-details";
+import { getQlPackFilePath } from "../common/ql";
+
+export async function getCodeScanningPack(
+  app: App,
+  cliServer: CodeQLCliServer,
+  language: QueryLanguage,
+): Promise<QlPackDetails> {
+  // Get pack
+  void app.logger.log(`Downloading pack for language: ${language}`);
+  const packName = `codeql/${language}-queries`;
+  const packDownloadResult = await cliServer.packDownload([packName]);
+  const downloadedPack = packDownloadResult.packs[0];
+
+  const packDir = join(
+    packDownloadResult.packDir,
+    downloadedPack.name,
+    downloadedPack.version,
+  );
+
+  // Resolve queries
+  void app.logger.log(`Resolving queries for pack: ${packName}`);
+  const suitePath = join(
+    packDir,
+    "codeql-suites",
+    `${language}-code-scanning.qls`,
+  );
+  const resolvedQueries = await cliServer.resolveQueries(suitePath);
+
+  const problemQueries = await filterToOnlyProblemQueries(
+    app,
+    cliServer,
+    resolvedQueries,
+  );
+
+  if (problemQueries.length === 0) {
+    throw Error(
+      `No problem queries found in published query pack: ${packName}.`,
+    );
+  }
+
+  // Return pack details
+  const qlPackFilePath = await getQlPackFilePath(packDir);
+
+  const qlPackDetails: QlPackDetails = {
+    queryFiles: problemQueries,
+    qlPackRootPath: packDir,
+    qlPackFilePath,
+    language,
+  };
+
+  return qlPackDetails;
+}
+
+async function filterToOnlyProblemQueries(
+  app: App,
+  cliServer: CodeQLCliServer,
+  queries: string[],
+): Promise<string[]> {
+  const problemQueries: string[] = [];
+  for (const query of queries) {
+    const queryMetadata = await cliServer.resolveMetadata(query);
+    if (
+      queryMetadata.kind === "problem" ||
+      queryMetadata.kind === "path-problem"
+    ) {
+      problemQueries.push(query);
+    } else {
+      void app.logger.log(`Skipping non-problem query ${query}`);
+    }
+  }
+  return problemQueries;
+}

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/code-scanning-pack.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/code-scanning-pack.test.ts
@@ -1,0 +1,30 @@
+import type { CodeQLCliServer } from "../../../../src/codeql-cli/cli";
+import type { App } from "../../../../src/common/app";
+import { QueryLanguage } from "../../../../src/common/query-language";
+import { ExtensionApp } from "../../../../src/common/vscode/vscode-app";
+import { getCodeScanningPack } from "../../../../src/variant-analysis/code-scanning-pack";
+import { getActivatedExtension } from "../../global.helper";
+
+describe("Code Scanning pack", () => {
+  let cli: CodeQLCliServer;
+  let app: App;
+
+  beforeEach(async () => {
+    const extension = await getActivatedExtension();
+    cli = extension.cliServer;
+    app = new ExtensionApp(extension.ctx);
+  });
+
+  it("should download pack for correct language and identify problem queries", async () => {
+    const pack = await getCodeScanningPack(app, cli, QueryLanguage.Javascript);
+    // Should include queries. Just check that at least one known query exists.
+    // It doesn't particularly matter which query we check for.
+    expect(
+      pack.queryFiles.find((q) => q.includes("PostMessageStar.ql")),
+    ).toBeDefined();
+    // Should not include non-problem queries.
+    expect(
+      pack.queryFiles.find((q) => q.includes("LinesOfCode.ql")),
+    ).not.toBeDefined();
+  });
+});

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/variant-analysis-manager.test.ts
@@ -477,41 +477,4 @@ describe("Variant Analysis Manager", () => {
       }
     }
   });
-
-  describe("runVariantAnalysisFromPublishedPack", () => {
-    // Temporarily disabling this until we add a way to receive multiple queries in the
-    // runVariantAnalysis function.
-    it("should download pack for correct language and identify problem queries", async () => {
-      const showQuickPickSpy = jest
-        .spyOn(window, "showQuickPick")
-        .mockResolvedValue(
-          mockedQuickPickItem({
-            label: "JavaScript",
-            description: "javascript",
-            language: "javascript",
-          }),
-        );
-
-      const runVariantAnalysisMock = jest.fn();
-      variantAnalysisManager.runVariantAnalysis = runVariantAnalysisMock;
-
-      await variantAnalysisManager.runVariantAnalysisFromPublishedPack();
-
-      expect(showQuickPickSpy).toHaveBeenCalledTimes(1);
-      expect(runVariantAnalysisMock).toHaveBeenCalledTimes(1);
-
-      console.log(runVariantAnalysisMock.mock.calls[0][0]);
-      const queries: string[] =
-        runVariantAnalysisMock.mock.calls[0][0].queryFiles;
-      // Should include queries. Just check that at least one known query exists.
-      // It doesn't particularly matter which query we check for.
-      expect(
-        queries.find((q) => q.includes("PostMessageStar.ql")),
-      ).toBeDefined();
-      // Should not include non-problem queries.
-      expect(
-        queries.find((q) => q.includes("LinesOfCode.ql")),
-      ).not.toBeDefined();
-    });
-  });
 });


### PR DESCRIPTION
Moved the logic that downloads the standard Code Scanning pack and prepares for a variant analysis, into a new module so that it can be re-used for model evaluation.

I've removed the tests in `variant-analysis-manager.test.ts` because it no longer seemed worth keeping it around considering the main bit that was being tested was moved to `code-scanning-pack.test.ts`.

I'm not too happy with the name of the new module/function so please shout if you have any suggestions.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
