### PR TITLE
Implement streaming for compare view

### DIFF
--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -360,6 +360,9 @@ interface ChangeCompareMessage {
 export type ToCompareViewMessage =
   | SetComparisonQueryInfoMessage
   | SetComparisonsMessage
+  | StreamingComparisonSetupMessage
+  | StreamingComparisonAddResultsMessage
+  | StreamingComparisonCompleteMessage
   | SetUserSettingsMsg;
 
 /**
@@ -418,6 +421,24 @@ export type InterpretedQueryCompareResult = {
   from: Result[];
   to: Result[];
 };
+
+export interface StreamingComparisonSetupMessage {
+  readonly t: "streamingComparisonSetup";
+  readonly currentResultSetName: string;
+  readonly message: string | undefined;
+  // The from and to fields will only contain a chunk of the results
+  readonly result: QueryCompareResult;
+}
+
+interface StreamingComparisonAddResultsMessage {
+  readonly t: "streamingComparisonAddResults";
+  // The from and to fields will only contain a chunk of the results
+  readonly result: QueryCompareResult;
+}
+
+interface StreamingComparisonCompleteMessage {
+  readonly t: "streamingComparisonComplete";
+}
 
 /**
  * Extract the name of the default result. Prefer returning

--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -424,6 +424,8 @@ export type InterpretedQueryCompareResult = {
 
 export interface StreamingComparisonSetupMessage {
   readonly t: "streamingComparisonSetup";
+  // The id of this streaming comparison
+  readonly id: string;
   readonly currentResultSetName: string;
   readonly message: string | undefined;
   // The from and to fields will only contain a chunk of the results
@@ -432,12 +434,14 @@ export interface StreamingComparisonSetupMessage {
 
 interface StreamingComparisonAddResultsMessage {
   readonly t: "streamingComparisonAddResults";
+  readonly id: string;
   // The from and to fields will only contain a chunk of the results
   readonly result: QueryCompareResult;
 }
 
 interface StreamingComparisonCompleteMessage {
   readonly t: "streamingComparisonComplete";
+  readonly id: string;
 }
 
 /**

--- a/extensions/ql-vscode/src/compare/compare-view.ts
+++ b/extensions/ql-vscode/src/compare/compare-view.ts
@@ -34,6 +34,7 @@ import {
 } from "./result-set-names";
 import { compareInterpretedResults } from "./interpreted-results";
 import { isCanary } from "../config";
+import { nanoid } from "nanoid";
 
 interface ComparePair {
   from: CompletedLocalQueryInfo;
@@ -206,6 +207,8 @@ export class CompareView extends AbstractWebview<
       return;
     }
 
+    const id = nanoid();
+
     // Streaming itself is implemented like this:
     // - 1 setup message which contains the first 1,000 results
     // - n "add results" messages which contain 1,000 results each
@@ -213,6 +216,7 @@ export class CompareView extends AbstractWebview<
 
     await this.postMessage({
       t: "streamingComparisonSetup",
+      id,
       result: this.chunkResults(result, 0, 1000),
       currentResultSetName,
       message,
@@ -226,12 +230,14 @@ export class CompareView extends AbstractWebview<
 
       await this.postMessage({
         t: "streamingComparisonAddResults",
+        id,
         result: chunk,
       });
     }
 
     await this.postMessage({
       t: "streamingComparisonComplete",
+      id,
     });
   }
 

--- a/extensions/ql-vscode/src/view/compare/Compare.tsx
+++ b/extensions/ql-vscode/src/view/compare/Compare.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { styled } from "styled-components";
 
 import type {
@@ -6,6 +6,8 @@ import type {
   SetComparisonsMessage,
   SetComparisonQueryInfoMessage,
   UserSettings,
+  StreamingComparisonSetupMessage,
+  QueryCompareResult,
 } from "../../common/interface-types";
 import { DEFAULT_USER_SETTINGS } from "../../common/interface-types";
 import CompareSelector from "./CompareSelector";
@@ -37,6 +39,12 @@ export function Compare(_: Record<string, never>): React.JSX.Element {
     DEFAULT_USER_SETTINGS,
   );
 
+  // This is a ref because we don't need to re-render when we get a new streaming comparison message
+  // and we don't want to change the listener every time we get a new message
+  const streamingComparisonRef = useRef<StreamingComparisonSetupMessage | null>(
+    null,
+  );
+
   const message = comparison?.message || "Empty comparison";
   const hasRows =
     comparison?.result &&
@@ -52,6 +60,72 @@ export function Compare(_: Record<string, never>): React.JSX.Element {
             break;
           case "setComparisons":
             setComparison(msg);
+            break;
+          case "streamingComparisonSetup":
+            setComparison(null);
+            streamingComparisonRef.current = msg;
+            break;
+          case "streamingComparisonAddResults": {
+            const prev = streamingComparisonRef.current;
+            if (prev === null) {
+              console.warn(
+                'Received "streamingComparisonAddResults" before "streamingComparisonSetup"',
+              );
+              break;
+            }
+
+            let result: QueryCompareResult;
+            switch (prev.result.kind) {
+              case "raw":
+                if (msg.result.kind !== "raw") {
+                  throw new Error(
+                    "Streaming comparison: expected raw results, got interpreted results",
+                  );
+                }
+
+                result = {
+                  ...prev.result,
+                  from: [...prev.result.from, ...msg.result.from],
+                  to: [...prev.result.to, ...msg.result.to],
+                };
+                break;
+              case "interpreted":
+                if (msg.result.kind !== "interpreted") {
+                  throw new Error(
+                    "Streaming comparison: expected interpreted results, got raw results",
+                  );
+                }
+
+                result = {
+                  ...prev.result,
+                  from: [...prev.result.from, ...msg.result.from],
+                  to: [...prev.result.to, ...msg.result.to],
+                };
+                break;
+              default:
+                throw new Error("Unexpected comparison result kind");
+            }
+
+            streamingComparisonRef.current = {
+              ...prev,
+              result,
+            };
+
+            break;
+          }
+          case "streamingComparisonComplete":
+            if (streamingComparisonRef.current === null) {
+              console.warn(
+                'Received "streamingComparisonComplete" before "streamingComparisonSetup"',
+              );
+              setComparison(null);
+              break;
+            }
+            setComparison({
+              ...streamingComparisonRef.current,
+              t: "setComparisons",
+            });
+            streamingComparisonRef.current = null;
             break;
           case "setUserSettings":
             setUserSettings(msg.userSettings);

--- a/extensions/ql-vscode/src/view/compare/Compare.tsx
+++ b/extensions/ql-vscode/src/view/compare/Compare.tsx
@@ -74,6 +74,13 @@ export function Compare(_: Record<string, never>): React.JSX.Element {
               break;
             }
 
+            if (prev.id !== msg.id) {
+              console.warn(
+                'Received "streamingComparisonAddResults" with different id, ignoring',
+              );
+              break;
+            }
+
             let result: QueryCompareResult;
             switch (prev.result.kind) {
               case "raw":
@@ -121,6 +128,14 @@ export function Compare(_: Record<string, never>): React.JSX.Element {
               setComparison(null);
               break;
             }
+
+            if (streamingComparisonRef.current.id !== msg.id) {
+              console.warn(
+                'Received "streamingComparisonComplete" with different id, ignoring',
+              );
+              break;
+            }
+
             setComparison({
               ...streamingComparisonRef.current,
               t: "setComparisons",


### PR DESCRIPTION
This implements streaming for the compare view to avoid a crash when the total JSON.stringified size of the comparison is larger than 1GB (i.e. the Node.js string limit). It does this as follows:
- All results are chunked into 1,000 results per message. This means we'll send at most 1,000 `to` **and** at most 1,000 `from` results in 1 message (i.e. 2,000 actual results).
- We'll send a "setup" message to tell the webview that we're starting a streaming result. This also contains a chunk.
- We'll then send as many "add results" messages as necessary to send all results.
- We'll send a "complete" message to tell the webview that we're done.

The 1,000 results per message is just a safe estimate where we should never run into the string limit. However, I can't really test this.