### PR TITLE
Improve support for Python arguments

### DIFF
--- a/extensions/ql-vscode/src/model-editor/languages/python/index.ts
+++ b/extensions/ql-vscode/src/model-editor/languages/python/index.ts
@@ -177,6 +177,7 @@ export const python: ModelsAsDataLanguage = {
     // Argument and Parameter are equivalent in Python, but we'll use Argument in the model editor
     const argumentsList = getArgumentsList(method.methodParameters).map(
       (argument, index): MethodArgument => {
+        // Keyword-only arguments end with `:` in the query
         if (argument.endsWith(":")) {
           return {
             path: `Argument[${argument}]`,
@@ -184,9 +185,18 @@ export const python: ModelsAsDataLanguage = {
           };
         }
 
+        // Positional-only arguments end with `/` in the query
+        if (argument.endsWith("/")) {
+          return {
+            path: `Argument[${index}]`,
+            label: `Argument[${index}]: ${argument.substring(0, argument.length - 1)}`,
+          };
+        }
+
+        // All other arguments are both keyword and positional
         return {
-          path: `Argument[${index}]`,
-          label: `Argument[${index}]: ${argument}`,
+          path: `Argument[${index},${argument}:]`,
+          label: `Argument[${index},${argument}:]: ${argument}`,
         };
       },
     );


### PR DESCRIPTION
This improves support for Python arguments by doing two things:
- When there is a function definition like:

```python
def foo(x, y)
  return x + y
```

It is possible to call the function as normal `foo(1, 2)`, which works with `Argument[0]` and `Argument[1]`. However, it's also possible to call this like `foo(1, y = 2)` or `foo(x = 1, y = 2)`, which doesn't work for those same values (since the function definition isn't always available). Therefore, this changes the generation of these arguments to `Argument[0,x:]` and `Argument[1,y:]`.
- When there is a function definition like:

```python
def foo(x, /, y)
  return x + y
```

It is not possible to call this like `foo(x = 5, y = 2)`, only as `foo(5, 2)` or `foo(5, y = 2)`. So, unlike above, we should ensure that these arguments are not modeled as both `Argument[0]` and `Argument[x:]`, but only as `Argument[0]`.

The CodeQL query will return `x/,y` as the parameter string for this function. When there are multiple positional-only arguments, each argument name will be suffixed by `/`.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
