### PR TITLE
Avoid uploading eslint sarif for dependabot PR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,7 +103,7 @@ jobs:
           npm run lint-ci
 
       - name: Upload ESLint results to Code Scanning
-        if: "${{ !cancelled() }}"
+        if: "${{ !cancelled() && !startsWith(github.head_ref, 'dependabot/')}}"
         uses: github/codeql-action/upload-sarif@main
         with:
           sarif_file: extensions/ql-vscode/build/eslint.sarif

--- a/extensions/ql-vscode/test/vscode-tests/activated-extension/jest.setup.ts
+++ b/extensions/ql-vscode/test/vscode-tests/activated-extension/jest.setup.ts
@@ -6,7 +6,7 @@ import {
 
 beforeAll(async () => {
   await beforeAllAction();
-});
+}, 20_000);
 
 beforeEach(async () => {
   await beforeEachAction();


### PR DESCRIPTION
Dependabot does not have `security-events: write` permission.

See https://github.com/github/codeql-action/pull/2485 for the original instance of this problem.

