### PR TITLE
Minor renames in variant analysis monitor tests

### DIFF
--- a/extensions/ql-vscode/test/vscode-tests/activated-extension/variant-analysis/variant-analysis-monitor.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/activated-extension/variant-analysis/variant-analysis-monitor.test.ts
@@ -36,7 +36,7 @@ describe("Variant Analysis Monitor", () => {
   let variantAnalysis: VariantAnalysis;
 
   const onVariantAnalysisChangeSpy = jest.fn();
-  const mockEecuteCommand = jest.fn();
+  const mockExecuteCommand = jest.fn();
 
   let logger: NotificationLogger;
 
@@ -51,7 +51,7 @@ describe("Variant Analysis Monitor", () => {
     variantAnalysisMonitor = new VariantAnalysisMonitor(
       createMockApp({
         commands: createMockCommandManager({
-          executeCommand: mockEecuteCommand,
+          executeCommand: mockExecuteCommand,
         }),
         logger,
       }),
@@ -124,10 +124,10 @@ describe("Variant Analysis Monitor", () => {
         );
         await variantAnalysisMonitor.monitorVariantAnalysis(variantAnalysis);
 
-        expect(mockEecuteCommand).toHaveBeenCalledTimes(succeededRepos.length);
+        expect(mockExecuteCommand).toHaveBeenCalledTimes(succeededRepos.length);
 
         succeededRepos.forEach((succeededRepo, index) => {
-          expect(mockEecuteCommand).toHaveBeenNthCalledWith(
+          expect(mockExecuteCommand).toHaveBeenNthCalledWith(
             index + 1,
             "codeQL.autoDownloadVariantAnalysisResult",
             mapScannedRepository(succeededRepo),
@@ -153,7 +153,7 @@ describe("Variant Analysis Monitor", () => {
       it("should succeed and not download any repos via a command", async () => {
         await variantAnalysisMonitor.monitorVariantAnalysis(variantAnalysis);
 
-        expect(mockEecuteCommand).not.toHaveBeenCalled();
+        expect(mockExecuteCommand).not.toHaveBeenCalled();
       });
     });
 
@@ -205,7 +205,7 @@ describe("Variant Analysis Monitor", () => {
         await variantAnalysisMonitor.monitorVariantAnalysis(variantAnalysis);
 
         expect(mockGetVariantAnalysisFromApi).toHaveBeenCalledTimes(4);
-        expect(mockEecuteCommand).toHaveBeenCalledTimes(5);
+        expect(mockExecuteCommand).toHaveBeenCalledTimes(5);
       });
     });
 
@@ -298,7 +298,7 @@ describe("Variant Analysis Monitor", () => {
       it("should not try to download any repos", async () => {
         await variantAnalysisMonitor.monitorVariantAnalysis(variantAnalysis);
 
-        expect(mockEecuteCommand).not.toHaveBeenCalled();
+        expect(mockExecuteCommand).not.toHaveBeenCalled();
       });
     });
 

--- a/extensions/ql-vscode/test/vscode-tests/activated-extension/variant-analysis/variant-analysis-monitor.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/activated-extension/variant-analysis/variant-analysis-monitor.test.ts
@@ -27,7 +27,7 @@ import { createMockLogger } from "../../../__mocks__/loggerMock";
 jest.setTimeout(60_000);
 
 describe("Variant Analysis Monitor", () => {
-  let mockGetVariantAnalysis: jest.SpiedFunction<
+  let mockGetVariantAnalysisFromApi: jest.SpiedFunction<
     typeof ghApiClient.getVariantAnalysis
   >;
   let variantAnalysisMonitor: VariantAnalysisMonitor;
@@ -60,7 +60,7 @@ describe("Variant Analysis Monitor", () => {
     );
     variantAnalysisMonitor.onVariantAnalysisChange(onVariantAnalysisChangeSpy);
 
-    mockGetVariantAnalysis = jest
+    mockGetVariantAnalysisFromApi = jest
       .spyOn(ghApiClient, "getVariantAnalysis")
       .mockRejectedValue(new Error("Not mocked"));
 
@@ -80,13 +80,13 @@ describe("Variant Analysis Monitor", () => {
 
     beforeEach(async () => {
       mockFailedApiResponse = createFailedMockApiResponse();
-      mockGetVariantAnalysis.mockResolvedValue(mockFailedApiResponse);
+      mockGetVariantAnalysisFromApi.mockResolvedValue(mockFailedApiResponse);
     });
 
     it("should mark as failed and stop monitoring", async () => {
       await variantAnalysisMonitor.monitorVariantAnalysis(variantAnalysis);
 
-      expect(mockGetVariantAnalysis).toHaveBeenCalledTimes(1);
+      expect(mockGetVariantAnalysisFromApi).toHaveBeenCalledTimes(1);
 
       expect(onVariantAnalysisChangeSpy).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -115,7 +115,7 @@ describe("Variant Analysis Monitor", () => {
           "succeeded",
         ]);
         mockApiResponse = createMockApiResponse("succeeded", scannedRepos);
-        mockGetVariantAnalysis.mockResolvedValue(mockApiResponse);
+        mockGetVariantAnalysisFromApi.mockResolvedValue(mockApiResponse);
       });
 
       it("should trigger a download extension command for each repo", async () => {
@@ -147,7 +147,7 @@ describe("Variant Analysis Monitor", () => {
       beforeEach(async () => {
         scannedRepos = createMockScannedRepos(["pending", "in_progress"]);
         mockApiResponse = createMockApiResponse("in_progress", scannedRepos);
-        mockGetVariantAnalysis.mockResolvedValue(mockApiResponse);
+        mockGetVariantAnalysisFromApi.mockResolvedValue(mockApiResponse);
       });
 
       it("should succeed and not download any repos via a command", async () => {
@@ -170,7 +170,7 @@ describe("Variant Analysis Monitor", () => {
           "pending",
         ]);
         mockApiResponse = createMockApiResponse("in_progress", scannedRepos);
-        mockGetVariantAnalysis.mockResolvedValueOnce(mockApiResponse);
+        mockGetVariantAnalysisFromApi.mockResolvedValueOnce(mockApiResponse);
 
         let nextApiResponse = {
           ...mockApiResponse,
@@ -178,7 +178,7 @@ describe("Variant Analysis Monitor", () => {
         };
         nextApiResponse.scanned_repositories[0].analysis_status = "succeeded";
         nextApiResponse.scanned_repositories[1].analysis_status = "succeeded";
-        mockGetVariantAnalysis.mockResolvedValueOnce(nextApiResponse);
+        mockGetVariantAnalysisFromApi.mockResolvedValueOnce(nextApiResponse);
 
         nextApiResponse = {
           ...mockApiResponse,
@@ -188,7 +188,7 @@ describe("Variant Analysis Monitor", () => {
         };
         nextApiResponse.scanned_repositories[2].analysis_status = "succeeded";
         nextApiResponse.scanned_repositories[5].analysis_status = "succeeded";
-        mockGetVariantAnalysis.mockResolvedValueOnce(nextApiResponse);
+        mockGetVariantAnalysisFromApi.mockResolvedValueOnce(nextApiResponse);
 
         nextApiResponse = {
           ...mockApiResponse,
@@ -198,13 +198,13 @@ describe("Variant Analysis Monitor", () => {
         };
         nextApiResponse.scanned_repositories[3].analysis_status = "succeeded";
         nextApiResponse.scanned_repositories[4].analysis_status = "failed";
-        mockGetVariantAnalysis.mockResolvedValueOnce(nextApiResponse);
+        mockGetVariantAnalysisFromApi.mockResolvedValueOnce(nextApiResponse);
       });
 
       it("should trigger a download extension command for each repo", async () => {
         await variantAnalysisMonitor.monitorVariantAnalysis(variantAnalysis);
 
-        expect(mockGetVariantAnalysis).toHaveBeenCalledTimes(4);
+        expect(mockGetVariantAnalysisFromApi).toHaveBeenCalledTimes(4);
         expect(mockEecuteCommand).toHaveBeenCalledTimes(5);
       });
     });
@@ -222,15 +222,15 @@ describe("Variant Analysis Monitor", () => {
           "pending",
         ]);
         mockApiResponse = createMockApiResponse("in_progress", scannedRepos);
-        mockGetVariantAnalysis.mockResolvedValueOnce(mockApiResponse);
+        mockGetVariantAnalysisFromApi.mockResolvedValueOnce(mockApiResponse);
 
-        mockGetVariantAnalysis.mockRejectedValueOnce(
+        mockGetVariantAnalysisFromApi.mockRejectedValueOnce(
           new Error("No internet connection"),
         );
-        mockGetVariantAnalysis.mockRejectedValueOnce(
+        mockGetVariantAnalysisFromApi.mockRejectedValueOnce(
           new Error("No internet connection"),
         );
-        mockGetVariantAnalysis.mockRejectedValueOnce(
+        mockGetVariantAnalysisFromApi.mockRejectedValueOnce(
           new Error("My different error"),
         );
 
@@ -241,15 +241,15 @@ describe("Variant Analysis Monitor", () => {
         nextApiResponse.scanned_repositories[0].analysis_status = "succeeded";
         nextApiResponse.scanned_repositories[1].analysis_status = "succeeded";
 
-        mockGetVariantAnalysis.mockResolvedValueOnce(nextApiResponse);
+        mockGetVariantAnalysisFromApi.mockResolvedValueOnce(nextApiResponse);
 
-        mockGetVariantAnalysis.mockRejectedValueOnce(
+        mockGetVariantAnalysisFromApi.mockRejectedValueOnce(
           new Error("My different error"),
         );
-        mockGetVariantAnalysis.mockRejectedValueOnce(
+        mockGetVariantAnalysisFromApi.mockRejectedValueOnce(
           new Error("My different error"),
         );
-        mockGetVariantAnalysis.mockRejectedValueOnce(
+        mockGetVariantAnalysisFromApi.mockRejectedValueOnce(
           new Error("Another different error"),
         );
 
@@ -262,7 +262,7 @@ describe("Variant Analysis Monitor", () => {
         nextApiResponse.scanned_repositories[4].analysis_status = "failed";
         nextApiResponse.scanned_repositories[5].analysis_status = "succeeded";
         nextApiResponse.status = "succeeded";
-        mockGetVariantAnalysis.mockResolvedValueOnce(nextApiResponse);
+        mockGetVariantAnalysisFromApi.mockResolvedValueOnce(nextApiResponse);
       });
 
       it("should only trigger the warning once per error", async () => {
@@ -292,7 +292,7 @@ describe("Variant Analysis Monitor", () => {
       beforeEach(async () => {
         scannedRepos = [];
         mockApiResponse = createMockApiResponse("succeeded", scannedRepos);
-        mockGetVariantAnalysis.mockResolvedValue(mockApiResponse);
+        mockGetVariantAnalysisFromApi.mockResolvedValue(mockApiResponse);
       });
 
       it("should not try to download any repos", async () => {
@@ -313,9 +313,9 @@ describe("Variant Analysis Monitor", () => {
           "pending",
         ]);
         mockApiResponse = createMockApiResponse("in_progress", scannedRepos);
-        mockGetVariantAnalysis.mockResolvedValueOnce(mockApiResponse);
+        mockGetVariantAnalysisFromApi.mockResolvedValueOnce(mockApiResponse);
 
-        mockGetVariantAnalysis.mockRejectedValueOnce(
+        mockGetVariantAnalysisFromApi.mockRejectedValueOnce(
           new RequestError("Not Found", 404, {
             request: {
               method: "GET",
@@ -336,7 +336,7 @@ describe("Variant Analysis Monitor", () => {
       it("should stop requesting the variant analysis", async () => {
         await variantAnalysisMonitor.monitorVariantAnalysis(variantAnalysis);
 
-        expect(mockGetVariantAnalysis).toHaveBeenCalledTimes(2);
+        expect(mockGetVariantAnalysisFromApi).toHaveBeenCalledTimes(2);
         expect(logger.showWarningMessage).toHaveBeenCalledTimes(1);
         expect(logger.showWarningMessage).toHaveBeenCalledWith(
           expect.stringMatching(/not found/i),
@@ -350,7 +350,7 @@ describe("Variant Analysis Monitor", () => {
           VariantAnalysisStatus.Canceling,
         );
         mockApiResponse = createMockApiResponse("in_progress");
-        mockGetVariantAnalysis.mockResolvedValue(mockApiResponse);
+        mockGetVariantAnalysisFromApi.mockResolvedValue(mockApiResponse);
 
         await variantAnalysisMonitor.monitorVariantAnalysis(variantAnalysis);
 


### PR DESCRIPTION
Quick PR to make some small renames of variables in the variant analysis monitor tests. See individual commits for easier diffing.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
