### PR TITLE
Add a version-check to BigInt quick-eval test

### DIFF
--- a/extensions/ql-vscode/test/data/debugger/QuickEvalBigIntQuery.ql
+++ b/extensions/ql-vscode/test/data/debugger/QuickEvalBigIntQuery.ql
@@ -1,0 +1,31 @@
+import QuickEvalLib
+
+class InterestingBigInt instanceof InterestingNumber
+{
+    QlBuiltins::BigInt getBigIntValue() {
+        result = super.getValue().toBigInt().pow(10)
+    }
+
+    string toString() {
+        result = super.toString()
+    }
+}
+
+class PrimeNumber extends InterestingNumber {
+    PrimeNumber() {
+        exists(int n | this = MkNumber(n) |
+            n in [
+                2,
+                3,
+                5,
+                7,
+                11,
+                13,
+                17,
+                19
+            ])
+    }
+}
+
+from InterestingNumber n
+select n.toString()

--- a/extensions/ql-vscode/test/data/debugger/QuickEvalLib.qll
+++ b/extensions/ql-vscode/test/data/debugger/QuickEvalLib.qll
@@ -17,8 +17,4 @@ abstract class InterestingNumber extends TNumber
     final int getValue() {
         result = value
     }
-
-    QlBuiltins::BigInt getBigIntValue() {
-        result = value.toBigInt()
-    }
 }

--- a/extensions/ql-vscode/test/unit-tests/common/files.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/common/files.test.ts
@@ -66,18 +66,19 @@ describe("files", () => {
 
     it("should scan a directory", async () => {
       const file1 = join(dataDir, "compute-default-strings.ql");
-      const file2 = join(dataDir, "debugger", "QuickEvalQuery.ql");
-      const file3 = join(dataDir, "debugger", "simple-query.ql");
-      const file4 = join(dataDir, "multiple-result-sets.ql");
-      const file5 = join(dataDir, "query.ql");
+      const file2 = join(dataDir, "debugger", "QuickEvalBigIntQuery.ql");
+      const file3 = join(dataDir, "debugger", "QuickEvalQuery.ql");
+      const file4 = join(dataDir, "debugger", "simple-query.ql");
+      const file5 = join(dataDir, "multiple-result-sets.ql");
+      const file6 = join(dataDir, "query.ql");
 
       const vaDir = join(dataDir, "variant-analysis-query-packs");
-      const file6 = join(vaDir, "workspace1", "dir1", "query1.ql");
-      const file7 = join(vaDir, "workspace1", "pack1", "query1.ql");
-      const file8 = join(vaDir, "workspace1", "pack1", "query2.ql");
-      const file9 = join(vaDir, "workspace1", "pack2", "query1.ql");
-      const file10 = join(vaDir, "workspace1", "query1.ql");
-      const file11 = join(vaDir, "workspace2", "query1.ql");
+      const file7 = join(vaDir, "workspace1", "dir1", "query1.ql");
+      const file8 = join(vaDir, "workspace1", "pack1", "query1.ql");
+      const file9 = join(vaDir, "workspace1", "pack1", "query2.ql");
+      const file10 = join(vaDir, "workspace1", "pack2", "query1.ql");
+      const file11 = join(vaDir, "workspace1", "query1.ql");
+      const file12 = join(vaDir, "workspace2", "query1.ql");
 
       const result = await gatherQlFiles([dataDir]);
       expect(result.sort()).toEqual([
@@ -93,6 +94,7 @@ describe("files", () => {
           file9,
           file10,
           file11,
+          file12,
         ],
         true,
       ]);
@@ -112,18 +114,19 @@ describe("files", () => {
 
     it("should avoid duplicates", async () => {
       const file1 = join(dataDir, "compute-default-strings.ql");
-      const file2 = join(dataDir, "debugger", "QuickEvalQuery.ql");
-      const file3 = join(dataDir, "debugger", "simple-query.ql");
-      const file4 = join(dataDir, "multiple-result-sets.ql");
-      const file5 = join(dataDir, "query.ql");
+      const file2 = join(dataDir, "debugger", "QuickEvalBigIntQuery.ql");
+      const file3 = join(dataDir, "debugger", "QuickEvalQuery.ql");
+      const file4 = join(dataDir, "debugger", "simple-query.ql");
+      const file5 = join(dataDir, "multiple-result-sets.ql");
+      const file6 = join(dataDir, "query.ql");
 
       const vaDir = join(dataDir, "variant-analysis-query-packs");
-      const file6 = join(vaDir, "workspace1", "dir1", "query1.ql");
-      const file7 = join(vaDir, "workspace1", "pack1", "query1.ql");
-      const file8 = join(vaDir, "workspace1", "pack1", "query2.ql");
-      const file9 = join(vaDir, "workspace1", "pack2", "query1.ql");
-      const file10 = join(vaDir, "workspace1", "query1.ql");
-      const file11 = join(vaDir, "workspace2", "query1.ql");
+      const file7 = join(vaDir, "workspace1", "dir1", "query1.ql");
+      const file8 = join(vaDir, "workspace1", "pack1", "query1.ql");
+      const file9 = join(vaDir, "workspace1", "pack1", "query2.ql");
+      const file10 = join(vaDir, "workspace1", "pack2", "query1.ql");
+      const file11 = join(vaDir, "workspace1", "query1.ql");
+      const file12 = join(vaDir, "workspace2", "query1.ql");
 
       const result = await gatherQlFiles([file1, dataDir, file3, file4, file5]);
       result[0].sort();
@@ -140,6 +143,7 @@ describe("files", () => {
           file9,
           file10,
           file11,
+          file12,
         ],
         true,
       ]);

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/debugger/debugger.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/debugger/debugger.test.ts
@@ -49,6 +49,9 @@ describeWithCodeQL()("Debugger", () => {
   const quickEvalQueryPath = getDataFolderFilePath(
     "debugger/QuickEvalQuery.ql",
   );
+  const quickEvalBigIntQueryPath = getDataFolderFilePath(
+    "debugger/QuickEvalBigIntQuery.ql",
+  );
   const quickEvalLibPath = getDataFolderFilePath("debugger/QuickEvalLib.qll");
 
   beforeEach(async () => {
@@ -146,11 +149,16 @@ describeWithCodeQL()("Debugger", () => {
 
   it("should run a quick evaluation with a bigint-valued result column", async () => {
     await withDebugController(appCommands, async (controller) => {
-      await selectForQuickEval(quickEvalLibPath, 20, 23, 20, 37);
+      const semver = await cli.getVersion();
+      if (semver.compare("2.18.4") < 0) {
+        // Skip this test if the CLI version is too old to support BigInt
+        return;
+      }
 
-      await controller.startDebuggingSelection({
-        query: quickEvalQueryPath, // The query context. This query extends the abstract class.
-      });
+      await selectForQuickEval(quickEvalBigIntQueryPath, 4, 23, 4, 37);
+
+      // Don't specify a query path, so we'll default to the active document ("QuickEvalBigIntQuery.ql")
+      await controller.startDebuggingSelection({});
       await controller.expectLaunched();
       const result = await controller.expectSucceeded();
       expect(result.started.quickEvalContext).toBeDefined();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Closes https://github.com/github/vscode-codeql/issues/3759

Fixes a problem in https://github.com/github/vscode-codeql/pull/3647 where the tests did not pass under older CLI versions.

This separates the BigInt code into its own file and quick-evals it only on CLI versions that support `QlBuiltins::BigInt`.
