### PR TITLE
Exclude more .vscode-test directories in check-types

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1963,7 +1963,7 @@
     "generate": "npm-run-all -p generate:*",
     "generate:schemas": "vite-node scripts/generate-schemas.ts",
     "generate:chromium-version": "vite-node scripts/generate-chromium-version.ts",
-    "check-types": "find . -type f -name \"tsconfig.json\" -not -path \"./node_modules/*\" -not -path \"./.vscode-test/*\" | sed -r 's|/[^/]+$||' | sort | uniq | xargs -I {} sh -c \"echo Checking types in {} && cd {} && npx tsc --noEmit\"",
+    "check-types": "find . -type f -name \"tsconfig.json\" -not -path \"./node_modules/*\" -not -path \"*/.vscode-test/*\" | sed -r 's|/[^/]+$||' | sort | uniq | xargs -I {} sh -c \"echo Checking types in {} && cd {} && npx tsc --noEmit\"",
     "postinstall": "patch-package",
     "prepare": "cd ../.. && husky"
   },


### PR DESCRIPTION
This excludes even more `.vscode-test` directories which are nested inside `test` directories, such as `./test/vscode-tests/no-workspace/.vscode-test/vscode-darwin-arm64-1.94.2/Visual Studio Code.app/Contents/Resources/app/node_modules/@microsoft/1ds-post-js/tsconfig.json`.

See https://github.com/github/vscode-codeql/pull/3761