### PR TITLE
Add logic to trigger model evaluation run

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -977,6 +977,7 @@ async function activateWithInstalledDistribution(
   const modelEditorModule = await ModelEditorModule.initialize(
     app,
     dbm,
+    variantAnalysisManager,
     cliServer,
     qs,
     tmpDir.name,

--- a/extensions/ql-vscode/src/model-editor/model-editor-module.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-module.ts
@@ -31,6 +31,7 @@ import { getModelsAsDataLanguage } from "./languages";
 import { INITIAL_MODE } from "./shared/mode";
 import { isSupportedLanguage } from "./supported-languages";
 import { DefaultNotifier, checkConsistency } from "./consistency-check";
+import type { VariantAnalysisManager } from "../variant-analysis/variant-analysis-manager";
 
 export class ModelEditorModule extends DisposableObject {
   private readonly queryStorageDir: string;
@@ -43,6 +44,7 @@ export class ModelEditorModule extends DisposableObject {
   private constructor(
     private readonly app: App,
     private readonly databaseManager: DatabaseManager,
+    private readonly variantAnalysisManager: VariantAnalysisManager,
     private readonly cliServer: CodeQLCliServer,
     private readonly queryRunner: QueryRunner,
     baseQueryStorageDir: string,
@@ -65,6 +67,7 @@ export class ModelEditorModule extends DisposableObject {
   public static async initialize(
     app: App,
     databaseManager: DatabaseManager,
+    variantAnalysisManager: VariantAnalysisManager,
     cliServer: CodeQLCliServer,
     queryRunner: QueryRunner,
     queryStorageDir: string,
@@ -72,6 +75,7 @@ export class ModelEditorModule extends DisposableObject {
     const modelEditorModule = new ModelEditorModule(
       app,
       databaseManager,
+      variantAnalysisManager,
       cliServer,
       queryRunner,
       queryStorageDir,
@@ -240,6 +244,7 @@ export class ModelEditorModule extends DisposableObject {
             this.modelingEvents,
             this.modelConfig,
             this.databaseManager,
+            this.variantAnalysisManager,
             this.cliServer,
             this.queryRunner,
             this.queryStorageDir,

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -59,6 +59,7 @@ import { runSuggestionsQuery } from "./suggestion-queries";
 import { parseAccessPathSuggestionRowsToOptions } from "./suggestions-bqrs";
 import { ModelEvaluator } from "./model-evaluator";
 import type { ModelEvaluationRunState } from "./shared/model-evaluation-run-state";
+import type { VariantAnalysisManager } from "../variant-analysis/variant-analysis-manager";
 
 export class ModelEditorView extends AbstractWebview<
   ToModelEditorMessage,
@@ -74,6 +75,7 @@ export class ModelEditorView extends AbstractWebview<
     private readonly modelingEvents: ModelingEvents,
     private readonly modelConfig: ModelConfigListener,
     private readonly databaseManager: DatabaseManager,
+    private readonly variantAnalysisManager: VariantAnalysisManager,
     private readonly cliServer: CodeQLCliServer,
     private readonly queryRunner: QueryRunner,
     private readonly queryStorageDir: string,
@@ -106,9 +108,13 @@ export class ModelEditorView extends AbstractWebview<
     this.languageDefinition = getModelsAsDataLanguage(language);
 
     this.modelEvaluator = new ModelEvaluator(
+      this.app.logger,
+      this.cliServer,
       modelingStore,
       modelingEvents,
+      this.variantAnalysisManager,
       databaseItem,
+      language,
       this.updateModelEvaluationRun.bind(this),
     );
     this.push(this.modelEvaluator);
@@ -730,6 +736,7 @@ export class ModelEditorView extends AbstractWebview<
         this.modelingEvents,
         this.modelConfig,
         this.databaseManager,
+        this.variantAnalysisManager,
         this.cliServer,
         this.queryRunner,
         this.queryStorageDir,

--- a/extensions/ql-vscode/src/model-editor/model-evaluator.ts
+++ b/extensions/ql-vscode/src/model-editor/model-evaluator.ts
@@ -50,7 +50,7 @@ export class ModelEvaluator extends DisposableObject {
       throw new Error("Unable to trigger evaluation run");
     }
 
-    // Submit varfiant analysis and monitor progress
+    // Submit variant analysis and monitor progress
     return withProgress(
       async (progress, token) => {
         let variantAnalysisId: number | undefined = undefined;
@@ -95,18 +95,22 @@ export class ModelEvaluator extends DisposableObject {
   private registerToModelingEvents() {
     this.push(
       this.modelingEvents.onModelEvaluationRunChanged(async (event) => {
-        if (
-          event.evaluationRun &&
-          event.dbUri === this.dbItem.databaseUri.toString()
-        ) {
-          const variantAnalysis = await this.getVariantAnalysisForRun(
-            event.evaluationRun,
-          );
-          const run: ModelEvaluationRunState = {
-            isPreparing: event.evaluationRun.isPreparing,
-            variantAnalysis,
-          };
-          await this.updateView(run);
+        if (event.dbUri === this.dbItem.databaseUri.toString()) {
+          if (!event.evaluationRun) {
+            await this.updateView({
+              isPreparing: false,
+              variantAnalysis: undefined,
+            });
+          } else {
+            const variantAnalysis = await this.getVariantAnalysisForRun(
+              event.evaluationRun,
+            );
+            const run: ModelEvaluationRunState = {
+              isPreparing: event.evaluationRun.isPreparing,
+              variantAnalysis,
+            };
+            await this.updateView(run);
+          }
         }
       }),
     );

--- a/extensions/ql-vscode/src/model-editor/modeling-store.ts
+++ b/extensions/ql-vscode/src/model-editor/modeling-store.ts
@@ -378,7 +378,7 @@ export class ModelingStore extends DisposableObject {
 
   public updateModelEvaluationRun(
     dbItem: DatabaseItem,
-    evaluationRun: ModelEvaluationRun,
+    evaluationRun: ModelEvaluationRun | undefined,
   ) {
     this.changeModelEvaluationRun(dbItem, (state) => {
       state.modelEvaluationRun = evaluationRun;

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -298,7 +298,7 @@ export class VariantAnalysisManager
     qlPackDetails: QlPackDetails,
     progress: ProgressCallback,
     token: CancellationToken,
-  ): Promise<void> {
+  ): Promise<number | undefined> {
     await saveBeforeStart();
 
     progress({
@@ -379,7 +379,7 @@ export class VariantAnalysisManager
     } catch (e: unknown) {
       // If the error is handled by the handleRequestError function, we don't need to throw
       if (e instanceof RequestError && handleRequestError(e, this.app.logger)) {
-        return;
+        return undefined;
       }
 
       throw e;
@@ -405,6 +405,8 @@ export class VariantAnalysisManager
       "codeQL.monitorNewVariantAnalysis",
       processedVariantAnalysis,
     );
+
+    return processedVariantAnalysis.id;
   }
 
   public async rehydrateVariantAnalysis(variantAnalysis: VariantAnalysis) {

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/model-editor-view.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/model-editor-view.test.ts
@@ -12,6 +12,7 @@ import { createMockModelingStore } from "../../../__mocks__/model-editor/modelin
 import type { ModelConfigListener } from "../../../../src/config";
 import { createMockModelingEvents } from "../../../__mocks__/model-editor/modelingEventsMock";
 import { QueryLanguage } from "../../../../src/common/query-language";
+import type { VariantAnalysisManager } from "../../../../src/variant-analysis/variant-analysis-manager";
 
 describe("ModelEditorView", () => {
   const app = createMockApp({});
@@ -21,6 +22,7 @@ describe("ModelEditorView", () => {
     onDidChangeConfiguration: jest.fn(),
   });
   const databaseManager = mockEmptyDatabaseManager();
+  const variantAnalysisManager = mockedObject<VariantAnalysisManager>({});
   const cliServer = mockedObject<CodeQLCliServer>({});
   const queryRunner = mockedObject<QueryRunner>({});
   const queryStorageDir = "/a/b/c/d";
@@ -48,6 +50,7 @@ describe("ModelEditorView", () => {
       modelingEvents,
       modelConfig,
       databaseManager,
+      variantAnalysisManager,
       cliServer,
       queryRunner,
       queryStorageDir,


### PR DESCRIPTION
Wires up the logic to actually trigger a variant analysis for a model evaluation.

This will currently fail while building a pack because of a known dependency we have on some CodeQL CLI changes (see internal issue).

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
