### PR TITLE
Remove now unnecessary patch to fix failing CLI tests

### DIFF
--- a/extensions/ql-vscode/patches/jest-runner-vscode+3.0.1.patch
+++ b/extensions/ql-vscode/patches/jest-runner-vscode+3.0.1.patch
@@ -1,29 +1,3 @@
-diff --git a/node_modules/jest-runner-vscode/dist/child/environment.js b/node_modules/jest-runner-vscode/dist/child/environment.js
-index 1ac28d5..f91f216 100644
---- a/node_modules/jest-runner-vscode/dist/child/environment.js
-+++ b/node_modules/jest-runner-vscode/dist/child/environment.js
-@@ -10,6 +10,21 @@ const wrap_io_1 = __importDefault(require("./wrap-io"));
- const load_pnp_1 = __importDefault(require("./load-pnp"));
- const ipc = new ipc_client_1.default('env');
- class VSCodeEnvironment extends jest_environment_node_1.default {
-+    constructor(config, context) {
-+        super(config, context);
-+        // The _VSCODE_NODE_MODULES is a proxy which will require a module if any property
-+        // on it is accessed. This is a workaround for the fact that jest will call
-+        // _isMockFunction on the module, which will cause that function to be required.
-+        this.global._VSCODE_NODE_MODULES = new Proxy(this.global._VSCODE_NODE_MODULES, {
-+          get(target, prop) {
-+            if (prop === '_isMockFunction') {
-+              return undefined;
-+            }
-+            return target[prop];
-+          },
-+        });
-+    }
-+
-     async setup() {
-         await super.setup();
-         await (0, load_pnp_1.default)();
 diff --git a/node_modules/jest-runner-vscode/dist/child/runner.js b/node_modules/jest-runner-vscode/dist/child/runner.js
 index 0663c5c..bdf4a8b 100644
 --- a/node_modules/jest-runner-vscode/dist/child/runner.js


### PR DESCRIPTION
This removes a patch that has become unnecessary as of [microsoft/vscode#227427](https://redirect.github.com/microsoft/vscode/pull/227427). This does break compatibility with older VS Code versions for tests, but we always run the tests with the newest version of VS Code.

Successful run: https://github.com/github/vscode-codeql/actions/runs/11176227294