### PR TITLE
Fix detection of Python instance methods

### DIFF
--- a/extensions/ql-vscode/src/model-editor/languages/python/access-paths.ts
+++ b/extensions/ql-vscode/src/model-editor/languages/python/access-paths.ts
@@ -112,7 +112,10 @@ export function pythonPath(
 export function pythonEndpointType(
   method: Omit<MethodDefinition, "endpointType">,
 ): EndpointType {
-  if (method.methodParameters.startsWith("(self,")) {
+  if (
+    method.methodParameters.startsWith("(self,") ||
+    method.methodParameters === "(self)"
+  ) {
     return EndpointType.Method;
   }
   return EndpointType.Function;


### PR DESCRIPTION
This fixes the detection of Python instance methods for methods without parameters (other than `self`).

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
