### PR TITLE
Use VSCodeBadge instead of custom styled component

### DIFF
--- a/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/MethodRow.tsx
@@ -1,4 +1,5 @@
 import {
+  VSCodeBadge,
   VSCodeButton,
   VSCodeLink,
   VSCodeProgressRing,
@@ -57,11 +58,7 @@ const ModelButtonsContainer = styled.div`
   gap: 1em;
 `;
 
-const UsagesButton = styled.button`
-  color: var(--vscode-editor-foreground);
-  background-color: var(--vscode-input-background);
-  border: none;
-  border-radius: 40%;
+const UsagesButton = styled(VSCodeBadge)`
   cursor: pointer;
 `;
 

--- a/extensions/ql-vscode/src/view/model-editor/ModelAlertsIndicator.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelAlertsIndicator.tsx
@@ -2,12 +2,9 @@ import { styled } from "styled-components";
 import type { ModeledMethod } from "../../model-editor/modeled-method";
 import type { ModelEvaluationRunState } from "../../model-editor/shared/model-evaluation-run-state";
 import type { ModelEditorViewState } from "../../model-editor/shared/view-state";
+import { VSCodeBadge } from "@vscode/webview-ui-toolkit/react";
 
-const ModelAlertsButton = styled.button`
-  color: var(--vscode-editor-foreground);
-  background-color: var(--vscode-input-background);
-  border: none;
-  border-radius: 40%;
+const ModelAlertsButton = styled(VSCodeBadge)`
   cursor: pointer;
 `;
 
@@ -36,6 +33,8 @@ export const ModelAlertsIndicator = ({
 
   return (
     <ModelAlertsButton
+      role="button"
+      aria-label="Model alerts"
       onClick={(event: React.MouseEvent) => {
         event.stopPropagation();
       }}


### PR DESCRIPTION
Changes a few buttons in the model editor to use the [`VSCodeBadge`](https://github.com/microsoft/vscode-webview-ui-toolkit/blob/main/src/badge/README.md) component from the webview UI toolkit. Follow-up from https://github.com/github/vscode-codeql/pull/3441#discussion_r1521510447.

Before: 
![image](https://github.com/github/vscode-codeql/assets/42641846/58f68d4a-8422-476e-888f-e4fa2b8af8b9)

After: 
![image](https://github.com/github/vscode-codeql/assets/42641846/375265c7-b3b7-47a3-ac69-4d71b00097a8)

## Checklist

N/A: the usages button has just changed a tiny amount, and the model alerts button is feature-flagged

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
