### PR TITLE
Add auto-model generation mode without separate file

### DIFF
--- a/extensions/ql-vscode/src/model-editor/languages/models-as-data.ts
+++ b/extensions/ql-vscode/src/model-editor/languages/models-as-data.ts
@@ -105,15 +105,34 @@ type ParseResultsToYaml = (
   logger: BaseLogger,
 ) => ModelExtension[];
 
+export enum AutoModelGenerationType {
+  /**
+   * Auto model generation is disabled and will not be run.
+   */
+  Disabled = "disabled",
+  /**
+   * The models are generated to a separate file (suffixed with .model.generated.yml).
+   */
+  SeparateFile = "separateFile",
+  /**
+   * The models are added as a model in the model editor, but are not automatically saved.
+   * The user can view them and choose to save them.
+   */
+  Models = "models",
+}
+
 type ModelsAsDataLanguageAutoModelGeneration = {
   queryConstraints: (mode: Mode) => QueryConstraints;
   filterQueries?: (queryPath: string) => boolean;
+  /**
+   * This function is only used when type is `separateFile`.
+   */
   parseResultsToYaml: ParseResultsToYaml;
   /**
-   * By default, auto model generation is enabled for all modes. This function can be used to
-   * override that behavior.
+   * This function is only used when type is `models`.
    */
-  enabled?: (context: GenerationContext) => boolean;
+  parseResults: ParseGenerationResults;
+  type: (context: GenerationContext) => AutoModelGenerationType;
 };
 
 type ModelsAsDataLanguageAccessPathSuggestions = {

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -54,7 +54,11 @@ import { telemetryListener } from "../common/vscode/telemetry";
 import type { ModelingStore } from "./modeling-store";
 import type { ModelingEvents } from "./modeling-events";
 import type { ModelsAsDataLanguage } from "./languages";
-import { createModelConfig, getModelsAsDataLanguage } from "./languages";
+import {
+  AutoModelGenerationType,
+  createModelConfig,
+  getModelsAsDataLanguage,
+} from "./languages";
 import { runGenerateQueries } from "./generate";
 import { ResponseError } from "vscode-jsonrpc";
 import { LSPErrorCodes } from "vscode-languageclient";
@@ -710,10 +714,12 @@ export class ModelEditorView extends AbstractWebview<
       return;
     }
 
-    if (
-      autoModelGeneration.enabled &&
-      !autoModelGeneration.enabled({ mode, config: this.modelConfig })
-    ) {
+    const autoModelType = autoModelGeneration.type({
+      mode,
+      config: this.modelConfig,
+    });
+
+    if (autoModelType === AutoModelGenerationType.Disabled) {
       return;
     }
 
@@ -734,14 +740,37 @@ export class ModelEditorView extends AbstractWebview<
             queryConstraints: autoModelGeneration.queryConstraints(mode),
             filterQueries: autoModelGeneration.filterQueries,
             onResults: (queryPath, results) => {
-              const extensions = autoModelGeneration.parseResultsToYaml(
-                queryPath,
-                results,
-                modelsAsDataLanguage,
-                this.app.logger,
-              );
+              switch (autoModelType) {
+                case AutoModelGenerationType.SeparateFile: {
+                  const extensions = autoModelGeneration.parseResultsToYaml(
+                    queryPath,
+                    results,
+                    modelsAsDataLanguage,
+                    this.app.logger,
+                  );
 
-              extensionFile.extensions.push(...extensions);
+                  extensionFile.extensions.push(...extensions);
+                  break;
+                }
+                case AutoModelGenerationType.Models: {
+                  const modeledMethods = autoModelGeneration.parseResults(
+                    queryPath,
+                    results,
+                    modelsAsDataLanguage,
+                    this.app.logger,
+                    {
+                      mode,
+                      config: this.modelConfig,
+                    },
+                  );
+
+                  this.addModeledMethodsFromArray(modeledMethods);
+                  break;
+                }
+                default: {
+                  assertNever(autoModelType);
+                }
+              }
             },
             cliServer: this.cliServer,
             queryRunner: this.queryRunner,
@@ -761,22 +790,24 @@ export class ModelEditorView extends AbstractWebview<
           return;
         }
 
-        progress({
-          step: 4000,
-          maxStep: 4000,
-          message: "Saving generated models",
-        });
+        if (autoModelType === AutoModelGenerationType.SeparateFile) {
+          progress({
+            step: 4000,
+            maxStep: 4000,
+            message: "Saving generated models",
+          });
 
-        const fileContents = `# This file was automatically generated from ${this.databaseItem.name}. Manual changes will not persist.\n\n${modelExtensionFileToYaml(extensionFile)}`;
-        const filePath = join(
-          this.extensionPack.path,
-          "models",
-          `${this.language}${GENERATED_MODELS_SUFFIX}`,
-        );
+          const fileContents = `# This file was automatically generated from ${this.databaseItem.name}. Manual changes will not persist.\n\n${modelExtensionFileToYaml(extensionFile)}`;
+          const filePath = join(
+            this.extensionPack.path,
+            "models",
+            `${this.language}${GENERATED_MODELS_SUFFIX}`,
+          );
 
-        await outputFile(filePath, fileContents);
+          await outputFile(filePath, fileContents);
 
-        void this.app.logger.log(`Saved generated model file to ${filePath}`);
+          void this.app.logger.log(`Saved generated model file to ${filePath}`);
+        }
       },
       {
         cancellable: false,


### PR DESCRIPTION
This adds a new "mode" to the auto-model generation that doesn't save the modeled methods in a separate file, but instead shows them to the user in the model editor UI, like the manual model generation. It allows overriding of how the models are parsed which is used to ensure only type models are parsed for Ruby.

The new mode isn't currently being used anywhere yet, but this will happen in a follow-up PR.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
