### PR TITLE
Fix code scanning alert about duplicate command usage

### DIFF
--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -273,6 +273,9 @@ export type VariantAnalysisCommands = {
   "codeQL.openVariantAnalysisLogs": (
     variantAnalysisId: number,
   ) => Promise<void>;
+  "codeQLModelAlerts.openVariantAnalysisLogs": (
+    variantAnalysisId: number,
+  ) => Promise<void>;
   "codeQL.openVariantAnalysisView": (
     variantAnalysisId: number,
   ) => Promise<void>;

--- a/extensions/ql-vscode/src/model-editor/model-alerts/model-alerts-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-alerts/model-alerts-view.ts
@@ -93,7 +93,7 @@ export class ModelAlertsView extends AbstractWebview<
         break;
       case "openActionsLogs":
         await this.app.commands.execute(
-          "codeQL.openVariantAnalysisLogs",
+          "codeQLModelAlerts.openVariantAnalysisLogs",
           msg.variantAnalysisId,
         );
         break;

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -191,6 +191,8 @@ export class VariantAnalysisManager
       "codeQL.monitorReauthenticatedVariantAnalysis":
         this.monitorVariantAnalysis.bind(this),
       "codeQL.openVariantAnalysisLogs": this.openVariantAnalysisLogs.bind(this),
+      "codeQLModelAlerts.openVariantAnalysisLogs":
+        this.openVariantAnalysisLogs.bind(this),
       "codeQL.openVariantAnalysisView": this.showView.bind(this),
       "codeQL.runVariantAnalysis":
         this.runVariantAnalysisFromCommandPalette.bind(this),


### PR DESCRIPTION
Fixes https://github.com/github/vscode-codeql/security/code-scanning/607 which I accidentally introduced in https://github.com/github/vscode-codeql/pull/3481 🙃 

## Checklist

N/A

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
