### PR TITLE
Fix Husky install deprecation warning

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1965,7 +1965,7 @@
     "generate:chromium-version": "vite-node scripts/generate-chromium-version.ts",
     "check-types": "find . -type f -name \"tsconfig.json\" -not -path \"./node_modules/*\" | sed -r 's|/[^/]+$||' | sort | uniq | xargs -I {} sh -c \"echo Checking types in {} && cd {} && npx tsc --noEmit\"",
     "postinstall": "patch-package",
-    "prepare": "cd ../.. && husky install"
+    "prepare": "cd ../.. && husky"
   },
   "dependencies": {
     "@floating-ui/react": "^0.26.12",


### PR DESCRIPTION
We were getting a deprecation warning for using the `husky install` command:

![Screenshot 2024-09-30 at 09 54 02](https://github.com/user-attachments/assets/5dbd2ee3-c50a-41b7-9b38-a9c93481738e)

It seems like we should just be using the `husky` command according to [the documentation](https://typicode.github.io/husky/how-to.html#manual-setup). This makes that change.