### PR TITLE
Move octokit throttling plugin dependency out of dev dependencies

### DIFF
--- a/extensions/ql-vscode/package-lock.json
+++ b/extensions/ql-vscode/package-lock.json
@@ -12,6 +12,7 @@
       "dependencies": {
         "@floating-ui/react": "^0.26.10",
         "@octokit/plugin-retry": "^6.0.1",
+        "@octokit/plugin-throttling": "^8.0.0",
         "@octokit/rest": "^20.0.2",
         "@vscode/codicons": "^0.0.35",
         "@vscode/debugadapter": "^1.59.0",
@@ -52,7 +53,6 @@
         "@babel/preset-typescript": "^7.21.4",
         "@faker-js/faker": "^8.4.1",
         "@github/markdownlint-github": "^0.6.2",
-        "@octokit/plugin-throttling": "^8.0.0",
         "@playwright/test": "^1.40.1",
         "@storybook/addon-a11y": "^8.0.8",
         "@storybook/addon-actions": "^8.0.8",
@@ -4379,7 +4379,6 @@
       "version": "8.1.3",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-8.1.3.tgz",
       "integrity": "sha512-pfyqaqpc0EXh5Cn4HX9lWYsZ4gGbjnSmUILeu4u2gnuM50K/wIk9s1Pxt3lVeVwekmITgN/nJdoh43Ka+vye8A==",
-      "dev": true,
       "dependencies": {
         "@octokit/types": "^12.2.0",
         "bottleneck": "^2.15.3"

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1969,6 +1969,7 @@
   },
   "dependencies": {
     "@floating-ui/react": "^0.26.10",
+    "@octokit/plugin-throttling": "^8.0.0",
     "@octokit/plugin-retry": "^6.0.1",
     "@octokit/rest": "^20.0.2",
     "@vscode/codicons": "^0.0.35",
@@ -2010,7 +2011,6 @@
     "@babel/preset-typescript": "^7.21.4",
     "@faker-js/faker": "^8.4.1",
     "@github/markdownlint-github": "^0.6.2",
-    "@octokit/plugin-throttling": "^8.0.0",
     "@playwright/test": "^1.40.1",
     "@storybook/addon-a11y": "^8.0.8",
     "@storybook/addon-actions": "^8.0.8",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1969,8 +1969,8 @@
   },
   "dependencies": {
     "@floating-ui/react": "^0.26.10",
-    "@octokit/plugin-throttling": "^8.0.0",
     "@octokit/plugin-retry": "^6.0.1",
+    "@octokit/plugin-throttling": "^8.0.0",
     "@octokit/rest": "^20.0.2",
     "@vscode/codicons": "^0.0.35",
     "@vscode/debugadapter": "^1.59.0",


### PR DESCRIPTION
The `@octokit/plugin-throttling` dependency was incorrectly placed in the `devDependencies` section.

## Checklist
N/A:
- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
