### PR TITLE
Setup Node in release workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,13 @@ jobs:
     env:
       VSCE_TOKEN: ${{ secrets.VSCE_TOKEN }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: extensions/ql-vscode/.nvmrc
+
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
@@ -144,6 +151,13 @@ jobs:
     env:
       OPEN_VSX_TOKEN: ${{ secrets.OPEN_VSX_TOKEN }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: extensions/ql-vscode/.nvmrc
+
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
This fixes warnings in the release workflows, such as [these ones](https://github.com/github/vscode-codeql/actions/runs/11049690420/job/30702536115#step:3:7). We need the checkout step to ensure we can access the `node-version-file`.