### PR TITLE
Wire up variant analysis updates to Model Alerts view

### DIFF
--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -739,7 +739,9 @@ interface OpenModelPackMessage {
 
 export type ToModelAlertsMessage =
   | SetModelAlertsViewStateMessage
-  | SetVariantAnalysisMessage;
+  | SetVariantAnalysisMessage
+  | SetRepoResultsMessage
+  | SetRepoStatesMessage;
 
 export type FromModelAlertsMessage =
   | CommonFromViewMessages

--- a/extensions/ql-vscode/src/model-editor/model-alerts/model-alerts-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-alerts/model-alerts-view.ts
@@ -15,7 +15,11 @@ import type { ModelingEvents } from "../modeling-events";
 import type { ModelingStore } from "../modeling-store";
 import type { DatabaseItem } from "../../databases/local-databases";
 import type { ExtensionPack } from "../shared/extension-pack";
-import type { VariantAnalysis } from "../../variant-analysis/shared/variant-analysis";
+import type {
+  VariantAnalysis,
+  VariantAnalysisScannedRepositoryResult,
+  VariantAnalysisScannedRepositoryState,
+} from "../../variant-analysis/shared/variant-analysis";
 
 export class ModelAlertsView extends AbstractWebview<
   ToModelAlertsMessage,
@@ -35,17 +39,12 @@ export class ModelAlertsView extends AbstractWebview<
     this.registerToModelingEvents();
   }
 
-  public async showView(variantAnalysis: VariantAnalysis) {
+  public async showView() {
     const panel = await this.getPanel();
     panel.reveal(undefined, true);
 
     await this.waitForPanelLoaded();
     await this.setViewState();
-
-    await this.postMessage({
-      t: "setVariantAnalysis",
-      variantAnalysis,
-    });
   }
 
   protected async getPanelConfig(): Promise<WebviewPanelConfig> {
@@ -93,6 +92,45 @@ export class ModelAlertsView extends AbstractWebview<
       viewState: {
         title: this.extensionPack.name,
       },
+    });
+  }
+
+  public async updateVariantAnalysis(
+    variantAnalysis: VariantAnalysis,
+  ): Promise<void> {
+    if (!this.isShowingPanel) {
+      return;
+    }
+
+    await this.postMessage({
+      t: "setVariantAnalysis",
+      variantAnalysis,
+    });
+  }
+
+  public async updateRepoState(
+    repoState: VariantAnalysisScannedRepositoryState,
+  ): Promise<void> {
+    if (!this.isShowingPanel) {
+      return;
+    }
+
+    await this.postMessage({
+      t: "setRepoStates",
+      repoStates: [repoState],
+    });
+  }
+
+  public async updateRepoResults(
+    repositoryResult: VariantAnalysisScannedRepositoryResult,
+  ): Promise<void> {
+    if (!this.isShowingPanel) {
+      return;
+    }
+
+    await this.postMessage({
+      t: "setRepoResults",
+      repoResults: [repositoryResult],
     });
   }
 

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -122,6 +122,21 @@ export class VariantAnalysisManager
   public readonly onVariantAnalysisRemoved =
     this._onVariantAnalysisRemoved.event;
 
+  private readonly _onRepoStateUpdated = this.push(
+    new EventEmitter<{
+      variantAnalysisId: number;
+      repoState: VariantAnalysisScannedRepositoryState;
+    }>(),
+  );
+
+  public readonly onRepoStatesUpdated = this._onRepoStateUpdated.event;
+
+  private readonly _onRepoResultsLoaded = this.push(
+    new EventEmitter<VariantAnalysisScannedRepositoryResult>(),
+  );
+
+  public readonly onRepoResultsLoaded = this._onRepoResultsLoaded.event;
+
   private readonly variantAnalysisMonitor: VariantAnalysisMonitor;
   private readonly variantAnalyses = new Map<number, VariantAnalysis>();
   private readonly views = new Map<number, VariantAnalysisView>();
@@ -685,6 +700,8 @@ export class VariantAnalysisManager
     await this.getView(
       repositoryResult.variantAnalysisId,
     )?.sendRepositoryResults([repositoryResult]);
