### PR TITLE
Link from alerts indicator to model alerts view

### DIFF
--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -752,10 +752,16 @@ interface StopEvaluationRunMessage {
   t: "stopEvaluationRun";
 }
 
+interface RevealModelMessage {
+  t: "revealModel";
+  modeledMethod: ModeledMethod;
+}
+
 export type ToModelAlertsMessage =
   | SetModelAlertsViewStateMessage
   | SetVariantAnalysisMessage
-  | SetRepoResultsMessage;
+  | SetRepoResultsMessage
+  | RevealModelMessage;
 
 export type FromModelAlertsMessage =
   | CommonFromViewMessages

--- a/extensions/ql-vscode/src/model-editor/model-alerts/model-alerts-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-alerts/model-alerts-view.ts
@@ -20,6 +20,7 @@ import type {
   VariantAnalysisScannedRepositoryResult,
 } from "../../variant-analysis/shared/variant-analysis";
 import type { AppEvent, AppEventEmitter } from "../../common/events";
+import type { ModeledMethod } from "../modeled-method";
 import type { MethodSignature } from "../method";
 
 export class ModelAlertsView extends AbstractWebview<
@@ -179,6 +180,14 @@ export class ModelAlertsView extends AbstractWebview<
         }
       }),
     );
+
+    this.push(
+      this.modelingEvents.onRevealInModelAlertsView(async (event) => {
+        if (event.dbUri === this.dbItem.databaseUri.toString()) {
+          await this.revealMethod(event.modeledMethod);
+        }
+      }),
+    );
   }
 
   private async stopEvaluationRun() {
@@ -194,5 +203,16 @@ export class ModelAlertsView extends AbstractWebview<
       this.dbItem.databaseUri.toString(),
       method,
     );
+  }
+
+  public async revealMethod(method: ModeledMethod): Promise<void> {
+    const panel = await this.getPanel();
+
+    panel?.reveal();
+
+    await this.postMessage({
+      t: "revealModel",
+      modeledMethod: method,
+    });
   }
 }

--- a/extensions/ql-vscode/src/model-editor/model-alerts/model-alerts-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-alerts/model-alerts-view.ts
@@ -205,7 +205,7 @@ export class ModelAlertsView extends AbstractWebview<
     );
   }
 
-  public async revealMethod(method: ModeledMethod): Promise<void> {
+  private async revealMethod(method: ModeledMethod): Promise<void> {
     const panel = await this.getPanel();
 
     panel?.reveal();

--- a/extensions/ql-vscode/src/view/model-alerts/ModelAlerts.tsx
+++ b/extensions/ql-vscode/src/view/model-alerts/ModelAlerts.tsx
@@ -17,6 +17,7 @@ import {
   filterAndSort,
 } from "../../model-editor/shared/model-alerts-filter-sort";
 import type { ModelAlertsFilterSortState } from "../../model-editor/shared/model-alerts-filter-sort";
+import type { ModeledMethod } from "../../model-editor/modeled-method";
 
 type Props = {
   initialViewState?: ModelAlertsViewState;
@@ -62,6 +63,10 @@ export function ModelAlerts({
   const [filterSortValue, setFilterSortValue] =
     useState<ModelAlertsFilterSortState>(defaultFilterSortState);
 
+  const [revealedModel, setRevealedModel] = useState<ModeledMethod | null>(
+    null,
+  );
+
   useEffect(() => {
     const listener = (evt: MessageEvent) => {
       if (evt.origin === window.origin) {
@@ -85,6 +90,10 @@ export function ModelAlerts({
                 ...msg.repoResults,
               ];
             });
+            break;
+          }
+          case "revealModel": {
+            setRevealedModel(msg.modeledMethod);
             break;
           }
         }
@@ -146,7 +155,11 @@ export function ModelAlerts({
             // but we don't have a unique identifier for models. In the future,
             // we may need to consider coming up with unique identifiers for models
             // and using those as keys.
-            <ModelAlertsResults key={i} modelAlerts={alerts} />
+            <ModelAlertsResults
+              key={i}
+              modelAlerts={alerts}
+              revealedModel={revealedModel}
+            />
           ))}
         </div>
       </div>

--- a/extensions/ql-vscode/src/view/model-alerts/ModelAlertsResults.tsx
+++ b/extensions/ql-vscode/src/view/model-alerts/ModelAlertsResults.tsx
@@ -1,13 +1,15 @@
 import { styled } from "styled-components";
 import type { ModelAlerts } from "../../model-editor/model-alerts/model-alerts";
 import { Codicon } from "../common";
-import { useCallback, useState } from "react";
 import { VSCodeBadge, VSCodeLink } from "@vscode/webview-ui-toolkit/react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { formatDecimal } from "../../common/number";
 import AnalysisAlertResult from "../variant-analysis/AnalysisAlertResult";
 import { MethodName } from "../model-editor/MethodName";
 import { ModelDetails } from "./ModelDetails";
 import { vscode } from "../vscode-api";
+import { createModeledMethodKey } from "../../model-editor/modeled-method";
+import type { ModeledMethod } from "../../model-editor/modeled-method";
 
 // This will ensure that these icons have a className which we can use in the TitleContainer
 const ExpandCollapseCodicon = styled(Codicon)``;
@@ -59,10 +61,12 @@ const Alert = styled.li`
 
 interface Props {
   modelAlerts: ModelAlerts;
+  revealedModel: ModeledMethod | null;
 }
 
 export const ModelAlertsResults = ({
   modelAlerts,
+  revealedModel,
 }: Props): React.JSX.Element => {
   const [isExpanded, setExpanded] = useState(true);
   const viewInModelEditor = useCallback(
@@ -73,6 +77,22 @@ export const ModelAlertsResults = ({
       }),
     [modelAlerts.model],
   );
+
+  const ref = useRef<HTMLElement>();
+
+  useEffect(() => {
+    if (
+      revealedModel &&
+      createModeledMethodKey(modelAlerts.model) ===
+        createModeledMethodKey(revealedModel)
+    ) {
+      ref.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "center",
+      });
+    }
+  }, [modelAlerts.model, revealedModel]);
+
   return (
     <div>
       <TitleContainer onClick={() => setExpanded(!isExpanded)}>

--- a/extensions/ql-vscode/src/view/model-editor/ModelAlertsIndicator.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelAlertsIndicator.tsx
@@ -24,7 +24,7 @@ export const ModelAlertsIndicator = ({
     return null;
   }
 
-  if (!evaluationRun || !modeledMethod) {
+  if (!evaluationRun?.variantAnalysis || !modeledMethod) {
     return null;
   }
 


### PR DESCRIPTION
Follow-up to https://github.com/github/vscode-codeql/pull/3516. When you click a "model alerts indicator" (in the model editor), it will open the corresponding model in the model alerts view: 

https://github.com/github/vscode-codeql/assets/42641846/e3532897-63b3-4d13-9980-936b0619a56b

⚠️ Note: The model alerts view uses mock data at the moment, so we just open the view and don't auto-scroll to a specific model yet. This behaviour is something to test properly once we have alert provenance!


## Checklist

N/A, feature-flagged for internal use/testing

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
