### PR TITLE
Some restructuring around variant analysis mapper functions

### DIFF
--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -45,7 +45,7 @@ import type {
 } from "./variant-analysis-results-manager";
 import { getQueryName, prepareRemoteQueryRun } from "./run-remote-query";
 import {
-  mapVariantAnalysis,
+  mapVariantAnalysisFromSubmission,
   mapVariantAnalysisRepositoryTask,
 } from "./variant-analysis-mapper";
 import PQueue from "p-queue";
@@ -387,7 +387,7 @@ export class VariantAnalysisManager
       throw e;
     }
 
-    const mappedVariantAnalysis = mapVariantAnalysis(
+    const mappedVariantAnalysis = mapVariantAnalysisFromSubmission(
       variantAnalysisSubmission,
       variantAnalysisResponse,
     );

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-mapper.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-mapper.ts
@@ -23,11 +23,11 @@ import {
   VariantAnalysisRepoStatus,
 } from "./shared/variant-analysis";
 
-export function mapVariantAnalysis(
+export function mapVariantAnalysisFromSubmission(
   submission: VariantAnalysisSubmission,
-  response: ApiVariantAnalysis,
+  apiVariantAnalysis: ApiVariantAnalysis,
 ): VariantAnalysis {
-  return mapUpdatedVariantAnalysis(
+  return mapVariantAnalysis(
     {
       language: submission.language,
       query: {
@@ -41,12 +41,23 @@ export function mapVariantAnalysis(
       executionStartTime: submission.startTime,
     },
     undefined,
-    response,
+    apiVariantAnalysis,
   );
 }
 
 export function mapUpdatedVariantAnalysis(
-  previousVariantAnalysis: Pick<
+  currentVariantAnalysis: VariantAnalysis,
+  apiVariantAnalysis: ApiVariantAnalysis,
+): VariantAnalysis {
+  return mapVariantAnalysis(
+    currentVariantAnalysis,
+    currentVariantAnalysis.status,
+    apiVariantAnalysis,
+  );
+}
+
+function mapVariantAnalysis(
+  currentVariantAnalysis: Pick<
     VariantAnalysis,
     "language" | "query" | "queries" | "databases" | "executionStartTime"
   >,
@@ -82,11 +93,11 @@ export function mapUpdatedVariantAnalysis(
       fullName: response.controller_repo.full_name,
       private: response.controller_repo.private,
     },
-    language: previousVariantAnalysis.language,
-    query: previousVariantAnalysis.query,
-    queries: previousVariantAnalysis.queries,
-    databases: previousVariantAnalysis.databases,
-    executionStartTime: previousVariantAnalysis.executionStartTime,
+    language: currentVariantAnalysis.language,
+    query: currentVariantAnalysis.query,
+    queries: currentVariantAnalysis.queries,
+    databases: currentVariantAnalysis.databases,
+    executionStartTime: currentVariantAnalysis.executionStartTime,
     createdAt: response.created_at,
     updatedAt: response.updated_at,
     status,

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-monitor.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-monitor.ts
@@ -128,8 +128,10 @@ export class VariantAnalysisMonitor extends DisposableObject {
       // may not be aware of it yet.
       const currentStatus = this.getVariantAnalysisStatus(variantAnalysis.id);
       variantAnalysis = mapUpdatedVariantAnalysis(
-        variantAnalysis,
-        currentStatus,
+        {
+          ...variantAnalysis,
+          status: currentStatus,
+        },
         variantAnalysisSummary,
       );
 

--- a/extensions/ql-vscode/test/unit-tests/variant-analysis/variant-analysis-mapper.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/variant-analysis/variant-analysis-mapper.test.ts
@@ -4,7 +4,7 @@ import type { VariantAnalysisScannedRepository } from "../../../src/variant-anal
 import { VariantAnalysisRepoStatus } from "../../../src/variant-analysis/shared/variant-analysis";
 import {
   mapScannedRepository,
-  mapVariantAnalysis,
+  mapVariantAnalysisFromSubmission,
   mapVariantAnalysisRepositoryTask,
 } from "../../../src/variant-analysis/variant-analysis-mapper";
 import {
@@ -17,7 +17,7 @@ import { createMockSubmission } from "../../factories/variant-analysis/shared/va
 import { createMockVariantAnalysisRepoTask } from "../../factories/variant-analysis/gh-api/variant-analysis-repo-task";
 import { QueryLanguage } from "../../../src/common/query-language";
 
-describe(mapVariantAnalysis.name, () => {
+describe(mapVariantAnalysisFromSubmission.name, () => {
   const scannedRepos = createMockScannedRepos();
   const skippedRepos = createMockSkippedRepos();
   const mockApiResponse = createMockApiResponse(
@@ -28,7 +28,10 @@ describe(mapVariantAnalysis.name, () => {
   const mockSubmission = createMockSubmission();
 
   it("should map an API response and return a variant analysis", () => {
-    const result = mapVariantAnalysis(mockSubmission, mockApiResponse);
+    const result = mapVariantAnalysisFromSubmission(
+      mockSubmission,
+      mockApiResponse,
+    );
 
     const {
       access_mismatch_repos,

--- a/extensions/ql-vscode/test/vscode-tests/activated-extension/variant-analysis/variant-analysis-monitor.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/activated-extension/variant-analysis/variant-analysis-monitor.test.ts
@@ -131,11 +131,7 @@ describe("Variant Analysis Monitor", () => {
             index + 1,
             "codeQL.autoDownloadVariantAnalysisResult",
             mapScannedRepository(succeededRepo),
-            mapUpdatedVariantAnalysis(
-              variantAnalysis,
-              variantAnalysis.status,
-              mockApiResponse,
-            ),
+            mapUpdatedVariantAnalysis(variantAnalysis, mockApiResponse),
           );
         });
       });


### PR DESCRIPTION
Some small changes to improve the mapper functions for variant analysis entities. We now have a `mapVariantAnalysisFromSubmission` and a `mapUpdatedVariantAnalysis` which match the use cases we have. They both call the same underlying non-exported function. 

We could go a step further and look at simplifying the non-exported function but there was no "obviously better" and quick refactoring there. We could get rid of the `Pick` and expect explicit inputs, or introduce a new type for the parts of a VariantAnalysis that do not change, but I don't think it's worth it at the moment.   

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
