### PR TITLE
Remove deprecated Husky commands

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 cd extensions/ql-vscode && npm run format-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 cd extensions/ql-vscode && ./scripts/forbid-test-only


### PR DESCRIPTION
This removes two lines from the Husky hooks that are deprecated:

```
husky - DEPRECATED

Please remove the following two lines from .husky/pre-push:

#!/usr/bin/env sh
. "$(dirname -- "$0")/_/husky.sh"

They WILL FAIL in v10.0.0
```