### PR TITLE
Fire an event when clicking the "model alerts indicator" button

### DIFF
--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -605,6 +605,11 @@ interface OpenModelAlertsViewMessage {
   t: "openModelAlertsView";
 }
 
+interface RevealInModelAlertsViewMessage {
+  t: "revealInModelAlertsView";
+  method: MethodSignature;
+}
+
 interface ModelDependencyMessage {
   t: "modelDependency";
 }
@@ -677,7 +682,8 @@ export type FromModelEditorMessage =
   | SetMultipleModeledMethodsMessage
   | StartModelEvaluationMessage
   | StopModelEvaluationMessage
-  | OpenModelAlertsViewMessage;
+  | OpenModelAlertsViewMessage
+  | RevealInModelAlertsViewMessage;
 
 interface RevealInEditorMessage {
   t: "revealInModelEditor";

--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -607,7 +607,7 @@ interface OpenModelAlertsViewMessage {
 
 interface RevealInModelAlertsViewMessage {
   t: "revealInModelAlertsView";
-  method: MethodSignature;
+  modeledMethod: ModeledMethod;
 }
 
 interface ModelDependencyMessage {

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -385,7 +385,7 @@ export class ModelEditorView extends AbstractWebview<
         await this.modelEvaluator.openModelAlertsView();
         break;
       case "revealInModelAlertsView":
-        await this.modelEvaluator.revealInModelAlertsView(msg.method);
+        await this.modelEvaluator.revealInModelAlertsView(msg.modeledMethod);
         break;
       case "telemetry":
         telemetryListener?.sendUIInteraction(msg.action);

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -384,6 +384,9 @@ export class ModelEditorView extends AbstractWebview<
       case "openModelAlertsView":
         await this.modelEvaluator.openModelAlertsView();
         break;
+      case "revealInModelAlertsView":
+        await this.modelEvaluator.revealInModelAlertsView(msg.method);
+        break;
       case "telemetry":
         telemetryListener?.sendUIInteraction(msg.action);
         break;

--- a/extensions/ql-vscode/src/model-editor/model-evaluator.ts
+++ b/extensions/ql-vscode/src/model-editor/model-evaluator.ts
@@ -21,6 +21,7 @@ import type { QlPackDetails } from "../variant-analysis/ql-pack-details";
 import type { App } from "../common/app";
 import { ModelAlertsView } from "./model-alerts/model-alerts-view";
 import type { ExtensionPack } from "./shared/extension-pack";
+import type { MethodSignature } from "./method";
 
 export class ModelEvaluator extends DisposableObject {
   // Cancellation token source to allow cancelling of the current run
@@ -156,6 +157,16 @@ export class ModelEvaluator extends DisposableObject {
 
       await this.modelAlertsView.updateVariantAnalysis(variantAnalysis);
     }
+  }
+
+  public async revealInModelAlertsView(method: MethodSignature) {
+    if (!this.modelingStore.isModelAlertsViewOpen(this.dbItem)) {
+      await this.openModelAlertsView();
+    }
+    this.modelingEvents.fireRevealInModelAlertsViewEvent(
+      this.dbItem.databaseUri.toString(),
+      method,
+    );
   }
 
   private registerToModelingEvents() {

--- a/extensions/ql-vscode/src/model-editor/model-evaluator.ts
+++ b/extensions/ql-vscode/src/model-editor/model-evaluator.ts
@@ -21,7 +21,7 @@ import type { QlPackDetails } from "../variant-analysis/ql-pack-details";
 import type { App } from "../common/app";
 import { ModelAlertsView } from "./model-alerts/model-alerts-view";
 import type { ExtensionPack } from "./shared/extension-pack";
-import type { MethodSignature } from "./method";
+import type { ModeledMethod } from "./modeled-method";
 
 export class ModelEvaluator extends DisposableObject {
   // Cancellation token source to allow cancelling of the current run
@@ -159,13 +159,13 @@ export class ModelEvaluator extends DisposableObject {
     }
   }
 
-  public async revealInModelAlertsView(method: MethodSignature) {
+  public async revealInModelAlertsView(modeledMethod: ModeledMethod) {
     if (!this.modelingStore.isModelAlertsViewOpen(this.dbItem)) {
       await this.openModelAlertsView();
     }
     this.modelingEvents.fireRevealInModelAlertsViewEvent(
       this.dbItem.databaseUri.toString(),
-      method,
+      modeledMethod,
     );
   }
 

--- a/extensions/ql-vscode/src/model-editor/modeling-events.ts
+++ b/extensions/ql-vscode/src/model-editor/modeling-events.ts
@@ -71,7 +71,7 @@ interface FocusModelAlertsViewEvent {
 
 interface RevealInModelAlertsViewEvent {
   dbUri: string;
-  method: MethodSignature;
+  modeledMethod: ModeledMethod;
 }
 
 export class ModelingEvents extends DisposableObject {
@@ -317,8 +317,8 @@ export class ModelingEvents extends DisposableObject {
 
   public fireRevealInModelAlertsViewEvent(
     dbUri: string,
-    method: MethodSignature,
+    modeledMethod: ModeledMethod,
   ) {
-    this.onRevealInModelAlertsViewEventEmitter.fire({ dbUri, method });
+    this.onRevealInModelAlertsViewEventEmitter.fire({ dbUri, modeledMethod });
   }
 }

--- a/extensions/ql-vscode/src/model-editor/modeling-events.ts
+++ b/extensions/ql-vscode/src/model-editor/modeling-events.ts
@@ -69,6 +69,11 @@ interface FocusModelAlertsViewEvent {
   dbUri: string;
 }
 
+interface RevealInModelAlertsViewEvent {
+  dbUri: string;
+  method: MethodSignature;
+}
+
 export class ModelingEvents extends DisposableObject {
   public readonly onActiveDbChanged: AppEvent<void>;
   public readonly onDbOpened: AppEvent<DatabaseItem>;
@@ -84,6 +89,7 @@ export class ModelingEvents extends DisposableObject {
   public readonly onRevealInModelEditor: AppEvent<RevealInModelEditorEvent>;
   public readonly onFocusModelEditor: AppEvent<FocusModelEditorEvent>;
   public readonly onFocusModelAlertsView: AppEvent<FocusModelAlertsViewEvent>;
+  public readonly onRevealInModelAlertsView: AppEvent<RevealInModelAlertsViewEvent>;
 
   private readonly onActiveDbChangedEventEmitter: AppEventEmitter<void>;
   private readonly onDbOpenedEventEmitter: AppEventEmitter<DatabaseItem>;
@@ -99,6 +105,7 @@ export class ModelingEvents extends DisposableObject {
   private readonly onRevealInModelEditorEventEmitter: AppEventEmitter<RevealInModelEditorEvent>;
   private readonly onFocusModelEditorEventEmitter: AppEventEmitter<FocusModelEditorEvent>;
   private readonly onFocusModelAlertsViewEventEmitter: AppEventEmitter<FocusModelAlertsViewEvent>;
+  private readonly onRevealInModelAlertsViewEventEmitter: AppEventEmitter<RevealInModelAlertsViewEvent>;
 
   constructor(app: App) {
     super();
@@ -176,6 +183,12 @@ export class ModelingEvents extends DisposableObject {
       app.createEventEmitter<FocusModelAlertsViewEvent>(),
     );
     this.onFocusModelAlertsView = this.onFocusModelAlertsViewEventEmitter.event;
+
+    this.onRevealInModelAlertsViewEventEmitter = this.push(
+      app.createEventEmitter<RevealInModelAlertsViewEvent>(),
+    );
+    this.onRevealInModelAlertsView =
+      this.onRevealInModelAlertsViewEventEmitter.event;
   }
 
   public fireActiveDbChangedEvent() {
@@ -300,5 +313,12 @@ export class ModelingEvents extends DisposableObject {
 
   public fireFocusModelAlertsViewEvent(dbUri: string) {
     this.onFocusModelAlertsViewEventEmitter.fire({ dbUri });
+  }
+
+  public fireRevealInModelAlertsViewEvent(
+    dbUri: string,
+    method: MethodSignature,
+  ) {
+    this.onRevealInModelAlertsViewEventEmitter.fire({ dbUri, method });
   }
 }

--- a/extensions/ql-vscode/src/view/model-editor/ModelAlertsIndicator.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelAlertsIndicator.tsx
@@ -3,6 +3,7 @@ import type { ModeledMethod } from "../../model-editor/modeled-method";
 import type { ModelEvaluationRunState } from "../../model-editor/shared/model-evaluation-run-state";
 import type { ModelEditorViewState } from "../../model-editor/shared/view-state";
 import { VSCodeBadge } from "@vscode/webview-ui-toolkit/react";
+import { vscode } from "../vscode-api";
 
 const ModelAlertsButton = styled(VSCodeBadge)`
   cursor: pointer;
@@ -27,6 +28,9 @@ export const ModelAlertsIndicator = ({
     return null;
   }
 
+  const revealInModelAlertsView = () =>
+    sendRevealInModelAlertsViewMessage(modeledMethod);
+
   // TODO: Once we have alert provenance, we can show actual alert counts here.
   // For now, we show a random number.
   const number = Math.floor(Math.random() * 10);
@@ -37,9 +41,17 @@ export const ModelAlertsIndicator = ({
       aria-label="Model alerts"
       onClick={(event: React.MouseEvent) => {
         event.stopPropagation();
+        revealInModelAlertsView();
       }}
     >
       {number}
     </ModelAlertsButton>
   );
 };
+
+function sendRevealInModelAlertsViewMessage(modeledMethod: ModeledMethod) {
+  vscode.postMessage({
+    t: "revealInModelAlertsView",
+    method: modeledMethod,
+  });
+}

--- a/extensions/ql-vscode/src/view/model-editor/ModelAlertsIndicator.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelAlertsIndicator.tsx
@@ -52,6 +52,6 @@ export const ModelAlertsIndicator = ({
 function sendRevealInModelAlertsViewMessage(modeledMethod: ModeledMethod) {
   vscode.postMessage({
     t: "revealInModelAlertsView",
-    method: modeledMethod,
+    modeledMethod,
   });
 }

--- a/extensions/ql-vscode/src/view/model-editor/ModelAlertsIndicator.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelAlertsIndicator.tsx
@@ -28,8 +28,12 @@ export const ModelAlertsIndicator = ({
     return null;
   }
 
-  const revealInModelAlertsView = () =>
-    sendRevealInModelAlertsViewMessage(modeledMethod);
+  const revealInModelAlertsView = () => {
+    vscode.postMessage({
+      t: "revealInModelAlertsView",
+      modeledMethod,
+    });
+  };
 
   // TODO: Once we have alert provenance, we can show actual alert counts here.
   // For now, we show a random number.
@@ -48,10 +52,3 @@ export const ModelAlertsIndicator = ({
     </ModelAlertsButton>
   );
 };
-
-function sendRevealInModelAlertsViewMessage(modeledMethod: ModeledMethod) {
-  vscode.postMessage({
-    t: "revealInModelAlertsView",
-    modeledMethod,
-  });
-}


### PR DESCRIPTION
In the model editor, you can click the "model alerts indicator" which will (eventually) open the corresponding alerts in the model alerts view.

![image](https://github.com/github/vscode-codeql/assets/42641846/8936e366-f5a3-4706-a600-879346e05d3c)

For now, this PR just adds some types etc to fire a "reveal in model alerts view" event when you click this button. In the next PR I'll add the logic for the model alerts view to listen for those events and do the relevant thing.


## Checklist

N/A, feature-flagged for internal use/testing

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
