### PR TITLE
Create token-not-used.ql to catch cases where we aren't using the progress bar token correctly

### DIFF
--- a/.github/codeql/queries/ProgressBar.qll
+++ b/.github/codeql/queries/ProgressBar.qll
@@ -9,8 +9,10 @@ abstract class ProgressBar extends CallExpr {
 
   predicate usesToken() { this.getCallback().getNumParameter() >= 2 }
 
+  Property getCancellableProperty() { result = this.getOptions().getPropertyByName("cancellable") }
+
   predicate isCancellable() {
-    this.getOptions().getPropertyByName("cancellable").getInit().(BooleanLiteral).getBoolValue() =
+    this.getCancellableProperty().getInit().(BooleanLiteral).getBoolValue() =
       true
   }
 }

--- a/.github/codeql/queries/ProgressBar.qll
+++ b/.github/codeql/queries/ProgressBar.qll
@@ -1,0 +1,32 @@
+import javascript
+
+abstract class ProgressBar extends CallExpr {
+  ProgressBar() { any() }
+
+  abstract Function getCallback();
+
+  abstract ObjectExpr getOptions();
+
+  predicate usesToken() { this.getCallback().getNumParameter() >= 2 }
+
+  predicate isCancellable() {
+    this.getOptions().getPropertyByName("cancellable").getInit().(BooleanLiteral).getBoolValue() =
+      true
+  }
+}
+
+class WithProgressCall extends ProgressBar {
+  WithProgressCall() { this.getCalleeName() = "withProgress" }
+
+  override Function getCallback() { result = this.getArgument(0) }
+
+  override ObjectExpr getOptions() { result = this.getArgument(1) }
+}
+
+class WithInheritedProgressCall extends ProgressBar {
+  WithInheritedProgressCall() { this.getCalleeName() = "withInheritedProgress" }
+
+  override Function getCallback() { result = this.getArgument(1) }
+
+  override ObjectExpr getOptions() { result = this.getArgument(2) }
+}

