### PR TITLE
Display length of shortest path in MRVA UI

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [UNRELEASED]
 
+- Update variant analysis view to display the length of the shortest path for path queries. #3659
+
 ## 1.13.1 - 29 May 2024
 
 - Fix a bug when re-importing test databases that erroneously showed old source code. [#3616](https://github.com/github/vscode-codeql/pull/3616)

--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [UNRELEASED]
 
-- Update variant analysis view to display the length of the shortest path for path queries. #3659
+- Update variant analysis view to display the length of the shortest path for path queries. [#3671](https://github.com/github/vscode-codeql/pull/3671)
 
 ## 1.13.1 - 29 May 2024
 

--- a/extensions/ql-vscode/src/view/common/CodePaths/CodePaths.tsx
+++ b/extensions/ql-vscode/src/view/common/CodePaths/CodePaths.tsx
@@ -52,9 +52,7 @@ export const CodePaths = ({
   return (
     <>
       <ShowPathsLink onClick={onShowPathsClick}>Show paths</ShowPathsLink>
-      <Label data-testid="shortest-path-length">
-        (Shortest: {getShortestPathLength(codeFlows)})
-      </Label>
+      <Label>(Shortest: {getShortestPathLength(codeFlows)})</Label>
     </>
   );
 };

--- a/extensions/ql-vscode/src/view/common/CodePaths/CodePaths.tsx
+++ b/extensions/ql-vscode/src/view/common/CodePaths/CodePaths.tsx
@@ -12,6 +12,18 @@ const ShowPathsLink = styled(VSCodeLink)`
   cursor: pointer;
 `;
 
+const Label = styled.span`
+  color: var(--vscode-descriptionForeground);
+  margin-left: 10px;
+`;
+
+function getShortestPathLength(codeFlows: CodeFlow[]): number {
+  const allPathLengths = codeFlows
+    .map((codeFlow) => codeFlow.threadFlows.length)
+    .flat();
+  return Math.min(...allPathLengths);
+}
+
 export type CodePathsProps = {
   codeFlows: CodeFlow[];
   ruleDescription: string;
@@ -40,6 +52,9 @@ export const CodePaths = ({
   return (
     <>
       <ShowPathsLink onClick={onShowPathsClick}>Show paths</ShowPathsLink>
+      <Label data-testid="shortest-path-length">
+        (Shortest: {getShortestPathLength(codeFlows)})
+      </Label>
     </>
   );
 };

--- a/extensions/ql-vscode/src/view/common/CodePaths/__tests__/CodePaths.spec.tsx
+++ b/extensions/ql-vscode/src/view/common/CodePaths/__tests__/CodePaths.spec.tsx
@@ -27,9 +27,7 @@ describe(CodePaths.name, () => {
   it("renders shortest path for code flows", () => {
     render();
 
-    expect(screen.getByTestId("shortest-path-length")).toHaveTextContent(
-      "(Shortest: 1)",
-    );
+    expect(screen.getByText("(Shortest: 1)")).toBeInTheDocument();
   });
 
   it("posts extension message when 'show paths' link clicked", async () => {

--- a/extensions/ql-vscode/src/view/common/CodePaths/__tests__/CodePaths.spec.tsx
+++ b/extensions/ql-vscode/src/view/common/CodePaths/__tests__/CodePaths.spec.tsx
@@ -24,6 +24,14 @@ describe(CodePaths.name, () => {
     expect(screen.getByText("Show paths")).toBeInTheDocument();
   });
 
+  it("renders shortest path for code flows", () => {
+    render();
+
+    expect(screen.getByTestId("shortest-path-length")).toHaveTextContent(
+      "(Shortest: 1)",
+    );
+  });
+
   it("posts extension message when 'show paths' link clicked", async () => {
     render();
 


### PR DESCRIPTION
Hey 👋 

This PR implements my feature request from #3659.
I'm totally open for changes of course (e.g. visualize it differently etc. - e.g. use a callout displaying only the number with a tooltip for more information)

Note:
* Due to the type definitions I assumed that the codeflows are available in the instances where this UI are displayed. (if not more checks would be warranted)
* I've added a `data-testid` to assert the textcontent of the label on one line.