### PR TITLE
Make the "Run variant analysis against published pack" command cancellable

### DIFF
--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -480,12 +480,7 @@ export class CodeQLCliServer implements Disposable {
       });
 
       return await this.handleProcessOutput(process, {
-        handleNullTerminator: true,
-        onListenStart: (process) => {
-          // Write the command followed by a null terminator.
-          process.stdin.write(JSON.stringify(args), "utf8");
-          process.stdin.write(this.nullBuffer);
-        },
+        handleNullTerminator: false,
         description,
         args,
         silent,
@@ -1587,12 +1582,20 @@ export class CodeQLCliServer implements Disposable {
   /**
    * Downloads a specified pack.
    * @param packs The `<package-scope/name[@version]>` of the packs to download.
+   * @param token The cancellation token. If not specified, the command will be run in the CLI server.
    */
-  async packDownload(packs: string[]): Promise<PackDownloadResult> {
+  async packDownload(
+    packs: string[],
+    token?: CancellationToken,
+  ): Promise<PackDownloadResult> {
     return this.runJsonCodeQlCliCommandWithAuthentication(
       ["pack", "download"],
       packs,
       "Downloading packs",
+      {
+        runInNewProcess: !!token, // Only run in a new process if a token is provided
+        token,
+      },
     );
   }
 

--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -535,6 +535,7 @@ export class CodeQLCliServer implements Disposable {
     let stdoutListener: ((newData: Buffer) => void) | undefined = undefined;
     let stderrListener: ((newData: Buffer) => void) | undefined = undefined;
     let closeListener: ((code: number | null) => void) | undefined = undefined;
+    let errorListener: ((err: Error) => void) | undefined = undefined;
 
     try {
       // The array of fragments of stdout
@@ -618,6 +619,9 @@ export class CodeQLCliServer implements Disposable {
             }
           }
         };
+        errorListener = (err) => {
+          reject(err);
+        };
 
         // Start listening to stdout
         process.stdout.addListener("data", stdoutListener);
@@ -625,6 +629,8 @@ export class CodeQLCliServer implements Disposable {
         process.stderr.addListener("data", stderrListener);
         // Listen for process exit.
         process.addListener("close", closeListener);
+        // Listen for errors
+        process.addListener("error", errorListener);
 
         onListenStart?.(process);
       });
@@ -667,6 +673,9 @@ export class CodeQLCliServer implements Disposable {
       }
       if (closeListener) {
         process.removeListener("close", closeListener);
+      }
+      if (errorListener) {
+        process.removeListener("error", errorListener);
       }
     }
   }

--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -500,6 +500,11 @@ export class CodeQLCliServer implements Disposable {
 
       throw e;
     } finally {
+      process.stdin.end();
+      process.kill();
+      process.stdout.destroy();
+      process.stderr.destroy();
+
       cancellationRegistration?.dispose();
     }
   }

