### PR TITLE
Add check for id property when running variant analysis

### DIFF
--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -327,6 +327,17 @@ export class VariantAnalysisManager
       );
     }
 
+    // It's not possible to interpret a BQRS file to SARIF without an id property.
+    if (
+      queryMetadata?.kind &&
+      ["problem", "path-problem"].includes(queryMetadata.kind) &&
+      !queryMetadata.id
+    ) {
+      throw new UserCancellationException(
+        `${firstQueryFile} does not have the required @id property for a ${queryMetadata.kind} query.`,
+      );
+    }
+
     const {
       actionBranch,
       base64Pack,

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -309,21 +309,6 @@ export class VariantAnalysisManager
       message: "Getting credentials",
     });
 
-    const {
-      actionBranch,
-      base64Pack,
-      repoSelection,
-      controllerRepo,
-      queryStartTime,
-    } = await prepareRemoteQueryRun(
-      this.cliServer,
-      this.app.credentials,
-      qlPackDetails,
-      progress,
-      token,
-      this.dbManager,
-    );
-
     // For now we get the metadata for the first query in the pack.
     // and use that in the submission and query history. In the future
     // we'll need to consider how to handle having multiple queries.
@@ -341,6 +326,21 @@ export class VariantAnalysisManager
         `Found unsupported language: ${qlPackDetails.language}`,
       );
     }
+
+    const {
+      actionBranch,
+      base64Pack,
+      repoSelection,
+      controllerRepo,
+      queryStartTime,
+    } = await prepareRemoteQueryRun(
+      this.cliServer,
+      this.app.credentials,
+      qlPackDetails,
+      progress,
+      token,
+      this.dbManager,
+    );
 
     const queryText = await readFile(firstQueryFile, "utf8");
 


### PR DESCRIPTION
This adds a check for variant analyses to ensure that the `@id` metadata is set when running a `problem` or `path-problem` query. This will ensure that this error is caught early.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
