### PR TITLE
Add model evaluation run to store and view

### DIFF
--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -25,6 +25,7 @@ import type {
   UrlValueResolvable,
 } from "./raw-result-types";
 import type { AccessPathSuggestionOptions } from "../model-editor/suggestions";
+import type { ModelEvaluationRun } from "../model-editor/model-evaluation-run";
 
 /**
  * This module contains types and code that are shared between
@@ -633,6 +634,11 @@ interface SetAccessPathSuggestionsMessage {
   accessPathSuggestions: AccessPathSuggestionOptions;
 }
 
+interface SetModelEvaluationRunMessage {
+  t: "setModelEvaluationRun";
+  run: ModelEvaluationRun | undefined;
+}
+
 export type ToModelEditorMessage =
   | SetExtensionPackStateMessage
   | SetMethodsMessage
@@ -641,7 +647,8 @@ export type ToModelEditorMessage =
   | SetInProgressMethodsMessage
   | SetProcessedByAutoModelMethodsMessage
   | RevealMethodMessage
-  | SetAccessPathSuggestionsMessage;
+  | SetAccessPathSuggestionsMessage
+  | SetModelEvaluationRunMessage;
 
 export type FromModelEditorMessage =
   | CommonFromViewMessages

--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -25,7 +25,7 @@ import type {
   UrlValueResolvable,
 } from "./raw-result-types";
 import type { AccessPathSuggestionOptions } from "../model-editor/suggestions";
-import type { ModelEvaluationRun } from "../model-editor/model-evaluation-run";
+import type { ModelEvaluationRunState } from "../model-editor/shared/model-evaluation-run-state";
 
 /**
  * This module contains types and code that are shared between
@@ -636,7 +636,7 @@ interface SetAccessPathSuggestionsMessage {
 
 interface SetModelEvaluationRunMessage {
   t: "setModelEvaluationRun";
-  run: ModelEvaluationRun | undefined;
+  run: ModelEvaluationRunState | undefined;
 }
 
 export type ToModelEditorMessage =

--- a/extensions/ql-vscode/src/model-editor/model-evaluation-run.ts
+++ b/extensions/ql-vscode/src/model-editor/model-evaluation-run.ts
@@ -1,0 +1,20 @@
+export interface ModelEvaluationRun {
+  status: ModelEvaluationStatus;
+  variantAnalysisId: number | undefined;
+}
+
+type ModelEvaluationStatus =
+  | "preparing"
+  | "inProgress"
+  | "succeeded"
+  | "failed"
+  | "canceled";
+
+export function evaluationRunIsRunning(
+  evaluationRun: ModelEvaluationRun,
+): boolean {
+  return (
+    evaluationRun.status === "preparing" ||
+    evaluationRun.status === "inProgress"
+  );
+}

--- a/extensions/ql-vscode/src/model-editor/model-evaluation-run.ts
+++ b/extensions/ql-vscode/src/model-editor/model-evaluation-run.ts
@@ -1,20 +1,4 @@
 export interface ModelEvaluationRun {
-  status: ModelEvaluationStatus;
+  isPreparing: boolean;
   variantAnalysisId: number | undefined;
-}
-
-type ModelEvaluationStatus =
-  | "preparing"
-  | "inProgress"
-  | "succeeded"
-  | "failed"
-  | "canceled";
-
-export function evaluationRunIsRunning(
-  evaluationRun: ModelEvaluationRun,
-): boolean {
-  return (
-    evaluationRun.status === "preparing" ||
-    evaluationRun.status === "inProgress"
-  );
 }

--- a/extensions/ql-vscode/src/model-editor/model-evaluator.ts
+++ b/extensions/ql-vscode/src/model-editor/model-evaluator.ts
@@ -1,0 +1,46 @@
+import type { ModelingStore } from "./modeling-store";
+import type { DatabaseItem } from "../databases/local-databases";
+import type { ModelEvaluationRun } from "./model-evaluation-run";
+import { DisposableObject } from "../common/disposable-object";
+import { sleep } from "../common/time";
+
+export class ModelEvaluator extends DisposableObject {
+  public constructor(
+    private readonly modelingStore: ModelingStore,
+    private readonly dbItem: DatabaseItem,
+  ) {
+    super();
+  }
+
+  public async startEvaluation() {
+    // Update store with evaluation run status
+    const evaluationRun: ModelEvaluationRun = {
+      status: "preparing",
+      variantAnalysisId: undefined,
+    };
+    this.modelingStore.updateModelEvaluationRun(this.dbItem, evaluationRun);
+
+    // For now, just wait 5 seconds and then update the store with the succeeded status.
+    // In the future, this will be replaced with the actual evaluation process.
+    void sleep(5000).then(() => {
+      const completedEvaluationRun: ModelEvaluationRun = {
+        status: "succeeded",
+        variantAnalysisId: undefined,
+      };
+      this.modelingStore.updateModelEvaluationRun(
+        this.dbItem,
+        completedEvaluationRun,
+      );
+    });
+  }
+
+  public async stopEvaluation() {
+    // For now just update the store with the canceled status.
+    // This will be fleshed out in the near future.
+    const evaluationRun: ModelEvaluationRun = {
+      status: "canceled",
+      variantAnalysisId: undefined,
+    };
+    this.modelingStore.updateModelEvaluationRun(this.dbItem, evaluationRun);
+  }
+}

--- a/extensions/ql-vscode/src/model-editor/model-evaluator.ts
+++ b/extensions/ql-vscode/src/model-editor/model-evaluator.ts
@@ -28,7 +28,7 @@ export class ModelEvaluator extends DisposableObject {
     };
     this.modelingStore.updateModelEvaluationRun(this.dbItem, evaluationRun);
 
-    // For now, just wait 5 seconds and then update the store with the succeeded status.
+    // For now, just wait 5 seconds and then update the store.
     // In the future, this will be replaced with the actual evaluation process.
     void sleep(5000).then(() => {
       const completedEvaluationRun: ModelEvaluationRun = {
@@ -43,7 +43,7 @@ export class ModelEvaluator extends DisposableObject {
   }
 
   public async stopEvaluation() {
-    // For now just update the store with the canceled status.
+    // For now just update the store.
     // This will be fleshed out in the near future.
     const evaluationRun: ModelEvaluationRun = {
       isPreparing: false,

--- a/extensions/ql-vscode/src/model-editor/model-evaluator.ts
+++ b/extensions/ql-vscode/src/model-editor/model-evaluator.ts
@@ -1,21 +1,29 @@
 import type { ModelingStore } from "./modeling-store";
+import type { ModelingEvents } from "./modeling-events";
 import type { DatabaseItem } from "../databases/local-databases";
 import type { ModelEvaluationRun } from "./model-evaluation-run";
 import { DisposableObject } from "../common/disposable-object";
 import { sleep } from "../common/time";
+import type { ModelEvaluationRunState } from "./shared/model-evaluation-run-state";
 
 export class ModelEvaluator extends DisposableObject {
   public constructor(
     private readonly modelingStore: ModelingStore,
+    private readonly modelingEvents: ModelingEvents,
     private readonly dbItem: DatabaseItem,
+    private readonly updateView: (
+      run: ModelEvaluationRunState,
+    ) => Promise<void>,
   ) {
     super();
+
+    this.registerToModelingEvents();
   }
 
   public async startEvaluation() {
     // Update store with evaluation run status
     const evaluationRun: ModelEvaluationRun = {
-      status: "preparing",
+      isPreparing: true,
       variantAnalysisId: undefined,
     };
     this.modelingStore.updateModelEvaluationRun(this.dbItem, evaluationRun);
@@ -24,7 +32,7 @@ export class ModelEvaluator extends DisposableObject {
     // In the future, this will be replaced with the actual evaluation process.
     void sleep(5000).then(() => {
       const completedEvaluationRun: ModelEvaluationRun = {
-        status: "succeeded",
+        isPreparing: false,
         variantAnalysisId: undefined,
       };
       this.modelingStore.updateModelEvaluationRun(
@@ -38,9 +46,28 @@ export class ModelEvaluator extends DisposableObject {
     // For now just update the store with the canceled status.
     // This will be fleshed out in the near future.
     const evaluationRun: ModelEvaluationRun = {
-      status: "canceled",
+      isPreparing: false,
       variantAnalysisId: undefined,
     };
     this.modelingStore.updateModelEvaluationRun(this.dbItem, evaluationRun);
+  }
+
+  private registerToModelingEvents() {
+    this.push(
+      this.modelingEvents.onModelEvaluationRunChanged(async (event) => {
+        if (
+          event.evaluationRun &&
+          event.dbUri === this.dbItem.databaseUri.toString()
+        ) {
+          const run: ModelEvaluationRunState = {
+            isPreparing: event.evaluationRun.isPreparing,
+
+            // TODO: Get variant analysis from id.
+            variantAnalysis: undefined,
+          };
+          await this.updateView(run);
+        }
+      }),
+    );
   }
 }

--- a/extensions/ql-vscode/src/model-editor/modeling-events.ts
+++ b/extensions/ql-vscode/src/model-editor/modeling-events.ts
@@ -3,6 +3,7 @@ import { DisposableObject } from "../common/disposable-object";
 import type { AppEvent, AppEventEmitter } from "../common/events";
 import type { DatabaseItem } from "../databases/local-databases";
 import type { Method, Usage } from "./method";
+import type { ModelEvaluationRun } from "./model-evaluation-run";
 import type { ModeledMethod } from "./modeled-method";
 import type { Mode } from "./shared/mode";
 
@@ -55,6 +56,11 @@ interface ProcessedByAutoModelMethodsChangedEvent {
   readonly methods: ReadonlySet<string>;
 }
 
+interface ModelEvaluationRunChangedEvent {
+  readonly dbUri: string;
+  readonly evaluationRun: ModelEvaluationRun | undefined;
+}
+
 interface RevealInModelEditorEvent {
   dbUri: string;
   method: Method;
@@ -76,6 +82,7 @@ export class ModelingEvents extends DisposableObject {
   public readonly onSelectedMethodChanged: AppEvent<SelectedMethodChangedEvent>;
   public readonly onInProgressMethodsChanged: AppEvent<InProgressMethodsChangedEvent>;
   public readonly onProcessedByAutoModelMethodsChanged: AppEvent<ProcessedByAutoModelMethodsChangedEvent>;
+  public readonly onModelEvaluationRunChanged: AppEvent<ModelEvaluationRunChangedEvent>;
   public readonly onRevealInModelEditor: AppEvent<RevealInModelEditorEvent>;
   public readonly onFocusModelEditor: AppEvent<FocusModelEditorEvent>;
 
@@ -90,6 +97,7 @@ export class ModelingEvents extends DisposableObject {
   private readonly onSelectedMethodChangedEventEmitter: AppEventEmitter<SelectedMethodChangedEvent>;
   private readonly onInProgressMethodsChangedEventEmitter: AppEventEmitter<InProgressMethodsChangedEvent>;
   private readonly onProcessedByAutoModelMethodsChangedEventEmitter: AppEventEmitter<ProcessedByAutoModelMethodsChangedEvent>;
+  private readonly onModelEvaluationRunChangedEventEmitter: AppEventEmitter<ModelEvaluationRunChangedEvent>;
   private readonly onRevealInModelEditorEventEmitter: AppEventEmitter<RevealInModelEditorEvent>;
   private readonly onFocusModelEditorEventEmitter: AppEventEmitter<FocusModelEditorEvent>;
 
@@ -154,6 +162,12 @@ export class ModelingEvents extends DisposableObject {
     );
     this.onProcessedByAutoModelMethodsChanged =
       this.onProcessedByAutoModelMethodsChangedEventEmitter.event;
+
+    this.onModelEvaluationRunChangedEventEmitter = this.push(
+      app.createEventEmitter<ModelEvaluationRunChangedEvent>(),
+    );
+    this.onModelEvaluationRunChanged =
+      this.onModelEvaluationRunChangedEventEmitter.event;
 
     this.onRevealInModelEditorEventEmitter = this.push(
       app.createEventEmitter<RevealInModelEditorEvent>(),
@@ -270,6 +284,16 @@ export class ModelingEvents extends DisposableObject {
     this.onProcessedByAutoModelMethodsChangedEventEmitter.fire({
       dbUri,
       methods,
+    });
+  }
+
+  public fireModelEvaluationRunChangedEvent(
+    dbUri: string,
+    evaluationRun: ModelEvaluationRun | undefined,
+  ) {
+    this.onModelEvaluationRunChangedEventEmitter.fire({
+      dbUri,
+      evaluationRun,
     });
   }
 

--- a/extensions/ql-vscode/src/model-editor/shared/model-evaluation-run-state.ts
+++ b/extensions/ql-vscode/src/model-editor/shared/model-evaluation-run-state.ts
@@ -1,0 +1,19 @@
+import { VariantAnalysisStatus } from "../../variant-analysis/shared/variant-analysis";
+import type { VariantAnalysis } from "../../variant-analysis/shared/variant-analysis";
+
+export interface ModelEvaluationRunState {
+  isPreparing: boolean;
+  variantAnalysis: VariantAnalysis | undefined;
+}
+
+export function modelEvaluationRunIsRunning(
+  run: ModelEvaluationRunState,
+): boolean {
+  return (
+    run.isPreparing ||
+    !!(
+      run.variantAnalysis &&
+      run.variantAnalysis.status !== VariantAnalysisStatus.InProgress
+    )
+  );
+}

--- a/extensions/ql-vscode/src/model-editor/shared/model-evaluation-run-state.ts
+++ b/extensions/ql-vscode/src/model-editor/shared/model-evaluation-run-state.ts
@@ -13,7 +13,7 @@ export function modelEvaluationRunIsRunning(
     run.isPreparing ||
     !!(
       run.variantAnalysis &&
-      run.variantAnalysis.status !== VariantAnalysisStatus.InProgress
+      run.variantAnalysis.status === VariantAnalysisStatus.InProgress
     )
   );
 }

--- a/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
@@ -102,7 +102,6 @@ const ModelEvaluation = ({
     return null;
   }
 
-  console.log("***** check evaluationRun", evaluationRun);
   if (!evaluationRun || !modelEvaluationRunIsRunning(evaluationRun)) {
     const customModelsExist = Object.values(modeledMethods).some(
       (methods) => methods.filter((m) => m.type !== "none").length > 0,
@@ -220,7 +219,6 @@ export function ModelEditor({
             setAccessPathSuggestions(msg.accessPathSuggestions);
             break;
           case "setModelEvaluationRun":
-            console.log("**** setModelEvaluationRun", msg.run);
             setEvaluationRun(msg.run);
             break;
           default:

--- a/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
@@ -20,8 +20,8 @@ import { Mode } from "../../model-editor/shared/mode";
 import { getLanguageDisplayName } from "../../common/query-language";
 import { INITIAL_HIDE_MODELED_METHODS_VALUE } from "../../model-editor/shared/hide-modeled-methods";
 import type { AccessPathSuggestionOptions } from "../../model-editor/suggestions";
-import type { ModelEvaluationRun } from "../../model-editor/model-evaluation-run";
-import { evaluationRunIsRunning } from "../../model-editor/model-evaluation-run";
+import type { ModelEvaluationRunState } from "../../model-editor/shared/model-evaluation-run-state";
+import { modelEvaluationRunIsRunning } from "../../model-editor/shared/model-evaluation-run-state";
 
 const LoadingContainer = styled.div`
   text-align: center;
@@ -96,14 +96,14 @@ const ModelEvaluation = ({
   modifiedSignatures: Set<string>;
   onStartEvaluation: () => void;
   onStopEvaluation: () => void;
-  evaluationRun: ModelEvaluationRun | undefined;
+  evaluationRun: ModelEvaluationRunState | undefined;
 }) => {
   if (!viewState.showEvaluationUi) {
     return null;
   }
 
   console.log("***** check evaluationRun", evaluationRun);
-  if (!evaluationRun || !evaluationRunIsRunning(evaluationRun)) {
+  if (!evaluationRun || !modelEvaluationRunIsRunning(evaluationRun)) {
     const customModelsExist = Object.values(modeledMethods).some(
       (methods) => methods.filter((m) => m.type !== "none").length > 0,
     );
@@ -170,7 +170,7 @@ export function ModelEditor({
   >(null);
 
   const [evaluationRun, setEvaluationRun] = useState<
-    ModelEvaluationRun | undefined
+    ModelEvaluationRunState | undefined
   >(undefined);
 
   useEffect(() => {

--- a/extensions/ql-vscode/test/__mocks__/model-editor/modelingEventsMock.ts
+++ b/extensions/ql-vscode/test/__mocks__/model-editor/modelingEventsMock.ts
@@ -13,6 +13,7 @@ export function createMockModelingEvents({
   onProcessedByAutoModelMethodsChanged = jest.fn(),
   onRevealInModelEditor = jest.fn(),
   onFocusModelEditor = jest.fn(),
+  onModelEvaluationRunChanged = jest.fn(),
 }: {
   onActiveDbChanged?: ModelingEvents["onActiveDbChanged"];
   onDbClosed?: ModelingEvents["onDbClosed"];
@@ -25,6 +26,7 @@ export function createMockModelingEvents({
   onProcessedByAutoModelMethodsChanged?: ModelingEvents["onProcessedByAutoModelMethodsChanged"];
   onRevealInModelEditor?: ModelingEvents["onRevealInModelEditor"];
   onFocusModelEditor?: ModelingEvents["onFocusModelEditor"];
+  onModelEvaluationRunChanged?: ModelingEvents["onModelEvaluationRunChanged"];
 } = {}): ModelingEvents {
   return mockedObject<ModelingEvents>({
     onActiveDbChanged,
@@ -38,5 +40,6 @@ export function createMockModelingEvents({
     onProcessedByAutoModelMethodsChanged,
     onRevealInModelEditor,
     onFocusModelEditor,
+    onModelEvaluationRunChanged,
   });
 }


### PR DESCRIPTION
This PR introduces the `ModelEvalutionRun` domain entity and wires up model evaluation run information to the modeling store and the model editor view. Some notes:
- The `ModelEvaluationRun` interface is pretty minimal at the moment. I expect it to grow while we build more features (e.g. it might need to contain model packs).
- The model evaluation run information is not yet persisted - it's only in memory (in the `ModelingStore`).
- A new `ModelEvaluator` class has been added to contain logic around model evaluation in order to keep changes in `model-editor-view` minimal. The implementation is pretty minimal for now and will be fleshed out in the near future.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
