### PR TITLE
Disable LLM model generation when not using github.com

### DIFF
--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -815,7 +815,10 @@ export interface ModelConfig {
 
 export class ModelConfigListener extends ConfigListener implements ModelConfig {
   protected handleDidChangeConfiguration(e: ConfigurationChangeEvent): void {
-    this.handleDidChangeConfigurationForRelevantSettings([MODEL_SETTING], e);
+    this.handleDidChangeConfigurationForRelevantSettings(
+      [MODEL_SETTING, VSCODE_GITHUB_ENTERPRISE_URI_SETTING],
+      e,
+    );
   }
 
   public get flowGeneration(): boolean {
@@ -823,7 +826,7 @@ export class ModelConfigListener extends ConfigListener implements ModelConfig {
   }
 
   public get llmGeneration(): boolean {
-    return !!LLM_GENERATION.getValue<boolean>();
+    return !!LLM_GENERATION.getValue<boolean>() && !hasEnterpriseUri();
   }
 
   /**


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Disable the LLM model generation feature when an enterprise URI is set. LLM generation is an in-progress feature that's also behind its own feature flag. It doesn't currently support enterprise environments, so we'll reenable this feature in the future once it is supported in more environments.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
