### PR TITLE
Remove `codeQL.model.enableAccessPathSuggestions` config

### DIFF
--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -737,10 +737,6 @@ const LLM_GENERATION_DEV_ENDPOINT = new Setting(
 const MODEL_EVALUATION = new Setting("evaluation", MODEL_SETTING);
 const MODEL_PACK_LOCATION = new Setting("packLocation", MODEL_SETTING);
 const ENABLE_PYTHON = new Setting("enablePython", MODEL_SETTING);
-const ENABLE_ACCESS_PATH_SUGGESTIONS = new Setting(
-  "enableAccessPathSuggestions",
-  MODEL_SETTING,
-);
 
 export type ModelConfigPackVariables = {
   database: string;
@@ -758,7 +754,6 @@ export interface ModelConfig {
     variables: ModelConfigPackVariables,
   ): string;
   enablePython: boolean;
-  enableAccessPathSuggestions: boolean;
 }
 
 export class ModelConfigListener extends ConfigListener implements ModelConfig {
@@ -812,10 +807,6 @@ export class ModelConfigListener extends ConfigListener implements ModelConfig {
 
   public get enablePython(): boolean {
     return !!ENABLE_PYTHON.getValue<boolean>();
-  }
-
-  public get enableAccessPathSuggestions(): boolean {
-    return !!ENABLE_ACCESS_PATH_SUGGESTIONS.getValue<boolean>();
   }
 }
 

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -348,17 +348,11 @@ export class ModelEditorView extends AbstractWebview<
           withProgress((progress) => this.loadMethods(progress), {
             cancellable: false,
           }),
-          // Only load access path suggestions if the feature is enabled
-          this.modelConfig.enableAccessPathSuggestions
-            ? withProgress(
-                (progress) => this.loadAccessPathSuggestions(progress),
-                {
-                  cancellable: false,
-                  location: ProgressLocation.Window,
-                  title: "Loading access path suggestions",
-                },
-              )
-            : undefined,
+          withProgress((progress) => this.loadAccessPathSuggestions(progress), {
+            cancellable: false,
+            location: ProgressLocation.Window,
+            title: "Loading access path suggestions",
+          }),
         ]);
         void telemetryListener?.sendUIInteraction("model-editor-switch-modes");
 
@@ -416,14 +410,11 @@ export class ModelEditorView extends AbstractWebview<
         await this.generateModeledMethodsOnStartup();
       }),
       this.loadExistingModeledMethods(),
-      // Only load access path suggestions if the feature is enabled
-      this.modelConfig.enableAccessPathSuggestions
-        ? withProgress((progress) => this.loadAccessPathSuggestions(progress), {
-            cancellable: false,
-            location: ProgressLocation.Window,
-            title: "Loading access path suggestions",
-          })
-        : undefined,
+      withProgress((progress) => this.loadAccessPathSuggestions(progress), {
+        cancellable: false,
+        location: ProgressLocation.Window,
+        title: "Loading access path suggestions",
+      }),
     ]);
   }
 


### PR DESCRIPTION
This feature is now enabled by default for supported languages (which currently only includes Ruby). It also makes the experience for unsupported languages better by not calling `withProgress` for unsupported languages (which would almost immediately exit out of `withProgress`).

No changelog entry is necessary because Ruby is currently only enabled in canary mode.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
