### PR TITLE
Extract saving of model extension YAML file

### DIFF
--- a/extensions/ql-vscode/src/model-editor/model-extension-file.schema.json
+++ b/extensions/ql-vscode/src/model-editor/model-extension-file.schema.json
@@ -8,35 +8,38 @@
         "extensions": {
           "type": "array",
           "items": {
-            "type": "object",
-            "properties": {
-              "addsTo": {
-                "type": "object",
-                "properties": {
-                  "pack": {
-                    "type": "string"
-                  },
-                  "extensible": {
-                    "type": "string"
-                  }
-                },
-                "required": ["pack", "extensible"]
-              },
-              "data": {
-                "type": "array",
-                "items": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/definitions/DataTuple"
-                  }
-                }
-              }
-            },
-            "required": ["addsTo", "data"]
+            "$ref": "#/definitions/ModelExtension"
           }
         }
       },
       "required": ["extensions"]
+    },
+    "ModelExtension": {
+      "type": "object",
+      "properties": {
+        "addsTo": {
+          "type": "object",
+          "properties": {
+            "pack": {
+              "type": "string"
+            },
+            "extensible": {
+              "type": "string"
+            }
+          },
+          "required": ["pack", "extensible"]
+        },
+        "data": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/DataTuple"
+            }
+          }
+        }
+      },
+      "required": ["addsTo", "data"]
     },
     "DataTuple": {
       "type": ["boolean", "number", "string"]

--- a/extensions/ql-vscode/src/model-editor/model-extension-file.ts
+++ b/extensions/ql-vscode/src/model-editor/model-extension-file.ts
@@ -7,7 +7,7 @@ export type DataTuple = boolean | number | string;
 
 type DataRow = DataTuple[];
 
-type ModelExtension = {
+export type ModelExtension = {
   addsTo: ExtensibleReference;
   data: DataRow[];
 };


### PR DESCRIPTION
This refactors the saving of YAML files for model extension files. Instead of directly constructing a string from the modeled methods, we will now create the structure of the YAML as a JS object. Then, we consume that object to create a YAML string. This would also allow us to e.g. dump the YAML directly, but the primary objective is to re-use this new function in a follow-up PR.

The YAML functions itself are pretty well-tested in [`yaml.test.ts`](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/test/unit-tests/model-editor/yaml.test.ts), so I'm pretty confident that this results in the same output in all instances.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