--- a/.github/codeql/queries/ProgressBar.qll
+++ b/.github/codeql/queries/ProgressBar.qll
@@ -7,7 +7,9 @@ abstract class ProgressBar extends CallExpr {
 
   abstract ObjectExpr getOptions();
 
-  predicate usesToken() { this.getCallback().getNumParameter() >= 2 }
+  predicate usesToken() { exists(this.getTokenParameter()) }
+
+  Parameter getTokenParameter() { result = this.getCallback().getParameter(1) }
 
   Property getCancellableProperty() { result = this.getOptions().getPropertyByName("cancellable") }
 

--- a/.github/codeql/queries/progress-not-cancellable.ql
+++ b/.github/codeql/queries/progress-not-cancellable.ql
@@ -14,4 +14,7 @@ import ProgressBar
 
 from ProgressBar t
 where not t.isCancellable() and t.usesToken()
-select t, "The token should not be used when the progress bar is not cancelable. Either stop using the token or mark the progress bar as cancellable."
+select t,
+  "The $@ should not be used when the progress bar is not cancellable. Either stop using the $@ or mark the progress bar as cancellable.",
+  t.getTokenParameter(), t.getTokenParameter().getName(), t.getTokenParameter(),
+  t.getTokenParameter().getName()

--- a/.github/codeql/queries/progress-not-cancellable.ql
+++ b/.github/codeql/queries/progress-not-cancellable.ql
@@ -1,0 +1,15 @@
+/**
+ * @name Using token for non-cancellable progress bar
+ * @kind problem
+ * @problem.severity warning
+ * @id vscode-codeql/progress-not-cancellable
+ * @description If we call `withProgress` with `cancellable: false` then the
+ * token that is given to us should be ignored because it won't ever be cancelled.
+ */
+
+import javascript
+import ProgressBar
+
+from ProgressBar t
+where not t.isCancellable() and t.usesToken()
+select t, "The token should not be used when the progress bar is not cancelable"

--- a/.github/codeql/queries/progress-not-cancellable.ql
+++ b/.github/codeql/queries/progress-not-cancellable.ql
@@ -3,8 +3,10 @@
  * @kind problem
  * @problem.severity warning
  * @id vscode-codeql/progress-not-cancellable
- * @description If we call `withProgress` with `cancellable: false` then the
+ * @description If we call `withProgress` without `cancellable: true` then the
  * token that is given to us should be ignored because it won't ever be cancelled.
+ * This makes the code more confusing as it tries to account for cases that can't
+ * happen. The fix is to either not use the token or make the progress bar cancellable.
  */
 
 import javascript
@@ -12,4 +14,4 @@ import ProgressBar
 
 from ProgressBar t
 where not t.isCancellable() and t.usesToken()
-select t, "The token should not be used when the progress bar is not cancelable"
+select t, "The token should not be used when the progress bar is not cancelable. Either stop using the token or mark the progress bar as cancellable."

--- a/.github/codeql/queries/token-not-used.ql
+++ b/.github/codeql/queries/token-not-used.ql
@@ -1,5 +1,5 @@
 /**
- * @name Don't ignore the token for a cancelable progress bar
+ * @name Don't ignore the token for a cancellable progress bar
  * @kind problem
  * @problem.severity warning
  * @id vscode-codeql/token-not-used

--- a/.github/codeql/queries/token-not-used.ql
+++ b/.github/codeql/queries/token-not-used.ql
@@ -10,32 +10,8 @@
  */
 
 import javascript
+import ProgressBar
 
-class NewTokenSource extends CallExpr {
-  NewTokenSource() {
-    this.getCalleeName() = "withProgress" or this.getCalleeName() = "withInheritedProgress"
-  }
-
-  Function getCallback() {
-    this.getCalleeName() = "withProgress" and result = this.getArgument(0)
-    or
-    this.getCalleeName() = "withInheritedProgress" and result = this.getArgument(1)
-  }
-
-  ObjectExpr getOptions() {
-    this.getCalleeName() = "withProgress" and result = this.getArgument(1)
-    or
-    this.getCalleeName() = "withInheritedProgress" and result = this.getArgument(2)
-  }
-
-  predicate usesToken() { this.getCallback().getNumParameter() >= 2 }
-
-  predicate isCancellable() {
-    this.getOptions().getPropertyByName("cancellable").getInit().(BooleanLiteral).getBoolValue() =
-      true
-  }
-}
-
-from NewTokenSource t
+from ProgressBar t
 where t.isCancellable() and not t.usesToken()
 select t, "This progress bar is cancelable but the token is not used"

--- a/.github/codeql/queries/token-not-used.ql
+++ b/.github/codeql/queries/token-not-used.ql
@@ -14,4 +14,4 @@ import ProgressBar
 
 from ProgressBar t
 where t.isCancellable() and not t.usesToken()
-select t, "This progress bar is cancelable but the token is not used"
+select t, "This progress bar is $@ but the token is not used", t.getCancellableProperty(), "cancellable"

--- a/.github/codeql/queries/token-not-used.ql
+++ b/.github/codeql/queries/token-not-used.ql
@@ -6,7 +6,8 @@
  * @description If we call `withProgress` with `cancellable: true` but then
  * ignore the token that is given to us, it will lead to a poor user experience
  * because the progress bar will appear to be canceled but it will not actually
- * affect the background process.
+ * affect the background process. Either check the token and respect when it
+ * has been cancelled, or mark the progress bar as not cancellable.
  */
 
 import javascript
@@ -14,4 +15,4 @@ import ProgressBar
 
 from ProgressBar t
 where t.isCancellable() and not t.usesToken()
-select t, "This progress bar is $@ but the token is not used", t.getCancellableProperty(), "cancellable"
+select t, "This progress bar is $@ but the token is not used. Either use the token or mark the progress bar as not cancellable.", t.getCancellableProperty(), "cancellable"


### PR DESCRIPTION
This PR adds a CodeQL query to catch cases where we use `withProgress` with `cancellable: true` but then don't actually use the token argument. This will lead to cases where the user clicks the "cancel" button and the progress bar goes away but the background process continues and the user cannot control it.

This was inspired by https://github.com/github/vscode-codeql/pull/3454#discussion_r1523033368 which was only caught because we manually spotted it.

This should hopefully also detect one other existing alert at https://github.com/github/vscode-codeql/blob/3005dacf4ed480aa76e541b7d3697f5a34571faf/extensions/ql-vscode/src/databases/local-databases-ui.ts#L950.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
