### PR TITLE
Generate separate file for generated type models in Ruby by default

### DIFF
--- a/extensions/ql-vscode/src/model-editor/generate.ts
+++ b/extensions/ql-vscode/src/model-editor/generate.ts
@@ -5,19 +5,15 @@ import type { QueryRunner } from "../query-server";
 import type { CodeQLCliServer } from "../codeql-cli/cli";
 import type { ProgressCallback } from "../common/vscode/progress";
 import { getOnDiskWorkspaceFolders } from "../common/vscode/workspace-folders";
-import type { ModeledMethod } from "./modeled-method";
 import { runQuery } from "../local-queries/run-query";
 import type { QueryConstraints } from "../local-queries";
 import { resolveQueries } from "../local-queries";
 import type { DecodedBqrs } from "../common/bqrs-cli-types";
+
 type GenerateQueriesOptions = {
   queryConstraints: QueryConstraints;
   filterQueries?: (queryPath: string) => boolean;
-  parseResults: (
-    queryPath: string,
-    results: DecodedBqrs,
-  ) => ModeledMethod[] | Promise<ModeledMethod[]>;
-  onResults: (results: ModeledMethod[]) => void | Promise<void>;
+  onResults: (queryPath: string, results: DecodedBqrs) => void | Promise<void>;
 
   cliServer: CodeQLCliServer;
   queryRunner: QueryRunner;
@@ -28,7 +24,7 @@ type GenerateQueriesOptions = {
 };
 
 export async function runGenerateQueries(options: GenerateQueriesOptions) {
-  const { queryConstraints, filterQueries, parseResults, onResults } = options;
+  const { queryConstraints, filterQueries, onResults } = options;
 
   options.progress({
     message: "Resolving queries",
@@ -55,7 +51,7 @@ export async function runGenerateQueries(options: GenerateQueriesOptions) {
 
     const bqrs = await runSingleGenerateQuery(queryPath, i, maxStep, options);
     if (bqrs) {
-      await onResults(await parseResults(queryPath, bqrs));
+      await onResults(queryPath, bqrs);
     }
   }
 }

--- a/extensions/ql-vscode/src/model-editor/languages/models-as-data.ts
+++ b/extensions/ql-vscode/src/model-editor/languages/models-as-data.ts
@@ -70,7 +70,7 @@ export type ModelsAsDataLanguagePredicate<T> = {
 
 export type GenerationContext = {
   mode: Mode;
-  isCanary: boolean;
+  config: ModelConfig;
 };
 
 type ParseGenerationResults = (

--- a/extensions/ql-vscode/src/model-editor/languages/models-as-data.ts
+++ b/extensions/ql-vscode/src/model-editor/languages/models-as-data.ts
@@ -7,7 +7,7 @@ import type {
   SummaryModeledMethod,
   TypeModeledMethod,
 } from "../modeled-method";
-import type { DataTuple } from "../model-extension-file";
+import type { DataTuple, ModelExtension } from "../model-extension-file";
 import type { Mode } from "../shared/mode";
 import type { QueryConstraints } from "../../local-queries/query-constraints";
 import type {
@@ -32,6 +32,11 @@ export type ModelsAsDataLanguagePredicate<T> = {
   readModeledMethod: ReadModeledMethod;
 };
 
+export type GenerationContext = {
+  mode: Mode;
+  isCanary: boolean;
+};
+
 type ParseGenerationResults = (
   // The path to the query that generated the results.
   queryPath: string,
@@ -42,24 +47,37 @@ type ParseGenerationResults = (
   modelsAsDataLanguage: ModelsAsDataLanguage,
   // The logger to use for logging.
   logger: BaseLogger,
+  // Context about this invocation of the generation.
+  context: GenerationContext,
 ) => ModeledMethod[];
 
 type ModelsAsDataLanguageModelGeneration = {
   queryConstraints: (mode: Mode) => QueryConstraints;
   filterQueries?: (queryPath: string) => boolean;
   parseResults: ParseGenerationResults;
+};
+
+type ParseResultsToYaml = (
+  // The path to the query that generated the results.
+  queryPath: string,
+  // The results of the query.
+  bqrs: DecodedBqrs,
+  // The language-specific predicate that was used to generate the results. This is passed to allow
+  // sharing of code between different languages.
+  modelsAsDataLanguage: ModelsAsDataLanguage,
+  // The logger to use for logging.
+  logger: BaseLogger,
+) => ModelExtension[];
+
+type ModelsAsDataLanguageAutoModelGeneration = {
+  queryConstraints: (mode: Mode) => QueryConstraints;
+  filterQueries?: (queryPath: string) => boolean;
+  parseResultsToYaml: ParseResultsToYaml;
   /**
-   * If autoRun is not undefined, the query will be run automatically when the user starts the
-   * model editor.
-   *
-   * This only applies to framework mode. Application mode will never run the query automatically.
+   * By default, auto model generation is enabled for all modes. This function can be used to
+   * override that behavior.
    */
-  autoRun?: {
-    /**
-     * If defined, will use a custom parsing function when the query is run automatically.
-     */
-    parseResults?: ParseGenerationResults;
-  };
+  enabled?: (context: GenerationContext) => boolean;
 };
 
 type ModelsAsDataLanguageAccessPathSuggestions = {
@@ -109,6 +127,7 @@ export type ModelsAsDataLanguage = {
   ) => EndpointType | undefined;
   predicates: ModelsAsDataLanguagePredicates;
   modelGeneration?: ModelsAsDataLanguageModelGeneration;
+  autoModelGeneration?: ModelsAsDataLanguageAutoModelGeneration;
   accessPathSuggestions?: ModelsAsDataLanguageAccessPathSuggestions;
   /**
    * Returns the list of valid arguments that can be selected for the given method.

--- a/extensions/ql-vscode/src/model-editor/languages/ruby/generate.ts
+++ b/extensions/ql-vscode/src/model-editor/languages/ruby/generate.ts
@@ -1,6 +1,9 @@
 import type { BaseLogger } from "../../../common/logging";
 import type { DecodedBqrs } from "../../../common/bqrs-cli-types";
-import type { ModelsAsDataLanguage } from "../models-as-data";
+import type {
+  GenerationContext,
+  ModelsAsDataLanguage,
+} from "../models-as-data";
 import type { ModeledMethod } from "../../modeled-method";
 import type { DataTuple } from "../../model-extension-file";
 
@@ -9,10 +12,21 @@ export function parseGenerateModelResults(
   bqrs: DecodedBqrs,
   modelsAsDataLanguage: ModelsAsDataLanguage,
   logger: BaseLogger,
+  { isCanary }: GenerationContext,
 ): ModeledMethod[] {
   const modeledMethods: ModeledMethod[] = [];
 
   for (const resultSetName in bqrs) {
+    if (
+      resultSetName ===
+        modelsAsDataLanguage.predicates.type?.extensiblePredicate &&
+      !isCanary
+    ) {
+      // Don't load generated type results in non-canary mode. These are already automatically
+      // generated on start-up.
+      continue;
+    }
+
     const definition = Object.values(modelsAsDataLanguage.predicates).find(
       (definition) => definition.extensiblePredicate === resultSetName,
     );

--- a/extensions/ql-vscode/src/model-editor/languages/ruby/generate.ts
+++ b/extensions/ql-vscode/src/model-editor/languages/ruby/generate.ts
@@ -12,7 +12,7 @@ export function parseGenerateModelResults(
   bqrs: DecodedBqrs,
   modelsAsDataLanguage: ModelsAsDataLanguage,
   logger: BaseLogger,
-  { isCanary }: GenerationContext,
+  { config }: GenerationContext,
 ): ModeledMethod[] {
   const modeledMethods: ModeledMethod[] = [];
 
@@ -20,10 +20,10 @@ export function parseGenerateModelResults(
     if (
       resultSetName ===
         modelsAsDataLanguage.predicates.type?.extensiblePredicate &&
-      !isCanary
+      !config.showTypeModels
     ) {
-      // Don't load generated type results in non-canary mode. These are already automatically
-      // generated on start-up.
+      // Don't load generated type results when type models are hidden. These are already
+      // automatically generated on start-up.
       continue;
     }
 

--- a/extensions/ql-vscode/src/model-editor/languages/ruby/index.ts
+++ b/extensions/ql-vscode/src/model-editor/languages/ruby/index.ts
@@ -209,8 +209,9 @@ export const ruby: ModelsAsDataLanguage = {
         },
       ];
     },
-    // Only enabled for framework mode in non-canary
-    enabled: ({ mode, isCanary }) => mode === Mode.Framework && !isCanary,
+    // Only enabled for framework mode when type models are hidden
+    enabled: ({ mode, config }) =>
+      mode === Mode.Framework && !config.showTypeModels,
   },
   accessPathSuggestions: {
     queryConstraints: (mode) => ({

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -40,7 +40,6 @@ import type { Method } from "./method";
 import type { ModeledMethod } from "./modeled-method";
 import type { ExtensionPack } from "./shared/extension-pack";
 import type { ModelConfigListener } from "../config";
-import { isCanary } from "../config";
 import { Mode } from "./shared/mode";
 import {
   GENERATED_MODELS_SUFFIX,
@@ -273,6 +272,7 @@ export class ModelEditorView extends AbstractWebview<
                 modeledMethods,
                 mode,
                 this.cliServer,
+                this.modelConfig,
                 this.app.logger,
               );
 
@@ -490,6 +490,7 @@ export class ModelEditorView extends AbstractWebview<
         this.extensionPack,
         this.language,
         this.cliServer,
+        this.modelConfig,
         this.app.logger,
       );
       this.modelingStore.setModeledMethods(this.databaseItem, modeledMethods);
@@ -663,7 +664,7 @@ export class ModelEditorView extends AbstractWebview<
                 this.app.logger,
                 {
                   mode,
-                  isCanary: isCanary(),
+                  config: this.modelConfig,
                 },
               );
 
@@ -701,7 +702,7 @@ export class ModelEditorView extends AbstractWebview<
 
     if (
       autoModelGeneration.enabled &&
-      !autoModelGeneration.enabled({ mode, isCanary: isCanary() })
+      !autoModelGeneration.enabled({ mode, config: this.modelConfig })
     ) {
       return;
     }

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -757,7 +757,7 @@ export class ModelEditorView extends AbstractWebview<
           message: "Saving generated models",
         });
 
-        const fileContents = `# This file was automatically generated based from ${this.databaseItem.name}. Manual changes will not persist.\n\n${modelExtensionFileToYaml(extensionFile)}`;
+        const fileContents = `# This file was automatically generated from ${this.databaseItem.name}. Manual changes will not persist.\n\n${modelExtensionFileToYaml(extensionFile)}`;
         const filePath = join(
           this.extensionPack.path,
           "models",

--- a/extensions/ql-vscode/src/model-editor/modeled-method-fs.ts
+++ b/extensions/ql-vscode/src/model-editor/modeled-method-fs.ts
@@ -12,7 +12,7 @@ import { load as loadYaml } from "js-yaml";
 import type { CodeQLCliServer } from "../codeql-cli/cli";
 import { pathsEqual } from "../common/files";
 import type { QueryLanguage } from "../common/query-language";
-import { isCanary } from "../config";
+import type { ModelConfig } from "./languages";
 
 export const GENERATED_MODELS_SUFFIX = ".model.generated.yml";
 
@@ -23,12 +23,14 @@ export async function saveModeledMethods(
   modeledMethods: Readonly<Record<string, readonly ModeledMethod[]>>,
   mode: Mode,
   cliServer: CodeQLCliServer,
+  modelConfig: ModelConfig,
   logger: NotificationLogger,
 ): Promise<void> {
   const existingModeledMethods = await loadModeledMethodFiles(
     extensionPack,
     language,
     cliServer,
+    modelConfig,
     logger,
   );
 
@@ -51,9 +53,14 @@ async function loadModeledMethodFiles(
   extensionPack: ExtensionPack,
   language: QueryLanguage,
   cliServer: CodeQLCliServer,
+  modelConfig: ModelConfig,
   logger: NotificationLogger,
 ): Promise<Record<string, Record<string, ModeledMethod[]>>> {
-  const modelFiles = await listModelFiles(extensionPack.path, cliServer);
+  const modelFiles = await listModelFiles(
+    extensionPack.path,
+    cliServer,
+    modelConfig,
+  );
 
   const modeledMethodsByFile: Record<
     string,
@@ -85,6 +92,7 @@ export async function loadModeledMethods(
   extensionPack: ExtensionPack,
   language: QueryLanguage,
   cliServer: CodeQLCliServer,
+  modelConfig: ModelConfig,
   logger: NotificationLogger,
 ): Promise<Record<string, ModeledMethod[]>> {
   const existingModeledMethods: Record<string, ModeledMethod[]> = {};
@@ -93,6 +101,7 @@ export async function loadModeledMethods(
     extensionPack,
     language,
     cliServer,
+    modelConfig,
     logger,
   );
   for (const modeledMethods of Object.values(modeledMethodsByFile)) {
@@ -111,6 +120,7 @@ export async function loadModeledMethods(
 export async function listModelFiles(
   extensionPackPath: string,
   cliServer: CodeQLCliServer,
+  modelConfig: ModelConfig,
 ): Promise<Set<string>> {
   const result = await cliServer.resolveExtensions(
     extensionPackPath,
@@ -121,8 +131,11 @@ export async function listModelFiles(
   for (const [path, extensions] of Object.entries(result.data)) {
     if (pathsEqual(path, extensionPackPath)) {
       for (const extension of extensions) {
-        // We only load generated models in canary mode
-        if (!isCanary() && extension.file.endsWith(GENERATED_MODELS_SUFFIX)) {
+        // We only load generated models when type models are shown
+        if (
+          !modelConfig.showTypeModels &&
+          extension.file.endsWith(GENERATED_MODELS_SUFFIX)
+        ) {
           continue;
         }
 

--- a/extensions/ql-vscode/src/model-editor/modeled-method-fs.ts
+++ b/extensions/ql-vscode/src/model-editor/modeled-method-fs.ts
@@ -12,6 +12,9 @@ import { load as loadYaml } from "js-yaml";
 import type { CodeQLCliServer } from "../codeql-cli/cli";
 import { pathsEqual } from "../common/files";
 import type { QueryLanguage } from "../common/query-language";
+import { isCanary } from "../config";
+
+export const GENERATED_MODELS_SUFFIX = ".model.generated.yml";
 
 export async function saveModeledMethods(
   extensionPack: ExtensionPack,
@@ -118,6 +121,11 @@ export async function listModelFiles(
   for (const [path, extensions] of Object.entries(result.data)) {
     if (pathsEqual(path, extensionPackPath)) {
       for (const extension of extensions) {
+        // We only load generated models in canary mode
+        if (!isCanary() && extension.file.endsWith(GENERATED_MODELS_SUFFIX)) {
+          continue;
+        }
+
         modelFiles.add(relative(extensionPackPath, extension.file));
       }
     }

--- a/extensions/ql-vscode/src/model-editor/yaml.ts
+++ b/extensions/ql-vscode/src/model-editor/yaml.ts
@@ -337,7 +337,7 @@ function validateModelExtensionFile(data: unknown): data is ModelExtensionFile {
  *
  * @param data The data extension file
  */
-function modelExtensionFileToYaml(data: ModelExtensionFile) {
+export function modelExtensionFileToYaml(data: ModelExtensionFile) {
   const extensions = data.extensions
     .map((extension) => {
       const data =

--- a/extensions/ql-vscode/test/unit-tests/model-editor/languages/ruby/generate.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/model-editor/languages/ruby/generate.test.ts
@@ -5,6 +5,7 @@ import { createMockLogger } from "../../../../__mocks__/loggerMock";
 import type { ModeledMethod } from "../../../../../src/model-editor/modeled-method";
 import { EndpointType } from "../../../../../src/model-editor/method";
 import { Mode } from "../../../../../src/model-editor/shared/mode";
+import { defaultModelConfig } from "../../../../../src/model-editor/languages";
 
 describe("parseGenerateModelResults", () => {
   it("should return the results", async () => {
@@ -78,8 +79,11 @@ describe("parseGenerateModelResults", () => {
       ruby,
       createMockLogger(),
       {
-        isCanary: true,
         mode: Mode.Framework,
+        config: {
+          ...defaultModelConfig,
+          showTypeModels: true,
+        },
       },
     );
     expect(result).toEqual([

--- a/extensions/ql-vscode/test/unit-tests/model-editor/languages/ruby/generate.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/model-editor/languages/ruby/generate.test.ts
@@ -4,6 +4,7 @@ import { ruby } from "../../../../../src/model-editor/languages/ruby";
 import { createMockLogger } from "../../../../__mocks__/loggerMock";
 import type { ModeledMethod } from "../../../../../src/model-editor/modeled-method";
 import { EndpointType } from "../../../../../src/model-editor/method";
+import { Mode } from "../../../../../src/model-editor/shared/mode";
 
 describe("parseGenerateModelResults", () => {
   it("should return the results", async () => {
@@ -76,6 +77,10 @@ describe("parseGenerateModelResults", () => {
       bqrs,
       ruby,
       createMockLogger(),
+      {
+        isCanary: true,
+        mode: Mode.Framework,
+      },
     );
     expect(result).toEqual([
       {

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/generate.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/generate.test.ts
@@ -14,6 +14,7 @@ import { ruby } from "../../../../src/model-editor/languages/ruby";
 import type { ModeledMethod } from "../../../../src/model-editor/modeled-method";
 import { EndpointType } from "../../../../src/model-editor/method";
 import { Mode } from "../../../../src/model-editor/shared/mode";
+import { defaultModelConfig } from "../../../../src/model-editor/languages";
 
 describe("runGenerateQueries", () => {
   const modelsAsDataLanguage = ruby;
@@ -136,8 +137,11 @@ describe("runGenerateQueries", () => {
             modelsAsDataLanguage,
             createMockLogger(),
             {
-              isCanary: true,
               mode: Mode.Framework,
+              config: {
+                ...defaultModelConfig,
+                showTypeModels: true,
+              },
             },
           ),
         );

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/generate.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/generate.test.ts
@@ -128,14 +128,20 @@ describe("runGenerateQueries", () => {
     await runGenerateQueries({
       queryConstraints: modelGeneration.queryConstraints(Mode.Framework),
       filterQueries: modelGeneration.filterQueries,
-      parseResults: (queryPath, results) =>
-        modelGeneration.parseResults(
-          queryPath,
-          results,
-          modelsAsDataLanguage,
-          createMockLogger(),
-        ),
-      onResults,
+      onResults: (queryPath, results) => {
+        onResults(
+          modelGeneration.parseResults(
+            queryPath,
+            results,
+            modelsAsDataLanguage,
+            createMockLogger(),
+            {
+              isCanary: true,
+              mode: Mode.Framework,
+            },
+          ),
+        );
+      },
       ...options,
     });
     expect(onResults).toHaveBeenCalledWith([


### PR DESCRIPTION
This will generate a separate file `models/ruby.model.generated.yml` when running the model editor for Ruby and type models are hidden (the default). This file is ignored by the model editor, but stores all type models generated by the query. This is part of hiding type models by default.

![Screenshot 2024-02-23 at 15 55 38](https://github.com/github/vscode-codeql/assets/1112623/eb9f9db3-e4e9-43ae-96c8-d75ef1996286)


## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
