### PR TITLE
Re-use setRepoResults instead of having a setReposResult message

### DIFF
--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -732,11 +732,6 @@ interface SetModelAlertsViewStateMessage {
   viewState: ModelAlertsViewState;
 }
 
-interface SetReposResultsMessage {
-  t: "setReposResults";
-  reposResults: VariantAnalysisScannedRepositoryResult[];
-}
-
 interface OpenModelPackMessage {
   t: "openModelPack";
   path: string;
@@ -754,8 +749,7 @@ interface StopEvaluationRunMessage {
 export type ToModelAlertsMessage =
   | SetModelAlertsViewStateMessage
   | SetVariantAnalysisMessage
-  | SetRepoResultsMessage
-  | SetReposResultsMessage;
+  | SetRepoResultsMessage;
 
 export type FromModelAlertsMessage =
   | CommonFromViewMessages

--- a/extensions/ql-vscode/src/model-editor/model-alerts/model-alerts-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-alerts/model-alerts-view.ts
@@ -143,15 +143,15 @@ export class ModelAlertsView extends AbstractWebview<
   }
 
   public async updateReposResults(
-    reposResults: VariantAnalysisScannedRepositoryResult[],
+    repoResults: VariantAnalysisScannedRepositoryResult[],
   ): Promise<void> {
     if (!this.isShowingPanel) {
       return;
     }
 
     await this.postMessage({
-      t: "setReposResults",
-      reposResults,
+      t: "setRepoResults",
+      repoResults,
     });
   }
 

--- a/extensions/ql-vscode/src/view/model-alerts/ModelAlerts.tsx
+++ b/extensions/ql-vscode/src/view/model-alerts/ModelAlerts.tsx
@@ -66,10 +66,6 @@ export function ModelAlerts({
             setVariantAnalysis(msg.variantAnalysis);
             break;
           }
-          case "setReposResults": {
-            setRepoResults(msg.reposResults);
-            break;
-          }
           case "setRepoResults": {
             setRepoResults((oldRepoResults) => {
               const newRepoIds = msg.repoResults.map((r) => r.repositoryId);


### PR DESCRIPTION
In https://github.com/github/vscode-codeql/pull/3503 I introduced a new message when I could have just re-used the existing message 🤦 this fixes that. 

The setRepoResults message can be re-used because its handling replaces any existing repo results. 

I still find the names of messages a bit confusing so that can be tidied up in a separate PR.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
