### PR TITLE
Use rich type columns and endpoint kinds for Python model editor

### DIFF
--- a/extensions/ql-vscode/src/model-editor/bqrs.ts
+++ b/extensions/ql-vscode/src/model-editor/bqrs.ts
@@ -33,6 +33,7 @@ export function decodeBqrsToMethods(
     let libraryVersion: string | undefined;
     let type: ModeledMethodType;
     let classification: CallClassification;
+    let endpointKindColumn: string | BqrsEntityValue | undefined;
     let endpointType: EndpointType | undefined = undefined;
 
     if (mode === Mode.Application) {
@@ -47,6 +48,7 @@ export function decodeBqrsToMethods(
         libraryVersion,
         type,
         classification,
+        endpointKindColumn,
       ] = tuple as ApplicationModeTuple;
     } else {
       [
@@ -58,6 +60,7 @@ export function decodeBqrsToMethods(
         supported,
         library,
         type,
+        endpointKindColumn,
       ] = tuple as FrameworkModeTuple;
 
       classification = CallClassification.Unknown;
@@ -68,13 +71,18 @@ export function decodeBqrsToMethods(
     }
 
     if (definition.endpointTypeForEndpoint) {
-      endpointType = definition.endpointTypeForEndpoint({
-        endpointType,
-        packageName,
-        typeName,
-        methodName,
-        methodParameters,
-      });
+      endpointType = definition.endpointTypeForEndpoint(
+        {
+          endpointType,
+          packageName,
+          typeName,
+          methodName,
+          methodParameters,
+        },
+        typeof endpointKindColumn === "object"
+          ? endpointKindColumn.label
+          : endpointKindColumn,
+      );
     }
 
     if (endpointType === undefined) {

--- a/extensions/ql-vscode/src/model-editor/languages/models-as-data.ts
+++ b/extensions/ql-vscode/src/model-editor/languages/models-as-data.ts
@@ -174,11 +174,14 @@ export type ModelsAsDataLanguage = {
    * be determined by heuristics.
    * @param method The method to get the endpoint type for. The endpoint type can be undefined if the
    *               query does not return an endpoint type.
+   * @param endpointKind An optional column that may be provided by the query to help determine the
+   *                     endpoint type.
    */
   endpointTypeForEndpoint?: (
     method: Omit<MethodDefinition, "endpointType"> & {
       endpointType: EndpointType | undefined;
     },
+    endpointKind: string | undefined,
   ) => EndpointType | undefined;
   predicates: ModelsAsDataLanguagePredicates;
   modelGeneration?: ModelsAsDataLanguageModelGeneration;

--- a/extensions/ql-vscode/src/model-editor/method.ts
+++ b/extensions/ql-vscode/src/model-editor/method.ts
@@ -29,6 +29,8 @@ export enum EndpointType {
   Method = "method",
   Constructor = "constructor",
   Function = "function",
+  StaticMethod = "staticMethod",
+  ClassMethod = "classMethod",
 }
 
 export interface MethodDefinition {

--- a/extensions/ql-vscode/src/model-editor/queries/query.ts
+++ b/extensions/ql-vscode/src/model-editor/queries/query.ts
@@ -17,6 +17,7 @@ export type Query = {
    * - libraryVersion: the version of the library that contains the external API. This is a string and can be empty if the version cannot be determined.
    * - type: the modeled kind of the method, either "sink", "source", "summary", or "neutral"
    * - classification: the classification of the use of the method, either "source", "test", "generated", or "unknown"
+   * - kind: the kind of the endpoint, language-specific, e.g. "method" or "function"
    */
   applicationModeQuery: string;
   /**
@@ -32,6 +33,7 @@ export type Query = {
    * - supported: whether this method is modeled. This should be a string representation of a boolean to satify the result pattern for a problem query.
    * - libraryName: the name of the file or library that contains the method. This is a string and usually the basename of a file.
    * - type: the modeled kind of the method, either "sink", "source", "summary", or "neutral"
+   * - kind: the kind of the endpoint, language-specific, e.g. "method" or "function"
    */
   frameworkModeQuery: string;
   dependencies?: {
@@ -50,6 +52,7 @@ export type ApplicationModeTuple = [
   string,
   ModeledMethodType,
   CallClassification,
+  string | BqrsEntityValue | undefined,
 ];
 
 export type FrameworkModeTuple = [
@@ -61,4 +64,5 @@ export type FrameworkModeTuple = [
   boolean,
   string,
   ModeledMethodType,
+  string | BqrsEntityValue | undefined,
 ];

--- a/extensions/ql-vscode/test/unit-tests/model-editor/languages/python/access-paths.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/model-editor/languages/python/access-paths.test.ts
@@ -1,16 +1,59 @@
 import {
   parsePythonAccessPath,
+  parsePythonType,
   pythonEndpointType,
   pythonPath,
 } from "../../../../../src/model-editor/languages/python/access-paths";
 import { EndpointType } from "../../../../../src/model-editor/method";
 
+describe("parsePythonType", () => {
+  it("parses a type with a package", () => {
+    expect(parsePythonType("requests.utils")).toEqual({
+      packageName: "requests",
+      typeName: "utils",
+    });
+  });
+
+  it("parses a nested type with a package", () => {
+    expect(parsePythonType("requests.adapters.HTTPAdapter")).toEqual({
+      packageName: "requests",
+      typeName: "adapters.HTTPAdapter",
+    });
+  });
+
+  it("parses a package without a type", () => {
+    expect(parsePythonType("requests")).toEqual({
+      packageName: "requests",
+      typeName: "",
+    });
+  });
+
+  it("parses an empty string", () => {
+    expect(parsePythonType("")).toEqual({
+      packageName: "",
+      typeName: "",
+    });
+  });
+});
+
 const testCases: Array<{
   path: string;
+  shortTypeName: string;
   method: ReturnType<typeof parsePythonAccessPath>;
 }> = [
   {
     path: "Member[CommonTokens].Member[Class].Instance.Member[foo]",
+    shortTypeName: "",
+    method: {
+      typeName: "CommonTokens.Class",
+      methodName: "foo",
+      endpointType: EndpointType.Method,
+      path: "",
+    },
+  },
+  {
+    path: "Member[foo]",
+    shortTypeName: "CommonTokens.Class",
     method: {
       typeName: "CommonTokens.Class",
       methodName: "foo",
@@ -20,6 +63,17 @@ const testCases: Array<{
   },
   {
     path: "Member[CommonTokens].Member[Class].Instance.Member[foo].Parameter[self]",
+    shortTypeName: "",
+    method: {
+      typeName: "CommonTokens.Class",
+      methodName: "foo",
+      endpointType: EndpointType.Method,
+      path: "Parameter[self]",
+    },
+  },
+  {
+    path: "Member[foo].Parameter[self]",
+    shortTypeName: "CommonTokens.Class",
     method: {
       typeName: "CommonTokens.Class",
       methodName: "foo",
@@ -29,6 +83,7 @@ const testCases: Array<{
   },
   {
     path: "Member[getSource].ReturnValue",
+    shortTypeName: "",
     method: {
       typeName: "",
       methodName: "getSource",
@@ -38,6 +93,17 @@ const testCases: Array<{
   },
   {
     path: "Member[CommonTokens].Member[makePromise].ReturnValue.Awaited",
+    shortTypeName: "",
+    method: {
+      typeName: "CommonTokens",
+      methodName: "makePromise",
+      endpointType: EndpointType.Function,
+      path: "ReturnValue.Awaited",
+    },
+  },
+  {
+    path: "Member[makePromise].ReturnValue.Awaited",
+    shortTypeName: "CommonTokens!",
     method: {
       typeName: "CommonTokens",
       methodName: "makePromise",
@@ -47,6 +113,17 @@ const testCases: Array<{
   },
   {
     path: "Member[ArgPos].Member[anyParam].Argument[any]",
+    shortTypeName: "",
+    method: {
+      typeName: "ArgPos",
+      methodName: "anyParam",
+      endpointType: EndpointType.Function,
+      path: "Argument[any]",
+    },
+  },
+  {
+    path: "Member[anyParam].Argument[any]",
+    shortTypeName: "ArgPos!",
     method: {
       typeName: "ArgPos",
       methodName: "anyParam",
@@ -56,6 +133,17 @@ const testCases: Array<{
   },
   {
     path: "Member[ArgPos].Instance.Member[self_thing].Argument[self]",
+    shortTypeName: "",
+    method: {
+      typeName: "ArgPos",
+      methodName: "self_thing",
+      endpointType: EndpointType.Method,
+      path: "Argument[self]",
+    },
+  },
+  {
+    path: "Member[self_thing].Argument[self]",
+    shortTypeName: "ArgPos",
     method: {
       typeName: "ArgPos",
       methodName: "self_thing",
@@ -66,44 +154,138 @@ const testCases: Array<{
 ];
 
 describe("parsePythonAccessPath", () => {
-  it.each(testCases)("parses $path", ({ path, method }) => {
-    expect(parsePythonAccessPath(path)).toEqual(method);
-  });
+  it.each(testCases)(
+    "parses $path with $shortTypeName",
+    ({ path, shortTypeName, method }) => {
+      expect(parsePythonAccessPath(path, shortTypeName)).toEqual(method);
+    },
+  );
 });
 
 describe("pythonPath", () => {
-  it.each(testCases)("constructs $path", ({ path, method }) => {
-    expect(
-      pythonPath(
-        method.typeName,
-        method.methodName,
-        method.endpointType,
-        method.path,
-      ),
-    ).toEqual(path);
+  it("returns empty for an empty method name", () => {
+    expect(pythonPath("", "ReturnValue")).toEqual("ReturnValue");
+  });
+
+  it("returns empty for an empty path", () => {
+    expect(pythonPath("foo", "")).toEqual("Member[foo]");
+  });
+
+  it("returns correctly for a full method name and path", () => {
+    expect(pythonPath("foo", "ReturnValue")).toEqual("Member[foo].ReturnValue");
   });
 });
 
 describe("pythonEndpointType", () => {
   it("returns method for a method", () => {
     expect(
-      pythonEndpointType({
-        packageName: "testlib",
-        typeName: "CommonTokens",
-        methodName: "foo",
-        methodParameters: "(self,a)",
-      }),
+      pythonEndpointType(
+        {
+          packageName: "testlib",
+          typeName: "CommonTokens",
+          methodName: "foo",
+          methodParameters: "(self,a)",
+        },
+        "InstanceMethod",
+      ),
     ).toEqual(EndpointType.Method);
+  });
+
+  it("returns class method for a class method", () => {
+    expect(
+      pythonEndpointType(
+        {
+          packageName: "testlib",
+          typeName: "CommonTokens",
+          methodName: "foo",
+          methodParameters: "(cls,a)",
+        },
+        "ClassMethod",
+      ),
+    ).toEqual(EndpointType.ClassMethod);
+  });
+
+  it("returns static method for a static method", () => {
+    expect(
+      pythonEndpointType(
+        {
+          packageName: "testlib",
+          typeName: "CommonTokens",
+          methodName: "foo",
+          methodParameters: "(a)",
+        },
+        "StaticMethod",
+      ),
+    ).toEqual(EndpointType.StaticMethod);
   });
 
   it("returns function for a function", () => {
     expect(
-      pythonEndpointType({
-        packageName: "testlib",
-        typeName: "CommonTokens",
-        methodName: "foo",
-        methodParameters: "(a)",
-      }),
+      pythonEndpointType(
+        {
+          packageName: "testlib",
+          typeName: "",
+          methodName: "foo",
+          methodParameters: "(a)",
+        },
+        "Function",
+      ),
+    ).toEqual(EndpointType.Function);
+  });
+
+  it("returns constructor for an init method", () => {
+    expect(
+      pythonEndpointType(
+        {
+          packageName: "testlib",
+          typeName: "CommonTokens",
+          methodName: "foo",
+          methodParameters: "(a)",
+        },
+        "InitMethod",
+      ),
+    ).toEqual(EndpointType.Constructor);
+  });
+
+  it("returns class for a class", () => {
+    expect(
+      pythonEndpointType(
+        {
+          packageName: "testlib",
+          typeName: "CommonTokens",
+          methodName: "",
+          methodParameters: "",
+        },
+        "Class",
+      ),
+    ).toEqual(EndpointType.Class);
+  });
+
+  it("returns method for a method without endpoint kind", () => {
+    expect(
+      pythonEndpointType(
+        {
+          packageName: "testlib",
+          typeName: "CommonTokens",
+          methodName: "foo",
+          methodParameters: "(self,a)",
+        },
+        undefined,
+      ),
+    ).toEqual(EndpointType.Method);
+  });
+
+  it("returns function for a function without endpoint kind", () => {
+    expect(
+      pythonEndpointType(
+        {
+          packageName: "testlib",
+          typeName: "CommonTokens",
+          methodName: "foo",
+          methodParameters: "(a)",
+        },
+        undefined,
+      ),
     ).toEqual(EndpointType.Function);
   });
 });


### PR DESCRIPTION
This makes changes to the Python model editor parsing code to incorporate the query changes from https://github.com/github/codeql/pull/15655. These changes consist of:
- Adding support for reading rich type columns (as implemented by https://github.com/github/codeql/pull/16490): This makes it possible to replace the columns `["requests", "Member[adapters].Member[HTTPAdapter].Instance.Member[add_headers]"]` by `["requests.HTTPAdapter", "Member[add_headers]"]`.
- Write rich type columns instead of complex paths. We still retain support for reading non-rich type columns.
- Use the `kind` column that has been added in https://github.com/github/codeql/pull/15655 (the last column returned in the query). This makes it possible to properly handle class methods, which we would otherwise need to detect by the name of the method argument rather than just receiving this information from the query.

For more information about the format of Python MaD, see [the documentation](https://github.com/github/codeql/blob/main/docs/codeql/codeql-language-guides/customizing-library-models-for-python.rst).