### PR TITLE
Add `codeQL.model.packLocation` setting

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -463,8 +463,20 @@
       },
       {
         "type": "object",
-        "title": "Log insights",
+        "title": "Model Editor",
         "order": 9,
+        "properties": {
+          "codeQL.model.packLocation": {
+            "type": "string",
+            "default": ".github/codeql/extensions/${name}-${language}",
+            "markdownDescription": "Location for newly created CodeQL model packs. The location can be either absolute or relative. If relative, it is relative to the workspace root.\n\nThe following variables are supported:\n* **${database}** - the name of the database\n* **${language}** - the name of the language\n* **${name}** - the name of the GitHub repository, or the name of the database if the database was not downloaded from GitHub\n* **${owner}** - the owner of the GitHub repository, or an empty string if the database was not downloaded from GitHub"
+          }
+        }
+      },
+      {
+        "type": "object",
+        "title": "Log insights",
+        "order": 10,
         "properties": {
           "codeQL.logInsights.joinOrderWarningThreshold": {
             "type": "number",
@@ -478,7 +490,7 @@
       {
         "type": "object",
         "title": "Telemetry",
-        "order": 10,
+        "order": 11,
         "properties": {
           "codeQL.telemetry.enableTelemetry": {
             "type": "boolean",

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -13,6 +13,7 @@ import {
   FilterKey,
   SortKey,
 } from "./variant-analysis/shared/variant-analysis-filter-sort";
+import { substituteConfigVariables } from "./common/config-template";
 
 export const ALL_SETTINGS: Setting[] = [];
 
@@ -734,18 +735,28 @@ const LLM_GENERATION_DEV_ENDPOINT = new Setting(
   MODEL_SETTING,
 );
 const MODEL_EVALUATION = new Setting("evaluation", MODEL_SETTING);
-const EXTENSIONS_DIRECTORY = new Setting("extensionsDirectory", MODEL_SETTING);
+const MODEL_PACK_LOCATION = new Setting("packLocation", MODEL_SETTING);
 const ENABLE_PYTHON = new Setting("enablePython", MODEL_SETTING);
 const ENABLE_ACCESS_PATH_SUGGESTIONS = new Setting(
   "enableAccessPathSuggestions",
   MODEL_SETTING,
 );
 
+export type ModelConfigPackVariables = {
+  database: string;
+  owner: string;
+  name: string;
+  language: string;
+};
+
 export interface ModelConfig {
   flowGeneration: boolean;
   llmGeneration: boolean;
   showTypeModels: boolean;
-  getExtensionsDirectory(languageId: string): string | undefined;
+  getPackLocation(
+    languageId: string,
+    variables: ModelConfigPackVariables,
+  ): string;
   enablePython: boolean;
   enableAccessPathSuggestions: boolean;
 }
@@ -787,10 +798,16 @@ export class ModelConfigListener extends ConfigListener implements ModelConfig {
     return !!MODEL_EVALUATION.getValue<boolean>();
   }
 
-  public getExtensionsDirectory(languageId: string): string | undefined {
-    return EXTENSIONS_DIRECTORY.getValue<string>({
-      languageId,
-    });
+  public getPackLocation(
+    languageId: string,
+    variables: ModelConfigPackVariables,
+  ): string {
+    return substituteConfigVariables(
+      MODEL_PACK_LOCATION.getValue<string>({
+        languageId,
+      }),
+      variables,
+    );
   }
 
   public get enablePython(): boolean {

--- a/extensions/ql-vscode/src/model-editor/extensions-workspace-folder.ts
+++ b/extensions/ql-vscode/src/model-editor/extensions-workspace-folder.ts
@@ -73,13 +73,13 @@ function findCommonAncestor(uris: Uri[]): Uri | undefined {
  *
  * The heuristic is as follows:
  * 1. If there is a workspace file (`<basename>.code-workspace`), use the directory containing that file
- * 1. If there is only 1 workspace folder, use that folder=
+ * 2. If there is only 1 workspace folder, use that folder
  * 3. If there is a common root directory for all workspace folders, use that directory
  *   - Workspace folders in the system temp directory are ignored
  *   - If the common root directory is the root of the filesystem, then it's not used
- * 5. If there is a .git directory in any workspace folder, use the directory containing that .git directory
+ * 4. If there is a .git directory in any workspace folder, use the directory containing that .git directory
  *    for which the .git directory is closest to a workspace folder
- * 6. If none of the above apply, return `undefined`
+ * 5. If none of the above apply, return `undefined`
  */
 export async function getRootWorkspaceDirectory(): Promise<Uri | undefined> {
   // If there is a valid workspace file, just use its directory as the directory for the extensions

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/extensions-workspace-folder.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/extensions-workspace-folder.test.ts
@@ -3,27 +3,28 @@ import { Uri, workspace } from "vscode";
 import type { DirectoryResult } from "tmp-promise";
 import { dir } from "tmp-promise";
 import { join } from "path";
-import { autoPickExtensionsDirectory } from "../../../../src/model-editor/extensions-workspace-folder";
+import {
+  ensurePackLocationIsInWorkspaceFolder,
+  getRootWorkspaceDirectory,
+  packLocationToAbsolute,
+} from "../../../../src/model-editor/extensions-workspace-folder";
 import * as files from "../../../../src/common/files";
 import { mkdirp } from "fs-extra";
 import type { NotificationLogger } from "../../../../src/common/logging";
 import { createMockLogger } from "../../../__mocks__/loggerMock";
+import { mockedObject } from "../../../mocked-object";
+import type { ModelConfig } from "../../../../src/config";
 
-describe("autoPickExtensionsDirectory", () => {
+describe("getRootWorkspaceDirectory", () => {
   let tmpDir: DirectoryResult;
   let rootDirectory: Uri;
-  let extensionsDirectory: Uri;
 
   let workspaceFoldersSpy: jest.SpyInstance<
     readonly WorkspaceFolder[] | undefined,
     []
   >;
   let workspaceFileSpy: jest.SpyInstance<Uri | undefined, []>;
-  let updateWorkspaceFoldersSpy: jest.SpiedFunction<
-    typeof workspace.updateWorkspaceFolders
-  >;
   let mockedTmpDirUri: Uri;
-  let logger: NotificationLogger;
 
   beforeEach(async () => {
     tmpDir = await dir({
@@ -31,12 +32,6 @@ describe("autoPickExtensionsDirectory", () => {
     });
 
     rootDirectory = Uri.joinPath(Uri.file(tmpDir.path), "root");
-    extensionsDirectory = Uri.joinPath(
-      rootDirectory,
-      ".github",
-      "codeql",
-      "extensions",
-    );
 
     const mockedTmpDir = join(tmpDir.path, ".tmp", "tmp");
     mockedTmpDirUri = Uri.file(mockedTmpDir);
@@ -47,42 +42,12 @@ describe("autoPickExtensionsDirectory", () => {
     workspaceFileSpy = jest
       .spyOn(workspace, "workspaceFile", "get")
       .mockReturnValue(undefined);
-    updateWorkspaceFoldersSpy = jest
-      .spyOn(workspace, "updateWorkspaceFolders")
-      .mockReturnValue(true);
 
     jest.spyOn(files, "tmpdir").mockReturnValue(mockedTmpDir);
-
-    logger = createMockLogger();
   });
 
   afterEach(async () => {
     await tmpDir.cleanup();
-  });
-
-  it("when a workspace folder with the correct path exists", async () => {
-    workspaceFoldersSpy.mockReturnValue([
-      {
-        uri: Uri.joinPath(rootDirectory, "codeql-custom-queries-java"),
-        name: "codeql-custom-queries-java",
-        index: 0,
-      },
-      {
-        uri: Uri.joinPath(rootDirectory, "codeql-custom-queries-python"),
-        name: "codeql-custom-queries-python",
-        index: 1,
-      },
-      {
-        uri: extensionsDirectory,
-        name: "CodeQL Extension Packs",
-        index: 2,
-      },
-    ]);
-
-    expect(await autoPickExtensionsDirectory(logger)).toEqual(
-      extensionsDirectory,
-    );
-    expect(updateWorkspaceFoldersSpy).not.toHaveBeenCalled();
   });
 
   it("when a workspace file exists", async () => {
@@ -103,36 +68,7 @@ describe("autoPickExtensionsDirectory", () => {
       Uri.joinPath(rootDirectory, "workspace.code-workspace"),
     );
 
-    expect(await autoPickExtensionsDirectory(logger)).toEqual(
-      extensionsDirectory,
-    );
-    expect(updateWorkspaceFoldersSpy).toHaveBeenCalledWith(2, 0, {
-      name: "CodeQL Extension Packs",
-      uri: extensionsDirectory,
-    });
-  });
-
-  it("when updating the workspace folders fails", async () => {
-    updateWorkspaceFoldersSpy.mockReturnValue(false);
-
-    workspaceFoldersSpy.mockReturnValue([
-      {
-        uri: Uri.file("/a/b/c"),
-        name: "codeql-custom-queries-java",
-        index: 0,
-      },
-      {
-        uri: Uri.joinPath(rootDirectory, "codeql-custom-queries-python"),
-        name: "codeql-custom-queries-python",
-        index: 1,
-      },
-    ]);
-
-    workspaceFileSpy.mockReturnValue(
-      Uri.joinPath(rootDirectory, "workspace.code-workspace"),
-    );
-
-    expect(await autoPickExtensionsDirectory(logger)).toEqual(undefined);
+    expect(await getRootWorkspaceDirectory()).toEqual(rootDirectory);
   });
 
   it("when a workspace file does not exist and there is a common root directory", async () => {
@@ -149,13 +85,9 @@ describe("autoPickExtensionsDirectory", () => {
       },
     ]);
 
-    expect(await autoPickExtensionsDirectory(logger)).toEqual(
-      extensionsDirectory,
+    expect((await getRootWorkspaceDirectory())?.fsPath).toEqual(
+      rootDirectory.fsPath,
     );
-    expect(updateWorkspaceFoldersSpy).toHaveBeenCalledWith(2, 0, {
-      name: "CodeQL Extension Packs",
-      uri: extensionsDirectory,
-    });
   });
 
   it("when a workspace file does not exist and there is a temp dir as workspace folder", async () => {
@@ -177,13 +109,9 @@ describe("autoPickExtensionsDirectory", () => {
       },
     ]);
 
-    expect(await autoPickExtensionsDirectory(logger)).toEqual(
-      extensionsDirectory,
+    expect((await getRootWorkspaceDirectory())?.fsPath).toEqual(
+      rootDirectory.fsPath,
     );
-    expect(updateWorkspaceFoldersSpy).toHaveBeenCalledWith(3, 0, {
-      name: "CodeQL Extension Packs",
-      uri: extensionsDirectory,
-    });
   });
 
   it("when a workspace file does not exist and there is no common root directory", async () => {
@@ -200,8 +128,7 @@ describe("autoPickExtensionsDirectory", () => {
       },
     ]);
 
-    expect(await autoPickExtensionsDirectory(logger)).toEqual(undefined);
-    expect(updateWorkspaceFoldersSpy).not.toHaveBeenCalled();
+    expect(await getRootWorkspaceDirectory()).toBeUndefined();
   });
 
   it("when a workspace file does not exist and there is a .git folder", async () => {
@@ -220,13 +147,7 @@ describe("autoPickExtensionsDirectory", () => {
       },
     ]);
 
-    expect(await autoPickExtensionsDirectory(logger)).toEqual(
-      extensionsDirectory,
-    );
-    expect(updateWorkspaceFoldersSpy).toHaveBeenCalledWith(2, 0, {
-      name: "CodeQL Extension Packs",
-      uri: extensionsDirectory,
-    });
+    expect(await getRootWorkspaceDirectory()).toEqual(rootDirectory);
   });
 
   it("when there is no on-disk workspace folder", async () => {
@@ -238,10 +159,268 @@ describe("autoPickExtensionsDirectory", () => {
       },
     ]);
 
-    expect(await autoPickExtensionsDirectory(logger)).toEqual(undefined);
+    expect(await getRootWorkspaceDirectory()).toBeUndefined();
+  });
+});
+
+describe("packLocationToAbsolute", () => {
+  let tmpDir: DirectoryResult;
+  let rootDirectory: Uri;
+  let extensionsDirectory: Uri;
+
+  let logger: NotificationLogger;
+
+  beforeEach(async () => {
+    tmpDir = await dir({
+      unsafeCleanup: true,
+    });
+
+    rootDirectory = Uri.joinPath(Uri.file(tmpDir.path), "root");
+    extensionsDirectory = Uri.joinPath(
+      rootDirectory,
+      ".github",
+      "codeql",
+      "extensions",
+    );
+
+    const mockedTmpDir = join(tmpDir.path, ".tmp", "tmp");
+
+    jest.spyOn(workspace, "workspaceFolders", "get").mockReturnValue([]);
+    jest
+      .spyOn(workspace, "workspaceFile", "get")
+      .mockReturnValue(Uri.joinPath(rootDirectory, "workspace.code-workspace"));
+
+    jest.spyOn(files, "tmpdir").mockReturnValue(mockedTmpDir);
+
+    logger = createMockLogger();
+  });
+
+  afterEach(async () => {
+    await tmpDir.cleanup();
+  });
+
+  it("when the location is absolute", async () => {
+    expect(
+      await packLocationToAbsolute(extensionsDirectory.fsPath, logger),
+    ).toEqual(extensionsDirectory.fsPath);
+  });
+
+  it("when the location is relative", async () => {
+    expect(
+      await packLocationToAbsolute(".github/codeql/extensions/my-pack", logger),
+    ).toEqual(Uri.joinPath(extensionsDirectory, "my-pack").fsPath);
+  });
+
+  it("when the location is invalid", async () => {
+    expect(
+      await packLocationToAbsolute("../".repeat(100), logger),
+    ).toBeUndefined();
+  });
+});
+
+describe("ensurePackLocationIsInWorkspaceFolder", () => {
+  let tmpDir: DirectoryResult;
+  let rootDirectory: Uri;
+  let extensionsDirectory: Uri;
+  let packLocation: string;
+
+  let workspaceFoldersSpy: jest.SpyInstance<
+    readonly WorkspaceFolder[] | undefined,
+    []
+  >;
+  let workspaceFileSpy: jest.SpyInstance<Uri | undefined, []>;
+  let updateWorkspaceFoldersSpy: jest.SpiedFunction<
+    typeof workspace.updateWorkspaceFolders
+  >;
+
+  let getPackLocation: jest.MockedFunction<ModelConfig["getPackLocation"]>;
+  let modelConfig: ModelConfig;
+  let logger: NotificationLogger;
+
+  beforeEach(async () => {
+    tmpDir = await dir({
+      unsafeCleanup: true,
+    });
+
+    rootDirectory = Uri.joinPath(Uri.file(tmpDir.path), "root");
+    extensionsDirectory = Uri.joinPath(
+      rootDirectory,
+      ".github",
+      "codeql",
+      "extensions",
+    );
+    packLocation = Uri.joinPath(extensionsDirectory, "my-pack").fsPath;
+
+    workspaceFoldersSpy = jest
+      .spyOn(workspace, "workspaceFolders", "get")
+      .mockReturnValue([
+        {
+          uri: Uri.joinPath(rootDirectory, "codeql-custom-queries-java"),
+          name: "codeql-custom-queries-java",
+          index: 0,
+        },
+        {
+          uri: Uri.joinPath(rootDirectory, "codeql-custom-queries-python"),
+          name: "codeql-custom-queries-python",
+          index: 1,
+        },
+      ]);
+    workspaceFileSpy = jest
+      .spyOn(workspace, "workspaceFile", "get")
+      .mockReturnValue(Uri.joinPath(rootDirectory, "workspace.code-workspace"));
+    updateWorkspaceFoldersSpy = jest
+      .spyOn(workspace, "updateWorkspaceFolders")
+      .mockReturnValue(true);
+
+    logger = createMockLogger();
+
+    getPackLocation = jest
+      .fn()
+      .mockImplementation(
+        (language, { name }) =>
+          Uri.joinPath(extensionsDirectory, `${name}-${language}`).fsPath,
+      );
+    modelConfig = mockedObject<ModelConfig>({
+      getPackLocation,
+    });
+  });
+
+  afterEach(async () => {
+    await tmpDir.cleanup();
+  });
+
+  it("when there is no workspace file", async () => {
+    workspaceFileSpy.mockReturnValue(undefined);
+
+    await ensurePackLocationIsInWorkspaceFolder(
+      packLocation,
+      modelConfig,
+      logger,
+    );
     expect(updateWorkspaceFoldersSpy).not.toHaveBeenCalled();
-    expect(logger.showErrorMessage).toHaveBeenCalledWith(
-      "Could not find any on-disk workspace folders. Please ensure that you have opened a folder or workspace.",
+  });
+
+  it("when a workspace folder with the correct path exists", async () => {
+    workspaceFoldersSpy.mockReturnValue([
+      {
+        uri: Uri.joinPath(rootDirectory, "codeql-custom-queries-java"),
+        name: "codeql-custom-queries-java",
+        index: 0,
+      },
+      {
+        uri: Uri.joinPath(rootDirectory, "codeql-custom-queries-python"),
+        name: "codeql-custom-queries-python",
+        index: 1,
+      },
+      {
+        uri: extensionsDirectory,
+        name: "CodeQL Extension Packs",
+        index: 2,
+      },
+    ]);
+
+    await ensurePackLocationIsInWorkspaceFolder(
+      packLocation,
+      modelConfig,
+      logger,
+    );
+    expect(updateWorkspaceFoldersSpy).not.toHaveBeenCalled();
+  });
+
+  it("when a workspace folder with the correct path does not exist in an unsaved workspace", async () => {
+    workspaceFileSpy.mockReturnValue(Uri.parse("untitled:1555503116870"));
+    workspaceFoldersSpy.mockReturnValue([
+      {
+        uri: Uri.file("/a/b/c"),
+        name: "codeql-custom-queries-java",
+        index: 0,
+      },
+      {
+        uri: Uri.joinPath(rootDirectory, "codeql-custom-queries-python"),
+        name: "codeql-custom-queries-python",
+        index: 1,
+      },
+    ]);
+
+    await ensurePackLocationIsInWorkspaceFolder(
+      packLocation,
+      modelConfig,
+      logger,
+    );
+    expect(updateWorkspaceFoldersSpy).toHaveBeenLastCalledWith(2, 0, {
+      name: "CodeQL Extension Packs",
+      uri: expect.any(Uri),
+    });
+    expect(updateWorkspaceFoldersSpy.mock.lastCall?.[2].uri.fsPath).toEqual(
+      extensionsDirectory.fsPath,
+    );
+  });
+
+  it("when a workspace folder with the correct path does not exist in a saved workspace", async () => {
+    workspaceFoldersSpy.mockReturnValue([
+      {
+        uri: Uri.file("/a/b/c"),
+        name: "codeql-custom-queries-java",
+        index: 0,
+      },
+      {
+        uri: Uri.joinPath(rootDirectory, "codeql-custom-queries-python"),
+        name: "codeql-custom-queries-python",
+        index: 1,
+      },
+    ]);
+
+    await ensurePackLocationIsInWorkspaceFolder(
+      packLocation,
+      modelConfig,
+      logger,
+    );
+    expect(updateWorkspaceFoldersSpy).toHaveBeenLastCalledWith(2, 0, {
+      name: "CodeQL Extension Packs",
+      uri: expect.any(Uri),
+    });
+    expect(updateWorkspaceFoldersSpy.mock.lastCall?.[2].uri.fsPath).toEqual(
+      extensionsDirectory.fsPath,
+    );
+  });
+
+  it("when all other pack locations are invalid", async () => {
+    getPackLocation.mockReturnValue("/");
+
+    await ensurePackLocationIsInWorkspaceFolder(
+      packLocation,
+      modelConfig,
+      logger,
+    );
+
+    expect(updateWorkspaceFoldersSpy).not.toHaveBeenCalled();
+  });
+
+  it("when there is no common root directory", async () => {
+    getPackLocation.mockImplementation(
+      (language, { name }) => `/${name}-${language}`,
+    );
+
+    await ensurePackLocationIsInWorkspaceFolder(
+      packLocation,
+      modelConfig,
+      logger,
+    );
+
+    expect(updateWorkspaceFoldersSpy).not.toHaveBeenCalled();
+  });
+
+  it("when updating the workspace folders fails", async () => {
+    updateWorkspaceFoldersSpy.mockReturnValue(false);
+
+    await ensurePackLocationIsInWorkspaceFolder(
+      packLocation,
+      modelConfig,
+      logger,
+    );
+
+    expect(logger.log).toHaveBeenCalledWith(
+      `Failed to add workspace folder for extensions at ${extensionsDirectory.fsPath}`,
     );
   });
 });


### PR DESCRIPTION
This adds the `codeQL.model.packLocation` setting, which allows users to specify the location of the CodeQL extension pack. This setting replaces the `codeQL.model.extensionsDirectory` setting, which has been removed.

The pack location supports variable substitutions and supports both absolute and relative paths. The default value is
`.github/codeql/extensions/${name}-${language}` which matches the previous defaults.

My plan is to add the CHANGELOG entry when all three settings have been added, rather than for each one individually.

![Screenshot 2024-04-05 at 14 47 05](https://github.com/github/vscode-codeql/assets/1112623/dc24d503-10b2-49de-9826-f8608b88bcea)

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