--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -369,9 +369,6 @@ export class CodeQLCliServer implements Disposable {
     onLine?: OnLineCallback,
     silent?: boolean,
   ): Promise<string> {
-    const stderrBuffers: Buffer[] = [];
-    // The current buffer of stderr of a single line. To be used for logging.
-    let currentLineStderrBuffer: Buffer = Buffer.alloc(0);
     if (this.commandInProcess) {
       throw new Error("runCodeQlCliInternal called while cli was running");
     }
@@ -383,8 +380,6 @@ export class CodeQLCliServer implements Disposable {
       }
       // Grab the process so that typescript know that it is always defined.
       const process = this.process;
-      // The array of fragments of stdout
-      const stdoutBuffers: Buffer[] = [];
 
       // Compute the full args array
       const args = command.concat(LOGGING_FLAGS).concat(commandArgs);
@@ -396,26 +391,83 @@ export class CodeQLCliServer implements Disposable {
         );
       }
       try {
-        await new Promise<void>((resolve, reject) => {
-          // Start listening to stdout
-          process.stdout.addListener("data", (newData: Buffer) => {
-            if (onLine) {
-              void (async () => {
-                const response = await onLine(newData.toString("utf-8"));
+        return await this.handleProcessOutput(process, {
+          handleNullTerminator: true,
+          onListenStart: (process) => {
+            // Write the command followed by a null terminator.
+            process.stdin.write(JSON.stringify(args), "utf8");
+            process.stdin.write(this.nullBuffer);
+          },
+          description,
+          args,
+          silent,
+          onLine,
+        });
+      } catch (err) {
+        // Kill the process if it isn't already dead.
+        this.killProcessIfRunning();
 
-                if (!response) {
-                  return;
-                }
+        throw err;
+      }
+    } finally {
+      this.commandInProcess = false;
+      // start running the next command immediately
+      this.runNext();
+    }
+  }
 
-                process.stdin.write(`${response}${EOL}`);
+  private async handleProcessOutput(
+    process: ChildProcessWithoutNullStreams,
+    {
+      handleNullTerminator,
+      args,
+      description,
+      onLine,
+      onListenStart,
+      silent,
+    }: {
+      handleNullTerminator: boolean;
+      args: string[];
+      description: string;
+      onLine?: OnLineCallback;
+      onListenStart?: (process: ChildProcessWithoutNullStreams) => void;
+      silent?: boolean;
+    },
+  ): Promise<string> {
+    const stderrBuffers: Buffer[] = [];
+    // The current buffer of stderr of a single line. To be used for logging.
+    let currentLineStderrBuffer: Buffer = Buffer.alloc(0);
 
-                // Remove newData from stdoutBuffers because the data has been consumed
-                // by the onLine callback.
-                stdoutBuffers.splice(stdoutBuffers.indexOf(newData), 1);
-              })();
-            }
+    // The listeners of the process. Declared here so they can be removed in the finally block.
+    let stdoutListener: ((newData: Buffer) => void) | undefined = undefined;
+    let stderrListener: ((newData: Buffer) => void) | undefined = undefined;
+    let closeListener: ((code: number | null) => void) | undefined = undefined;
 
-            stdoutBuffers.push(newData);
+    try {
+      // The array of fragments of stdout
+      const stdoutBuffers: Buffer[] = [];
+
+      await new Promise<void>((resolve, reject) => {
+        stdoutListener = (newData: Buffer) => {
+          if (onLine) {
+            void (async () => {
+              const response = await onLine(newData.toString("utf-8"));
+
+              if (!response) {
+                return;
+              }
+
+              process.stdin.write(`${response}${EOL}`);
+
+              // Remove newData from stdoutBuffers because the data has been consumed
+              // by the onLine callback.
+              stdoutBuffers.splice(stdoutBuffers.indexOf(newData), 1);
+            })();
+          }
+
+          stdoutBuffers.push(newData);
+
+          if (handleNullTerminator) {
             // If the buffer ends in '0' then exit.
             // We don't have to check the middle as no output will be written after the null until
             // the next command starts
@@ -425,89 +477,104 @@ export class CodeQLCliServer implements Disposable {
             ) {
               resolve();
             }
-          });
-          // Listen to stderr
-          process.stderr.addListener("data", (newData: Buffer) => {
-            stderrBuffers.push(newData);
+          }
+        };
+        stderrListener = (newData: Buffer) => {
+          stderrBuffers.push(newData);
 
-            if (!silent) {
-              currentLineStderrBuffer = Buffer.concat([
-                currentLineStderrBuffer,
-                newData,
-              ]);
+          if (!silent) {
+            currentLineStderrBuffer = Buffer.concat([
+              currentLineStderrBuffer,
+              newData,
+            ]);
 
-              // Print the stderr to the logger as it comes in. We need to ensure that
-              // we don't split messages on the same line, so we buffer the stderr and
-              // split it on EOLs.
-              const eolBuffer = Buffer.from(EOL);
+            // Print the stderr to the logger as it comes in. We need to ensure that
+            // we don't split messages on the same line, so we buffer the stderr and
+            // split it on EOLs.
+            const eolBuffer = Buffer.from(EOL);
 
-              let hasCreatedSubarray = false;
+            let hasCreatedSubarray = false;
 
-              let eolIndex;
-              while (
-                (eolIndex = currentLineStderrBuffer.indexOf(eolBuffer)) !== -1
-              ) {
-                const line = currentLineStderrBuffer.subarray(0, eolIndex);
-                void this.logger.log(line.toString("utf-8"));
-                currentLineStderrBuffer = currentLineStderrBuffer.subarray(
-                  eolIndex + eolBuffer.length,
-                );
-                hasCreatedSubarray = true;
-              }
-
-              // We have created a subarray, which means that the complete original buffer is now referenced
-              // by the subarray. We need to create a new buffer to avoid memory leaks.
-              if (hasCreatedSubarray) {
-                currentLineStderrBuffer = Buffer.from(currentLineStderrBuffer);
-              }
+            let eolIndex;
+            while (
+              (eolIndex = currentLineStderrBuffer.indexOf(eolBuffer)) !== -1
+            ) {
+              const line = currentLineStderrBuffer.subarray(0, eolIndex);
+              void this.logger.log(line.toString("utf-8"));
+              currentLineStderrBuffer = currentLineStderrBuffer.subarray(
+                eolIndex + eolBuffer.length,
+              );
+              hasCreatedSubarray = true;
             }
-          });
-          // Listen for process exit.
-          process.addListener("close", (code) =>
-            reject(new ExitCodeError(code)),
-          );
-          // Write the command followed by a null terminator.
-          process.stdin.write(JSON.stringify(args), "utf8");
-          process.stdin.write(this.nullBuffer);
-        });
-        // Join all the data together
-        const fullBuffer = Buffer.concat(stdoutBuffers);
-        // Make sure we remove the terminator;
-        const data = fullBuffer.toString("utf8", 0, fullBuffer.length - 1);
-        if (!silent) {
-          void this.logger.log(currentLineStderrBuffer.toString("utf8"));
-          currentLineStderrBuffer = Buffer.alloc(0);
-          void this.logger.log("CLI command succeeded.");
-        }
-        return data;
-      } catch (err) {
-        // Kill the process if it isn't already dead.
-        this.killProcessIfRunning();
 
-        // Report the error (if there is a stderr then use that otherwise just report the error code or nodejs error)
-        const cliError = getCliError(
-          err,
-          stderrBuffers.length > 0
-            ? Buffer.concat(stderrBuffers).toString("utf8")
-            : undefined,
-          description,
-          args,
-        );
-        cliError.stack += getErrorStack(err);
-        throw cliError;
-      } finally {
-        if (!silent && currentLineStderrBuffer.length > 0) {
-          void this.logger.log(currentLineStderrBuffer.toString("utf8"));
-        }
-        // Remove the listeners we set up.
-        process.stdout.removeAllListeners("data");
-        process.stderr.removeAllListeners("data");
-        process.removeAllListeners("close");
+            // We have created a subarray, which means that the complete original buffer is now referenced
+            // by the subarray. We need to create a new buffer to avoid memory leaks.
+            if (hasCreatedSubarray) {
+              currentLineStderrBuffer = Buffer.from(currentLineStderrBuffer);
+            }
+          }
+        };
+        closeListener = (code) => {
+          if (handleNullTerminator) {
+            reject(new ExitCodeError(code));
+          } else {
+            if (code === 0) {
+              resolve();
+            } else {
+              reject(new ExitCodeError(code));
+            }
+          }
+        };
+
+        // Start listening to stdout
+        process.stdout.addListener("data", stdoutListener);
+        // Listen to stderr
+        process.stderr.addListener("data", stderrListener);
+        // Listen for process exit.
+        process.addListener("close", closeListener);
+
+        onListenStart?.(process);
+      });
+      // Join all the data together
+      const fullBuffer = Buffer.concat(stdoutBuffers);
+      // Make sure we remove the terminator
+      const data = fullBuffer.toString(
+        "utf8",
+        0,
+        handleNullTerminator ? fullBuffer.length - 1 : fullBuffer.length,
+      );
+      if (!silent) {
+        void this.logger.log(currentLineStderrBuffer.toString("utf8"));
+        currentLineStderrBuffer = Buffer.alloc(0);
+        void this.logger.log("CLI command succeeded.");
       }
+      return data;
+    } catch (err) {
+      // Report the error (if there is a stderr then use that otherwise just report the error code or nodejs error)
+      const cliError = getCliError(
+        err,
+        stderrBuffers.length > 0
+          ? Buffer.concat(stderrBuffers).toString("utf8")
+          : undefined,
+        description,
+        args,
+      );
+      cliError.stack += getErrorStack(err);
+      throw cliError;
     } finally {
-      this.commandInProcess = false;
-      // start running the next command immediately
-      this.runNext();
+      if (!silent && currentLineStderrBuffer.length > 0) {
+        void this.logger.log(currentLineStderrBuffer.toString("utf8"));
+      }
+      // Remove the listeners we set up.
+      if (stdoutListener) {
+        process.stdout.removeListener("data", stdoutListener);
+      }
+      if (stderrListener) {
+        process.stderr.removeListener("data", stderrListener);
+      }
+      if (closeListener) {
+        process.removeListener("close", closeListener);
+      }
     }
   }
 

