### PR TITLE
Remove `codeQL.model.showTypeModels` config

### DIFF
--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -725,7 +725,6 @@ export async function setAutogenerateQlPacks(choice: AutogenerateQLPacks) {
 const MODEL_SETTING = new Setting("model", ROOT_SETTING);
 const FLOW_GENERATION = new Setting("flowGeneration", MODEL_SETTING);
 const LLM_GENERATION = new Setting("llmGeneration", MODEL_SETTING);
-const SHOW_TYPE_MODELS = new Setting("showTypeModels", MODEL_SETTING);
 const LLM_GENERATION_BATCH_SIZE = new Setting(
   "llmGenerationBatchSize",
   MODEL_SETTING,
@@ -749,7 +748,6 @@ export type ModelConfigPackVariables = {
 export interface ModelConfig {
   flowGeneration: boolean;
   llmGeneration: boolean;
-  showTypeModels: boolean;
   getPackLocation(
     languageId: string,
     variables: ModelConfigPackVariables,
@@ -769,10 +767,6 @@ export class ModelConfigListener extends ConfigListener implements ModelConfig {
 
   public get llmGeneration(): boolean {
     return !!LLM_GENERATION.getValue<boolean>();
-  }
-
-  public get showTypeModels(): boolean {
-    return !!SHOW_TYPE_MODELS.getValue<boolean>();
   }
 
   /**

--- a/extensions/ql-vscode/src/model-editor/languages/models-as-data.ts
+++ b/extensions/ql-vscode/src/model-editor/languages/models-as-data.ts
@@ -20,7 +20,7 @@ import type { AccessPathSuggestionRow } from "../suggestions";
 // This is a subset of the model config that doesn't import the vscode module.
 // It only includes settings that are actually used.
 export type ModelConfig = {
-  showTypeModels: boolean;
+  flowGeneration: boolean;
 };
 
 /**
@@ -32,12 +32,12 @@ export type ModelConfig = {
  */
 export function createModelConfig(modelConfig: ModelConfig): ModelConfig {
   return {
-    showTypeModels: modelConfig.showTypeModels,
+    flowGeneration: modelConfig.flowGeneration,
   };
 }
 
 export const defaultModelConfig: ModelConfig = {
-  showTypeModels: false,
+  flowGeneration: false,
 };
 
 type GenerateMethodDefinition<T> = (method: T) => DataTuple[];

--- a/extensions/ql-vscode/src/model-editor/languages/ruby/generate.ts
+++ b/extensions/ql-vscode/src/model-editor/languages/ruby/generate.ts
@@ -1,9 +1,6 @@
 import type { BaseLogger } from "../../../common/logging";
 import type { DecodedBqrs } from "../../../common/bqrs-cli-types";
-import type {
-  GenerationContext,
-  ModelsAsDataLanguage,
-} from "../models-as-data";
+import type { ModelsAsDataLanguage } from "../models-as-data";
 import type { ModeledMethod } from "../../modeled-method";
 import type { DataTuple } from "../../model-extension-file";
 
@@ -12,21 +9,10 @@ export function parseGenerateModelResults(
   bqrs: DecodedBqrs,
   modelsAsDataLanguage: ModelsAsDataLanguage,
   logger: BaseLogger,
-  { config }: GenerationContext,
 ): ModeledMethod[] {
   const modeledMethods: ModeledMethod[] = [];
 
   for (const resultSetName in bqrs) {
-    if (
-      resultSetName ===
-        modelsAsDataLanguage.predicates.type?.extensiblePredicate &&
-      !config.showTypeModels
-    ) {
-      // Don't load generated type results when type models are hidden. These are already
-      // automatically generated on start-up.
-      continue;
-    }
-
     const definition = Object.values(modelsAsDataLanguage.predicates).find(
       (definition) => definition.extensiblePredicate === resultSetName,
     );

--- a/extensions/ql-vscode/src/model-editor/languages/ruby/index.ts
+++ b/extensions/ql-vscode/src/model-editor/languages/ruby/index.ts
@@ -170,7 +170,6 @@ export const ruby: ModelsAsDataLanguage = {
           methodParameters: "",
         };
       },
-      isHidden: ({ config }) => !config.showTypeModels,
     },
   },
   modelGeneration: {
@@ -210,7 +209,7 @@ export const ruby: ModelsAsDataLanguage = {
         },
       ];
     },
-    parseResults: (queryPath, bqrs, modelsAsDataLanguage, logger, context) => {
+    parseResults: (queryPath, bqrs, modelsAsDataLanguage, logger) => {
       // Only parse type models when automatically generating models
       const typePredicate = modelsAsDataLanguage.predicates.type;
       if (!typePredicate) {
@@ -229,13 +228,12 @@ export const ruby: ModelsAsDataLanguage = {
         },
         modelsAsDataLanguage,
         logger,
-        context,
       );
     },
     // Only enabled for framework mode when type models are hidden
-    type: ({ mode, config }) =>
-      mode === Mode.Framework && !config.showTypeModels
-        ? AutoModelGenerationType.SeparateFile
+    type: ({ mode }) =>
+      mode === Mode.Framework
+        ? AutoModelGenerationType.Models
         : AutoModelGenerationType.Disabled,
   },
   accessPathSuggestions: {

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -278,7 +278,6 @@ export class ModelEditorView extends AbstractWebview<
                 modeledMethods,
                 mode,
                 this.cliServer,
-                this.modelConfig,
                 this.app.logger,
               );
 
@@ -487,7 +486,6 @@ export class ModelEditorView extends AbstractWebview<
         this.extensionPack,
         this.language,
         this.cliServer,
-        this.modelConfig,
         this.app.logger,
       );
       this.modelingStore.setModeledMethods(this.databaseItem, modeledMethods);

--- a/extensions/ql-vscode/src/view/model-editor/__tests__/ModelTypeDropdown.spec.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/__tests__/ModelTypeDropdown.spec.tsx
@@ -36,33 +36,7 @@ describe(ModelTypeDropdown.name, () => {
     );
   });
 
-  it("allows changing the type to 'Type' for Ruby when type models are shown", async () => {
-    const method = createMethod();
-    const modeledMethod = createNoneModeledMethod();
-
-    render(
-      <ModelTypeDropdown
-        language={QueryLanguage.Ruby}
-        modeledMethod={modeledMethod}
-        modelPending={false}
-        onChange={onChange}
-        method={method}
-        modelConfig={{
-          ...defaultModelConfig,
-          showTypeModels: true,
-        }}
-      />,
-    );
-
-    await userEvent.selectOptions(screen.getByRole("combobox"), "type");
-    expect(onChange).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: "type",
-      }),
-    );
-  });
-
-  it("does not allow changing the type to 'Type' for Ruby when type models are not shown", async () => {
+  it("allows changing the type to 'Type' for Ruby", async () => {
     const method = createMethod();
     const modeledMethod = createNoneModeledMethod();
 
@@ -77,9 +51,12 @@ describe(ModelTypeDropdown.name, () => {
       />,
     );
 
-    expect(
-      screen.queryByRole("option", { name: "Type" }),
-    ).not.toBeInTheDocument();
+    await userEvent.selectOptions(screen.getByRole("combobox"), "type");
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "type",
+      }),
+    );
   });
 
   it("does not allow changing the type to 'Type' for Java", async () => {

--- a/extensions/ql-vscode/test/unit-tests/model-editor/languages/ruby/generate.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/model-editor/languages/ruby/generate.test.ts
@@ -4,8 +4,6 @@ import { ruby } from "../../../../../src/model-editor/languages/ruby";
 import { createMockLogger } from "../../../../__mocks__/loggerMock";
 import type { ModeledMethod } from "../../../../../src/model-editor/modeled-method";
 import { EndpointType } from "../../../../../src/model-editor/method";
-import { Mode } from "../../../../../src/model-editor/shared/mode";
-import { defaultModelConfig } from "../../../../../src/model-editor/languages";
 
 describe("parseGenerateModelResults", () => {
   it("should return the results", async () => {
@@ -78,13 +76,6 @@ describe("parseGenerateModelResults", () => {
       bqrs,
       ruby,
       createMockLogger(),
-      {
-        mode: Mode.Framework,
-        config: {
-          ...defaultModelConfig,
-          showTypeModels: true,
-        },
-      },
     );
     expect(result).toEqual([
       {

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/model-editor/modeled-method-fs.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/model-editor/modeled-method-fs.test.ts
@@ -13,7 +13,6 @@ import { homedir, tmpdir } from "os";
 import { mkdir, rm } from "fs-extra";
 import { nanoid } from "nanoid";
 import { QueryLanguage } from "../../../../src/common/query-language";
-import { defaultModelConfig } from "../../../../src/model-editor/languages";
 
 const dummyExtensionPackContents = `
 name: dummy/pack
@@ -136,11 +135,7 @@ describe("modeled-method-fs", () => {
     it("should return the empty set when the extension pack is empty", async () => {
       const extensionPackPath = writeExtensionPackFiles("extension-pack", []);
 
-      const modelFiles = await listModelFiles(
-        extensionPackPath,
-        cli,
-        defaultModelConfig,
-      );
+      const modelFiles = await listModelFiles(extensionPackPath, cli);
       expect(modelFiles).toEqual(new Set());
     });
 
@@ -150,11 +145,7 @@ describe("modeled-method-fs", () => {
         "library2.model.yml",
       ]);
 
-      const modelFiles = await listModelFiles(
-        extensionPackPath,
-        cli,
-        defaultModelConfig,
-      );
+      const modelFiles = await listModelFiles(extensionPackPath, cli);
       expect(modelFiles).toEqual(
         new Set([
           join("models", "library1.model.yml"),
@@ -163,40 +154,16 @@ describe("modeled-method-fs", () => {
       );
     });
 
-    it("should ignore generated type models when type models are hidden", async () => {
+    it("should ignore generated models", async () => {
       const extensionPackPath = writeExtensionPackFiles("extension-pack", [
         "library1.model.yml",
         "library2.model.yml",
         "library.model.generated.yml",
       ]);
 
-      const modelFiles = await listModelFiles(
-        extensionPackPath,
-        cli,
-        defaultModelConfig,
-      );
+      const modelFiles = await listModelFiles(extensionPackPath, cli);
       expect(modelFiles).toEqual(
         new Set([
-          join("models", "library1.model.yml"),
-          join("models", "library2.model.yml"),
-        ]),
-      );
-    });
-
-    it("should include generated type models when type models are shown", async () => {
-      const extensionPackPath = writeExtensionPackFiles("extension-pack", [
-        "library1.model.yml",
-        "library2.model.yml",
-        "library.model.generated.yml",
-      ]);
-
-      const modelFiles = await listModelFiles(extensionPackPath, cli, {
-        ...defaultModelConfig,
-        showTypeModels: true,
-      });
-      expect(modelFiles).toEqual(
-        new Set([
-          join("models", "library.model.generated.yml"),
           join("models", "library1.model.yml"),
           join("models", "library2.model.yml"),
         ]),
@@ -209,11 +176,7 @@ describe("modeled-method-fs", () => {
       ]);
       writeExtensionPackFiles("another-extension-pack", ["library2.model.yml"]);
 
-      const modelFiles = await listModelFiles(
-        extensionPackPath,
-        cli,
-        defaultModelConfig,
-      );
+      const modelFiles = await listModelFiles(extensionPackPath, cli);
       expect(modelFiles).toEqual(
         new Set([join("models", "library1.model.yml")]),
       );
@@ -230,7 +193,6 @@ describe("modeled-method-fs", () => {
         makeExtensionPack(extensionPackPath),
         QueryLanguage.Java,
         cli,
-        defaultModelConfig,
         extLogger,
       );
 

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/generate.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/generate.test.ts
@@ -138,10 +138,7 @@ describe("runGenerateQueries", () => {
             createMockLogger(),
             {
               mode: Mode.Framework,
-              config: {
-                ...defaultModelConfig,
-                showTypeModels: true,
-              },
+              config: defaultModelConfig,
             },
           ),
         );

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/method-modeling/method-modeling-view-provider.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/method-modeling/method-modeling-view-provider.test.ts
@@ -4,7 +4,10 @@ import { MethodModelingViewProvider } from "../../../../../src/model-editor/meth
 import { createMockApp } from "../../../../__mocks__/appMock";
 import { createMockModelingStore } from "../../../../__mocks__/model-editor/modelingStoreMock";
 import { mockedObject } from "../../../../mocked-object";
-import type { FromMethodModelingMessage } from "../../../../../src/common/interface-types";
+import type {
+  FromMethodModelingMessage,
+  ToMethodModelingMessage,
+} from "../../../../../src/common/interface-types";
 import { DisposableObject } from "../../../../../src/common/disposable-object";
 import { ModelingEvents } from "../../../../../src/model-editor/modeling-events";
 import type {
@@ -17,6 +20,7 @@ import {
   createMethod,
   createUsage,
 } from "../../../../factories/model-editor/method-factories";
+import { QueryLanguage } from "../../../../../src/common/query-language";
 
 describe("method modeling view provider", () => {
   // Modeling store
@@ -45,7 +49,7 @@ describe("method modeling view provider", () => {
     const modelingEvents = new ModelingEvents(app);
 
     const modelConfigListener = mockedObject<ModelConfigListener>({
-      showTypeModels: true,
+      flowGeneration: true,
       onDidChangeConfiguration: jest.fn(),
     });
 
@@ -91,10 +95,10 @@ describe("method modeling view provider", () => {
       viewState: {
         language: undefined,
         modelConfig: {
-          showTypeModels: true,
+          flowGeneration: true,
         },
       },
-    });
+    } satisfies ToMethodModelingMessage);
   });
 
   it("should load webview when active DB but no selected method", async () => {
@@ -116,10 +120,10 @@ describe("method modeling view provider", () => {
       viewState: {
         language: undefined,
         modelConfig: {
-          showTypeModels: true,
+          flowGeneration: true,
         },
       },
-    });
+    } satisfies ToMethodModelingMessage);
     expect(postMessage).toHaveBeenNthCalledWith(2, {
       t: "setInModelingMode",
       inModelingMode: true,
@@ -127,12 +131,12 @@ describe("method modeling view provider", () => {
     expect(postMessage).toHaveBeenNthCalledWith(3, {
       t: "setMethodModelingPanelViewState",
       viewState: {
-        language: "java",
+        language: QueryLanguage.Java,
         modelConfig: {
-          showTypeModels: true,
+          flowGeneration: true,
         },
       },
-    });
+    } satisfies ToMethodModelingMessage);
   });
 
   it("should load webview when active DB and a selected method", async () => {
@@ -165,10 +169,10 @@ describe("method modeling view provider", () => {
       viewState: {
         language: undefined,
         modelConfig: {
-          showTypeModels: true,
+          flowGeneration: true,
         },
       },
-    });
+    } satisfies ToMethodModelingMessage);
     expect(postMessage).toHaveBeenNthCalledWith(2, {
       t: "setInModelingMode",
       inModelingMode: true,
@@ -176,12 +180,12 @@ describe("method modeling view provider", () => {
     expect(postMessage).toHaveBeenNthCalledWith(3, {
       t: "setMethodModelingPanelViewState",
       viewState: {
-        language: "java",
+        language: QueryLanguage.Java,
         modelConfig: {
-          showTypeModels: true,
+          flowGeneration: true,
         },
       },
-    });
+    } satisfies ToMethodModelingMessage);
     expect(postMessage).toHaveBeenNthCalledWith(4, {
       t: "setSelectedMethod",
       method: selectedMethodDetails.method,


### PR DESCRIPTION
This removes the `codeQL.model.showTypeModels` setting. We will now always show type models in the model editor. This also means that the "auto-generation mode" needs to change to `models` to ensure that the type models are actually shown to the user. This is done for Ruby, which is currently the only language to show type models.

This does not need a changelog entry because the Ruby model editor is only available in canary mode.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
