### PR TITLE
Fix warning in package.json about "editor.wordBasedSuggestions"

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -53,10 +53,10 @@
     "configurationDefaults": {
       "[ql]": {
         "debug.saveBeforeStart": "nonUntitledEditorsInActiveGroup",
-        "editor.wordBasedSuggestions": false
+        "editor.wordBasedSuggestions": "off"
       },
       "[dbscheme]": {
-        "editor.wordBasedSuggestions": false
+        "editor.wordBasedSuggestions": "off"
       }
     },
     "debuggers": [


### PR DESCRIPTION
There's been a minor warning in our package.json file about `"editor.wordBasedSuggestions": false` having an invalid property:

![image](https://github.com/github/vscode-codeql/assets/42641846/ffb40d2f-fc74-4a59-9809-4aba9557eb71)

I've changed `false` to `"off"` to appease the system!

## Checklist

N/A—no user-visible impact

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
