### PR TITLE
Remove repoStates state tracking from model evaluation

### DIFF
--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -749,8 +749,7 @@ interface StopEvaluationRunMessage {
 export type ToModelAlertsMessage =
   | SetModelAlertsViewStateMessage
   | SetVariantAnalysisMessage
-  | SetRepoResultsMessage
-  | SetRepoStatesMessage;
+  | SetRepoResultsMessage;
 
 export type FromModelAlertsMessage =
   | CommonFromViewMessages

--- a/extensions/ql-vscode/src/model-editor/model-alerts/model-alerts-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-alerts/model-alerts-view.ts
@@ -18,7 +18,6 @@ import type { ExtensionPack } from "../shared/extension-pack";
 import type {
   VariantAnalysis,
   VariantAnalysisScannedRepositoryResult,
-  VariantAnalysisScannedRepositoryState,
 } from "../../variant-analysis/shared/variant-analysis";
 import type { AppEvent, AppEventEmitter } from "../../common/events";
 
@@ -124,19 +123,6 @@ export class ModelAlertsView extends AbstractWebview<
     await this.postMessage({
       t: "setVariantAnalysis",
       variantAnalysis,
-    });
-  }
-
-  public async updateRepoState(
-    repoState: VariantAnalysisScannedRepositoryState,
-  ): Promise<void> {
-    if (!this.isShowingPanel) {
-      return;
-    }
-
-    await this.postMessage({
-      t: "setRepoStates",
-      repoStates: [repoState],
     });
   }
 

--- a/extensions/ql-vscode/src/model-editor/model-evaluator.ts
+++ b/extensions/ql-vscode/src/model-editor/model-evaluator.ts
@@ -261,14 +261,6 @@ export class ModelEvaluator extends DisposableObject {
     );
 
     this.push(
-      this.variantAnalysisManager.onRepoStatesUpdated(async (e) => {
-        if (e.variantAnalysisId === variantAnalysisId) {
-          await this.modelAlertsView?.updateRepoState(e.repoState);
-        }
-      }),
-    );
-
-    this.push(
       this.variantAnalysisManager.onRepoResultsLoaded(async (e) => {
         if (e.variantAnalysisId === variantAnalysisId) {
           await this.modelAlertsView?.updateRepoResults(e);

--- a/extensions/ql-vscode/src/view/model-alerts/ModelAlerts.tsx
+++ b/extensions/ql-vscode/src/view/model-alerts/ModelAlerts.tsx
@@ -4,7 +4,6 @@ import type { ToModelAlertsMessage } from "../../common/interface-types";
 import type {
   VariantAnalysis,
   VariantAnalysisScannedRepositoryResult,
-  VariantAnalysisScannedRepositoryState,
 } from "../../variant-analysis/shared/variant-analysis";
 import { vscode } from "../vscode-api";
 import { ModelAlertsHeader } from "./ModelAlertsHeader";
@@ -12,14 +11,12 @@ import { ModelAlertsHeader } from "./ModelAlertsHeader";
 type Props = {
   initialViewState?: ModelAlertsViewState;
   variantAnalysis?: VariantAnalysis;
-  repoStates?: VariantAnalysisScannedRepositoryState[];
   repoResults?: VariantAnalysisScannedRepositoryResult[];
 };
 
 export function ModelAlerts({
   initialViewState,
   variantAnalysis: initialVariantAnalysis,
-  repoStates: initialRepoStates = [],
   repoResults: initialRepoResults = [],
 }: Props): React.JSX.Element {
   const onOpenModelPackClick = useCallback((path: string) => {
@@ -42,8 +39,6 @@ export function ModelAlerts({
   const [variantAnalysis, setVariantAnalysis] = useState<
     VariantAnalysis | undefined
   >(initialVariantAnalysis);
-  const [repoStates, setRepoStates] =
-    useState<VariantAnalysisScannedRepositoryState[]>(initialRepoStates);
   const [repoResults, setRepoResults] =
     useState<VariantAnalysisScannedRepositoryResult[]>(initialRepoResults);
 
@@ -58,18 +53,6 @@ export function ModelAlerts({
           }
           case "setVariantAnalysis": {
             setVariantAnalysis(msg.variantAnalysis);
-            break;
-          }
-          case "setRepoStates": {
-            setRepoStates((oldRepoStates) => {
-              const newRepoIds = msg.repoStates.map((r) => r.repositoryId);
-              return [
-                ...oldRepoStates.filter(
-                  (v) => !newRepoIds.includes(v.repositoryId),
-                ),
-                ...msg.repoStates,
-              ];
-            });
             break;
           }
           case "setRepoResults": {
@@ -121,10 +104,6 @@ export function ModelAlerts({
         onViewLogsClick={onViewLogsClick}
         stopRunClick={onStopRunClick}
       ></ModelAlertsHeader>
-      <div>
-        <h3>Repo states</h3>
-        <p>{JSON.stringify(repoStates, null, 2)}</p>
-      </div>
       <div>
         <h3>Repo results</h3>
         <p>{JSON.stringify(repoResults, null, 2)}</p>


### PR DESCRIPTION
It looks like we won't need this state after all, so we should remove it.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
