### PR TITLE
Update Ruby model generation query constraints

### DIFF
--- a/extensions/ql-vscode/src/model-editor/languages/models-as-data.ts
+++ b/extensions/ql-vscode/src/model-editor/languages/models-as-data.ts
@@ -33,7 +33,7 @@ export type ModelsAsDataLanguagePredicate<T> = {
 };
 
 type ModelsAsDataLanguageModelGeneration = {
-  queryConstraints: QueryConstraints;
+  queryConstraints: (mode: Mode) => QueryConstraints;
   filterQueries?: (queryPath: string) => boolean;
   parseResults: (
     // The path to the query that generated the results.

--- a/extensions/ql-vscode/src/model-editor/languages/ruby/index.ts
+++ b/extensions/ql-vscode/src/model-editor/languages/ruby/index.ts
@@ -172,9 +172,10 @@ export const ruby: ModelsAsDataLanguage = {
     },
   },
   modelGeneration: {
-    queryConstraints: {
-      "query path": "queries/modeling/GenerateModel.ql",
-    },
+    queryConstraints: (mode) => ({
+      kind: "table",
+      "tags contain all": ["modeleditor", "generate-model", modeTag(mode)],
+    }),
     parseResults: parseGenerateModelResults,
   },
   accessPathSuggestions: {

--- a/extensions/ql-vscode/src/model-editor/languages/static/index.ts
+++ b/extensions/ql-vscode/src/model-editor/languages/static/index.ts
@@ -141,9 +141,9 @@ export const staticLanguage: ModelsAsDataLanguage = {
     },
   },
   modelGeneration: {
-    queryConstraints: {
+    queryConstraints: () => ({
       "tags contain": ["modelgenerator"],
-    },
+    }),
     filterQueries: filterFlowModelQueries,
     parseResults: parseFlowModelResults,
   },

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -619,7 +619,7 @@ export class ModelEditorView extends AbstractWebview<
 
         try {
           await runGenerateQueries({
-            queryConstraints: modelGeneration.queryConstraints,
+            queryConstraints: modelGeneration.queryConstraints(mode),
             filterQueries: modelGeneration.filterQueries,
             parseResults: (queryPath, results) =>
               modelGeneration.parseResults(

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/generate.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/generate.test.ts
@@ -13,6 +13,7 @@ import { runGenerateQueries } from "../../../../src/model-editor/generate";
 import { ruby } from "../../../../src/model-editor/languages/ruby";
 import type { ModeledMethod } from "../../../../src/model-editor/modeled-method";
 import { EndpointType } from "../../../../src/model-editor/method";
+import { Mode } from "../../../../src/model-editor/shared/mode";
 
 describe("runGenerateQueries", () => {
   const modelsAsDataLanguage = ruby;
@@ -125,7 +126,7 @@ describe("runGenerateQueries", () => {
     };
 
     await runGenerateQueries({
-      queryConstraints: modelGeneration.queryConstraints,
+      queryConstraints: modelGeneration.queryConstraints(Mode.Framework),
       filterQueries: modelGeneration.filterQueries,
       parseResults: (queryPath, results) =>
         modelGeneration.parseResults(


### PR DESCRIPTION
Since CodeQL v2.16.0, the Ruby model generation query [has proper query tags](https://github.com/github/codeql/commit/9b998a39b4b9b06de3c18c07529f339362a02f37), so we shouldn't be using the query path anymore.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
