### PR TITLE
Update model alert processing to track repo results

### DIFF
--- a/extensions/ql-vscode/src/model-editor/model-alerts/model-alerts.ts
+++ b/extensions/ql-vscode/src/model-editor/model-alerts/model-alerts.ts
@@ -3,5 +3,11 @@ import type { ModeledMethod } from "../modeled-method";
 
 export interface ModelAlerts {
   model: ModeledMethod;
-  alerts: AnalysisAlert[];
+  alerts: Array<{
+    alert: AnalysisAlert;
+    repository: {
+      id: number;
+      fullName: string;
+    };
+  }>;
 }

--- a/extensions/ql-vscode/src/stories/model-alerts/ModelAlerts.stories.tsx
+++ b/extensions/ql-vscode/src/stories/model-alerts/ModelAlerts.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryFn } from "@storybook/react";
 
 import { ModelAlerts as ModelAlertsComponent } from "../../view/model-alerts/ModelAlerts";
 import { createMockVariantAnalysis } from "../../../test/factories/variant-analysis/shared/variant-analysis";
+import type { VariantAnalysisScannedRepositoryResult } from "../../variant-analysis/shared/variant-analysis";
 
 export default {
   title: "Model Alerts/Model Alerts",
@@ -12,19 +13,30 @@ const Template: StoryFn<typeof ModelAlertsComponent> = (args) => (
   <ModelAlertsComponent {...args} />
 );
 
+const variantAnalysis = createMockVariantAnalysis({
+  modelPacks: [
+    {
+      name: "Model pack 1",
+      path: "/path/to/model-pack-1",
+    },
+    {
+      name: "Model pack 2",
+      path: "/path/to/model-pack-2",
+    },
+  ],
+});
+
+const repoResults: VariantAnalysisScannedRepositoryResult[] = (
+  variantAnalysis.scannedRepos || []
+).map((repo) => ({
+  variantAnalysisId: variantAnalysis.id,
+  repositoryId: repo.repository.id,
+  interpretedResults: [],
+}));
+
 export const ModelAlerts = Template.bind({});
 ModelAlerts.args = {
   initialViewState: { title: "codeql/sql2o-models" },
-  variantAnalysis: createMockVariantAnalysis({
-    modelPacks: [
-      {
-        name: "Model pack 1",
-        path: "/path/to/model-pack-1",
-      },
-      {
-        name: "Model pack 2",
-        path: "/path/to/model-pack-2",
-      },
-    ],
-  }),
+  variantAnalysis,
+  repoResults,
 };

--- a/extensions/ql-vscode/src/stories/model-alerts/ModelAlertsResults.stories.tsx
+++ b/extensions/ql-vscode/src/stories/model-alerts/ModelAlertsResults.stories.tsx
@@ -17,6 +17,14 @@ export const ModelAlertsResults = Template.bind({});
 ModelAlertsResults.args = {
   modelAlerts: {
     model: createSinkModeledMethod(),
-    alerts: [createMockAnalysisAlert()],
+    alerts: [
+      {
+        repository: {
+          id: 1,
+          fullName: "expressjs/express",
+        },
+        alert: createMockAnalysisAlert(),
+      },
+    ],
   },
 };

--- a/extensions/ql-vscode/src/view/model-alerts/ModelAlerts.tsx
+++ b/extensions/ql-vscode/src/view/model-alerts/ModelAlerts.tsx
@@ -93,14 +93,12 @@ export function ModelAlerts({
   }, []);
 
   const modelAlerts = useMemo(() => {
-    if (!repoResults) {
+    if (!repoResults || !variantAnalysis) {
       return [];
     }
 
-    const alerts = repoResults.flatMap((a) => a.interpretedResults ?? []);
-
-    return calculateModelAlerts(alerts);
-  }, [repoResults]);
+    return calculateModelAlerts(variantAnalysis, repoResults);
+  }, [variantAnalysis, repoResults]);
 
   if (viewState === undefined || variantAnalysis === undefined) {
     return <></>;

--- a/extensions/ql-vscode/src/view/model-alerts/ModelAlertsResults.tsx
+++ b/extensions/ql-vscode/src/view/model-alerts/ModelAlertsResults.tsx
@@ -80,7 +80,7 @@ export const ModelAlertsResults = ({
           <AlertsContainer>
             {modelAlerts.alerts.map((r, i) => (
               <Alert key={i}>
-                <AnalysisAlertResult alert={r} />
+                <AnalysisAlertResult alert={r.alert} />
               </Alert>
             ))}
           </AlertsContainer>


### PR DESCRIPTION
In order to implement some of the filtering we want in the `ModelAlerts` view, we need to keep track of which repo an alert has come from. This PR updates the `ModelAlerts` entity to hold repository information and the `alerts-processor` to propagate it.

I'm not convinced about the shape of the `ModelAlerts` entity yet - I think things will be clearer once we have alert provenance information.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
