### PR TITLE
Add `codeQL.model.packName` setting

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -470,6 +470,11 @@
             "type": "string",
             "default": ".github/codeql/extensions/${name}-${language}",
             "markdownDescription": "Location for newly created CodeQL model packs. The location can be either absolute or relative. If relative, it is relative to the workspace root.\n\nThe following variables are supported:\n* **${database}** - the name of the database\n* **${language}** - the name of the language\n* **${name}** - the name of the GitHub repository, or the name of the database if the database was not downloaded from GitHub\n* **${owner}** - the owner of the GitHub repository, or an empty string if the database was not downloaded from GitHub"
+          },
+          "codeQL.model.packName": {
+            "type": "string",
+            "default": "${owner}/${name}-${language}",
+            "markdownDescription": "Name of newly created CodeQL model packs. If the result is not a valid pack name, it will be converted to a valid pack name.\n\nThe following variables are supported:\n* **${database}** - the name of the database\n* **${language}** - the name of the language\n* **${name}** - the name of the GitHub repository, or the name of the database if the database was not downloaded from GitHub\n* **${owner}** - the owner of the GitHub repository, or an empty string if the database was not downloaded from GitHub"
           }
         }
       },

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -736,6 +736,7 @@ const LLM_GENERATION_DEV_ENDPOINT = new Setting(
 );
 const MODEL_EVALUATION = new Setting("evaluation", MODEL_SETTING);
 const MODEL_PACK_LOCATION = new Setting("packLocation", MODEL_SETTING);
+const MODEL_PACK_NAME = new Setting("packName", MODEL_SETTING);
 const ENABLE_PYTHON = new Setting("enablePython", MODEL_SETTING);
 const ENABLE_ACCESS_PATH_SUGGESTIONS = new Setting(
   "enableAccessPathSuggestions",
@@ -757,6 +758,7 @@ export interface ModelConfig {
     languageId: string,
     variables: ModelConfigPackVariables,
   ): string;
+  getPackName(languageId: string, variables: ModelConfigPackVariables): string;
   enablePython: boolean;
   enableAccessPathSuggestions: boolean;
 }
