### PR TITLE
Refactor events to fix the method modeling panel getting stuck showing "start modeling"

### DIFF
--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -693,11 +693,6 @@ interface SetMethodModelingPanelViewStateMessage {
   viewState: MethodModelingPanelViewState;
 }
 
-interface SetMethodMessage {
-  t: "setMethod";
-  method: Method | undefined;
-}
-
 interface SetMethodModifiedMessage {
   t: "setMethodModified";
   isModified: boolean;
@@ -718,7 +713,6 @@ interface SetSelectedMethodMessage {
 
 export type ToMethodModelingMessage =
   | SetMethodModelingPanelViewStateMessage
-  | SetMethodMessage
   | SetMultipleModeledMethodsMessage
   | SetMethodModifiedMessage
   | SetNoMethodSelectedMessage

--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -703,6 +703,10 @@ interface SetMethodModifiedMessage {
   isModified: boolean;
 }
 
+interface SetNoMethodSelectedMessage {
+  t: "setNoMethodSelected";
+}
+
 interface SetSelectedMethodMessage {
   t: "setSelectedMethod";
   method: Method;
@@ -717,6 +721,7 @@ export type ToMethodModelingMessage =
   | SetMethodMessage
   | SetMultipleModeledMethodsMessage
   | SetMethodModifiedMessage
+  | SetNoMethodSelectedMessage
   | SetSelectedMethodMessage
   | SetInModelingModeMessage
   | SetInProgressMessage

--- a/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-panel.ts
+++ b/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-panel.ts
@@ -2,10 +2,8 @@ import { window } from "vscode";
 import type { App } from "../../common/app";
 import { DisposableObject } from "../../common/disposable-object";
 import { MethodModelingViewProvider } from "./method-modeling-view-provider";
-import type { Method } from "../method";
 import type { ModelingStore } from "../modeling-store";
 import { ModelConfigListener } from "../../config";
-import type { DatabaseItem } from "../../databases/local-databases";
 import type { ModelingEvents } from "../modeling-events";
 
 export class MethodModelingPanel extends DisposableObject {
@@ -35,12 +33,5 @@ export class MethodModelingPanel extends DisposableObject {
         this.provider,
       ),
     );
-  }
-
-  public async setMethod(
-    databaseItem: DatabaseItem,
-    method: Method,
-  ): Promise<void> {
-    await this.provider.setMethod(databaseItem, method);
   }
 }

--- a/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
+++ b/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
@@ -242,7 +242,9 @@ export class MethodModelingViewProvider extends AbstractWebviewViewProvider<
         }
 
         if (dbUri === this.databaseItem?.databaseUri.toString()) {
-          await this.setMethod(undefined, undefined);
+          await this.postMessage({
+            t: "setNoMethodSelected",
+          });
         }
       }),
     );

--- a/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
+++ b/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
@@ -38,7 +38,7 @@ export class MethodModelingViewProvider extends AbstractWebviewViewProvider<
   }
 
   protected override async onWebViewLoaded(): Promise<void> {
-    await Promise.all([this.setViewState(), this.setInitialState()]);
+    await this.setInitialState();
     this.registerToModelingEvents();
     this.registerToModelConfigEvents();
   }
@@ -104,29 +104,25 @@ export class MethodModelingViewProvider extends AbstractWebviewViewProvider<
   }
 
   private async setInitialState(): Promise<void> {
-    if (this.modelingStore.hasStateForActiveDb()) {
-      const selectedMethod = this.modelingStore.getSelectedMethodDetails();
-      if (selectedMethod) {
-        this.databaseItem = selectedMethod.databaseItem;
-        this.language = tryGetQueryLanguage(
-          selectedMethod.databaseItem.language,
-        );
-        this.method = selectedMethod.method;
+    await this.setViewState();
 
-        await this.postMessage({
-          t: "setSelectedMethod",
-          method: selectedMethod.method,
-          modeledMethods: selectedMethod.modeledMethods,
-          isModified: selectedMethod.isModified,
-          isInProgress: selectedMethod.isInProgress,
-          processedByAutoModel: selectedMethod.processedByAutoModel,
-        });
-      }
+    const stateForActiveDb = this.modelingStore.getStateForActiveDb();
+    if (!stateForActiveDb) {
+      return;
+    }
 
-      await this.postMessage({
-        t: "setInModelingMode",
-        inModelingMode: true,
-      });
+    await this.setDatabaseItem(stateForActiveDb.databaseItem);
+
+    const selectedMethod = this.modelingStore.getSelectedMethodDetails();
+    if (selectedMethod) {
+      await this.setSelectedMethod(
+        stateForActiveDb.databaseItem,
+        selectedMethod.method,
+        selectedMethod.modeledMethods,
+        selectedMethod.isModified,
+        selectedMethod.isInProgress,
+        selectedMethod.processedByAutoModel,
+      );
     }
   }
 

--- a/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
+++ b/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
@@ -52,6 +52,18 @@ export class MethodModelingViewProvider extends AbstractWebviewViewProvider<
     });
   }
 
