### PR TITLE
Bump minimum VS Code version for warnings

### DIFF
--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -300,12 +300,12 @@ const shouldUpdateOnNextActivationKey = "shouldUpdateOnNextActivation";
 
 const codeQlVersionRange = DEFAULT_DISTRIBUTION_VERSION_RANGE;
 
-// This is the minimum version of vscode that we _want_ to support. We want to update to Node 18, but that
-// requires 1.82 or later. If we change the minimum version in the package.json, then anyone on an older version of vscode will
+// This is the minimum version of vscode that we _want_ to support. We want to update to Node 20, but that
+// requires 1.90 or later. If we change the minimum version in the package.json, then anyone on an older version of vscode will
 // silently be unable to upgrade. So, the solution is to first bump the minimum version here and release. Then
 // bump the version in the package.json and release again. This way, anyone on an older version of vscode will get a warning
 // before silently being refused to upgrade.
-const MIN_VERSION = "1.82.0";
+const MIN_VERSION = "1.90.0";
 
 function sendConfigTelemetryData() {
   const config: Record<string, string> = {};


### PR DESCRIPTION
We are only running unit tests on Node 20 and we can't upgrade certain dependencies (like https://github.com/github/vscode-codeql/pull/3705) because we still support versions of VS Code that use Node 18. This will bump the minimum VS Code version for warnings to 1.90.0 which is the first version of VS Code that [uses Node 20](https://github.com/microsoft/vscode/commit/5216c044283ba1f3c66caa092fd75ba0b3e3e5ca).

After releasing the extension once, we can upgrade the minimum version in `package.json`.