### PR TITLE
Add Ruby as a fully-supported model editor language

### DIFF
--- a/extensions/ql-vscode/src/model-editor/supported-languages.ts
+++ b/extensions/ql-vscode/src/model-editor/supported-languages.ts
@@ -1,6 +1,5 @@
 import { QueryLanguage } from "../common/query-language";
 import type { ModelConfig } from "../config";
-import { isCanary } from "../config";
 
 /**
  * Languages that are always supported by the model editor. These languages
@@ -9,6 +8,7 @@ import { isCanary } from "../config";
 export const SUPPORTED_LANGUAGES: QueryLanguage[] = [
   QueryLanguage.Java,
   QueryLanguage.CSharp,
+  QueryLanguage.Ruby,
 ];
 
 export function isSupportedLanguage(
@@ -17,11 +17,6 @@ export function isSupportedLanguage(
 ) {
   if (SUPPORTED_LANGUAGES.includes(language)) {
     return true;
-  }
-
-  if (language === QueryLanguage.Ruby) {
-    // Ruby is only enabled when in canary mode
-    return isCanary();
   }
 
   if (language === QueryLanguage.Python) {


### PR DESCRIPTION
This removes the requirement to have `codeQL.canary` set for the Ruby model editor.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