+  private async setDatabaseItem(databaseItem: DatabaseItem): Promise<void> {
+    this.databaseItem = databaseItem;
+
+    await this.postMessage({
+      t: "setInModelingMode",
+      inModelingMode: true,
+    });
+
+    this.language = tryGetQueryLanguage(databaseItem.language);
+    await this.setViewState();
+  }
+
   public async setMethod(
     databaseItem: DatabaseItem | undefined,
     method: Method | undefined,
@@ -201,15 +213,7 @@ export class MethodModelingViewProvider extends AbstractWebviewViewProvider<
 
     this.push(
       this.modelingEvents.onDbOpened(async (databaseItem) => {
-        this.databaseItem = databaseItem;
-
-        await this.postMessage({
-          t: "setInModelingMode",
-          inModelingMode: true,
-        });
-
-        this.language = tryGetQueryLanguage(databaseItem.language);
-        await this.setViewState();
+        await this.setDatabaseItem(databaseItem);
       }),
     );
 

--- a/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
+++ b/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
@@ -16,6 +16,7 @@ import type { ModelingEvents } from "../modeling-events";
 import type { QueryLanguage } from "../../common/query-language";
 import { tryGetQueryLanguage } from "../../common/query-language";
 import { createModelConfig } from "../languages";
+import type { ModeledMethod } from "../modeled-method";
 
 export class MethodModelingViewProvider extends AbstractWebviewViewProvider<
   ToMethodModelingMessage,
@@ -78,6 +79,28 @@ export class MethodModelingViewProvider extends AbstractWebviewViewProvider<
         method,
       });
     }
+  }
+
+  private async setSelectedMethod(
+    databaseItem: DatabaseItem,
+    method: Method,
+    modeledMethods: readonly ModeledMethod[],
+    isModified: boolean,
+    isInProgress: boolean,
+    processedByAutoModel: boolean,
+  ): Promise<void> {
+    this.method = method;
+    this.databaseItem = databaseItem;
+    this.language = tryGetQueryLanguage(databaseItem.language);
+
+    await this.postMessage({
+      t: "setSelectedMethod",
+      method,
+      modeledMethods,
+      isModified,
+      isInProgress,
+      processedByAutoModel,
+    });
   }
 
   private async setInitialState(): Promise<void> {
@@ -195,18 +218,14 @@ export class MethodModelingViewProvider extends AbstractWebviewViewProvider<
     this.push(
       this.modelingEvents.onSelectedMethodChanged(async (e) => {
         if (this.webviewView) {
-          this.method = e.method;
-          this.databaseItem = e.databaseItem;
-          this.language = tryGetQueryLanguage(e.databaseItem.language);
-
-          await this.postMessage({
-            t: "setSelectedMethod",
-            method: e.method,
-            modeledMethods: e.modeledMethods,
-            isModified: e.isModified,
-            isInProgress: e.isInProgress,
-            processedByAutoModel: e.processedByAutoModel,
-          });
+          await this.setSelectedMethod(
+            e.databaseItem,
+            e.method,
+            e.modeledMethods,
+            e.isModified,
+            e.isInProgress,
+            e.processedByAutoModel,
+          );
         }
       }),
     );

--- a/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
+++ b/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
@@ -65,22 +65,6 @@ export class MethodModelingViewProvider extends AbstractWebviewViewProvider<
     await this.setViewState();
   }
 
-  public async setMethod(
-    databaseItem: DatabaseItem | undefined,
-    method: Method | undefined,
-  ): Promise<void> {
-    this.method = method;
-    this.databaseItem = databaseItem;
-    this.language = databaseItem && tryGetQueryLanguage(databaseItem.language);
-
-    if (this.isShowingView) {
-      await this.postMessage({
-        t: "setMethod",
-        method,
-      });
-    }
-  }
-
   private async setSelectedMethod(
     databaseItem: DatabaseItem,
     method: Method,

--- a/extensions/ql-vscode/src/model-editor/methods-usage/methods-usage-panel.ts
+++ b/extensions/ql-vscode/src/model-editor/methods-usage/methods-usage-panel.ts
@@ -57,7 +57,7 @@ export class MethodsUsagePanel extends DisposableObject {
     };
   }
 
