### PR TITLE
Always use the latest released CodeQL version in E2E tests

### DIFF
--- a/extensions/ql-vscode/test/e2e/docker/Dockerfile
+++ b/extensions/ql-vscode/test/e2e/docker/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
     unzip \
   && rm -rf /var/lib/apt/lists/*
 
-RUN wget -q -O /tmp/codeql.zip https://github.com/github/codeql-cli-binaries/releases/download/v2.15.5/codeql-linux64.zip \
+RUN wget -q -O /tmp/codeql.zip https://github.com/github/codeql-cli-binaries/releases/latest/download/codeql-linux64.zip \
   && unzip -q /tmp/codeql.zip -d /opt \
   && rm -rf /tmp/codeql.zip
 


### PR DESCRIPTION
This will always download the latest released CodeQL version rather than being fixed to v2.15.5.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