@@ -804,6 +806,18 @@ export class ModelConfigListener extends ConfigListener implements ModelConfig {
   ): string {
     return substituteConfigVariables(
       MODEL_PACK_LOCATION.getValue<string>({
+        languageId,
+      }),
+      variables,
+    );
+  }
+
+  public getPackName(
+    languageId: string,
+    variables: ModelConfigPackVariables,
+  ): string {
+    return substituteConfigVariables(
+      MODEL_PACK_NAME.getValue<string>({
         languageId,
       }),
       variables,

--- a/extensions/ql-vscode/src/model-editor/extension-pack-name.ts
+++ b/extensions/ql-vscode/src/model-editor/extension-pack-name.ts
@@ -15,11 +15,8 @@ export function formatPackName(packName: ExtensionPackName): string {
   return `${packName.scope}/${packName.name}`;
 }
 
-export function autoNameExtensionPack(
-  name: string,
-  language: string,
-): ExtensionPackName | undefined {
-  let packName = `${name}-${language}`;
+export function sanitizePackName(userPackName: string): ExtensionPackName {
+  let packName = userPackName;
   if (!packName.includes("/")) {
     packName = `pack/${packName}`;
   }

--- a/extensions/ql-vscode/src/model-editor/extension-pack-name.ts
+++ b/extensions/ql-vscode/src/model-editor/extension-pack-name.ts
@@ -17,6 +17,17 @@ export function formatPackName(packName: ExtensionPackName): string {
 
 export function sanitizePackName(userPackName: string): ExtensionPackName {
   let packName = userPackName;
+
+  packName = packName.trim();
+
+  while (packName.startsWith("/")) {
+    packName = packName.slice(1);
+  }
+
+  while (packName.endsWith("/")) {
+    packName = packName.slice(0, -1);
+  }
+
   if (!packName.includes("/")) {
     packName = `pack/${packName}`;
   }

--- a/extensions/ql-vscode/test/unit-tests/model-editor/extension-pack-name.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/model-editor/extension-pack-name.test.ts
@@ -58,6 +58,18 @@ describe("sanitizePackName", () => {
       name: "a/b--d--e-d-csharp",
       expected: "a/b-d-e-d-csharp",
     },
+    {
+      name: "/github/vscode-codeql",
+      expected: "github/vscode-codeql",
+    },
+    {
+      name: "github/vscode-codeql/",
+      expected: "github/vscode-codeql",
+    },
+    {
+      name: "///github/vscode-codeql///",
+      expected: "github/vscode-codeql",
+    },
   ];
 
   test.each(testCases)(

--- a/extensions/ql-vscode/test/unit-tests/model-editor/extension-pack-name.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/model-editor/extension-pack-name.test.ts
@@ -1,82 +1,69 @@
 import {
-  autoNameExtensionPack,
+  sanitizePackName,
   formatPackName,
   parsePackName,
   validatePackName,
 } from "../../../src/model-editor/extension-pack-name";
 
-describe("autoNameExtensionPack", () => {
+describe("sanitizePackName", () => {
   const testCases: Array<{
     name: string;
-    language: string;
     expected: string;
   }> = [
     {
-      name: "github/vscode-codeql",
-      language: "javascript",
+      name: "github/vscode-codeql-javascript",
       expected: "github/vscode-codeql-javascript",
     },
     {
-      name: "vscode-codeql",
-      language: "a",
+      name: "vscode-codeql-a",
       expected: "pack/vscode-codeql-a",
     },
     {
-      name: "b",
-      language: "java",
+      name: "b-java",
       expected: "pack/b-java",
     },
     {
-      name: "a/b",
-      language: "csharp",
+      name: "a/b-csharp",
       expected: "a/b-csharp",
     },
     {
-      name: "-/b",
-      language: "csharp",
+      name: "-/b-csharp",
       expected: "pack/b-csharp",
     },
     {
-      name: "a/b/c/d",
-      language: "csharp",
+      name: "a/b/c/d-csharp",
       expected: "a/b-c-d-csharp",
     },
     {
-      name: "JAVA/CodeQL",
-      language: "csharp",
+      name: "JAVA/CodeQL-csharp",
       expected: "java/codeql-csharp",
     },
     {
-      name: "my new pack",
-      language: "swift",
+      name: "my new pack-swift",
       expected: "pack/my-new-pack-swift",
     },
     {
-      name: "gïthub/vscode-codeql",
-      language: "javascript",
+      name: "gïthub/vscode-codeql-javascript",
       expected: "gthub/vscode-codeql-javascript",
     },
     {
-      name: "a/b-",
-      language: "csharp",
+      name: "a/b-csharp",
       expected: "a/b-csharp",
     },
     {
-      name: "-a-/b",
-      language: "ruby",
+      name: "-a-/b-ruby",
       expected: "a/b-ruby",
     },
     {
-      name: "a/b--d--e-d-",
-      language: "csharp",
+      name: "a/b--d--e-d-csharp",
       expected: "a/b-d-e-d-csharp",
     },
   ];
 
   test.each(testCases)(
     "$name with $language = $expected",
-    ({ name, language, expected }) => {
-      const result = autoNameExtensionPack(name, language);
+    ({ name, expected }) => {
+      const result = sanitizePackName(name);
       expect(result).not.toBeUndefined();
       if (!result) {
         return;


### PR DESCRIPTION
This adds the `codeQL.model.packName` setting, which allows users to specify the name of the CodeQL model pack. Like the `codeQL.model.packLocation` setting added in https://github.com/github/vscode-codeql/pull/3539, this supports variable substitutions. After the variable substitution has been performed, we'll try to "sanitize" the name to make it valid. The default value is `${owner}/${name}-${language}` which matches the previous behavior.

My plan is to add the CHANGELOG entry when all three settings have been added, rather than for each one individually.

![Screenshot 2024-04-08 at 13 55 35](https://github.com/github/vscode-codeql/assets/1112623/5194fe65-ec19-4542-a26a-9ba69df13643)

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
