### PR TITLE
Use wider type for "reveal in model editor"

### DIFF
--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -10,7 +10,7 @@ import type {
 } from "../variant-analysis/shared/variant-analysis-filter-sort";
 import type { ErrorLike } from "../common/errors";
 import type { DataFlowPaths } from "../variant-analysis/shared/data-flow-paths";
-import type { Method } from "../model-editor/method";
+import type { Method, MethodSignature } from "../model-editor/method";
 import type { ModeledMethod } from "../model-editor/modeled-method";
 import type {
   MethodModelingPanelViewState,
@@ -681,7 +681,7 @@ export type FromModelEditorMessage =
 
 interface RevealInEditorMessage {
   t: "revealInModelEditor";
-  method: Method;
+  method: MethodSignature;
 }
 
 interface StartModelingMessage {

--- a/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
+++ b/extensions/ql-vscode/src/model-editor/method-modeling/method-modeling-view-provider.ts
@@ -6,7 +6,7 @@ import { telemetryListener } from "../../common/vscode/telemetry";
 import { showAndLogExceptionWithTelemetry } from "../../common/logging/notifications";
 import type { App } from "../../common/app";
 import { redactableError } from "../../common/errors";
-import type { Method } from "../method";
+import type { Method, MethodSignature } from "../method";
 import type { ModelingStore } from "../modeling-store";
 import { AbstractWebviewViewProvider } from "../../common/vscode/abstract-webview-view-provider";
 import { assertNever } from "../../common/helpers-pure";
@@ -163,7 +163,7 @@ export class MethodModelingViewProvider extends AbstractWebviewViewProvider<
     }
   }
 
-  private async revealInModelEditor(method: Method): Promise<void> {
+  private async revealInModelEditor(method: MethodSignature): Promise<void> {
     if (!this.databaseItem) {
       return;
     }

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -36,7 +36,7 @@ import {
   externalApiQueriesProgressMaxStep,
   runModelEditorQueries,
 } from "./model-editor-queries";
-import type { Method } from "./method";
+import type { MethodSignature } from "./method";
 import type { ModeledMethod } from "./modeled-method";
 import type { ExtensionPack } from "./shared/extension-pack";
 import type { ModelConfigListener } from "../config";
@@ -431,7 +431,7 @@ export class ModelEditorView extends AbstractWebview<
     this.panel?.reveal();
   }
 
-  public async revealMethod(method: Method): Promise<void> {
+  public async revealMethod(method: MethodSignature): Promise<void> {
     this.panel?.reveal();
 
     await this.postMessage({

--- a/extensions/ql-vscode/src/model-editor/modeling-events.ts
+++ b/extensions/ql-vscode/src/model-editor/modeling-events.ts
@@ -2,7 +2,7 @@ import type { App } from "../common/app";
 import { DisposableObject } from "../common/disposable-object";
 import type { AppEvent, AppEventEmitter } from "../common/events";
 import type { DatabaseItem } from "../databases/local-databases";
-import type { Method, Usage } from "./method";
+import type { Method, MethodSignature, Usage } from "./method";
 import type { ModelEvaluationRun } from "./model-evaluation-run";
 import type { ModeledMethod } from "./modeled-method";
 import type { Mode } from "./shared/mode";
@@ -58,7 +58,7 @@ interface ModelEvaluationRunChangedEvent {
 
 interface RevealInModelEditorEvent {
   dbUri: string;
-  method: Method;
+  method: MethodSignature;
 }
 
 interface FocusModelEditorEvent {
@@ -285,7 +285,7 @@ export class ModelingEvents extends DisposableObject {
     });
   }
 
-  public fireRevealInModelEditorEvent(dbUri: string, method: Method) {
+  public fireRevealInModelEditorEvent(dbUri: string, method: MethodSignature) {
     this.onRevealInModelEditorEventEmitter.fire({
       dbUri,
       method,


### PR DESCRIPTION
The model alerts view will have a button that lets you open the method in the model editor (to be added in a follow-up PR):

![image](https://github.com/github/vscode-codeql/assets/42641846/beab73cd-1d7c-447c-8b13-fdd1ef2c4482)

I want to re-use the existing "reveal in model editor" event (used by the method modeling side bar), but that uses the `Method` type (instead of `ModeledMethod`, like in the model alerts view).

Both of those extend the `MethodSignature` type, so I think it makes sense to use that as a suitable "wider" type to accommodate both. I've tested that the button in the method modeling side bar still works as normal 🧪 🎉 



## Checklist

N/A, no user visible impact

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