-  public async revealItem(
+  private async revealItem(
     methodSignature: string,
     usage: Usage,
   ): Promise<void> {
@@ -106,6 +106,12 @@ export class MethodsUsagePanel extends DisposableObject {
         if (event.isActiveDb) {
           await this.handleStateChangeEvent();
         }
+      }),
+    );
+
+    this.push(
+      this.modelingEvents.onSelectedMethodChanged(async (event) => {
+        await this.revealItem(event.method.signature, event.usage);
       }),
     );
   }

--- a/extensions/ql-vscode/src/model-editor/model-editor-module.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-module.ts
@@ -37,7 +37,6 @@ export class ModelEditorModule extends DisposableObject {
   private readonly queryStorageDir: string;
   private readonly modelingStore: ModelingStore;
   private readonly modelingEvents: ModelingEvents;
-  private readonly methodsUsagePanel: MethodsUsagePanel;
   private readonly modelConfig: ModelConfigListener;
 
   private constructor(
@@ -52,7 +51,7 @@ export class ModelEditorModule extends DisposableObject {
     this.queryStorageDir = join(baseQueryStorageDir, "model-editor-results");
     this.modelingEvents = new ModelingEvents(app);
     this.modelingStore = new ModelingStore(this.modelingEvents);
-    this.methodsUsagePanel = this.push(
+    this.push(
       new MethodsUsagePanel(this.modelingStore, this.modelingEvents, cliServer),
     );
     this.push(
@@ -106,7 +105,7 @@ export class ModelEditorModule extends DisposableObject {
   private registerToModelingEvents(): void {
     this.push(
       this.modelingEvents.onSelectedMethodChanged(async (event) => {
-        await this.showMethod(event.databaseItem, event.method, event.usage);
+        await this.showMethod(event.databaseItem, event.usage);
       }),
     );
 
@@ -127,10 +126,8 @@ export class ModelEditorModule extends DisposableObject {
 
   private async showMethod(
     databaseItem: DatabaseItem,
-    method: Method,
     usage: Usage,
   ): Promise<void> {
-    await this.methodsUsagePanel.revealItem(method.signature, usage);
     await showResolvableLocation(usage.url, databaseItem, this.app.logger);
   }
 

--- a/extensions/ql-vscode/src/model-editor/model-editor-module.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-module.ts
@@ -105,7 +105,11 @@ export class ModelEditorModule extends DisposableObject {
   private registerToModelingEvents(): void {
     this.push(
       this.modelingEvents.onSelectedMethodChanged(async (event) => {
-        await this.showMethod(event.databaseItem, event.usage);
+        await showResolvableLocation(
+          event.usage.url,
+          event.databaseItem,
+          this.app.logger,
+        );
       }),
     );
 
@@ -122,13 +126,6 @@ export class ModelEditorModule extends DisposableObject {
         );
       }),
     );
-  }
-
-  private async showMethod(
-    databaseItem: DatabaseItem,
-    usage: Usage,
-  ): Promise<void> {
-    await showResolvableLocation(usage.url, databaseItem, this.app.logger);
   }
 
   private async openModelEditor(): Promise<void> {

--- a/extensions/ql-vscode/src/model-editor/model-editor-module.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-module.ts
@@ -38,7 +38,6 @@ export class ModelEditorModule extends DisposableObject {
   private readonly modelingStore: ModelingStore;
   private readonly modelingEvents: ModelingEvents;
   private readonly methodsUsagePanel: MethodsUsagePanel;
-  private readonly methodModelingPanel: MethodModelingPanel;
   private readonly modelConfig: ModelConfigListener;
 
   private constructor(
@@ -56,7 +55,7 @@ export class ModelEditorModule extends DisposableObject {
     this.methodsUsagePanel = this.push(
       new MethodsUsagePanel(this.modelingStore, this.modelingEvents, cliServer),
     );
-    this.methodModelingPanel = this.push(
+    this.push(
       new MethodModelingPanel(app, this.modelingStore, this.modelingEvents),
     );
     this.modelConfig = this.push(new ModelConfigListener());
@@ -132,7 +131,6 @@ export class ModelEditorModule extends DisposableObject {
     usage: Usage,
   ): Promise<void> {
     await this.methodsUsagePanel.revealItem(method.signature, usage);
-    await this.methodModelingPanel.setMethod(databaseItem, method);
     await showResolvableLocation(usage.url, databaseItem, this.app.logger);
   }
 

--- a/extensions/ql-vscode/src/view/method-modeling/MethodModelingView.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/MethodModelingView.tsx
@@ -53,9 +53,6 @@ export function MethodModelingView({
           case "setInModelingMode":
             setInModelingMode(msg.inModelingMode);
             break;
-          case "setMethod":
-            setMethod(msg.method);
-            break;
           case "setMultipleModeledMethods":
             setModeledMethods(msg.modeledMethods);
             break;

--- a/extensions/ql-vscode/src/view/method-modeling/MethodModelingView.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/MethodModelingView.tsx
@@ -62,6 +62,13 @@ export function MethodModelingView({
           case "setMethodModified":
             setIsMethodModified(msg.isModified);
             break;
+          case "setNoMethodSelected":
+            setMethod(undefined);
+            setModeledMethods([]);
+            setIsMethodModified(false);
+            setIsModelingInProgress(false);
+            setIsProcessedByAutoModel(false);
+            break;
           case "setSelectedMethod":
             setMethod(msg.method);
             setModeledMethods(msg.modeledMethods);

--- a/extensions/ql-vscode/test/__mocks__/model-editor/modelingEventsMock.ts
+++ b/extensions/ql-vscode/test/__mocks__/model-editor/modelingEventsMock.ts
@@ -4,6 +4,7 @@ import type { ModelingEvents } from "../../../src/model-editor/modeling-events";
 export function createMockModelingEvents({
   onActiveDbChanged = jest.fn(),
   onDbClosed = jest.fn(),
+  onSelectedMethodChanged = jest.fn(),
   onMethodsChanged = jest.fn(),
   onHideModeledMethodsChanged = jest.fn(),
   onModeChanged = jest.fn(),
@@ -16,6 +17,7 @@ export function createMockModelingEvents({
 }: {
   onActiveDbChanged?: ModelingEvents["onActiveDbChanged"];
   onDbClosed?: ModelingEvents["onDbClosed"];
+  onSelectedMethodChanged?: ModelingEvents["onSelectedMethodChanged"];
   onMethodsChanged?: ModelingEvents["onMethodsChanged"];
   onHideModeledMethodsChanged?: ModelingEvents["onHideModeledMethodsChanged"];
   onModeChanged?: ModelingEvents["onModeChanged"];
@@ -29,6 +31,7 @@ export function createMockModelingEvents({
   return mockedObject<ModelingEvents>({
     onActiveDbChanged,
     onDbClosed,
+    onSelectedMethodChanged,
     onMethodsChanged,
     onHideModeledMethodsChanged,
     onModeChanged,


### PR DESCRIPTION
This PR fixes the method modeling panel getting stuck showing "start modeling" if you open the model editor before you open the QL sidebar panel.

The problem was that when the webview loaded we weren't setting the `language` field correctly in the webview. There needs to be a call to `setViewState()` after determining the language.

I recommend reviewing commit by commit.

The actual fix is made in https://github.com/github/vscode-codeql/commit/d4413424c19121b2bd5b81539d8619f9480cc814 which is the third commit. The two commits before that are refactoring methods so we can reuse code. For this fix I've not worried about being inefficient with sending webview messages. For example since `setDatabaseItem` calls `setViewState` we don't have to call it before in this case, but I felt the complexity of having branches and relying on methods always calling other methods was not worth the minimal cost of calling `setViewState` twice when loading initial data.

The commits after the fix could be moved to a separate PR if preferable. I noticed another potential bug which was that we had both the `setMethod` and the `setSelectedMethod` webview messages which both set the method in the view but `setMethod` doesn't contain all the other fields. This could mean if we used `setMethod` we could end up with state like `isModified` or `modeledMethods` being outdated and incorrect. Luckily we avoided the bug because every time we did call `setMethod` (except when setting the method to `undefined`) we also called `setSelectedMethod`, so essentially `setMethod` is unnecessary. Indeed we can remove it and replace it with `setSelectedMethod` and a new `setNoMethodSelected` message and also simplify class interfaces by changing where we listen to modeling store events from.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
