### PR TITLE
Add view test for ModelAlertsIndicator

### DIFF
--- a/extensions/ql-vscode/src/view/model-editor/ModelAlertsIndicator.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelAlertsIndicator.tsx
@@ -11,7 +11,7 @@ const ModelAlertsButton = styled.button`
   cursor: pointer;
 `;
 
-type Props = {
+export type Props = {
   viewState: ModelEditorViewState;
   modeledMethod: ModeledMethod;
   evaluationRun: ModelEvaluationRunState | undefined;

--- a/extensions/ql-vscode/src/view/model-editor/__tests__/ModelAlertsIndicator.spec.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/__tests__/ModelAlertsIndicator.spec.tsx
@@ -1,0 +1,70 @@
+import { render as reactRender, screen } from "@testing-library/react";
+import { createMethod } from "../../../../test/factories/model-editor/method-factories";
+import { createSummaryModeledMethod } from "../../../../test/factories/model-editor/modeled-method-factories";
+import { createMockModelEditorViewState } from "../../../../test/factories/model-editor/view-state";
+import type { Props } from "../ModelAlertsIndicator";
+import { ModelAlertsIndicator } from "../ModelAlertsIndicator";
+import { createMockVariantAnalysis } from "../../../../test/factories/variant-analysis/shared/variant-analysis";
+import { VariantAnalysisStatus } from "../../../variant-analysis/shared/variant-analysis";
+
+describe(ModelAlertsIndicator.name, () => {
+  const method = createMethod();
+  const modeledMethod = createSummaryModeledMethod(method);
+  const evaluationRun = {
+    isPreparing: false,
+    variantAnalysis: createMockVariantAnalysis({
+      status: VariantAnalysisStatus.Succeeded,
+    }),
+  };
+
+  const render = (props: Partial<Props> = {}) =>
+    reactRender(
+      <ModelAlertsIndicator
+        viewState={createMockModelEditorViewState({ showEvaluationUi: true })}
+        modeledMethod={modeledMethod}
+        evaluationRun={evaluationRun}
+        {...props}
+      />,
+    );
+
+  describe("when showEvaluationUi is false", () => {
+    it("does not render anything", () => {
+      render({
+        viewState: createMockModelEditorViewState({ showEvaluationUi: false }),
+      });
+
+      expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when there is no evaluation run", () => {
+    it("does not render anything", () => {
+      render({
+        evaluationRun: undefined,
+      });
+
+      expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when there is no modeled method", () => {
+    it("does not render anything", () => {
+      render({
+        modeledMethod: undefined,
+      });
+
+      expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when there is an evaluation run and a modeled method", () => {
+    // TODO: Once we have alert provenance, this will be an actual alert count instead of a random number.
+    it("renders a button with a random number", () => {
+      render();
+
+      const button = screen.queryByRole("button");
+      expect(button).toBeInTheDocument();
+      expect(button).toHaveTextContent(/\d/);
+    });
+  });
+});


### PR DESCRIPTION
Follow-up to https://github.com/github/vscode-codeql/pull/3441 to add a test! There's not much logic to test at the moment, but there will be in future 🔮 

## Checklist

N/A, no user-facing changes

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
