### PR TITLE
Enable BigInt results in Quick Evals

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [UNRELEASED]
 
+- Support result columns of type `QlBuiltins::BigInt` in quick evaluations. [#3647](https://github.com/github/vscode-codeql/pull/3647)
+
 ## 1.16.0 - 10 October 2024
 
 - Increase the required version of VS Code to 1.90.0. [#3737](https://github.com/github/vscode-codeql/pull/3737)

--- a/extensions/ql-vscode/src/common/bqrs-cli-types.ts
+++ b/extensions/ql-vscode/src/common/bqrs-cli-types.ts
@@ -11,6 +11,7 @@ export namespace BqrsColumnKindCode {
   export const BOOLEAN = "b";
   export const DATE = "d";
   export const ENTITY = "e";
+  export const BIGINT = "z";
 }
 
 export type BqrsColumnKind =
@@ -19,7 +20,8 @@ export type BqrsColumnKind =
   | typeof BqrsColumnKindCode.STRING
   | typeof BqrsColumnKindCode.BOOLEAN
   | typeof BqrsColumnKindCode.DATE
-  | typeof BqrsColumnKindCode.ENTITY;
+  | typeof BqrsColumnKindCode.ENTITY
+  | typeof BqrsColumnKindCode.BIGINT;
 
 export interface BqrsSchemaColumn {
   name?: string;
@@ -79,7 +81,8 @@ export type BqrsKind =
   | "Integer"
   | "Boolean"
   | "Date"
-  | "Entity";
+  | "Entity"
+  | "BigInt";
 
 interface BqrsColumn {
   name?: string;

--- a/extensions/ql-vscode/src/common/bqrs-raw-results-mapper.ts
+++ b/extensions/ql-vscode/src/common/bqrs-raw-results-mapper.ts
@@ -76,6 +76,8 @@ function mapColumnKind(kind: BqrsColumnKind): ColumnKind {
       return ColumnKind.Date;
     case BqrsColumnKindCode.ENTITY:
       return ColumnKind.Entity;
+    case BqrsColumnKindCode.BIGINT:
+      return ColumnKind.BigInt;
     default:
       assertNever(kind);
   }

--- a/extensions/ql-vscode/src/common/raw-result-types.ts
+++ b/extensions/ql-vscode/src/common/raw-result-types.ts
@@ -5,6 +5,7 @@ export enum ColumnKind {
   Boolean = "boolean",
   Date = "date",
   Entity = "entity",
+  BigInt = "bigint",
 }
 
 export type Column = {
@@ -61,6 +62,11 @@ type CellValueNumber = {
   value: number;
 };
 
+type CellValueBigInt = {
+  type: "number";
+  value: number;
+};
+
 type CellValueString = {
   type: "string";
   value: string;
@@ -75,7 +81,8 @@ export type CellValue =
   | CellValueEntity
   | CellValueNumber
   | CellValueString
-  | CellValueBoolean;
+  | CellValueBoolean
+  | CellValueBigInt;
 
 export type Row = CellValue[];
 

--- a/extensions/ql-vscode/test/data/debugger/QuickEvalLib.qll
+++ b/extensions/ql-vscode/test/data/debugger/QuickEvalLib.qll
@@ -17,4 +17,8 @@ abstract class InterestingNumber extends TNumber
     final int getValue() {
         result = value
     }
+
+    QlBuiltins::BigInt getBigIntValue() {
+        result = value.toBigInt()
+    }
 }

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/debugger/debugger.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/debugger/debugger.test.ts
@@ -144,6 +144,25 @@ describeWithCodeQL()("Debugger", () => {
     });
   });
 
+  it("should run a quick evaluation with a bigint-valued result column", async () => {
+    await withDebugController(appCommands, async (controller) => {
+      await selectForQuickEval(quickEvalLibPath, 20, 23, 20, 37);
+
+      await controller.startDebuggingSelection({
+        query: quickEvalQueryPath, // The query context. This query extends the abstract class.
+      });
+      await controller.expectLaunched();
+      const result = await controller.expectSucceeded();
+      expect(result.started.quickEvalContext).toBeDefined();
+      expect(result.started.quickEvalContext!.quickEvalText).toBe(
+        "getBigIntValue",
+      );
+      expect(result.results.queryTarget.quickEvalPosition).toBeDefined();
+      expect(await getResultCount(result.results.outputDir, cli)).toBe(8);
+      await controller.expectStopped();
+    });
+  });
+
   it("should save dirty documents before launching a debug session", async () => {
     await withDebugController(appCommands, async (controller) => {
       const editor = await selectForQuickEval(quickEvalLibPath, 4, 15, 4, 32);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Enable `QlBuiltins::BigInt` results in Quick Evals. This involves updating the VS Code extension to understand the BigInt type as it is encoded in BQRS.

Commits:
- [Enable BigInt results in Quick Evals](https://github.com/github/vscode-codeql/pull/3647/commits/ac60ba3a4934e1223e5f16a40128db4b5e66f4b3): implementation
- [Test BigInt-valued quick-eval](https://github.com/github/vscode-codeql/pull/3647/commits/8af1f087aca2935a542f0536f39a09fd2f4b2b42): integration test
- [Add CHANGELOG entry](https://github.com/github/vscode-codeql/pull/3647/commits/c4eaf54dd7e036a6395cbfa8e1084f4b4792c2b5): changelog entry
