### PR TITLE
Only allow one open model alerts view

### DIFF
--- a/extensions/ql-vscode/src/model-editor/model-alerts/model-alerts-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-alerts/model-alerts-view.ts
@@ -11,6 +11,9 @@ import type { App } from "../../common/app";
 import { redactableError } from "../../common/errors";
 import { extLogger } from "../../common/logging/vscode";
 import { showAndLogExceptionWithTelemetry } from "../../common/logging";
+import type { ModelingEvents } from "../modeling-events";
+import type { ModelingStore } from "../modeling-store";
+import type { DatabaseItem } from "../../databases/local-databases";
 
 export class ModelAlertsView extends AbstractWebview<
   ToModelAlertsMessage,
@@ -18,8 +21,15 @@ export class ModelAlertsView extends AbstractWebview<
 > {
   public static readonly viewType = "codeQL.modelAlerts";
 
-  public constructor(app: App) {
+  public constructor(
+    app: App,
+    private readonly modelingEvents: ModelingEvents,
+    private readonly modelingStore: ModelingStore,
+    private readonly dbItem: DatabaseItem,
+  ) {
     super(app);
+
+    this.registerToModelingEvents();
   }
 
   public async showView() {
@@ -40,7 +50,14 @@ export class ModelAlertsView extends AbstractWebview<
   }
 
   protected onPanelDispose(): void {
-    // Nothing to dispose
+    const evaluationRun = this.modelingStore.getModelEvaluationRun(this.dbItem);
+    if (evaluationRun === undefined) {
+      return;
+    }
+    this.modelingStore.updateModelEvaluationRun(this.dbItem, {
+      ...evaluationRun,
+      isModelAlertsViewOpen: false,
+    });
   }
 
   protected async onMessage(msg: FromModelAlertsMessage): Promise<void> {
@@ -63,5 +80,19 @@ export class ModelAlertsView extends AbstractWebview<
       default:
         assertNever(msg);
     }
+  }
+
+  public async focusView(): Promise<void> {
+    this.panel?.reveal();
+  }
+
+  private registerToModelingEvents() {
+    this.push(
+      this.modelingEvents.onFocusModelAlertsView(async (event) => {
+        if (event.dbUri === this.dbItem.databaseUri.toString()) {
+          await this.focusView();
+        }
+      }),
+    );
   }
 }

