### PR TITLE
Rename getVariantAnalysis to tryGetVariantAnalysis

### DIFF
--- a/extensions/ql-vscode/src/model-editor/model-evaluator.ts
+++ b/extensions/ql-vscode/src/model-editor/model-evaluator.ts
@@ -120,7 +120,7 @@ export class ModelEvaluator extends DisposableObject {
     evaluationRun: ModelEvaluationRun,
   ): Promise<VariantAnalysis | undefined> {
     if (evaluationRun.variantAnalysisId) {
-      return await this.variantAnalysisManager.getVariantAnalysis(
+      return await this.variantAnalysisManager.tryGetVariantAnalysis(
         evaluationRun.variantAnalysisId,
       );
     }

--- a/extensions/ql-vscode/src/variant-analysis/export-results.ts
+++ b/extensions/ql-vscode/src/variant-analysis/export-results.ts
@@ -42,7 +42,7 @@ export async function exportVariantAnalysisResults(
   await withProgress(
     async (progress: ProgressCallback, token: CancellationToken) => {
       const variantAnalysis =
-        await variantAnalysisManager.getVariantAnalysis(variantAnalysisId);
+        await variantAnalysisManager.tryGetVariantAnalysis(variantAnalysisId);
       if (!variantAnalysis) {
         void extLogger.log(
           `Could not find variant analysis with id ${variantAnalysisId}`,

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-content-provider.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-content-provider.ts
@@ -22,7 +22,7 @@ export const createVariantAnalysisContentProvider = (
     const variantAnalysisId = parseInt(variantAnalysisIdString);
 
     const variantAnalysis =
-      await variantAnalysisManager.getVariantAnalysis(variantAnalysisId);
+      await variantAnalysisManager.tryGetVariantAnalysis(variantAnalysisId);
     if (!variantAnalysis) {
       void showAndLogWarningMessage(
         extLogger,

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -484,7 +484,7 @@ export class VariantAnalysisManager
   }
 
   public async openQueryText(variantAnalysisId: number): Promise<void> {
-    const variantAnalysis = await this.getVariantAnalysis(variantAnalysisId);
+    const variantAnalysis = await this.tryGetVariantAnalysis(variantAnalysisId);
     if (!variantAnalysis) {
       void showAndLogWarningMessage(
         this.app.logger,
@@ -515,7 +515,7 @@ export class VariantAnalysisManager
   }
 
   public async openQueryFile(variantAnalysisId: number): Promise<void> {
-    const variantAnalysis = await this.getVariantAnalysis(variantAnalysisId);
+    const variantAnalysis = await this.tryGetVariantAnalysis(variantAnalysisId);
 
     if (!variantAnalysis) {
       void showAndLogWarningMessage(
@@ -557,7 +557,7 @@ export class VariantAnalysisManager
     return this.views.get(variantAnalysisId);
   }
 
-  public async getVariantAnalysis(
+  public async tryGetVariantAnalysis(
     variantAnalysisId: number,
   ): Promise<VariantAnalysis | undefined> {
     return this.variantAnalyses.get(variantAnalysisId);

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-view-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-view-manager.ts
@@ -19,7 +19,7 @@ export interface VariantAnalysisViewManager<
   unregisterView(view: T): void;
   getView(variantAnalysisId: number): T | undefined;
 
-  getVariantAnalysis(
+  tryGetVariantAnalysis(
     variantAnalysisId: number,
   ): Promise<VariantAnalysis | undefined>;
   getRepoStates(

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-view.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-view.ts
@@ -96,7 +96,7 @@ export class VariantAnalysisView
   }
 
   protected async getPanelConfig(): Promise<WebviewPanelConfig> {
-    const variantAnalysis = await this.manager.getVariantAnalysis(
+    const variantAnalysis = await this.manager.tryGetVariantAnalysis(
       this.variantAnalysisId,
     );
 
@@ -178,7 +178,7 @@ export class VariantAnalysisView
 
     void this.app.logger.log("Variant analysis view loaded");
 
-    const variantAnalysis = await this.manager.getVariantAnalysis(
+    const variantAnalysis = await this.manager.tryGetVariantAnalysis(
       this.variantAnalysisId,
     );
 

--- a/extensions/ql-vscode/test/vscode-tests/activated-extension/variant-analysis/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/activated-extension/variant-analysis/variant-analysis-manager.test.ts
@@ -109,7 +109,9 @@ describe("Variant Analysis Manager", () => {
         await variantAnalysisManager.rehydrateVariantAnalysis(variantAnalysis);
 
         expect(
-          await variantAnalysisManager.getVariantAnalysis(variantAnalysis.id),
+          await variantAnalysisManager.tryGetVariantAnalysis(
+            variantAnalysis.id,
+          ),
         ).toEqual(variantAnalysis);
       });
 


### PR DESCRIPTION
A quick PR to rename the `getVariantAnalysis()` function of the `VariantAnalysisManager` to `tryGetVariantAnalysis()` to better reflect its behaviour. In a future PR I'm planning to introduce a `getVariantAnalysis()` that throws an error if the analysis doesn't exist.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
