### PR TITLE
Improve source map script

### DIFF
--- a/extensions/ql-vscode/scripts/source-map.ts
+++ b/extensions/ql-vscode/scripts/source-map.ts
@@ -41,6 +41,7 @@ async function extractSourceMap() {
   const releaseAssetsDirectory = resolve(
     __dirname,
     "..",
+    "artifacts",
     "release-assets",
     versionNumber,
   );
@@ -64,7 +65,9 @@ async function extractSourceMap() {
     ]);
 
     const sourcemapAsset = release.assets.find(
-      (asset) => asset.name === `vscode-codeql-sourcemaps-${versionNumber}.zip`,
+      (asset) =>
+        asset.label === `vscode-codeql-sourcemaps-${versionNumber}.zip` ||
+        asset.name === "vscode-codeql-sourcemaps.zip",
     );
 
     if (sourcemapAsset) {
@@ -213,9 +216,7 @@ extractSourceMap().catch((e: unknown) => {
 function runGh(args: readonly string[]): string {
   const gh = spawnSync("gh", args);
   if (gh.status !== 0) {
-    throw new Error(
-      `Failed to get the source map for ${versionNumber}: ${gh.stderr}`,
-    );
+    throw new Error(`Failed to run gh ${args.join(" ")}: ${gh.stderr}`);
   }
   return gh.stdout.toString("utf-8");
 }
@@ -227,6 +228,7 @@ function runGhJSON<T>(args: readonly string[]): T {
 type ReleaseAsset = {
   id: string;
   name: string;
+  label: string;
 };
 
 type Release = {


### PR DESCRIPTION
This fixes some minor bugs in the source map script:
- It now shows which `gh` command failed instead of just showing a generic error which didn't include which command failed
- It now takes into account both the `label` and the `name` of the release assets, which can apparently be different:
   ```json
   {
      "apiUrl": "https://api.github.com/repos/github/vscode-codeql/releases/assets/198176998",
      "contentType": "application/zip",
      "createdAt": "2024-10-10T12:38:02Z",
      "downloadCount": 4,
      "id": "RA_kwDODJYu-M4Lz_Dm",
      "label": "vscode-codeql-sourcemaps-v1.16.0.zip",
      "name": "vscode-codeql-sourcemaps.zip",
      "size": 3509607,
      "state": "uploaded",
      "updatedAt": "2024-10-10T12:38:02Z",
      "url": "https://github.com/github/vscode-codeql/releases/download/v1.16.0/vscode-codeql-sourcemaps.zip"
    }
    ```
- It downloads the release assets to the `artifacts` directory so they are gitignored.