### PR TITLE
Add new ModelPacks component

### DIFF
--- a/extensions/ql-vscode/src/common/model-pack-details.ts
+++ b/extensions/ql-vscode/src/common/model-pack-details.ts
@@ -1,0 +1,4 @@
+export interface ModelPackDetails {
+  name: string;
+  path: string;
+}

--- a/extensions/ql-vscode/src/stories/model-alerts/ModelPacks.stories.tsx
+++ b/extensions/ql-vscode/src/stories/model-alerts/ModelPacks.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryFn } from "@storybook/react";
+
+import { ModelPacks as ModelPacksComponent } from "../../view/model-alerts/ModelPacks";
+
+export default {
+  title: "Model Alerts/Model Packs",
+  component: ModelPacksComponent,
+  argTypes: {
+    openModelPackClick: {
+      action: "open-model-pack-clicked",
+      table: {
+        disable: true,
+      },
+    },
+  },
+} as Meta<typeof ModelPacksComponent>;
+
+const Template: StoryFn<typeof ModelPacksComponent> = (args) => (
+  <ModelPacksComponent {...args} />
+);
+
+export const ModelPacks = Template.bind({});
+ModelPacks.args = {
+  modelPacks: [
+    {
+      name: "Model pack 1",
+      path: "/path/to/model-pack-1",
+    },
+    {
+      name: "Model pack 2",
+      path: "/path/to/model-pack-2",
+    },
+  ],
+};

--- a/extensions/ql-vscode/src/view/model-alerts/ModelPacks.tsx
+++ b/extensions/ql-vscode/src/view/model-alerts/ModelPacks.tsx
@@ -1,0 +1,43 @@
+import { styled } from "styled-components";
+import { LinkIconButton } from "../common/LinkIconButton";
+import type { ModelPackDetails } from "../../common/model-pack-details";
+
+const Title = styled.h3`
+  font-size: medium;
+  font-weight: 500;
+  margin: 0;
+`;
+
+const List = styled.ul`
+  list-style: none;
+  padding: 0;
+  margin-top: 5px;
+`;
+
+export const ModelPacks = ({
+  modelPacks,
+  openModelPackClick,
+}: {
+  modelPacks: ModelPackDetails[];
+  openModelPackClick: (path: string) => void;
+}): React.JSX.Element => {
+  if (modelPacks.length <= 0) {
+    return <></>;
+  }
+
+  return (
+    <>
+      <Title>Model packs</Title>
+      <List>
+        {modelPacks.map((modelPack) => (
+          <li key={modelPack.path}>
+            <LinkIconButton onClick={() => openModelPackClick(modelPack.path)}>
+              <span slot="start" className="codicon codicon-file-code"></span>
+              {modelPack.name}
+            </LinkIconButton>
+          </li>
+        ))}
+      </List>
+    </>
+  );
+};


### PR DESCRIPTION
Adds a new `ModelPacks` React component to show the model packs used during an evaluation run. This is not used anywhere yet - it will be wired up in a follow up PR.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
