### PR TITLE
Show test results for tests with warnings

### DIFF
--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -156,9 +156,17 @@ type ResolvedQueries = string[];
 type ResolvedTests = string[];
 
 /**
- * A compilation message for a test message (either an error or a warning)
+ * The severity of a compilation message for a test message.
  */
-interface CompilationMessage {
+export enum CompilationMessageSeverity {
+  Error = "ERROR",
+  Warning = "WARNING",
+}
+
+/**
+ * A compilation message for a test message (either an error or a warning).
+ */
+export interface CompilationMessage {
   /**
    * The text of the message
    */
@@ -170,7 +178,7 @@ interface CompilationMessage {
   /**
    * The severity of the message
    */
-  severity: number;
+  severity: CompilationMessageSeverity;
 }
 
 /**

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-testing/test-runner-helpers.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-testing/test-runner-helpers.ts
@@ -11,6 +11,7 @@ export const mockTestsInfo = {
   dPath: Uri.parse("file:/ab/c/d.ql").fsPath,
   gPath: Uri.parse("file:/ab/c/e/f/g.ql").fsPath,
   hPath: Uri.parse("file:/ab/c/e/f/h.ql").fsPath,
+  kPath: Uri.parse("file:/ab/c/e/f/k.ql").fsPath,
 };
 
 /**
@@ -88,6 +89,28 @@ function mockRunTests(): jest.Mock<any, any> {
         compilationMs: 5000,
         evaluationMs: 6000,
         messages: [],
+      });
+      yield Promise.resolve({
+        test: mockTestsInfo.kPath,
+        pass: false,
+        diff: ["jkh", "tuv"],
+        failureStage: "RESULT",
+        compilationMs: 7000,
+        evaluationMs: 8000,
+        // a warning in an otherwise successful test
+        messages: [
+          {
+            position: {
+              fileName: mockTestsInfo.kPath,
+              line: 1,
+              column: 1,
+              endLine: 2,
+              endColumn: 2,
+            },
+            message: "abc",
+            severity: "WARNING",
+          },
+        ],
       });
     })(),
   );

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-testing/test-runner.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-testing/test-runner.test.ts
@@ -94,7 +94,7 @@ describe("test-runner", () => {
       eventHandlerSpy,
     );
 
-    expect(eventHandlerSpy).toHaveBeenCalledTimes(3);
+    expect(eventHandlerSpy).toHaveBeenCalledTimes(4);
 
     expect(eventHandlerSpy).toHaveBeenNthCalledWith(1, {
       test: mockTestsInfo.dPath,
@@ -132,6 +132,27 @@ describe("test-runner", () => {
       diff: ["jkh", "tuv"],
       failureStage: "RESULT",
       messages: [],
+    });
+    expect(eventHandlerSpy).toHaveBeenNthCalledWith(4, {
+      test: mockTestsInfo.kPath,
+      pass: false,
+      compilationMs: 7000,
+      evaluationMs: 8000,
+      diff: ["jkh", "tuv"],
+      failureStage: "RESULT",
+      messages: [
+        {
+          position: {
+            fileName: mockTestsInfo.kPath,
+            line: 1,
+            column: 1,
+            endLine: 2,
+            endColumn: 2,
+          },
+          message: "abc",
+          severity: "WARNING",
+        },
+      ],
     });
   });
 


### PR DESCRIPTION
This fixes tests with warnings that would error out instead of showing the diff. It now results in:

![Screenshot 2024-02-28 at 10 48 48](https://github.com/github/vscode-codeql/assets/1112623/4bbe60bd-4e6b-4674-8c09-e87a955450da)

The warning being shown in the actual output is expected and is [part of normal testing of CodeQL](https://github.com/search?q=repo%3Agithub%2Fcodeql+%22WARNING%3A+%22+path%3A*.expected&type=code). I don't think that's something that can be changed.

Closes https://github.com/github/vscode-codeql/issues/3386

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
