### PR TITLE
Delete hasStateForActiveDb as it is unused

### DIFF
--- a/extensions/ql-vscode/src/model-editor/modeling-store.ts
+++ b/extensions/ql-vscode/src/model-editor/modeling-store.ts
@@ -113,10 +113,6 @@ export class ModelingStore extends DisposableObject {
     return this.state.get(this.activeDb);
   }
 
-  public hasStateForActiveDb(): boolean {
-    return !!this.getStateForActiveDb();
-  }
-
   public anyDbsBeingModeled(): boolean {
     return this.state.size > 0;
   }


### PR DESCRIPTION
I only just noticed that `hasStateForActiveDb` is now completely unused after I removed the only usage of it in https://github.com/github/vscode-codeql/pull/3439

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
