### PR TITLE
Use file handle in TeeLogger

### DIFF
--- a/extensions/ql-vscode/src/common/disposable-object.ts
+++ b/extensions/ql-vscode/src/common/disposable-object.ts
@@ -88,7 +88,3 @@ export class DisposableObject implements Disposable {
     }
   }
 }
-
-export function isDisposable(obj: unknown): obj is Disposable {
-  return obj !== undefined && typeof (obj as Disposable).dispose === "function";
-}

--- a/extensions/ql-vscode/src/common/disposable-object.ts
+++ b/extensions/ql-vscode/src/common/disposable-object.ts
@@ -88,3 +88,7 @@ export class DisposableObject implements Disposable {
     }
   }
 }
+
+export function isDisposable(obj: unknown): obj is Disposable {
+  return obj !== undefined && typeof (obj as Disposable).dispose === "function";
+}

--- a/extensions/ql-vscode/src/common/logging/tee-logger.ts
+++ b/extensions/ql-vscode/src/common/logging/tee-logger.ts
@@ -58,6 +58,13 @@ export class TeeLogger implements Logger, Disposable {
       } catch (e) {
         // Write an error message to the primary log, and stop trying to write to the side log.
         this.error = true;
+        try {
+          await this.fileHandle?.close();
+        } catch (e) {
+          void this.logger.log(
+            `Failed to close file handle: ${getErrorMessage(e)}`,
+          );
+        }
         this.fileHandle = undefined;
         const errorMessage = getErrorMessage(e);
         await this.logger.log(
@@ -76,7 +83,13 @@ export class TeeLogger implements Logger, Disposable {
   }
 
   dispose(): void {
-    void this.fileHandle?.close();
+    try {
+      void this.fileHandle?.close();
+    } catch (e) {
+      void this.logger.log(
+        `Failed to close file handle: ${getErrorMessage(e)}`,
+      );
+    }
     this.fileHandle = undefined;
   }
 }

--- a/extensions/ql-vscode/src/language-support/contextual/query-resolver.ts
+++ b/extensions/ql-vscode/src/language-support/contextual/query-resolver.ts
@@ -92,11 +92,12 @@ export async function runContextualQuery(
   void extLogger.log(
     `Running contextual query ${query}; results will be stored in ${queryRun.outputDir.querySaveDir}`,
   );
-  const results = await queryRun.evaluate(
-    progress,
-    token,
-    new TeeLogger(qs.logger, queryRun.outputDir.logPath),
-  );
-  await cleanup?.();
-  return results;
+  const teeLogger = new TeeLogger(qs.logger, queryRun.outputDir.logPath);
+
+  try {
+    return await queryRun.evaluate(progress, token, teeLogger);
+  } finally {
+    await cleanup?.();
+    teeLogger.dispose();
+  }
 }

--- a/extensions/ql-vscode/src/local-queries/local-query-run.ts
+++ b/extensions/ql-vscode/src/local-queries/local-query-run.ts
@@ -25,6 +25,7 @@ import { redactableError } from "../common/errors";
 import type { LocalQueries } from "./local-queries";
 import { tryGetQueryMetadata } from "../codeql-cli/query-metadata";
 import { telemetryListener } from "../common/vscode/telemetry";
+import { isDisposable } from "../common/disposable-object";
 
 function formatResultMessage(result: CoreQueryResults): string {
   switch (result.resultType) {
@@ -61,6 +62,10 @@ export class LocalQueryRun {
     private readonly localQueries: LocalQueries,
     private readonly queryInfo: LocalQueryInfo,
     private readonly dbItem: DatabaseItem,
+    /**
+     * The logger is only available while the query is running and will be disposed of when the
+     * query completes.
+     */
     public readonly logger: Logger, // Public so that other clients, like the debug adapter, know where to send log output
     private readonly queryHistoryManager: QueryHistoryManager,
     private readonly cliServer: CodeQLCliServer,
@@ -92,6 +97,10 @@ export class LocalQueryRun {
     // Note we must update the query history view after showing results as the
     // display and sorting might depend on the number of results
     await this.queryHistoryManager.refreshTreeView();
+
+    if (isDisposable(this.logger)) {
+      this.logger.dispose();
+    }
   }
 
   /**
@@ -110,6 +119,10 @@ export class LocalQueryRun {
     err.message = `Error running query: ${err.message}`;
     this.queryInfo.failureReason = err.message;
     await this.queryHistoryManager.refreshTreeView();
+
+    if (isDisposable(this.logger)) {
+      this.logger.dispose();
+    }
   }
 
   /**

--- a/extensions/ql-vscode/src/local-queries/local-query-run.ts
+++ b/extensions/ql-vscode/src/local-queries/local-query-run.ts
@@ -25,7 +25,7 @@ import { redactableError } from "../common/errors";
 import type { LocalQueries } from "./local-queries";
 import { tryGetQueryMetadata } from "../codeql-cli/query-metadata";
 import { telemetryListener } from "../common/vscode/telemetry";
-import { isDisposable } from "../common/disposable-object";
+import type { Disposable } from "../common/disposable-object";
 
 function formatResultMessage(result: CoreQueryResults): string {
   switch (result.resultType) {
@@ -66,7 +66,7 @@ export class LocalQueryRun {
      * The logger is only available while the query is running and will be disposed of when the
      * query completes.
      */
-    public readonly logger: Logger, // Public so that other clients, like the debug adapter, know where to send log output
+    public readonly logger: Logger & Disposable, // Public so that other clients, like the debug adapter, know where to send log output
     private readonly queryHistoryManager: QueryHistoryManager,
     private readonly cliServer: CodeQLCliServer,
   ) {}
@@ -98,9 +98,7 @@ export class LocalQueryRun {
     // display and sorting might depend on the number of results
     await this.queryHistoryManager.refreshTreeView();
 
-    if (isDisposable(this.logger)) {
-      this.logger.dispose();
-    }
+    this.logger.dispose();
   }
 
   /**
@@ -120,9 +118,7 @@ export class LocalQueryRun {
     this.queryInfo.failureReason = err.message;
     await this.queryHistoryManager.refreshTreeView();
 
-    if (isDisposable(this.logger)) {
-      this.logger.dispose();
-    }
+    this.logger.dispose();
   }
 
   /**

--- a/extensions/ql-vscode/test/common/logging/output-channel-logger.test.ts
+++ b/extensions/ql-vscode/test/common/logging/output-channel-logger.test.ts
@@ -5,6 +5,7 @@ import { dirSync } from "tmp";
 import type { BaseLogger, Logger } from "../../../src/common/logging";
 import { TeeLogger } from "../../../src/common/logging";
 import { OutputChannelLogger } from "../../../src/common/logging/vscode";
+import type { Disposable } from "../../../src/common/disposable-object";
 
 jest.setTimeout(999999);
 
@@ -66,6 +67,8 @@ describe("OutputChannelLogger tests", function () {
 
     // should have created 1 side log
     expect(readdirSync(tempFolders.storagePath.name)).toEqual(["hucairz"]);
+
+    hucairz.dispose();
   });
 
   it("should create a side log", async () => {
@@ -86,12 +89,15 @@ describe("OutputChannelLogger tests", function () {
     expect(
       readFileSync(join(tempFolders.storagePath.name, "second"), "utf8"),
     ).toBe("yyy\n");
+
+    first.dispose();
+    second.dispose();
   });
 
   function createSideLogger(
     logger: Logger,
     additionalLogLocation: string,
-  ): BaseLogger {
+  ): BaseLogger & Disposable {
     return new TeeLogger(
       logger,
       join(tempFolders.storagePath.name, additionalLogLocation),


### PR DESCRIPTION
This switches the `TeeLogger` from using the `appendFile` function to manually opening and closing a file handle and calling `appendFile` on the file handle. This results in a more efficient implementation as the file handle is only opened once and closed once, instead of being opened and closed for every log message. This should result in less "too many open files" errors.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