--- a/extensions/ql-vscode/src/codeql-cli/query-language.ts
+++ b/extensions/ql-vscode/src/codeql-cli/query-language.ts
@@ -1,5 +1,5 @@
 import type { CodeQLCliServer } from "./cli";
-import type { Uri } from "vscode";
+import type { CancellationToken, Uri } from "vscode";
 import { window } from "vscode";
 import {
   getLanguageDisplayName,
@@ -50,6 +50,7 @@ export async function findLanguage(
 export async function askForLanguage(
   cliServer: CodeQLCliServer,
   throwOnEmpty = true,
+  token?: CancellationToken,
 ): Promise<QueryLanguage | undefined> {
   const supportedLanguages = await cliServer.getSupportedLanguages();
 
@@ -62,10 +63,14 @@ export async function askForLanguage(
     }))
     .sort((a, b) => a.label.localeCompare(b.label));
 
-  const selectedItem = await window.showQuickPick(items, {
-    placeHolder: "Select target query language",
-    ignoreFocusOut: true,
-  });
+  const selectedItem = await window.showQuickPick(
+    items,
+    {
+      placeHolder: "Select target query language",
+      ignoreFocusOut: true,
+    },
+    token,
+  );
   if (!selectedItem) {
     // This only happens if the user cancels the quick pick.
     if (throwOnEmpty) {

--- a/extensions/ql-vscode/src/model-editor/model-evaluator.ts
+++ b/extensions/ql-vscode/src/model-editor/model-evaluator.ts
@@ -18,6 +18,7 @@ import type { CancellationToken } from "vscode";
 import { CancellationTokenSource } from "vscode";
 import type { QlPackDetails } from "../variant-analysis/ql-pack-details";
 import type { App } from "../common/app";
+import { MultiCancellationToken } from "../common/vscode/multi-cancellation-token";
 import { ModelAlertsView } from "./model-alerts/model-alerts-view";
 
 export class ModelEvaluator extends DisposableObject {
@@ -68,11 +69,11 @@ export class ModelEvaluator extends DisposableObject {
 
     // Submit variant analysis and monitor progress
     return withProgress(
-      (progress) =>
+      (progress, token) =>
         this.runVariantAnalysis(
           qlPack,
           progress,
-          this.cancellationSource.token,
+          new MultiCancellationToken(token, this.cancellationSource.token),
         ),
       {
         title: "Run model evaluation",

--- a/extensions/ql-vscode/src/model-editor/model-evaluator.ts
+++ b/extensions/ql-vscode/src/model-editor/model-evaluator.ts
@@ -18,7 +18,6 @@ import type { CancellationToken } from "vscode";
 import { CancellationTokenSource } from "vscode";
 import type { QlPackDetails } from "../variant-analysis/ql-pack-details";
 import type { App } from "../common/app";
-import { MultiCancellationToken } from "../common/vscode/multi-cancellation-token";
 import { ModelAlertsView } from "./model-alerts/model-alerts-view";
 
 export class ModelEvaluator extends DisposableObject {
@@ -69,15 +68,15 @@ export class ModelEvaluator extends DisposableObject {
 
     // Submit variant analysis and monitor progress
     return withProgress(
-      (progress, token) =>
+      (progress) =>
         this.runVariantAnalysis(
           qlPack,
           progress,
-          new MultiCancellationToken(token, this.cancellationSource.token),
+          this.cancellationSource.token,
         ),
       {
         title: "Run model evaluation",
-        cancellable: true,
+        cancellable: false,
       },
     );
   }

--- a/extensions/ql-vscode/src/model-editor/model-evaluator.ts
+++ b/extensions/ql-vscode/src/model-editor/model-evaluator.ts
@@ -75,7 +75,7 @@ export class ModelEvaluator extends DisposableObject {
         ),
       {
         title: "Run model evaluation",
-        cancellable: false,
+        cancellable: true,
       },
     );
   }

--- a/extensions/ql-vscode/src/model-editor/model-evaluator.ts
+++ b/extensions/ql-vscode/src/model-editor/model-evaluator.ts
@@ -58,6 +58,7 @@ export class ModelEvaluator extends DisposableObject {
       this.app.logger,
       this.cliServer,
       this.language,
+      this.cancellationSource.token,
     );
 
     if (!qlPack) {

--- a/extensions/ql-vscode/src/variant-analysis/code-scanning-pack.ts
+++ b/extensions/ql-vscode/src/variant-analysis/code-scanning-pack.ts
@@ -9,16 +9,18 @@ import type { QlPackDetails } from "./ql-pack-details";
 import { getQlPackFilePath } from "../common/ql";
 import type { SuiteInstruction } from "../packaging/suite-instruction";
 import { SARIF_RESULTS_QUERY_KINDS } from "../common/query-metadata";
+import type { CancellationToken } from "vscode";
 
 export async function resolveCodeScanningQueryPack(
   logger: BaseLogger,
   cliServer: CodeQLCliServer,
   language: QueryLanguage,
+  token: CancellationToken,
 ): Promise<QlPackDetails> {
   // Get pack
   void logger.log(`Downloading pack for language: ${language}`);
   const packName = `codeql/${language}-queries`;
-  const packDownloadResult = await cliServer.packDownload([packName]);
+  const packDownloadResult = await cliServer.packDownload([packName], token);
   const downloadedPack = packDownloadResult.packs[0];
 
   const packDir = join(

--- a/extensions/ql-vscode/src/variant-analysis/run-remote-query.ts
+++ b/extensions/ql-vscode/src/variant-analysis/run-remote-query.ts
@@ -54,6 +54,7 @@ async function generateQueryPack(
   cliServer: CodeQLCliServer,
   qlPackDetails: QlPackDetails,
   tmpDir: RemoteQueryTempDir,
+  token: CancellationToken,
 ): Promise<string> {
   const workspaceFolders = getOnDiskWorkspaceFolders();
   const extensionPacks = await getExtensionPacksToInject(
@@ -148,6 +149,7 @@ async function generateQueryPack(
     bundlePath,
     tmpDir.compiledPackDir,
     precompilationOpts,
+    token,
   );
   const base64Pack = (await readFile(bundlePath)).toString("base64");
   return base64Pack;
@@ -331,7 +333,12 @@ export async function prepareRemoteQueryRun(
   let base64Pack: string;
 
   try {
-    base64Pack = await generateQueryPack(cliServer, qlPackDetails, tempDir);
+    base64Pack = await generateQueryPack(
+      cliServer,
+      qlPackDetails,
+      tempDir,
+      token,
+    );
   } finally {
     await tempDir.remoteQueryDir.cleanup();
   }

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -221,42 +221,48 @@ export class VariantAnalysisManager
   }
 
   public async runVariantAnalysisFromPublishedPack(): Promise<void> {
-    return withProgress(async (progress, token) => {
-      progress({
-        maxStep: 7,
-        step: 0,
-        message: "Determining query language",
-      });
+    return withProgress(
+      async (progress, token) => {
+        progress({
+          maxStep: 7,
+          step: 0,
+          message: "Determining query language",
+        });
 
-      const language = await askForLanguage(this.cliServer);
-      if (!language) {
-        return;
-      }
+        const language = await askForLanguage(this.cliServer);
+        if (!language) {
+          return;
+        }
 
-      progress({
-        maxStep: 7,
-        step: 2,
-        message: "Downloading query pack and resolving queries",
-      });
+        progress({
+          maxStep: 7,
+          step: 2,
+          message: "Downloading query pack and resolving queries",
+        });
 
-      // Build up details to pass to the functions that run the variant analysis.
-      const qlPackDetails = await resolveCodeScanningQueryPack(
-        this.app.logger,
-        this.cliServer,
-        language,
-      );
+        // Build up details to pass to the functions that run the variant analysis.
+        const qlPackDetails = await resolveCodeScanningQueryPack(
+          this.app.logger,
+          this.cliServer,
+          language,
+        );
 
-      await this.runVariantAnalysis(
-        qlPackDetails,
-        (p) =>
-          progress({
-            ...p,
-            maxStep: p.maxStep + 3,
-            step: p.step + 3,
-          }),
-        token,
-      );
-    });
+        await this.runVariantAnalysis(
+          qlPackDetails,
+          (p) =>
+            progress({
+              ...p,
+              maxStep: p.maxStep + 3,
+              step: p.step + 3,
+            }),
+          token,
+        );
+      },
+      {
+        title: "Run Variant Analysis",
+        cancellable: true,
+      },
+    );
   }
 
   private async runVariantAnalysisCommand(queryFiles: Uri[]): Promise<void> {

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -245,6 +245,7 @@ export class VariantAnalysisManager
           this.app.logger,
           this.cliServer,
           language,
+          token,
         );
 
         await this.runVariantAnalysis(

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -229,7 +229,7 @@ export class VariantAnalysisManager
           message: "Determining query language",
         });
 
-        const language = await askForLanguage(this.cliServer);
+        const language = await askForLanguage(this.cliServer, true, token);
         if (!language) {
           return;
         }

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/jest.config.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/jest.config.ts
@@ -9,6 +9,8 @@ const config: Config = {
   // CLI integration tests call into the CLI and execute queries, so these are expected to take a lot longer
   // than the default 5 seconds.
   testTimeout: 180_000, // 3 minutes
+  // Ensure that Jest exits even when there are some remaining handles open
+  forceExit: true,
 };
 
 export default config;

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/code-scanning-pack.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/variant-analysis/code-scanning-pack.test.ts
@@ -1,3 +1,4 @@
+import { CancellationTokenSource } from "vscode";
 import type { CodeQLCliServer } from "../../../../src/codeql-cli/cli";
 import type { App } from "../../../../src/common/app";
 import { QueryLanguage } from "../../../../src/common/query-language";
@@ -20,6 +21,7 @@ describe("Code Scanning pack", () => {
       app.logger,
       cli,
       QueryLanguage.Javascript,
+      new CancellationTokenSource().token,
     );
     // Should include queries. Just check that at least one known query exists.
     // It doesn't particularly matter which query we check for.


### PR DESCRIPTION
This makes the "Run variant analysis against published pack" command cancellable by starting a separate CLI process for downloading packs and bundling the query pack since these are both long-running commands.

Unfortunately, I wasn't able to fix an issue where the tests would timeout on ubuntu-latest because Jest didn't exit. Therefore, I've added the `forceExit` flag to the CLI integration tests.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
