### PR TITLE
Use suite file instead of manually filtering queries

### DIFF
--- a/extensions/ql-vscode/src/common/query-metadata.ts
+++ b/extensions/ql-vscode/src/common/query-metadata.ts
@@ -1,4 +1,4 @@
-const SARIF_RESULTS_QUERY_KINDS = [
+export const SARIF_RESULTS_QUERY_KINDS = [
   "problem",
   "alert",
   "path-problem",

--- a/extensions/ql-vscode/src/model-editor/extension-pack-metadata.schema.json
+++ b/extensions/ql-vscode/src/model-editor/extension-pack-metadata.schema.json
@@ -111,6 +111,9 @@
         "description": {
           "type": "string"
         },
+        "import": {
+          "type": "string"
+        },
         "from": {
           "type": "string"
         }

--- a/extensions/ql-vscode/src/packaging/qlpack-file.schema.json
+++ b/extensions/ql-vscode/src/packaging/qlpack-file.schema.json
@@ -111,6 +111,9 @@
         "description": {
           "type": "string"
         },
+        "import": {
+          "type": "string"
+        },
         "from": {
           "type": "string"
         }

--- a/extensions/ql-vscode/src/packaging/suite-instruction.ts
+++ b/extensions/ql-vscode/src/packaging/suite-instruction.ts
@@ -8,5 +8,6 @@ export interface SuiteInstruction {
   include?: Record<string, string[]>;
   exclude?: Record<string, string[]>;
   description?: string;
+  import?: string;
   from?: string;
 }

--- a/extensions/ql-vscode/src/variant-analysis/code-scanning-pack.ts
+++ b/extensions/ql-vscode/src/variant-analysis/code-scanning-pack.ts
@@ -1,10 +1,13 @@
 import { join } from "path";
+import { outputFile } from "fs-extra";
+import { dump } from "js-yaml";
+import { file } from "tmp-promise";
 import type { BaseLogger } from "../common/logging";
 import type { QueryLanguage } from "../common/query-language";
 import type { CodeQLCliServer } from "../codeql-cli/cli";
 import type { QlPackDetails } from "./ql-pack-details";
 import { getQlPackFilePath } from "../common/ql";
-import { isSarifResultsQueryKind } from "../common/query-metadata";
+import type { SuiteInstruction } from "../packaging/suite-instruction";
 
 export async function resolveCodeScanningQueryPack(
   logger: BaseLogger,
@@ -25,20 +28,30 @@ export async function resolveCodeScanningQueryPack(
 
   // Resolve queries
   void logger.log(`Resolving queries for pack: ${packName}`);
-  const suitePath = join(
-    packDir,
-    "codeql-suites",
-    `${language}-code-scanning.qls`,
-  );
+
+  const suiteFile = await file({
+    postfix: ".qls",
+  });
+  const suitePath = suiteFile.path;
+  const suiteYaml: SuiteInstruction[] = [
+    {
+      import: `codeql-suites/${language}-code-scanning.qls`,
+      from: `${downloadedPack.name}@${downloadedPack.version}`,
+    },
+    // Exclude any non-problem queries
+    {
+      exclude: {
+        kind: ["diagnostic", "metric"],
+      },
+    },
+  ];
+  await outputFile(suitePath, dump(suiteYaml), "utf8");
+
   const resolvedQueries = await cliServer.resolveQueries(suitePath);
 
-  const problemQueries = await filterToOnlyProblemQueries(
-    logger,
-    cliServer,
-    resolvedQueries,
-  );
+  await suiteFile.cleanup();
 
-  if (problemQueries.length === 0) {
+  if (resolvedQueries.length === 0) {
     throw Error(
       `No problem queries found in published query pack: ${packName}.`,
     );
@@ -48,28 +61,11 @@ export async function resolveCodeScanningQueryPack(
   const qlPackFilePath = await getQlPackFilePath(packDir);
 
   const qlPackDetails: QlPackDetails = {
-    queryFiles: problemQueries,
+    queryFiles: resolvedQueries,
     qlPackRootPath: packDir,
     qlPackFilePath,
     language,
   };
 
   return qlPackDetails;
-}
-
-async function filterToOnlyProblemQueries(
-  logger: BaseLogger,
-  cliServer: CodeQLCliServer,
-  queries: string[],
-): Promise<string[]> {
-  const problemQueries: string[] = [];
-  for (const query of queries) {
-    const queryMetadata = await cliServer.resolveMetadata(query);
-    if (isSarifResultsQueryKind(queryMetadata.kind)) {
-      problemQueries.push(query);
-    } else {
-      void logger.log(`Skipping non-problem query ${query}`);
-    }
-  }
-  return problemQueries;
 }

--- a/extensions/ql-vscode/src/variant-analysis/code-scanning-pack.ts
+++ b/extensions/ql-vscode/src/variant-analysis/code-scanning-pack.ts
@@ -8,6 +8,7 @@ import type { CodeQLCliServer } from "../codeql-cli/cli";
 import type { QlPackDetails } from "./ql-pack-details";
 import { getQlPackFilePath } from "../common/ql";
 import type { SuiteInstruction } from "../packaging/suite-instruction";
+import { SARIF_RESULTS_QUERY_KINDS } from "../common/query-metadata";
 
 export async function resolveCodeScanningQueryPack(
   logger: BaseLogger,
@@ -34,10 +35,15 @@ export async function resolveCodeScanningQueryPack(
       import: `codeql-suites/${language}-code-scanning.qls`,
       from: `${downloadedPack.name}@${downloadedPack.version}`,
     },
-    // Exclude any non-problem queries
     {
-      exclude: {
-        kind: ["diagnostic", "metric"],
+      // This is necessary to ensure that the next import filter
+      // is applied correctly
+      exclude: {},
+    },
+    {
+      // Only include problem queries
+      include: {
+        kind: SARIF_RESULTS_QUERY_KINDS,
       },
     },
   ];


### PR DESCRIPTION
When resolving the Code Scanning pack, we were manually filtering out non-problem queries by calling `codeql resolve metadata` on every resolved query. This switches it to using a custom suite file (`.qls`) which can do the same but without requiring many calls to `codeql resolve metadata`. There should be no changes in behavior.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
