### PR TITLE
Don't show notification after local query cancellation

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [UNRELEASED]
 
+- Don't show notification after local query cancellation. [#3489](https://github.com/github/vscode-codeql/pull/3489)
 - Databases created from [CodeQL test cases](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/testing-custom-queries) are now copied into a shared VS Code storage location. This avoids a bug where re-running test cases would fail if the test's database is already imported into the workspace. [#3433](https://github.com/github/vscode-codeql/pull/3433)
 
 ## 1.12.3 - 29 February 2024

--- a/extensions/ql-vscode/src/local-queries/local-queries.ts
+++ b/extensions/ql-vscode/src/local-queries/local-queries.ts
@@ -2,7 +2,10 @@ import type {
   ProgressCallback,
   ProgressUpdate,
 } from "../common/vscode/progress";
-import { withProgress } from "../common/vscode/progress";
+import {
+  UserCancellationException,
+  withProgress,
+} from "../common/vscode/progress";
 import type { CancellationToken, Range, TabInputText } from "vscode";
 import { CancellationTokenSource, Uri, window } from "vscode";
 import {
@@ -492,7 +495,12 @@ export class LocalQueries extends DisposableObject {
         // to unify both error handling paths.
         const err = asError(e);
         await localQueryRun.fail(err);
-        throw e;
+
+        if (token.isCancellationRequested) {
+          throw new UserCancellationException(err.message, true);
+        } else {
+          throw e;
+        }
       }
     } finally {
       source.dispose();


### PR DESCRIPTION
Update error handling of running a local query to check if cancellation was requested by the user, and avoid showing a notification when that happens.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
