### PR TITLE
Update variant analysis monitor to get the whole variant analysis object

### DIFF
--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -146,7 +146,7 @@ export class VariantAnalysisManager
       new VariantAnalysisMonitor(
         app,
         this.shouldCancelMonitorVariantAnalysis.bind(this),
-        this.getVariantAnalysisStatus.bind(this),
+        this.getVariantAnalysis.bind(this),
       ),
     );
     this.variantAnalysisMonitor.onVariantAnalysisChange(
@@ -606,17 +606,14 @@ export class VariantAnalysisManager
     return !this.variantAnalyses.has(variantAnalysisId);
   }
 
-  private getVariantAnalysisStatus(
-    variantAnalysisId: number,
-  ): VariantAnalysisStatus {
-    const variantAnalysis = this.variantAnalyses.get(variantAnalysisId);
+  private getVariantAnalysis(variantAnalysisId: number): VariantAnalysis {
+    const variantAnalysis = this.tryGetVariantAnalysis(variantAnalysisId);
+
     if (!variantAnalysis) {
-      throw new Error(
-        `No variant analysis found with id: ${variantAnalysisId}.`,
-      );
+      throw new Error(`No variant analysis with id: ${variantAnalysisId}`);
     }
 
-    return variantAnalysis.status;
+    return variantAnalysis;
   }
 
   public async onVariantAnalysisUpdated(

--- a/extensions/ql-vscode/test/vscode-tests/activated-extension/variant-analysis/variant-analysis-monitor.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/activated-extension/variant-analysis/variant-analysis-monitor.test.ts
@@ -32,7 +32,7 @@ describe("Variant Analysis Monitor", () => {
   >;
   let variantAnalysisMonitor: VariantAnalysisMonitor;
   let shouldCancelMonitor: jest.Mock<Promise<boolean>, [number]>;
-  let mockGetVariantAnalysisStatus: jest.Mock<VariantAnalysisStatus, [number]>;
+  let mockGetVariantAnalysis: jest.Mock<VariantAnalysis, [number]>;
   let variantAnalysis: VariantAnalysis;
 
   const onVariantAnalysisChangeSpy = jest.fn();
@@ -44,7 +44,7 @@ describe("Variant Analysis Monitor", () => {
     variantAnalysis = createMockVariantAnalysis({});
 
     shouldCancelMonitor = jest.fn();
-    mockGetVariantAnalysisStatus = jest.fn();
+    mockGetVariantAnalysis = jest.fn();
 
     logger = createMockLogger();
 
@@ -56,13 +56,15 @@ describe("Variant Analysis Monitor", () => {
         logger,
       }),
       shouldCancelMonitor,
-      mockGetVariantAnalysisStatus,
+      mockGetVariantAnalysis,
     );
     variantAnalysisMonitor.onVariantAnalysisChange(onVariantAnalysisChangeSpy);
 
     mockGetVariantAnalysisFromApi = jest
       .spyOn(ghApiClient, "getVariantAnalysis")
       .mockRejectedValue(new Error("Not mocked"));
+
+    mockGetVariantAnalysis.mockReturnValue(variantAnalysis);
 
     limitNumberOfAttemptsToMonitor();
   });
@@ -342,9 +344,11 @@ describe("Variant Analysis Monitor", () => {
 
     describe("cancelation", () => {
       it("should maintain canceling status", async () => {
-        mockGetVariantAnalysisStatus.mockReturnValueOnce(
-          VariantAnalysisStatus.Canceling,
-        );
+        mockGetVariantAnalysis.mockReturnValueOnce({
+          ...variantAnalysis,
+          status: VariantAnalysisStatus.Canceling,
+        });
+
         mockApiResponse = createMockApiResponse("in_progress");
         mockGetVariantAnalysisFromApi.mockResolvedValue(mockApiResponse);
 


### PR DESCRIPTION
Currently the variant analysis monitor gets the up to date status of the variant analysis from the manager. In order to avoid potentially operating on outdated information, we change that to get the whole variant analysis object instead.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
