### PR TITLE
Fix modeled method FS test

### DIFF
--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/model-editor/modeled-method-fs.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/model-editor/modeled-method-fs.test.ts
@@ -55,6 +55,12 @@ describe("modeled-method-fs", () => {
   let cli: CodeQLCliServer;
 
   beforeEach(async () => {
+    if (!process.env.TEST_CODEQL_PATH) {
+      fail(
+        "TEST_CODEQL_PATH environment variable not set. It should point to the absolute path to a checkout of the codeql repository.",
+      );
+    }
+
     // On windows, make sure to use a temp directory that isn't an alias and therefore won't be canonicalised by CodeQL.
     // The tmp package doesn't support this, so we have to do it manually.
     // See https://github.com/github/vscode-codeql/pull/2605 for more context.
@@ -73,11 +79,16 @@ describe("modeled-method-fs", () => {
       name: "workspace",
       index: 0,
     };
+    const codeqlWorkspaceFolder = {
+      uri: Uri.file(process.env.TEST_CODEQL_PATH),
+      name: "ql",
+      index: 1,
+    };
     workspacePath = workspaceFolder.uri.fsPath;
     mkdirSync(workspacePath);
     jest
       .spyOn(workspace, "workspaceFolders", "get")
-      .mockReturnValue([workspaceFolder]);
+      .mockReturnValue([workspaceFolder, codeqlWorkspaceFolder]);
 
     const extension = await getActivatedExtension();
     cli = extension.cliServer;


### PR DESCRIPTION
- Part of https://github.com/github/vscode-codeql/issues/3578

This fixes the modeled method FS tests for older CodeQL versions by using the CodeQL libraries from the workspace rather than downloading them.

[CLI run](https://github.com/github/vscode-codeql/actions/runs/8892859543)

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
