### PR TITLE
Detect when the github-enterprise.uri setting is set

### DIFF
--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -4,7 +4,7 @@ import type {
   ConfigurationScope,
   Event,
 } from "vscode";
-import { ConfigurationTarget, EventEmitter, workspace } from "vscode";
+import { ConfigurationTarget, EventEmitter, workspace, Uri } from "vscode";
 import type { DistributionManager } from "./codeql-cli/distribution";
 import { extLogger } from "./common/logging/vscode";
 import { ONE_DAY_IN_MS } from "./common/time";
@@ -14,6 +14,7 @@ import {
   SortKey,
 } from "./variant-analysis/shared/variant-analysis-filter-sort";
 import { substituteConfigVariables } from "./common/config-template";
+import { getErrorMessage } from "./common/helpers-pure";
 
 export const ALL_SETTINGS: Setting[] = [];
 
@@ -68,6 +69,52 @@ export const VSCODE_SAVE_BEFORE_START_SETTING = new Setting(
   "saveBeforeStart",
   VSCODE_DEBUG_SETTING,
 );
+
+const VSCODE_GITHUB_ENTERPRISE_SETTING = new Setting(
+  "github-enterprise",
+  undefined,
+);
+export const VSCODE_GITHUB_ENTERPRISE_URI_SETTING = new Setting(
+  "uri",
+  VSCODE_GITHUB_ENTERPRISE_SETTING,
+);
+
+/**
+ * Get the value of the `github-enterprise.uri` setting, parsed as a URI.
+ * If the value is not set or cannot be parsed, return `undefined`.
+ */
+export function getEnterpriseUri(): Uri | undefined {
+  const config = VSCODE_GITHUB_ENTERPRISE_URI_SETTING.getValue<string>();
+  if (config) {
+    try {
+      let uri = Uri.parse(config, true);
+      if (uri.scheme === "http") {
+        uri = uri.with({ scheme: "https" });
+      }
+      return uri;
+    } catch (e) {
+      void extLogger.log(
+        `Failed to parse the GitHub Enterprise URI: ${getErrorMessage(e)}`,
+      );
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Is the GitHub Enterprise URI set?
+ */
+export function hasEnterpriseUri(): boolean {
+  return getEnterpriseUri() !== undefined;
+}
+
+/**
+ * Is the GitHub Enterprise URI set to something that looks like GHEC-DR?
+ */
+export function hasGhecDrUri(): boolean {
+  const uri = getEnterpriseUri();
+  return uri !== undefined && uri.authority.match(/.*\.ghe\.com/) !== null;
+}
 
 const ROOT_SETTING = new Setting("codeQL");
 
@@ -575,6 +622,11 @@ export function getVariantAnalysisDefaultResultsSort(): SortKey {
  * Note: This command is only available for internal users.
  */
 const ACTION_BRANCH = new Setting("actionBranch", VARIANT_ANALYSIS_SETTING);
+
+export const VARIANT_ANALYSIS_ENABLE_GHEC_DR = new Setting(
+  "enable_ghec_dr",
+  VARIANT_ANALYSIS_SETTING,
+);
 
 export function getActionBranch(): string {
   return ACTION_BRANCH.getValue<string>() || "main";

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -113,7 +113,7 @@ export function hasEnterpriseUri(): boolean {
  */
 export function hasGhecDrUri(): boolean {
   const uri = getEnterpriseUri();
-  return uri !== undefined && uri.authority.match(/.*\.ghe\.com/) !== null;
+  return uri !== undefined && uri.authority.toLowerCase().endsWith(".ghe.com");
 }
 
 const ROOT_SETTING = new Setting("codeQL");

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -624,7 +624,7 @@ export function getVariantAnalysisDefaultResultsSort(): SortKey {
 const ACTION_BRANCH = new Setting("actionBranch", VARIANT_ANALYSIS_SETTING);
 
 export const VARIANT_ANALYSIS_ENABLE_GHEC_DR = new Setting(
-  "enable_ghec_dr",
+  "enableGhecDr",
   VARIANT_ANALYSIS_SETTING,
 );
 

--- a/extensions/ql-vscode/src/variant-analysis/ghec-dr.ts
+++ b/extensions/ql-vscode/src/variant-analysis/ghec-dr.ts
@@ -1,0 +1,18 @@
+import {
+  VARIANT_ANALYSIS_ENABLE_GHEC_DR,
+  hasEnterpriseUri,
+  hasGhecDrUri,
+} from "../config";
+
+/**
+ * Determines whether MRVA should be enabled or not for the current GitHub host.
+ * This is based on the `github-enterprise.uri` setting.
+ */
+export function isVariantAnalysisEnabledForGitHubHost(): boolean {
+  return (
+    // MRVA is always enabled on github.com
+    !hasEnterpriseUri() ||
+    // MRVA can be enabled on GHEC-DR using a feature flag
+    (hasGhecDrUri() && !!VARIANT_ANALYSIS_ENABLE_GHEC_DR.getValue<boolean>())
+  );
+}

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -97,6 +97,8 @@ import { getOnDiskWorkspaceFolders } from "../common/vscode/workspace-folders";
 import { findVariantAnalysisQlPackRoot } from "./ql";
 import { resolveCodeScanningQueryPack } from "./code-scanning-pack";
 import { isSarifResultsQueryKind } from "../common/query-metadata";
+import { isVariantAnalysisEnabledForGitHubHost } from "./ghec-dr";
+import { getEnterpriseUri } from "../config";
 
 const maxRetryCount = 3;
 
@@ -327,6 +329,12 @@ export class VariantAnalysisManager
     token: CancellationToken,
     openViewAfterSubmission = true,
   ): Promise<number | undefined> {
+    if (!isVariantAnalysisEnabledForGitHubHost()) {
+      throw new Error(
+        `Multi-repository variant analysis is not enabled for ${getEnterpriseUri()}`,
+      );
+    }
+
     await saveBeforeStart();
 
     progress({

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/variant-analysis/ghec-dr.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/variant-analysis/ghec-dr.test.ts
@@ -1,0 +1,44 @@
+import { ConfigurationTarget } from "vscode";
+import {
+  VARIANT_ANALYSIS_ENABLE_GHEC_DR,
+  VSCODE_GITHUB_ENTERPRISE_URI_SETTING,
+} from "../../../../src/config";
+import { isVariantAnalysisEnabledForGitHubHost } from "../../../../src/variant-analysis/ghec-dr";
+
+describe("checkVariantAnalysisEnabled", () => {
+  it("returns cleanly when no enterprise URI is set", async () => {
+    expect(isVariantAnalysisEnabledForGitHubHost()).toBe(true);
+  });
+
+  it("returns false when GHES enterprise URI is set", async () => {
+    await VSCODE_GITHUB_ENTERPRISE_URI_SETTING.updateValue(
+      "https://github.example.com",
+      ConfigurationTarget.Global,
+    );
+    await VARIANT_ANALYSIS_ENABLE_GHEC_DR.updateValue(
+      "true",
+      ConfigurationTarget.Global,
+    );
+    expect(isVariantAnalysisEnabledForGitHubHost()).toBe(false);
+  });
+
+  it("returns false when GHEC-DR URI is set but variant analysis feature flag is not set", async () => {
+    await VSCODE_GITHUB_ENTERPRISE_URI_SETTING.updateValue(
+      "https://github.example.com",
+      ConfigurationTarget.Global,
+    );
+    expect(isVariantAnalysisEnabledForGitHubHost()).toBe(false);
+  });
+
+  it("returns true when GHEC-DR URI is set and variant analysis feature flag is set", async () => {
+    await VSCODE_GITHUB_ENTERPRISE_URI_SETTING.updateValue(
+      "https://example.ghe.com",
+      ConfigurationTarget.Global,
+    );
+    await VARIANT_ANALYSIS_ENABLE_GHEC_DR.updateValue(
+      "true",
+      ConfigurationTarget.Global,
+    );
+    expect(isVariantAnalysisEnabledForGitHubHost()).toBe(true);
+  });
+});

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/variant-analysis/ghec-dr.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/variant-analysis/ghec-dr.test.ts
@@ -10,7 +10,15 @@ describe("checkVariantAnalysisEnabled", () => {
     expect(isVariantAnalysisEnabledForGitHubHost()).toBe(true);
   });
 
-  it("returns false when GHES enterprise URI is set", async () => {
+  it("returns false when GHES enterprise URI is set and variant analysis feature flag is not set", async () => {
+    await VSCODE_GITHUB_ENTERPRISE_URI_SETTING.updateValue(
+      "https://github.example.com",
+      ConfigurationTarget.Global,
+    );
+    expect(isVariantAnalysisEnabledForGitHubHost()).toBe(false);
+  });
+
+  it("returns false when GHES enterprise URI is set and variant analysis feature flag is set", async () => {
     await VSCODE_GITHUB_ENTERPRISE_URI_SETTING.updateValue(
       "https://github.example.com",
       ConfigurationTarget.Global,
@@ -22,9 +30,9 @@ describe("checkVariantAnalysisEnabled", () => {
     expect(isVariantAnalysisEnabledForGitHubHost()).toBe(false);
   });
 
-  it("returns false when GHEC-DR URI is set but variant analysis feature flag is not set", async () => {
+  it("returns false when GHEC-DR URI is set and variant analysis feature flag is not set", async () => {
     await VSCODE_GITHUB_ENTERPRISE_URI_SETTING.updateValue(
-      "https://github.example.com",
+      "https://example.ghe.com",
       ConfigurationTarget.Global,
     );
     expect(isVariantAnalysisEnabledForGitHubHost()).toBe(false);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

This adds code that reads the `github-enterprise.uri` setting and uses that to decide if we're on github.com, a GHES instance, or GHEC-DR (which as far as I know is the public name so I'll try to refer to it that way in this repo).

The logic for parsing the URI is taken from https://github.com/microsoft/vscode-pull-request-github/blob/a116c509bf98f066f302f25f1716d884df3322db/src/github/utils.ts#L1275 so we keep vaguely consistent with that extension. I'm not totally sure about the logic of ignoring an invalid URI but that's how they've coded it (or actually their code might throw an error).

Then we also add another setting to act as a feature flag to allow using MRVA on GHEC-DR. Right now this is the only thing that these settings control, and they're only checked when trying to trigger a new MRVA. I think that only checking when triggering a new MRVA is probably the best compromise, rather than trying to hide all existence of MRVA in the extension. I think it fits nicely with our decision around requiring a different workspace for each GitHub environment.

Eventually we'll remove the feature flag so MRVA is always enabled on GHEC-DR, though we'll have to keep some of this code to check for other values of the `github-enterprise.uri` setting like GHES URIs.

I do think this turned out more complicated that I expected it to be. I'm not sure if that's because I've made it more complicated than it needs to be or if this is just how it has to be.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