--- a/extensions/ql-vscode/src/model-editor/model-alerts/model-alerts-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-alerts/model-alerts-view.ts
@@ -50,14 +50,7 @@ export class ModelAlertsView extends AbstractWebview<
   }
 
   protected onPanelDispose(): void {
-    const evaluationRun = this.modelingStore.getModelEvaluationRun(this.dbItem);
-    if (evaluationRun === undefined) {
-      return;
-    }
-    this.modelingStore.updateModelEvaluationRun(this.dbItem, {
-      ...evaluationRun,
-      isModelAlertsViewOpen: false,
-    });
+    this.modelingStore.updateIsModelAlertsViewOpen(this.dbItem, false);
   }
 
   protected async onMessage(msg: FromModelAlertsMessage): Promise<void> {

--- a/extensions/ql-vscode/src/model-editor/model-evaluation-run.ts
+++ b/extensions/ql-vscode/src/model-editor/model-evaluation-run.ts
@@ -1,5 +1,4 @@
 export interface ModelEvaluationRun {
   isPreparing: boolean;
   variantAnalysisId: number | undefined;
-  isModelAlertsViewOpen?: boolean;
 }

--- a/extensions/ql-vscode/src/model-editor/model-evaluation-run.ts
+++ b/extensions/ql-vscode/src/model-editor/model-evaluation-run.ts
@@ -1,4 +1,5 @@
 export interface ModelEvaluationRun {
   isPreparing: boolean;
   variantAnalysisId: number | undefined;
+  isModelAlertsViewOpen?: boolean;
 }

--- a/extensions/ql-vscode/src/model-editor/model-evaluator.ts
+++ b/extensions/ql-vscode/src/model-editor/model-evaluator.ts
@@ -107,8 +107,27 @@ export class ModelEvaluator extends DisposableObject {
   }
 
   public async openModelAlertsView() {
-    const view = new ModelAlertsView(this.app);
-    await view.showView();
+    const evaluationRun = this.modelingStore.getModelEvaluationRun(this.dbItem);
+    if (evaluationRun === undefined) {
+      return;
+    } else if (this.modelingStore.isModelAlertsViewOpen(evaluationRun)) {
+      this.modelingEvents.fireFocusModelAlertsViewEvent(
+        this.dbItem.databaseUri.toString(),
+      );
+      return;
+    } else {
+      this.modelingStore.updateModelEvaluationRun(this.dbItem, {
+        ...evaluationRun,
+        isModelAlertsViewOpen: true,
+      });
+      const view = new ModelAlertsView(
+        this.app,
+        this.modelingEvents,
+        this.modelingStore,
+        this.dbItem,
+      );
+      await view.showView();
+    }
   }
 
   private registerToModelingEvents() {

--- a/extensions/ql-vscode/src/model-editor/model-evaluator.ts
+++ b/extensions/ql-vscode/src/model-editor/model-evaluator.ts
@@ -107,19 +107,13 @@ export class ModelEvaluator extends DisposableObject {
   }
 
   public async openModelAlertsView() {
-    const evaluationRun = this.modelingStore.getModelEvaluationRun(this.dbItem);
-    if (evaluationRun === undefined) {
-      return;
-    } else if (this.modelingStore.isModelAlertsViewOpen(evaluationRun)) {
+    if (this.modelingStore.isModelAlertsViewOpen(this.dbItem)) {
       this.modelingEvents.fireFocusModelAlertsViewEvent(
         this.dbItem.databaseUri.toString(),
       );
       return;
     } else {
-      this.modelingStore.updateModelEvaluationRun(this.dbItem, {
-        ...evaluationRun,
-        isModelAlertsViewOpen: true,
-      });
+      this.modelingStore.updateIsModelAlertsViewOpen(this.dbItem, true);
       const view = new ModelAlertsView(
         this.app,
         this.modelingEvents,

--- a/extensions/ql-vscode/src/model-editor/modeling-events.ts
+++ b/extensions/ql-vscode/src/model-editor/modeling-events.ts
@@ -65,6 +65,10 @@ interface FocusModelEditorEvent {
   dbUri: string;
 }
 
+interface FocusModelAlertsViewEvent {
+  dbUri: string;
+}
+
 export class ModelingEvents extends DisposableObject {
   public readonly onActiveDbChanged: AppEvent<void>;
   public readonly onDbOpened: AppEvent<DatabaseItem>;
@@ -79,6 +83,7 @@ export class ModelingEvents extends DisposableObject {
   public readonly onModelEvaluationRunChanged: AppEvent<ModelEvaluationRunChangedEvent>;
   public readonly onRevealInModelEditor: AppEvent<RevealInModelEditorEvent>;
   public readonly onFocusModelEditor: AppEvent<FocusModelEditorEvent>;
+  public readonly onFocusModelAlertsView: AppEvent<FocusModelAlertsViewEvent>;
 
   private readonly onActiveDbChangedEventEmitter: AppEventEmitter<void>;
   private readonly onDbOpenedEventEmitter: AppEventEmitter<DatabaseItem>;
@@ -93,6 +98,7 @@ export class ModelingEvents extends DisposableObject {
   private readonly onModelEvaluationRunChangedEventEmitter: AppEventEmitter<ModelEvaluationRunChangedEvent>;
   private readonly onRevealInModelEditorEventEmitter: AppEventEmitter<RevealInModelEditorEvent>;
   private readonly onFocusModelEditorEventEmitter: AppEventEmitter<FocusModelEditorEvent>;
+  private readonly onFocusModelAlertsViewEventEmitter: AppEventEmitter<FocusModelAlertsViewEvent>;
 
   constructor(app: App) {
     super();
@@ -165,6 +171,11 @@ export class ModelingEvents extends DisposableObject {
       app.createEventEmitter<FocusModelEditorEvent>(),
     );
     this.onFocusModelEditor = this.onFocusModelEditorEventEmitter.event;
+
+    this.onFocusModelAlertsViewEventEmitter = this.push(
+      app.createEventEmitter<FocusModelAlertsViewEvent>(),
+    );
+    this.onFocusModelAlertsView = this.onFocusModelAlertsViewEventEmitter.event;
   }
 
   public fireActiveDbChangedEvent() {
@@ -285,5 +296,9 @@ export class ModelingEvents extends DisposableObject {
     this.onFocusModelEditorEventEmitter.fire({
       dbUri,
     });
+  }
+
+  public fireFocusModelAlertsViewEvent(dbUri: string) {
+    this.onFocusModelAlertsViewEventEmitter.fire({ dbUri });
   }
 }

--- a/extensions/ql-vscode/src/model-editor/modeling-store.ts
+++ b/extensions/ql-vscode/src/model-editor/modeling-store.ts
@@ -498,4 +498,8 @@ export class ModelingStore extends DisposableObject {
       state.modelEvaluationRun,
     );
   }
+
+  public isModelAlertsViewOpen(evaluationRun: ModelEvaluationRun): boolean {
+    return evaluationRun.isModelAlertsViewOpen ?? false;
+  }
 }

--- a/extensions/ql-vscode/src/model-editor/modeling-store.ts
+++ b/extensions/ql-vscode/src/model-editor/modeling-store.ts
@@ -20,6 +20,7 @@ interface InternalDbModelingState {
   selectedMethod: Method | undefined;
   selectedUsage: Usage | undefined;
   modelEvaluationRun: ModelEvaluationRun | undefined;
+  isModelAlertsViewOpen: boolean | undefined;
 }
 
 export interface DbModelingState {
@@ -34,6 +35,7 @@ export interface DbModelingState {
   readonly selectedMethod: Method | undefined;
   readonly selectedUsage: Usage | undefined;
   readonly modelEvaluationRun: ModelEvaluationRun | undefined;
+  readonly isModelAlertsViewOpen: boolean | undefined;
 }
 
 export interface SelectedMethodDetails {
@@ -71,6 +73,7 @@ export class ModelingStore extends DisposableObject {
       selectedUsage: undefined,
       inProgressMethods: new Set(),
       modelEvaluationRun: undefined,
+      isModelAlertsViewOpen: undefined,
     });
 
     this.modelingEvents.fireDbOpenedEvent(databaseItem);
@@ -499,7 +502,12 @@ export class ModelingStore extends DisposableObject {
     );
   }
 
-  public isModelAlertsViewOpen(evaluationRun: ModelEvaluationRun): boolean {
-    return evaluationRun.isModelAlertsViewOpen ?? false;
+  public isModelAlertsViewOpen(dbItem: DatabaseItem): boolean {
+    return this.getState(dbItem).isModelAlertsViewOpen ?? false;
+  }
+
+  public updateIsModelAlertsViewOpen(dbItem: DatabaseItem, isOpen: boolean) {
+    const state = this.getState(dbItem);
+    state.isModelAlertsViewOpen = isOpen;
   }
 }

--- a/extensions/ql-vscode/src/model-editor/modeling-store.ts
+++ b/extensions/ql-vscode/src/model-editor/modeling-store.ts
@@ -20,7 +20,7 @@ interface InternalDbModelingState {
   selectedMethod: Method | undefined;
   selectedUsage: Usage | undefined;
   modelEvaluationRun: ModelEvaluationRun | undefined;
-  isModelAlertsViewOpen: boolean | undefined;
+  isModelAlertsViewOpen: boolean;
 }
 
 export interface DbModelingState {
@@ -35,7 +35,7 @@ export interface DbModelingState {
   readonly selectedMethod: Method | undefined;
   readonly selectedUsage: Usage | undefined;
   readonly modelEvaluationRun: ModelEvaluationRun | undefined;
-  readonly isModelAlertsViewOpen: boolean | undefined;
+  readonly isModelAlertsViewOpen: boolean;
 }
 
 export interface SelectedMethodDetails {
@@ -73,7 +73,7 @@ export class ModelingStore extends DisposableObject {
       selectedUsage: undefined,
       inProgressMethods: new Set(),
       modelEvaluationRun: undefined,
-      isModelAlertsViewOpen: undefined,
+      isModelAlertsViewOpen: false,
     });
 
     this.modelingEvents.fireDbOpenedEvent(databaseItem);
@@ -506,8 +506,18 @@ export class ModelingStore extends DisposableObject {
     return this.getState(dbItem).isModelAlertsViewOpen ?? false;
   }
 
-  public updateIsModelAlertsViewOpen(dbItem: DatabaseItem, isOpen: boolean) {
+  private changeIsModelAlertsViewOpen(
+    dbItem: DatabaseItem,
+    updateState: (state: InternalDbModelingState) => void,
+  ) {
     const state = this.getState(dbItem);
-    state.isModelAlertsViewOpen = isOpen;
+
+    updateState(state);
+  }
+
+  public updateIsModelAlertsViewOpen(dbItem: DatabaseItem, isOpen: boolean) {
+    this.changeIsModelAlertsViewOpen(dbItem, (state) => {
+      state.isModelAlertsViewOpen = isOpen;
+    });
   }
 }

--- a/extensions/ql-vscode/src/view/model-editor/ModelEvaluation.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelEvaluation.tsx
@@ -34,7 +34,8 @@ export const ModelEvaluation = ({
 
   const shouldShowStopButton = !shouldShowEvaluateButton;
 
-  const shouldShowEvaluationRunLink = !!evaluationRun;
+  const shouldShowEvaluationRunLink =
+    !!evaluationRun && evaluationRun.variantAnalysis;
 
   const customModelsExist = Object.values(modeledMethods).some(
     (methods) => methods.filter((m) => m.type !== "none").length > 0,

--- a/extensions/ql-vscode/src/view/model-editor/__tests__/ModelEvaluation.spec.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/__tests__/ModelEvaluation.spec.tsx
@@ -98,11 +98,32 @@ describe(ModelEvaluation.name, () => {
       expect(screen.queryByText("Stop evaluation")).not.toBeInTheDocument();
     });
 
-    it("renders 'Stop evaluation' button and 'Evaluation run' link when there is an in progress evaluation", () => {
+    it("renders 'Stop evaluation' button when there is an in progress evaluation, but no variant analysis yet", () => {
       render({
         evaluationRun: {
           isPreparing: true,
           variantAnalysis: undefined,
+        },
+      });
+
+      const stopEvaluationButton = screen.queryByText("Stop evaluation");
+      expect(stopEvaluationButton).toBeInTheDocument();
+      expect(
+        stopEvaluationButton?.getElementsByTagName("input")[0],
+      ).toBeEnabled();
+
+      expect(screen.queryByText("Evaluation run")).not.toBeInTheDocument();
+
+      expect(screen.queryByText("Evaluate")).not.toBeInTheDocument();
+    });
+
+    it("renders 'Stop evaluation' button and 'Evaluation run' link when there is an in progress evaluation with variant analysis", () => {
+      render({
+        evaluationRun: {
+          isPreparing: false,
+          variantAnalysis: createMockVariantAnalysis({
+            status: VariantAnalysisStatus.InProgress,
+          }),
         },
       });
 


### PR DESCRIPTION
There should only ever be one model alerts view open, so this PR adds some logic to check that we don't already have one! 👀 

The second commit is a related tweak that makes sure we can't open the model alerts view until the variant analysis has kicked off. (This is similar to the MRVA results view, which only opens once the actual workflow run has been triggered, since there's nothing to show otherwise.)

## Checklist

N/A—feature-flagged for internal use/testing 🏴 

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
