### PR TITLE
Don't open variant analysis view when running a model evaluation run

### DIFF
--- a/extensions/ql-vscode/src/model-editor/model-evaluator.ts
+++ b/extensions/ql-vscode/src/model-editor/model-evaluator.ts
@@ -60,6 +60,7 @@ export class ModelEvaluator extends DisposableObject {
               qlPack,
               progress,
               token,
+              false,
             );
         } catch (e) {
           this.modelingStore.updateModelEvaluationRun(this.dbItem, undefined);

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -300,6 +300,7 @@ export class VariantAnalysisManager
     qlPackDetails: QlPackDetails,
     progress: ProgressCallback,
     token: CancellationToken,
+    openViewAfterSubmission = true,
   ): Promise<number | undefined> {
     await saveBeforeStart();
 
@@ -399,10 +400,13 @@ export class VariantAnalysisManager
       `Variant analysis ${mappedVariantAnalysis.query.name} submitted for processing`,
     );
 
-    void this.app.commands.execute(
-      "codeQL.openVariantAnalysisView",
-      mappedVariantAnalysis.id,
-    );
+    if (openViewAfterSubmission) {
+      void this.app.commands.execute(
+        "codeQL.openVariantAnalysisView",
+        mappedVariantAnalysis.id,
+      );
+    }
+
     void this.app.commands.execute(
       "codeQL.monitorNewVariantAnalysis",
       mappedVariantAnalysis,


### PR DESCRIPTION
We don't want the variant analysis view to automatically open so this change updates the `runVariantAnalysis` function to allow callers to control whether to auto-open the view or not.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
