### PR TITLE
Allow compatible CLIs to generate summary symbols file

### DIFF
--- a/extensions/ql-vscode/src/codeql-cli/cli-version.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli-version.ts
@@ -12,6 +12,7 @@ interface VersionResult {
 export interface CliFeatures {
   featuresInVersionResult?: boolean;
   mrvaPackCreate?: boolean;
+  generateSummarySymbolMap?: boolean;
 }
 
 export interface VersionAndFeatures {

--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -1211,10 +1211,15 @@ export class CodeQLCliServer implements Disposable {
     outputPath: string,
     endSummaryPath: string,
   ): Promise<string> {
+    const supportsGenerateSummarySymbolMap =
+      await this.cliConstraints.supportsGenerateSummarySymbolMap();
     const subcommandArgs = [
       "--format=text",
       `--end-summary=${endSummaryPath}`,
       "--sourcemap",
+      ...(supportsGenerateSummarySymbolMap
+        ? ["--summary-symbol-map", "--minify-output"]
+        : []),
       inputPath,
       outputPath,
     ];
@@ -1952,5 +1957,9 @@ export class CliVersionConstraint {
 
   async supportsMrvaPackCreate(): Promise<boolean> {
     return (await this.cli.getFeatures()).mrvaPackCreate === true;
+  }
+
+  async supportsGenerateSummarySymbolMap(): Promise<boolean> {
+    return (await this.cli.getFeatures()).generateSummarySymbolMap === true;
   }
 }

--- a/extensions/ql-vscode/src/run-queries-shared.ts
+++ b/extensions/ql-vscode/src/run-queries-shared.ts
@@ -544,9 +544,16 @@ export async function generateEvalLogSummaries(
     await cliServer.generateJsonLogSummary(log, jsonSummary);
 
     if (humanReadableSummary !== undefined) {
-      progress(progressUpdate(3, 3, "Generating summary symbols file"));
       summarySymbols = outputDir.evalLogSummarySymbolsPath;
-      await generateSummarySymbolsFile(humanReadableSummary, summarySymbols);
+      if (
+        !(await cliServer.cliConstraints.supportsGenerateSummarySymbolMap())
+      ) {
+        // We're using an old CLI that cannot generate the summary symbols file while generating the
+        // human-readable log summary. As a fallback, create it by parsing the human-readable
+        // summary.
+        progress(progressUpdate(3, 3, "Generating summary symbols file"));
+        await generateSummarySymbolsFile(humanReadableSummary, summarySymbols);
+      }
     }
   }
 


### PR DESCRIPTION
This should be much faster than generating it in the extension.

No change-note since this should be a seamless change.