### PR TITLE
Add a new "model alerts" webview (for showing results from model evaluation)

### DIFF
--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -600,6 +600,10 @@ interface StopModelEvaluationMessage {
   t: "stopModelEvaluation";
 }
 
+interface OpenModelAlertsViewMessage {
+  t: "openModelAlertsView";
+}
+
 interface ModelDependencyMessage {
   t: "modelDependency";
 }
@@ -671,7 +675,8 @@ export type FromModelEditorMessage =
   | HideModeledMethodsMessage
   | SetMultipleModeledMethodsMessage
   | StartModelEvaluationMessage
-  | StopModelEvaluationMessage;
+  | StopModelEvaluationMessage
+  | OpenModelAlertsViewMessage;
 
 interface RevealInEditorMessage {
   t: "revealInModelEditor";

--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -726,3 +726,11 @@ export type ToMethodModelingMessage =
   | SetInModelingModeMessage
   | SetInProgressMessage
   | SetProcessedByAutoModelMessage;
+
+interface SetModelAlertsMessage {
+  t: "setModelAlerts";
+}
+
+export type ToModelAlertsMessage = SetModelAlertsMessage;
+
+export type FromModelAlertsMessage = CommonFromViewMessages;

--- a/extensions/ql-vscode/src/common/vscode/webview-html.ts
+++ b/extensions/ql-vscode/src/common/vscode/webview-html.ts
@@ -10,7 +10,8 @@ export type WebviewKind =
   | "variant-analysis"
   | "data-flow-paths"
   | "model-editor"
-  | "method-modeling";
+  | "method-modeling"
+  | "model-alerts";
 
 export interface WebviewMessage {
   t: string;

--- a/extensions/ql-vscode/src/model-editor/model-alerts/model-alerts-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-alerts/model-alerts-view.ts
@@ -4,8 +4,8 @@ import { AbstractWebview } from "../../common/vscode/abstract-webview";
 import { assertNever } from "../../common/helpers-pure";
 import { telemetryListener } from "../../common/vscode/telemetry";
 import type {
-  FromDataFlowPathsMessage,
-  ToDataFlowPathsMessage,
+  FromModelAlertsMessage,
+  ToModelAlertsMessage,
 } from "../../common/interface-types";
 import type { App } from "../../common/app";
 import { redactableError } from "../../common/errors";
@@ -13,8 +13,8 @@ import { extLogger } from "../../common/logging/vscode";
 import { showAndLogExceptionWithTelemetry } from "../../common/logging";
 
 export class ModelAlertsView extends AbstractWebview<
-  ToDataFlowPathsMessage,
-  FromDataFlowPathsMessage
+  ToModelAlertsMessage,
+  FromModelAlertsMessage
 > {
   public static readonly viewType = "codeQL.modelAlerts";
 
@@ -43,7 +43,7 @@ export class ModelAlertsView extends AbstractWebview<
     // Nothing to dispose
   }
 
-  protected async onMessage(msg: FromDataFlowPathsMessage): Promise<void> {
+  protected async onMessage(msg: FromModelAlertsMessage): Promise<void> {
     switch (msg.t) {
       case "viewLoaded":
         this.onWebViewLoaded();

--- a/extensions/ql-vscode/src/model-editor/model-alerts/model-alerts-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-alerts/model-alerts-view.ts
@@ -1,0 +1,67 @@
+import { ViewColumn } from "vscode";
+import type { WebviewPanelConfig } from "../../common/vscode/abstract-webview";
+import { AbstractWebview } from "../../common/vscode/abstract-webview";
+import { assertNever } from "../../common/helpers-pure";
+import { telemetryListener } from "../../common/vscode/telemetry";
+import type {
+  FromDataFlowPathsMessage,
+  ToDataFlowPathsMessage,
+} from "../../common/interface-types";
+import type { App } from "../../common/app";
+import { redactableError } from "../../common/errors";
+import { extLogger } from "../../common/logging/vscode";
+import { showAndLogExceptionWithTelemetry } from "../../common/logging";
+
+export class ModelAlertsView extends AbstractWebview<
+  ToDataFlowPathsMessage,
+  FromDataFlowPathsMessage
+> {
+  public static readonly viewType = "codeQL.modelAlerts";
+
+  public constructor(app: App) {
+    super(app);
+  }
+
+  public async showView() {
+    const panel = await this.getPanel();
+    panel.reveal(undefined, true);
+
+    await this.waitForPanelLoaded();
+  }
+
+  protected async getPanelConfig(): Promise<WebviewPanelConfig> {
+    return {
+      viewId: ModelAlertsView.viewType,
+      title: "Model Alerts",
+      viewColumn: ViewColumn.Active,
+      preserveFocus: true,
+      view: "model-alerts",
+    };
+  }
+
+  protected onPanelDispose(): void {
+    // Nothing to dispose
+  }
+
+  protected async onMessage(msg: FromDataFlowPathsMessage): Promise<void> {
+    switch (msg.t) {
+      case "viewLoaded":
+        this.onWebViewLoaded();
+        break;
+      case "telemetry":
+        telemetryListener?.sendUIInteraction(msg.action);
+        break;
+      case "unhandledError":
+        void showAndLogExceptionWithTelemetry(
+          extLogger,
+          telemetryListener,
+          redactableError(
+            msg.error,
+          )`Unhandled error in model alerts view: ${msg.error.message}`,
+        );
+        break;
+      default:
+        assertNever(msg);
+    }
+  }
+}

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -125,7 +125,7 @@ export class ModelEditorView extends AbstractWebview<
     this.languageDefinition = getModelsAsDataLanguage(language);
 
     this.modelEvaluator = new ModelEvaluator(
-      this.app.logger,
+      this.app,
       this.cliServer,
       modelingStore,
       modelingEvents,
@@ -379,6 +379,9 @@ export class ModelEditorView extends AbstractWebview<
         break;
       case "stopModelEvaluation":
         await this.modelEvaluator.stopEvaluation();
+        break;
+      case "openModelAlertsView":
+        await this.modelEvaluator.openModelAlertsView();
         break;
       case "telemetry":
         telemetryListener?.sendUIInteraction(msg.action);

--- a/extensions/ql-vscode/src/view/model-alerts/ModelAlerts.tsx
+++ b/extensions/ql-vscode/src/view/model-alerts/ModelAlerts.tsx
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+
+export function ModelAlerts(): React.JSX.Element {
+  useEffect(() => {
+    const listener = (evt: MessageEvent) => {
+      // sanitize origin
+      const origin = evt.origin.replace(/\n|\r/g, "");
+      console.error(`Invalid event origin ${origin}`);
+    };
+    window.addEventListener("message", listener);
+
+    return () => {
+      window.removeEventListener("message", listener);
+    };
+  }, []);
+
+  return <>hello world</>;
+}

--- a/extensions/ql-vscode/src/view/model-alerts/ModelAlerts.tsx
+++ b/extensions/ql-vscode/src/view/model-alerts/ModelAlerts.tsx
@@ -3,9 +3,13 @@ import { useEffect } from "react";
 export function ModelAlerts(): React.JSX.Element {
   useEffect(() => {
     const listener = (evt: MessageEvent) => {
-      // sanitize origin
-      const origin = evt.origin.replace(/\n|\r/g, "");
-      console.error(`Invalid event origin ${origin}`);
+      if (evt.origin === window.origin) {
+        // TODO: handle messages
+      } else {
+        // sanitize origin
+        const origin = evt.origin.replace(/\n|\r/g, "");
+        console.error(`Invalid event origin ${origin}`);
+      }
     };
     window.addEventListener("message", listener);
 

--- a/extensions/ql-vscode/src/view/model-alerts/index.tsx
+++ b/extensions/ql-vscode/src/view/model-alerts/index.tsx
@@ -1,0 +1,8 @@
+import type { WebviewDefinition } from "../webview-definition";
+import { ModelAlerts } from "./ModelAlerts";
+
+const definition: WebviewDefinition = {
+  component: <ModelAlerts />,
+};
+
+export default definition;

--- a/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
@@ -277,7 +277,9 @@ export function ModelEditor({
   }, []);
 
   const openModelAlertsView = useCallback(() => {
-    // TODO
+    vscode.postMessage({
+      t: "openModelAlertsView",
+    });
   }, []);
 
   const onGenerateFromSourceClick = useCallback(() => {

--- a/extensions/ql-vscode/src/view/webview.tsx
+++ b/extensions/ql-vscode/src/view/webview.tsx
@@ -11,6 +11,7 @@ import methodModelingView from "./method-modeling";
 import modelEditorView from "./model-editor";
 import resultsView from "./results";
 import variantAnalysisView from "./variant-analysis";
+import modelAlertsView from "./model-alerts";
 
 // Allow all views to use Codicons
 import "@vscode/codicons/dist/codicon.css";
@@ -22,6 +23,7 @@ const views: Record<string, WebviewDefinition> = {
   "model-editor": modelEditorView,
   results: resultsView,
   "variant-analysis": variantAnalysisView,
+  "model-alerts": modelAlertsView,
 };
 
 const render = () => {

--- a/extensions/ql-vscode/test/vscode-tests/activated-extension/model-editor/model-evaluator.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/activated-extension/model-editor/model-evaluator.test.ts
@@ -1,4 +1,5 @@
 import type { CodeQLCliServer } from "../../../../src/codeql-cli/cli";
+import type { App } from "../../../../src/common/app";
 import type { BaseLogger } from "../../../../src/common/logging";
 import { QueryLanguage } from "../../../../src/common/query-language";
 import type { DatabaseItem } from "../../../../src/databases/local-databases";
@@ -15,6 +16,7 @@ import { mockedObject } from "../../../mocked-object";
 describe("Model Evaluator", () => {
   let modelEvaluator: ModelEvaluator;
   let logger: BaseLogger;
+  let app: App;
   let cliServer: CodeQLCliServer;
   let modelingStore: ModelingStore;
   let modelingEvents: ModelingEvents;
@@ -26,6 +28,7 @@ describe("Model Evaluator", () => {
 
   beforeEach(() => {
     logger = createMockLogger();
+    app = mockedObject<App>({ logger });
     cliServer = mockedObject<CodeQLCliServer>({});
     getModelEvaluationRunMock = jest.fn();
     modelingStore = createMockModelingStore({
@@ -40,7 +43,7 @@ describe("Model Evaluator", () => {
     updateView = jest.fn();
 
     modelEvaluator = new ModelEvaluator(
-      logger,
+      app,
       cliServer,
       modelingStore,
       modelingEvents,


### PR DESCRIPTION
This PR adds a (currently empty) "Model alerts" webview, which can be opened by clicking "Evaluation run" from the model editor. In future, this will be populated with evaluation results, but for now it looks like this 😂 

https://github.com/github/vscode-codeql/assets/42641846/ffee2626-d700-461e-9922-2fd6f919afc5

See internal linked issue for more context and future work! 

## Checklist

N/A (feature-flagged for internal use)

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
