### PR TITLE
Upgrade E2E test dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,3 +37,10 @@ updates:
       day: "thursday" # Thursday is arbitrary
     labels:
       - "Update dependencies"
+  - package-ecosystem: docker
+    directory: "extensions/ql-vscode/test/e2e"
+    schedule:
+      interval: "weekly"
+      day: "thursday" # Thursday is arbitrary
+    labels:
+      - "Update dependencies"

--- a/extensions/ql-vscode/test/e2e/docker-compose.yml
+++ b/extensions/ql-vscode/test/e2e/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     depends_on:
       - files-init
   files-init:
-    image: alpine:3.19.0
+    image: alpine:3.19.1
     restart: "no"
     # Since we're not running the code-server container using the same user as our host user,
     # we need to set the permissions on the mounted volumes to match the user inside the container.

--- a/extensions/ql-vscode/test/e2e/docker/Dockerfile
+++ b/extensions/ql-vscode/test/e2e/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM codercom/code-server:4.20.0
+FROM codercom/code-server:4.23.1
 
 USER root
 


### PR DESCRIPTION
This upgrades the `code-server` image to [v4.23.1](https://github.com/coder/code-server/releases/tag/v4.23.1) which runs VS Code 1.88.1. It also enables Dependabot for this Dockerfile such that we'll automatically get updates in the future.

I've also upgraded Alpine in the `docker-compose.yml` file since there's a new version, but this should not result in any changes.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
