### PR TITLE
Fix incorrect supported CLI version warning

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -446,8 +446,9 @@ export async function activate(
       }
 
       if (
-        CliVersionConstraint.OLDEST_SUPPORTED_CLI_VERSION.compare(ver.version) <
-        0
+        CliVersionConstraint.OLDEST_SUPPORTED_CLI_VERSION.compare(
+          ver.version,
+        ) <= 0
       ) {
         return;
       }


### PR DESCRIPTION
This fixes an issue with the supported CLI version warning. When you were on the oldest supported CLI version, we would show a confusing warning. This fixes the comparison to consider the oldest supported CLI version as supported.

Closes https://github.com/github/vscode-codeql/issues/3601

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
