### PR TITLE
Remove the enableGhecDr flag

### DIFF
--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -680,11 +680,6 @@ export function getVariantAnalysisDefaultResultsSort(): SortKey {
  */
 const ACTION_BRANCH = new Setting("actionBranch", VARIANT_ANALYSIS_SETTING);
 
-export const VARIANT_ANALYSIS_ENABLE_GHEC_DR = new Setting(
-  "enableGhecDr",
-  VARIANT_ANALYSIS_SETTING,
-);
-
 export function getActionBranch(): string {
   return ACTION_BRANCH.getValue<string>() || "main";
 }

--- a/extensions/ql-vscode/src/variant-analysis/ghec-dr.ts
+++ b/extensions/ql-vscode/src/variant-analysis/ghec-dr.ts
@@ -1,18 +1,10 @@
-import {
-  VARIANT_ANALYSIS_ENABLE_GHEC_DR,
-  hasEnterpriseUri,
-  hasGhecDrUri,
-} from "../config";
+import { hasEnterpriseUri, hasGhecDrUri } from "../config";
 
 /**
  * Determines whether MRVA should be enabled or not for the current GitHub host.
+ * MRVA is enabled on github.com and GHEC-DR.
  * This is based on the `github-enterprise.uri` setting.
  */
 export function isVariantAnalysisEnabledForGitHubHost(): boolean {
-  return (
-    // MRVA is always enabled on github.com
-    !hasEnterpriseUri() ||
-    // MRVA can be enabled on GHEC-DR using a feature flag
-    (hasGhecDrUri() && !!VARIANT_ANALYSIS_ENABLE_GHEC_DR.getValue<boolean>())
-  );
+  return !hasEnterpriseUri() || hasGhecDrUri();
 }

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/variant-analysis/ghec-dr.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/variant-analysis/ghec-dr.test.ts
@@ -1,16 +1,13 @@
 import { ConfigurationTarget } from "vscode";
-import {
-  VARIANT_ANALYSIS_ENABLE_GHEC_DR,
-  VSCODE_GITHUB_ENTERPRISE_URI_SETTING,
-} from "../../../../src/config";
+import { VSCODE_GITHUB_ENTERPRISE_URI_SETTING } from "../../../../src/config";
 import { isVariantAnalysisEnabledForGitHubHost } from "../../../../src/variant-analysis/ghec-dr";
 
 describe("checkVariantAnalysisEnabled", () => {
-  it("returns cleanly when no enterprise URI is set", async () => {
+  it("returns true when no enterprise URI is set", async () => {
     expect(isVariantAnalysisEnabledForGitHubHost()).toBe(true);
   });
 
-  it("returns false when GHES enterprise URI is set and variant analysis feature flag is not set", async () => {
+  it("returns false when GHES enterprise URI is set", async () => {
     await VSCODE_GITHUB_ENTERPRISE_URI_SETTING.updateValue(
       "https://github.example.com",
       ConfigurationTarget.Global,
@@ -18,33 +15,9 @@ describe("checkVariantAnalysisEnabled", () => {
     expect(isVariantAnalysisEnabledForGitHubHost()).toBe(false);
   });
 
-  it("returns false when GHES enterprise URI is set and variant analysis feature flag is set", async () => {
-    await VSCODE_GITHUB_ENTERPRISE_URI_SETTING.updateValue(
-      "https://github.example.com",
-      ConfigurationTarget.Global,
-    );
-    await VARIANT_ANALYSIS_ENABLE_GHEC_DR.updateValue(
-      "true",
-      ConfigurationTarget.Global,
-    );
-    expect(isVariantAnalysisEnabledForGitHubHost()).toBe(false);
-  });
-
-  it("returns false when GHEC-DR URI is set and variant analysis feature flag is not set", async () => {
+  it("returns true when a GHEC-DR URI is set", async () => {
     await VSCODE_GITHUB_ENTERPRISE_URI_SETTING.updateValue(
       "https://example.ghe.com",
-      ConfigurationTarget.Global,
-    );
-    expect(isVariantAnalysisEnabledForGitHubHost()).toBe(false);
-  });
-
-  it("returns true when GHEC-DR URI is set and variant analysis feature flag is set", async () => {
-    await VSCODE_GITHUB_ENTERPRISE_URI_SETTING.updateValue(
-      "https://example.ghe.com",
-      ConfigurationTarget.Global,
-    );
-    await VARIANT_ANALYSIS_ENABLE_GHEC_DR.updateValue(
-      "true",
       ConfigurationTarget.Global,
     );
     expect(isVariantAnalysisEnabledForGitHubHost()).toBe(true);


### PR DESCRIPTION
The feature is now fully enabled on the API side for all GHEC-DR instances. We should remove the feature flag on the extension side too. To use it now all you'll need to do is set `github-enterprise.uri`.

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
