### PR TITLE
Use CancellationTokenSource instead of casting dummy objects

### DIFF
--- a/extensions/ql-vscode/test/factories/query-history/local-query-history-item.ts
+++ b/extensions/ql-vscode/test/factories/query-history/local-query-history-item.ts
@@ -6,7 +6,7 @@ import type {
   QueryWithResults,
 } from "../../../src/run-queries-shared";
 import { QueryOutputDir } from "../../../src/local-queries/query-output-dir";
-import type { CancellationTokenSource } from "vscode";
+import { CancellationTokenSource } from "vscode";
 import type { QueryMetadata } from "../../../src/common/interface-types";
 import type { QueryLanguage } from "../../../src/common/query-language";
 
@@ -31,12 +31,6 @@ export function createMockLocalQueryInfo({
   language?: QueryLanguage;
   outputDir?: QueryOutputDir | undefined;
 }): LocalQueryInfo {
-  const cancellationToken = {
-    dispose: () => {
-      /**/
-    },
-  } as CancellationTokenSource;
-
   const initialQueryInfo = {
     queryText: "select 1",
     isQuickQuery: false,
@@ -54,7 +48,10 @@ export function createMockLocalQueryInfo({
     outputDir,
   } as InitialQueryInfo;
 
-  const localQuery = new LocalQueryInfo(initialQueryInfo, cancellationToken);
+  const localQuery = new LocalQueryInfo(
+    initialQueryInfo,
+    new CancellationTokenSource(),
+  );
 
   localQuery.failureReason = failureReason;
   localQuery.cancel = () => {

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/queries.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/queries.test.ts
@@ -1,5 +1,5 @@
 import type { CancellationToken, ExtensionContext, Range } from "vscode";
-import { Uri } from "vscode";
+import { CancellationTokenSource, Uri } from "vscode";
 import { join, dirname } from "path";
 import {
   pathExistsSync,
@@ -125,11 +125,7 @@ describeWithCodeQL()("Queries", () => {
     safeDel(qlFile);
     safeDel(qlpackFile);
 
-    token = {
-      onCancellationRequested: (_) => {
-        void _;
-      },
-    } as CancellationToken;
+    token = new CancellationTokenSource().token;
 
     dbItem = await ensureTestDatabase(databaseManager, cli);
   });

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/store/query-history-store.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/store/query-history-store.test.ts
@@ -10,8 +10,7 @@ import type { QueryWithResults } from "../../../../../src/run-queries-shared";
 import { QueryEvaluationInfo } from "../../../../../src/run-queries-shared";
 import { QueryOutputDir } from "../../../../../src/local-queries/query-output-dir";
 import type { DatabaseInfo } from "../../../../../src/common/interface-types";
-import type { CancellationTokenSource } from "vscode";
-import { Uri } from "vscode";
+import { CancellationTokenSource, Uri } from "vscode";
 import { tmpDir } from "../../../../../src/tmp-dir";
 import type { QueryHistoryInfo } from "../../../../../src/query-history/query-history-info";
 import { createMockVariantAnalysisHistoryItem } from "../../../../factories/query-history/variant-analysis-history-item";
@@ -220,11 +219,7 @@ describe("write and read", () => {
         id: `some-id-${dbName}`,
         outputDir: outputDir ? outputDir : undefined,
       } as InitialQueryInfo,
-      {
-        dispose: () => {
-          /**/
-        },
-      } as CancellationTokenSource,
+      new CancellationTokenSource(),
     );
 
     if (queryWithResults) {

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-results.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-results.test.ts
@@ -21,8 +21,7 @@ import type {
   SortedResultSetInfo,
 } from "../../../src/common/interface-types";
 import type { CodeQLCliServer, SourceInfo } from "../../../src/codeql-cli/cli";
-import type { CancellationTokenSource } from "vscode";
-import { Uri } from "vscode";
+import { CancellationTokenSource, Uri } from "vscode";
 import { tmpDir } from "../../../src/tmp-dir";
 import { sleep } from "../../../src/common/time";
 import { mockedObject } from "../utils/mocking.helpers";
@@ -462,11 +461,7 @@ describe("query-results", () => {
         id: `some-id-${dbName}`,
         outputDir: new QueryOutputDir("path/to/output/dir"),
       } as InitialQueryInfo,
-      {
-        dispose: () => {
-          /**/
-        },
-      } as CancellationTokenSource,
+      new CancellationTokenSource(),
     );
 
     if (queryWithResults) {


### PR DESCRIPTION
In a few cases in the tests we need either a `CancellationToken` or `CancellationTokenSource` and we're building a minimal object and then forcibly casting it to the right type. Using `CancellationTokenSource` is not hard so I see no reason we shouldn't use the real class in all of these cases.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
