### PR TITLE
Three minor improvements to `testproj` import

### DIFF
--- a/extensions/ql-vscode/src/databases/database-fetcher.ts
+++ b/extensions/ql-vscode/src/databases/database-fetcher.ts
@@ -666,7 +666,9 @@ function isFile(databaseUrl: string) {
  *
  * @param databasePath The full path to the unzipped database
  */
-async function ensureZippedSourceLocation(databasePath: string): Promise<void> {
+export async function ensureZippedSourceLocation(
+  databasePath: string,
+): Promise<void> {
   const srcFolderPath = join(databasePath, "src");
   const srcZipPath = `${srcFolderPath}.zip`;
 

--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -995,14 +995,15 @@ export class DatabaseUI extends DisposableObject {
       return undefined;
     }
 
-    if (byFolder) {
+    if (byFolder && !uri.fsPath.endsWith("testproj")) {
       const fixedUri = await this.fixDbUri(uri);
       // we are selecting a database folder
       return await this.databaseManager.openDatabase(fixedUri, {
         type: "folder",
       });
     } else {
-      // we are selecting a database archive. Must unzip into a workspace-controlled area
+      // we are selecting a database archive or a testproj.
+      // Unzip archives (if an archive) and copy into a workspace-controlled area
       // before importing.
       return await importLocalDatabase(
         this.app.commands,

--- a/extensions/ql-vscode/src/databases/local-databases/database-manager.ts
+++ b/extensions/ql-vscode/src/databases/local-databases/database-manager.ts
@@ -43,6 +43,7 @@ import { DatabaseResolver } from "./database-resolver";
 import { telemetryListener } from "../../common/vscode/telemetry";
 import type { LanguageContextStore } from "../../language-context-store";
 import type { DatabaseOrigin } from "./database-origin";
+import { ensureZippedSourceLocation } from "../database-fetcher";
 
 /**
  * The name of the key in the workspaceState dictionary in which we
@@ -260,6 +261,7 @@ export class DatabaseManager extends DisposableObject {
 
     await this.removeDatabaseItem(dbItem);
     await copy(dbItem.origin.path, databaseUri.fsPath);
+    await ensureZippedSourceLocation(databaseUri.fsPath);
     const newDbItem = new DatabaseItemImpl(databaseUri, dbItem.contents, {
       dateAdded: Date.now(),
       language: dbItem.language,

--- a/extensions/ql-vscode/src/databases/local-databases/database-manager.ts
+++ b/extensions/ql-vscode/src/databases/local-databases/database-manager.ts
@@ -227,8 +227,16 @@ export class DatabaseManager extends DisposableObject {
       "codeql-database.yml",
     );
 
+    let originStat;
     try {
-      const originStat = await stat(originDbYml);
+      originStat = await stat(originDbYml);
+    } catch (e) {
+      // if there is an error here, assume that the origin database
+      // is no longer available. Safely ignore and do not try to re-import.
+      return false;
+    }
+
+    try {
       const importedStat = await stat(importedDbYml);
       return originStat.mtimeMs > importedStat.mtimeMs;
     } catch (e) {


### PR DESCRIPTION
When importing from a directory, check for testproj

Use the testproj style import when using the folder icon to import a
database. This means that if the database directory ends with `testproj`
copy the database into workspace storage and make it available for
re-importing when the origin database changes.

Safely check for out of date databases

When checking to re-import test databases, if the target database is
missing or otherwise unavailable, avoid the check and just continue.

This avoids a bug where a user would delete a test database and there
would be an error when trying to run a query.

Ensure database sources are zipped on re-import

(Commit-by-commit review is recommended).

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
