### PR TITLE
Fix `isQuickEvalCount` logic

### DIFF
--- a/extensions/ql-vscode/src/run-queries-shared.ts
+++ b/extensions/ql-vscode/src/run-queries-shared.ts
@@ -495,8 +495,7 @@ export async function createInitialQueryInfo(
   outputDir: QueryOutputDir,
 ): Promise<InitialQueryInfo> {
   const isQuickEval = selectedQuery.quickEval !== undefined;
-  const isQuickEvalCount =
-    selectedQuery.quickEval?.quickEvalCount !== undefined;
+  const isQuickEvalCount = Boolean(selectedQuery.quickEval?.quickEvalCount);
   return {
     queryPath: selectedQuery.queryPath,
     isQuickEval,


### PR DESCRIPTION
The UI would often show `Quick evaluation counts` even for normal (non counts) quick evaluations.

Since `false !== undefined` evaluates to true, we would assign the
wrong value to `isQuickEvalCount` when `selectedQuery.quickEval?.quickEvalCount` is false

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

## Checklist

**No user facing changes**

- [x] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ x Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
