### PR TITLE
Remove feature flag for Python model editor

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [UNRELEASED]
 
+- Add Python support to the CodeQL Model Editor. [#3676](https://github.com/github/vscode-codeql/pull/3676)
 - Update variant analysis view to display the length of the shortest path for path queries. [#3671](https://github.com/github/vscode-codeql/pull/3671)
 
 ## 1.13.1 - 29 May 2024

--- a/extensions/ql-vscode/src/config.ts
+++ b/extensions/ql-vscode/src/config.ts
@@ -840,7 +840,6 @@ const LLM_GENERATION_DEV_ENDPOINT = new Setting(
 const MODEL_EVALUATION = new Setting("evaluation", MODEL_SETTING);
 const MODEL_PACK_LOCATION = new Setting("packLocation", MODEL_SETTING);
 const MODEL_PACK_NAME = new Setting("packName", MODEL_SETTING);
-const ENABLE_PYTHON = new Setting("enablePython", MODEL_SETTING);
 
 export type ModelConfigPackVariables = {
   database: string;
@@ -857,7 +856,6 @@ export interface ModelConfig {
     variables: ModelConfigPackVariables,
   ): string;
   getPackName(languageId: string, variables: ModelConfigPackVariables): string;
-  enablePython: boolean;
 }
 
 export class ModelConfigListener extends ConfigListener implements ModelConfig {
@@ -918,10 +916,6 @@ export class ModelConfigListener extends ConfigListener implements ModelConfig {
       }),
       variables,
     );
-  }
-
-  public get enablePython(): boolean {
-    return !!ENABLE_PYTHON.getValue<boolean>();
   }
 }
 

--- a/extensions/ql-vscode/src/model-editor/supported-languages.ts
+++ b/extensions/ql-vscode/src/model-editor/supported-languages.ts
@@ -9,19 +9,15 @@ export const SUPPORTED_LANGUAGES: QueryLanguage[] = [
   QueryLanguage.Java,
   QueryLanguage.CSharp,
   QueryLanguage.Ruby,
+  QueryLanguage.Python,
 ];
 
 export function isSupportedLanguage(
   language: QueryLanguage,
-  modelConfig: ModelConfig,
+  _modelConfig: ModelConfig,
 ) {
   if (SUPPORTED_LANGUAGES.includes(language)) {
     return true;
-  }
-
-  if (language === QueryLanguage.Python) {
-    // Python is only enabled when the config setting is set
-    return modelConfig.enablePython;
   }
 
   return false;


### PR DESCRIPTION
This removes the feature flag `codeQL.model.enablePython` config setting and enables the Python model editor for everyone.