### PR TITLE
Report progress for post-evaluation actions

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [UNRELEASED]
 
 - Fix a bug when re-importing test databases that erroneously showed old source code. [#3616](https://github.com/github/vscode-codeql/pull/3616)
+- Update the progress window with details on potentially long-running post-processing steps after running a query. [#3622](https://github.com/github/vscode-codeql/pull/3622)
 
 ## 1.13.0 - 1 May 2024
 

--- a/extensions/ql-vscode/src/common/vscode/progress.ts
+++ b/extensions/ql-vscode/src/common/vscode/progress.ts
@@ -33,6 +33,14 @@ export interface ProgressUpdate {
   message: string;
 }
 
+export function progressUpdate(
+  step: number,
+  maxStep: number,
+  message: string,
+): ProgressUpdate {
+  return { step, maxStep, message };
+}
+
 export type ProgressCallback = (p: ProgressUpdate) => void;
 
 // Make certain properties within a type optional

--- a/extensions/ql-vscode/src/debugger/debugger-ui.ts
+++ b/extensions/ql-vscode/src/debugger/debugger-ui.ts
@@ -135,7 +135,7 @@ class QLDebugAdapterTracker
   ): Promise<void> {
     if (this.localQueryRun !== undefined) {
       const results: CoreQueryResults = body;
-      await this.localQueryRun.complete(results);
+      await this.localQueryRun.complete(results, (_) => {});
       this.localQueryRun = undefined;
     }
   }

--- a/extensions/ql-vscode/src/local-queries/local-queries.ts
+++ b/extensions/ql-vscode/src/local-queries/local-queries.ts
@@ -485,7 +485,7 @@ export class LocalQueries extends DisposableObject {
           localQueryRun.logger,
         );
 
-        await localQueryRun.complete(results);
+        await localQueryRun.complete(results, progress);
 
         return results;
       } catch (e) {


### PR DESCRIPTION
Generating and parsing log summaries can be quite slow, so we should update the progress window with messages about what's being worked on.

I don't really know TypeScript, so there may be a nicer way of achieving what I've done here. 🤷

## Checklist

- [ ] [CHANGELOG.md](https://github.com/github/vscode-codeql/blob/main/extensions/ql-vscode/CHANGELOG.md) has been updated to incorporate all user visible changes made by this pull request.
- [ ] Issues have been created for any UI or other user-facing changes made by this pull request.
- [ ] _[Maintainers only]_ If this pull request makes user-facing changes that require documentation changes, open a corresponding docs pull request in the [github/codeql](https://github.com/github/codeql/tree/main/docs/codeql/codeql-for-visual-studio-code) repo and add the `ready-for-doc-review` label there.
