### PR TITLE
Fix ModelAlerts view stories

### DIFF
--- a/extensions/ql-vscode/src/stories/model-alerts/ModelAlerts.stories.tsx
+++ b/extensions/ql-vscode/src/stories/model-alerts/ModelAlerts.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryFn } from "@storybook/react";
 
 import { ModelAlerts as ModelAlertsComponent } from "../../view/model-alerts/ModelAlerts";
+import { createMockVariantAnalysis } from "../../../test/factories/variant-analysis/shared/variant-analysis";
 
 export default {
   title: "Model Alerts/Model Alerts",
@@ -14,4 +15,16 @@ const Template: StoryFn<typeof ModelAlertsComponent> = (args) => (
 export const ModelAlerts = Template.bind({});
 ModelAlerts.args = {
   initialViewState: { title: "codeql/sql2o-models" },
+  variantAnalysis: createMockVariantAnalysis({
+    modelPacks: [
+      {
+        name: "Model pack 1",
+        path: "/path/to/model-pack-1",
+      },
+      {
+        name: "Model pack 2",
+        path: "/path/to/model-pack-2",
+      },
+    ],
+  }),
 };

--- a/extensions/ql-vscode/src/view/model-alerts/ModelAlerts.tsx
+++ b/extensions/ql-vscode/src/view/model-alerts/ModelAlerts.tsx
@@ -11,9 +11,17 @@ import { vscode } from "../vscode-api";
 
 type Props = {
   initialViewState?: ModelAlertsViewState;
+  variantAnalysis?: VariantAnalysis;
+  repoStates?: VariantAnalysisScannedRepositoryState[];
+  repoResults?: VariantAnalysisScannedRepositoryResult[];
 };
 
-export function ModelAlerts({ initialViewState }: Props): React.JSX.Element {
+export function ModelAlerts({
+  initialViewState,
+  variantAnalysis: initialVariantAnalysis,
+  repoStates: initialRepoStates = [],
+  repoResults: initialRepoResults = [],
+}: Props): React.JSX.Element {
   const onOpenModelPackClick = useCallback((path: string) => {
     vscode.postMessage({
       t: "openModelPack",
@@ -33,13 +41,11 @@ export function ModelAlerts({ initialViewState }: Props): React.JSX.Element {
 
   const [variantAnalysis, setVariantAnalysis] = useState<
     VariantAnalysis | undefined
-  >(undefined);
-  const [repoStates, setRepoStates] = useState<
-    VariantAnalysisScannedRepositoryState[]
-  >([]);
-  const [repoResults, setRepoResults] = useState<
-    VariantAnalysisScannedRepositoryResult[]
-  >([]);
+  >(initialVariantAnalysis);
+  const [repoStates, setRepoStates] =
+    useState<VariantAnalysisScannedRepositoryState[]>(initialRepoStates);
+  const [repoResults, setRepoResults] =
+    useState<VariantAnalysisScannedRepositoryResult[]>(initialRepoResults);
 
   useEffect(() => {
     const listener = (evt: MessageEvent) => {


### PR DESCRIPTION
The `ModelAlerts` view won't return any HTML if the `variantAnalysis` isn't set, so I've updated the component to be able to receive that, along with repo states and repo results, through props. We follow this pattern elsewhere.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
