### PR TITLE
Show model packs in Model Alerts view

### DIFF
--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -732,6 +732,15 @@ interface SetModelAlertsViewStateMessage {
   viewState: ModelAlertsViewState;
 }
 
-export type ToModelAlertsMessage = SetModelAlertsViewStateMessage;
+interface OpenModelPackMessage {
+  t: "openModelPack";
+  path: string;
+}
 
-export type FromModelAlertsMessage = CommonFromViewMessages;
+export type ToModelAlertsMessage =
+  | SetModelAlertsViewStateMessage
+  | SetVariantAnalysisMessage;
+
+export type FromModelAlertsMessage =
+  | CommonFromViewMessages
+  | OpenModelPackMessage;

--- a/extensions/ql-vscode/src/model-editor/model-evaluator.ts
+++ b/extensions/ql-vscode/src/model-editor/model-evaluator.ts
@@ -124,7 +124,26 @@ export class ModelEvaluator extends DisposableObject {
         this.dbItem,
         this.extensionPack,
       );
-      await view.showView();
+
+      // There should be a variant analysis available at this point, as the
+      // view can only opened when the variant analysis is complete. So we
+      // send this to the view. This is temporary until we have logic to
+      // listen to variant analysis updates and update the view accordingly.
+      const evaluationRun = this.modelingStore.getModelEvaluationRun(
+        this.dbItem,
+      );
+      if (!evaluationRun) {
+        throw new Error("No evaluation run available");
+      }
+
+      const variantAnalysis =
+        await this.getVariantAnalysisForRun(evaluationRun);
+
+      if (!variantAnalysis) {
+        throw new Error("No variant analysis available");
+      }
+
+      await view.showView(variantAnalysis);
     }
   }
 

--- a/extensions/ql-vscode/src/view/model-alerts/ModelAlerts.tsx
+++ b/extensions/ql-vscode/src/view/model-alerts/ModelAlerts.tsx
@@ -1,16 +1,29 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { ModelAlertsHeader } from "./ModelAlertsHeader";
 import type { ModelAlertsViewState } from "../../model-editor/shared/view-state";
 import type { ToModelAlertsMessage } from "../../common/interface-types";
+import type { VariantAnalysis } from "../../variant-analysis/shared/variant-analysis";
+import { vscode } from "../vscode-api";
 
 type Props = {
   initialViewState?: ModelAlertsViewState;
 };
 
 export function ModelAlerts({ initialViewState }: Props): React.JSX.Element {
+  const onOpenModelPackClick = useCallback((path: string) => {
+    vscode.postMessage({
+      t: "openModelPack",
+      path,
+    });
+  }, []);
+
   const [viewState, setViewState] = useState<ModelAlertsViewState | undefined>(
     initialViewState,
   );
+
+  const [variantAnalysis, setVariantAnalysis] = useState<
+    VariantAnalysis | undefined
+  >(undefined);
 
   useEffect(() => {
     const listener = (evt: MessageEvent) => {
@@ -20,6 +33,9 @@ export function ModelAlerts({ initialViewState }: Props): React.JSX.Element {
           case "setModelAlertsViewState": {
             setViewState(msg.viewState);
             break;
+          }
+          case "setVariantAnalysis": {
+            setVariantAnalysis(msg.variantAnalysis);
           }
         }
       } else {
@@ -35,9 +51,15 @@ export function ModelAlerts({ initialViewState }: Props): React.JSX.Element {
     };
   }, []);
 
-  if (viewState === undefined) {
+  if (viewState === undefined || variantAnalysis === undefined) {
     return <></>;
   }
 
-  return <ModelAlertsHeader viewState={viewState}></ModelAlertsHeader>;
+  return (
+    <ModelAlertsHeader
+      viewState={viewState}
+      variantAnalysis={variantAnalysis}
+      openModelPackClick={onOpenModelPackClick}
+    ></ModelAlertsHeader>
+  );
 }

--- a/extensions/ql-vscode/src/view/model-alerts/ModelAlertsHeader.tsx
+++ b/extensions/ql-vscode/src/view/model-alerts/ModelAlertsHeader.tsx
@@ -1,8 +1,26 @@
 import type { ModelAlertsViewState } from "../../model-editor/shared/view-state";
+import type { VariantAnalysis } from "../../variant-analysis/shared/variant-analysis";
 import { ViewTitle } from "../common";
+import { ModelPacks } from "./ModelPacks";
 
-type Props = { viewState: ModelAlertsViewState };
+type Props = {
+  viewState: ModelAlertsViewState;
+  variantAnalysis: VariantAnalysis;
+  openModelPackClick: (path: string) => void;
+};
 
-export const ModelAlertsHeader = ({ viewState }: Props) => {
-  return <ViewTitle>Model evaluation results for {viewState.title}</ViewTitle>;
+export const ModelAlertsHeader = ({
+  viewState,
+  variantAnalysis,
+  openModelPackClick,
+}: Props) => {
+  return (
+    <>
+      <ViewTitle>Model evaluation results for {viewState.title}</ViewTitle>
+      <ModelPacks
+        modelPacks={variantAnalysis.modelPacks || []}
+        openModelPackClick={openModelPackClick}
+      ></ModelPacks>
+    </>
+  );
 };

--- a/extensions/ql-vscode/src/view/vscode-api.ts
+++ b/extensions/ql-vscode/src/view/vscode-api.ts
@@ -1,6 +1,7 @@
 import type {
   FromCompareViewMessage,
   FromMethodModelingMessage,
+  FromModelAlertsMessage,
   FromModelEditorMessage,
   FromResultsViewMsg,
   FromVariantAnalysisMessage,
@@ -17,7 +18,8 @@ export interface VsCodeApi {
       | FromCompareViewMessage
       | FromVariantAnalysisMessage
       | FromModelEditorMessage
-      | FromMethodModelingMessage,
+      | FromMethodModelingMessage
+      | FromModelAlertsMessage,
   ): void;
 
   /**


### PR DESCRIPTION
Wires up showing model packs in the Model Alerts view.

To show the model packs we pass in the variant analysis to the view. We currently only send the variant analysis during creation of the view and do not update it at all as live results come in. That will be handled separately. 

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
