### PR TITLE
Hide system defined lists when enterprise URI is set

### DIFF
--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -570,6 +570,7 @@ export async function setRemoteControllerRepo(repo: string | undefined) {
 export interface VariantAnalysisConfig {
   controllerRepo: string | undefined;
   onDidChangeConfiguration?: Event<void>;
+  showSystemDefinedRepositoryLists: boolean;
 }
 
 export class VariantAnalysisConfigListener
@@ -578,13 +579,17 @@ export class VariantAnalysisConfigListener
 {
   protected handleDidChangeConfiguration(e: ConfigurationChangeEvent): void {
     this.handleDidChangeConfigurationForRelevantSettings(
-      [VARIANT_ANALYSIS_SETTING],
+      [VARIANT_ANALYSIS_SETTING, VSCODE_GITHUB_ENTERPRISE_URI_SETTING],
       e,
     );
   }
 
   public get controllerRepo(): string | undefined {
     return getRemoteControllerRepo();
+  }
+
+  public get showSystemDefinedRepositoryLists(): boolean {
+    return !hasEnterpriseUri();
   }
 }
 

--- a/extensions/ql-vscode/src/databases/db-tree-creator.ts
+++ b/extensions/ql-vscode/src/databases/db-tree-creator.ts
@@ -1,3 +1,4 @@
+import type { VariantAnalysisConfig } from "../config";
 import type { DbConfig, RemoteRepositoryList } from "./config/db-config";
 import { SelectedDbItemKind } from "./config/db-config";
 import type {
@@ -13,13 +14,17 @@ import { ExpandedDbItemKind } from "./db-item-expansion";
 
 export function createRemoteTree(
   dbConfig: DbConfig,
+  variantAnalysisConfig: VariantAnalysisConfig,
   expandedItems: ExpandedDbItem[],
 ): RootRemoteDbItem {
-  const systemDefinedLists = [
-    createSystemDefinedList(10, dbConfig),
-    createSystemDefinedList(100, dbConfig),
-    createSystemDefinedList(1000, dbConfig),
-  ];
+  const systemDefinedLists =
+    variantAnalysisConfig.showSystemDefinedRepositoryLists
+      ? [
+          createSystemDefinedList(10, dbConfig),
+          createSystemDefinedList(100, dbConfig),
+          createSystemDefinedList(1000, dbConfig),
+        ]
+      : [];
 
   const userDefinedRepoLists =
     dbConfig.databases.variantAnalysis.repositoryLists.map((r) =>

--- a/extensions/ql-vscode/test/unit-tests/databases/db-tree-creator.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/databases/db-tree-creator.test.ts
@@ -1,3 +1,4 @@
+import type { VariantAnalysisConfig } from "../../../src/config";
 import type { DbConfig } from "../../../src/databases/config/db-config";
 import { SelectedDbItemKind } from "../../../src/databases/config/db-config";
 import {
@@ -12,11 +13,20 @@ import { createRemoteTree } from "../../../src/databases/db-tree-creator";
 import { createDbConfig } from "../../factories/db-config-factories";
 
 describe("db tree creator", () => {
+  const defaultVariantAnalysisConfig: VariantAnalysisConfig = {
+    controllerRepo: "foo/bar",
+    showSystemDefinedRepositoryLists: true,
+  };
+
   describe("createRemoteTree", () => {
     it("should build root node and system defined lists", () => {
       const dbConfig = createDbConfig();
 
-      const dbTreeRoot = createRemoteTree(dbConfig, []);
+      const dbTreeRoot = createRemoteTree(
+        dbConfig,
+        defaultVariantAnalysisConfig,
+        [],
+      );
 
       expect(dbTreeRoot).toBeTruthy();
       expect(dbTreeRoot.kind).toBe(DbItemKind.RootRemote);
@@ -45,6 +55,24 @@ describe("db tree creator", () => {
       });
     });
 
+    it("displays empty list when no remote user defined list nodes and system defined lists are disabled", () => {
+      const dbConfig = createDbConfig();
+
+      const dbTreeRoot = createRemoteTree(
+        dbConfig,
+        {
+          ...defaultVariantAnalysisConfig,
+          showSystemDefinedRepositoryLists: false,
+        },
+        [],
+      );
+
+      expect(dbTreeRoot).toBeTruthy();
+      expect(dbTreeRoot.kind).toBe(DbItemKind.RootRemote);
+      expect(dbTreeRoot.expanded).toBe(false);
+      expect(dbTreeRoot.children.length).toBe(0);
+    });
+
     it("should create remote user defined list nodes", () => {
       const dbConfig = createDbConfig({
         remoteLists: [
@@ -59,10 +87,15 @@ describe("db tree creator", () => {
         ],
       });
 
-      const dbTreeRoot = createRemoteTree(dbConfig, []);
+      const dbTreeRoot = createRemoteTree(
+        dbConfig,
+        defaultVariantAnalysisConfig,
+        [],
+      );
 
       expect(dbTreeRoot).toBeTruthy();
       expect(dbTreeRoot.kind).toBe(DbItemKind.RootRemote);
+      expect(dbTreeRoot.children.length).toBe(5);
       const repositoryListNodes = dbTreeRoot.children.filter(
         isRemoteUserDefinedListDbItem,
       );
@@ -102,12 +135,76 @@ describe("db tree creator", () => {
       });
     });
 
+    it("shows only user defined list nodes when system defined lists are disabled", () => {
+      const dbConfig = createDbConfig({
+        remoteLists: [
+          {
+            name: "my-list-1",
+            repositories: ["owner1/repo1", "owner1/repo2", "owner2/repo1"],
+          },
+          {
+            name: "my-list-2",
+            repositories: ["owner3/repo1", "owner3/repo2", "owner4/repo1"],
+          },
+        ],
+      });
+
+      const dbTreeRoot = createRemoteTree(
+        dbConfig,
+        {
+          ...defaultVariantAnalysisConfig,
+          showSystemDefinedRepositoryLists: false,
+        },
+        [],
+      );
+
+      expect(dbTreeRoot).toBeTruthy();
+      expect(dbTreeRoot.kind).toBe(DbItemKind.RootRemote);
+      expect(dbTreeRoot.children.length).toBe(2);
+      expect(dbTreeRoot.children[0]).toEqual({
+        kind: DbItemKind.RemoteUserDefinedList,
+        selected: false,
+        expanded: false,
+        listName: dbConfig.databases.variantAnalysis.repositoryLists[0].name,
+        repos:
+          dbConfig.databases.variantAnalysis.repositoryLists[0].repositories.map(
+            (repo) => ({
+              kind: DbItemKind.RemoteRepo,
+              selected: false,
+              repoFullName: repo,
+              parentListName:
+                dbConfig.databases.variantAnalysis.repositoryLists[0].name,
+            }),
+          ),
+      });
+      expect(dbTreeRoot.children[1]).toEqual({
+        kind: DbItemKind.RemoteUserDefinedList,
+        selected: false,
+        expanded: false,
+        listName: dbConfig.databases.variantAnalysis.repositoryLists[1].name,
+        repos:
+          dbConfig.databases.variantAnalysis.repositoryLists[1].repositories.map(
+            (repo) => ({
+              kind: DbItemKind.RemoteRepo,
+              selected: false,
+              repoFullName: repo,
+              parentListName:
+                dbConfig.databases.variantAnalysis.repositoryLists[1].name,
+            }),
+          ),
+      });
+    });
+
     it("should create remote owner nodes", () => {
       const dbConfig: DbConfig = createDbConfig({
         remoteOwners: ["owner1", "owner2"],
       });
 
-      const dbTreeRoot = createRemoteTree(dbConfig, []);
+      const dbTreeRoot = createRemoteTree(
+        dbConfig,
+        defaultVariantAnalysisConfig,
+        [],
+      );
 
       expect(dbTreeRoot).toBeTruthy();
       expect(dbTreeRoot.kind).toBe(DbItemKind.RootRemote);
@@ -131,7 +228,11 @@ describe("db tree creator", () => {
         remoteRepos: ["owner1/repo1", "owner1/repo2", "owner2/repo1"],
       });
 
-      const dbTreeRoot = createRemoteTree(dbConfig, []);
+      const dbTreeRoot = createRemoteTree(
+        dbConfig,
+        defaultVariantAnalysisConfig,
+        [],
+      );
 
       expect(dbTreeRoot).toBeTruthy();
       expect(dbTreeRoot.kind).toBe(DbItemKind.RootRemote);
@@ -170,7 +271,11 @@ describe("db tree creator", () => {
           },
         });
 
-        const dbTreeRoot = createRemoteTree(dbConfig, []);
+        const dbTreeRoot = createRemoteTree(
+          dbConfig,
+          defaultVariantAnalysisConfig,
+          [],
+        );
 
         expect(dbTreeRoot).toBeTruthy();
         expect(dbTreeRoot.kind).toBe(DbItemKind.RootRemote);
@@ -191,7 +296,11 @@ describe("db tree creator", () => {
           },
         });
 
-        const dbTreeRoot = createRemoteTree(dbConfig, []);
+        const dbTreeRoot = createRemoteTree(
+          dbConfig,
+          defaultVariantAnalysisConfig,
+          [],
+        );
 
         expect(dbTreeRoot).toBeTruthy();
         expect(dbTreeRoot.kind).toBe(DbItemKind.RootRemote);
@@ -213,7 +322,11 @@ describe("db tree creator", () => {
           },
         });
 
-        const dbTreeRoot = createRemoteTree(dbConfig, []);
+        const dbTreeRoot = createRemoteTree(
+          dbConfig,
+          defaultVariantAnalysisConfig,
+          [],
+        );
 
         expect(dbTreeRoot).toBeTruthy();
         expect(dbTreeRoot.kind).toBe(DbItemKind.RootRemote);
@@ -240,7 +353,11 @@ describe("db tree creator", () => {
           },
         });
 
-        const dbTreeRoot = createRemoteTree(dbConfig, []);
+        const dbTreeRoot = createRemoteTree(
+          dbConfig,
+          defaultVariantAnalysisConfig,
+          [],
+        );
 
         expect(dbTreeRoot).toBeTruthy();
 
@@ -265,7 +382,11 @@ describe("db tree creator", () => {
           },
         ];
 
-        const dbTreeRoot = createRemoteTree(dbConfig, expanded);
+        const dbTreeRoot = createRemoteTree(
+          dbConfig,
+          defaultVariantAnalysisConfig,
+          expanded,
+        );
 
         expect(dbTreeRoot).toBeTruthy();
         expect(dbTreeRoot.kind).toBe(DbItemKind.RootRemote);
@@ -291,7 +412,11 @@ describe("db tree creator", () => {
           },
         ];
 
-        const dbTreeRoot = createRemoteTree(dbConfig, expanded);
+        const dbTreeRoot = createRemoteTree(
+          dbConfig,
+          defaultVariantAnalysisConfig,
+          expanded,
+        );
 
         expect(dbTreeRoot).toBeTruthy();
         expect(dbTreeRoot.kind).toBe(DbItemKind.RootRemote);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Only show the "top10", "top100", "top1000" repository lists when MRVA is configured to github.com instead of another github instance.

I decided to add this to `VariantAnalysisConfigListener` because it's clearly a feature that's related to variant analysis (Thanks `@koesie10` for reminding me in the other PR that this interface exists), though technically it only depends on the `github-enterprise.uri` value. Still though I feel it makes logical sense to put it here. 🤷🏼

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
