### PR TITLE
Fix incomplete removal of databases

### DIFF
--- a/extensions/ql-vscode/src/databases/database-fetcher.ts
+++ b/extensions/ql-vscode/src/databases/database-fetcher.ts
@@ -400,6 +400,7 @@ async function databaseArchiveFetcher(
       nameOverride,
       {
         addSourceArchiveFolder,
+        extensionManagedLocation: unzipPath,
       },
     );
     return item;

--- a/extensions/ql-vscode/src/databases/local-databases/database-item-impl.ts
+++ b/extensions/ql-vscode/src/databases/local-databases/database-item-impl.ts
@@ -66,6 +66,10 @@ export class DatabaseItemImpl implements DatabaseItem {
     return this.options.origin;
   }
 
+  public get extensionManagedLocation(): string | undefined {
+    return this.options.extensionManagedLocation;
+  }
+
   public resolveSourceFile(uriStr: string | undefined): Uri {
     const sourceArchive = this.sourceArchive;
     const uri = uriStr ? Uri.parse(uriStr, true) : undefined;

--- a/extensions/ql-vscode/src/databases/local-databases/database-item.ts
+++ b/extensions/ql-vscode/src/databases/local-databases/database-item.ts
@@ -31,6 +31,12 @@ export interface DatabaseItem {
    */
   readonly origin: DatabaseOrigin | undefined;
 
+  /**
+   * The location of the base storage location as managed by the extension, or undefined
+   * if unknown or not managed by the extension.
+   */
+  readonly extensionManagedLocation: string | undefined;
+
   /** If the database is invalid, describes why. */
   readonly error: Error | undefined;
 

--- a/extensions/ql-vscode/src/databases/local-databases/database-options.ts
+++ b/extensions/ql-vscode/src/databases/local-databases/database-options.ts
@@ -5,10 +5,12 @@ export interface DatabaseOptions {
   dateAdded?: number | undefined;
   language?: string;
   origin?: DatabaseOrigin;
+  extensionManagedLocation?: string;
 }
 
 export interface FullDatabaseOptions extends DatabaseOptions {
   dateAdded: number | undefined;
   language: string | undefined;
   origin: DatabaseOrigin | undefined;
+  extensionManagedLocation: string | undefined;
 }

--- a/extensions/ql-vscode/test/factories/databases/databases.ts
+++ b/extensions/ql-vscode/test/factories/databases/databases.ts
@@ -14,6 +14,7 @@ export function mockDbOptions(): FullDatabaseOptions {
     origin: {
       type: "folder",
     },
+    extensionManagedLocation: undefined,
   };
 }
 

--- a/extensions/ql-vscode/test/factories/databases/databases.ts
+++ b/extensions/ql-vscode/test/factories/databases/databases.ts
@@ -19,7 +19,7 @@ export function mockDbOptions(): FullDatabaseOptions {
 }
 
 export function createMockDB(
-  dir: DirResult,
+  dir: DirResult | string,
   dbOptions = mockDbOptions(),
   // source archive location must be a real(-ish) location since
   // tests will add this to the workspace location
@@ -39,10 +39,18 @@ export function createMockDB(
   );
 }
 
-export function sourceLocationUri(dir: DirResult) {
+export function sourceLocationUri(dir: DirResult | string) {
+  if (typeof dir === "string") {
+    return Uri.file(join(dir, "src.zip"));
+  }
+
   return Uri.file(join(dir.name, "src.zip"));
 }
 
-export function dbLocationUri(dir: DirResult) {
+export function dbLocationUri(dir: DirResult | string) {
+  if (typeof dir === "string") {
+    return Uri.file(join(dir, "db"));
+  }
+
   return Uri.file(join(dir.name, "db"));
 }

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-queries/local-databases.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-queries/local-databases.test.ts
@@ -604,6 +604,7 @@ describe("local databases", () => {
         origin: {
           type: "folder",
         },
+        extensionManagedLocation: undefined,
       };
       mockDbItem = createMockDB(dir, options);
 

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-queries/local-databases.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/local-queries/local-databases.test.ts
@@ -242,6 +242,37 @@ describe("local databases", () => {
       await expect(pathExists(mockDbItem.databaseUri.fsPath)).resolves.toBe(
         false,
       );
+      await expect(pathExists(dir.name)).resolves.toBe(true);
+    });
+
+    it("should remove a database item with an extension managed location", async () => {
+      const dbLocation = join(dir.name, "org-repo-12");
+      await ensureDir(dbLocation);
+
+      const mockDbItem = createMockDB(dbLocation, {
+        ...mockDbOptions(),
+        extensionManagedLocation: dbLocation,
+      });
+      await ensureDir(mockDbItem.databaseUri.fsPath);
+
+      // pretend that this item is the first workspace folder in the list
+      jest
+        .spyOn(mockDbItem, "belongsToSourceArchiveExplorerUri")
+        .mockReturnValue(true);
+
+      await (databaseManager as any).addDatabaseItem(mockDbItem);
+
+      updateSpy.mockClear();
+
+      await databaseManager.removeDatabaseItem(mockDbItem);
+
+      expect(databaseManager.databaseItems).toEqual([]);
+      expect(updateSpy).toHaveBeenCalledWith("databaseList", []);
+      // should remove the folder
+      expect(workspace.updateWorkspaceFolders).toHaveBeenCalledWith(0, 1);
+
+      // should delete the complete extension managed location
+      await expect(pathExists(dbLocation)).resolves.toBe(false);
     });
 
     it("should remove a database item outside of the extension controlled area", async () => {


### PR DESCRIPTION
When downloading a database from GitHub, the folder structure looks like this within the `${context.storageUri}/cpp` directory:

![Screenshot 2024-03-08 at 13 46 44](https://github.com/github/vscode-codeql/assets/1112623/7b30c725-c05e-4c36-94a5-0f179a46c0ea)

When removing this database, we were only deleting the shown `cpp` directory, and not the top-level `cpp` directory because we were deleting the directory that contained the database, rather than the directory that was created during the download.

This fixes it by storing the directory that we create during download on the database item so we can remove that directory when removing the database.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
