### PR TITLE
Add model packs to variant analyses

### DIFF
--- a/extensions/ql-vscode/src/variant-analysis/shared/variant-analysis.ts
+++ b/extensions/ql-vscode/src/variant-analysis/shared/variant-analysis.ts
@@ -1,6 +1,7 @@
 import type { Repository, RepositoryWithMetadata } from "./repository";
 import type { AnalysisAlert, AnalysisRawResults } from "./analysis-result";
 import { QueryLanguage } from "../../common/query-language";
+import type { ModelPackDetails } from "../../common/model-pack-details";
 
 export interface VariantAnalysis {
   id: number;
@@ -13,6 +14,7 @@ export interface VariantAnalysis {
     kind?: string;
   };
   queries?: VariantAnalysisQueries;
+  modelPacks?: ModelPackDetails[];
   databases: {
     repositories?: string[];
     repositoryLists?: string[];

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -350,6 +350,7 @@ export class VariantAnalysisManager
     const {
       actionBranch,
       base64Pack,
+      modelPacks,
       repoSelection,
       controllerRepo,
       queryStartTime,
@@ -410,6 +411,7 @@ export class VariantAnalysisManager
     const mappedVariantAnalysis = mapVariantAnalysisFromSubmission(
       variantAnalysisSubmission,
       variantAnalysisResponse,
+      modelPacks,
     );
 
     await this.onVariantAnalysisSubmitted(mappedVariantAnalysis);

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-mapper.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-mapper.ts
@@ -1,3 +1,4 @@
+import type { ModelPackDetails } from "../common/model-pack-details";
 import type {
   VariantAnalysis as ApiVariantAnalysis,
   VariantAnalysisScannedRepository as ApiVariantAnalysisScannedRepository,
@@ -26,6 +27,7 @@ import {
 export function mapVariantAnalysisFromSubmission(
   submission: VariantAnalysisSubmission,
   apiVariantAnalysis: ApiVariantAnalysis,
+  modelPacks: ModelPackDetails[],
 ): VariantAnalysis {
   return mapVariantAnalysis(
     {
@@ -37,6 +39,7 @@ export function mapVariantAnalysisFromSubmission(
         kind: submission.query.kind,
       },
       queries: submission.queries,
+      modelPacks,
       databases: submission.databases,
       executionStartTime: submission.startTime,
     },
@@ -59,7 +62,12 @@ export function mapUpdatedVariantAnalysis(
 function mapVariantAnalysis(
   currentVariantAnalysis: Pick<
     VariantAnalysis,
-    "language" | "query" | "queries" | "databases" | "executionStartTime"
+    | "language"
+    | "query"
+    | "queries"
+    | "databases"
+    | "executionStartTime"
+    | "modelPacks"
   >,
   currentStatus: VariantAnalysisStatus | undefined,
   response: ApiVariantAnalysis,
@@ -96,6 +104,7 @@ function mapVariantAnalysis(
     language: currentVariantAnalysis.language,
     query: currentVariantAnalysis.query,
     queries: currentVariantAnalysis.queries,
+    modelPacks: currentVariantAnalysis.modelPacks,
     databases: currentVariantAnalysis.databases,
     executionStartTime: currentVariantAnalysis.executionStartTime,
     createdAt: response.created_at,

--- a/extensions/ql-vscode/test/unit-tests/variant-analysis/variant-analysis-mapper.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/variant-analysis/variant-analysis-mapper.test.ts
@@ -31,6 +31,7 @@ describe(mapVariantAnalysisFromSubmission.name, () => {
     const result = mapVariantAnalysisFromSubmission(
       mockSubmission,
       mockApiResponse,
+      [],
     );
 
     const {
@@ -54,6 +55,7 @@ describe(mapVariantAnalysisFromSubmission.name, () => {
         text: mockSubmission.query.text,
         kind: "table",
       },
+      modelPacks: [],
       databases: {
         repositories: ["1", "2", "3"],
       },


### PR DESCRIPTION
Adds `modelPacks` to variant analysis entities and flows that through from when the packs are discovered to when the entity is created.

The `modelPacks` property is not persisted yet so it's not mapped over when transforming to query history items. This is intentional - we will change that once we're more confident with the shape of the data. See internal linked issue for details.

Note that this is not used yet, it will be wired up in a follow up PR.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