+
+    this._onRepoResultsLoaded.fire(repositoryResult);
   }
 
   private async onRepoStateUpdated(
@@ -700,6 +717,8 @@ export class VariantAnalysisManager
     }
 
     repoStates[repoState.repositoryId] = repoState;
+
+    this._onRepoStateUpdated.fire({ variantAnalysisId, repoState });
   }
 
   private async onDidChangeSessions(

--- a/extensions/ql-vscode/src/view/model-alerts/ModelAlerts.tsx
+++ b/extensions/ql-vscode/src/view/model-alerts/ModelAlerts.tsx
@@ -2,7 +2,11 @@ import { useCallback, useEffect, useState } from "react";
 import { ModelAlertsHeader } from "./ModelAlertsHeader";
 import type { ModelAlertsViewState } from "../../model-editor/shared/view-state";
 import type { ToModelAlertsMessage } from "../../common/interface-types";
-import type { VariantAnalysis } from "../../variant-analysis/shared/variant-analysis";
+import type {
+  VariantAnalysis,
+  VariantAnalysisScannedRepositoryResult,
+  VariantAnalysisScannedRepositoryState,
+} from "../../variant-analysis/shared/variant-analysis";
 import { vscode } from "../vscode-api";
 
 type Props = {
@@ -24,6 +28,12 @@ export function ModelAlerts({ initialViewState }: Props): React.JSX.Element {
   const [variantAnalysis, setVariantAnalysis] = useState<
     VariantAnalysis | undefined
   >(undefined);
+  const [repoStates, setRepoStates] = useState<
+    VariantAnalysisScannedRepositoryState[]
+  >([]);
+  const [repoResults, setRepoResults] = useState<
+    VariantAnalysisScannedRepositoryResult[]
+  >([]);
 
   useEffect(() => {
     const listener = (evt: MessageEvent) => {
@@ -36,6 +46,31 @@ export function ModelAlerts({ initialViewState }: Props): React.JSX.Element {
           }
           case "setVariantAnalysis": {
             setVariantAnalysis(msg.variantAnalysis);
+            break;
+          }
+          case "setRepoStates": {
+            setRepoStates((oldRepoStates) => {
+              const newRepoIds = msg.repoStates.map((r) => r.repositoryId);
+              return [
+                ...oldRepoStates.filter(
+                  (v) => !newRepoIds.includes(v.repositoryId),
+                ),
+                ...msg.repoStates,
+              ];
+            });
+            break;
+          }
+          case "setRepoResults": {
+            setRepoResults((oldRepoResults) => {
+              const newRepoIds = msg.repoResults.map((r) => r.repositoryId);
+              return [
+                ...oldRepoResults.filter(
+                  (v) => !newRepoIds.includes(v.repositoryId),
+                ),
+                ...msg.repoResults,
+              ];
+            });
+            break;
           }
         }
       } else {
@@ -56,10 +91,20 @@ export function ModelAlerts({ initialViewState }: Props): React.JSX.Element {
   }
 
   return (
-    <ModelAlertsHeader
-      viewState={viewState}
-      variantAnalysis={variantAnalysis}
-      openModelPackClick={onOpenModelPackClick}
-    ></ModelAlertsHeader>
+    <>
+      <ModelAlertsHeader
+        viewState={viewState}
+        variantAnalysis={variantAnalysis}
+        openModelPackClick={onOpenModelPackClick}
+      ></ModelAlertsHeader>
+      <div>
+        <h3>Repo states</h3>
+        <p>{JSON.stringify(repoStates, null, 2)}</p>
+      </div>
+      <div>
+        <h3>Repo results</h3>
+        <p>{JSON.stringify(repoResults, null, 2)}</p>
+      </div>
+    </>
   );
 }


### PR DESCRIPTION
Updates model evaluation to listen to updates to pieces of state that relate to variant analyses (variant analysis, repo states, repo results) and propagate those updates to the Model Alerts view.

To achieve this, I've updated the `VariantAnalysisManager` to publish events for changes to the repo states and repo results (it was already publishing events for variant analyses updates).

The view doesn't use the repo states and repo results properly yet - it just prints stuff out as JSON. 

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
