### PR TITLE
Push decision to use credentials or not down to where the creds are used

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Update variant analysis view to show when cancelation is in progress. [#3405](https://github.com/github/vscode-codeql/pull/3405)
 - Remove support for CodeQL CLI versions older than 2.13.5. [#3371](https://github.com/github/vscode-codeql/pull/3371)
 - Add a timeout to downloading databases and the CodeQL CLI. These can be changed using the `codeQL.addingDatabases.downloadTimeout` and `codeQL.cli.downloadTimeout` settings respectively. [#3373](https://github.com/github/vscode-codeql/pull/3373)
+- When downloading a CodeQL database through the model editor, only use credentials when in canary mode. [#3440](https://github.com/github/vscode-codeql/pull/3440)
 
 ## 1.12.2 - 14 February 2024
 

--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -49,7 +49,6 @@ import {
 } from "./database-fetcher";
 import { asError, asyncFilter, getErrorMessage } from "../common/helpers-pure";
 import type { QueryRunner } from "../query-server";
-import { isCanary } from "../config";
 import type { App } from "../common/app";
 import { redactableError } from "../common/errors";
 import type { LocalDatabasesCommands } from "../common/commands";
@@ -558,13 +557,10 @@ export class DatabaseUI extends DisposableObject {
   private async handleChooseDatabaseGithub(): Promise<void> {
     return withProgress(
       async (progress) => {
-        const credentials = isCanary() ? this.app.credentials : undefined;
-
         await promptImportGithubDatabase(
-          this.app.commands,
+          this.app,
           this.databaseManager,
           this.storagePath,
-          credentials,
           progress,
           this.queryServer.cliServer,
         );

--- a/extensions/ql-vscode/src/local-queries/local-queries.ts
+++ b/extensions/ql-vscode/src/local-queries/local-queries.ts
@@ -10,7 +10,7 @@ import {
   showAndLogErrorMessage,
   showAndLogWarningMessage,
 } from "../common/logging";
-import { isCanary, MAX_QUERIES } from "../config";
+import { MAX_QUERIES } from "../config";
 import { gatherQlFiles } from "../common/files";
 import { basename } from "path";
 import { showBinaryChoiceDialog } from "../common/vscode/dialog";
@@ -322,14 +322,12 @@ export class LocalQueries extends DisposableObject {
   private async createSkeletonQuery(): Promise<void> {
     await withProgress(
       async (progress: ProgressCallback) => {
-        const credentials = isCanary() ? this.app.credentials : undefined;
         const contextStoragePath =
           this.app.workspaceStoragePath || this.app.globalStoragePath;
         const language = this.languageContextStore.selectedLanguage;
         const skeletonQueryWizard = new SkeletonQueryWizard(
           this.cliServer,
           progress,
-          credentials,
           this.app,
           this.databaseManager,
           contextStoragePath,

--- a/extensions/ql-vscode/src/local-queries/skeleton-query-wizard.ts
+++ b/extensions/ql-vscode/src/local-queries/skeleton-query-wizard.ts
@@ -2,7 +2,6 @@ import { dirname, join } from "path";
 import { Uri, window, window as Window, workspace } from "vscode";
 import type { CodeQLCliServer } from "../codeql-cli/cli";
 import { showAndLogExceptionWithTelemetry } from "../common/logging";
-import type { Credentials } from "../common/authentication";
 import type { QueryLanguage } from "../common/query-language";
 import { getLanguageDisplayName } from "../common/query-language";
 import {
@@ -61,7 +60,6 @@ export class SkeletonQueryWizard {
   constructor(
     private readonly cliServer: CodeQLCliServer,
     private readonly progress: ProgressCallback,
-    private readonly credentials: Credentials | undefined,
     private readonly app: App,
     private readonly databaseManager: DatabaseManager,
     private readonly databaseStoragePath: string | undefined,
@@ -388,9 +386,9 @@ export class SkeletonQueryWizard {
 
     await downloadGitHubDatabase(
       chosenRepo,
+      this.app,
       this.databaseManager,
       this.databaseStoragePath,
-      this.credentials,
       progress,
       this.cliServer,
       this.language,

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -917,10 +917,9 @@ export class ModelEditorView extends AbstractWebview<
     // imported to the query server, so we need to register it to our workspace.
     const makeSelected = false;
     const addedDatabase = await promptImportGithubDatabase(
-      this.app.commands,
+      this.app,
       this.databaseManager,
       this.app.workspaceStoragePath ?? this.app.globalStoragePath,
-      this.app.credentials,
       progress,
       this.cliServer,
       this.databaseItem.language,

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/local-queries/skeleton-query-wizard.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/local-queries/skeleton-query-wizard.test.ts
@@ -18,7 +18,6 @@ import {
   removeSync,
 } from "fs-extra";
 import { dirname, join } from "path";
-import { testCredentialsWithStub } from "../../../factories/authentication";
 import type {
   DatabaseItem,
   DatabaseManager,
@@ -69,7 +68,6 @@ describe("SkeletonQueryWizard", () => {
     typeof CodeQLCliServer.prototype.resolveQlpacks
   >;
 
-  const credentials = testCredentialsWithStub();
   const chosenLanguage = "ruby";
   const selectedItems: QueryTreeViewItem[] = [];
 
@@ -145,7 +143,6 @@ describe("SkeletonQueryWizard", () => {
     wizard = new SkeletonQueryWizard(
       mockCli,
       jest.fn(),
-      credentials,
       mockApp,
       mockDatabaseManager,
       storagePath,
@@ -173,7 +170,6 @@ describe("SkeletonQueryWizard", () => {
       wizard = new SkeletonQueryWizard(
         mockCli,
         jest.fn(),
-        credentials,
         mockApp,
         mockDatabaseManager,
         storagePath,
@@ -322,7 +318,6 @@ describe("SkeletonQueryWizard", () => {
           wizard = new SkeletonQueryWizard(
             mockCli,
             jest.fn(),
-            credentials,
             mockApp,
             mockDatabaseManagerWithItems,
             storagePath,
@@ -372,7 +367,6 @@ describe("SkeletonQueryWizard", () => {
           wizard = new SkeletonQueryWizard(
             mockCli,
             jest.fn(),
-            credentials,
             mockApp,
             mockDatabaseManagerWithItems,
             storagePath,
@@ -508,7 +502,6 @@ describe("SkeletonQueryWizard", () => {
       wizard = new SkeletonQueryWizard(
         mockCli,
         jest.fn(),
-        credentials,
         mockApp,
         mockDatabaseManager,
         storagePath,
@@ -730,7 +723,6 @@ describe("SkeletonQueryWizard", () => {
           wizard = new SkeletonQueryWizard(
             mockCli,
             jest.fn(),
-            credentials,
             mockApp,
             mockDatabaseManager,
             storagePath,
@@ -760,7 +752,6 @@ describe("SkeletonQueryWizard", () => {
           wizard = new SkeletonQueryWizard(
             mockCli,
             jest.fn(),
-            credentials,
             mockApp,
             mockDatabaseManager,
             storagePath,
@@ -794,7 +785,6 @@ describe("SkeletonQueryWizard", () => {
           wizard = new SkeletonQueryWizard(
             mockCli,
             jest.fn(),
-            credentials,
             mockApp,
             mockDatabaseManager,
             storagePath,
@@ -838,7 +828,6 @@ describe("SkeletonQueryWizard", () => {
           wizard = new SkeletonQueryWizard(
             mockCli,
             jest.fn(),
-            credentials,
             mockApp,
             mockDatabaseManager,
             storagePath,


### PR DESCRIPTION
This fixes a potential bug I spotted where we might unexpectedly prompt a user for credentials to download a CodeQL database.

The code for downloading databases from GitHub is in `promptImportGithubDatabase` and `downloadGitHubDatabase` and both of those took an optional `Credentials` parameter. It is then up to the caller to decide whether to use credentials or not. In this PR we push the decision further down so we only decide in `downloadGitHubDatabase` and therefore use the same logic for all cases.

The current logic around using credentials is:
- In `handleChooseDatabaseGithub` in `local-databases-ui.ts` (called when manually importing a database by command palette or UI), we were using credentials only when the canary flag was set.
- In `createSkeletonQuery` in `local-queries.ts`, we were using credentials only when the canary flag was set.
- In `promptImportDatabase` in `model-editor-view.ts` (called when modeling a dependency or generating modeled methods), we were always using credentials.

This seems like a bug to me as the rest of the model editor doesn't require canary mode, and in all other instances of downloading a database it doesn't prompt for credentials when not in canary mode.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
