### PR TITLE
Added error handling on webview message processing

### DIFF
--- a/extensions/ql-vscode/src/common/vscode/abstract-webview.ts
+++ b/extensions/ql-vscode/src/common/vscode/abstract-webview.ts
@@ -13,6 +13,8 @@ import { tmpDir } from "../../tmp-dir";
 import type { WebviewMessage, WebviewKind } from "./webview-html";
 import { getHtmlForWebview } from "./webview-html";
 import type { DeepReadonly } from "../readonly";
+import { runWithErrorHandling } from "./error-handling";
+import { telemetryListener } from "./telemetry";
 
 export type WebviewPanelConfig = {
   viewId: string;
@@ -117,7 +119,12 @@ export abstract class AbstractWebview<
     );
     this.push(
       panel.webview.onDidReceiveMessage(
-        async (e) => this.onMessage(e),
+        async (e) =>
+          runWithErrorHandling(
+            () => this.onMessage(e),
+            this.app.logger,
+            telemetryListener,
+          ),
         undefined,
       ),
     );

--- a/extensions/ql-vscode/src/common/vscode/error-handling.ts
+++ b/extensions/ql-vscode/src/common/vscode/error-handling.ts
@@ -1,0 +1,81 @@
+import {
+  showAndLogWarningMessage,
+  showAndLogExceptionWithTelemetry,
+} from "../logging";
+import type { NotificationLogger } from "../logging";
+import { extLogger } from "../logging/vscode";
+import type { AppTelemetry } from "../telemetry";
+import { telemetryListener } from "./telemetry";
+import { asError, getErrorMessage } from "../helpers-pure";
+import { redactableError } from "../errors";
+import { UserCancellationException } from "./progress";
+import { CliError } from "../../codeql-cli/cli-errors";
+import { EOL } from "os";
+
+/**
+ * Executes a task with error handling. It provides a uniform way to handle errors.
+ *
+ * @template T - A function type that takes an unknown number of arguments and returns a Promise.
+ * @param {T} task - The task to be executed.
+ * @param {NotificationLogger} [logger=extLogger] - The logger to use for error reporting.
+ * @param {AppTelemetry | undefined} [telemetry=telemetryListener] - The telemetry listener to use for error reporting.
+ * @param {string} [commandId] - The optional command id associated with the task.
+ * @param {...unknown} args - The arguments to be passed to the task.
+ * @returns {Promise<unknown>} The result of the task, or undefined if an error occurred.
+ * @throws {Error} If an error occurs during the execution of the task.
+ */
+export async function runWithErrorHandling<
+  T extends (...args: unknown[]) => Promise<unknown>,
+>(
+  task: T,
+  logger: NotificationLogger = extLogger,
+  telemetry: AppTelemetry | undefined = telemetryListener,
+  commandId?: string,
+  ...args: unknown[]
+): Promise<unknown> {
+  const startTime = Date.now();
+  let error: Error | undefined;
+
+  try {
+    return await task(...args);
+  } catch (e) {
+    error = asError(e);
+    const errorMessage = redactableError(error)`${
+      getErrorMessage(e) || e
+    }${commandId ? ` (${commandId})` : ""}`;
+
+    const extraTelemetryProperties = commandId
+      ? { command: commandId }
+      : undefined;
+
+    if (e instanceof UserCancellationException) {
+      // User has cancelled this action manually
+      if (e.silent) {
+        void logger.log(errorMessage.fullMessage);
+      } else {
+        void showAndLogWarningMessage(logger, errorMessage.fullMessage);
+      }
+    } else if (e instanceof CliError) {
+      const fullMessage = `${e.commandDescription} failed with args:${EOL}    ${e.commandArgs.join(" ")}${EOL}${
+        e.stderr ?? e.cause
+      }`;
+      void showAndLogExceptionWithTelemetry(logger, telemetry, errorMessage, {
+        fullMessage,
+        extraTelemetryProperties,
+      });
+    } else {
+      // Include the full stack in the error log only.
+      const fullMessage = errorMessage.fullMessageWithStack;
+      void showAndLogExceptionWithTelemetry(logger, telemetry, errorMessage, {
+        fullMessage,
+        extraTelemetryProperties,
+      });
+    }
+    return undefined;
+  } finally {
+    if (commandId) {
+      const executionTime = Date.now() - startTime;
+      telemetryListener?.sendCommandUsage(commandId, executionTime, error);
+    }
+  }
+}

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -95,10 +95,7 @@ import {
   telemetryListener,
 } from "./common/vscode/telemetry";
 import type { ProgressCallback } from "./common/vscode/progress";
-import {
-  UserCancellationException,
-  withProgress,
-} from "./common/vscode/progress";
+import { withProgress } from "./common/vscode/progress";
 import { CodeQlStatusBarHandler } from "./status-bar";
 import { getPackagingCommands } from "./packaging";
 import { HistoryItemLabelProvider } from "./query-history/history-item-label-provider";
@@ -1188,10 +1185,6 @@ function addUnhandledRejectionListener() {
       extension && getErrorStack(error).includes(extension.extensionPath);
 
     if (isFromThisExtension) {
-      if (error instanceof UserCancellationException && error.silent) {
-        return;
-      }
-
       const message = redactableError(
         asError(error),
       )`Unhandled error: ${getErrorMessage(error)}`;

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -95,7 +95,10 @@ import {
   telemetryListener,
 } from "./common/vscode/telemetry";
 import type { ProgressCallback } from "./common/vscode/progress";
-import { withProgress } from "./common/vscode/progress";
+import {
+  UserCancellationException,
+  withProgress,
+} from "./common/vscode/progress";
 import { CodeQlStatusBarHandler } from "./status-bar";
 import { getPackagingCommands } from "./packaging";
 import { HistoryItemLabelProvider } from "./query-history/history-item-label-provider";
@@ -1185,6 +1188,10 @@ function addUnhandledRejectionListener() {
       extension && getErrorStack(error).includes(extension.extensionPath);
 
     if (isFromThisExtension) {
+      if (error instanceof UserCancellationException && error.silent) {
+        return;
+      }
+
       const message = redactableError(
         asError(error),
       )`Unhandled error: ${getErrorMessage(error)}`;


### PR DESCRIPTION
#### Original approach of the PR
Currently a `UserCancellationException` is thrown with `silent: true` and there is no `catch` statement around the operation that triggered the exception, the `UserCancellationException` is unhandled and the global error handler is hit.

This PR adds a check for silent `UserCancellationException` in the global error handler. 

#### Updated approach of the PR
Add error handling around webview message processing and use the same logic as we do for commands. We use the same logic by extracting it into a reusable function.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
