### PR TITLE
Refactor: extract function for canonicalising modeled methods

### DIFF
--- a/extensions/ql-vscode/src/model-editor/modeled-method.ts
+++ b/extensions/ql-vscode/src/model-editor/modeled-method.ts
@@ -1,3 +1,4 @@
+import { assertNever } from "../common/helpers-pure";
 import type { MethodSignature } from "./method";
 import type { ModelingStatus } from "./shared/modeling-status";
 
@@ -167,5 +168,88 @@ export function calculateNewProvenance(
     default:
       // The method has been modeled manually.
       return "manual";
+  }
+}
+
+export function createModeledMethodKey(modeledMethod: ModeledMethod): string {
+  const canonicalModeledMethod = canonicalizeModeledMethod(modeledMethod);
+  return JSON.stringify(
+    canonicalModeledMethod,
+    // This ensures the keys are always in the same order
+    Object.keys(canonicalModeledMethod).sort(),
+  );
+}
+
+/**
+ * This method will reset any properties which are not used for the specific type of modeled method.
+ *
+ * It will also set the `provenance` to `manual` since multiple modelings of the same method with a
+ * different provenance are not actually different.
+ *
+ * The returned canonical modeled method should only be used for comparisons. It should not be used
+ * for display purposes, saving the model, or any other purpose which requires the original modeled
+ * method to be preserved.
+ *
+ * @param modeledMethod The modeled method to canonicalize
+ */
+function canonicalizeModeledMethod(
+  modeledMethod: ModeledMethod,
+): ModeledMethod {
+  const methodSignature: MethodSignature = {
+    endpointType: modeledMethod.endpointType,
+    signature: modeledMethod.signature,
+    packageName: modeledMethod.packageName,
+    typeName: modeledMethod.typeName,
+    methodName: modeledMethod.methodName,
+    methodParameters: modeledMethod.methodParameters,
+  };
+
+  switch (modeledMethod.type) {
+    case "none":
+      return {
+        ...methodSignature,
+        type: "none",
+      };
+    case "source":
+      return {
+        ...methodSignature,
+        type: "source",
+        output: modeledMethod.output,
+        kind: modeledMethod.kind,
+        provenance: "manual",
+      };
+    case "sink":
+      return {
+        ...methodSignature,
+        type: "sink",
+        input: modeledMethod.input,
+        kind: modeledMethod.kind,
+        provenance: "manual",
+      };
+    case "summary":
+      return {
+        ...methodSignature,
+        type: "summary",
+        input: modeledMethod.input,
+        output: modeledMethod.output,
+        kind: modeledMethod.kind,
+        provenance: "manual",
+      };
+    case "neutral":
+      return {
+        ...methodSignature,
+        type: "neutral",
+        kind: modeledMethod.kind,
+        provenance: "manual",
+      };
+    case "type":
+      return {
+        ...methodSignature,
+        type: "type",
+        relatedTypeName: modeledMethod.relatedTypeName,
+        path: modeledMethod.path,
+      };
+    default:
+      assertNever(modeledMethod);
   }
 }


### PR DESCRIPTION
[🍐 paired with Charis]

We don't currently (I think) have an easy way to check whether two modeled methods are the same. I've shuffled some stuff around, so that you can now compare modeled methods by checking that their "key" is the same, i.e. `createModeledMethodKey(method1) === createModeledMethodKey(method2)`.

(Not used yet, but I plan to use this for jumping between corresponding models in the model editor and the model alerts view)

## Checklist

N/A: no user-facing changes

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
