### PR TITLE
Enable type models for Python in the model editor

### DIFF
--- a/extensions/ql-vscode/src/model-editor/languages/python/index.ts
+++ b/extensions/ql-vscode/src/model-editor/languages/python/index.ts
@@ -173,6 +173,31 @@ export const python: ModelsAsDataLanguage = {
         };
       },
     },
+    type: {
+      extensiblePredicate: "typeModel",
+      // extensible predicate typeModel(string type1, string type2, string path);
+      generateMethodDefinition: (method) => [
+        method.relatedTypeName,
+        pythonType(method.packageName, method.typeName, method.endpointType),
+        pythonPath(method.methodName, method.path),
+      ],
+      readModeledMethod: (row) => {
+        const { packageName, typeName, methodName, endpointType, path } =
+          parsePythonTypeAndPath(row[1] as string, row[2] as string);
+
+        return {
+          type: "type",
+          relatedTypeName: row[0] as string,
+          path,
+          signature: pythonMethodSignature(typeName, methodName),
+          endpointType,
+          packageName,
+          typeName,
+          methodName,
+          methodParameters: "",
+        };
+      },
+    },
   },
   getArgumentOptions: (method) => {
     // Argument and Parameter are equivalent in Python, but we'll use Argument in the model editor


### PR DESCRIPTION
This enables type models for Python in the model editor. There is no query for generating type models or for complex access path suggestions, so a simple text box will be shown to enter the path and related type.

- Based on https://github.com/github/vscode-codeql/pull/3653