### PR TITLE
Skip logging warning for multi-query variant analyses

### DIFF
--- a/extensions/ql-vscode/src/query-history/query-history-manager.ts
+++ b/extensions/ql-vscode/src/query-history/query-history-manager.ts
@@ -418,6 +418,11 @@ export class QueryHistoryManager extends DisposableObject {
             });
             await this.refreshTreeView();
           } else {
+            if (variantAnalysis.queries !== undefined) {
+              // This is a variant analysis that contains multiple queries, which
+              // is not fully supported yet. So we ignore it from the query history.
+              return;
+            }
             void this.app.logger.log(
               "Variant analysis status update event received for unknown variant analysis",
             );


### PR DESCRIPTION
Multi-query variant analyses aren't currently tracked in the query history so the query history manager would log warnings when it would receive updates for them. This change stops logging warnings for those. 

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
