### PR TITLE
Re-enable windows 8.3 paths in tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,6 +144,19 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     steps:
+      # Enable 8.3 filename creation. This is not required to run the extension but it is required for the unit tests to pass.
+      # This feature is currently enabled by default in Windows 11 for the C: drive and therefore we must maintain support for it.
+      # This setting needs to be enabled before files are created, i.e. before we checkout the repository.
+      - name: Enable 8.3 filenames
+        shell: pwsh
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: |
+          $shortNameEnableProcess = Start-Process -FilePath fsutil.exe -ArgumentList ('8dot3name', 'set', '0') -Wait -PassThru
+          $shortNameEnableExitCode = $shortNameEnableProcess.ExitCode
+          if ($shortNameEnableExitCode -ne 0) {
+              exit $shortNameEnableExitCode
+          }
+
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/extensions/ql-vscode/test/unit-tests/common/short-paths.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/common/short-paths.test.ts
@@ -1,0 +1,96 @@
+import { platform } from "os";
+import type { BaseLogger } from "../../../src/common/logging";
+import { expandShortPaths } from "../../../src/common/short-paths";
+import { join } from "path";
+
+describe("expandShortPaths", () => {
+  let logger: BaseLogger;
+
+  beforeEach(() => {
+    logger = {
+      log: jest.fn(),
+    };
+  });
+
+  describe("on POSIX", () => {
+    if (platform() === "win32") {
+      console.log(`Skipping test on Windows`);
+      return;
+    }
+
+    it("should return the same path for non-Windows platforms", async () => {
+      const path = "/home/user/some~path";
+      const result = await expandShortPaths(path, logger);
+
+      expect(logger.log).not.toHaveBeenCalled();
+      expect(result).toBe(path);
+    });
+  });
+
+  describe("on Windows", () => {
+    if (platform() !== "win32") {
+      console.log(`Skipping test on non-Windows`);
+      return;
+    }
+
+    it("should return the same path if no short components", async () => {
+      const path = "C:\\Program Files\\Some Folder";
+      const result = await expandShortPaths(path, logger);
+
+      expect(logger.log).toHaveBeenCalledWith(
+        `Expanding short paths in: ${path}`,
+      );
+      expect(logger.log).toHaveBeenCalledWith(
+        "Skipping due to no short components",
+      );
+      expect(result).toBe(path);
+    });
+
+    it("should not attempt to expand long paths with '~' in the name", async () => {
+      const testDir = join(__dirname, "../data/short-paths");
+      const path = join(testDir, "textfile-with~tilde.txt");
+      const result = await expandShortPaths(path, logger);
+
+      expect(logger.log).toHaveBeenCalledWith(
+        `Expanding short paths in: ${path}`,
+      );
+      expect(logger.log).toHaveBeenCalledWith(
+        `Expanding short path component: textfile-with~tilde.txt`,
+      );
+      expect(logger.log).toHaveBeenCalledWith(`Component is not a short name`);
+      expect(result).toBe(join(testDir, "textfile-with~tilde.txt"));
+    });
+
+    it("should expand a short path", async () => {
+      const path = "C:\\PROGRA~1\\Some Folder";
+      const result = await expandShortPaths(path, logger);
+
+      expect(logger.log).toHaveBeenCalledWith(
+        `Expanding short paths in: ${path}`,
+      );
+      expect(logger.log).toHaveBeenCalledWith(
+        `Expanding short path component: PROGRA~1`,
+      );
+      expect(result).toBe("C:\\Program Files\\Some Folder");
+    });
+
+    it("should expand multiple short paths", async () => {
+      const testDir = join(__dirname, "../data/short-paths");
+      const path = join(testDir, "FOLDER~1", "TEXTFI~1.TXT");
+      const result = await expandShortPaths(path, logger);
+
+      expect(logger.log).toHaveBeenCalledWith(
+        `Expanding short paths in: ${path}`,
+      );
+      expect(logger.log).toHaveBeenCalledWith(
+        `Expanding short path component: FOLDER~1`,
+      );
+      expect(logger.log).toHaveBeenCalledWith(
+        `Expanding short path component: TEXTFI~1.TXT`,
+      );
+      expect(result).toBe(
+        join(testDir, "folder with space", ".textfile+extra.characters.txt"),
+      );
+    });
+  });
+});


### PR DESCRIPTION
This PR reverts https://github.com/github/vscode-codeql/pull/3637 and also includes configuration that was removed from the windows actions runner images in https://github.com/actions/runner-images/commit/5ecfd27e8fd0a1b4e8c88072772f9bbab9c82b83

This PR supersedes https://github.com/github/vscode-codeql/pull/3638.

Sadly we have to keep the support for 8.3 filenames in the extension as users may still encounter them, as we believe the feature is still enabled by default on Windows 11 for the `C:` drive, although the actions team determined it was not enabled for the Azure Marketplace Windows 2019 image.

@dbartol 