### PR TITLE
Add "view" button in model alerts view

### DIFF
--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -755,4 +755,5 @@ export type FromModelAlertsMessage =
   | CommonFromViewMessages
   | OpenModelPackMessage
   | OpenActionsLogsMessage
-  | StopEvaluationRunMessage;
+  | StopEvaluationRunMessage
+  | RevealInEditorMessage;

--- a/extensions/ql-vscode/src/model-editor/model-alerts/model-alerts-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-alerts/model-alerts-view.ts
@@ -20,6 +20,7 @@ import type {
   VariantAnalysisScannedRepositoryResult,
 } from "../../variant-analysis/shared/variant-analysis";
 import type { AppEvent, AppEventEmitter } from "../../common/events";
+import type { MethodSignature } from "../method";
 
 export class ModelAlertsView extends AbstractWebview<
   ToModelAlertsMessage,
@@ -102,6 +103,9 @@ export class ModelAlertsView extends AbstractWebview<
       case "stopEvaluationRun":
         await this.stopEvaluationRun();
         break;
+      case "revealInModelEditor":
+        await this.revealInModelEditor(msg.method);
+        break;
       default:
         assertNever(msg);
     }
@@ -179,5 +183,16 @@ export class ModelAlertsView extends AbstractWebview<
 
   private async stopEvaluationRun() {
     this.onEvaluationRunStopClickedEventEmitter.fire();
+  }
+
+  private async revealInModelEditor(method: MethodSignature): Promise<void> {
+    if (!this.dbItem) {
+      return;
+    }
+
+    this.modelingEvents.fireRevealInModelEditorEvent(
+      this.dbItem.databaseUri.toString(),
+      method,
+    );
   }
 }

--- a/extensions/ql-vscode/src/view/model-alerts/ModelAlertsResults.tsx
+++ b/extensions/ql-vscode/src/view/model-alerts/ModelAlertsResults.tsx
@@ -1,12 +1,14 @@
 import { styled } from "styled-components";
 import type { ModelAlerts } from "../../model-editor/model-alerts/model-alerts";
 import { Codicon } from "../common";
-import { useState } from "react";
-import { VSCodeBadge } from "@vscode/webview-ui-toolkit/react";
+import { useCallback, useState } from "react";
+import { VSCodeBadge, VSCodeLink } from "@vscode/webview-ui-toolkit/react";
 import { formatDecimal } from "../../common/number";
 import AnalysisAlertResult from "../variant-analysis/AnalysisAlertResult";
 import { MethodName } from "../model-editor/MethodName";
 import { ModelDetails } from "./ModelDetails";
+import { vscode } from "../vscode-api";
+import type { ModeledMethod } from "../../model-editor/modeled-method";
 
 // This will ensure that these icons have a className which we can use in the TitleContainer
 const ExpandCollapseCodicon = styled(Codicon)``;
@@ -36,6 +38,11 @@ const ModelTypeText = styled.span`
   color: var(--vscode-descriptionForeground);
 `;
 
+const ViewLink = styled(VSCodeLink)`
+  white-space: nowrap;
+  padding: 0 0 0.25em 1em;
+`;
+
 const ModelDetailsContainer = styled.div`
   padding-top: 10px;
 `;
@@ -59,6 +66,10 @@ export const ModelAlertsResults = ({
   modelAlerts,
 }: Props): React.JSX.Element => {
   const [isExpanded, setExpanded] = useState(true);
+  const viewInModelEditor = useCallback(
+    () => sendRevealInModelEditorMessage(modelAlerts.model),
+    [modelAlerts.model],
+  );
   return (
     <div>
       <TitleContainer onClick={() => setExpanded(!isExpanded)}>
@@ -71,6 +82,7 @@ export const ModelAlertsResults = ({
         <VSCodeBadge>{formatDecimal(modelAlerts.alerts.length)}</VSCodeBadge>
         <MethodName {...modelAlerts.model}></MethodName>
         <ModelTypeText>{modelAlerts.model.type}</ModelTypeText>
+        <ViewLink onClick={viewInModelEditor}>View</ViewLink>
       </TitleContainer>
       {isExpanded && (
         <>
@@ -89,3 +101,10 @@ export const ModelAlertsResults = ({
     </div>
   );
 };
+
+function sendRevealInModelEditorMessage(modeledMethod: ModeledMethod) {
+  vscode.postMessage({
+    t: "revealInModelEditor",
+    method: modeledMethod,
+  });
+}

--- a/extensions/ql-vscode/src/view/model-alerts/ModelAlertsResults.tsx
+++ b/extensions/ql-vscode/src/view/model-alerts/ModelAlertsResults.tsx
@@ -8,7 +8,6 @@ import AnalysisAlertResult from "../variant-analysis/AnalysisAlertResult";
 import { MethodName } from "../model-editor/MethodName";
 import { ModelDetails } from "./ModelDetails";
 import { vscode } from "../vscode-api";
-import type { ModeledMethod } from "../../model-editor/modeled-method";
 
 // This will ensure that these icons have a className which we can use in the TitleContainer
 const ExpandCollapseCodicon = styled(Codicon)``;
@@ -67,7 +66,11 @@ export const ModelAlertsResults = ({
 }: Props): React.JSX.Element => {
   const [isExpanded, setExpanded] = useState(true);
   const viewInModelEditor = useCallback(
-    () => sendRevealInModelEditorMessage(modelAlerts.model),
+    () =>
+      vscode.postMessage({
+        t: "revealInModelEditor",
+        method: modelAlerts.model,
+      }),
     [modelAlerts.model],
   );
   return (
@@ -101,10 +104,3 @@ export const ModelAlertsResults = ({
     </div>
   );
 };
-
-function sendRevealInModelEditorMessage(modeledMethod: ModeledMethod) {
-  vscode.postMessage({
-    t: "revealInModelEditor",
-    method: modeledMethod,
-  });
-}


### PR DESCRIPTION
Adds a "View" link in the model alerts view. This will focus on the modeled method in the model editor (same as the "Review in editor" button in the method modeling side bar): 

https://github.com/github/vscode-codeql/assets/42641846/35ac7ebe-fdc2-4829-be4d-fece84183a42

(⚠️ Note: The model alerts view just uses mock data, so there isn't a corresponding method in the model editor to focus on yet! I don't know how to mock this more usefully, so we might need to wait for alert provenance?) 

## Checklist

N/A, feature-flagged for internal use/testing

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
