### PR TITLE
Avoid using a @treemap query in testplan

### DIFF
--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -53,11 +53,11 @@ choose to go through some of the Optional Test Cases.
 
 #### Test case 3: Running a non-problem query and viewing results
 
-1. Open the [cpp FunLinesOfCode query](https://github.com/github/codeql/blob/main/cpp/ql/src/Metrics/Functions/FunLinesOfCode.ql).
+1. Open the [cpp HubClasses query](https://github.com/github/codeql/blob/main/cpp/ql/src/Architecture/General%20Class-Level%20Information/HubClasses.ql).
 2. Select the `google/brotli` database (or download it if you don't have one already)
 3. Run a local query.
 4. Once the query completes:
-   - Chose the `#select` result set from the drop-down
+   - Check that the `#select` result set is shown
    - Check that the results table is rendered
    - Check that result locations can be clicked on
 


### PR DESCRIPTION
Replaces the query used in the test plan from `@kind treemap` to `@kind table`. The intention is to test a generic non-problem query and not specifically `treemap` which is a kind that is rarely used and we don't necessarily have full support for. It's more important to test a `table` query since those are more likely to be run by users.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
