### PR TITLE
Reduce repetition in `MultipleModeledMethodsPanel.spec.tsx`

### DIFF
--- a/extensions/ql-vscode/src/view/method-modeling/__tests__/MultipleModeledMethodsPanel.spec.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/__tests__/MultipleModeledMethodsPanel.spec.tsx
@@ -10,31 +10,43 @@ import { MultipleModeledMethodsPanel } from "../MultipleModeledMethodsPanel";
 import { userEvent } from "@testing-library/user-event";
 import type { ModeledMethod } from "../../../model-editor/modeled-method";
 import { QueryLanguage } from "../../../common/query-language";
+import type { ModelingStatus } from "../../../model-editor/shared/modeling-status";
 
 describe(MultipleModeledMethodsPanel.name, () => {
-  const render = (props: MultipleModeledMethodsPanelProps) =>
-    reactRender(<MultipleModeledMethodsPanel {...props} />);
-
   const language = QueryLanguage.Java;
   const method = createMethod();
   const isModelingInProgress = false;
   const isProcessedByAutoModel = false;
-  const modelingStatus = "unmodeled";
+  const modelingStatus: ModelingStatus = "unmodeled";
   const onChange = jest.fn<void, [string, ModeledMethod[]]>();
+
+  const baseProps = {
+    language,
+    method,
+    modelingStatus,
+    isModelingInProgress,
+    isProcessedByAutoModel,
+    onChange,
+  };
+
+  const createRender =
+    (modeledMethods: ModeledMethod[]) =>
+    (props: Partial<MultipleModeledMethodsPanelProps> = {}) =>
+      reactRender(
+        <MultipleModeledMethodsPanel
+          {...baseProps}
+          modeledMethods={modeledMethods}
+          {...props}
+        />,
+      );
 
   describe("with no modeled methods", () => {
     const modeledMethods: ModeledMethod[] = [];
 
+    const render = createRender(modeledMethods);
+
     it("renders the method modeling inputs once", () => {
-      render({
-        language,
-        method,
-        modeledMethods,
-        modelingStatus,
-        isModelingInProgress,
-        isProcessedByAutoModel,
-        onChange,
-      });
+      render();
 
       expect(screen.getAllByRole("combobox")).toHaveLength(4);
       expect(
@@ -45,15 +57,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
     });
 
     it("disables all pagination", () => {
-      render({
-        language,
-        method,
-        modeledMethods,
-        modelingStatus,
-        isModelingInProgress,
-        isProcessedByAutoModel,
-        onChange,
-      });
+      render();
 
       expect(
         screen
@@ -68,15 +72,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
     });
 
     it("cannot add or delete modeling", () => {
-      render({
-        language,
-        method,
-        modeledMethods,
-        modelingStatus,
-        isModelingInProgress,
-        isProcessedByAutoModel,
-        onChange,
-      });
+      render();
 
       expect(
         screen
@@ -99,16 +95,10 @@ describe(MultipleModeledMethodsPanel.name, () => {
       }),
     ];
 
+    const render = createRender(modeledMethods);
+
     it("renders the method modeling inputs once", () => {
-      render({
-        language,
-        method,
-        modeledMethods,
-        modelingStatus,
-        isModelingInProgress,
-        isProcessedByAutoModel,
-        onChange,
-      });
+      render();
 
       expect(screen.getAllByRole("combobox")).toHaveLength(4);
       expect(
@@ -119,15 +109,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
     });
 
     it("disables all pagination", () => {
-      render({
-        language,
-        method,
-        modeledMethods,
-        modelingStatus,
-        isModelingInProgress,
-        isProcessedByAutoModel,
-        onChange,
-      });
+      render();
 
       expect(
         screen
@@ -141,15 +123,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
     });
 
     it("cannot delete modeling", () => {
-      render({
-        language,
-        method,
-        modeledMethods,
-        modelingStatus,
-        isModelingInProgress,
-        isProcessedByAutoModel,
-        onChange,
-      });
+      render();
 
       expect(
         screen
@@ -159,15 +133,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
     });
 
     it("can add modeling", async () => {
-      render({
-        language,
-        method,
-        modeledMethods,
-        modelingStatus,
-        isModelingInProgress,
-        isProcessedByAutoModel,
-        onChange,
-      });
+      render();
 
       await userEvent.click(screen.getByLabelText("Add modeling"));
 
@@ -186,29 +152,16 @@ describe(MultipleModeledMethodsPanel.name, () => {
     });
 
     it("changes selection to the newly added modeling", async () => {
-      const { rerender } = render({
-        language,
-        method,
-        modeledMethods,
-        modelingStatus,
-        isModelingInProgress,
-        isProcessedByAutoModel,
-        onChange,
-      });
+      const { rerender } = render();
 
       await userEvent.click(screen.getByLabelText("Add modeling"));
 
       rerender(
         <MultipleModeledMethodsPanel
-          language={language}
-          method={method}
+          {...baseProps}
           modeledMethods={
             onChange.mock.calls[onChange.mock.calls.length - 1][1]
           }
-          isModelingInProgress={isModelingInProgress}
-          isProcessedByAutoModel={isProcessedByAutoModel}
-          modelingStatus={modelingStatus}
-          onChange={onChange}
         />,
       );
 
@@ -226,16 +179,10 @@ describe(MultipleModeledMethodsPanel.name, () => {
       }),
     ];
 
+    const render = createRender(modeledMethods);
+
     it("renders the method modeling inputs once", () => {
-      render({
-        language,
-        method,
-        modeledMethods,
-        isModelingInProgress,
-        isProcessedByAutoModel,
-        modelingStatus,
-        onChange,
-      });
+      render();
 
       expect(screen.getAllByRole("combobox")).toHaveLength(4);
       expect(
@@ -246,15 +193,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
     });
 
     it("renders the pagination", () => {
-      render({
-        language,
-        method,
-        modeledMethods,
-        isModelingInProgress,
-        isProcessedByAutoModel,
-        modelingStatus,
-        onChange,
-      });
+      render();
 
       expect(screen.getByLabelText("Previous modeling")).toBeInTheDocument();
       expect(screen.getByLabelText("Next modeling")).toBeInTheDocument();
@@ -262,15 +201,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
     });
 
     it("disables the correct pagination", async () => {
-      render({
-        language,
-        method,
-        modeledMethods,
-        isModelingInProgress,
-        isProcessedByAutoModel,
-        modelingStatus,
-        onChange,
-      });
+      render();
 
       expect(
         screen
@@ -283,15 +214,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
     });
 
     it("can use the pagination", async () => {
-      render({
-        language,
-        method,
-        modeledMethods,
-        isModelingInProgress,
-        isProcessedByAutoModel,
-        modelingStatus,
-        onChange,
-      });
+      render();
 
       await userEvent.click(screen.getByLabelText("Next modeling"));
 
@@ -321,27 +244,14 @@ describe(MultipleModeledMethodsPanel.name, () => {
     });
 
     it("correctly updates selected pagination index when the number of models decreases", async () => {
-      const { rerender } = render({
-        language,
-        method,
-        modeledMethods,
-        isModelingInProgress,
-        isProcessedByAutoModel,
-        modelingStatus,
-        onChange,
-      });
+      const { rerender } = render();
 
       await userEvent.click(screen.getByLabelText("Next modeling"));
 
       rerender(
         <MultipleModeledMethodsPanel
-          language={language}
-          method={method}
+          {...baseProps}
           modeledMethods={[modeledMethods[1]]}
-          isModelingInProgress={isModelingInProgress}
-          isProcessedByAutoModel={isProcessedByAutoModel}
-          modelingStatus={modelingStatus}
-          onChange={onChange}
         />,
       );
 
@@ -354,29 +264,13 @@ describe(MultipleModeledMethodsPanel.name, () => {
     });
 
     it("does not show errors", () => {
-      render({
-        language,
-        method,
-        modeledMethods,
-        isModelingInProgress,
-        isProcessedByAutoModel,
-        modelingStatus,
-        onChange,
-      });
+      render();
 
       expect(screen.queryByRole("alert")).not.toBeInTheDocument();
     });
 
     it("can update the first modeling", async () => {
-      render({
-        language,
-        method,
-        modeledMethods,
-        isModelingInProgress,
-        isProcessedByAutoModel,
-        modelingStatus,
-        onChange,
-      });
+      render();
 
       const modelTypeDropdown = screen.getByRole("combobox", {
         name: "Model type",
@@ -402,15 +296,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
     });
 
     it("can update the second modeling", async () => {
-      render({
-        language,
-        method,
-        modeledMethods,
-        isModelingInProgress,
-        isProcessedByAutoModel,
-        modelingStatus,
-        onChange,
-      });
+      render();
 
       await userEvent.click(screen.getByLabelText("Next modeling"));
 
@@ -438,15 +324,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
     });
 
     it("can delete modeling", async () => {
-      render({
-        language,
-        method,
-        modeledMethods,
-        isModelingInProgress,
-        isProcessedByAutoModel,
-        modelingStatus,
-        onChange,
-      });
+      render();
 
       await userEvent.click(screen.getByLabelText("Delete modeling"));
 
@@ -457,15 +335,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
     });
 
     it("can add modeling", async () => {
-      render({
-        language,
-        method,
-        modeledMethods,
-        isModelingInProgress,
-        isProcessedByAutoModel,
-        modelingStatus,
-        onChange,
-      });
+      render();
 
       await userEvent.click(screen.getByLabelText("Add modeling"));
 
@@ -484,29 +354,16 @@ describe(MultipleModeledMethodsPanel.name, () => {
     });
 
     it("shows an error when adding a neutral modeling", async () => {
-      const { rerender } = render({
-        language,
-        method,
-        modeledMethods,
-        isModelingInProgress,
-        isProcessedByAutoModel,
-        modelingStatus,
-        onChange,
-      });
+      const { rerender } = render();
 
       await userEvent.click(screen.getByLabelText("Add modeling"));
 
       rerender(
         <MultipleModeledMethodsPanel
-          language={language}
-          method={method}
+          {...baseProps}
           modeledMethods={
             onChange.mock.calls[onChange.mock.calls.length - 1][1]
           }
-          isModelingInProgress={isModelingInProgress}
-          isProcessedByAutoModel={isProcessedByAutoModel}
-          modelingStatus={modelingStatus}
-          onChange={onChange}
         />,
       );
 
@@ -520,15 +377,10 @@ describe(MultipleModeledMethodsPanel.name, () => {
 
       rerender(
         <MultipleModeledMethodsPanel
-          language={language}
-          method={method}
+          {...baseProps}
           modeledMethods={
             onChange.mock.calls[onChange.mock.calls.length - 1][1]
           }
-          isModelingInProgress={isModelingInProgress}
-          isProcessedByAutoModel={isProcessedByAutoModel}
-          modelingStatus={modelingStatus}
-          onChange={onChange}
         />,
       );
 
@@ -540,15 +392,10 @@ describe(MultipleModeledMethodsPanel.name, () => {
 
       rerender(
         <MultipleModeledMethodsPanel
-          language={language}
-          method={method}
+          {...baseProps}
           modeledMethods={
             onChange.mock.calls[onChange.mock.calls.length - 1][1]
           }
-          isModelingInProgress={isModelingInProgress}
-          isProcessedByAutoModel={isProcessedByAutoModel}
-          modelingStatus={modelingStatus}
-          onChange={onChange}
         />,
       );
 
@@ -559,15 +406,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
     });
 
     it("changes selection to the newly added modeling", async () => {
-      const { rerender } = render({
-        language,
-        method,
-        modeledMethods,
-        isModelingInProgress,
-        isProcessedByAutoModel,
-        modelingStatus,
-        onChange,
-      });
+      const { rerender } = render();
 
       expect(screen.getByText("1/2")).toBeInTheDocument();
 
@@ -575,15 +414,10 @@ describe(MultipleModeledMethodsPanel.name, () => {
 
       rerender(
         <MultipleModeledMethodsPanel
-          language={language}
-          method={method}
+          {...baseProps}
           modeledMethods={
             onChange.mock.calls[onChange.mock.calls.length - 1][1]
           }
-          isModelingInProgress={isModelingInProgress}
-          isProcessedByAutoModel={isProcessedByAutoModel}
-          modelingStatus={modelingStatus}
-          onChange={onChange}
         />,
       );
 
@@ -610,16 +444,10 @@ describe(MultipleModeledMethodsPanel.name, () => {
       }),
     ];
 
+    const render = createRender(modeledMethods);
+
     it("can use the pagination", async () => {
-      render({
-        language,
-        method,
-        modeledMethods,
-        isModelingInProgress,
-        isProcessedByAutoModel,
-        modelingStatus,
-        onChange,
-      });
+      render();
 
       expect(
         screen
@@ -703,27 +531,14 @@ describe(MultipleModeledMethodsPanel.name, () => {
     });
 
     it("preserves selection when a modeling other than the selected modeling is removed", async () => {
-      const { rerender } = render({
-        language,
-        method,
-        modeledMethods,
-        isModelingInProgress,
-        isProcessedByAutoModel,
-        modelingStatus,
-        onChange,
-      });
+      const { rerender } = render();
 
       expect(screen.getByText("1/3")).toBeInTheDocument();
 
       rerender(
         <MultipleModeledMethodsPanel
-          language={language}
-          method={method}
+          {...baseProps}
           modeledMethods={modeledMethods.slice(0, 2)}
-          isModelingInProgress={isModelingInProgress}
-          isProcessedByAutoModel={isProcessedByAutoModel}
-          modelingStatus={modelingStatus}
-          onChange={onChange}
         />,
       );
 
@@ -731,15 +546,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
     });
 
     it("reduces selection when the selected modeling is removed", async () => {
-      const { rerender } = render({
-        language,
-        method,
-        modeledMethods,
-        isModelingInProgress,
-        isProcessedByAutoModel,
-        modelingStatus,
-        onChange,
-      });
+      const { rerender } = render();
 
       await userEvent.click(screen.getByLabelText("Next modeling"));
       await userEvent.click(screen.getByLabelText("Next modeling"));
@@ -747,13 +554,8 @@ describe(MultipleModeledMethodsPanel.name, () => {
 
       rerender(
         <MultipleModeledMethodsPanel
-          language={language}
-          method={method}
+          {...baseProps}
           modeledMethods={modeledMethods.slice(0, 2)}
-          isModelingInProgress={isModelingInProgress}
-          isProcessedByAutoModel={isProcessedByAutoModel}
-          modelingStatus={modelingStatus}
-          onChange={onChange}
         />,
       );
 
@@ -774,16 +576,10 @@ describe(MultipleModeledMethodsPanel.name, () => {
       }),
     ];
 
+    const render = createRender(modeledMethods);
+
     it("can add modeling", () => {
-      render({
-        language,
-        method,
-        modeledMethods,
-        isModelingInProgress,
-        isProcessedByAutoModel,
-        modelingStatus,
-        onChange,
-      });
+      render();
 
       expect(
         screen.getByLabelText("Add modeling").getElementsByTagName("input")[0],
@@ -791,15 +587,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
     });
 
     it("can delete first modeling", async () => {
-      render({
-        language,
-        method,
-        modeledMethods,
-        isModelingInProgress,
-        isProcessedByAutoModel,
-        modelingStatus,
-        onChange,
-      });
+      render();
 
       await userEvent.click(screen.getByLabelText("Delete modeling"));
 
@@ -810,15 +598,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
     });
 
     it("can delete second modeling", async () => {
-      render({
-        language,
-        method,
-        modeledMethods,
-        isModelingInProgress,
-        isProcessedByAutoModel,
-        modelingStatus,
-        onChange,
-      });
+      render();
 
       await userEvent.click(screen.getByLabelText("Next modeling"));
       await userEvent.click(screen.getByLabelText("Delete modeling"));
@@ -830,15 +610,7 @@ describe(MultipleModeledMethodsPanel.name, () => {
     });
 
     it("can add modeling after deleting second modeling", async () => {
-      const { rerender } = render({
-        language,
-        method,
-        modeledMethods,
-        isModelingInProgress,
-        isProcessedByAutoModel,
-        modelingStatus,
-        onChange,
-      });
+      const { rerender } = render();
 
       await userEvent.click(screen.getByLabelText("Next modeling"));
       await userEvent.click(screen.getByLabelText("Delete modeling"));
@@ -850,13 +622,8 @@ describe(MultipleModeledMethodsPanel.name, () => {
 
       rerender(
         <MultipleModeledMethodsPanel
-          language={language}
-          method={method}
+          {...baseProps}
           modeledMethods={modeledMethods.slice(0, 1)}
-          isModelingInProgress={isModelingInProgress}
-          isProcessedByAutoModel={isProcessedByAutoModel}
-          modelingStatus={modelingStatus}
-          onChange={onChange}
         />,
       );
 
@@ -888,30 +655,16 @@ describe(MultipleModeledMethodsPanel.name, () => {
       }),
     ];
 
+    const render = createRender(modeledMethods);
+
     it("shows errors", () => {
-      render({
-        language,
-        method,
-        modeledMethods,
-        isModelingInProgress,
-        isProcessedByAutoModel,
-        modelingStatus,
-        onChange,
-      });
+      render();
 
       expect(screen.getByRole("alert")).toBeInTheDocument();
     });
 
     it("shows the correct error message", async () => {
-      render({
-        language,
-        method,
-        modeledMethods,
-        isModelingInProgress,
-        isProcessedByAutoModel,
-        modelingStatus,
-        onChange,
-      });
+      render();
 
       expect(
         screen.getByText("Error: Duplicated classification"),


### PR DESCRIPTION
Adding or removing a prop from the `MultipleModeledMethodsPanel` component required adding/removing that prop from almost 40 separate places in this file (29 tests + 9 `rerender` calls = 38). This moves all of this to a simple `render` function that doesn't require any props, so now you only need to change it in 1 place (`baseProps`).

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
