### PR TITLE
Update supported sink and source kinds in the model editor

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [UNRELEASED]
 
+- Add new supported source and sink kinds in the CodeQL Model Editor [#3511](https://github.com/github/vscode-codeql/pull/3511)
+
 ## 1.12.4 - 20 March 2024
 
 - Don't show notification after local query cancellation. [#3489](https://github.com/github/vscode-codeql/pull/3489)

--- a/extensions/ql-vscode/src/model-editor/languages/csharp/index.ts
+++ b/extensions/ql-vscode/src/model-editor/languages/csharp/index.ts
@@ -1,0 +1,15 @@
+import type { ModelsAsDataLanguage } from "../models-as-data";
+import { staticLanguage } from "../static";
+
+export const csharp: ModelsAsDataLanguage = {
+  ...staticLanguage,
+  predicates: {
+    ...staticLanguage.predicates,
+    sink: {
+      ...staticLanguage.predicates.sink,
+    },
+    source: {
+      ...staticLanguage.predicates.source,
+    },
+  },
+};

--- a/extensions/ql-vscode/src/model-editor/languages/csharp/index.ts
+++ b/extensions/ql-vscode/src/model-editor/languages/csharp/index.ts
@@ -10,6 +10,12 @@ export const csharp: ModelsAsDataLanguage = {
     },
     source: {
       ...staticLanguage.predicates.source,
+      supportedKinds: [
+        ...staticLanguage.predicates.source.supportedKinds,
+        // https://github.com/github/codeql/blob/0c5ea975a4c4dc5c439b908c006e440cb9bdf926/shared/mad/codeql/mad/ModelValidation.qll#L122-L123
+        "file-write",
+        "windows-registry",
+      ],
     },
   },
 };

--- a/extensions/ql-vscode/src/model-editor/languages/java/index.ts
+++ b/extensions/ql-vscode/src/model-editor/languages/java/index.ts
@@ -1,0 +1,15 @@
+import type { ModelsAsDataLanguage } from "../models-as-data";
+import { staticLanguage } from "../static";
+
+export const java: ModelsAsDataLanguage = {
+  ...staticLanguage,
+  predicates: {
+    ...staticLanguage.predicates,
+    sink: {
+      ...staticLanguage.predicates.sink,
+    },
+    source: {
+      ...staticLanguage.predicates.source,
+    },
+  },
+};

--- a/extensions/ql-vscode/src/model-editor/languages/java/index.ts
+++ b/extensions/ql-vscode/src/model-editor/languages/java/index.ts
@@ -7,9 +7,36 @@ export const java: ModelsAsDataLanguage = {
     ...staticLanguage.predicates,
     sink: {
       ...staticLanguage.predicates.sink,
+      supportedKinds: [
+        ...staticLanguage.predicates.sink.supportedKinds,
+        // https://github.com/github/codeql/blob/0c5ea975a4c4dc5c439b908c006e440cb9bdf926/shared/mad/codeql/mad/ModelValidation.qll#L32-L37
+        "bean-validation",
+        "fragment-injection",
+        "groovy-injection",
+        "hostname-verification",
+        "information-leak",
+        "intent-redirection",
+        "jexl-injection",
+        "jndi-injection",
+        "mvel-injection",
+        "notification",
+        "ognl-injection",
+        "pending-intents",
+        "response-splitting",
+        "trust-boundary-violation",
+        "template-injection",
+        "xpath-injection",
+        "xslt-injection",
+      ],
     },
     source: {
       ...staticLanguage.predicates.source,
+      supportedKinds: [
+        ...staticLanguage.predicates.source.supportedKinds,
+        // https://github.com/github/codeql/blob/0c5ea975a4c4dc5c439b908c006e440cb9bdf926/shared/mad/codeql/mad/ModelValidation.qll#L120-L121
+        "android-external-storage-dir",
+        "contentprovider",
+      ],
     },
   },
 };

--- a/extensions/ql-vscode/src/model-editor/languages/languages.ts
+++ b/extensions/ql-vscode/src/model-editor/languages/languages.ts
@@ -3,13 +3,14 @@ import type {
   ModelsAsDataLanguage,
   ModelsAsDataLanguagePredicates,
 } from "./models-as-data";
+import { csharp } from "./csharp";
+import { java } from "./java";
 import { python } from "./python";
 import { ruby } from "./ruby";
-import { staticLanguage } from "./static";
 
 const languages: Partial<Record<QueryLanguage, ModelsAsDataLanguage>> = {
-  [QueryLanguage.CSharp]: staticLanguage,
-  [QueryLanguage.Java]: staticLanguage,
+  [QueryLanguage.CSharp]: csharp,
+  [QueryLanguage.Java]: java,
   [QueryLanguage.Python]: python,
   [QueryLanguage.Ruby]: ruby,
 };

--- a/extensions/ql-vscode/src/model-editor/languages/shared.ts
+++ b/extensions/ql-vscode/src/model-editor/languages/shared.ts
@@ -6,10 +6,13 @@ export const sharedExtensiblePredicates = {
 };
 
 export const sharedKinds = {
-  source: ["local", "remote"],
+  // https://github.com/github/codeql/blob/0c5ea975a4c4dc5c439b908c006e440cb9bdf926/shared/mad/codeql/mad/ModelValidation.qll#L118-L119
+  source: ["local", "remote", "file", "commandargs", "database", "environment"],
+  // Bhttps://github.com/github/codeql/blob/0c5ea975a4c4dc5c439b908c006e440cb9bdf926/shared/mad/codeql/mad/ModelValidation.qll#L28-L31
   sink: [
     "code-injection",
     "command-injection",
+    "environment-injection",
     "file-content-store",
     "html-injection",
     "js-injection",
@@ -20,6 +23,8 @@ export const sharedKinds = {
     "sql-injection",
     "url-redirection",
   ],
+  // https://github.com/github/codeql/blob/0c5ea975a4c4dc5c439b908c006e440cb9bdf926/shared/mad/codeql/mad/ModelValidation.qll#L142-L143
   summary: ["taint", "value"],
+  // https://github.com/github/codeql/blob/0c5ea975a4c4dc5c439b908c006e440cb9bdf926/shared/mad/codeql/mad/ModelValidation.qll#L155-L156
   neutral: ["summary", "source", "sink"],
 };

--- a/extensions/ql-vscode/src/model-editor/languages/static/index.ts
+++ b/extensions/ql-vscode/src/model-editor/languages/static/index.ts
@@ -10,7 +10,7 @@ function readRowToMethod(row: DataTuple[]): string {
   return `${row[0]}.${row[1]}#${row[3]}${row[4]}`;
 }
 
-export const staticLanguage: ModelsAsDataLanguage = {
+export const staticLanguage = {
   createMethodSignature: ({
     packageName,
     typeName,
@@ -168,4 +168,4 @@ export const staticLanguage: ModelsAsDataLanguage = {
         argumentsList.length > 0 ? argumentsList[0].path : "Argument[this]",
     };
   },
-};
+} satisfies ModelsAsDataLanguage;


### PR DESCRIPTION
This updates the supported sink and source kinds that are shown in the model editor to [the latest CodeQL valid source/sink kinds](https://github.com/github/codeql/blob/0c5ea975a4c4dc5c439b908c006e440cb9bdf926/shared/mad/codeql/mad/ModelValidation.qll). It splits out Java and C# since these will now have different source/sink kinds.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
