### PR TITLE
Center align model evaluation run link

### DIFF
--- a/extensions/ql-vscode/src/view/model-editor/ModelEvaluation.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelEvaluation.tsx
@@ -1,3 +1,4 @@
+import { styled } from "styled-components";
 import { VSCodeButton, VSCodeLink } from "@vscode/webview-ui-toolkit/react";
 import type { ModeledMethod } from "../../model-editor/modeled-method";
 import type { ModelEditorViewState } from "../../model-editor/shared/view-state";
@@ -15,6 +16,11 @@ export type Props = {
   openModelAlertsView: () => void;
   evaluationRun: ModelEvaluationRunState | undefined;
 };
+
+const RunLink = styled(VSCodeLink)`
+  display: flex;
+  align-items: center;
+`;
 
 export const ModelEvaluation = ({
   viewState,
@@ -61,12 +67,12 @@ export const ModelEvaluation = ({
         </VSCodeButton>
       )}
       {shouldShowEvaluationRunLink && (
-        <VSCodeLink>
+        <RunLink>
           <LinkIconButton onClick={openModelAlertsView}>
             <span slot="end" className="codicon codicon-link-external"></span>
             Evaluation run
           </LinkIconButton>
-        </VSCodeLink>
+        </RunLink>
       )}
     </>
   );


### PR DESCRIPTION
The evaluation run link was not aligned very well so this makes a small update to fix that

Before
<img width="648" alt="link-before" src="https://github.com/github/vscode-codeql/assets/311693/c3dd91ec-ff35-47e4-a060-1018240573e8">

After
<img width="645" alt="link-after" src="https://github.com/github/vscode-codeql/assets/311693/4f955a9f-2048-402d-a03c-d3924e6c780d">


## Checklist
N/A
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
