### PR TITLE
Only compare source and sink in SARIF comparison

### DIFF
--- a/extensions/ql-vscode/src/compare/sarif-diff.ts
+++ b/extensions/ql-vscode/src/compare/sarif-diff.ts
@@ -85,7 +85,7 @@ function toCanonicalResult(result: Result): Result {
 /**
  * Compare the alerts of two queries. Use deep equality to determine if
  * results have been added or removed across two invocations of a query.
- * It first canonicalizes the results by to ensure that when small changes
+ * It first canonicalizes the results to ensure that when small changes
  * to the query are made, the results are still considered the same. This
  * includes the removal of all paths except for the source and sink.
  *

--- a/extensions/ql-vscode/src/compare/sarif-diff.ts
+++ b/extensions/ql-vscode/src/compare/sarif-diff.ts
@@ -1,4 +1,4 @@
-import type { Location, Result } from "sarif";
+import type { Location, Result, ThreadFlowLocation } from "sarif";
 
 function toCanonicalLocation(location: Location): Location {
   if (location.physicalLocation?.artifactLocation?.index !== undefined) {
@@ -25,6 +25,19 @@ function toCanonicalLocation(location: Location): Location {
   return location;
 }
 
+function toCanonicalThreadFlowLocation(
+  threadFlowLocation: ThreadFlowLocation,
+): ThreadFlowLocation {
+  if (threadFlowLocation.location) {
+    return {
+      ...threadFlowLocation,
+      location: toCanonicalLocation(threadFlowLocation.location),
+    };
+  }
+
+  return threadFlowLocation;
+}
+
 function toCanonicalResult(result: Result): Result {
   const canonicalResult = {
     ...result,
@@ -40,37 +53,30 @@ function toCanonicalResult(result: Result): Result {
       canonicalResult.relatedLocations.map(toCanonicalLocation);
   }
 
-  if (canonicalResult.codeFlows) {
-    canonicalResult.codeFlows = canonicalResult.codeFlows.map((codeFlow) => {
-      if (codeFlow.threadFlows) {
-        return {
-          ...codeFlow,
-          threadFlows: codeFlow.threadFlows.map((threadFlow) => {
-            if (threadFlow.locations) {
-              return {
-                ...threadFlow,
-                locations: threadFlow.locations.map((threadFlowLocation) => {
-                  if (threadFlowLocation.location) {
-                    return {
-                      ...threadFlowLocation,
-                      location: toCanonicalLocation(
-                        threadFlowLocation.location,
-                      ),
-                    };
-                  }
+  if (canonicalResult.codeFlows && canonicalResult.codeFlows.length > 0) {
+    // If there are codeFlows, we don't want to compare the full codeFlows. Instead, we just want to compare the
+    // source and the sink (i.e. the first and last item). CodeQL should guarantee that the first and last threadFlow
+    // of every codeFlow is the same (i.e. every codeFlow has the same source and sink). Therefore, we just compare the
+    // first codeFlow and ignore the other codeFlows completely.
+    // If the codeFlow has a length of 1, this doesn't change the result.
 
-                  return threadFlowLocation;
-                }),
-              };
-            }
+    const source = {
+      ...canonicalResult.codeFlows[0].threadFlows[0],
+    };
+    const sink = {
+      ...canonicalResult.codeFlows[0].threadFlows[
+        canonicalResult.codeFlows[0].threadFlows.length - 1
+      ],
+    };
+    source.locations = source.locations.map(toCanonicalThreadFlowLocation);
+    sink.locations = sink.locations.map(toCanonicalThreadFlowLocation);
 
-            return threadFlow;
-          }),
-        };
-      }
-
-      return codeFlow;
-    });
+    canonicalResult.codeFlows = [
+      {
+        ...canonicalResult.codeFlows[0],
+        threadFlows: [source, sink],
+      },
+    ];
   }
 
   return canonicalResult;
@@ -79,11 +85,9 @@ function toCanonicalResult(result: Result): Result {
 /**
  * Compare the alerts of two queries. Use deep equality to determine if
  * results have been added or removed across two invocations of a query.
- *
- * Assumptions:
- *
- * 1. Queries have the same sort order
- * 2. Results are not changed or re-ordered, they are only added or removed
+ * It first canonicalizes the results by to ensure that when small changes
+ * to the query are made, the results are still considered the same. This
+ * includes the removal of all paths except for the source and sink.
  *
  * @param fromResults the source query
  * @param toResults the target query
@@ -104,19 +108,30 @@ export function sarifDiff(fromResults: Result[], toResults: Result[]) {
   const canonicalFromResults = fromResults.map(toCanonicalResult);
   const canonicalToResults = toResults.map(toCanonicalResult);
 
-  const results = {
+  const diffResults = {
     from: arrayDiff(canonicalFromResults, canonicalToResults),
     to: arrayDiff(canonicalToResults, canonicalFromResults),
   };
 
   if (
-    fromResults.length === results.from.length &&
-    toResults.length === results.to.length
+    fromResults.length === diffResults.from.length &&
+    toResults.length === diffResults.to.length
   ) {
     throw new Error("CodeQL Compare: No overlap between the selected queries.");
   }
 
-  return results;
+  // We don't want to return the canonical results, we want to return the original results.
+  // We can retrieve this by finding the index of the canonical result in the canonical results
+  // and then using that index to find the original result. This is possible because we know that
+  // we did a 1-to-1 map between the canonical results and the original results.
+  return {
+    from: diffResults.from.map(
+      (result) => fromResults[canonicalFromResults.indexOf(result)],
+    ),
+    to: diffResults.to.map(
+      (result) => toResults[canonicalToResults.indexOf(result)],
+    ),
+  };
 }
 
 function arrayDiff<T>(source: readonly T[], toRemove: readonly T[]): T[] {

--- a/extensions/ql-vscode/test/unit-tests/compare/differentPathsDifferentSourceSink.json
+++ b/extensions/ql-vscode/test/unit-tests/compare/differentPathsDifferentSourceSink.json
@@ -1,0 +1,23905 @@
+{
+  "result1": {
+    "ruleId": "java/polynomial-redos",
+    "ruleIndex": 0,
+    "rule": {
+      "id": "java/polynomial-redos",
+      "index": 0
+    },
+    "message": {
+      "text": "This [regular expression](1) that depends on a [user-provided value](2) may run slow on strings with many repetitions of '\\\\t'."
+    },
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
+            "uri": "src/java.base/share/classes/java/lang/String.java",
+            "uriBaseId": "%SRCROOT%",
+            "index": 0
+          },
+          "region": {
+            "startLine": 2855,
+            "startColumn": 39,
+            "endColumn": 43
+          }
+        }
+      }
+    ],
+    "partialFingerprints": {
+      "primaryLocationLineHash": "5270db7557dfd174:1",
+      "primaryLocationStartColumnFingerprint": "30"
+    },
+    "codeFlows": [
+      {
+        "threadFlows": [
+          {
+            "locations": [
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/resolver/implementations/ResolverDirectHTTP.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 45
+                    },
+                    "region": {
+                      "startLine": 142,
+                      "startColumn": 43,
+                      "endColumn": 73
+                    }
+                  },
+                  "message": {
+                    "text": "getInputStream(...) : InputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 0,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "source"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/resolver/implementations/ResolverDirectHTTP.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 45
+                    },
+                    "region": {
+                      "startLine": 147,
+                      "startColumn": 32,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "inputStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/resolver/implementations/ResolverDirectHTTP.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 45
+                    },
+                    "region": {
+                      "startLine": 147,
+                      "startColumn": 49,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "buf [post update] : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 9,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/resolver/implementations/ResolverDirectHTTP.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 45
+                    },
+                    "region": {
+                      "startLine": 148,
+                      "startColumn": 32,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "buf : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/resolver/implementations/ResolverDirectHTTP.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 45
+                    },
+                    "region": {
+                      "startLine": 148,
+                      "startColumn": 21,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "baos [post update] : ByteArrayOutputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 10,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/resolver/implementations/ResolverDirectHTTP.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 45
+                    },
+                    "region": {
+                      "startLine": 154,
+                      "startColumn": 66,
+                      "endColumn": 70
+                    }
+                  },
+                  "message": {
+                    "text": "baos : ByteArrayOutputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/resolver/implementations/ResolverDirectHTTP.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 45
+                    },
+                    "region": {
+                      "startLine": 154,
+                      "startColumn": 66,
+                      "endColumn": 84
+                    }
+                  },
+                  "message": {
+                    "text": "toByteArray(...) : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 11,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 126,
+                      "startColumn": 30,
+                      "endColumn": 48
+                    }
+                  },
+                  "message": {
+                    "text": "inputOctets : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 128,
+                      "startColumn": 22,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "inputOctets : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 128,
+                      "startColumn": 9,
+                      "endColumn": 13
+                    }
+                  },
+                  "message": {
+                    "text": "this [post update] : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/resolver/implementations/ResolverDirectHTTP.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 45
+                    },
+                    "region": {
+                      "startLine": 154,
+                      "startColumn": 44,
+                      "endColumn": 85
+                    }
+                  },
+                  "message": {
+                    "text": "new XMLSignatureInput(...) : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/resolver/implementations/ResolverDirectHTTP.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 45
+                    },
+                    "region": {
+                      "startLine": 160,
+                      "startColumn": 24,
+                      "endColumn": 30
+                    }
+                  },
+                  "message": {
+                    "text": "result : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/resolver/ResourceResolver.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 47
+                    },
+                    "region": {
+                      "startLine": 162,
+                      "startColumn": 24,
+                      "endColumn": 58
+                    }
+                  },
+                  "message": {
+                    "text": "engineResolveURI(...) : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMURIDereferencer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 48
+                    },
+                    "region": {
+                      "startLine": 144,
+                      "startColumn": 36,
+                      "endColumn": 72
+                    }
+                  },
+                  "message": {
+                    "text": "resolve(...) : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMURIDereferencer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 48
+                    },
+                    "region": {
+                      "startLine": 146,
+                      "startColumn": 50,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "in : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheOctetStreamData.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 49
+                    },
+                    "region": {
+                      "startLine": 37,
+                      "startColumn": 34,
+                      "endColumn": 54
+                    }
+                  },
+                  "message": {
+                    "text": "xi : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheOctetStreamData.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 49
+                    },
+                    "region": {
+                      "startLine": 40,
+                      "startColumn": 15,
+                      "endColumn": 17
+                    }
+                  },
+                  "message": {
+                    "text": "xi : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 243,
+                      "startColumn": 24,
+                      "endColumn": 38
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 249,
+                      "startColumn": 62,
+                      "endColumn": 67
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 249,
+                      "startColumn": 62,
+                      "endColumn": 67
+                    }
+                  },
+                  "message": {
+                    "text": "bytes : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 249,
+                      "startColumn": 37,
+                      "endColumn": 68
+                    }
+                  },
+                  "message": {
+                    "text": "new ByteArrayInputStream(...) : ByteArrayInputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 12,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 250,
+                      "startColumn": 20,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "inputOctetStreamProxy : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheOctetStreamData.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 49
+                    },
+                    "region": {
+                      "startLine": 40,
+                      "startColumn": 15,
+                      "endColumn": 34
+                    }
+                  },
+                  "message": {
+                    "text": "getOctetStream(...) : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheOctetStreamData.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 49
+                    },
+                    "region": {
+                      "startLine": 40,
+                      "startColumn": 9,
+                      "endColumn": 73
+                    }
+                  },
+                  "message": {
+                    "text": "this <constr(this)> [post update] : ApacheOctetStreamData"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 13,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMURIDereferencer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 48
+                    },
+                    "region": {
+                      "startLine": 146,
+                      "startColumn": 24,
+                      "endColumn": 53
+                    }
+                  },
+                  "message": {
+                    "text": "new ApacheOctetStreamData(...) : ApacheOctetStreamData"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMReference.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 50
+                    },
+                    "region": {
+                      "startLine": 416,
+                      "startColumn": 20,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "dereference(...) : ApacheOctetStreamData"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMReference.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 50
+                    },
+                    "region": {
+                      "startLine": 423,
+                      "startColumn": 16,
+                      "endColumn": 20
+                    }
+                  },
+                  "message": {
+                    "text": "data : ApacheOctetStreamData"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMReference.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 50
+                    },
+                    "region": {
+                      "startLine": 354,
+                      "startColumn": 20,
+                      "endColumn": 44
+                    }
+                  },
+                  "message": {
+                    "text": "dereference(...) : ApacheOctetStreamData"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMReference.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 50
+                    },
+                    "region": {
+                      "startLine": 358,
+                      "startColumn": 33,
+                      "endColumn": 37
+                    }
+                  },
+                  "message": {
+                    "text": "data : ApacheOctetStreamData"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMReference.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 50
+                    },
+                    "region": {
+                      "startLine": 426,
+                      "startColumn": 30,
+                      "endColumn": 51
+                    }
+                  },
+                  "message": {
+                    "text": "dereferencedData : ApacheOctetStreamData"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMReference.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 50
+                    },
+                    "region": {
+                      "startLine": 481,
+                      "startColumn": 27,
+                      "endColumn": 48
+                    }
+                  },
+                  "message": {
+                    "text": "(...)... : ApacheOctetStreamData"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMReference.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 50
+                    },
+                    "region": {
+                      "startLine": 481,
+                      "startColumn": 26,
+                      "endColumn": 66
+                    }
+                  },
+                  "message": {
+                    "text": "getOctetStream(...) : InputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 14,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 137,
+                      "startColumn": 30,
+                      "endColumn": 58
+                    }
+                  },
+                  "message": {
+                    "text": "inputOctetStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 138,
+                      "startColumn": 38,
+                      "endColumn": 54
+                    }
+                  },
+                  "message": {
+                    "text": "inputOctetStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 138,
+                      "startColumn": 9,
+                      "endColumn": 13
+                    }
+                  },
+                  "message": {
+                    "text": "this [post update] : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMReference.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 50
+                    },
+                    "region": {
+                      "startLine": 480,
+                      "startColumn": 26,
+                      "endLine": 481,
+                      "endColumn": 67
+                    }
+                  },
+                  "message": {
+                    "text": "new XMLSignatureInput(...) : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMReference.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 50
+                    },
+                    "region": {
+                      "startLine": 531,
+                      "startColumn": 25,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "xi : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 487,
+                      "startColumn": 17,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 501,
+                      "startColumn": 41,
+                      "endColumn": 45
+                    }
+                  },
+                  "message": {
+                    "text": "this : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/c14n/implementations/CanonicalizerBase.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 51
+                    },
+                    "region": {
+                      "startLine": 137,
+                      "startColumn": 36,
+                      "endColumn": 59
+                    }
+                  },
+                  "message": {
+                    "text": "input : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/c14n/implementations/CanonicalizerBase.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 51
+                    },
+                    "region": {
+                      "startLine": 154,
+                      "startColumn": 52,
+                      "endColumn": 57
+                    }
+                  },
+                  "message": {
+                    "text": "input : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 193,
+                      "startColumn": 22,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 194,
+                      "startColumn": 16,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 214,
+                      "startColumn": 22,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 226,
+                      "startColumn": 13,
+                      "endColumn": 29
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 562,
+                      "startColumn": 18,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 565,
+                      "startColumn": 42,
+                      "endColumn": 46
+                    }
+                  },
+                  "message": {
+                    "text": "this : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 243,
+                      "startColumn": 24,
+                      "endColumn": 38
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 245,
+                      "startColumn": 20,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 245,
+                      "startColumn": 20,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "inputOctetStreamProxy : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 565,
+                      "startColumn": 42,
+                      "endColumn": 63
+                    }
+                  },
+                  "message": {
+                    "text": "getOctetStream(...) : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/XMLUtils.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 52
+                    },
+                    "region": {
+                      "startLine": 955,
+                      "startColumn": 33,
+                      "endColumn": 56
+                    }
+                  },
+                  "message": {
+                    "text": "inputStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/XMLUtils.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 52
+                    },
+                    "region": {
+                      "startLine": 957,
+                      "startColumn": 36,
+                      "endColumn": 47
+                    }
+                  },
+                  "message": {
+                    "text": "inputStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/parser/XMLParserImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 53
+                    },
+                    "region": {
+                      "startLine": 60,
+                      "startColumn": 27,
+                      "endColumn": 50
+                    }
+                  },
+                  "message": {
+                    "text": "inputStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/parser/XMLParserImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 53
+                    },
+                    "region": {
+                      "startLine": 69,
+                      "startColumn": 46,
+                      "endColumn": 57
+                    }
+                  },
+                  "message": {
+                    "text": "inputStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/javax/xml/parsers/DocumentBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 54
+                    },
+                    "region": {
+                      "startLine": 115,
+                      "startColumn": 27,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/javax/xml/parsers/DocumentBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 54
+                    },
+                    "region": {
+                      "startLine": 121,
+                      "startColumn": 42,
+                      "endColumn": 44
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 127,
+                      "startColumn": 25,
+                      "endColumn": 47
+                    }
+                  },
+                  "message": {
+                    "text": "byteStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 129,
+                      "startColumn": 23,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "byteStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 248,
+                      "startColumn": 32,
+                      "endColumn": 54
+                    }
+                  },
+                  "message": {
+                    "text": "byteStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 250,
+                      "startColumn": 27,
+                      "endColumn": 37
+                    }
+                  },
+                  "message": {
+                    "text": "byteStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 250,
+                      "startColumn": 9,
+                      "endColumn": 13
+                    }
+                  },
+                  "message": {
+                    "text": "this [post update] : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 129,
+                      "startColumn": 9,
+                      "endColumn": 34
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> [post update] : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/javax/xml/parsers/DocumentBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 54
+                    },
+                    "region": {
+                      "startLine": 121,
+                      "startColumn": 26,
+                      "endColumn": 45
+                    }
+                  },
+                  "message": {
+                    "text": "new InputSource(...) : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/javax/xml/parsers/DocumentBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 54
+                    },
+                    "region": {
+                      "startLine": 122,
+                      "startColumn": 22,
+                      "endColumn": 24
+                    }
+                  },
+                  "message": {
+                    "text": "in : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/jaxp/DocumentBuilderImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 56
+                    },
+                    "region": {
+                      "startLine": 329,
+                      "startColumn": 27,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/jaxp/DocumentBuilderImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 56
+                    },
+                    "region": {
+                      "startLine": 342,
+                      "startColumn": 25,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/DOMParser.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 57
+                    },
+                    "region": {
+                      "startLine": 235,
+                      "startColumn": 23,
+                      "endColumn": 46
+                    }
+                  },
+                  "message": {
+                    "text": "inputSource : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/DOMParser.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 57
+                    },
+                    "region": {
+                      "startLine": 244,
+                      "startColumn": 42,
+                      "endColumn": 53
+                    }
+                  },
+                  "message": {
+                    "text": "inputSource : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 264,
+                      "startColumn": 24,
+                      "endColumn": 37
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 266,
+                      "startColumn": 16,
+                      "endColumn": 26
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 266,
+                      "startColumn": 16,
+                      "endColumn": 26
+                    }
+                  },
+                  "message": {
+                    "text": "byteStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/DOMParser.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 57
+                    },
+                    "region": {
+                      "startLine": 244,
+                      "startColumn": 42,
+                      "endColumn": 69
+                    }
+                  },
+                  "message": {
+                    "text": "getByteStream(...) : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xni/parser/XMLInputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 58
+                    },
+                    "region": {
+                      "startLine": 234,
+                      "startColumn": 31,
+                      "endColumn": 53
+                    }
+                  },
+                  "message": {
+                    "text": "byteStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xni/parser/XMLInputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 58
+                    },
+                    "region": {
+                      "startLine": 235,
+                      "startColumn": 23,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "byteStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xni/parser/XMLInputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 58
+                    },
+                    "region": {
+                      "startLine": 235,
+                      "startColumn": 9,
+                      "endColumn": 20
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> [post update] : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/DOMParser.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 57
+                    },
+                    "region": {
+                      "startLine": 244,
+                      "startColumn": 13,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "xmlInputSource [post update] : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/DOMParser.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 57
+                    },
+                    "region": {
+                      "startLine": 247,
+                      "startColumn": 19,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "xmlInputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XMLParser.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 59
+                    },
+                    "region": {
+                      "startLine": 128,
+                      "startColumn": 23,
+                      "endColumn": 49
+                    }
+                  },
+                  "message": {
+                    "text": "inputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XMLParser.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 59
+                    },
+                    "region": {
+                      "startLine": 141,
+                      "startColumn": 30,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "inputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/opti/SchemaParsingConfig.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 60
+                    },
+                    "region": {
+                      "startLine": 686,
+                      "startColumn": 23,
+                      "endColumn": 44
+                    }
+                  },
+                  "message": {
+                    "text": "source : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/opti/SchemaParsingConfig.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 60
+                    },
+                    "region": {
+                      "startLine": 695,
+                      "startColumn": 28,
+                      "endColumn": 34
+                    }
+                  },
+                  "message": {
+                    "text": "source : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/opti/SchemaParsingConfig.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 60
+                    },
+                    "region": {
+                      "startLine": 556,
+                      "startColumn": 32,
+                      "endColumn": 58
+                    }
+                  },
+                  "message": {
+                    "text": "inputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/opti/SchemaParsingConfig.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 60
+                    },
+                    "region": {
+                      "startLine": 564,
+                      "startColumn": 24,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "inputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/opti/SchemaParsingConfig.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 60
+                    },
+                    "region": {
+                      "startLine": 564,
+                      "startColumn": 9,
+                      "endColumn": 21
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> [post update] : SchemaParsingConfig [fInputSource, fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/opti/SchemaParsingConfig.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 60
+                    },
+                    "region": {
+                      "startLine": 695,
+                      "startColumn": 13,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> [post update] : SchemaParsingConfig [fInputSource, fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/opti/SchemaParsingConfig.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 60
+                    },
+                    "region": {
+                      "startLine": 696,
+                      "startColumn": 13,
+                      "endColumn": 24
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : SchemaParsingConfig [fInputSource, fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/opti/SchemaParsingConfig.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 60
+                    },
+                    "region": {
+                      "startLine": 584,
+                      "startColumn": 20,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : SchemaParsingConfig [fInputSource, fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/opti/SchemaParsingConfig.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 60
+                    },
+                    "region": {
+                      "startLine": 593,
+                      "startColumn": 70,
+                      "endColumn": 82
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : SchemaParsingConfig [fInputSource, fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/opti/SchemaParsingConfig.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 60
+                    },
+                    "region": {
+                      "startLine": 593,
+                      "startColumn": 70,
+                      "endColumn": 82
+                    }
+                  },
+                  "message": {
+                    "text": "fInputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLVersionDetector.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 61
+                    },
+                    "region": {
+                      "startLine": 149,
+                      "startColumn": 38,
+                      "endColumn": 64
+                    }
+                  },
+                  "message": {
+                    "text": "inputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLVersionDetector.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 61
+                    },
+                    "region": {
+                      "startLine": 150,
+                      "startColumn": 74,
+                      "endColumn": 85
+                    }
+                  },
+                  "message": {
+                    "text": "inputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 626,
+                      "startColumn": 70,
+                      "endColumn": 99
+                    }
+                  },
+                  "message": {
+                    "text": "xmlInputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 648,
+                      "startColumn": 22,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "xmlInputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xni/parser/XMLInputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 58
+                    },
+                    "region": {
+                      "startLine": 239,
+                      "startColumn": 24,
+                      "endColumn": 37
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xni/parser/XMLInputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 58
+                    },
+                    "region": {
+                      "startLine": 240,
+                      "startColumn": 16,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xni/parser/XMLInputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 58
+                    },
+                    "region": {
+                      "startLine": 240,
+                      "startColumn": 16,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "fByteStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 648,
+                      "startColumn": 22,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "getByteStream(...) : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 697,
+                      "startColumn": 80,
+                      "endColumn": 86
+                    }
+                  },
+                  "message": {
+                    "text": "stream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3003,
+                      "startColumn": 38,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3005,
+                      "startColumn": 28,
+                      "endColumn": 30
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3005,
+                      "startColumn": 13,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> [post update] : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 697,
+                      "startColumn": 54,
+                      "endColumn": 87
+                    }
+                  },
+                  "message": {
+                    "text": "new RewindableInputStream(...) : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 720,
+                      "startColumn": 29,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "stream : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3089,
+                      "startColumn": 21,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3099,
+                      "startColumn": 24,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3099,
+                      "startColumn": 24,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "fInputStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3687,
+                      "startColumn": 21,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3701,
+                      "startColumn": 22,
+                      "endLine": 3702,
+                      "endColumn": 71
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3649,
+                      "startColumn": 20,
+                      "endColumn": 24
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3652,
+                      "startColumn": 30,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "super : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3652,
+                      "startColumn": 41,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "b [post update] : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 1,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1964,
+                      "startColumn": 47,
+                      "endColumn": 93
+                    }
+                  },
+                  "message": {
+                    "text": "new HttpInputStream(...) : HttpInputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "id": "AdditionalTaintStep",
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1985,
+                      "startColumn": 24,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "inputStream : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1573,
+                      "startColumn": 44,
+                      "endColumn": 61
+                    }
+                  },
+                  "message": {
+                    "text": "getInputStream0(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 809,
+                      "startColumn": 20,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "run(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 816,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "result : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 571,
+                      "startColumn": 20,
+                      "endColumn": 62
+                    }
+                  },
+                  "message": {
+                    "text": "executePrivileged(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 89,
+                      "startColumn": 18,
+                      "endColumn": 51
+                    }
+                  },
+                  "message": {
+                    "text": "doPrivileged(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 93,
+                      "startColumn": 16,
+                      "endColumn": 18
+                    }
+                  },
+                  "message": {
+                    "text": "is : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 75,
+                      "startColumn": 31,
+                      "endColumn": 56
+                    }
+                  },
+                  "message": {
+                    "text": "getResourceAsStream(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 76,
+                      "startColumn": 20,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "is : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 76,
+                      "startColumn": 20,
+                      "endColumn": 37
+                    }
+                  },
+                  "message": {
+                    "text": "readAllBytes(...) : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 2,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 80,
+                      "startColumn": 16,
+                      "endColumn": 20
+                    }
+                  },
+                  "message": {
+                    "text": "data : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/util/ResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 12
+                    },
+                    "region": {
+                      "startLine": 561,
+                      "startColumn": 22,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "handleGetObject(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/util/ResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 12
+                    },
+                    "region": {
+                      "startLine": 574,
+                      "startColumn": 16,
+                      "endColumn": 19
+                    }
+                  },
+                  "message": {
+                    "text": "obj : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 326,
+                      "startColumn": 44,
+                      "endColumn": 60
+                    }
+                  },
+                  "message": {
+                    "text": "getObject(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 328,
+                      "startColumn": 45,
+                      "endColumn": 50
+                    }
+                  },
+                  "message": {
+                    "text": "value : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 328,
+                      "startColumn": 29,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "values [post update] : TextAndMnemonicHashMap [<map.value>] : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 3,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 337,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "values : TextAndMnemonicHashMap [<map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 298,
+                      "startColumn": 20,
+                      "endColumn": 39
+                    }
+                  },
+                  "message": {
+                    "text": "getResourceCache(...) : TextAndMnemonicHashMap [<map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 298,
+                      "startColumn": 20,
+                      "endColumn": 48
+                    }
+                  },
+                  "message": {
+                    "text": "get(...) : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 4,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 172,
+                      "startColumn": 42,
+                      "endColumn": 74
+                    }
+                  },
+                  "message": {
+                    "text": "getFromResourceBundle(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 172,
+                      "startColumn": 16,
+                      "endColumn": 74
+                    }
+                  },
+                  "message": {
+                    "text": "...?...:... : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/rtf/MockAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 14
+                    },
+                    "region": {
+                      "startLine": 67,
+                      "startColumn": 16,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "get(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 15
+                    },
+                    "region": {
+                      "startLine": 151,
+                      "startColumn": 25,
+                      "endColumn": 50
+                    }
+                  },
+                  "message": {
+                    "text": "getAttribute(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 15
+                    },
+                    "region": {
+                      "startLine": 154,
+                      "startColumn": 16,
+                      "endColumn": 21
+                    }
+                  },
+                  "message": {
+                    "text": "value : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 15
+                    },
+                    "region": {
+                      "startLine": 328,
+                      "startColumn": 28,
+                      "endColumn": 45
+                    }
+                  },
+                  "message": {
+                    "text": "getAttribute(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 15
+                    },
+                    "region": {
+                      "startLine": 336,
+                      "startColumn": 16,
+                      "endColumn": 17
+                    }
+                  },
+                  "message": {
+                    "text": "s : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 1304,
+                      "startColumn": 27,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 1336,
+                      "startColumn": 39,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "arg : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 311,
+                      "startColumn": 45,
+                      "endColumn": 55
+                    }
+                  },
+                  "message": {
+                    "text": "str : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 313,
+                      "startColumn": 22,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "str : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 313,
+                      "startColumn": 9,
+                      "endColumn": 14
+                    }
+                  },
+                  "message": {
+                    "text": "super [post update] : StringBuffer"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 5,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 1336,
+                      "startColumn": 25,
+                      "endColumn": 31
+                    }
+                  },
+                  "message": {
+                    "text": "result [post update] : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 1364,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "result : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 885,
+                      "startColumn": 16,
+                      "endColumn": 66
+                    }
+                  },
+                  "message": {
+                    "text": "subformat(...) : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/Format.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 18
+                    },
+                    "region": {
+                      "startLine": 159,
+                      "startColumn": 16,
+                      "endColumn": 69
+                    }
+                  },
+                  "message": {
+                    "text": "format(...) : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 713,
+                      "startColumn": 32,
+                      "endColumn": 40
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 717,
+                      "startColumn": 27,
+                      "endColumn": 40
+                    }
+                  },
+                  "message": {
+                    "text": "toStringCache : String"
+                  }
+                },
+                "taxa": [
+                  {
+                    "id": "entrypointFieldStep",
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 717,
+                      "startColumn": 16,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "new String(...) : String"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 6,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/Format.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 18
+                    },
+                    "region": {
+                      "startLine": 159,
+                      "startColumn": 16,
+                      "endColumn": 80
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 860,
+                      "startColumn": 16,
+                      "endColumn": 38
+                    }
+                  },
+                  "message": {
+                    "text": "format(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/DatatypeException.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 19
+                    },
+                    "region": {
+                      "startLine": 102,
+                      "startColumn": 23,
+                      "endColumn": 64
+                    }
+                  },
+                  "message": {
+                    "text": "format(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/DatatypeException.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 19
+                    },
+                    "region": {
+                      "startLine": 109,
+                      "startColumn": 16,
+                      "endColumn": 19
+                    }
+                  },
+                  "message": {
+                    "text": "msg : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/javax/xml/parsers/FactoryConfigurationError.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 20
+                    },
+                    "region": {
+                      "startLine": 111,
+                      "startColumn": 20,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "getMessage(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "make/jdk/src/classes/build/tools/module/ModuleInfoExtraTest.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 21
+                    },
+                    "region": {
+                      "startLine": 254,
+                      "startColumn": 18,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "getMessage(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 2854,
+                      "startColumn": 20,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 2855,
+                      "startColumn": 39,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "this"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "threadFlows": [
+          {
+            "locations": [
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/resolver/implementations/ResolverDirectHTTP.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 45
+                    },
+                    "region": {
+                      "startLine": 142,
+                      "startColumn": 43,
+                      "endColumn": 73
+                    }
+                  },
+                  "message": {
+                    "text": "getInputStream(...) : InputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 0,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "source"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/resolver/implementations/ResolverDirectHTTP.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 45
+                    },
+                    "region": {
+                      "startLine": 147,
+                      "startColumn": 32,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "inputStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/resolver/implementations/ResolverDirectHTTP.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 45
+                    },
+                    "region": {
+                      "startLine": 147,
+                      "startColumn": 49,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "buf [post update] : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 9,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/resolver/implementations/ResolverDirectHTTP.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 45
+                    },
+                    "region": {
+                      "startLine": 148,
+                      "startColumn": 32,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "buf : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/resolver/implementations/ResolverDirectHTTP.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 45
+                    },
+                    "region": {
+                      "startLine": 148,
+                      "startColumn": 21,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "baos [post update] : ByteArrayOutputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 10,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/resolver/implementations/ResolverDirectHTTP.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 45
+                    },
+                    "region": {
+                      "startLine": 154,
+                      "startColumn": 66,
+                      "endColumn": 70
+                    }
+                  },
+                  "message": {
+                    "text": "baos : ByteArrayOutputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/resolver/implementations/ResolverDirectHTTP.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 45
+                    },
+                    "region": {
+                      "startLine": 154,
+                      "startColumn": 66,
+                      "endColumn": 84
+                    }
+                  },
+                  "message": {
+                    "text": "toByteArray(...) : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 11,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 126,
+                      "startColumn": 30,
+                      "endColumn": 48
+                    }
+                  },
+                  "message": {
+                    "text": "inputOctets : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 128,
+                      "startColumn": 22,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "inputOctets : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 128,
+                      "startColumn": 9,
+                      "endColumn": 13
+                    }
+                  },
+                  "message": {
+                    "text": "this [post update] : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/resolver/implementations/ResolverDirectHTTP.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 45
+                    },
+                    "region": {
+                      "startLine": 154,
+                      "startColumn": 44,
+                      "endColumn": 85
+                    }
+                  },
+                  "message": {
+                    "text": "new XMLSignatureInput(...) : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/resolver/implementations/ResolverDirectHTTP.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 45
+                    },
+                    "region": {
+                      "startLine": 160,
+                      "startColumn": 24,
+                      "endColumn": 30
+                    }
+                  },
+                  "message": {
+                    "text": "result : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/resolver/ResourceResolver.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 47
+                    },
+                    "region": {
+                      "startLine": 162,
+                      "startColumn": 24,
+                      "endColumn": 58
+                    }
+                  },
+                  "message": {
+                    "text": "engineResolveURI(...) : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMURIDereferencer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 48
+                    },
+                    "region": {
+                      "startLine": 144,
+                      "startColumn": 36,
+                      "endColumn": 72
+                    }
+                  },
+                  "message": {
+                    "text": "resolve(...) : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMURIDereferencer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 48
+                    },
+                    "region": {
+                      "startLine": 148,
+                      "startColumn": 46,
+                      "endColumn": 48
+                    }
+                  },
+                  "message": {
+                    "text": "in : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheNodeSetData.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 62
+                    },
+                    "region": {
+                      "startLine": 43,
+                      "startColumn": 30,
+                      "endColumn": 50
+                    }
+                  },
+                  "message": {
+                    "text": "xi : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheNodeSetData.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 62
+                    },
+                    "region": {
+                      "startLine": 44,
+                      "startColumn": 19,
+                      "endColumn": 21
+                    }
+                  },
+                  "message": {
+                    "text": "xi : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheNodeSetData.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 62
+                    },
+                    "region": {
+                      "startLine": 44,
+                      "startColumn": 9,
+                      "endColumn": 13
+                    }
+                  },
+                  "message": {
+                    "text": "this [post update] : ApacheNodeSetData [xi, bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMURIDereferencer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 48
+                    },
+                    "region": {
+                      "startLine": 148,
+                      "startColumn": 24,
+                      "endColumn": 49
+                    }
+                  },
+                  "message": {
+                    "text": "new ApacheNodeSetData(...) : ApacheNodeSetData [xi, bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMReference.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 50
+                    },
+                    "region": {
+                      "startLine": 416,
+                      "startColumn": 20,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "dereference(...) : ApacheNodeSetData [xi, bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMReference.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 50
+                    },
+                    "region": {
+                      "startLine": 423,
+                      "startColumn": 16,
+                      "endColumn": 20
+                    }
+                  },
+                  "message": {
+                    "text": "data : ApacheNodeSetData [xi, bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMReference.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 50
+                    },
+                    "region": {
+                      "startLine": 354,
+                      "startColumn": 20,
+                      "endColumn": 44
+                    }
+                  },
+                  "message": {
+                    "text": "dereference(...) : ApacheNodeSetData [xi, bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMReference.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 50
+                    },
+                    "region": {
+                      "startLine": 358,
+                      "startColumn": 33,
+                      "endColumn": 37
+                    }
+                  },
+                  "message": {
+                    "text": "data : ApacheNodeSetData [xi, bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMReference.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 50
+                    },
+                    "region": {
+                      "startLine": 426,
+                      "startColumn": 30,
+                      "endColumn": 51
+                    }
+                  },
+                  "message": {
+                    "text": "dereferencedData : ApacheNodeSetData [xi, bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMReference.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 50
+                    },
+                    "region": {
+                      "startLine": 456,
+                      "startColumn": 48,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "data : ApacheNodeSetData [xi, bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 63
+                    },
+                    "region": {
+                      "startLine": 167,
+                      "startColumn": 27,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "data : ApacheNodeSetData [xi, bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 63
+                    },
+                    "region": {
+                      "startLine": 170,
+                      "startColumn": 30,
+                      "endColumn": 34
+                    }
+                  },
+                  "message": {
+                    "text": "data : ApacheNodeSetData [xi, bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheCanonicalizer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 64
+                    },
+                    "region": {
+                      "startLine": 185,
+                      "startColumn": 27,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "data : ApacheNodeSetData [xi, bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheCanonicalizer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 64
+                    },
+                    "region": {
+                      "startLine": 214,
+                      "startColumn": 19,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "(...)... : ApacheNodeSetData [xi, bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheNodeSetData.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 62
+                    },
+                    "region": {
+                      "startLine": 62,
+                      "startColumn": 30,
+                      "endColumn": 50
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : ApacheNodeSetData [xi, bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheNodeSetData.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 62
+                    },
+                    "region": {
+                      "startLine": 63,
+                      "startColumn": 16,
+                      "endColumn": 18
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : ApacheNodeSetData [xi, bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheNodeSetData.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 62
+                    },
+                    "region": {
+                      "startLine": 63,
+                      "startColumn": 16,
+                      "endColumn": 18
+                    }
+                  },
+                  "message": {
+                    "text": "xi : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheCanonicalizer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 64
+                    },
+                    "region": {
+                      "startLine": 214,
+                      "startColumn": 18,
+                      "endColumn": 59
+                    }
+                  },
+                  "message": {
+                    "text": "getXMLSignatureInput(...) : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheCanonicalizer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 64
+                    },
+                    "region": {
+                      "startLine": 241,
+                      "startColumn": 51,
+                      "endColumn": 53
+                    }
+                  },
+                  "message": {
+                    "text": "in : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/transforms/Transform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 65
+                    },
+                    "region": {
+                      "startLine": 324,
+                      "startColumn": 9,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "input : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/transforms/Transform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 65
+                    },
+                    "region": {
+                      "startLine": 330,
+                      "startColumn": 58,
+                      "endColumn": 63
+                    }
+                  },
+                  "message": {
+                    "text": "input : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/transforms/implementations/TransformEnvelopedSignature.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 66
+                    },
+                    "region": {
+                      "startLine": 59,
+                      "startColumn": 9,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "input : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/transforms/implementations/TransformEnvelopedSignature.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 66
+                    },
+                    "region": {
+                      "startLine": 81,
+                      "startColumn": 16,
+                      "endColumn": 21
+                    }
+                  },
+                  "message": {
+                    "text": "input : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/transforms/Transform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 65
+                    },
+                    "region": {
+                      "startLine": 330,
+                      "startColumn": 22,
+                      "endColumn": 109
+                    }
+                  },
+                  "message": {
+                    "text": "enginePerformTransform(...) : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/transforms/Transform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 65
+                    },
+                    "region": {
+                      "startLine": 341,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "result : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheCanonicalizer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 64
+                    },
+                    "region": {
+                      "startLine": 241,
+                      "startColumn": 18,
+                      "endColumn": 66
+                    }
+                  },
+                  "message": {
+                    "text": "performTransform(...) : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheCanonicalizer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 64
+                    },
+                    "region": {
+                      "startLine": 243,
+                      "startColumn": 50,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "in : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheOctetStreamData.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 49
+                    },
+                    "region": {
+                      "startLine": 37,
+                      "startColumn": 34,
+                      "endColumn": 54
+                    }
+                  },
+                  "message": {
+                    "text": "xi : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheOctetStreamData.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 49
+                    },
+                    "region": {
+                      "startLine": 40,
+                      "startColumn": 15,
+                      "endColumn": 17
+                    }
+                  },
+                  "message": {
+                    "text": "xi : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 243,
+                      "startColumn": 24,
+                      "endColumn": 38
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 248,
+                      "startColumn": 13,
+                      "endColumn": 18
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 248,
+                      "startColumn": 13,
+                      "endColumn": 18
+                    }
+                  },
+                  "message": {
+                    "text": "bytes : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 249,
+                      "startColumn": 62,
+                      "endColumn": 67
+                    }
+                  },
+                  "message": {
+                    "text": "bytes : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 249,
+                      "startColumn": 37,
+                      "endColumn": 68
+                    }
+                  },
+                  "message": {
+                    "text": "new ByteArrayInputStream(...) : ByteArrayInputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 12,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 249,
+                      "startColumn": 13,
+                      "endColumn": 34
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> [post update] : XMLSignatureInput [inputOctetStreamProxy] : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 250,
+                      "startColumn": 20,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : XMLSignatureInput [inputOctetStreamProxy] : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 250,
+                      "startColumn": 20,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "inputOctetStreamProxy : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheOctetStreamData.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 49
+                    },
+                    "region": {
+                      "startLine": 40,
+                      "startColumn": 15,
+                      "endColumn": 34
+                    }
+                  },
+                  "message": {
+                    "text": "getOctetStream(...) : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheOctetStreamData.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 49
+                    },
+                    "region": {
+                      "startLine": 40,
+                      "startColumn": 9,
+                      "endColumn": 73
+                    }
+                  },
+                  "message": {
+                    "text": "this <constr(this)> [post update] : ApacheOctetStreamData [octetStream] : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheCanonicalizer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 64
+                    },
+                    "region": {
+                      "startLine": 243,
+                      "startColumn": 24,
+                      "endColumn": 53
+                    }
+                  },
+                  "message": {
+                    "text": "new ApacheOctetStreamData(...) : ApacheOctetStreamData [octetStream] : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 63
+                    },
+                    "region": {
+                      "startLine": 170,
+                      "startColumn": 16,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "transform(...) : ApacheOctetStreamData [octetStream] : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMReference.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 50
+                    },
+                    "region": {
+                      "startLine": 456,
+                      "startColumn": 28,
+                      "endColumn": 66
+                    }
+                  },
+                  "message": {
+                    "text": "transform(...) : ApacheOctetStreamData [octetStream] : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMReference.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 50
+                    },
+                    "region": {
+                      "startLine": 456,
+                      "startColumn": 48,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "data : ApacheOctetStreamData [octetStream] : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 63
+                    },
+                    "region": {
+                      "startLine": 167,
+                      "startColumn": 27,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "data : ApacheOctetStreamData [octetStream] : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 63
+                    },
+                    "region": {
+                      "startLine": 170,
+                      "startColumn": 30,
+                      "endColumn": 34
+                    }
+                  },
+                  "message": {
+                    "text": "data : ApacheOctetStreamData [octetStream] : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheCanonicalizer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 64
+                    },
+                    "region": {
+                      "startLine": 185,
+                      "startColumn": 27,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "data : ApacheOctetStreamData [octetStream] : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheCanonicalizer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 64
+                    },
+                    "region": {
+                      "startLine": 231,
+                      "startColumn": 23,
+                      "endColumn": 44
+                    }
+                  },
+                  "message": {
+                    "text": "(...)... : ApacheOctetStreamData [octetStream] : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/javax/xml/crypto/OctetStreamData.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 67
+                    },
+                    "region": {
+                      "startLine": 83,
+                      "startColumn": 24,
+                      "endColumn": 38
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : ApacheOctetStreamData [octetStream] : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/javax/xml/crypto/OctetStreamData.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 67
+                    },
+                    "region": {
+                      "startLine": 84,
+                      "startColumn": 16,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : ApacheOctetStreamData [octetStream] : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/javax/xml/crypto/OctetStreamData.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 67
+                    },
+                    "region": {
+                      "startLine": 84,
+                      "startColumn": 16,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "octetStream : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheCanonicalizer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 64
+                    },
+                    "region": {
+                      "startLine": 231,
+                      "startColumn": 22,
+                      "endColumn": 62
+                    }
+                  },
+                  "message": {
+                    "text": "getOctetStream(...) : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 137,
+                      "startColumn": 30,
+                      "endColumn": 58
+                    }
+                  },
+                  "message": {
+                    "text": "inputOctetStream : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 138,
+                      "startColumn": 38,
+                      "endColumn": 54
+                    }
+                  },
+                  "message": {
+                    "text": "inputOctetStream : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 138,
+                      "startColumn": 9,
+                      "endColumn": 13
+                    }
+                  },
+                  "message": {
+                    "text": "this [post update] : XMLSignatureInput [inputOctetStreamProxy] : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheCanonicalizer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 64
+                    },
+                    "region": {
+                      "startLine": 230,
+                      "startColumn": 22,
+                      "endLine": 231,
+                      "endColumn": 63
+                    }
+                  },
+                  "message": {
+                    "text": "new XMLSignatureInput(...) : XMLSignatureInput [inputOctetStreamProxy] : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheCanonicalizer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 64
+                    },
+                    "region": {
+                      "startLine": 241,
+                      "startColumn": 51,
+                      "endColumn": 53
+                    }
+                  },
+                  "message": {
+                    "text": "in : XMLSignatureInput [inputOctetStreamProxy] : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/transforms/Transform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 65
+                    },
+                    "region": {
+                      "startLine": 324,
+                      "startColumn": 9,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "input : XMLSignatureInput [inputOctetStreamProxy] : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/transforms/Transform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 65
+                    },
+                    "region": {
+                      "startLine": 330,
+                      "startColumn": 58,
+                      "endColumn": 63
+                    }
+                  },
+                  "message": {
+                    "text": "input : XMLSignatureInput [inputOctetStreamProxy] : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/transforms/implementations/TransformEnvelopedSignature.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 66
+                    },
+                    "region": {
+                      "startLine": 59,
+                      "startColumn": 9,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "input : XMLSignatureInput [inputOctetStreamProxy] : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/transforms/implementations/TransformEnvelopedSignature.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 66
+                    },
+                    "region": {
+                      "startLine": 81,
+                      "startColumn": 16,
+                      "endColumn": 21
+                    }
+                  },
+                  "message": {
+                    "text": "input : XMLSignatureInput [inputOctetStreamProxy] : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/transforms/Transform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 65
+                    },
+                    "region": {
+                      "startLine": 330,
+                      "startColumn": 22,
+                      "endColumn": 109
+                    }
+                  },
+                  "message": {
+                    "text": "enginePerformTransform(...) : XMLSignatureInput [inputOctetStreamProxy] : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/transforms/Transform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 65
+                    },
+                    "region": {
+                      "startLine": 341,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "result : XMLSignatureInput [inputOctetStreamProxy] : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheCanonicalizer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 64
+                    },
+                    "region": {
+                      "startLine": 241,
+                      "startColumn": 18,
+                      "endColumn": 66
+                    }
+                  },
+                  "message": {
+                    "text": "performTransform(...) : XMLSignatureInput [inputOctetStreamProxy] : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheCanonicalizer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 64
+                    },
+                    "region": {
+                      "startLine": 243,
+                      "startColumn": 50,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "in : XMLSignatureInput [inputOctetStreamProxy] : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheOctetStreamData.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 49
+                    },
+                    "region": {
+                      "startLine": 37,
+                      "startColumn": 34,
+                      "endColumn": 54
+                    }
+                  },
+                  "message": {
+                    "text": "xi : XMLSignatureInput [inputOctetStreamProxy] : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheOctetStreamData.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 49
+                    },
+                    "region": {
+                      "startLine": 40,
+                      "startColumn": 15,
+                      "endColumn": 17
+                    }
+                  },
+                  "message": {
+                    "text": "xi : XMLSignatureInput [inputOctetStreamProxy] : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 243,
+                      "startColumn": 24,
+                      "endColumn": 38
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : XMLSignatureInput [inputOctetStreamProxy] : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 245,
+                      "startColumn": 20,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : XMLSignatureInput [inputOctetStreamProxy] : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 245,
+                      "startColumn": 20,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "inputOctetStreamProxy : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheOctetStreamData.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 49
+                    },
+                    "region": {
+                      "startLine": 40,
+                      "startColumn": 15,
+                      "endColumn": 34
+                    }
+                  },
+                  "message": {
+                    "text": "getOctetStream(...) : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheOctetStreamData.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 49
+                    },
+                    "region": {
+                      "startLine": 40,
+                      "startColumn": 9,
+                      "endColumn": 73
+                    }
+                  },
+                  "message": {
+                    "text": "this <constr(this)> [post update] : ApacheOctetStreamData"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 13,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheCanonicalizer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 64
+                    },
+                    "region": {
+                      "startLine": 243,
+                      "startColumn": 24,
+                      "endColumn": 53
+                    }
+                  },
+                  "message": {
+                    "text": "new ApacheOctetStreamData(...) : ApacheOctetStreamData"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 63
+                    },
+                    "region": {
+                      "startLine": 170,
+                      "startColumn": 16,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "transform(...) : ApacheOctetStreamData"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMReference.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 50
+                    },
+                    "region": {
+                      "startLine": 456,
+                      "startColumn": 28,
+                      "endColumn": 66
+                    }
+                  },
+                  "message": {
+                    "text": "transform(...) : ApacheOctetStreamData"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMReference.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 50
+                    },
+                    "region": {
+                      "startLine": 456,
+                      "startColumn": 48,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "data : ApacheOctetStreamData"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 63
+                    },
+                    "region": {
+                      "startLine": 167,
+                      "startColumn": 27,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "data : ApacheOctetStreamData"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 63
+                    },
+                    "region": {
+                      "startLine": 170,
+                      "startColumn": 30,
+                      "endColumn": 34
+                    }
+                  },
+                  "message": {
+                    "text": "data : ApacheOctetStreamData"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheCanonicalizer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 64
+                    },
+                    "region": {
+                      "startLine": 185,
+                      "startColumn": 27,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "data : ApacheOctetStreamData"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheCanonicalizer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 64
+                    },
+                    "region": {
+                      "startLine": 231,
+                      "startColumn": 23,
+                      "endColumn": 44
+                    }
+                  },
+                  "message": {
+                    "text": "(...)... : ApacheOctetStreamData"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheCanonicalizer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 64
+                    },
+                    "region": {
+                      "startLine": 231,
+                      "startColumn": 22,
+                      "endColumn": 62
+                    }
+                  },
+                  "message": {
+                    "text": "getOctetStream(...) : InputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 14,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 137,
+                      "startColumn": 30,
+                      "endColumn": 58
+                    }
+                  },
+                  "message": {
+                    "text": "inputOctetStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 138,
+                      "startColumn": 38,
+                      "endColumn": 54
+                    }
+                  },
+                  "message": {
+                    "text": "inputOctetStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 138,
+                      "startColumn": 9,
+                      "endColumn": 13
+                    }
+                  },
+                  "message": {
+                    "text": "this [post update] : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheCanonicalizer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 64
+                    },
+                    "region": {
+                      "startLine": 230,
+                      "startColumn": 22,
+                      "endLine": 231,
+                      "endColumn": 63
+                    }
+                  },
+                  "message": {
+                    "text": "new XMLSignatureInput(...) : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheCanonicalizer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 64
+                    },
+                    "region": {
+                      "startLine": 241,
+                      "startColumn": 51,
+                      "endColumn": 53
+                    }
+                  },
+                  "message": {
+                    "text": "in : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/transforms/Transform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 65
+                    },
+                    "region": {
+                      "startLine": 324,
+                      "startColumn": 9,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "input : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/transforms/Transform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 65
+                    },
+                    "region": {
+                      "startLine": 330,
+                      "startColumn": 58,
+                      "endColumn": 63
+                    }
+                  },
+                  "message": {
+                    "text": "input : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/transforms/implementations/TransformEnvelopedSignature.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 66
+                    },
+                    "region": {
+                      "startLine": 59,
+                      "startColumn": 9,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "input : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/transforms/implementations/TransformEnvelopedSignature.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 66
+                    },
+                    "region": {
+                      "startLine": 81,
+                      "startColumn": 16,
+                      "endColumn": 21
+                    }
+                  },
+                  "message": {
+                    "text": "input : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/transforms/Transform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 65
+                    },
+                    "region": {
+                      "startLine": 330,
+                      "startColumn": 22,
+                      "endColumn": 109
+                    }
+                  },
+                  "message": {
+                    "text": "enginePerformTransform(...) : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/transforms/Transform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 65
+                    },
+                    "region": {
+                      "startLine": 341,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "result : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheCanonicalizer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 64
+                    },
+                    "region": {
+                      "startLine": 241,
+                      "startColumn": 18,
+                      "endColumn": 66
+                    }
+                  },
+                  "message": {
+                    "text": "performTransform(...) : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheCanonicalizer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 64
+                    },
+                    "region": {
+                      "startLine": 245,
+                      "startColumn": 46,
+                      "endColumn": 48
+                    }
+                  },
+                  "message": {
+                    "text": "in : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheNodeSetData.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 62
+                    },
+                    "region": {
+                      "startLine": 43,
+                      "startColumn": 30,
+                      "endColumn": 50
+                    }
+                  },
+                  "message": {
+                    "text": "xi : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheNodeSetData.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 62
+                    },
+                    "region": {
+                      "startLine": 44,
+                      "startColumn": 19,
+                      "endColumn": 21
+                    }
+                  },
+                  "message": {
+                    "text": "xi : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheNodeSetData.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 62
+                    },
+                    "region": {
+                      "startLine": 44,
+                      "startColumn": 9,
+                      "endColumn": 13
+                    }
+                  },
+                  "message": {
+                    "text": "this [post update] : ApacheNodeSetData [xi, inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheCanonicalizer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 64
+                    },
+                    "region": {
+                      "startLine": 245,
+                      "startColumn": 24,
+                      "endColumn": 49
+                    }
+                  },
+                  "message": {
+                    "text": "new ApacheNodeSetData(...) : ApacheNodeSetData [xi, inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 63
+                    },
+                    "region": {
+                      "startLine": 170,
+                      "startColumn": 16,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "transform(...) : ApacheNodeSetData [xi, inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 63
+                    },
+                    "region": {
+                      "startLine": 167,
+                      "startColumn": 27,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "data : ApacheOctetStreamData"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 63
+                    },
+                    "region": {
+                      "startLine": 170,
+                      "startColumn": 30,
+                      "endColumn": 34
+                    }
+                  },
+                  "message": {
+                    "text": "data : ApacheOctetStreamData"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheCanonicalizer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 64
+                    },
+                    "region": {
+                      "startLine": 185,
+                      "startColumn": 27,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "data : ApacheOctetStreamData"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheCanonicalizer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 64
+                    },
+                    "region": {
+                      "startLine": 231,
+                      "startColumn": 23,
+                      "endColumn": 44
+                    }
+                  },
+                  "message": {
+                    "text": "(...)... : ApacheOctetStreamData"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheCanonicalizer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 64
+                    },
+                    "region": {
+                      "startLine": 231,
+                      "startColumn": 22,
+                      "endColumn": 62
+                    }
+                  },
+                  "message": {
+                    "text": "getOctetStream(...) : InputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 14,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 137,
+                      "startColumn": 30,
+                      "endColumn": 58
+                    }
+                  },
+                  "message": {
+                    "text": "inputOctetStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 138,
+                      "startColumn": 38,
+                      "endColumn": 54
+                    }
+                  },
+                  "message": {
+                    "text": "inputOctetStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 138,
+                      "startColumn": 9,
+                      "endColumn": 13
+                    }
+                  },
+                  "message": {
+                    "text": "this [post update] : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheCanonicalizer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 64
+                    },
+                    "region": {
+                      "startLine": 230,
+                      "startColumn": 22,
+                      "endLine": 231,
+                      "endColumn": 63
+                    }
+                  },
+                  "message": {
+                    "text": "new XMLSignatureInput(...) : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheCanonicalizer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 64
+                    },
+                    "region": {
+                      "startLine": 241,
+                      "startColumn": 51,
+                      "endColumn": 53
+                    }
+                  },
+                  "message": {
+                    "text": "in : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/transforms/Transform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 65
+                    },
+                    "region": {
+                      "startLine": 324,
+                      "startColumn": 9,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "input : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/transforms/Transform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 65
+                    },
+                    "region": {
+                      "startLine": 330,
+                      "startColumn": 58,
+                      "endColumn": 63
+                    }
+                  },
+                  "message": {
+                    "text": "input : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/transforms/implementations/TransformEnvelopedSignature.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 66
+                    },
+                    "region": {
+                      "startLine": 59,
+                      "startColumn": 9,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "input : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/transforms/implementations/TransformEnvelopedSignature.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 66
+                    },
+                    "region": {
+                      "startLine": 77,
+                      "startColumn": 13,
+                      "endColumn": 18
+                    }
+                  },
+                  "message": {
+                    "text": "input : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 541,
+                      "startColumn": 17,
+                      "endColumn": 30
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 543,
+                      "startColumn": 13,
+                      "endColumn": 29
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 562,
+                      "startColumn": 18,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 565,
+                      "startColumn": 42,
+                      "endColumn": 46
+                    }
+                  },
+                  "message": {
+                    "text": "this : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 243,
+                      "startColumn": 24,
+                      "endColumn": 38
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 244,
+                      "startColumn": 13,
+                      "endColumn": 34
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 244,
+                      "startColumn": 13,
+                      "endColumn": 34
+                    }
+                  },
+                  "message": {
+                    "text": "inputOctetStreamProxy : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 245,
+                      "startColumn": 20,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "inputOctetStreamProxy : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 565,
+                      "startColumn": 42,
+                      "endColumn": 63
+                    }
+                  },
+                  "message": {
+                    "text": "getOctetStream(...) : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/XMLUtils.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 52
+                    },
+                    "region": {
+                      "startLine": 955,
+                      "startColumn": 33,
+                      "endColumn": 56
+                    }
+                  },
+                  "message": {
+                    "text": "inputStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/XMLUtils.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 52
+                    },
+                    "region": {
+                      "startLine": 957,
+                      "startColumn": 36,
+                      "endColumn": 47
+                    }
+                  },
+                  "message": {
+                    "text": "inputStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/parser/XMLParserImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 53
+                    },
+                    "region": {
+                      "startLine": 60,
+                      "startColumn": 27,
+                      "endColumn": 50
+                    }
+                  },
+                  "message": {
+                    "text": "inputStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/parser/XMLParserImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 53
+                    },
+                    "region": {
+                      "startLine": 74,
+                      "startColumn": 50,
+                      "endColumn": 61
+                    }
+                  },
+                  "message": {
+                    "text": "inputStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/javax/xml/parsers/DocumentBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 54
+                    },
+                    "region": {
+                      "startLine": 115,
+                      "startColumn": 27,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/javax/xml/parsers/DocumentBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 54
+                    },
+                    "region": {
+                      "startLine": 121,
+                      "startColumn": 42,
+                      "endColumn": 44
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 127,
+                      "startColumn": 25,
+                      "endColumn": 47
+                    }
+                  },
+                  "message": {
+                    "text": "byteStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 129,
+                      "startColumn": 23,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "byteStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 248,
+                      "startColumn": 32,
+                      "endColumn": 54
+                    }
+                  },
+                  "message": {
+                    "text": "byteStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 250,
+                      "startColumn": 27,
+                      "endColumn": 37
+                    }
+                  },
+                  "message": {
+                    "text": "byteStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 250,
+                      "startColumn": 9,
+                      "endColumn": 13
+                    }
+                  },
+                  "message": {
+                    "text": "this [post update] : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 129,
+                      "startColumn": 9,
+                      "endColumn": 34
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> [post update] : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/javax/xml/parsers/DocumentBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 54
+                    },
+                    "region": {
+                      "startLine": 121,
+                      "startColumn": 26,
+                      "endColumn": 45
+                    }
+                  },
+                  "message": {
+                    "text": "new InputSource(...) : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/javax/xml/parsers/DocumentBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 54
+                    },
+                    "region": {
+                      "startLine": 122,
+                      "startColumn": 22,
+                      "endColumn": 24
+                    }
+                  },
+                  "message": {
+                    "text": "in : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/jaxp/DocumentBuilderImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 56
+                    },
+                    "region": {
+                      "startLine": 329,
+                      "startColumn": 27,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/jaxp/DocumentBuilderImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 56
+                    },
+                    "region": {
+                      "startLine": 342,
+                      "startColumn": 25,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/DOMParser.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 57
+                    },
+                    "region": {
+                      "startLine": 235,
+                      "startColumn": 23,
+                      "endColumn": 46
+                    }
+                  },
+                  "message": {
+                    "text": "inputSource : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/DOMParser.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 57
+                    },
+                    "region": {
+                      "startLine": 244,
+                      "startColumn": 42,
+                      "endColumn": 53
+                    }
+                  },
+                  "message": {
+                    "text": "inputSource : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 264,
+                      "startColumn": 24,
+                      "endColumn": 37
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 266,
+                      "startColumn": 16,
+                      "endColumn": 26
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 266,
+                      "startColumn": 16,
+                      "endColumn": 26
+                    }
+                  },
+                  "message": {
+                    "text": "byteStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/DOMParser.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 57
+                    },
+                    "region": {
+                      "startLine": 244,
+                      "startColumn": 42,
+                      "endColumn": 69
+                    }
+                  },
+                  "message": {
+                    "text": "getByteStream(...) : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xni/parser/XMLInputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 58
+                    },
+                    "region": {
+                      "startLine": 234,
+                      "startColumn": 31,
+                      "endColumn": 53
+                    }
+                  },
+                  "message": {
+                    "text": "byteStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xni/parser/XMLInputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 58
+                    },
+                    "region": {
+                      "startLine": 235,
+                      "startColumn": 23,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "byteStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xni/parser/XMLInputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 58
+                    },
+                    "region": {
+                      "startLine": 235,
+                      "startColumn": 9,
+                      "endColumn": 20
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> [post update] : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/DOMParser.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 57
+                    },
+                    "region": {
+                      "startLine": 244,
+                      "startColumn": 13,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "xmlInputSource [post update] : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/DOMParser.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 57
+                    },
+                    "region": {
+                      "startLine": 247,
+                      "startColumn": 19,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "xmlInputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XMLParser.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 59
+                    },
+                    "region": {
+                      "startLine": 128,
+                      "startColumn": 23,
+                      "endColumn": 49
+                    }
+                  },
+                  "message": {
+                    "text": "inputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XMLParser.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 59
+                    },
+                    "region": {
+                      "startLine": 141,
+                      "startColumn": 30,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "inputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/DTDConfiguration.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 68
+                    },
+                    "region": {
+                      "startLine": 598,
+                      "startColumn": 23,
+                      "endColumn": 44
+                    }
+                  },
+                  "message": {
+                    "text": "source : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/DTDConfiguration.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 68
+                    },
+                    "region": {
+                      "startLine": 607,
+                      "startColumn": 28,
+                      "endColumn": 34
+                    }
+                  },
+                  "message": {
+                    "text": "source : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/DTDConfiguration.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 68
+                    },
+                    "region": {
+                      "startLine": 491,
+                      "startColumn": 32,
+                      "endColumn": 58
+                    }
+                  },
+                  "message": {
+                    "text": "inputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/DTDConfiguration.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 68
+                    },
+                    "region": {
+                      "startLine": 499,
+                      "startColumn": 24,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "inputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/DTDConfiguration.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 68
+                    },
+                    "region": {
+                      "startLine": 499,
+                      "startColumn": 9,
+                      "endColumn": 21
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> [post update] : DTDConfiguration [fInputSource, fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/DTDConfiguration.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 68
+                    },
+                    "region": {
+                      "startLine": 607,
+                      "startColumn": 13,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> [post update] : DTDConfiguration [fInputSource, fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/DTDConfiguration.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 68
+                    },
+                    "region": {
+                      "startLine": 608,
+                      "startColumn": 13,
+                      "endColumn": 24
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : DTDConfiguration [fInputSource, fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/DTDConfiguration.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 68
+                    },
+                    "region": {
+                      "startLine": 519,
+                      "startColumn": 20,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : DTDConfiguration [fInputSource, fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/DTDConfiguration.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 68
+                    },
+                    "region": {
+                      "startLine": 526,
+                      "startColumn": 41,
+                      "endColumn": 53
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : DTDConfiguration [fInputSource, fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/DTDConfiguration.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 68
+                    },
+                    "region": {
+                      "startLine": 526,
+                      "startColumn": 41,
+                      "endColumn": 53
+                    }
+                  },
+                  "message": {
+                    "text": "fInputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLDocumentScannerImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 69
+                    },
+                    "region": {
+                      "startLine": 253,
+                      "startColumn": 32,
+                      "endColumn": 58
+                    }
+                  },
+                  "message": {
+                    "text": "inputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLDocumentScannerImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 69
+                    },
+                    "region": {
+                      "startLine": 256,
+                      "startColumn": 44,
+                      "endColumn": 55
+                    }
+                  },
+                  "message": {
+                    "text": "inputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 1347,
+                      "startColumn": 37,
+                      "endColumn": 66
+                    }
+                  },
+                  "message": {
+                    "text": "xmlInputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 1349,
+                      "startColumn": 39,
+                      "endColumn": 53
+                    }
+                  },
+                  "message": {
+                    "text": "xmlInputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 1394,
+                      "startColumn": 13,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "xmlInputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 1398,
+                      "startColumn": 58,
+                      "endColumn": 72
+                    }
+                  },
+                  "message": {
+                    "text": "xmlInputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 626,
+                      "startColumn": 70,
+                      "endColumn": 99
+                    }
+                  },
+                  "message": {
+                    "text": "xmlInputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 648,
+                      "startColumn": 22,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "xmlInputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xni/parser/XMLInputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 58
+                    },
+                    "region": {
+                      "startLine": 239,
+                      "startColumn": 24,
+                      "endColumn": 37
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xni/parser/XMLInputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 58
+                    },
+                    "region": {
+                      "startLine": 240,
+                      "startColumn": 16,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xni/parser/XMLInputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 58
+                    },
+                    "region": {
+                      "startLine": 240,
+                      "startColumn": 16,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "fByteStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 648,
+                      "startColumn": 22,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "getByteStream(...) : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 697,
+                      "startColumn": 80,
+                      "endColumn": 86
+                    }
+                  },
+                  "message": {
+                    "text": "stream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3003,
+                      "startColumn": 38,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3005,
+                      "startColumn": 28,
+                      "endColumn": 30
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3005,
+                      "startColumn": 13,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> [post update] : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 697,
+                      "startColumn": 54,
+                      "endColumn": 87
+                    }
+                  },
+                  "message": {
+                    "text": "new RewindableInputStream(...) : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 726,
+                      "startColumn": 29,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "stream : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3089,
+                      "startColumn": 21,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3118,
+                      "startColumn": 20,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3118,
+                      "startColumn": 20,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "fInputStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3687,
+                      "startColumn": 21,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3692,
+                      "startColumn": 17,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3701,
+                      "startColumn": 22,
+                      "endLine": 3702,
+                      "endColumn": 71
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3649,
+                      "startColumn": 20,
+                      "endColumn": 24
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3652,
+                      "startColumn": 30,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "super : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3652,
+                      "startColumn": 41,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "b [post update] : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 1,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1971,
+                      "startColumn": 35,
+                      "endColumn": 67
+                    }
+                  },
+                  "message": {
+                    "text": "new HttpInputStream(...) : HttpInputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "id": "AdditionalTaintStep",
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1985,
+                      "startColumn": 24,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "inputStream : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1581,
+                      "startColumn": 24,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "getInputStream0(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/net/URL.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 22
+                    },
+                    "region": {
+                      "startLine": 1317,
+                      "startColumn": 16,
+                      "endColumn": 49
+                    }
+                  },
+                  "message": {
+                    "text": "getInputStream(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 586,
+                      "startColumn": 43,
+                      "endColumn": 59
+                    }
+                  },
+                  "message": {
+                    "text": "openStream(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 587,
+                      "startColumn": 64,
+                      "endColumn": 66
+                    }
+                  },
+                  "message": {
+                    "text": "in : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 587,
+                      "startColumn": 42,
+                      "endColumn": 79
+                    }
+                  },
+                  "message": {
+                    "text": "new InputStreamReader(...) : InputStreamReader"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 7,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 591,
+                      "startColumn": 37,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "reader : InputStreamReader"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/Reader.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 24
+                    },
+                    "region": {
+                      "startLine": 264,
+                      "startColumn": 16,
+                      "endColumn": 20
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : InputStreamReader"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/Reader.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 24
+                    },
+                    "region": {
+                      "startLine": 265,
+                      "startColumn": 16,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : InputStreamReader"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/Reader.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 24
+                    },
+                    "region": {
+                      "startLine": 265,
+                      "startColumn": 21,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "cbuf [post update] : char[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 8,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 591,
+                      "startColumn": 49,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "buf [post update] : char[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 592,
+                      "startColumn": 39,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "buf : char[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 232,
+                      "startColumn": 33,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "str : char[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 233,
+                      "startColumn": 22,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "str : char[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 233,
+                      "startColumn": 9,
+                      "endColumn": 14
+                    }
+                  },
+                  "message": {
+                    "text": "super [post update] : StringBuilder"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 5,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 592,
+                      "startColumn": 29,
+                      "endColumn": 31
+                    }
+                  },
+                  "message": {
+                    "text": "sb [post update] : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 595,
+                      "startColumn": 34,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "sb : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 451,
+                      "startColumn": 19,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 453,
+                      "startColumn": 27,
+                      "endColumn": 31
+                    }
+                  },
+                  "message": {
+                    "text": "this : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 1486,
+                      "startColumn": 19,
+                      "endColumn": 40
+                    }
+                  },
+                  "message": {
+                    "text": "builder : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 1487,
+                      "startColumn": 14,
+                      "endColumn": 21
+                    }
+                  },
+                  "message": {
+                    "text": "builder : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 1487,
+                      "startColumn": 9,
+                      "endColumn": 29
+                    }
+                  },
+                  "message": {
+                    "text": "this <constr(this)> [post update] : String"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 6,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 453,
+                      "startColumn": 16,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "new String(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 595,
+                      "startColumn": 34,
+                      "endColumn": 47
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 604,
+                      "startColumn": 40,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "str : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 2718,
+                      "startColumn": 19,
+                      "endColumn": 28
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 2722,
+                      "startColumn": 20,
+                      "endColumn": 24
+                    }
+                  },
+                  "message": {
+                    "text": "this : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 604,
+                      "startColumn": 40,
+                      "endColumn": 60
+                    }
+                  },
+                  "message": {
+                    "text": "substring(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 778,
+                      "startColumn": 20,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "run(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 785,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "result : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 319,
+                      "startColumn": 16,
+                      "endColumn": 76
+                    }
+                  },
+                  "message": {
+                    "text": "executePrivileged(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/security/provider/SubjectCodeSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 26
+                    },
+                    "region": {
+                      "startLine": 369,
+                      "startColumn": 25,
+                      "endLine": 374,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "doPrivileged(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/security/provider/SubjectCodeSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 26
+                    },
+                    "region": {
+                      "startLine": 386,
+                      "startColumn": 16,
+                      "endColumn": 24
+                    }
+                  },
+                  "message": {
+                    "text": "returnMe : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 4230,
+                      "startColumn": 41,
+                      "endColumn": 55
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 4230,
+                      "startColumn": 16,
+                      "endColumn": 55
+                    }
+                  },
+                  "message": {
+                    "text": "...?...:... : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 173,
+                      "startColumn": 23,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "valueOf(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 178,
+                      "startColumn": 33,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "str : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 179,
+                      "startColumn": 22,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "str : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 179,
+                      "startColumn": 9,
+                      "endColumn": 14
+                    }
+                  },
+                  "message": {
+                    "text": "super [post update] : StringBuilder"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 5,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 173,
+                      "startColumn": 16,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> [post update] : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.naming/share/classes/javax/naming/directory/BasicAttribute.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 27
+                    },
+                    "region": {
+                      "startLine": 221,
+                      "startColumn": 17,
+                      "endColumn": 23
+                    }
+                  },
+                  "message": {
+                    "text": "answer [post update] : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.naming/share/classes/javax/naming/directory/BasicAttribute.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 27
+                    },
+                    "region": {
+                      "startLine": 225,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "answer : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 451,
+                      "startColumn": 19,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 453,
+                      "startColumn": 27,
+                      "endColumn": 31
+                    }
+                  },
+                  "message": {
+                    "text": "this : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 1486,
+                      "startColumn": 19,
+                      "endColumn": 40
+                    }
+                  },
+                  "message": {
+                    "text": "builder : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 1487,
+                      "startColumn": 14,
+                      "endColumn": 21
+                    }
+                  },
+                  "message": {
+                    "text": "builder : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 1487,
+                      "startColumn": 9,
+                      "endColumn": 29
+                    }
+                  },
+                  "message": {
+                    "text": "this <constr(this)> [post update] : String"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 6,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 453,
+                      "startColumn": 16,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "new String(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.naming/share/classes/javax/naming/directory/BasicAttribute.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 27
+                    },
+                    "region": {
+                      "startLine": 225,
+                      "startColumn": 16,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.naming/share/classes/javax/naming/directory/ModificationItem.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 28
+                    },
+                    "region": {
+                      "startLine": 118,
+                      "startColumn": 41,
+                      "endColumn": 56
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.naming/share/classes/javax/naming/directory/ModificationItem.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 28
+                    },
+                    "region": {
+                      "startLine": 118,
+                      "startColumn": 21,
+                      "endColumn": 56
+                    }
+                  },
+                  "message": {
+                    "text": "... + ... : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.naming/share/classes/javax/naming/directory/AttributeModificationException.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 29
+                    },
+                    "region": {
+                      "startLine": 131,
+                      "startColumn": 22,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.naming/share/classes/javax/naming/directory/AttributeModificationException.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 29
+                    },
+                    "region": {
+                      "startLine": 133,
+                      "startColumn": 16,
+                      "endColumn": 20
+                    }
+                  },
+                  "message": {
+                    "text": "orig : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/WriteAbortedException.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 30
+                    },
+                    "region": {
+                      "startLine": 74,
+                      "startColumn": 48,
+                      "endColumn": 65
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/WriteAbortedException.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 30
+                    },
+                    "region": {
+                      "startLine": 74,
+                      "startColumn": 20,
+                      "endColumn": 65
+                    }
+                  },
+                  "message": {
+                    "text": "... + ... : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/javax/xml/parsers/FactoryConfigurationError.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 20
+                    },
+                    "region": {
+                      "startLine": 111,
+                      "startColumn": 20,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "getMessage(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "make/jdk/src/classes/build/tools/module/ModuleInfoExtraTest.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 21
+                    },
+                    "region": {
+                      "startLine": 270,
+                      "startColumn": 18,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "getMessage(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 2854,
+                      "startColumn": 20,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 2855,
+                      "startColumn": 39,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "this"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "threadFlows": [
+          {
+            "locations": [
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/resolver/implementations/ResolverDirectHTTP.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 45
+                    },
+                    "region": {
+                      "startLine": 142,
+                      "startColumn": 43,
+                      "endColumn": 73
+                    }
+                  },
+                  "message": {
+                    "text": "getInputStream(...) : InputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 0,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "source"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/resolver/implementations/ResolverDirectHTTP.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 45
+                    },
+                    "region": {
+                      "startLine": 147,
+                      "startColumn": 32,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "inputStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/resolver/implementations/ResolverDirectHTTP.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 45
+                    },
+                    "region": {
+                      "startLine": 147,
+                      "startColumn": 49,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "buf [post update] : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 9,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/resolver/implementations/ResolverDirectHTTP.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 45
+                    },
+                    "region": {
+                      "startLine": 148,
+                      "startColumn": 32,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "buf : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/resolver/implementations/ResolverDirectHTTP.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 45
+                    },
+                    "region": {
+                      "startLine": 148,
+                      "startColumn": 21,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "baos [post update] : ByteArrayOutputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 10,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/resolver/implementations/ResolverDirectHTTP.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 45
+                    },
+                    "region": {
+                      "startLine": 154,
+                      "startColumn": 66,
+                      "endColumn": 70
+                    }
+                  },
+                  "message": {
+                    "text": "baos : ByteArrayOutputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/resolver/implementations/ResolverDirectHTTP.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 45
+                    },
+                    "region": {
+                      "startLine": 154,
+                      "startColumn": 66,
+                      "endColumn": 84
+                    }
+                  },
+                  "message": {
+                    "text": "toByteArray(...) : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 11,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 126,
+                      "startColumn": 30,
+                      "endColumn": 48
+                    }
+                  },
+                  "message": {
+                    "text": "inputOctets : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 128,
+                      "startColumn": 22,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "inputOctets : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 128,
+                      "startColumn": 9,
+                      "endColumn": 13
+                    }
+                  },
+                  "message": {
+                    "text": "this [post update] : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/resolver/implementations/ResolverDirectHTTP.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 45
+                    },
+                    "region": {
+                      "startLine": 154,
+                      "startColumn": 44,
+                      "endColumn": 85
+                    }
+                  },
+                  "message": {
+                    "text": "new XMLSignatureInput(...) : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/resolver/implementations/ResolverDirectHTTP.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 45
+                    },
+                    "region": {
+                      "startLine": 160,
+                      "startColumn": 24,
+                      "endColumn": 30
+                    }
+                  },
+                  "message": {
+                    "text": "result : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/resolver/ResourceResolver.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 47
+                    },
+                    "region": {
+                      "startLine": 162,
+                      "startColumn": 24,
+                      "endColumn": 58
+                    }
+                  },
+                  "message": {
+                    "text": "engineResolveURI(...) : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMURIDereferencer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 48
+                    },
+                    "region": {
+                      "startLine": 144,
+                      "startColumn": 36,
+                      "endColumn": 72
+                    }
+                  },
+                  "message": {
+                    "text": "resolve(...) : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMURIDereferencer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 48
+                    },
+                    "region": {
+                      "startLine": 146,
+                      "startColumn": 50,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "in : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheOctetStreamData.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 49
+                    },
+                    "region": {
+                      "startLine": 37,
+                      "startColumn": 34,
+                      "endColumn": 54
+                    }
+                  },
+                  "message": {
+                    "text": "xi : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheOctetStreamData.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 49
+                    },
+                    "region": {
+                      "startLine": 40,
+                      "startColumn": 15,
+                      "endColumn": 17
+                    }
+                  },
+                  "message": {
+                    "text": "xi : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 243,
+                      "startColumn": 24,
+                      "endColumn": 38
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 249,
+                      "startColumn": 62,
+                      "endColumn": 67
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 249,
+                      "startColumn": 62,
+                      "endColumn": 67
+                    }
+                  },
+                  "message": {
+                    "text": "bytes : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 249,
+                      "startColumn": 37,
+                      "endColumn": 68
+                    }
+                  },
+                  "message": {
+                    "text": "new ByteArrayInputStream(...) : ByteArrayInputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 12,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 250,
+                      "startColumn": 20,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "inputOctetStreamProxy : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheOctetStreamData.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 49
+                    },
+                    "region": {
+                      "startLine": 40,
+                      "startColumn": 15,
+                      "endColumn": 34
+                    }
+                  },
+                  "message": {
+                    "text": "getOctetStream(...) : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheOctetStreamData.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 49
+                    },
+                    "region": {
+                      "startLine": 40,
+                      "startColumn": 9,
+                      "endColumn": 73
+                    }
+                  },
+                  "message": {
+                    "text": "this <constr(this)> [post update] : ApacheOctetStreamData"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 13,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMURIDereferencer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 48
+                    },
+                    "region": {
+                      "startLine": 146,
+                      "startColumn": 24,
+                      "endColumn": 53
+                    }
+                  },
+                  "message": {
+                    "text": "new ApacheOctetStreamData(...) : ApacheOctetStreamData"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMRetrievalMethod.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 70
+                    },
+                    "region": {
+                      "startLine": 242,
+                      "startColumn": 21,
+                      "endColumn": 53
+                    }
+                  },
+                  "message": {
+                    "text": "dereference(...) : ApacheOctetStreamData"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMRetrievalMethod.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 70
+                    },
+                    "region": {
+                      "startLine": 247,
+                      "startColumn": 60,
+                      "endColumn": 64
+                    }
+                  },
+                  "message": {
+                    "text": "data : ApacheOctetStreamData"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 63
+                    },
+                    "region": {
+                      "startLine": 148,
+                      "startColumn": 27,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "data : ApacheOctetStreamData"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 63
+                    },
+                    "region": {
+                      "startLine": 151,
+                      "startColumn": 30,
+                      "endColumn": 34
+                    }
+                  },
+                  "message": {
+                    "text": "data : ApacheOctetStreamData"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 71
+                    },
+                    "region": {
+                      "startLine": 103,
+                      "startColumn": 27,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "data : ApacheOctetStreamData"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 71
+                    },
+                    "region": {
+                      "startLine": 109,
+                      "startColumn": 28,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "data : ApacheOctetStreamData"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 71
+                    },
+                    "region": {
+                      "startLine": 124,
+                      "startColumn": 30,
+                      "endColumn": 39
+                    }
+                  },
+                  "message": {
+                    "text": "data : ApacheOctetStreamData"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 71
+                    },
+                    "region": {
+                      "startLine": 173,
+                      "startColumn": 23,
+                      "endColumn": 44
+                    }
+                  },
+                  "message": {
+                    "text": "(...)... : ApacheOctetStreamData"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 71
+                    },
+                    "region": {
+                      "startLine": 173,
+                      "startColumn": 22,
+                      "endColumn": 62
+                    }
+                  },
+                  "message": {
+                    "text": "getOctetStream(...) : InputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 14,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 137,
+                      "startColumn": 30,
+                      "endColumn": 58
+                    }
+                  },
+                  "message": {
+                    "text": "inputOctetStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 138,
+                      "startColumn": 38,
+                      "endColumn": 54
+                    }
+                  },
+                  "message": {
+                    "text": "inputOctetStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 138,
+                      "startColumn": 9,
+                      "endColumn": 13
+                    }
+                  },
+                  "message": {
+                    "text": "this [post update] : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 71
+                    },
+                    "region": {
+                      "startLine": 172,
+                      "startColumn": 22,
+                      "endLine": 173,
+                      "endColumn": 63
+                    }
+                  },
+                  "message": {
+                    "text": "new XMLSignatureInput(...) : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 71
+                    },
+                    "region": {
+                      "startLine": 183,
+                      "startColumn": 49,
+                      "endColumn": 51
+                    }
+                  },
+                  "message": {
+                    "text": "in : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/transforms/Transform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 65
+                    },
+                    "region": {
+                      "startLine": 324,
+                      "startColumn": 9,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "input : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/transforms/Transform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 65
+                    },
+                    "region": {
+                      "startLine": 330,
+                      "startColumn": 58,
+                      "endColumn": 63
+                    }
+                  },
+                  "message": {
+                    "text": "input : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/transforms/implementations/TransformXPath.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 72
+                    },
+                    "region": {
+                      "startLine": 71,
+                      "startColumn": 9,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "input : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/transforms/implementations/TransformXPath.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 72
+                    },
+                    "region": {
+                      "startLine": 108,
+                      "startColumn": 20,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "input : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/transforms/Transform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 65
+                    },
+                    "region": {
+                      "startLine": 330,
+                      "startColumn": 22,
+                      "endColumn": 109
+                    }
+                  },
+                  "message": {
+                    "text": "enginePerformTransform(...) : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/transforms/Transform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 65
+                    },
+                    "region": {
+                      "startLine": 341,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "result : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 71
+                    },
+                    "region": {
+                      "startLine": 183,
+                      "startColumn": 22,
+                      "endColumn": 64
+                    }
+                  },
+                  "message": {
+                    "text": "performTransform(...) : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 71
+                    },
+                    "region": {
+                      "startLine": 191,
+                      "startColumn": 50,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "in : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheOctetStreamData.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 49
+                    },
+                    "region": {
+                      "startLine": 37,
+                      "startColumn": 34,
+                      "endColumn": 54
+                    }
+                  },
+                  "message": {
+                    "text": "xi : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheOctetStreamData.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 49
+                    },
+                    "region": {
+                      "startLine": 41,
+                      "startColumn": 19,
+                      "endColumn": 21
+                    }
+                  },
+                  "message": {
+                    "text": "xi : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheOctetStreamData.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 49
+                    },
+                    "region": {
+                      "startLine": 41,
+                      "startColumn": 9,
+                      "endColumn": 13
+                    }
+                  },
+                  "message": {
+                    "text": "this [post update] : ApacheOctetStreamData [xi, inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 71
+                    },
+                    "region": {
+                      "startLine": 191,
+                      "startColumn": 24,
+                      "endColumn": 53
+                    }
+                  },
+                  "message": {
+                    "text": "new ApacheOctetStreamData(...) : ApacheOctetStreamData [xi, inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 71
+                    },
+                    "region": {
+                      "startLine": 109,
+                      "startColumn": 16,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "transformIt(...) : ApacheOctetStreamData [xi, inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 63
+                    },
+                    "region": {
+                      "startLine": 151,
+                      "startColumn": 16,
+                      "endColumn": 39
+                    }
+                  },
+                  "message": {
+                    "text": "transform(...) : ApacheOctetStreamData [xi, inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 63
+                    },
+                    "region": {
+                      "startLine": 148,
+                      "startColumn": 27,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "data : ApacheOctetStreamData"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 63
+                    },
+                    "region": {
+                      "startLine": 151,
+                      "startColumn": 30,
+                      "endColumn": 34
+                    }
+                  },
+                  "message": {
+                    "text": "data : ApacheOctetStreamData"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 71
+                    },
+                    "region": {
+                      "startLine": 103,
+                      "startColumn": 27,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "data : ApacheOctetStreamData"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 71
+                    },
+                    "region": {
+                      "startLine": 109,
+                      "startColumn": 28,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "data : ApacheOctetStreamData"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 71
+                    },
+                    "region": {
+                      "startLine": 124,
+                      "startColumn": 30,
+                      "endColumn": 39
+                    }
+                  },
+                  "message": {
+                    "text": "data : ApacheOctetStreamData"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 71
+                    },
+                    "region": {
+                      "startLine": 173,
+                      "startColumn": 23,
+                      "endColumn": 44
+                    }
+                  },
+                  "message": {
+                    "text": "(...)... : ApacheOctetStreamData"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 71
+                    },
+                    "region": {
+                      "startLine": 173,
+                      "startColumn": 22,
+                      "endColumn": 62
+                    }
+                  },
+                  "message": {
+                    "text": "getOctetStream(...) : InputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 14,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 137,
+                      "startColumn": 30,
+                      "endColumn": 58
+                    }
+                  },
+                  "message": {
+                    "text": "inputOctetStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 138,
+                      "startColumn": 38,
+                      "endColumn": 54
+                    }
+                  },
+                  "message": {
+                    "text": "inputOctetStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 138,
+                      "startColumn": 9,
+                      "endColumn": 13
+                    }
+                  },
+                  "message": {
+                    "text": "this [post update] : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 71
+                    },
+                    "region": {
+                      "startLine": 172,
+                      "startColumn": 22,
+                      "endLine": 173,
+                      "endColumn": 63
+                    }
+                  },
+                  "message": {
+                    "text": "new XMLSignatureInput(...) : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 71
+                    },
+                    "region": {
+                      "startLine": 183,
+                      "startColumn": 49,
+                      "endColumn": 51
+                    }
+                  },
+                  "message": {
+                    "text": "in : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/transforms/Transform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 65
+                    },
+                    "region": {
+                      "startLine": 324,
+                      "startColumn": 9,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "input : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/transforms/Transform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 65
+                    },
+                    "region": {
+                      "startLine": 330,
+                      "startColumn": 58,
+                      "endColumn": 63
+                    }
+                  },
+                  "message": {
+                    "text": "input : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/transforms/implementations/TransformXPath.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 72
+                    },
+                    "region": {
+                      "startLine": 71,
+                      "startColumn": 9,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "input : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/transforms/implementations/TransformXPath.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 72
+                    },
+                    "region": {
+                      "startLine": 106,
+                      "startColumn": 13,
+                      "endColumn": 18
+                    }
+                  },
+                  "message": {
+                    "text": "input : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 541,
+                      "startColumn": 17,
+                      "endColumn": 30
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 543,
+                      "startColumn": 13,
+                      "endColumn": 29
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 562,
+                      "startColumn": 18,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 565,
+                      "startColumn": 42,
+                      "endColumn": 46
+                    }
+                  },
+                  "message": {
+                    "text": "this : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 243,
+                      "startColumn": 24,
+                      "endColumn": 38
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 245,
+                      "startColumn": 20,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 245,
+                      "startColumn": 20,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "inputOctetStreamProxy : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 565,
+                      "startColumn": 42,
+                      "endColumn": 63
+                    }
+                  },
+                  "message": {
+                    "text": "getOctetStream(...) : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/XMLUtils.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 52
+                    },
+                    "region": {
+                      "startLine": 955,
+                      "startColumn": 33,
+                      "endColumn": 56
+                    }
+                  },
+                  "message": {
+                    "text": "inputStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/XMLUtils.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 52
+                    },
+                    "region": {
+                      "startLine": 957,
+                      "startColumn": 36,
+                      "endColumn": 47
+                    }
+                  },
+                  "message": {
+                    "text": "inputStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/parser/XMLParserImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 53
+                    },
+                    "region": {
+                      "startLine": 60,
+                      "startColumn": 27,
+                      "endColumn": 50
+                    }
+                  },
+                  "message": {
+                    "text": "inputStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/parser/XMLParserImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 53
+                    },
+                    "region": {
+                      "startLine": 69,
+                      "startColumn": 46,
+                      "endColumn": 57
+                    }
+                  },
+                  "message": {
+                    "text": "inputStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/javax/xml/parsers/DocumentBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 54
+                    },
+                    "region": {
+                      "startLine": 115,
+                      "startColumn": 27,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/javax/xml/parsers/DocumentBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 54
+                    },
+                    "region": {
+                      "startLine": 121,
+                      "startColumn": 42,
+                      "endColumn": 44
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 127,
+                      "startColumn": 25,
+                      "endColumn": 47
+                    }
+                  },
+                  "message": {
+                    "text": "byteStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 129,
+                      "startColumn": 23,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "byteStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 248,
+                      "startColumn": 32,
+                      "endColumn": 54
+                    }
+                  },
+                  "message": {
+                    "text": "byteStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 250,
+                      "startColumn": 27,
+                      "endColumn": 37
+                    }
+                  },
+                  "message": {
+                    "text": "byteStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 250,
+                      "startColumn": 9,
+                      "endColumn": 13
+                    }
+                  },
+                  "message": {
+                    "text": "this [post update] : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 129,
+                      "startColumn": 9,
+                      "endColumn": 34
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> [post update] : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/javax/xml/parsers/DocumentBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 54
+                    },
+                    "region": {
+                      "startLine": 121,
+                      "startColumn": 26,
+                      "endColumn": 45
+                    }
+                  },
+                  "message": {
+                    "text": "new InputSource(...) : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/javax/xml/parsers/DocumentBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 54
+                    },
+                    "region": {
+                      "startLine": 122,
+                      "startColumn": 22,
+                      "endColumn": 24
+                    }
+                  },
+                  "message": {
+                    "text": "in : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/jaxp/DocumentBuilderImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 56
+                    },
+                    "region": {
+                      "startLine": 329,
+                      "startColumn": 27,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/jaxp/DocumentBuilderImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 56
+                    },
+                    "region": {
+                      "startLine": 342,
+                      "startColumn": 25,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/DOMParser.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 57
+                    },
+                    "region": {
+                      "startLine": 235,
+                      "startColumn": 23,
+                      "endColumn": 46
+                    }
+                  },
+                  "message": {
+                    "text": "inputSource : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/DOMParser.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 57
+                    },
+                    "region": {
+                      "startLine": 244,
+                      "startColumn": 42,
+                      "endColumn": 53
+                    }
+                  },
+                  "message": {
+                    "text": "inputSource : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 264,
+                      "startColumn": 24,
+                      "endColumn": 37
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 266,
+                      "startColumn": 16,
+                      "endColumn": 26
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 266,
+                      "startColumn": 16,
+                      "endColumn": 26
+                    }
+                  },
+                  "message": {
+                    "text": "byteStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/DOMParser.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 57
+                    },
+                    "region": {
+                      "startLine": 244,
+                      "startColumn": 42,
+                      "endColumn": 69
+                    }
+                  },
+                  "message": {
+                    "text": "getByteStream(...) : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xni/parser/XMLInputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 58
+                    },
+                    "region": {
+                      "startLine": 234,
+                      "startColumn": 31,
+                      "endColumn": 53
+                    }
+                  },
+                  "message": {
+                    "text": "byteStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xni/parser/XMLInputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 58
+                    },
+                    "region": {
+                      "startLine": 235,
+                      "startColumn": 23,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "byteStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xni/parser/XMLInputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 58
+                    },
+                    "region": {
+                      "startLine": 235,
+                      "startColumn": 9,
+                      "endColumn": 20
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> [post update] : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/DOMParser.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 57
+                    },
+                    "region": {
+                      "startLine": 244,
+                      "startColumn": 13,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "xmlInputSource [post update] : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/DOMParser.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 57
+                    },
+                    "region": {
+                      "startLine": 247,
+                      "startColumn": 19,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "xmlInputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XMLParser.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 59
+                    },
+                    "region": {
+                      "startLine": 128,
+                      "startColumn": 23,
+                      "endColumn": 49
+                    }
+                  },
+                  "message": {
+                    "text": "inputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XMLParser.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 59
+                    },
+                    "region": {
+                      "startLine": 141,
+                      "startColumn": 30,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "inputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XML11DTDConfiguration.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 73
+                    },
+                    "region": {
+                      "startLine": 662,
+                      "startColumn": 23,
+                      "endColumn": 44
+                    }
+                  },
+                  "message": {
+                    "text": "source : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XML11DTDConfiguration.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 73
+                    },
+                    "region": {
+                      "startLine": 671,
+                      "startColumn": 28,
+                      "endColumn": 34
+                    }
+                  },
+                  "message": {
+                    "text": "source : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XML11DTDConfiguration.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 73
+                    },
+                    "region": {
+                      "startLine": 514,
+                      "startColumn": 32,
+                      "endColumn": 58
+                    }
+                  },
+                  "message": {
+                    "text": "inputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XML11DTDConfiguration.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 73
+                    },
+                    "region": {
+                      "startLine": 522,
+                      "startColumn": 24,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "inputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XML11DTDConfiguration.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 73
+                    },
+                    "region": {
+                      "startLine": 522,
+                      "startColumn": 9,
+                      "endColumn": 21
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> [post update] : XML11DTDConfiguration [fInputSource, fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XML11DTDConfiguration.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 73
+                    },
+                    "region": {
+                      "startLine": 671,
+                      "startColumn": 13,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> [post update] : XML11DTDConfiguration [fInputSource, fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XML11DTDConfiguration.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 73
+                    },
+                    "region": {
+                      "startLine": 672,
+                      "startColumn": 13,
+                      "endColumn": 24
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : XML11DTDConfiguration [fInputSource, fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XML11DTDConfiguration.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 73
+                    },
+                    "region": {
+                      "startLine": 697,
+                      "startColumn": 20,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : XML11DTDConfiguration [fInputSource, fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XML11DTDConfiguration.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 73
+                    },
+                    "region": {
+                      "startLine": 706,
+                      "startColumn": 70,
+                      "endColumn": 82
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : XML11DTDConfiguration [fInputSource, fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XML11DTDConfiguration.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 73
+                    },
+                    "region": {
+                      "startLine": 706,
+                      "startColumn": 70,
+                      "endColumn": 82
+                    }
+                  },
+                  "message": {
+                    "text": "fInputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLVersionDetector.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 61
+                    },
+                    "region": {
+                      "startLine": 149,
+                      "startColumn": 38,
+                      "endColumn": 64
+                    }
+                  },
+                  "message": {
+                    "text": "inputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLVersionDetector.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 61
+                    },
+                    "region": {
+                      "startLine": 150,
+                      "startColumn": 74,
+                      "endColumn": 85
+                    }
+                  },
+                  "message": {
+                    "text": "inputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 626,
+                      "startColumn": 70,
+                      "endColumn": 99
+                    }
+                  },
+                  "message": {
+                    "text": "xmlInputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 648,
+                      "startColumn": 22,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "xmlInputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xni/parser/XMLInputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 58
+                    },
+                    "region": {
+                      "startLine": 239,
+                      "startColumn": 24,
+                      "endColumn": 37
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xni/parser/XMLInputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 58
+                    },
+                    "region": {
+                      "startLine": 240,
+                      "startColumn": 16,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xni/parser/XMLInputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 58
+                    },
+                    "region": {
+                      "startLine": 240,
+                      "startColumn": 16,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "fByteStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 648,
+                      "startColumn": 22,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "getByteStream(...) : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 697,
+                      "startColumn": 80,
+                      "endColumn": 86
+                    }
+                  },
+                  "message": {
+                    "text": "stream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3003,
+                      "startColumn": 38,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3005,
+                      "startColumn": 28,
+                      "endColumn": 30
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3005,
+                      "startColumn": 13,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> [post update] : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 697,
+                      "startColumn": 54,
+                      "endColumn": 87
+                    }
+                  },
+                  "message": {
+                    "text": "new RewindableInputStream(...) : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 774,
+                      "startColumn": 29,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "stream : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3089,
+                      "startColumn": 21,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3099,
+                      "startColumn": 24,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3099,
+                      "startColumn": 24,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "fInputStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3687,
+                      "startColumn": 21,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3701,
+                      "startColumn": 22,
+                      "endLine": 3702,
+                      "endColumn": 71
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3649,
+                      "startColumn": 20,
+                      "endColumn": 24
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3652,
+                      "startColumn": 30,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "super : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3652,
+                      "startColumn": 41,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "b [post update] : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 1,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1964,
+                      "startColumn": 47,
+                      "endColumn": 93
+                    }
+                  },
+                  "message": {
+                    "text": "new HttpInputStream(...) : HttpInputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "id": "AdditionalTaintStep",
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1964,
+                      "startColumn": 33,
+                      "endColumn": 44
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> [post update] : HttpURLConnection [inputStream] : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1970,
+                      "startColumn": 23,
+                      "endColumn": 34
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : HttpURLConnection [inputStream] : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1970,
+                      "startColumn": 23,
+                      "endColumn": 34
+                    }
+                  },
+                  "message": {
+                    "text": "inputStream : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1985,
+                      "startColumn": 24,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "inputStream : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1581,
+                      "startColumn": 24,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "getInputStream0(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/ftp/FtpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 31
+                    },
+                    "region": {
+                      "startLine": 424,
+                      "startColumn": 20,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "getInputStream(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/net/URL.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 22
+                    },
+                    "region": {
+                      "startLine": 1317,
+                      "startColumn": 16,
+                      "endColumn": 49
+                    }
+                  },
+                  "message": {
+                    "text": "getInputStream(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/Module.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 32
+                    },
+                    "region": {
+                      "startLine": 1735,
+                      "startColumn": 24,
+                      "endColumn": 40
+                    }
+                  },
+                  "message": {
+                    "text": "openStream(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 86,
+                      "startColumn": 20,
+                      "endColumn": 68
+                    }
+                  },
+                  "message": {
+                    "text": "getResourceAsStream(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 809,
+                      "startColumn": 20,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "run(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 816,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "result : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 571,
+                      "startColumn": 20,
+                      "endColumn": 62
+                    }
+                  },
+                  "message": {
+                    "text": "executePrivileged(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 89,
+                      "startColumn": 18,
+                      "endColumn": 51
+                    }
+                  },
+                  "message": {
+                    "text": "doPrivileged(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 93,
+                      "startColumn": 16,
+                      "endColumn": 18
+                    }
+                  },
+                  "message": {
+                    "text": "is : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 75,
+                      "startColumn": 31,
+                      "endColumn": 56
+                    }
+                  },
+                  "message": {
+                    "text": "getResourceAsStream(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 76,
+                      "startColumn": 20,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "is : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 76,
+                      "startColumn": 20,
+                      "endColumn": 37
+                    }
+                  },
+                  "message": {
+                    "text": "readAllBytes(...) : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 2,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 80,
+                      "startColumn": 16,
+                      "endColumn": 20
+                    }
+                  },
+                  "message": {
+                    "text": "data : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/util/ResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 12
+                    },
+                    "region": {
+                      "startLine": 561,
+                      "startColumn": 22,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "handleGetObject(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/util/ResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 12
+                    },
+                    "region": {
+                      "startLine": 574,
+                      "startColumn": 16,
+                      "endColumn": 19
+                    }
+                  },
+                  "message": {
+                    "text": "obj : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/util/ResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 12
+                    },
+                    "region": {
+                      "startLine": 564,
+                      "startColumn": 23,
+                      "endColumn": 44
+                    }
+                  },
+                  "message": {
+                    "text": "getObject(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/util/ResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 12
+                    },
+                    "region": {
+                      "startLine": 574,
+                      "startColumn": 16,
+                      "endColumn": 19
+                    }
+                  },
+                  "message": {
+                    "text": "obj : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 326,
+                      "startColumn": 44,
+                      "endColumn": 60
+                    }
+                  },
+                  "message": {
+                    "text": "getObject(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 328,
+                      "startColumn": 45,
+                      "endColumn": 50
+                    }
+                  },
+                  "message": {
+                    "text": "value : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 328,
+                      "startColumn": 29,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "values [post update] : TextAndMnemonicHashMap [<map.value>] : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 3,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 335,
+                      "startColumn": 34,
+                      "endColumn": 40
+                    }
+                  },
+                  "message": {
+                    "text": "values : TextAndMnemonicHashMap [<map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 335,
+                      "startColumn": 13,
+                      "endColumn": 26
+                    }
+                  },
+                  "message": {
+                    "text": "resourceCache [post update] : HashMap [<map.value>, <map.value>] : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 3,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 335,
+                      "startColumn": 13,
+                      "endColumn": 26
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> [post update] : UIDefaults [resourceCache, <map.value>, <map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 298,
+                      "startColumn": 20,
+                      "endColumn": 39
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> [post update] : UIDefaults [resourceCache, <map.value>, <map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 172,
+                      "startColumn": 42,
+                      "endColumn": 74
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> [post update] : UIDefaults [resourceCache, <map.value>, <map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/plaf/nimbus/NimbusLookAndFeel.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 544,
+                      "startColumn": 23,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "uiDefaults [post update] : UIDefaults [resourceCache, <map.value>, <map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/plaf/nimbus/NimbusLookAndFeel.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 548,
+                      "startColumn": 23,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "uiDefaults : UIDefaults [resourceCache, <map.value>, <map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 170,
+                      "startColumn": 19,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : UIDefaults [resourceCache, <map.value>, <map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 172,
+                      "startColumn": 42,
+                      "endColumn": 74
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : UIDefaults [resourceCache, <map.value>, <map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 281,
+                      "startColumn": 20,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : UIDefaults [resourceCache, <map.value>, <map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 298,
+                      "startColumn": 20,
+                      "endColumn": 39
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : UIDefaults [resourceCache, <map.value>, <map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 305,
+                      "startColumn": 33,
+                      "endColumn": 49
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : UIDefaults [resourceCache, <map.value>, <map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 306,
+                      "startColumn": 38,
+                      "endColumn": 51
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : UIDefaults [resourceCache, <map.value>, <map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 306,
+                      "startColumn": 38,
+                      "endColumn": 51
+                    }
+                  },
+                  "message": {
+                    "text": "resourceCache : HashMap [<map.value>, <map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 306,
+                      "startColumn": 38,
+                      "endColumn": 58
+                    }
+                  },
+                  "message": {
+                    "text": "get(...) : TextAndMnemonicHashMap [<map.value>] : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 4,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 337,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "values : TextAndMnemonicHashMap [<map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 298,
+                      "startColumn": 20,
+                      "endColumn": 39
+                    }
+                  },
+                  "message": {
+                    "text": "getResourceCache(...) : TextAndMnemonicHashMap [<map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 298,
+                      "startColumn": 20,
+                      "endColumn": 48
+                    }
+                  },
+                  "message": {
+                    "text": "get(...) : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 4,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 172,
+                      "startColumn": 42,
+                      "endColumn": 74
+                    }
+                  },
+                  "message": {
+                    "text": "getFromResourceBundle(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 172,
+                      "startColumn": 16,
+                      "endColumn": 74
+                    }
+                  },
+                  "message": {
+                    "text": "...?...:... : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/plaf/nimbus/NimbusLookAndFeel.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 548,
+                      "startColumn": 23,
+                      "endColumn": 65
+                    }
+                  },
+                  "message": {
+                    "text": "get(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/plaf/nimbus/NimbusLookAndFeel.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 558,
+                      "startColumn": 20,
+                      "endColumn": 23
+                    }
+                  },
+                  "message": {
+                    "text": "obj : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 241,
+                      "startColumn": 21,
+                      "endColumn": 59
+                    }
+                  },
+                  "message": {
+                    "text": "createValue(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 244,
+                      "startColumn": 16,
+                      "endColumn": 21
+                    }
+                  },
+                  "message": {
+                    "text": "value : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 171,
+                      "startColumn": 24,
+                      "endColumn": 47
+                    }
+                  },
+                  "message": {
+                    "text": "getFromHashtable(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 172,
+                      "startColumn": 16,
+                      "endColumn": 74
+                    }
+                  },
+                  "message": {
+                    "text": "...?...:... : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/MultiUIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 34
+                    },
+                    "region": {
+                      "startLine": 59,
+                      "startColumn": 24,
+                      "endColumn": 38
+                    }
+                  },
+                  "message": {
+                    "text": "get(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/MultiUIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 34
+                    },
+                    "region": {
+                      "startLine": 61,
+                      "startColumn": 20,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "value : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/rtf/MockAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 14
+                    },
+                    "region": {
+                      "startLine": 67,
+                      "startColumn": 16,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "get(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/StyleContext.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 35
+                    },
+                    "region": {
+                      "startLine": 1496,
+                      "startColumn": 20,
+                      "endColumn": 53
+                    }
+                  },
+                  "message": {
+                    "text": "getAttribute(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 15
+                    },
+                    "region": {
+                      "startLine": 151,
+                      "startColumn": 25,
+                      "endColumn": 50
+                    }
+                  },
+                  "message": {
+                    "text": "getAttribute(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 15
+                    },
+                    "region": {
+                      "startLine": 154,
+                      "startColumn": 16,
+                      "endColumn": 21
+                    }
+                  },
+                  "message": {
+                    "text": "value : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/html/StyleSheet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 36
+                    },
+                    "region": {
+                      "startLine": 845,
+                      "startColumn": 20,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "getAttribute(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 15
+                    },
+                    "region": {
+                      "startLine": 328,
+                      "startColumn": 28,
+                      "endColumn": 45
+                    }
+                  },
+                  "message": {
+                    "text": "getAttribute(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 15
+                    },
+                    "region": {
+                      "startLine": 336,
+                      "startColumn": 16,
+                      "endColumn": 17
+                    }
+                  },
+                  "message": {
+                    "text": "s : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/tree/DefaultMutableTreeNode.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 37
+                    },
+                    "region": {
+                      "startLine": 1264,
+                      "startColumn": 20,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 1304,
+                      "startColumn": 27,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 1349,
+                      "startColumn": 35,
+                      "endColumn": 38
+                    }
+                  },
+                  "message": {
+                    "text": "arg : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 311,
+                      "startColumn": 45,
+                      "endColumn": 55
+                    }
+                  },
+                  "message": {
+                    "text": "str : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 313,
+                      "startColumn": 22,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "str : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 313,
+                      "startColumn": 9,
+                      "endColumn": 14
+                    }
+                  },
+                  "message": {
+                    "text": "super [post update] : StringBuffer"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 5,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 1349,
+                      "startColumn": 21,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "result [post update] : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 1364,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "result : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 885,
+                      "startColumn": 16,
+                      "endColumn": 66
+                    }
+                  },
+                  "message": {
+                    "text": "subformat(...) : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/Format.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 18
+                    },
+                    "region": {
+                      "startLine": 159,
+                      "startColumn": 16,
+                      "endColumn": 69
+                    }
+                  },
+                  "message": {
+                    "text": "format(...) : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 713,
+                      "startColumn": 32,
+                      "endColumn": 40
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 715,
+                      "startColumn": 47,
+                      "endColumn": 51
+                    }
+                  },
+                  "message": {
+                    "text": "this : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 715,
+                      "startColumn": 36,
+                      "endColumn": 58
+                    }
+                  },
+                  "message": {
+                    "text": "new String(...) : String"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 6,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 715,
+                      "startColumn": 20,
+                      "endColumn": 58
+                    }
+                  },
+                  "message": {
+                    "text": "...=... : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/Format.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 18
+                    },
+                    "region": {
+                      "startLine": 159,
+                      "startColumn": 16,
+                      "endColumn": 80
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/jdk.internal.opt/share/classes/jdk/internal/joptsimple/internal/Messages.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 38
+                    },
+                    "region": {
+                      "startLine": 75,
+                      "startColumn": 16,
+                      "endColumn": 37
+                    }
+                  },
+                  "message": {
+                    "text": "format(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/jdk.internal.opt/share/classes/jdk/internal/joptsimple/OptionException.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 39
+                    },
+                    "region": {
+                      "startLine": 152,
+                      "startColumn": 16,
+                      "endColumn": 121
+                    }
+                  },
+                  "message": {
+                    "text": "message(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/jdk.internal.opt/share/classes/jdk/internal/joptsimple/OptionException.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 39
+                    },
+                    "region": {
+                      "startLine": 148,
+                      "startColumn": 16,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "formattedMessage(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/jdk.internal.opt/share/classes/jdk/internal/joptsimple/OptionException.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 39
+                    },
+                    "region": {
+                      "startLine": 144,
+                      "startColumn": 16,
+                      "endColumn": 55
+                    }
+                  },
+                  "message": {
+                    "text": "localizedMessage(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/javax/xml/transform/TransformerFactoryConfigurationError.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 40
+                    },
+                    "region": {
+                      "startLine": 110,
+                      "startColumn": 20,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "getMessage(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "make/jdk/src/classes/build/tools/module/ModuleInfoExtraTest.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 21
+                    },
+                    "region": {
+                      "startLine": 254,
+                      "startColumn": 18,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "getMessage(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 2854,
+                      "startColumn": 20,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 2855,
+                      "startColumn": 39,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "this"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "threadFlows": [
+          {
+            "locations": [
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/resolver/implementations/ResolverDirectHTTP.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 45
+                    },
+                    "region": {
+                      "startLine": 142,
+                      "startColumn": 43,
+                      "endColumn": 73
+                    }
+                  },
+                  "message": {
+                    "text": "getInputStream(...) : InputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 0,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "source"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/resolver/implementations/ResolverDirectHTTP.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 45
+                    },
+                    "region": {
+                      "startLine": 147,
+                      "startColumn": 32,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "inputStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/resolver/implementations/ResolverDirectHTTP.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 45
+                    },
+                    "region": {
+                      "startLine": 147,
+                      "startColumn": 49,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "buf [post update] : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 9,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/resolver/implementations/ResolverDirectHTTP.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 45
+                    },
+                    "region": {
+                      "startLine": 148,
+                      "startColumn": 32,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "buf : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/resolver/implementations/ResolverDirectHTTP.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 45
+                    },
+                    "region": {
+                      "startLine": 148,
+                      "startColumn": 21,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "baos [post update] : ByteArrayOutputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 10,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/resolver/implementations/ResolverDirectHTTP.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 45
+                    },
+                    "region": {
+                      "startLine": 154,
+                      "startColumn": 66,
+                      "endColumn": 70
+                    }
+                  },
+                  "message": {
+                    "text": "baos : ByteArrayOutputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/resolver/implementations/ResolverDirectHTTP.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 45
+                    },
+                    "region": {
+                      "startLine": 154,
+                      "startColumn": 66,
+                      "endColumn": 84
+                    }
+                  },
+                  "message": {
+                    "text": "toByteArray(...) : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 11,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 126,
+                      "startColumn": 30,
+                      "endColumn": 48
+                    }
+                  },
+                  "message": {
+                    "text": "inputOctets : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 128,
+                      "startColumn": 22,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "inputOctets : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 128,
+                      "startColumn": 9,
+                      "endColumn": 13
+                    }
+                  },
+                  "message": {
+                    "text": "this [post update] : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/resolver/implementations/ResolverDirectHTTP.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 45
+                    },
+                    "region": {
+                      "startLine": 154,
+                      "startColumn": 44,
+                      "endColumn": 85
+                    }
+                  },
+                  "message": {
+                    "text": "new XMLSignatureInput(...) : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/resolver/implementations/ResolverDirectHTTP.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 45
+                    },
+                    "region": {
+                      "startLine": 160,
+                      "startColumn": 24,
+                      "endColumn": 30
+                    }
+                  },
+                  "message": {
+                    "text": "result : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/resolver/ResourceResolver.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 47
+                    },
+                    "region": {
+                      "startLine": 162,
+                      "startColumn": 24,
+                      "endColumn": 58
+                    }
+                  },
+                  "message": {
+                    "text": "engineResolveURI(...) : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMURIDereferencer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 48
+                    },
+                    "region": {
+                      "startLine": 144,
+                      "startColumn": 36,
+                      "endColumn": 72
+                    }
+                  },
+                  "message": {
+                    "text": "resolve(...) : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMURIDereferencer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 48
+                    },
+                    "region": {
+                      "startLine": 146,
+                      "startColumn": 50,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "in : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheOctetStreamData.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 49
+                    },
+                    "region": {
+                      "startLine": 37,
+                      "startColumn": 34,
+                      "endColumn": 54
+                    }
+                  },
+                  "message": {
+                    "text": "xi : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheOctetStreamData.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 49
+                    },
+                    "region": {
+                      "startLine": 41,
+                      "startColumn": 19,
+                      "endColumn": 21
+                    }
+                  },
+                  "message": {
+                    "text": "xi : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheOctetStreamData.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 49
+                    },
+                    "region": {
+                      "startLine": 41,
+                      "startColumn": 9,
+                      "endColumn": 13
+                    }
+                  },
+                  "message": {
+                    "text": "this [post update] : ApacheOctetStreamData [xi, bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMURIDereferencer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 48
+                    },
+                    "region": {
+                      "startLine": 146,
+                      "startColumn": 24,
+                      "endColumn": 53
+                    }
+                  },
+                  "message": {
+                    "text": "new ApacheOctetStreamData(...) : ApacheOctetStreamData [xi, bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMReference.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 50
+                    },
+                    "region": {
+                      "startLine": 416,
+                      "startColumn": 20,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "dereference(...) : ApacheOctetStreamData [xi, bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMReference.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 50
+                    },
+                    "region": {
+                      "startLine": 423,
+                      "startColumn": 16,
+                      "endColumn": 20
+                    }
+                  },
+                  "message": {
+                    "text": "data : ApacheOctetStreamData [xi, bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMReference.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 50
+                    },
+                    "region": {
+                      "startLine": 354,
+                      "startColumn": 20,
+                      "endColumn": 44
+                    }
+                  },
+                  "message": {
+                    "text": "dereference(...) : ApacheOctetStreamData [xi, bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMReference.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 50
+                    },
+                    "region": {
+                      "startLine": 358,
+                      "startColumn": 33,
+                      "endColumn": 37
+                    }
+                  },
+                  "message": {
+                    "text": "data : ApacheOctetStreamData [xi, bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMReference.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 50
+                    },
+                    "region": {
+                      "startLine": 426,
+                      "startColumn": 30,
+                      "endColumn": 51
+                    }
+                  },
+                  "message": {
+                    "text": "dereferencedData : ApacheOctetStreamData [xi, bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMReference.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 50
+                    },
+                    "region": {
+                      "startLine": 493,
+                      "startColumn": 42,
+                      "endColumn": 46
+                    }
+                  },
+                  "message": {
+                    "text": "data : ApacheOctetStreamData [xi, bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 71
+                    },
+                    "region": {
+                      "startLine": 103,
+                      "startColumn": 27,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "data : ApacheOctetStreamData [xi, bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 71
+                    },
+                    "region": {
+                      "startLine": 109,
+                      "startColumn": 28,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "data : ApacheOctetStreamData [xi, bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 71
+                    },
+                    "region": {
+                      "startLine": 124,
+                      "startColumn": 30,
+                      "endColumn": 39
+                    }
+                  },
+                  "message": {
+                    "text": "data : ApacheOctetStreamData [xi, bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 71
+                    },
+                    "region": {
+                      "startLine": 155,
+                      "startColumn": 19,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "(...)... : ApacheOctetStreamData [xi, bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheOctetStreamData.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 49
+                    },
+                    "region": {
+                      "startLine": 44,
+                      "startColumn": 30,
+                      "endColumn": 50
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : ApacheOctetStreamData [xi, bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheOctetStreamData.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 49
+                    },
+                    "region": {
+                      "startLine": 45,
+                      "startColumn": 16,
+                      "endColumn": 18
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : ApacheOctetStreamData [xi, bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheOctetStreamData.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 49
+                    },
+                    "region": {
+                      "startLine": 45,
+                      "startColumn": 16,
+                      "endColumn": 18
+                    }
+                  },
+                  "message": {
+                    "text": "xi : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 71
+                    },
+                    "region": {
+                      "startLine": 155,
+                      "startColumn": 18,
+                      "endColumn": 59
+                    }
+                  },
+                  "message": {
+                    "text": "getXMLSignatureInput(...) : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 71
+                    },
+                    "region": {
+                      "startLine": 183,
+                      "startColumn": 49,
+                      "endColumn": 51
+                    }
+                  },
+                  "message": {
+                    "text": "in : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/transforms/Transform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 65
+                    },
+                    "region": {
+                      "startLine": 324,
+                      "startColumn": 9,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "input : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/transforms/Transform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 65
+                    },
+                    "region": {
+                      "startLine": 330,
+                      "startColumn": 58,
+                      "endColumn": 63
+                    }
+                  },
+                  "message": {
+                    "text": "input : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/transforms/implementations/TransformXPath.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 72
+                    },
+                    "region": {
+                      "startLine": 71,
+                      "startColumn": 9,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "input : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/transforms/implementations/TransformXPath.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 72
+                    },
+                    "region": {
+                      "startLine": 108,
+                      "startColumn": 20,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "input : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/transforms/Transform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 65
+                    },
+                    "region": {
+                      "startLine": 330,
+                      "startColumn": 22,
+                      "endColumn": 109
+                    }
+                  },
+                  "message": {
+                    "text": "enginePerformTransform(...) : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/transforms/Transform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 65
+                    },
+                    "region": {
+                      "startLine": 341,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "result : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 71
+                    },
+                    "region": {
+                      "startLine": 183,
+                      "startColumn": 22,
+                      "endColumn": 64
+                    }
+                  },
+                  "message": {
+                    "text": "performTransform(...) : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 71
+                    },
+                    "region": {
+                      "startLine": 191,
+                      "startColumn": 50,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "in : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheOctetStreamData.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 49
+                    },
+                    "region": {
+                      "startLine": 37,
+                      "startColumn": 34,
+                      "endColumn": 54
+                    }
+                  },
+                  "message": {
+                    "text": "xi : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheOctetStreamData.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 49
+                    },
+                    "region": {
+                      "startLine": 40,
+                      "startColumn": 15,
+                      "endColumn": 17
+                    }
+                  },
+                  "message": {
+                    "text": "xi : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 243,
+                      "startColumn": 24,
+                      "endColumn": 38
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 249,
+                      "startColumn": 62,
+                      "endColumn": 67
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : XMLSignatureInput [bytes] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 249,
+                      "startColumn": 62,
+                      "endColumn": 67
+                    }
+                  },
+                  "message": {
+                    "text": "bytes : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 249,
+                      "startColumn": 37,
+                      "endColumn": 68
+                    }
+                  },
+                  "message": {
+                    "text": "new ByteArrayInputStream(...) : ByteArrayInputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 12,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 250,
+                      "startColumn": 20,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "inputOctetStreamProxy : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheOctetStreamData.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 49
+                    },
+                    "region": {
+                      "startLine": 40,
+                      "startColumn": 15,
+                      "endColumn": 34
+                    }
+                  },
+                  "message": {
+                    "text": "getOctetStream(...) : ByteArrayInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheOctetStreamData.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 49
+                    },
+                    "region": {
+                      "startLine": 40,
+                      "startColumn": 9,
+                      "endColumn": 73
+                    }
+                  },
+                  "message": {
+                    "text": "this <constr(this)> [post update] : ApacheOctetStreamData"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 13,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 71
+                    },
+                    "region": {
+                      "startLine": 191,
+                      "startColumn": 24,
+                      "endColumn": 53
+                    }
+                  },
+                  "message": {
+                    "text": "new ApacheOctetStreamData(...) : ApacheOctetStreamData"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/ApacheTransform.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 71
+                    },
+                    "region": {
+                      "startLine": 109,
+                      "startColumn": 16,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "transformIt(...) : ApacheOctetStreamData"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMReference.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 50
+                    },
+                    "region": {
+                      "startLine": 493,
+                      "startColumn": 28,
+                      "endColumn": 56
+                    }
+                  },
+                  "message": {
+                    "text": "transform(...) : ApacheOctetStreamData"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMReference.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 50
+                    },
+                    "region": {
+                      "startLine": 495,
+                      "startColumn": 27,
+                      "endColumn": 48
+                    }
+                  },
+                  "message": {
+                    "text": "(...)... : ApacheOctetStreamData"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMReference.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 50
+                    },
+                    "region": {
+                      "startLine": 495,
+                      "startColumn": 26,
+                      "endColumn": 66
+                    }
+                  },
+                  "message": {
+                    "text": "getOctetStream(...) : InputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 14,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 137,
+                      "startColumn": 30,
+                      "endColumn": 58
+                    }
+                  },
+                  "message": {
+                    "text": "inputOctetStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 138,
+                      "startColumn": 38,
+                      "endColumn": 54
+                    }
+                  },
+                  "message": {
+                    "text": "inputOctetStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 138,
+                      "startColumn": 9,
+                      "endColumn": 13
+                    }
+                  },
+                  "message": {
+                    "text": "this [post update] : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMReference.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 50
+                    },
+                    "region": {
+                      "startLine": 494,
+                      "startColumn": 26,
+                      "endLine": 495,
+                      "endColumn": 67
+                    }
+                  },
+                  "message": {
+                    "text": "new XMLSignatureInput(...) : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/org/jcp/xml/dsig/internal/dom/DOMReference.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 50
+                    },
+                    "region": {
+                      "startLine": 533,
+                      "startColumn": 25,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "xi : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 482,
+                      "startColumn": 17,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 484,
+                      "startColumn": 9,
+                      "endColumn": 40
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 487,
+                      "startColumn": 17,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 501,
+                      "startColumn": 41,
+                      "endColumn": 45
+                    }
+                  },
+                  "message": {
+                    "text": "this : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/c14n/implementations/CanonicalizerBase.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 51
+                    },
+                    "region": {
+                      "startLine": 137,
+                      "startColumn": 36,
+                      "endColumn": 59
+                    }
+                  },
+                  "message": {
+                    "text": "input : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/c14n/implementations/CanonicalizerBase.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 51
+                    },
+                    "region": {
+                      "startLine": 149,
+                      "startColumn": 39,
+                      "endColumn": 44
+                    }
+                  },
+                  "message": {
+                    "text": "input : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/c14n/implementations/Canonicalizer20010315.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 74
+                    },
+                    "region": {
+                      "startLine": 300,
+                      "startColumn": 42,
+                      "endColumn": 65
+                    }
+                  },
+                  "message": {
+                    "text": "input : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/c14n/implementations/Canonicalizer20010315.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 74
+                    },
+                    "region": {
+                      "startLine": 309,
+                      "startColumn": 45,
+                      "endColumn": 50
+                    }
+                  },
+                  "message": {
+                    "text": "input : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 193,
+                      "startColumn": 22,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 194,
+                      "startColumn": 16,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 214,
+                      "startColumn": 22,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 226,
+                      "startColumn": 13,
+                      "endColumn": 29
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 562,
+                      "startColumn": 18,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 565,
+                      "startColumn": 42,
+                      "endColumn": 46
+                    }
+                  },
+                  "message": {
+                    "text": "this : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 243,
+                      "startColumn": 24,
+                      "endColumn": 38
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 245,
+                      "startColumn": 20,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : XMLSignatureInput [inputOctetStreamProxy] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 245,
+                      "startColumn": 20,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "inputOctetStreamProxy : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/signature/XMLSignatureInput.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 46
+                    },
+                    "region": {
+                      "startLine": 565,
+                      "startColumn": 42,
+                      "endColumn": 63
+                    }
+                  },
+                  "message": {
+                    "text": "getOctetStream(...) : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/XMLUtils.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 52
+                    },
+                    "region": {
+                      "startLine": 955,
+                      "startColumn": 33,
+                      "endColumn": 56
+                    }
+                  },
+                  "message": {
+                    "text": "inputStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/XMLUtils.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 52
+                    },
+                    "region": {
+                      "startLine": 957,
+                      "startColumn": 36,
+                      "endColumn": 47
+                    }
+                  },
+                  "message": {
+                    "text": "inputStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/parser/XMLParserImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 53
+                    },
+                    "region": {
+                      "startLine": 60,
+                      "startColumn": 27,
+                      "endColumn": 50
+                    }
+                  },
+                  "message": {
+                    "text": "inputStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/parser/XMLParserImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 53
+                    },
+                    "region": {
+                      "startLine": 69,
+                      "startColumn": 46,
+                      "endColumn": 57
+                    }
+                  },
+                  "message": {
+                    "text": "inputStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/javax/xml/parsers/DocumentBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 54
+                    },
+                    "region": {
+                      "startLine": 115,
+                      "startColumn": 27,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/javax/xml/parsers/DocumentBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 54
+                    },
+                    "region": {
+                      "startLine": 121,
+                      "startColumn": 42,
+                      "endColumn": 44
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 127,
+                      "startColumn": 25,
+                      "endColumn": 47
+                    }
+                  },
+                  "message": {
+                    "text": "byteStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 129,
+                      "startColumn": 23,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "byteStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 248,
+                      "startColumn": 32,
+                      "endColumn": 54
+                    }
+                  },
+                  "message": {
+                    "text": "byteStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 250,
+                      "startColumn": 27,
+                      "endColumn": 37
+                    }
+                  },
+                  "message": {
+                    "text": "byteStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 250,
+                      "startColumn": 9,
+                      "endColumn": 13
+                    }
+                  },
+                  "message": {
+                    "text": "this [post update] : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 129,
+                      "startColumn": 9,
+                      "endColumn": 34
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> [post update] : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/javax/xml/parsers/DocumentBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 54
+                    },
+                    "region": {
+                      "startLine": 121,
+                      "startColumn": 26,
+                      "endColumn": 45
+                    }
+                  },
+                  "message": {
+                    "text": "new InputSource(...) : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/javax/xml/parsers/DocumentBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 54
+                    },
+                    "region": {
+                      "startLine": 122,
+                      "startColumn": 22,
+                      "endColumn": 24
+                    }
+                  },
+                  "message": {
+                    "text": "in : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/jaxp/DocumentBuilderImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 56
+                    },
+                    "region": {
+                      "startLine": 329,
+                      "startColumn": 27,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/jaxp/DocumentBuilderImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 56
+                    },
+                    "region": {
+                      "startLine": 342,
+                      "startColumn": 25,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/DOMParser.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 57
+                    },
+                    "region": {
+                      "startLine": 235,
+                      "startColumn": 23,
+                      "endColumn": 46
+                    }
+                  },
+                  "message": {
+                    "text": "inputSource : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/DOMParser.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 57
+                    },
+                    "region": {
+                      "startLine": 244,
+                      "startColumn": 42,
+                      "endColumn": 53
+                    }
+                  },
+                  "message": {
+                    "text": "inputSource : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 264,
+                      "startColumn": 24,
+                      "endColumn": 37
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 266,
+                      "startColumn": 16,
+                      "endColumn": 26
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 266,
+                      "startColumn": 16,
+                      "endColumn": 26
+                    }
+                  },
+                  "message": {
+                    "text": "byteStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/DOMParser.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 57
+                    },
+                    "region": {
+                      "startLine": 244,
+                      "startColumn": 42,
+                      "endColumn": 69
+                    }
+                  },
+                  "message": {
+                    "text": "getByteStream(...) : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xni/parser/XMLInputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 58
+                    },
+                    "region": {
+                      "startLine": 234,
+                      "startColumn": 31,
+                      "endColumn": 53
+                    }
+                  },
+                  "message": {
+                    "text": "byteStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xni/parser/XMLInputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 58
+                    },
+                    "region": {
+                      "startLine": 235,
+                      "startColumn": 23,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "byteStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xni/parser/XMLInputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 58
+                    },
+                    "region": {
+                      "startLine": 235,
+                      "startColumn": 9,
+                      "endColumn": 20
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> [post update] : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/DOMParser.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 57
+                    },
+                    "region": {
+                      "startLine": 244,
+                      "startColumn": 13,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "xmlInputSource [post update] : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/DOMParser.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 57
+                    },
+                    "region": {
+                      "startLine": 247,
+                      "startColumn": 19,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "xmlInputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XMLParser.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 59
+                    },
+                    "region": {
+                      "startLine": 128,
+                      "startColumn": 23,
+                      "endColumn": 49
+                    }
+                  },
+                  "message": {
+                    "text": "inputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XMLParser.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 59
+                    },
+                    "region": {
+                      "startLine": 141,
+                      "startColumn": 30,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "inputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XML11NonValidatingConfiguration.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 75
+                    },
+                    "region": {
+                      "startLine": 590,
+                      "startColumn": 23,
+                      "endColumn": 44
+                    }
+                  },
+                  "message": {
+                    "text": "source : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XML11NonValidatingConfiguration.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 75
+                    },
+                    "region": {
+                      "startLine": 599,
+                      "startColumn": 28,
+                      "endColumn": 34
+                    }
+                  },
+                  "message": {
+                    "text": "source : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XML11NonValidatingConfiguration.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 75
+                    },
+                    "region": {
+                      "startLine": 442,
+                      "startColumn": 32,
+                      "endColumn": 58
+                    }
+                  },
+                  "message": {
+                    "text": "inputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XML11NonValidatingConfiguration.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 75
+                    },
+                    "region": {
+                      "startLine": 450,
+                      "startColumn": 24,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "inputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XML11NonValidatingConfiguration.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 75
+                    },
+                    "region": {
+                      "startLine": 450,
+                      "startColumn": 9,
+                      "endColumn": 21
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> [post update] : XML11NonValidatingConfiguration [fInputSource, fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XML11NonValidatingConfiguration.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 75
+                    },
+                    "region": {
+                      "startLine": 599,
+                      "startColumn": 13,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> [post update] : XML11NonValidatingConfiguration [fInputSource, fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XML11NonValidatingConfiguration.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 75
+                    },
+                    "region": {
+                      "startLine": 600,
+                      "startColumn": 13,
+                      "endColumn": 24
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : XML11NonValidatingConfiguration [fInputSource, fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XML11NonValidatingConfiguration.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 75
+                    },
+                    "region": {
+                      "startLine": 625,
+                      "startColumn": 20,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : XML11NonValidatingConfiguration [fInputSource, fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XML11NonValidatingConfiguration.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 75
+                    },
+                    "region": {
+                      "startLine": 634,
+                      "startColumn": 70,
+                      "endColumn": 82
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : XML11NonValidatingConfiguration [fInputSource, fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XML11NonValidatingConfiguration.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 75
+                    },
+                    "region": {
+                      "startLine": 634,
+                      "startColumn": 70,
+                      "endColumn": 82
+                    }
+                  },
+                  "message": {
+                    "text": "fInputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLVersionDetector.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 61
+                    },
+                    "region": {
+                      "startLine": 149,
+                      "startColumn": 38,
+                      "endColumn": 64
+                    }
+                  },
+                  "message": {
+                    "text": "inputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLVersionDetector.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 61
+                    },
+                    "region": {
+                      "startLine": 150,
+                      "startColumn": 74,
+                      "endColumn": 85
+                    }
+                  },
+                  "message": {
+                    "text": "inputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 626,
+                      "startColumn": 70,
+                      "endColumn": 99
+                    }
+                  },
+                  "message": {
+                    "text": "xmlInputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 648,
+                      "startColumn": 22,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "xmlInputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xni/parser/XMLInputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 58
+                    },
+                    "region": {
+                      "startLine": 239,
+                      "startColumn": 24,
+                      "endColumn": 37
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xni/parser/XMLInputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 58
+                    },
+                    "region": {
+                      "startLine": 240,
+                      "startColumn": 16,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xni/parser/XMLInputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 58
+                    },
+                    "region": {
+                      "startLine": 240,
+                      "startColumn": 16,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "fByteStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 648,
+                      "startColumn": 22,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "getByteStream(...) : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 697,
+                      "startColumn": 80,
+                      "endColumn": 86
+                    }
+                  },
+                  "message": {
+                    "text": "stream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3003,
+                      "startColumn": 38,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3005,
+                      "startColumn": 28,
+                      "endColumn": 30
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3005,
+                      "startColumn": 13,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> [post update] : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 697,
+                      "startColumn": 54,
+                      "endColumn": 87
+                    }
+                  },
+                  "message": {
+                    "text": "new RewindableInputStream(...) : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 779,
+                      "startColumn": 29,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "stream : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3089,
+                      "startColumn": 21,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3099,
+                      "startColumn": 24,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3099,
+                      "startColumn": 24,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "fInputStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3687,
+                      "startColumn": 21,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3701,
+                      "startColumn": 22,
+                      "endLine": 3702,
+                      "endColumn": 71
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3649,
+                      "startColumn": 20,
+                      "endColumn": 24
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3652,
+                      "startColumn": 30,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "super : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3652,
+                      "startColumn": 41,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "b [post update] : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 1,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1971,
+                      "startColumn": 35,
+                      "endColumn": 67
+                    }
+                  },
+                  "message": {
+                    "text": "new HttpInputStream(...) : HttpInputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "id": "AdditionalTaintStep",
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1971,
+                      "startColumn": 21,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> [post update] : HttpURLConnection [inputStream] : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1983,
+                      "startColumn": 17,
+                      "endColumn": 23
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : HttpURLConnection [inputStream] : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1984,
+                      "startColumn": 17,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : HttpURLConnection [inputStream] : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1985,
+                      "startColumn": 24,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : HttpURLConnection [inputStream] : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1985,
+                      "startColumn": 24,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "inputStream : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1573,
+                      "startColumn": 44,
+                      "endColumn": 61
+                    }
+                  },
+                  "message": {
+                    "text": "getInputStream0(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 809,
+                      "startColumn": 20,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "run(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 816,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "result : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 571,
+                      "startColumn": 20,
+                      "endColumn": 62
+                    }
+                  },
+                  "message": {
+                    "text": "executePrivileged(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 89,
+                      "startColumn": 18,
+                      "endColumn": 51
+                    }
+                  },
+                  "message": {
+                    "text": "doPrivileged(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 93,
+                      "startColumn": 16,
+                      "endColumn": 18
+                    }
+                  },
+                  "message": {
+                    "text": "is : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 75,
+                      "startColumn": 31,
+                      "endColumn": 56
+                    }
+                  },
+                  "message": {
+                    "text": "getResourceAsStream(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 76,
+                      "startColumn": 20,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "is : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 76,
+                      "startColumn": 20,
+                      "endColumn": 37
+                    }
+                  },
+                  "message": {
+                    "text": "readAllBytes(...) : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 2,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 80,
+                      "startColumn": 16,
+                      "endColumn": 20
+                    }
+                  },
+                  "message": {
+                    "text": "data : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/util/ResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 12
+                    },
+                    "region": {
+                      "startLine": 561,
+                      "startColumn": 22,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "handleGetObject(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/util/ResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 12
+                    },
+                    "region": {
+                      "startLine": 574,
+                      "startColumn": 16,
+                      "endColumn": 19
+                    }
+                  },
+                  "message": {
+                    "text": "obj : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 326,
+                      "startColumn": 44,
+                      "endColumn": 60
+                    }
+                  },
+                  "message": {
+                    "text": "getObject(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 328,
+                      "startColumn": 45,
+                      "endColumn": 50
+                    }
+                  },
+                  "message": {
+                    "text": "value : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 328,
+                      "startColumn": 29,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "values [post update] : TextAndMnemonicHashMap [<map.value>] : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 3,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 337,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "values : TextAndMnemonicHashMap [<map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 298,
+                      "startColumn": 20,
+                      "endColumn": 39
+                    }
+                  },
+                  "message": {
+                    "text": "getResourceCache(...) : TextAndMnemonicHashMap [<map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 298,
+                      "startColumn": 20,
+                      "endColumn": 48
+                    }
+                  },
+                  "message": {
+                    "text": "get(...) : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 4,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 172,
+                      "startColumn": 42,
+                      "endColumn": 74
+                    }
+                  },
+                  "message": {
+                    "text": "getFromResourceBundle(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 172,
+                      "startColumn": 16,
+                      "endColumn": 74
+                    }
+                  },
+                  "message": {
+                    "text": "...?...:... : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/MultiUIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 34
+                    },
+                    "region": {
+                      "startLine": 65,
+                      "startColumn": 39,
+                      "endColumn": 53
+                    }
+                  },
+                  "message": {
+                    "text": "get(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/MultiUIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 34
+                    },
+                    "region": {
+                      "startLine": 67,
+                      "startColumn": 24,
+                      "endColumn": 29
+                    }
+                  },
+                  "message": {
+                    "text": "value : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/rtf/MockAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 14
+                    },
+                    "region": {
+                      "startLine": 67,
+                      "startColumn": 16,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "get(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/AbstractDocument.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 41
+                    },
+                    "region": {
+                      "startLine": 1939,
+                      "startColumn": 28,
+                      "endColumn": 61
+                    }
+                  },
+                  "message": {
+                    "text": "getAttribute(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/AbstractDocument.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 41
+                    },
+                    "region": {
+                      "startLine": 1949,
+                      "startColumn": 20,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "value : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 15
+                    },
+                    "region": {
+                      "startLine": 151,
+                      "startColumn": 25,
+                      "endColumn": 50
+                    }
+                  },
+                  "message": {
+                    "text": "getAttribute(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 15
+                    },
+                    "region": {
+                      "startLine": 154,
+                      "startColumn": 16,
+                      "endColumn": 21
+                    }
+                  },
+                  "message": {
+                    "text": "value : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 15
+                    },
+                    "region": {
+                      "startLine": 328,
+                      "startColumn": 28,
+                      "endColumn": 45
+                    }
+                  },
+                  "message": {
+                    "text": "getAttribute(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 15
+                    },
+                    "region": {
+                      "startLine": 336,
+                      "startColumn": 16,
+                      "endColumn": 17
+                    }
+                  },
+                  "message": {
+                    "text": "s : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/invoke/ClassSpecializer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 42
+                    },
+                    "region": {
+                      "startLine": 262,
+                      "startColumn": 53,
+                      "endColumn": 67
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/invoke/ClassSpecializer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 42
+                    },
+                    "region": {
+                      "startLine": 262,
+                      "startColumn": 20,
+                      "endColumn": 144
+                    }
+                  },
+                  "message": {
+                    "text": "... + ... : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 1304,
+                      "startColumn": 27,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 1336,
+                      "startColumn": 39,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "arg : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 311,
+                      "startColumn": 45,
+                      "endColumn": 55
+                    }
+                  },
+                  "message": {
+                    "text": "str : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 313,
+                      "startColumn": 22,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "str : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 313,
+                      "startColumn": 9,
+                      "endColumn": 14
+                    }
+                  },
+                  "message": {
+                    "text": "super [post update] : StringBuffer"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 5,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 1336,
+                      "startColumn": 25,
+                      "endColumn": 31
+                    }
+                  },
+                  "message": {
+                    "text": "result [post update] : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 1364,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "result : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 885,
+                      "startColumn": 16,
+                      "endColumn": 66
+                    }
+                  },
+                  "message": {
+                    "text": "subformat(...) : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/Format.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 18
+                    },
+                    "region": {
+                      "startLine": 159,
+                      "startColumn": 16,
+                      "endColumn": 69
+                    }
+                  },
+                  "message": {
+                    "text": "format(...) : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 713,
+                      "startColumn": 32,
+                      "endColumn": 40
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 717,
+                      "startColumn": 27,
+                      "endColumn": 40
+                    }
+                  },
+                  "message": {
+                    "text": "toStringCache : String"
+                  }
+                },
+                "taxa": [
+                  {
+                    "id": "entrypointFieldStep",
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 717,
+                      "startColumn": 16,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "new String(...) : String"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 6,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/Format.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 18
+                    },
+                    "region": {
+                      "startLine": 159,
+                      "startColumn": 16,
+                      "endColumn": 80
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 860,
+                      "startColumn": 16,
+                      "endColumn": 38
+                    }
+                  },
+                  "message": {
+                    "text": "format(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/util/ErrorMsg.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 43
+                    },
+                    "region": {
+                      "startLine": 293,
+                      "startColumn": 15,
+                      "endColumn": 63
+                    }
+                  },
+                  "message": {
+                    "text": "format(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/util/ErrorMsg.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 43
+                    },
+                    "region": {
+                      "startLine": 294,
+                      "startColumn": 16,
+                      "endColumn": 37
+                    }
+                  },
+                  "message": {
+                    "text": "... + ... : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/util/TypeCheckError.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 44
+                    },
+                    "region": {
+                      "startLine": 77,
+                      "startColumn": 16,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/util/TypeCheckError.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 44
+                    },
+                    "region": {
+                      "startLine": 62,
+                      "startColumn": 16,
+                      "endColumn": 26
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/javax/xml/transform/TransformerFactoryConfigurationError.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 40
+                    },
+                    "region": {
+                      "startLine": 110,
+                      "startColumn": 20,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "getMessage(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "make/jdk/src/classes/build/tools/module/ModuleInfoExtraTest.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 21
+                    },
+                    "region": {
+                      "startLine": 270,
+                      "startColumn": 18,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "getMessage(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 2854,
+                      "startColumn": 20,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 2855,
+                      "startColumn": 39,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "this"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "relatedLocations": [
+      {
+        "id": 1,
+        "physicalLocation": {
+          "artifactLocation": {
+            "uri": "src/jdk.compiler/share/classes/com/sun/tools/javac/main/Main.java",
+            "uriBaseId": "%SRCROOT%",
+            "index": 1
+          },
+          "region": {
+            "startLine": 379,
+            "startColumn": 42,
+            "endColumn": 46
+          }
+        },
+        "message": {
+          "text": "regular expression"
+        }
+      },
+      {
+        "id": 2,
+        "physicalLocation": {
+          "artifactLocation": {
+            "uri": "src/java.xml.crypto/share/classes/com/sun/org/apache/xml/internal/security/utils/resolver/implementations/ResolverDirectHTTP.java",
+            "uriBaseId": "%SRCROOT%",
+            "index": 45
+          },
+          "region": {
+            "startLine": 142,
+            "startColumn": 43,
+            "endColumn": 73
+          }
+        },
+        "message": {
+          "text": "user-provided value"
+        }
+      }
+    ]
+  },
+  "result2": {
+    "ruleId": "java/polynomial-redos",
+    "ruleIndex": 0,
+    "rule": {
+      "id": "java/polynomial-redos",
+      "index": 0
+    },
+    "message": {
+      "text": "This [regular expression](1) that depends on a [user-provided value](2) may run slow on strings with many repetitions of '\\\\t'."
+    },
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
+            "uri": "src/java.base/share/classes/java/lang/String.java",
+            "uriBaseId": "%SRCROOT%",
+            "index": 0
+          },
+          "region": {
+            "startLine": 2855,
+            "startColumn": 39,
+            "endColumn": 43
+          }
+        }
+      }
+    ],
+    "partialFingerprints": {
+      "primaryLocationLineHash": "5270db7557dfd174:1",
+      "primaryLocationStartColumnFingerprint": "30"
+    },
+    "codeFlows": [
+      {
+        "threadFlows": [
+          {
+            "locations": [
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/net/URLClassLoader.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 31
+                    },
+                    "region": {
+                      "startLine": 296,
+                      "startColumn": 30,
+                      "endColumn": 51
+                    }
+                  },
+                  "message": {
+                    "text": "getInputStream(...) : InputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 0,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "source"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/net/URLClassLoader.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 31
+                    },
+                    "region": {
+                      "startLine": 309,
+                      "startColumn": 20,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/Class.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 51
+                    },
+                    "region": {
+                      "startLine": 2950,
+                      "startColumn": 20,
+                      "endColumn": 48
+                    }
+                  },
+                  "message": {
+                    "text": "getResourceAsStream(...) : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/jdk.jfr/share/classes/jdk/jfr/internal/SecuritySupport.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 52
+                    },
+                    "region": {
+                      "startLine": 406,
+                      "startColumn": 47,
+                      "endColumn": 94
+                    }
+                  },
+                  "message": {
+                    "text": "getResourceAsStream(...) : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/jdk.jfr/share/classes/jdk/jfr/internal/SecuritySupport.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 52
+                    },
+                    "region": {
+                      "startLine": 215,
+                      "startColumn": 28,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "call(...) : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 809,
+                      "startColumn": 20,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "run(...) : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 816,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "result : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 571,
+                      "startColumn": 20,
+                      "endColumn": 62
+                    }
+                  },
+                  "message": {
+                    "text": "executePrivileged(...) : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 89,
+                      "startColumn": 18,
+                      "endColumn": 51
+                    }
+                  },
+                  "message": {
+                    "text": "doPrivileged(...) : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 93,
+                      "startColumn": 16,
+                      "endColumn": 18
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 75,
+                      "startColumn": 31,
+                      "endColumn": 56
+                    }
+                  },
+                  "message": {
+                    "text": "getResourceAsStream(...) : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 76,
+                      "startColumn": 20,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 76,
+                      "startColumn": 20,
+                      "endColumn": 37
+                    }
+                  },
+                  "message": {
+                    "text": "readAllBytes(...) : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 2,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 80,
+                      "startColumn": 16,
+                      "endColumn": 20
+                    }
+                  },
+                  "message": {
+                    "text": "data : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/util/ResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 12
+                    },
+                    "region": {
+                      "startLine": 561,
+                      "startColumn": 22,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "handleGetObject(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/util/ResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 12
+                    },
+                    "region": {
+                      "startLine": 574,
+                      "startColumn": 16,
+                      "endColumn": 19
+                    }
+                  },
+                  "message": {
+                    "text": "obj : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 326,
+                      "startColumn": 44,
+                      "endColumn": 60
+                    }
+                  },
+                  "message": {
+                    "text": "getObject(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 328,
+                      "startColumn": 45,
+                      "endColumn": 50
+                    }
+                  },
+                  "message": {
+                    "text": "value : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 328,
+                      "startColumn": 29,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "values [post update] : TextAndMnemonicHashMap [<map.value>] : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 3,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 337,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "values : TextAndMnemonicHashMap [<map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 298,
+                      "startColumn": 20,
+                      "endColumn": 39
+                    }
+                  },
+                  "message": {
+                    "text": "getResourceCache(...) : TextAndMnemonicHashMap [<map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 298,
+                      "startColumn": 20,
+                      "endColumn": 48
+                    }
+                  },
+                  "message": {
+                    "text": "get(...) : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 4,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 172,
+                      "startColumn": 42,
+                      "endColumn": 74
+                    }
+                  },
+                  "message": {
+                    "text": "getFromResourceBundle(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 172,
+                      "startColumn": 16,
+                      "endColumn": 74
+                    }
+                  },
+                  "message": {
+                    "text": "...?...:... : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/rtf/MockAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 14
+                    },
+                    "region": {
+                      "startLine": 67,
+                      "startColumn": 16,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "get(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 15
+                    },
+                    "region": {
+                      "startLine": 151,
+                      "startColumn": 25,
+                      "endColumn": 50
+                    }
+                  },
+                  "message": {
+                    "text": "getAttribute(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 15
+                    },
+                    "region": {
+                      "startLine": 154,
+                      "startColumn": 16,
+                      "endColumn": 21
+                    }
+                  },
+                  "message": {
+                    "text": "value : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 15
+                    },
+                    "region": {
+                      "startLine": 328,
+                      "startColumn": 28,
+                      "endColumn": 45
+                    }
+                  },
+                  "message": {
+                    "text": "getAttribute(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 15
+                    },
+                    "region": {
+                      "startLine": 336,
+                      "startColumn": 16,
+                      "endColumn": 17
+                    }
+                  },
+                  "message": {
+                    "text": "s : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 1304,
+                      "startColumn": 27,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 1336,
+                      "startColumn": 39,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "arg : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 311,
+                      "startColumn": 45,
+                      "endColumn": 55
+                    }
+                  },
+                  "message": {
+                    "text": "str : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 313,
+                      "startColumn": 22,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "str : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 313,
+                      "startColumn": 9,
+                      "endColumn": 14
+                    }
+                  },
+                  "message": {
+                    "text": "super [post update] : StringBuffer"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 5,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 1336,
+                      "startColumn": 25,
+                      "endColumn": 31
+                    }
+                  },
+                  "message": {
+                    "text": "result [post update] : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 1364,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "result : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 885,
+                      "startColumn": 16,
+                      "endColumn": 66
+                    }
+                  },
+                  "message": {
+                    "text": "subformat(...) : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/Format.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 18
+                    },
+                    "region": {
+                      "startLine": 159,
+                      "startColumn": 16,
+                      "endColumn": 69
+                    }
+                  },
+                  "message": {
+                    "text": "format(...) : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 713,
+                      "startColumn": 32,
+                      "endColumn": 40
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 717,
+                      "startColumn": 27,
+                      "endColumn": 40
+                    }
+                  },
+                  "message": {
+                    "text": "toStringCache : String"
+                  }
+                },
+                "taxa": [
+                  {
+                    "id": "entrypointFieldStep",
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 717,
+                      "startColumn": 16,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "new String(...) : String"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 6,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/Format.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 18
+                    },
+                    "region": {
+                      "startLine": 159,
+                      "startColumn": 16,
+                      "endColumn": 80
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 860,
+                      "startColumn": 16,
+                      "endColumn": 38
+                    }
+                  },
+                  "message": {
+                    "text": "format(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/DatatypeException.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 19
+                    },
+                    "region": {
+                      "startLine": 102,
+                      "startColumn": 23,
+                      "endColumn": 64
+                    }
+                  },
+                  "message": {
+                    "text": "format(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/DatatypeException.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 19
+                    },
+                    "region": {
+                      "startLine": 109,
+                      "startColumn": 16,
+                      "endColumn": 19
+                    }
+                  },
+                  "message": {
+                    "text": "msg : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/javax/xml/parsers/FactoryConfigurationError.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 20
+                    },
+                    "region": {
+                      "startLine": 111,
+                      "startColumn": 20,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "getMessage(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "make/jdk/src/classes/build/tools/module/ModuleInfoExtraTest.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 21
+                    },
+                    "region": {
+                      "startLine": 254,
+                      "startColumn": 18,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "getMessage(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 2854,
+                      "startColumn": 20,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 2855,
+                      "startColumn": 39,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "this"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "threadFlows": [
+          {
+            "locations": [
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/net/URLClassLoader.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 31
+                    },
+                    "region": {
+                      "startLine": 296,
+                      "startColumn": 30,
+                      "endColumn": 51
+                    }
+                  },
+                  "message": {
+                    "text": "getInputStream(...) : InputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 0,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "source"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/net/URLClassLoader.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 31
+                    },
+                    "region": {
+                      "startLine": 309,
+                      "startColumn": 20,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/java/beans/Beans.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 32
+                    },
+                    "region": {
+                      "startLine": 203,
+                      "startColumn": 20,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "getResourceAsStream(...) : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/java/beans/Beans.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 32
+                    },
+                    "region": {
+                      "startLine": 209,
+                      "startColumn": 60,
+                      "endColumn": 63
+                    }
+                  },
+                  "message": {
+                    "text": "ins : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/java/beans/Beans.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 32
+                    },
+                    "region": {
+                      "startLine": 498,
+                      "startColumn": 40,
+                      "endColumn": 54
+                    }
+                  },
+                  "message": {
+                    "text": "in : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/java/beans/Beans.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 32
+                    },
+                    "region": {
+                      "startLine": 501,
+                      "startColumn": 15,
+                      "endColumn": 17
+                    }
+                  },
+                  "message": {
+                    "text": "in : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/java/beans/Beans.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 32
+                    },
+                    "region": {
+                      "startLine": 501,
+                      "startColumn": 9,
+                      "endColumn": 19
+                    }
+                  },
+                  "message": {
+                    "text": "this <constr(this)> [post update] : ObjectInputStreamWithLoader [bin, in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/java/beans/Beans.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 32
+                    },
+                    "region": {
+                      "startLine": 209,
+                      "startColumn": 28,
+                      "endColumn": 69
+                    }
+                  },
+                  "message": {
+                    "text": "new ObjectInputStreamWithLoader(...) : ObjectInputStreamWithLoader [bin, in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/java/beans/Beans.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 32
+                    },
+                    "region": {
+                      "startLine": 211,
+                      "startColumn": 26,
+                      "endColumn": 30
+                    }
+                  },
+                  "message": {
+                    "text": "oins : ObjectInputStreamWithLoader [bin, in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 494,
+                      "startColumn": 25,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : ObjectInputStreamWithLoader [bin, in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 496,
+                      "startColumn": 16,
+                      "endColumn": 40
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : ObjectInputStreamWithLoader [bin, in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 525,
+                      "startColumn": 26,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : ObjectInputStreamWithLoader [bin, in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 538,
+                      "startColumn": 26,
+                      "endColumn": 50
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : ObjectInputStreamWithLoader [bin, in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 1692,
+                      "startColumn": 20,
+                      "endColumn": 31
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : ObjectInputStreamWithLoader [bin, in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 1748,
+                      "startColumn": 41,
+                      "endColumn": 60
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : ObjectInputStreamWithLoader [bin, in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 2132,
+                      "startColumn": 20,
+                      "endColumn": 29
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : ObjectInputStreamWithLoader [bin, in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 2163,
+                      "startColumn": 17,
+                      "endColumn": 20
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : ObjectInputStreamWithLoader [bin, in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 2163,
+                      "startColumn": 17,
+                      "endColumn": 20
+                    }
+                  },
+                  "message": {
+                    "text": "bin : BlockDataInputStream [in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 3368,
+                      "startColumn": 21,
+                      "endColumn": 30
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : BlockDataInputStream [in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 3372,
+                      "startColumn": 25,
+                      "endColumn": 48
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : BlockDataInputStream [in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 3327,
+                      "startColumn": 13,
+                      "endColumn": 17
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : BlockDataInputStream [in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 3348,
+                      "startColumn": 24,
+                      "endColumn": 26
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : BlockDataInputStream [in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 3348,
+                      "startColumn": 24,
+                      "endColumn": 26
+                    }
+                  },
+                  "message": {
+                    "text": "in : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 3348,
+                      "startColumn": 32,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "b [post update] : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 1,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 408,
+                      "startColumn": 15,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "new BlockDataInputStream(...) : BlockDataInputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "id": "AdditionalTaintStep",
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 408,
+                      "startColumn": 9,
+                      "endColumn": 12
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> [post update] : ObjectInputStream [bin] : BlockDataInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.naming/share/classes/com/sun/jndi/ldap/Obj.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 34
+                    },
+                    "region": {
+                      "startLine": 539,
+                      "startColumn": 21,
+                      "endColumn": 49
+                    }
+                  },
+                  "message": {
+                    "text": "new ObjectInputStream(...) : ObjectInputStream [bin] : BlockDataInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.naming/share/classes/com/sun/jndi/ldap/Obj.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 34
+                    },
+                    "region": {
+                      "startLine": 541,
+                      "startColumn": 24,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "deserial : ObjectInputStream [bin] : BlockDataInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 494,
+                      "startColumn": 25,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : ObjectInputStream [bin] : BlockDataInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 496,
+                      "startColumn": 16,
+                      "endColumn": 40
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : ObjectInputStream [bin] : BlockDataInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 525,
+                      "startColumn": 26,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : ObjectInputStream [bin] : BlockDataInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 538,
+                      "startColumn": 26,
+                      "endColumn": 50
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : ObjectInputStream [bin] : BlockDataInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 1692,
+                      "startColumn": 20,
+                      "endColumn": 31
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : ObjectInputStream [bin] : BlockDataInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 1742,
+                      "startColumn": 41,
+                      "endColumn": 61
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : ObjectInputStream [bin] : BlockDataInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 2115,
+                      "startColumn": 20,
+                      "endColumn": 30
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : ObjectInputStream [bin] : BlockDataInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 2118,
+                      "startColumn": 36,
+                      "endColumn": 39
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : ObjectInputStream [bin] : BlockDataInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 2118,
+                      "startColumn": 36,
+                      "endColumn": 39
+                    }
+                  },
+                  "message": {
+                    "text": "bin : BlockDataInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 2118,
+                      "startColumn": 36,
+                      "endColumn": 49
+                    }
+                  },
+                  "message": {
+                    "text": "readUTF(...) : String"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 9,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 2125,
+                      "startColumn": 16,
+                      "endColumn": 19
+                    }
+                  },
+                  "message": {
+                    "text": "str : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 1742,
+                      "startColumn": 41,
+                      "endColumn": 61
+                    }
+                  },
+                  "message": {
+                    "text": "readString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 1807,
+                      "startColumn": 33,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "obj : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 1809,
+                      "startColumn": 20,
+                      "endColumn": 23
+                    }
+                  },
+                  "message": {
+                    "text": "obj : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 1742,
+                      "startColumn": 28,
+                      "endColumn": 62
+                    }
+                  },
+                  "message": {
+                    "text": "checkResolve(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 538,
+                      "startColumn": 26,
+                      "endColumn": 50
+                    }
+                  },
+                  "message": {
+                    "text": "readObject0(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 548,
+                      "startColumn": 20,
+                      "endColumn": 23
+                    }
+                  },
+                  "message": {
+                    "text": "obj : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 496,
+                      "startColumn": 16,
+                      "endColumn": 40
+                    }
+                  },
+                  "message": {
+                    "text": "readObject(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.naming/share/classes/com/sun/jndi/ldap/Obj.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 34
+                    },
+                    "region": {
+                      "startLine": 541,
+                      "startColumn": 24,
+                      "endColumn": 45
+                    }
+                  },
+                  "message": {
+                    "text": "readObject(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.naming/share/classes/com/sun/jndi/ldap/Obj.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 34
+                    },
+                    "region": {
+                      "startLine": 240,
+                      "startColumn": 24,
+                      "endColumn": 65
+                    }
+                  },
+                  "message": {
+                    "text": "deserializeObject(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.naming/share/classes/com/sun/jndi/ldap/LdapBindingEnumeration.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 35
+                    },
+                    "region": {
+                      "startLine": 65,
+                      "startColumn": 62,
+                      "endColumn": 85
+                    }
+                  },
+                  "message": {
+                    "text": "decodeObject(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 809,
+                      "startColumn": 20,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "run(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 816,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "result : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 714,
+                      "startColumn": 20,
+                      "endColumn": 62
+                    }
+                  },
+                  "message": {
+                    "text": "executePrivileged(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1586,
+                      "startColumn": 28,
+                      "endLine": 1588,
+                      "endColumn": 73
+                    }
+                  },
+                  "message": {
+                    "text": "doPrivileged(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1632,
+                      "startColumn": 20,
+                      "endColumn": 71
+                    }
+                  },
+                  "message": {
+                    "text": "unwrap(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1071,
+                      "startColumn": 13,
+                      "endColumn": 92
+                    }
+                  },
+                  "message": {
+                    "text": "unwrap(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1075,
+                      "startColumn": 61,
+                      "endColumn": 74
+                    }
+                  },
+                  "message": {
+                    "text": "handbackValue : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1075,
+                      "startColumn": 17,
+                      "endColumn": 76
+                    }
+                  },
+                  "message": {
+                    "text": "{...} : Object[] [[]] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1087,
+                      "startColumn": 15,
+                      "endColumn": 21
+                    }
+                  },
+                  "message": {
+                    "text": "params : Object[] [[]] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1380,
+                      "startColumn": 42,
+                      "endColumn": 63
+                    }
+                  },
+                  "message": {
+                    "text": "params : Object[] [[]] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1402,
+                      "startColumn": 52,
+                      "endColumn": 58
+                    }
+                  },
+                  "message": {
+                    "text": "params : Object[] [[]] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1304,
+                      "startColumn": 51,
+                      "endColumn": 66
+                    }
+                  },
+                  "message": {
+                    "text": "params : Object[] [[]] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1306,
+                      "startColumn": 27,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "params : Object[] [[]] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1306,
+                      "startColumn": 13,
+                      "endColumn": 17
+                    }
+                  },
+                  "message": {
+                    "text": "this [post update] : PrivilegedOperation [params, []] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1402,
+                      "startColumn": 17,
+                      "endColumn": 59
+                    }
+                  },
+                  "message": {
+                    "text": "new PrivilegedOperation(...) : PrivilegedOperation [params, []] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1405,
+                      "startColumn": 28,
+                      "endColumn": 30
+                    }
+                  },
+                  "message": {
+                    "text": "op : PrivilegedOperation [params, []] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1309,
+                      "startColumn": 23,
+                      "endColumn": 26
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : PrivilegedOperation [params, []] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1310,
+                      "startColumn": 43,
+                      "endColumn": 49
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : PrivilegedOperation [params, []] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1310,
+                      "startColumn": 43,
+                      "endColumn": 49
+                    }
+                  },
+                  "message": {
+                    "text": "params : Object[] [[]] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1421,
+                      "startColumn": 47,
+                      "endColumn": 62
+                    }
+                  },
+                  "message": {
+                    "text": "params : Object[] [[]] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1427,
+                      "startColumn": 52,
+                      "endColumn": 58
+                    }
+                  },
+                  "message": {
+                    "text": "params : Object[] [[]] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1427,
+                      "startColumn": 52,
+                      "endColumn": 61
+                    }
+                  },
+                  "message": {
+                    "text": "...[...] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1427,
+                      "startColumn": 44,
+                      "endColumn": 61
+                    }
+                  },
+                  "message": {
+                    "text": "(...)... : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerAccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 3
+                    },
+                    "region": {
+                      "startLine": 170,
+                      "startColumn": 39,
+                      "endColumn": 55
+                    }
+                  },
+                  "message": {
+                    "text": "className : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerAccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 3
+                    },
+                    "region": {
+                      "startLine": 177,
+                      "startColumn": 21,
+                      "endColumn": 30
+                    }
+                  },
+                  "message": {
+                    "text": "className : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerFileAccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 4
+                    },
+                    "region": {
+                      "startLine": 247,
+                      "startColumn": 29,
+                      "endColumn": 45
+                    }
+                  },
+                  "message": {
+                    "text": "className : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerFileAccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 4
+                    },
+                    "region": {
+                      "startLine": 248,
+                      "startColumn": 40,
+                      "endColumn": 49
+                    }
+                  },
+                  "message": {
+                    "text": "className : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerFileAccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 4
+                    },
+                    "region": {
+                      "startLine": 303,
+                      "startColumn": 70,
+                      "endColumn": 80
+                    }
+                  },
+                  "message": {
+                    "text": "arg : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerFileAccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 4
+                    },
+                    "region": {
+                      "startLine": 333,
+                      "startColumn": 56,
+                      "endColumn": 59
+                    }
+                  },
+                  "message": {
+                    "text": "arg : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerFileAccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 4
+                    },
+                    "region": {
+                      "startLine": 360,
+                      "startColumn": 61,
+                      "endColumn": 77
+                    }
+                  },
+                  "message": {
+                    "text": "className : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerFileAccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 4
+                    },
+                    "region": {
+                      "startLine": 362,
+                      "startColumn": 50,
+                      "endColumn": 59
+                    }
+                  },
+                  "message": {
+                    "text": "className : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerFileAccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 4
+                    },
+                    "region": {
+                      "startLine": 368,
+                      "startColumn": 59,
+                      "endColumn": 75
+                    }
+                  },
+                  "message": {
+                    "text": "className : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerFileAccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 4
+                    },
+                    "region": {
+                      "startLine": 387,
+                      "startColumn": 16,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "className : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 2854,
+                      "startColumn": 20,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 2855,
+                      "startColumn": 39,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "this"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "threadFlows": [
+          {
+            "locations": [
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/net/URLClassLoader.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 31
+                    },
+                    "region": {
+                      "startLine": 296,
+                      "startColumn": 30,
+                      "endColumn": 51
+                    }
+                  },
+                  "message": {
+                    "text": "getInputStream(...) : InputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 0,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "source"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/net/URLClassLoader.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 31
+                    },
+                    "region": {
+                      "startLine": 309,
+                      "startColumn": 20,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/jdk/xml/internal/SecuritySupport.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 53
+                    },
+                    "region": {
+                      "startLine": 465,
+                      "startColumn": 23,
+                      "endColumn": 51
+                    }
+                  },
+                  "message": {
+                    "text": "getResourceAsStream(...) : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/jdk/xml/internal/SecuritySupport.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 53
+                    },
+                    "region": {
+                      "startLine": 467,
+                      "startColumn": 20,
+                      "endColumn": 23
+                    }
+                  },
+                  "message": {
+                    "text": "ris : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 778,
+                      "startColumn": 20,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "run(...) : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 785,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "result : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 319,
+                      "startColumn": 16,
+                      "endColumn": 76
+                    }
+                  },
+                  "message": {
+                    "text": "executePrivileged(...) : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 1592,
+                      "startColumn": 13,
+                      "endLine": 1600,
+                      "endColumn": 15
+                    }
+                  },
+                  "message": {
+                    "text": "doPrivileged(...) : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 1604,
+                      "startColumn": 41,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "inputStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/javax/xml/parsers/DocumentBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 54
+                    },
+                    "region": {
+                      "startLine": 115,
+                      "startColumn": 27,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/javax/xml/parsers/DocumentBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 54
+                    },
+                    "region": {
+                      "startLine": 121,
+                      "startColumn": 42,
+                      "endColumn": 44
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 127,
+                      "startColumn": 25,
+                      "endColumn": 47
+                    }
+                  },
+                  "message": {
+                    "text": "byteStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 129,
+                      "startColumn": 23,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "byteStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 248,
+                      "startColumn": 32,
+                      "endColumn": 54
+                    }
+                  },
+                  "message": {
+                    "text": "byteStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 250,
+                      "startColumn": 27,
+                      "endColumn": 37
+                    }
+                  },
+                  "message": {
+                    "text": "byteStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 250,
+                      "startColumn": 9,
+                      "endColumn": 13
+                    }
+                  },
+                  "message": {
+                    "text": "this [post update] : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 129,
+                      "startColumn": 9,
+                      "endColumn": 34
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> [post update] : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/javax/xml/parsers/DocumentBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 54
+                    },
+                    "region": {
+                      "startLine": 121,
+                      "startColumn": 26,
+                      "endColumn": 45
+                    }
+                  },
+                  "message": {
+                    "text": "new InputSource(...) : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/javax/xml/parsers/DocumentBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 54
+                    },
+                    "region": {
+                      "startLine": 122,
+                      "startColumn": 22,
+                      "endColumn": 24
+                    }
+                  },
+                  "message": {
+                    "text": "in : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/jaxp/DocumentBuilderImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 56
+                    },
+                    "region": {
+                      "startLine": 329,
+                      "startColumn": 27,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/jaxp/DocumentBuilderImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 56
+                    },
+                    "region": {
+                      "startLine": 342,
+                      "startColumn": 25,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/DOMParser.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 57
+                    },
+                    "region": {
+                      "startLine": 235,
+                      "startColumn": 23,
+                      "endColumn": 46
+                    }
+                  },
+                  "message": {
+                    "text": "inputSource : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/DOMParser.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 57
+                    },
+                    "region": {
+                      "startLine": 244,
+                      "startColumn": 42,
+                      "endColumn": 53
+                    }
+                  },
+                  "message": {
+                    "text": "inputSource : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 264,
+                      "startColumn": 24,
+                      "endColumn": 37
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 266,
+                      "startColumn": 16,
+                      "endColumn": 26
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : InputSource [byteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/org/xml/sax/InputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 55
+                    },
+                    "region": {
+                      "startLine": 266,
+                      "startColumn": 16,
+                      "endColumn": 26
+                    }
+                  },
+                  "message": {
+                    "text": "byteStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/DOMParser.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 57
+                    },
+                    "region": {
+                      "startLine": 244,
+                      "startColumn": 42,
+                      "endColumn": 69
+                    }
+                  },
+                  "message": {
+                    "text": "getByteStream(...) : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xni/parser/XMLInputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 58
+                    },
+                    "region": {
+                      "startLine": 234,
+                      "startColumn": 31,
+                      "endColumn": 53
+                    }
+                  },
+                  "message": {
+                    "text": "byteStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xni/parser/XMLInputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 58
+                    },
+                    "region": {
+                      "startLine": 235,
+                      "startColumn": 23,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "byteStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xni/parser/XMLInputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 58
+                    },
+                    "region": {
+                      "startLine": 235,
+                      "startColumn": 9,
+                      "endColumn": 20
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> [post update] : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/DOMParser.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 57
+                    },
+                    "region": {
+                      "startLine": 244,
+                      "startColumn": 13,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "xmlInputSource [post update] : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/DOMParser.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 57
+                    },
+                    "region": {
+                      "startLine": 247,
+                      "startColumn": 19,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "xmlInputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XMLParser.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 59
+                    },
+                    "region": {
+                      "startLine": 128,
+                      "startColumn": 23,
+                      "endColumn": 49
+                    }
+                  },
+                  "message": {
+                    "text": "inputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/parsers/XMLParser.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 59
+                    },
+                    "region": {
+                      "startLine": 141,
+                      "startColumn": 30,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "inputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/opti/SchemaParsingConfig.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 60
+                    },
+                    "region": {
+                      "startLine": 686,
+                      "startColumn": 23,
+                      "endColumn": 44
+                    }
+                  },
+                  "message": {
+                    "text": "source : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/opti/SchemaParsingConfig.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 60
+                    },
+                    "region": {
+                      "startLine": 695,
+                      "startColumn": 28,
+                      "endColumn": 34
+                    }
+                  },
+                  "message": {
+                    "text": "source : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/opti/SchemaParsingConfig.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 60
+                    },
+                    "region": {
+                      "startLine": 556,
+                      "startColumn": 32,
+                      "endColumn": 58
+                    }
+                  },
+                  "message": {
+                    "text": "inputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/opti/SchemaParsingConfig.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 60
+                    },
+                    "region": {
+                      "startLine": 564,
+                      "startColumn": 24,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "inputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/opti/SchemaParsingConfig.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 60
+                    },
+                    "region": {
+                      "startLine": 564,
+                      "startColumn": 9,
+                      "endColumn": 21
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> [post update] : SchemaParsingConfig [fInputSource, fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/opti/SchemaParsingConfig.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 60
+                    },
+                    "region": {
+                      "startLine": 695,
+                      "startColumn": 13,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> [post update] : SchemaParsingConfig [fInputSource, fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/opti/SchemaParsingConfig.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 60
+                    },
+                    "region": {
+                      "startLine": 696,
+                      "startColumn": 13,
+                      "endColumn": 24
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : SchemaParsingConfig [fInputSource, fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/opti/SchemaParsingConfig.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 60
+                    },
+                    "region": {
+                      "startLine": 584,
+                      "startColumn": 20,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : SchemaParsingConfig [fInputSource, fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/opti/SchemaParsingConfig.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 60
+                    },
+                    "region": {
+                      "startLine": 593,
+                      "startColumn": 70,
+                      "endColumn": 82
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : SchemaParsingConfig [fInputSource, fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xs/opti/SchemaParsingConfig.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 60
+                    },
+                    "region": {
+                      "startLine": 593,
+                      "startColumn": 70,
+                      "endColumn": 82
+                    }
+                  },
+                  "message": {
+                    "text": "fInputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLVersionDetector.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 61
+                    },
+                    "region": {
+                      "startLine": 149,
+                      "startColumn": 38,
+                      "endColumn": 64
+                    }
+                  },
+                  "message": {
+                    "text": "inputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLVersionDetector.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 61
+                    },
+                    "region": {
+                      "startLine": 150,
+                      "startColumn": 74,
+                      "endColumn": 85
+                    }
+                  },
+                  "message": {
+                    "text": "inputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 626,
+                      "startColumn": 70,
+                      "endColumn": 99
+                    }
+                  },
+                  "message": {
+                    "text": "xmlInputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 648,
+                      "startColumn": 22,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "xmlInputSource : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xni/parser/XMLInputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 58
+                    },
+                    "region": {
+                      "startLine": 239,
+                      "startColumn": 24,
+                      "endColumn": 37
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xni/parser/XMLInputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 58
+                    },
+                    "region": {
+                      "startLine": 240,
+                      "startColumn": 16,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : XMLInputSource [fByteStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/xni/parser/XMLInputSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 58
+                    },
+                    "region": {
+                      "startLine": 240,
+                      "startColumn": 16,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "fByteStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 648,
+                      "startColumn": 22,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "getByteStream(...) : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 697,
+                      "startColumn": 80,
+                      "endColumn": 86
+                    }
+                  },
+                  "message": {
+                    "text": "stream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3003,
+                      "startColumn": 38,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3005,
+                      "startColumn": 28,
+                      "endColumn": 30
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3005,
+                      "startColumn": 13,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> [post update] : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 697,
+                      "startColumn": 54,
+                      "endColumn": 87
+                    }
+                  },
+                  "message": {
+                    "text": "new RewindableInputStream(...) : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 720,
+                      "startColumn": 29,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "stream : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3089,
+                      "startColumn": 21,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3099,
+                      "startColumn": 24,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3099,
+                      "startColumn": 24,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "fInputStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3687,
+                      "startColumn": 21,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3701,
+                      "startColumn": 22,
+                      "endLine": 3702,
+                      "endColumn": 71
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3649,
+                      "startColumn": 20,
+                      "endColumn": 24
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3652,
+                      "startColumn": 30,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "super : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3652,
+                      "startColumn": 41,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "b [post update] : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 1,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1964,
+                      "startColumn": 47,
+                      "endColumn": 93
+                    }
+                  },
+                  "message": {
+                    "text": "new HttpInputStream(...) : HttpInputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "id": "AdditionalTaintStep",
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1985,
+                      "startColumn": 24,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "inputStream : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1581,
+                      "startColumn": 24,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "getInputStream0(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/net/URL.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 22
+                    },
+                    "region": {
+                      "startLine": 1317,
+                      "startColumn": 16,
+                      "endColumn": 49
+                    }
+                  },
+                  "message": {
+                    "text": "getInputStream(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 586,
+                      "startColumn": 43,
+                      "endColumn": 59
+                    }
+                  },
+                  "message": {
+                    "text": "openStream(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 587,
+                      "startColumn": 64,
+                      "endColumn": 66
+                    }
+                  },
+                  "message": {
+                    "text": "in : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 587,
+                      "startColumn": 42,
+                      "endColumn": 79
+                    }
+                  },
+                  "message": {
+                    "text": "new InputStreamReader(...) : InputStreamReader"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 7,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 591,
+                      "startColumn": 37,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "reader : InputStreamReader"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/Reader.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 24
+                    },
+                    "region": {
+                      "startLine": 264,
+                      "startColumn": 16,
+                      "endColumn": 20
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : InputStreamReader"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/Reader.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 24
+                    },
+                    "region": {
+                      "startLine": 265,
+                      "startColumn": 16,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : InputStreamReader"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/Reader.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 24
+                    },
+                    "region": {
+                      "startLine": 265,
+                      "startColumn": 21,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "cbuf [post update] : char[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 8,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 591,
+                      "startColumn": 49,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "buf [post update] : char[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 592,
+                      "startColumn": 39,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "buf : char[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 232,
+                      "startColumn": 33,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "str : char[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 233,
+                      "startColumn": 22,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "str : char[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 233,
+                      "startColumn": 9,
+                      "endColumn": 14
+                    }
+                  },
+                  "message": {
+                    "text": "super [post update] : StringBuilder"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 5,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 592,
+                      "startColumn": 29,
+                      "endColumn": 31
+                    }
+                  },
+                  "message": {
+                    "text": "sb [post update] : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 595,
+                      "startColumn": 34,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "sb : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 451,
+                      "startColumn": 19,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 453,
+                      "startColumn": 27,
+                      "endColumn": 31
+                    }
+                  },
+                  "message": {
+                    "text": "this : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 1486,
+                      "startColumn": 19,
+                      "endColumn": 40
+                    }
+                  },
+                  "message": {
+                    "text": "builder : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 1487,
+                      "startColumn": 14,
+                      "endColumn": 21
+                    }
+                  },
+                  "message": {
+                    "text": "builder : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 1487,
+                      "startColumn": 9,
+                      "endColumn": 29
+                    }
+                  },
+                  "message": {
+                    "text": "this <constr(this)> [post update] : String"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 6,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 453,
+                      "startColumn": 16,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "new String(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 595,
+                      "startColumn": 34,
+                      "endColumn": 47
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 604,
+                      "startColumn": 40,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "str : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 2718,
+                      "startColumn": 19,
+                      "endColumn": 28
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 2722,
+                      "startColumn": 20,
+                      "endColumn": 24
+                    }
+                  },
+                  "message": {
+                    "text": "this : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 604,
+                      "startColumn": 40,
+                      "endColumn": 60
+                    }
+                  },
+                  "message": {
+                    "text": "substring(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 778,
+                      "startColumn": 20,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "run(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 785,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "result : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 319,
+                      "startColumn": 16,
+                      "endColumn": 76
+                    }
+                  },
+                  "message": {
+                    "text": "executePrivileged(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/security/provider/SubjectCodeSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 26
+                    },
+                    "region": {
+                      "startLine": 369,
+                      "startColumn": 25,
+                      "endLine": 374,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "doPrivileged(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/security/provider/SubjectCodeSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 26
+                    },
+                    "region": {
+                      "startLine": 386,
+                      "startColumn": 16,
+                      "endColumn": 24
+                    }
+                  },
+                  "message": {
+                    "text": "returnMe : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 4230,
+                      "startColumn": 41,
+                      "endColumn": 55
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 4230,
+                      "startColumn": 16,
+                      "endColumn": 55
+                    }
+                  },
+                  "message": {
+                    "text": "...?...:... : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 173,
+                      "startColumn": 23,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "valueOf(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 178,
+                      "startColumn": 33,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "str : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 179,
+                      "startColumn": 22,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "str : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 179,
+                      "startColumn": 9,
+                      "endColumn": 14
+                    }
+                  },
+                  "message": {
+                    "text": "super [post update] : StringBuilder"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 5,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 173,
+                      "startColumn": 16,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> [post update] : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.naming/share/classes/javax/naming/directory/BasicAttribute.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 27
+                    },
+                    "region": {
+                      "startLine": 221,
+                      "startColumn": 17,
+                      "endColumn": 23
+                    }
+                  },
+                  "message": {
+                    "text": "answer [post update] : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.naming/share/classes/javax/naming/directory/BasicAttribute.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 27
+                    },
+                    "region": {
+                      "startLine": 225,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "answer : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 451,
+                      "startColumn": 19,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 453,
+                      "startColumn": 27,
+                      "endColumn": 31
+                    }
+                  },
+                  "message": {
+                    "text": "this : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 1486,
+                      "startColumn": 19,
+                      "endColumn": 40
+                    }
+                  },
+                  "message": {
+                    "text": "builder : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 1487,
+                      "startColumn": 14,
+                      "endColumn": 21
+                    }
+                  },
+                  "message": {
+                    "text": "builder : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 1487,
+                      "startColumn": 9,
+                      "endColumn": 29
+                    }
+                  },
+                  "message": {
+                    "text": "this <constr(this)> [post update] : String"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 6,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 453,
+                      "startColumn": 16,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "new String(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.naming/share/classes/javax/naming/directory/BasicAttribute.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 27
+                    },
+                    "region": {
+                      "startLine": 225,
+                      "startColumn": 16,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.naming/share/classes/javax/naming/directory/ModificationItem.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 28
+                    },
+                    "region": {
+                      "startLine": 118,
+                      "startColumn": 41,
+                      "endColumn": 56
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.naming/share/classes/javax/naming/directory/ModificationItem.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 28
+                    },
+                    "region": {
+                      "startLine": 118,
+                      "startColumn": 21,
+                      "endColumn": 56
+                    }
+                  },
+                  "message": {
+                    "text": "... + ... : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.naming/share/classes/javax/naming/directory/AttributeModificationException.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 29
+                    },
+                    "region": {
+                      "startLine": 131,
+                      "startColumn": 22,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.naming/share/classes/javax/naming/directory/AttributeModificationException.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 29
+                    },
+                    "region": {
+                      "startLine": 133,
+                      "startColumn": 16,
+                      "endColumn": 20
+                    }
+                  },
+                  "message": {
+                    "text": "orig : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/WriteAbortedException.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 30
+                    },
+                    "region": {
+                      "startLine": 74,
+                      "startColumn": 48,
+                      "endColumn": 65
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/WriteAbortedException.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 30
+                    },
+                    "region": {
+                      "startLine": 74,
+                      "startColumn": 20,
+                      "endColumn": 65
+                    }
+                  },
+                  "message": {
+                    "text": "... + ... : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/javax/xml/parsers/FactoryConfigurationError.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 20
+                    },
+                    "region": {
+                      "startLine": 111,
+                      "startColumn": 20,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "getMessage(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "make/jdk/src/classes/build/tools/module/ModuleInfoExtraTest.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 21
+                    },
+                    "region": {
+                      "startLine": 270,
+                      "startColumn": 18,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "getMessage(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 2854,
+                      "startColumn": 20,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 2855,
+                      "startColumn": 39,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "this"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "threadFlows": [
+          {
+            "locations": [
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/net/URLClassLoader.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 31
+                    },
+                    "region": {
+                      "startLine": 296,
+                      "startColumn": 30,
+                      "endColumn": 51
+                    }
+                  },
+                  "message": {
+                    "text": "getInputStream(...) : InputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 0,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "source"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/net/URLClassLoader.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 31
+                    },
+                    "region": {
+                      "startLine": 309,
+                      "startColumn": 20,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management/share/classes/javax/management/loading/MLet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 62
+                    },
+                    "region": {
+                      "startLine": 1228,
+                      "startColumn": 26,
+                      "endColumn": 55
+                    }
+                  },
+                  "message": {
+                    "text": "getResourceAsStream(...) : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management/share/classes/javax/management/loading/MLet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 62
+                    },
+                    "region": {
+                      "startLine": 1231,
+                      "startColumn": 67,
+                      "endColumn": 69
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management/share/classes/javax/management/loading/MLetObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 63
+                    },
+                    "region": {
+                      "startLine": 51,
+                      "startColumn": 34,
+                      "endColumn": 48
+                    }
+                  },
+                  "message": {
+                    "text": "in : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management/share/classes/javax/management/loading/MLetObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 63
+                    },
+                    "region": {
+                      "startLine": 54,
+                      "startColumn": 15,
+                      "endColumn": 17
+                    }
+                  },
+                  "message": {
+                    "text": "in : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management/share/classes/javax/management/loading/MLetObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 63
+                    },
+                    "region": {
+                      "startLine": 54,
+                      "startColumn": 9,
+                      "endColumn": 19
+                    }
+                  },
+                  "message": {
+                    "text": "this <constr(this)> [post update] : MLetObjectInputStream [bin, in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management/share/classes/javax/management/loading/MLet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 62
+                    },
+                    "region": {
+                      "startLine": 1231,
+                      "startColumn": 41,
+                      "endColumn": 76
+                    }
+                  },
+                  "message": {
+                    "text": "new MLetObjectInputStream(...) : MLetObjectInputStream [bin, in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management/share/classes/javax/management/loading/MLet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 62
+                    },
+                    "region": {
+                      "startLine": 1232,
+                      "startColumn": 36,
+                      "endColumn": 39
+                    }
+                  },
+                  "message": {
+                    "text": "ois : MLetObjectInputStream [bin, in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 494,
+                      "startColumn": 25,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : MLetObjectInputStream [bin, in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 496,
+                      "startColumn": 16,
+                      "endColumn": 40
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : MLetObjectInputStream [bin, in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 525,
+                      "startColumn": 26,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : MLetObjectInputStream [bin, in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 538,
+                      "startColumn": 26,
+                      "endColumn": 50
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : MLetObjectInputStream [bin, in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 1692,
+                      "startColumn": 20,
+                      "endColumn": 31
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : MLetObjectInputStream [bin, in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 1748,
+                      "startColumn": 41,
+                      "endColumn": 60
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : MLetObjectInputStream [bin, in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 2132,
+                      "startColumn": 20,
+                      "endColumn": 29
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : MLetObjectInputStream [bin, in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 2163,
+                      "startColumn": 17,
+                      "endColumn": 20
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : MLetObjectInputStream [bin, in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 2163,
+                      "startColumn": 17,
+                      "endColumn": 20
+                    }
+                  },
+                  "message": {
+                    "text": "bin : BlockDataInputStream [in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 3368,
+                      "startColumn": 21,
+                      "endColumn": 30
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : BlockDataInputStream [in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 3372,
+                      "startColumn": 25,
+                      "endColumn": 48
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : BlockDataInputStream [in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 3327,
+                      "startColumn": 13,
+                      "endColumn": 17
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : BlockDataInputStream [in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 3342,
+                      "startColumn": 29,
+                      "endColumn": 31
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : BlockDataInputStream [in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 3342,
+                      "startColumn": 29,
+                      "endColumn": 31
+                    }
+                  },
+                  "message": {
+                    "text": "in : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 3342,
+                      "startColumn": 37,
+                      "endColumn": 40
+                    }
+                  },
+                  "message": {
+                    "text": "buf [post update] : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 1,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 3344,
+                      "startColumn": 38,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "buf : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 3344,
+                      "startColumn": 46,
+                      "endColumn": 47
+                    }
+                  },
+                  "message": {
+                    "text": "b [post update] : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 10,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 408,
+                      "startColumn": 15,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "new BlockDataInputStream(...) : BlockDataInputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "id": "AdditionalTaintStep",
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 408,
+                      "startColumn": 9,
+                      "endColumn": 12
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> [post update] : ObjectInputStream [bin] : BlockDataInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.rmi/share/classes/sun/rmi/server/MarshalInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 64
+                    },
+                    "region": {
+                      "startLine": 109,
+                      "startColumn": 9,
+                      "endColumn": 19
+                    }
+                  },
+                  "message": {
+                    "text": "this <constr(this)> [post update] : MarshalInputStream [bin] : BlockDataInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.rmi/share/classes/java/rmi/MarshalledObject.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 65
+                    },
+                    "region": {
+                      "startLine": 325,
+                      "startColumn": 13,
+                      "endColumn": 26
+                    }
+                  },
+                  "message": {
+                    "text": "this <constr(this)> [post update] : MarshalledObjectInputStream [bin] : BlockDataInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.rmi/share/classes/java/rmi/MarshalledObject.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 65
+                    },
+                    "region": {
+                      "startLine": 181,
+                      "startColumn": 13,
+                      "endColumn": 73
+                    }
+                  },
+                  "message": {
+                    "text": "new MarshalledObjectInputStream(...) : MarshalledObjectInputStream [bin] : BlockDataInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.rmi/share/classes/java/rmi/MarshalledObject.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 65
+                    },
+                    "region": {
+                      "startLine": 183,
+                      "startColumn": 21,
+                      "endColumn": 23
+                    }
+                  },
+                  "message": {
+                    "text": "in : MarshalledObjectInputStream [bin] : BlockDataInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 494,
+                      "startColumn": 25,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : MarshalledObjectInputStream [bin] : BlockDataInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 496,
+                      "startColumn": 16,
+                      "endColumn": 40
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : MarshalledObjectInputStream [bin] : BlockDataInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 525,
+                      "startColumn": 26,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : MarshalledObjectInputStream [bin] : BlockDataInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 538,
+                      "startColumn": 26,
+                      "endColumn": 50
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : MarshalledObjectInputStream [bin] : BlockDataInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 1692,
+                      "startColumn": 20,
+                      "endColumn": 31
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : MarshalledObjectInputStream [bin] : BlockDataInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 1742,
+                      "startColumn": 41,
+                      "endColumn": 61
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : MarshalledObjectInputStream [bin] : BlockDataInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 2115,
+                      "startColumn": 20,
+                      "endColumn": 30
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : MarshalledObjectInputStream [bin] : BlockDataInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 2118,
+                      "startColumn": 36,
+                      "endColumn": 39
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : MarshalledObjectInputStream [bin] : BlockDataInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 2118,
+                      "startColumn": 36,
+                      "endColumn": 39
+                    }
+                  },
+                  "message": {
+                    "text": "bin : BlockDataInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 2118,
+                      "startColumn": 36,
+                      "endColumn": 49
+                    }
+                  },
+                  "message": {
+                    "text": "readUTF(...) : String"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 9,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 2125,
+                      "startColumn": 16,
+                      "endColumn": 19
+                    }
+                  },
+                  "message": {
+                    "text": "str : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 1742,
+                      "startColumn": 41,
+                      "endColumn": 61
+                    }
+                  },
+                  "message": {
+                    "text": "readString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 1807,
+                      "startColumn": 33,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "obj : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 1811,
+                      "startColumn": 36,
+                      "endColumn": 39
+                    }
+                  },
+                  "message": {
+                    "text": "obj : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 927,
+                      "startColumn": 36,
+                      "endColumn": 46
+                    }
+                  },
+                  "message": {
+                    "text": "obj : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 928,
+                      "startColumn": 16,
+                      "endColumn": 19
+                    }
+                  },
+                  "message": {
+                    "text": "obj : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 1811,
+                      "startColumn": 22,
+                      "endColumn": 40
+                    }
+                  },
+                  "message": {
+                    "text": "resolveObject(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 1824,
+                      "startColumn": 16,
+                      "endColumn": 19
+                    }
+                  },
+                  "message": {
+                    "text": "rep : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 1742,
+                      "startColumn": 28,
+                      "endColumn": 62
+                    }
+                  },
+                  "message": {
+                    "text": "checkResolve(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 538,
+                      "startColumn": 26,
+                      "endColumn": 50
+                    }
+                  },
+                  "message": {
+                    "text": "readObject0(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 548,
+                      "startColumn": 20,
+                      "endColumn": 23
+                    }
+                  },
+                  "message": {
+                    "text": "obj : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 496,
+                      "startColumn": 16,
+                      "endColumn": 40
+                    }
+                  },
+                  "message": {
+                    "text": "readObject(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.rmi/share/classes/java/rmi/MarshalledObject.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 65
+                    },
+                    "region": {
+                      "startLine": 183,
+                      "startColumn": 21,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "readObject(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.rmi/share/classes/java/rmi/MarshalledObject.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 65
+                    },
+                    "region": {
+                      "startLine": 183,
+                      "startColumn": 17,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "(...)... : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.rmi/share/classes/java/rmi/MarshalledObject.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 65
+                    },
+                    "region": {
+                      "startLine": 185,
+                      "startColumn": 16,
+                      "endColumn": 19
+                    }
+                  },
+                  "message": {
+                    "text": "obj : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1590,
+                      "startColumn": 46,
+                      "endColumn": 54
+                    }
+                  },
+                  "message": {
+                    "text": "get(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/Class.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 51
+                    },
+                    "region": {
+                      "startLine": 3989,
+                      "startColumn": 19,
+                      "endColumn": 29
+                    }
+                  },
+                  "message": {
+                    "text": "obj : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/Class.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 51
+                    },
+                    "region": {
+                      "startLine": 3992,
+                      "startColumn": 16,
+                      "endColumn": 23
+                    }
+                  },
+                  "message": {
+                    "text": "(...)... : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1590,
+                      "startColumn": 28,
+                      "endColumn": 55
+                    }
+                  },
+                  "message": {
+                    "text": "cast(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1632,
+                      "startColumn": 20,
+                      "endColumn": 71
+                    }
+                  },
+                  "message": {
+                    "text": "unwrap(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1210,
+                      "startColumn": 13,
+                      "endColumn": 92
+                    }
+                  },
+                  "message": {
+                    "text": "unwrap(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1214,
+                      "startColumn": 61,
+                      "endColumn": 74
+                    }
+                  },
+                  "message": {
+                    "text": "handbackValue : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1214,
+                      "startColumn": 17,
+                      "endColumn": 76
+                    }
+                  },
+                  "message": {
+                    "text": "{...} : Object[] [[]] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1226,
+                      "startColumn": 15,
+                      "endColumn": 21
+                    }
+                  },
+                  "message": {
+                    "text": "params : Object[] [[]] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1380,
+                      "startColumn": 42,
+                      "endColumn": 63
+                    }
+                  },
+                  "message": {
+                    "text": "params : Object[] [[]] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1402,
+                      "startColumn": 52,
+                      "endColumn": 58
+                    }
+                  },
+                  "message": {
+                    "text": "params : Object[] [[]] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1304,
+                      "startColumn": 51,
+                      "endColumn": 66
+                    }
+                  },
+                  "message": {
+                    "text": "params : Object[] [[]] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1306,
+                      "startColumn": 27,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "params : Object[] [[]] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1306,
+                      "startColumn": 13,
+                      "endColumn": 17
+                    }
+                  },
+                  "message": {
+                    "text": "this [post update] : PrivilegedOperation [params, []] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1402,
+                      "startColumn": 17,
+                      "endColumn": 59
+                    }
+                  },
+                  "message": {
+                    "text": "new PrivilegedOperation(...) : PrivilegedOperation [params, []] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1412,
+                      "startColumn": 54,
+                      "endColumn": 56
+                    }
+                  },
+                  "message": {
+                    "text": "op : PrivilegedOperation [params, []] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 707,
+                      "startColumn": 22,
+                      "endColumn": 57
+                    }
+                  },
+                  "message": {
+                    "text": "action : PrivilegedOperation [params, []] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 714,
+                      "startColumn": 38,
+                      "endColumn": 44
+                    }
+                  },
+                  "message": {
+                    "text": "action : PrivilegedOperation [params, []] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 798,
+                      "startColumn": 27,
+                      "endColumn": 62
+                    }
+                  },
+                  "message": {
+                    "text": "action : PrivilegedOperation [params, []] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 809,
+                      "startColumn": 20,
+                      "endColumn": 26
+                    }
+                  },
+                  "message": {
+                    "text": "action : PrivilegedOperation [params, []] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1309,
+                      "startColumn": 23,
+                      "endColumn": 26
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : PrivilegedOperation [params, []] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1310,
+                      "startColumn": 43,
+                      "endColumn": 49
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : PrivilegedOperation [params, []] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1310,
+                      "startColumn": 43,
+                      "endColumn": 49
+                    }
+                  },
+                  "message": {
+                    "text": "params : Object[] [[]] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1421,
+                      "startColumn": 47,
+                      "endColumn": 62
+                    }
+                  },
+                  "message": {
+                    "text": "params : Object[] [[]] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1431,
+                      "startColumn": 52,
+                      "endColumn": 58
+                    }
+                  },
+                  "message": {
+                    "text": "params : Object[] [[]] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1431,
+                      "startColumn": 52,
+                      "endColumn": 61
+                    }
+                  },
+                  "message": {
+                    "text": "...[...] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1431,
+                      "startColumn": 44,
+                      "endColumn": 61
+                    }
+                  },
+                  "message": {
+                    "text": "(...)... : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerAccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 3
+                    },
+                    "region": {
+                      "startLine": 220,
+                      "startColumn": 39,
+                      "endColumn": 55
+                    }
+                  },
+                  "message": {
+                    "text": "className : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerAccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 3
+                    },
+                    "region": {
+                      "startLine": 230,
+                      "startColumn": 21,
+                      "endColumn": 30
+                    }
+                  },
+                  "message": {
+                    "text": "className : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerFileAccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 4
+                    },
+                    "region": {
+                      "startLine": 247,
+                      "startColumn": 29,
+                      "endColumn": 45
+                    }
+                  },
+                  "message": {
+                    "text": "className : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerFileAccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 4
+                    },
+                    "region": {
+                      "startLine": 248,
+                      "startColumn": 40,
+                      "endColumn": 49
+                    }
+                  },
+                  "message": {
+                    "text": "className : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerFileAccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 4
+                    },
+                    "region": {
+                      "startLine": 303,
+                      "startColumn": 70,
+                      "endColumn": 80
+                    }
+                  },
+                  "message": {
+                    "text": "arg : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerFileAccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 4
+                    },
+                    "region": {
+                      "startLine": 333,
+                      "startColumn": 56,
+                      "endColumn": 59
+                    }
+                  },
+                  "message": {
+                    "text": "arg : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerFileAccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 4
+                    },
+                    "region": {
+                      "startLine": 360,
+                      "startColumn": 61,
+                      "endColumn": 77
+                    }
+                  },
+                  "message": {
+                    "text": "className : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerFileAccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 4
+                    },
+                    "region": {
+                      "startLine": 362,
+                      "startColumn": 50,
+                      "endColumn": 59
+                    }
+                  },
+                  "message": {
+                    "text": "className : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerFileAccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 4
+                    },
+                    "region": {
+                      "startLine": 368,
+                      "startColumn": 59,
+                      "endColumn": 75
+                    }
+                  },
+                  "message": {
+                    "text": "className : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerFileAccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 4
+                    },
+                    "region": {
+                      "startLine": 387,
+                      "startColumn": 16,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "className : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 2854,
+                      "startColumn": 20,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 2855,
+                      "startColumn": 39,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "this"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "relatedLocations": [
+      {
+        "id": 1,
+        "physicalLocation": {
+          "artifactLocation": {
+            "uri": "src/jdk.compiler/share/classes/com/sun/tools/javac/main/Main.java",
+            "uriBaseId": "%SRCROOT%",
+            "index": 1
+          },
+          "region": {
+            "startLine": 379,
+            "startColumn": 42,
+            "endColumn": 46
+          }
+        },
+        "message": {
+          "text": "regular expression"
+        }
+      },
+      {
+        "id": 2,
+        "physicalLocation": {
+          "artifactLocation": {
+            "uri": "src/java.base/share/classes/java/net/URLClassLoader.java",
+            "uriBaseId": "%SRCROOT%",
+            "index": 31
+          },
+          "region": {
+            "startLine": 296,
+            "startColumn": 30,
+            "endColumn": 51
+          }
+        },
+        "message": {
+          "text": "user-provided value"
+        }
+      }
+    ]
+  }
+}

--- a/extensions/ql-vscode/test/unit-tests/compare/differentPathsSameSourceSink.json
+++ b/extensions/ql-vscode/test/unit-tests/compare/differentPathsSameSourceSink.json
@@ -1,0 +1,13390 @@
+{
+  "result1": {
+    "ruleId": "java/polynomial-redos",
+    "ruleIndex": 0,
+    "rule": {
+      "id": "java/polynomial-redos",
+      "index": 0
+    },
+    "message": {
+      "text": "This [regular expression](1) that depends on a [user-provided value](2) may run slow on strings with many repetitions of '\\\\t'."
+    },
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
+            "uri": "src/java.base/share/classes/java/lang/String.java",
+            "uriBaseId": "%SRCROOT%",
+            "index": 0
+          },
+          "region": {
+            "startLine": 2855,
+            "startColumn": 39,
+            "endColumn": 43
+          }
+        }
+      }
+    ],
+    "partialFingerprints": {
+      "primaryLocationLineHash": "5270db7557dfd174:1",
+      "primaryLocationStartColumnFingerprint": "30"
+    },
+    "codeFlows": [
+      {
+        "threadFlows": [
+          {
+            "locations": [
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 654,
+                      "startColumn": 30,
+                      "endColumn": 54
+                    }
+                  },
+                  "message": {
+                    "text": "getInputStream(...) : InputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 0,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "source"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 697,
+                      "startColumn": 80,
+                      "endColumn": 86
+                    }
+                  },
+                  "message": {
+                    "text": "stream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3003,
+                      "startColumn": 38,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3005,
+                      "startColumn": 28,
+                      "endColumn": 30
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3005,
+                      "startColumn": 13,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> [post update] : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 697,
+                      "startColumn": 54,
+                      "endColumn": 87
+                    }
+                  },
+                  "message": {
+                    "text": "new RewindableInputStream(...) : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 720,
+                      "startColumn": 29,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "stream : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3089,
+                      "startColumn": 21,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3099,
+                      "startColumn": 24,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3099,
+                      "startColumn": 24,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "fInputStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3687,
+                      "startColumn": 21,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3701,
+                      "startColumn": 22,
+                      "endLine": 3702,
+                      "endColumn": 71
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3649,
+                      "startColumn": 20,
+                      "endColumn": 24
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3652,
+                      "startColumn": 30,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "super : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3652,
+                      "startColumn": 41,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "b [post update] : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 1,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1964,
+                      "startColumn": 47,
+                      "endColumn": 93
+                    }
+                  },
+                  "message": {
+                    "text": "new HttpInputStream(...) : HttpInputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "id": "AdditionalTaintStep",
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1985,
+                      "startColumn": 24,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "inputStream : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1573,
+                      "startColumn": 44,
+                      "endColumn": 61
+                    }
+                  },
+                  "message": {
+                    "text": "getInputStream0(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 809,
+                      "startColumn": 20,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "run(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 816,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "result : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 571,
+                      "startColumn": 20,
+                      "endColumn": 62
+                    }
+                  },
+                  "message": {
+                    "text": "executePrivileged(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 89,
+                      "startColumn": 18,
+                      "endColumn": 51
+                    }
+                  },
+                  "message": {
+                    "text": "doPrivileged(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 93,
+                      "startColumn": 16,
+                      "endColumn": 18
+                    }
+                  },
+                  "message": {
+                    "text": "is : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 75,
+                      "startColumn": 31,
+                      "endColumn": 56
+                    }
+                  },
+                  "message": {
+                    "text": "getResourceAsStream(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 76,
+                      "startColumn": 20,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "is : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 76,
+                      "startColumn": 20,
+                      "endColumn": 37
+                    }
+                  },
+                  "message": {
+                    "text": "readAllBytes(...) : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 2,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 80,
+                      "startColumn": 16,
+                      "endColumn": 20
+                    }
+                  },
+                  "message": {
+                    "text": "data : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/util/ResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 12
+                    },
+                    "region": {
+                      "startLine": 561,
+                      "startColumn": 22,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "handleGetObject(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/util/ResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 12
+                    },
+                    "region": {
+                      "startLine": 574,
+                      "startColumn": 16,
+                      "endColumn": 19
+                    }
+                  },
+                  "message": {
+                    "text": "obj : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 326,
+                      "startColumn": 44,
+                      "endColumn": 60
+                    }
+                  },
+                  "message": {
+                    "text": "getObject(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 328,
+                      "startColumn": 45,
+                      "endColumn": 50
+                    }
+                  },
+                  "message": {
+                    "text": "value : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 328,
+                      "startColumn": 29,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "values [post update] : TextAndMnemonicHashMap [<map.value>] : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 3,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 337,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "values : TextAndMnemonicHashMap [<map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 298,
+                      "startColumn": 20,
+                      "endColumn": 39
+                    }
+                  },
+                  "message": {
+                    "text": "getResourceCache(...) : TextAndMnemonicHashMap [<map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 298,
+                      "startColumn": 20,
+                      "endColumn": 48
+                    }
+                  },
+                  "message": {
+                    "text": "get(...) : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 4,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 172,
+                      "startColumn": 42,
+                      "endColumn": 74
+                    }
+                  },
+                  "message": {
+                    "text": "getFromResourceBundle(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 172,
+                      "startColumn": 16,
+                      "endColumn": 74
+                    }
+                  },
+                  "message": {
+                    "text": "...?...:... : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/rtf/MockAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 14
+                    },
+                    "region": {
+                      "startLine": 67,
+                      "startColumn": 16,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "get(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 15
+                    },
+                    "region": {
+                      "startLine": 151,
+                      "startColumn": 25,
+                      "endColumn": 50
+                    }
+                  },
+                  "message": {
+                    "text": "getAttribute(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 15
+                    },
+                    "region": {
+                      "startLine": 154,
+                      "startColumn": 16,
+                      "endColumn": 21
+                    }
+                  },
+                  "message": {
+                    "text": "value : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 15
+                    },
+                    "region": {
+                      "startLine": 328,
+                      "startColumn": 28,
+                      "endColumn": 45
+                    }
+                  },
+                  "message": {
+                    "text": "getAttribute(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 15
+                    },
+                    "region": {
+                      "startLine": 336,
+                      "startColumn": 16,
+                      "endColumn": 17
+                    }
+                  },
+                  "message": {
+                    "text": "s : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 1304,
+                      "startColumn": 27,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 1336,
+                      "startColumn": 39,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "arg : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 311,
+                      "startColumn": 45,
+                      "endColumn": 55
+                    }
+                  },
+                  "message": {
+                    "text": "str : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 313,
+                      "startColumn": 22,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "str : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 313,
+                      "startColumn": 9,
+                      "endColumn": 14
+                    }
+                  },
+                  "message": {
+                    "text": "super [post update] : StringBuffer"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 5,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 1336,
+                      "startColumn": 25,
+                      "endColumn": 31
+                    }
+                  },
+                  "message": {
+                    "text": "result [post update] : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 1364,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "result : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 885,
+                      "startColumn": 16,
+                      "endColumn": 66
+                    }
+                  },
+                  "message": {
+                    "text": "subformat(...) : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/Format.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 18
+                    },
+                    "region": {
+                      "startLine": 159,
+                      "startColumn": 16,
+                      "endColumn": 69
+                    }
+                  },
+                  "message": {
+                    "text": "format(...) : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 713,
+                      "startColumn": 32,
+                      "endColumn": 40
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 717,
+                      "startColumn": 27,
+                      "endColumn": 40
+                    }
+                  },
+                  "message": {
+                    "text": "toStringCache : String"
+                  }
+                },
+                "taxa": [
+                  {
+                    "id": "entrypointFieldStep",
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 717,
+                      "startColumn": 16,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "new String(...) : String"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 6,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/Format.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 18
+                    },
+                    "region": {
+                      "startLine": 159,
+                      "startColumn": 16,
+                      "endColumn": 80
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 860,
+                      "startColumn": 16,
+                      "endColumn": 38
+                    }
+                  },
+                  "message": {
+                    "text": "format(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/DatatypeException.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 19
+                    },
+                    "region": {
+                      "startLine": 102,
+                      "startColumn": 23,
+                      "endColumn": 64
+                    }
+                  },
+                  "message": {
+                    "text": "format(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/DatatypeException.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 19
+                    },
+                    "region": {
+                      "startLine": 109,
+                      "startColumn": 16,
+                      "endColumn": 19
+                    }
+                  },
+                  "message": {
+                    "text": "msg : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/javax/xml/parsers/FactoryConfigurationError.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 20
+                    },
+                    "region": {
+                      "startLine": 111,
+                      "startColumn": 20,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "getMessage(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "make/jdk/src/classes/build/tools/module/ModuleInfoExtraTest.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 21
+                    },
+                    "region": {
+                      "startLine": 254,
+                      "startColumn": 18,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "getMessage(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 2854,
+                      "startColumn": 20,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 2855,
+                      "startColumn": 39,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "this"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "threadFlows": [
+          {
+            "locations": [
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 654,
+                      "startColumn": 30,
+                      "endColumn": 54
+                    }
+                  },
+                  "message": {
+                    "text": "getInputStream(...) : InputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 0,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "source"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 697,
+                      "startColumn": 80,
+                      "endColumn": 86
+                    }
+                  },
+                  "message": {
+                    "text": "stream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3003,
+                      "startColumn": 38,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3005,
+                      "startColumn": 28,
+                      "endColumn": 30
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3005,
+                      "startColumn": 13,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> [post update] : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 697,
+                      "startColumn": 54,
+                      "endColumn": 87
+                    }
+                  },
+                  "message": {
+                    "text": "new RewindableInputStream(...) : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 726,
+                      "startColumn": 29,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "stream : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3089,
+                      "startColumn": 21,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3118,
+                      "startColumn": 20,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3118,
+                      "startColumn": 20,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "fInputStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3687,
+                      "startColumn": 21,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3692,
+                      "startColumn": 17,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3701,
+                      "startColumn": 22,
+                      "endLine": 3702,
+                      "endColumn": 71
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3649,
+                      "startColumn": 20,
+                      "endColumn": 24
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3652,
+                      "startColumn": 30,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "super : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3652,
+                      "startColumn": 41,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "b [post update] : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 1,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1971,
+                      "startColumn": 35,
+                      "endColumn": 67
+                    }
+                  },
+                  "message": {
+                    "text": "new HttpInputStream(...) : HttpInputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "id": "AdditionalTaintStep",
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1985,
+                      "startColumn": 24,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "inputStream : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1581,
+                      "startColumn": 24,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "getInputStream0(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/net/URL.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 22
+                    },
+                    "region": {
+                      "startLine": 1317,
+                      "startColumn": 16,
+                      "endColumn": 49
+                    }
+                  },
+                  "message": {
+                    "text": "getInputStream(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 586,
+                      "startColumn": 43,
+                      "endColumn": 59
+                    }
+                  },
+                  "message": {
+                    "text": "openStream(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 587,
+                      "startColumn": 64,
+                      "endColumn": 66
+                    }
+                  },
+                  "message": {
+                    "text": "in : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 587,
+                      "startColumn": 42,
+                      "endColumn": 79
+                    }
+                  },
+                  "message": {
+                    "text": "new InputStreamReader(...) : InputStreamReader"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 7,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 591,
+                      "startColumn": 37,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "reader : InputStreamReader"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/Reader.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 24
+                    },
+                    "region": {
+                      "startLine": 264,
+                      "startColumn": 16,
+                      "endColumn": 20
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : InputStreamReader"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/Reader.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 24
+                    },
+                    "region": {
+                      "startLine": 265,
+                      "startColumn": 16,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : InputStreamReader"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/Reader.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 24
+                    },
+                    "region": {
+                      "startLine": 265,
+                      "startColumn": 21,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "cbuf [post update] : char[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 8,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 591,
+                      "startColumn": 49,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "buf [post update] : char[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 592,
+                      "startColumn": 39,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "buf : char[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 232,
+                      "startColumn": 33,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "str : char[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 233,
+                      "startColumn": 22,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "str : char[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 233,
+                      "startColumn": 9,
+                      "endColumn": 14
+                    }
+                  },
+                  "message": {
+                    "text": "super [post update] : StringBuilder"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 5,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 592,
+                      "startColumn": 29,
+                      "endColumn": 31
+                    }
+                  },
+                  "message": {
+                    "text": "sb [post update] : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 595,
+                      "startColumn": 34,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "sb : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 451,
+                      "startColumn": 19,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 453,
+                      "startColumn": 27,
+                      "endColumn": 31
+                    }
+                  },
+                  "message": {
+                    "text": "this : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 1486,
+                      "startColumn": 19,
+                      "endColumn": 40
+                    }
+                  },
+                  "message": {
+                    "text": "builder : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 1487,
+                      "startColumn": 14,
+                      "endColumn": 21
+                    }
+                  },
+                  "message": {
+                    "text": "builder : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 1487,
+                      "startColumn": 9,
+                      "endColumn": 29
+                    }
+                  },
+                  "message": {
+                    "text": "this <constr(this)> [post update] : String"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 6,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 453,
+                      "startColumn": 16,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "new String(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 595,
+                      "startColumn": 34,
+                      "endColumn": 47
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 604,
+                      "startColumn": 40,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "str : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 2718,
+                      "startColumn": 19,
+                      "endColumn": 28
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 2722,
+                      "startColumn": 20,
+                      "endColumn": 24
+                    }
+                  },
+                  "message": {
+                    "text": "this : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 604,
+                      "startColumn": 40,
+                      "endColumn": 60
+                    }
+                  },
+                  "message": {
+                    "text": "substring(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 778,
+                      "startColumn": 20,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "run(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 785,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "result : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 319,
+                      "startColumn": 16,
+                      "endColumn": 76
+                    }
+                  },
+                  "message": {
+                    "text": "executePrivileged(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/security/provider/SubjectCodeSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 26
+                    },
+                    "region": {
+                      "startLine": 369,
+                      "startColumn": 25,
+                      "endLine": 374,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "doPrivileged(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/security/provider/SubjectCodeSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 26
+                    },
+                    "region": {
+                      "startLine": 386,
+                      "startColumn": 16,
+                      "endColumn": 24
+                    }
+                  },
+                  "message": {
+                    "text": "returnMe : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 4230,
+                      "startColumn": 41,
+                      "endColumn": 55
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 4230,
+                      "startColumn": 16,
+                      "endColumn": 55
+                    }
+                  },
+                  "message": {
+                    "text": "...?...:... : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 173,
+                      "startColumn": 23,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "valueOf(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 178,
+                      "startColumn": 33,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "str : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 179,
+                      "startColumn": 22,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "str : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 179,
+                      "startColumn": 9,
+                      "endColumn": 14
+                    }
+                  },
+                  "message": {
+                    "text": "super [post update] : StringBuilder"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 5,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 173,
+                      "startColumn": 16,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> [post update] : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.naming/share/classes/javax/naming/directory/BasicAttribute.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 27
+                    },
+                    "region": {
+                      "startLine": 221,
+                      "startColumn": 17,
+                      "endColumn": 23
+                    }
+                  },
+                  "message": {
+                    "text": "answer [post update] : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.naming/share/classes/javax/naming/directory/BasicAttribute.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 27
+                    },
+                    "region": {
+                      "startLine": 225,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "answer : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 451,
+                      "startColumn": 19,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 453,
+                      "startColumn": 27,
+                      "endColumn": 31
+                    }
+                  },
+                  "message": {
+                    "text": "this : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 1486,
+                      "startColumn": 19,
+                      "endColumn": 40
+                    }
+                  },
+                  "message": {
+                    "text": "builder : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 1487,
+                      "startColumn": 14,
+                      "endColumn": 21
+                    }
+                  },
+                  "message": {
+                    "text": "builder : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 1487,
+                      "startColumn": 9,
+                      "endColumn": 29
+                    }
+                  },
+                  "message": {
+                    "text": "this <constr(this)> [post update] : String"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 6,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 453,
+                      "startColumn": 16,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "new String(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.naming/share/classes/javax/naming/directory/BasicAttribute.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 27
+                    },
+                    "region": {
+                      "startLine": 225,
+                      "startColumn": 16,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.naming/share/classes/javax/naming/directory/ModificationItem.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 28
+                    },
+                    "region": {
+                      "startLine": 118,
+                      "startColumn": 41,
+                      "endColumn": 56
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.naming/share/classes/javax/naming/directory/ModificationItem.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 28
+                    },
+                    "region": {
+                      "startLine": 118,
+                      "startColumn": 21,
+                      "endColumn": 56
+                    }
+                  },
+                  "message": {
+                    "text": "... + ... : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.naming/share/classes/javax/naming/directory/AttributeModificationException.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 29
+                    },
+                    "region": {
+                      "startLine": 131,
+                      "startColumn": 22,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.naming/share/classes/javax/naming/directory/AttributeModificationException.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 29
+                    },
+                    "region": {
+                      "startLine": 133,
+                      "startColumn": 16,
+                      "endColumn": 20
+                    }
+                  },
+                  "message": {
+                    "text": "orig : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/WriteAbortedException.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 30
+                    },
+                    "region": {
+                      "startLine": 74,
+                      "startColumn": 48,
+                      "endColumn": 65
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/WriteAbortedException.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 30
+                    },
+                    "region": {
+                      "startLine": 74,
+                      "startColumn": 20,
+                      "endColumn": 65
+                    }
+                  },
+                  "message": {
+                    "text": "... + ... : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/javax/xml/parsers/FactoryConfigurationError.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 20
+                    },
+                    "region": {
+                      "startLine": 111,
+                      "startColumn": 20,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "getMessage(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "make/jdk/src/classes/build/tools/module/ModuleInfoExtraTest.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 21
+                    },
+                    "region": {
+                      "startLine": 270,
+                      "startColumn": 18,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "getMessage(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 2854,
+                      "startColumn": 20,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 2855,
+                      "startColumn": 39,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "this"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "threadFlows": [
+          {
+            "locations": [
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 654,
+                      "startColumn": 30,
+                      "endColumn": 54
+                    }
+                  },
+                  "message": {
+                    "text": "getInputStream(...) : InputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 0,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "source"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 697,
+                      "startColumn": 80,
+                      "endColumn": 86
+                    }
+                  },
+                  "message": {
+                    "text": "stream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3003,
+                      "startColumn": 38,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3005,
+                      "startColumn": 28,
+                      "endColumn": 30
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3005,
+                      "startColumn": 13,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> [post update] : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 697,
+                      "startColumn": 54,
+                      "endColumn": 87
+                    }
+                  },
+                  "message": {
+                    "text": "new RewindableInputStream(...) : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 774,
+                      "startColumn": 29,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "stream : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3089,
+                      "startColumn": 21,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3099,
+                      "startColumn": 24,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3099,
+                      "startColumn": 24,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "fInputStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3687,
+                      "startColumn": 21,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3701,
+                      "startColumn": 22,
+                      "endLine": 3702,
+                      "endColumn": 71
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3649,
+                      "startColumn": 20,
+                      "endColumn": 24
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3652,
+                      "startColumn": 30,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "super : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3652,
+                      "startColumn": 41,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "b [post update] : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 1,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1964,
+                      "startColumn": 47,
+                      "endColumn": 93
+                    }
+                  },
+                  "message": {
+                    "text": "new HttpInputStream(...) : HttpInputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "id": "AdditionalTaintStep",
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1964,
+                      "startColumn": 33,
+                      "endColumn": 44
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> [post update] : HttpURLConnection [inputStream] : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1970,
+                      "startColumn": 23,
+                      "endColumn": 34
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : HttpURLConnection [inputStream] : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1970,
+                      "startColumn": 23,
+                      "endColumn": 34
+                    }
+                  },
+                  "message": {
+                    "text": "inputStream : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1985,
+                      "startColumn": 24,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "inputStream : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1581,
+                      "startColumn": 24,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "getInputStream0(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/ftp/FtpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 31
+                    },
+                    "region": {
+                      "startLine": 424,
+                      "startColumn": 20,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "getInputStream(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/net/URL.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 22
+                    },
+                    "region": {
+                      "startLine": 1317,
+                      "startColumn": 16,
+                      "endColumn": 49
+                    }
+                  },
+                  "message": {
+                    "text": "getInputStream(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/Module.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 32
+                    },
+                    "region": {
+                      "startLine": 1735,
+                      "startColumn": 24,
+                      "endColumn": 40
+                    }
+                  },
+                  "message": {
+                    "text": "openStream(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 86,
+                      "startColumn": 20,
+                      "endColumn": 68
+                    }
+                  },
+                  "message": {
+                    "text": "getResourceAsStream(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 809,
+                      "startColumn": 20,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "run(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 816,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "result : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 571,
+                      "startColumn": 20,
+                      "endColumn": 62
+                    }
+                  },
+                  "message": {
+                    "text": "executePrivileged(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 89,
+                      "startColumn": 18,
+                      "endColumn": 51
+                    }
+                  },
+                  "message": {
+                    "text": "doPrivileged(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 93,
+                      "startColumn": 16,
+                      "endColumn": 18
+                    }
+                  },
+                  "message": {
+                    "text": "is : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 75,
+                      "startColumn": 31,
+                      "endColumn": 56
+                    }
+                  },
+                  "message": {
+                    "text": "getResourceAsStream(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 76,
+                      "startColumn": 20,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "is : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 76,
+                      "startColumn": 20,
+                      "endColumn": 37
+                    }
+                  },
+                  "message": {
+                    "text": "readAllBytes(...) : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 2,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 80,
+                      "startColumn": 16,
+                      "endColumn": 20
+                    }
+                  },
+                  "message": {
+                    "text": "data : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/util/ResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 12
+                    },
+                    "region": {
+                      "startLine": 561,
+                      "startColumn": 22,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "handleGetObject(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/util/ResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 12
+                    },
+                    "region": {
+                      "startLine": 574,
+                      "startColumn": 16,
+                      "endColumn": 19
+                    }
+                  },
+                  "message": {
+                    "text": "obj : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/util/ResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 12
+                    },
+                    "region": {
+                      "startLine": 564,
+                      "startColumn": 23,
+                      "endColumn": 44
+                    }
+                  },
+                  "message": {
+                    "text": "getObject(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/util/ResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 12
+                    },
+                    "region": {
+                      "startLine": 574,
+                      "startColumn": 16,
+                      "endColumn": 19
+                    }
+                  },
+                  "message": {
+                    "text": "obj : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 326,
+                      "startColumn": 44,
+                      "endColumn": 60
+                    }
+                  },
+                  "message": {
+                    "text": "getObject(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 328,
+                      "startColumn": 45,
+                      "endColumn": 50
+                    }
+                  },
+                  "message": {
+                    "text": "value : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 328,
+                      "startColumn": 29,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "values [post update] : TextAndMnemonicHashMap [<map.value>] : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 3,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 335,
+                      "startColumn": 34,
+                      "endColumn": 40
+                    }
+                  },
+                  "message": {
+                    "text": "values : TextAndMnemonicHashMap [<map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 335,
+                      "startColumn": 13,
+                      "endColumn": 26
+                    }
+                  },
+                  "message": {
+                    "text": "resourceCache [post update] : HashMap [<map.value>, <map.value>] : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 3,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 335,
+                      "startColumn": 13,
+                      "endColumn": 26
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> [post update] : UIDefaults [resourceCache, <map.value>, <map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 298,
+                      "startColumn": 20,
+                      "endColumn": 39
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> [post update] : UIDefaults [resourceCache, <map.value>, <map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 172,
+                      "startColumn": 42,
+                      "endColumn": 74
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> [post update] : UIDefaults [resourceCache, <map.value>, <map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/plaf/nimbus/NimbusLookAndFeel.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 544,
+                      "startColumn": 23,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "uiDefaults [post update] : UIDefaults [resourceCache, <map.value>, <map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/plaf/nimbus/NimbusLookAndFeel.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 548,
+                      "startColumn": 23,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "uiDefaults : UIDefaults [resourceCache, <map.value>, <map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 170,
+                      "startColumn": 19,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : UIDefaults [resourceCache, <map.value>, <map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 172,
+                      "startColumn": 42,
+                      "endColumn": 74
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : UIDefaults [resourceCache, <map.value>, <map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 281,
+                      "startColumn": 20,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : UIDefaults [resourceCache, <map.value>, <map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 298,
+                      "startColumn": 20,
+                      "endColumn": 39
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : UIDefaults [resourceCache, <map.value>, <map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 305,
+                      "startColumn": 33,
+                      "endColumn": 49
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : UIDefaults [resourceCache, <map.value>, <map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 306,
+                      "startColumn": 38,
+                      "endColumn": 51
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : UIDefaults [resourceCache, <map.value>, <map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 306,
+                      "startColumn": 38,
+                      "endColumn": 51
+                    }
+                  },
+                  "message": {
+                    "text": "resourceCache : HashMap [<map.value>, <map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 306,
+                      "startColumn": 38,
+                      "endColumn": 58
+                    }
+                  },
+                  "message": {
+                    "text": "get(...) : TextAndMnemonicHashMap [<map.value>] : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 4,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 337,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "values : TextAndMnemonicHashMap [<map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 298,
+                      "startColumn": 20,
+                      "endColumn": 39
+                    }
+                  },
+                  "message": {
+                    "text": "getResourceCache(...) : TextAndMnemonicHashMap [<map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 298,
+                      "startColumn": 20,
+                      "endColumn": 48
+                    }
+                  },
+                  "message": {
+                    "text": "get(...) : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 4,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 172,
+                      "startColumn": 42,
+                      "endColumn": 74
+                    }
+                  },
+                  "message": {
+                    "text": "getFromResourceBundle(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 172,
+                      "startColumn": 16,
+                      "endColumn": 74
+                    }
+                  },
+                  "message": {
+                    "text": "...?...:... : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/plaf/nimbus/NimbusLookAndFeel.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 548,
+                      "startColumn": 23,
+                      "endColumn": 65
+                    }
+                  },
+                  "message": {
+                    "text": "get(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/plaf/nimbus/NimbusLookAndFeel.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 558,
+                      "startColumn": 20,
+                      "endColumn": 23
+                    }
+                  },
+                  "message": {
+                    "text": "obj : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 241,
+                      "startColumn": 21,
+                      "endColumn": 59
+                    }
+                  },
+                  "message": {
+                    "text": "createValue(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 244,
+                      "startColumn": 16,
+                      "endColumn": 21
+                    }
+                  },
+                  "message": {
+                    "text": "value : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 171,
+                      "startColumn": 24,
+                      "endColumn": 47
+                    }
+                  },
+                  "message": {
+                    "text": "getFromHashtable(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 172,
+                      "startColumn": 16,
+                      "endColumn": 74
+                    }
+                  },
+                  "message": {
+                    "text": "...?...:... : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/MultiUIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 34
+                    },
+                    "region": {
+                      "startLine": 59,
+                      "startColumn": 24,
+                      "endColumn": 38
+                    }
+                  },
+                  "message": {
+                    "text": "get(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/MultiUIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 34
+                    },
+                    "region": {
+                      "startLine": 61,
+                      "startColumn": 20,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "value : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/rtf/MockAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 14
+                    },
+                    "region": {
+                      "startLine": 67,
+                      "startColumn": 16,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "get(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/StyleContext.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 35
+                    },
+                    "region": {
+                      "startLine": 1496,
+                      "startColumn": 20,
+                      "endColumn": 53
+                    }
+                  },
+                  "message": {
+                    "text": "getAttribute(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 15
+                    },
+                    "region": {
+                      "startLine": 151,
+                      "startColumn": 25,
+                      "endColumn": 50
+                    }
+                  },
+                  "message": {
+                    "text": "getAttribute(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 15
+                    },
+                    "region": {
+                      "startLine": 154,
+                      "startColumn": 16,
+                      "endColumn": 21
+                    }
+                  },
+                  "message": {
+                    "text": "value : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/html/StyleSheet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 36
+                    },
+                    "region": {
+                      "startLine": 845,
+                      "startColumn": 20,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "getAttribute(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 15
+                    },
+                    "region": {
+                      "startLine": 328,
+                      "startColumn": 28,
+                      "endColumn": 45
+                    }
+                  },
+                  "message": {
+                    "text": "getAttribute(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 15
+                    },
+                    "region": {
+                      "startLine": 336,
+                      "startColumn": 16,
+                      "endColumn": 17
+                    }
+                  },
+                  "message": {
+                    "text": "s : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/tree/DefaultMutableTreeNode.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 37
+                    },
+                    "region": {
+                      "startLine": 1264,
+                      "startColumn": 20,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 1304,
+                      "startColumn": 27,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 1349,
+                      "startColumn": 35,
+                      "endColumn": 38
+                    }
+                  },
+                  "message": {
+                    "text": "arg : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 311,
+                      "startColumn": 45,
+                      "endColumn": 55
+                    }
+                  },
+                  "message": {
+                    "text": "str : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 313,
+                      "startColumn": 22,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "str : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 313,
+                      "startColumn": 9,
+                      "endColumn": 14
+                    }
+                  },
+                  "message": {
+                    "text": "super [post update] : StringBuffer"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 5,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 1349,
+                      "startColumn": 21,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "result [post update] : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 1364,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "result : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 885,
+                      "startColumn": 16,
+                      "endColumn": 66
+                    }
+                  },
+                  "message": {
+                    "text": "subformat(...) : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/Format.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 18
+                    },
+                    "region": {
+                      "startLine": 159,
+                      "startColumn": 16,
+                      "endColumn": 69
+                    }
+                  },
+                  "message": {
+                    "text": "format(...) : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 713,
+                      "startColumn": 32,
+                      "endColumn": 40
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 715,
+                      "startColumn": 47,
+                      "endColumn": 51
+                    }
+                  },
+                  "message": {
+                    "text": "this : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 715,
+                      "startColumn": 36,
+                      "endColumn": 58
+                    }
+                  },
+                  "message": {
+                    "text": "new String(...) : String"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 6,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 715,
+                      "startColumn": 20,
+                      "endColumn": 58
+                    }
+                  },
+                  "message": {
+                    "text": "...=... : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/Format.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 18
+                    },
+                    "region": {
+                      "startLine": 159,
+                      "startColumn": 16,
+                      "endColumn": 80
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/jdk.internal.opt/share/classes/jdk/internal/joptsimple/internal/Messages.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 38
+                    },
+                    "region": {
+                      "startLine": 75,
+                      "startColumn": 16,
+                      "endColumn": 37
+                    }
+                  },
+                  "message": {
+                    "text": "format(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/jdk.internal.opt/share/classes/jdk/internal/joptsimple/OptionException.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 39
+                    },
+                    "region": {
+                      "startLine": 152,
+                      "startColumn": 16,
+                      "endColumn": 121
+                    }
+                  },
+                  "message": {
+                    "text": "message(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/jdk.internal.opt/share/classes/jdk/internal/joptsimple/OptionException.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 39
+                    },
+                    "region": {
+                      "startLine": 148,
+                      "startColumn": 16,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "formattedMessage(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/jdk.internal.opt/share/classes/jdk/internal/joptsimple/OptionException.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 39
+                    },
+                    "region": {
+                      "startLine": 144,
+                      "startColumn": 16,
+                      "endColumn": 55
+                    }
+                  },
+                  "message": {
+                    "text": "localizedMessage(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/javax/xml/transform/TransformerFactoryConfigurationError.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 40
+                    },
+                    "region": {
+                      "startLine": 110,
+                      "startColumn": 20,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "getMessage(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "make/jdk/src/classes/build/tools/module/ModuleInfoExtraTest.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 21
+                    },
+                    "region": {
+                      "startLine": 254,
+                      "startColumn": 18,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "getMessage(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 2854,
+                      "startColumn": 20,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 2855,
+                      "startColumn": 39,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "this"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "threadFlows": [
+          {
+            "locations": [
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 654,
+                      "startColumn": 30,
+                      "endColumn": 54
+                    }
+                  },
+                  "message": {
+                    "text": "getInputStream(...) : InputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 0,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "source"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 697,
+                      "startColumn": 80,
+                      "endColumn": 86
+                    }
+                  },
+                  "message": {
+                    "text": "stream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3003,
+                      "startColumn": 38,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3005,
+                      "startColumn": 28,
+                      "endColumn": 30
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3005,
+                      "startColumn": 13,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> [post update] : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 697,
+                      "startColumn": 54,
+                      "endColumn": 87
+                    }
+                  },
+                  "message": {
+                    "text": "new RewindableInputStream(...) : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 779,
+                      "startColumn": 29,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "stream : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3089,
+                      "startColumn": 21,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3099,
+                      "startColumn": 24,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3099,
+                      "startColumn": 24,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "fInputStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3687,
+                      "startColumn": 21,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3701,
+                      "startColumn": 22,
+                      "endLine": 3702,
+                      "endColumn": 71
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3649,
+                      "startColumn": 20,
+                      "endColumn": 24
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3652,
+                      "startColumn": 30,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "super : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3652,
+                      "startColumn": 41,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "b [post update] : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 1,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1971,
+                      "startColumn": 35,
+                      "endColumn": 67
+                    }
+                  },
+                  "message": {
+                    "text": "new HttpInputStream(...) : HttpInputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "id": "AdditionalTaintStep",
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1971,
+                      "startColumn": 21,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> [post update] : HttpURLConnection [inputStream] : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1983,
+                      "startColumn": 17,
+                      "endColumn": 23
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : HttpURLConnection [inputStream] : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1984,
+                      "startColumn": 17,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : HttpURLConnection [inputStream] : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1985,
+                      "startColumn": 24,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : HttpURLConnection [inputStream] : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1985,
+                      "startColumn": 24,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "inputStream : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1573,
+                      "startColumn": 44,
+                      "endColumn": 61
+                    }
+                  },
+                  "message": {
+                    "text": "getInputStream0(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 809,
+                      "startColumn": 20,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "run(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 816,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "result : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 571,
+                      "startColumn": 20,
+                      "endColumn": 62
+                    }
+                  },
+                  "message": {
+                    "text": "executePrivileged(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 89,
+                      "startColumn": 18,
+                      "endColumn": 51
+                    }
+                  },
+                  "message": {
+                    "text": "doPrivileged(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 93,
+                      "startColumn": 16,
+                      "endColumn": 18
+                    }
+                  },
+                  "message": {
+                    "text": "is : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 75,
+                      "startColumn": 31,
+                      "endColumn": 56
+                    }
+                  },
+                  "message": {
+                    "text": "getResourceAsStream(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 76,
+                      "startColumn": 20,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "is : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 76,
+                      "startColumn": 20,
+                      "endColumn": 37
+                    }
+                  },
+                  "message": {
+                    "text": "readAllBytes(...) : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 2,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 80,
+                      "startColumn": 16,
+                      "endColumn": 20
+                    }
+                  },
+                  "message": {
+                    "text": "data : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/util/ResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 12
+                    },
+                    "region": {
+                      "startLine": 561,
+                      "startColumn": 22,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "handleGetObject(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/util/ResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 12
+                    },
+                    "region": {
+                      "startLine": 574,
+                      "startColumn": 16,
+                      "endColumn": 19
+                    }
+                  },
+                  "message": {
+                    "text": "obj : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 326,
+                      "startColumn": 44,
+                      "endColumn": 60
+                    }
+                  },
+                  "message": {
+                    "text": "getObject(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 328,
+                      "startColumn": 45,
+                      "endColumn": 50
+                    }
+                  },
+                  "message": {
+                    "text": "value : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 328,
+                      "startColumn": 29,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "values [post update] : TextAndMnemonicHashMap [<map.value>] : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 3,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 337,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "values : TextAndMnemonicHashMap [<map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 298,
+                      "startColumn": 20,
+                      "endColumn": 39
+                    }
+                  },
+                  "message": {
+                    "text": "getResourceCache(...) : TextAndMnemonicHashMap [<map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 298,
+                      "startColumn": 20,
+                      "endColumn": 48
+                    }
+                  },
+                  "message": {
+                    "text": "get(...) : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 4,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 172,
+                      "startColumn": 42,
+                      "endColumn": 74
+                    }
+                  },
+                  "message": {
+                    "text": "getFromResourceBundle(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 172,
+                      "startColumn": 16,
+                      "endColumn": 74
+                    }
+                  },
+                  "message": {
+                    "text": "...?...:... : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/MultiUIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 34
+                    },
+                    "region": {
+                      "startLine": 65,
+                      "startColumn": 39,
+                      "endColumn": 53
+                    }
+                  },
+                  "message": {
+                    "text": "get(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/MultiUIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 34
+                    },
+                    "region": {
+                      "startLine": 67,
+                      "startColumn": 24,
+                      "endColumn": 29
+                    }
+                  },
+                  "message": {
+                    "text": "value : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/rtf/MockAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 14
+                    },
+                    "region": {
+                      "startLine": 67,
+                      "startColumn": 16,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "get(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/AbstractDocument.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 41
+                    },
+                    "region": {
+                      "startLine": 1939,
+                      "startColumn": 28,
+                      "endColumn": 61
+                    }
+                  },
+                  "message": {
+                    "text": "getAttribute(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/AbstractDocument.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 41
+                    },
+                    "region": {
+                      "startLine": 1949,
+                      "startColumn": 20,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "value : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 15
+                    },
+                    "region": {
+                      "startLine": 151,
+                      "startColumn": 25,
+                      "endColumn": 50
+                    }
+                  },
+                  "message": {
+                    "text": "getAttribute(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 15
+                    },
+                    "region": {
+                      "startLine": 154,
+                      "startColumn": 16,
+                      "endColumn": 21
+                    }
+                  },
+                  "message": {
+                    "text": "value : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 15
+                    },
+                    "region": {
+                      "startLine": 328,
+                      "startColumn": 28,
+                      "endColumn": 45
+                    }
+                  },
+                  "message": {
+                    "text": "getAttribute(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 15
+                    },
+                    "region": {
+                      "startLine": 336,
+                      "startColumn": 16,
+                      "endColumn": 17
+                    }
+                  },
+                  "message": {
+                    "text": "s : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/invoke/ClassSpecializer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 42
+                    },
+                    "region": {
+                      "startLine": 262,
+                      "startColumn": 53,
+                      "endColumn": 67
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/invoke/ClassSpecializer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 42
+                    },
+                    "region": {
+                      "startLine": 262,
+                      "startColumn": 20,
+                      "endColumn": 144
+                    }
+                  },
+                  "message": {
+                    "text": "... + ... : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 1304,
+                      "startColumn": 27,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 1336,
+                      "startColumn": 39,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "arg : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 311,
+                      "startColumn": 45,
+                      "endColumn": 55
+                    }
+                  },
+                  "message": {
+                    "text": "str : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 313,
+                      "startColumn": 22,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "str : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 313,
+                      "startColumn": 9,
+                      "endColumn": 14
+                    }
+                  },
+                  "message": {
+                    "text": "super [post update] : StringBuffer"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 5,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 1336,
+                      "startColumn": 25,
+                      "endColumn": 31
+                    }
+                  },
+                  "message": {
+                    "text": "result [post update] : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 1364,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "result : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 885,
+                      "startColumn": 16,
+                      "endColumn": 66
+                    }
+                  },
+                  "message": {
+                    "text": "subformat(...) : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/Format.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 18
+                    },
+                    "region": {
+                      "startLine": 159,
+                      "startColumn": 16,
+                      "endColumn": 69
+                    }
+                  },
+                  "message": {
+                    "text": "format(...) : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 713,
+                      "startColumn": 32,
+                      "endColumn": 40
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 717,
+                      "startColumn": 27,
+                      "endColumn": 40
+                    }
+                  },
+                  "message": {
+                    "text": "toStringCache : String"
+                  }
+                },
+                "taxa": [
+                  {
+                    "id": "entrypointFieldStep",
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 717,
+                      "startColumn": 16,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "new String(...) : String"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 6,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/Format.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 18
+                    },
+                    "region": {
+                      "startLine": 159,
+                      "startColumn": 16,
+                      "endColumn": 80
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 860,
+                      "startColumn": 16,
+                      "endColumn": 38
+                    }
+                  },
+                  "message": {
+                    "text": "format(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/util/ErrorMsg.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 43
+                    },
+                    "region": {
+                      "startLine": 293,
+                      "startColumn": 15,
+                      "endColumn": 63
+                    }
+                  },
+                  "message": {
+                    "text": "format(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/util/ErrorMsg.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 43
+                    },
+                    "region": {
+                      "startLine": 294,
+                      "startColumn": 16,
+                      "endColumn": 37
+                    }
+                  },
+                  "message": {
+                    "text": "... + ... : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/util/TypeCheckError.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 44
+                    },
+                    "region": {
+                      "startLine": 77,
+                      "startColumn": 16,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/compiler/util/TypeCheckError.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 44
+                    },
+                    "region": {
+                      "startLine": 62,
+                      "startColumn": 16,
+                      "endColumn": 26
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/javax/xml/transform/TransformerFactoryConfigurationError.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 40
+                    },
+                    "region": {
+                      "startLine": 110,
+                      "startColumn": 20,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "getMessage(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "make/jdk/src/classes/build/tools/module/ModuleInfoExtraTest.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 21
+                    },
+                    "region": {
+                      "startLine": 270,
+                      "startColumn": 18,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "getMessage(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 2854,
+                      "startColumn": 20,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 2855,
+                      "startColumn": 39,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "this"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "relatedLocations": [
+      {
+        "id": 1,
+        "physicalLocation": {
+          "artifactLocation": {
+            "uri": "src/jdk.compiler/share/classes/com/sun/tools/javac/main/Main.java",
+            "uriBaseId": "%SRCROOT%",
+            "index": 1
+          },
+          "region": {
+            "startLine": 379,
+            "startColumn": 42,
+            "endColumn": 46
+          }
+        },
+        "message": {
+          "text": "regular expression"
+        }
+      },
+      {
+        "id": 2,
+        "physicalLocation": {
+          "artifactLocation": {
+            "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+            "uriBaseId": "%SRCROOT%",
+            "index": 9
+          },
+          "region": {
+            "startLine": 654,
+            "startColumn": 30,
+            "endColumn": 54
+          }
+        },
+        "message": {
+          "text": "user-provided value"
+        }
+      }
+    ]
+  },
+  "result2": {
+    "ruleId": "java/polynomial-redos",
+    "ruleIndex": 0,
+    "rule": {
+      "id": "java/polynomial-redos",
+      "index": 0
+    },
+    "message": {
+      "text": "This [regular expression](1) that depends on a [user-provided value](2) may run slow on strings with many repetitions of '\\\\t'."
+    },
+    "locations": [
+      {
+        "physicalLocation": {
+          "artifactLocation": {
+            "uri": "src/java.base/share/classes/java/lang/String.java",
+            "uriBaseId": "%SRCROOT%",
+            "index": 0
+          },
+          "region": {
+            "startLine": 2855,
+            "startColumn": 39,
+            "endColumn": 43
+          }
+        }
+      }
+    ],
+    "partialFingerprints": {
+      "primaryLocationLineHash": "5270db7557dfd174:1",
+      "primaryLocationStartColumnFingerprint": "30"
+    },
+    "codeFlows": [
+      {
+        "threadFlows": [
+          {
+            "locations": [
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 654,
+                      "startColumn": 30,
+                      "endColumn": 54
+                    }
+                  },
+                  "message": {
+                    "text": "getInputStream(...) : InputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 0,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "source"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 697,
+                      "startColumn": 80,
+                      "endColumn": 86
+                    }
+                  },
+                  "message": {
+                    "text": "stream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3003,
+                      "startColumn": 38,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3005,
+                      "startColumn": 28,
+                      "endColumn": 30
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3005,
+                      "startColumn": 13,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> [post update] : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 697,
+                      "startColumn": 54,
+                      "endColumn": 87
+                    }
+                  },
+                  "message": {
+                    "text": "new RewindableInputStream(...) : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 720,
+                      "startColumn": 29,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "stream : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3089,
+                      "startColumn": 21,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3099,
+                      "startColumn": 24,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3099,
+                      "startColumn": 24,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "fInputStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3687,
+                      "startColumn": 21,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3701,
+                      "startColumn": 22,
+                      "endLine": 3702,
+                      "endColumn": 71
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3649,
+                      "startColumn": 20,
+                      "endColumn": 24
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3652,
+                      "startColumn": 30,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "super : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3652,
+                      "startColumn": 41,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "b [post update] : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 1,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1964,
+                      "startColumn": 47,
+                      "endColumn": 93
+                    }
+                  },
+                  "message": {
+                    "text": "new HttpInputStream(...) : HttpInputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "id": "AdditionalTaintStep",
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1985,
+                      "startColumn": 24,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "inputStream : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1573,
+                      "startColumn": 44,
+                      "endColumn": 61
+                    }
+                  },
+                  "message": {
+                    "text": "getInputStream0(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 809,
+                      "startColumn": 20,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "run(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 816,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "result : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 571,
+                      "startColumn": 20,
+                      "endColumn": 62
+                    }
+                  },
+                  "message": {
+                    "text": "executePrivileged(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 89,
+                      "startColumn": 18,
+                      "endColumn": 51
+                    }
+                  },
+                  "message": {
+                    "text": "doPrivileged(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 93,
+                      "startColumn": 16,
+                      "endColumn": 18
+                    }
+                  },
+                  "message": {
+                    "text": "is : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 75,
+                      "startColumn": 31,
+                      "endColumn": 56
+                    }
+                  },
+                  "message": {
+                    "text": "getResourceAsStream(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 76,
+                      "startColumn": 20,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "is : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 76,
+                      "startColumn": 20,
+                      "endColumn": 37
+                    }
+                  },
+                  "message": {
+                    "text": "readAllBytes(...) : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 2,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 80,
+                      "startColumn": 16,
+                      "endColumn": 20
+                    }
+                  },
+                  "message": {
+                    "text": "data : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/util/ResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 12
+                    },
+                    "region": {
+                      "startLine": 561,
+                      "startColumn": 22,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "handleGetObject(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/util/ResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 12
+                    },
+                    "region": {
+                      "startLine": 574,
+                      "startColumn": 16,
+                      "endColumn": 19
+                    }
+                  },
+                  "message": {
+                    "text": "obj : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 326,
+                      "startColumn": 44,
+                      "endColumn": 60
+                    }
+                  },
+                  "message": {
+                    "text": "getObject(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 328,
+                      "startColumn": 45,
+                      "endColumn": 50
+                    }
+                  },
+                  "message": {
+                    "text": "value : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 328,
+                      "startColumn": 29,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "values [post update] : TextAndMnemonicHashMap [<map.value>] : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 3,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 337,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "values : TextAndMnemonicHashMap [<map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 298,
+                      "startColumn": 20,
+                      "endColumn": 39
+                    }
+                  },
+                  "message": {
+                    "text": "getResourceCache(...) : TextAndMnemonicHashMap [<map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 298,
+                      "startColumn": 20,
+                      "endColumn": 48
+                    }
+                  },
+                  "message": {
+                    "text": "get(...) : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 4,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 172,
+                      "startColumn": 42,
+                      "endColumn": 74
+                    }
+                  },
+                  "message": {
+                    "text": "getFromResourceBundle(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 172,
+                      "startColumn": 16,
+                      "endColumn": 74
+                    }
+                  },
+                  "message": {
+                    "text": "...?...:... : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/rtf/MockAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 14
+                    },
+                    "region": {
+                      "startLine": 67,
+                      "startColumn": 16,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "get(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 15
+                    },
+                    "region": {
+                      "startLine": 151,
+                      "startColumn": 25,
+                      "endColumn": 50
+                    }
+                  },
+                  "message": {
+                    "text": "getAttribute(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 15
+                    },
+                    "region": {
+                      "startLine": 154,
+                      "startColumn": 16,
+                      "endColumn": 21
+                    }
+                  },
+                  "message": {
+                    "text": "value : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 15
+                    },
+                    "region": {
+                      "startLine": 328,
+                      "startColumn": 28,
+                      "endColumn": 45
+                    }
+                  },
+                  "message": {
+                    "text": "getAttribute(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 15
+                    },
+                    "region": {
+                      "startLine": 336,
+                      "startColumn": 16,
+                      "endColumn": 17
+                    }
+                  },
+                  "message": {
+                    "text": "s : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 1304,
+                      "startColumn": 27,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 1336,
+                      "startColumn": 39,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "arg : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 311,
+                      "startColumn": 45,
+                      "endColumn": 55
+                    }
+                  },
+                  "message": {
+                    "text": "str : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 313,
+                      "startColumn": 22,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "str : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 313,
+                      "startColumn": 9,
+                      "endColumn": 14
+                    }
+                  },
+                  "message": {
+                    "text": "super [post update] : StringBuffer"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 5,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 1336,
+                      "startColumn": 25,
+                      "endColumn": 31
+                    }
+                  },
+                  "message": {
+                    "text": "result [post update] : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 1364,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "result : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 885,
+                      "startColumn": 16,
+                      "endColumn": 66
+                    }
+                  },
+                  "message": {
+                    "text": "subformat(...) : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/Format.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 18
+                    },
+                    "region": {
+                      "startLine": 159,
+                      "startColumn": 16,
+                      "endColumn": 69
+                    }
+                  },
+                  "message": {
+                    "text": "format(...) : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 713,
+                      "startColumn": 32,
+                      "endColumn": 40
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 717,
+                      "startColumn": 27,
+                      "endColumn": 40
+                    }
+                  },
+                  "message": {
+                    "text": "toStringCache : String"
+                  }
+                },
+                "taxa": [
+                  {
+                    "id": "entrypointFieldStep",
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 717,
+                      "startColumn": 16,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "new String(...) : String"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 6,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/Format.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 18
+                    },
+                    "region": {
+                      "startLine": 159,
+                      "startColumn": 16,
+                      "endColumn": 80
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 860,
+                      "startColumn": 16,
+                      "endColumn": 38
+                    }
+                  },
+                  "message": {
+                    "text": "format(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/DatatypeException.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 19
+                    },
+                    "region": {
+                      "startLine": 102,
+                      "startColumn": 23,
+                      "endColumn": 64
+                    }
+                  },
+                  "message": {
+                    "text": "format(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/dv/DatatypeException.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 19
+                    },
+                    "region": {
+                      "startLine": 109,
+                      "startColumn": 16,
+                      "endColumn": 19
+                    }
+                  },
+                  "message": {
+                    "text": "msg : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/javax/xml/parsers/FactoryConfigurationError.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 20
+                    },
+                    "region": {
+                      "startLine": 111,
+                      "startColumn": 20,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "getMessage(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "make/jdk/src/classes/build/tools/module/ModuleInfoExtraTest.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 21
+                    },
+                    "region": {
+                      "startLine": 254,
+                      "startColumn": 18,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "getMessage(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 2854,
+                      "startColumn": 20,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 2855,
+                      "startColumn": 39,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "this"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "threadFlows": [
+          {
+            "locations": [
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 654,
+                      "startColumn": 30,
+                      "endColumn": 54
+                    }
+                  },
+                  "message": {
+                    "text": "getInputStream(...) : InputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 0,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "source"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 697,
+                      "startColumn": 80,
+                      "endColumn": 86
+                    }
+                  },
+                  "message": {
+                    "text": "stream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3003,
+                      "startColumn": 38,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3005,
+                      "startColumn": 28,
+                      "endColumn": 30
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3005,
+                      "startColumn": 13,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> [post update] : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 697,
+                      "startColumn": 54,
+                      "endColumn": 87
+                    }
+                  },
+                  "message": {
+                    "text": "new RewindableInputStream(...) : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 726,
+                      "startColumn": 29,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "stream : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3089,
+                      "startColumn": 21,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3118,
+                      "startColumn": 20,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3118,
+                      "startColumn": 20,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "fInputStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3687,
+                      "startColumn": 21,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3692,
+                      "startColumn": 17,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3701,
+                      "startColumn": 22,
+                      "endLine": 3702,
+                      "endColumn": 71
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3649,
+                      "startColumn": 20,
+                      "endColumn": 24
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3652,
+                      "startColumn": 30,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "super : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3652,
+                      "startColumn": 41,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "b [post update] : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 1,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1971,
+                      "startColumn": 35,
+                      "endColumn": 67
+                    }
+                  },
+                  "message": {
+                    "text": "new HttpInputStream(...) : HttpInputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "id": "AdditionalTaintStep",
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1985,
+                      "startColumn": 24,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "inputStream : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1581,
+                      "startColumn": 24,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "getInputStream0(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/net/URL.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 22
+                    },
+                    "region": {
+                      "startLine": 1317,
+                      "startColumn": 16,
+                      "endColumn": 49
+                    }
+                  },
+                  "message": {
+                    "text": "getInputStream(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 586,
+                      "startColumn": 43,
+                      "endColumn": 59
+                    }
+                  },
+                  "message": {
+                    "text": "openStream(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 587,
+                      "startColumn": 64,
+                      "endColumn": 66
+                    }
+                  },
+                  "message": {
+                    "text": "in : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 587,
+                      "startColumn": 42,
+                      "endColumn": 79
+                    }
+                  },
+                  "message": {
+                    "text": "new InputStreamReader(...) : InputStreamReader"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 7,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 591,
+                      "startColumn": 37,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "reader : InputStreamReader"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/Reader.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 24
+                    },
+                    "region": {
+                      "startLine": 264,
+                      "startColumn": 16,
+                      "endColumn": 20
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : InputStreamReader"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/Reader.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 24
+                    },
+                    "region": {
+                      "startLine": 265,
+                      "startColumn": 16,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : InputStreamReader"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/Reader.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 24
+                    },
+                    "region": {
+                      "startLine": 265,
+                      "startColumn": 21,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "cbuf [post update] : char[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 8,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 591,
+                      "startColumn": 49,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "buf [post update] : char[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 592,
+                      "startColumn": 39,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "buf : char[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 232,
+                      "startColumn": 33,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "str : char[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 233,
+                      "startColumn": 22,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "str : char[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 233,
+                      "startColumn": 9,
+                      "endColumn": 14
+                    }
+                  },
+                  "message": {
+                    "text": "super [post update] : StringBuilder"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 5,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 592,
+                      "startColumn": 29,
+                      "endColumn": 31
+                    }
+                  },
+                  "message": {
+                    "text": "sb [post update] : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 595,
+                      "startColumn": 34,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "sb : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 451,
+                      "startColumn": 19,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 453,
+                      "startColumn": 27,
+                      "endColumn": 31
+                    }
+                  },
+                  "message": {
+                    "text": "this : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 1486,
+                      "startColumn": 19,
+                      "endColumn": 40
+                    }
+                  },
+                  "message": {
+                    "text": "builder : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 1487,
+                      "startColumn": 14,
+                      "endColumn": 21
+                    }
+                  },
+                  "message": {
+                    "text": "builder : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 1487,
+                      "startColumn": 9,
+                      "endColumn": 29
+                    }
+                  },
+                  "message": {
+                    "text": "this <constr(this)> [post update] : String"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 6,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 453,
+                      "startColumn": 16,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "new String(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 595,
+                      "startColumn": 34,
+                      "endColumn": 47
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 604,
+                      "startColumn": 40,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "str : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 2718,
+                      "startColumn": 19,
+                      "endColumn": 28
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 2722,
+                      "startColumn": 20,
+                      "endColumn": 24
+                    }
+                  },
+                  "message": {
+                    "text": "this : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/Metacity.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 23
+                    },
+                    "region": {
+                      "startLine": 604,
+                      "startColumn": 40,
+                      "endColumn": 60
+                    }
+                  },
+                  "message": {
+                    "text": "substring(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 778,
+                      "startColumn": 20,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "run(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 785,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "result : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 319,
+                      "startColumn": 16,
+                      "endColumn": 76
+                    }
+                  },
+                  "message": {
+                    "text": "executePrivileged(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/security/provider/SubjectCodeSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 26
+                    },
+                    "region": {
+                      "startLine": 369,
+                      "startColumn": 25,
+                      "endLine": 374,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "doPrivileged(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/security/provider/SubjectCodeSource.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 26
+                    },
+                    "region": {
+                      "startLine": 386,
+                      "startColumn": 16,
+                      "endColumn": 24
+                    }
+                  },
+                  "message": {
+                    "text": "returnMe : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 4230,
+                      "startColumn": 41,
+                      "endColumn": 55
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 4230,
+                      "startColumn": 16,
+                      "endColumn": 55
+                    }
+                  },
+                  "message": {
+                    "text": "...?...:... : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 173,
+                      "startColumn": 23,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "valueOf(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 178,
+                      "startColumn": 33,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "str : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 179,
+                      "startColumn": 22,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "str : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 179,
+                      "startColumn": 9,
+                      "endColumn": 14
+                    }
+                  },
+                  "message": {
+                    "text": "super [post update] : StringBuilder"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 5,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 173,
+                      "startColumn": 16,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> [post update] : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.naming/share/classes/javax/naming/directory/BasicAttribute.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 27
+                    },
+                    "region": {
+                      "startLine": 221,
+                      "startColumn": 17,
+                      "endColumn": 23
+                    }
+                  },
+                  "message": {
+                    "text": "answer [post update] : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.naming/share/classes/javax/naming/directory/BasicAttribute.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 27
+                    },
+                    "region": {
+                      "startLine": 225,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "answer : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 451,
+                      "startColumn": 19,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 453,
+                      "startColumn": 27,
+                      "endColumn": 31
+                    }
+                  },
+                  "message": {
+                    "text": "this : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 1486,
+                      "startColumn": 19,
+                      "endColumn": 40
+                    }
+                  },
+                  "message": {
+                    "text": "builder : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 1487,
+                      "startColumn": 14,
+                      "endColumn": 21
+                    }
+                  },
+                  "message": {
+                    "text": "builder : StringBuilder"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 1487,
+                      "startColumn": 9,
+                      "endColumn": 29
+                    }
+                  },
+                  "message": {
+                    "text": "this <constr(this)> [post update] : String"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 6,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuilder.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 25
+                    },
+                    "region": {
+                      "startLine": 453,
+                      "startColumn": 16,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "new String(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.naming/share/classes/javax/naming/directory/BasicAttribute.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 27
+                    },
+                    "region": {
+                      "startLine": 225,
+                      "startColumn": 16,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.naming/share/classes/javax/naming/directory/ModificationItem.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 28
+                    },
+                    "region": {
+                      "startLine": 118,
+                      "startColumn": 41,
+                      "endColumn": 56
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.naming/share/classes/javax/naming/directory/ModificationItem.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 28
+                    },
+                    "region": {
+                      "startLine": 118,
+                      "startColumn": 21,
+                      "endColumn": 56
+                    }
+                  },
+                  "message": {
+                    "text": "... + ... : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.naming/share/classes/javax/naming/directory/AttributeModificationException.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 29
+                    },
+                    "region": {
+                      "startLine": 131,
+                      "startColumn": 22,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.naming/share/classes/javax/naming/directory/AttributeModificationException.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 29
+                    },
+                    "region": {
+                      "startLine": 133,
+                      "startColumn": 16,
+                      "endColumn": 20
+                    }
+                  },
+                  "message": {
+                    "text": "orig : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/WriteAbortedException.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 30
+                    },
+                    "region": {
+                      "startLine": 74,
+                      "startColumn": 48,
+                      "endColumn": 65
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/WriteAbortedException.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 30
+                    },
+                    "region": {
+                      "startLine": 74,
+                      "startColumn": 20,
+                      "endColumn": 65
+                    }
+                  },
+                  "message": {
+                    "text": "... + ... : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/javax/xml/parsers/FactoryConfigurationError.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 20
+                    },
+                    "region": {
+                      "startLine": 111,
+                      "startColumn": 20,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "getMessage(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "make/jdk/src/classes/build/tools/module/ModuleInfoExtraTest.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 21
+                    },
+                    "region": {
+                      "startLine": 270,
+                      "startColumn": 18,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "getMessage(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 2854,
+                      "startColumn": 20,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 2855,
+                      "startColumn": 39,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "this"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "threadFlows": [
+          {
+            "locations": [
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 654,
+                      "startColumn": 30,
+                      "endColumn": 54
+                    }
+                  },
+                  "message": {
+                    "text": "getInputStream(...) : InputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 0,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "source"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 697,
+                      "startColumn": 80,
+                      "endColumn": 86
+                    }
+                  },
+                  "message": {
+                    "text": "stream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3003,
+                      "startColumn": 38,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3005,
+                      "startColumn": 28,
+                      "endColumn": 30
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3005,
+                      "startColumn": 13,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> [post update] : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 697,
+                      "startColumn": 54,
+                      "endColumn": 87
+                    }
+                  },
+                  "message": {
+                    "text": "new RewindableInputStream(...) : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 774,
+                      "startColumn": 29,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "stream : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3089,
+                      "startColumn": 21,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3099,
+                      "startColumn": 24,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3099,
+                      "startColumn": 24,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "fInputStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3687,
+                      "startColumn": 21,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3701,
+                      "startColumn": 22,
+                      "endLine": 3702,
+                      "endColumn": 71
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3649,
+                      "startColumn": 20,
+                      "endColumn": 24
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3652,
+                      "startColumn": 30,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "super : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3652,
+                      "startColumn": 41,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "b [post update] : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 1,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1964,
+                      "startColumn": 47,
+                      "endColumn": 93
+                    }
+                  },
+                  "message": {
+                    "text": "new HttpInputStream(...) : HttpInputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "id": "AdditionalTaintStep",
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1964,
+                      "startColumn": 33,
+                      "endColumn": 44
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> [post update] : HttpURLConnection [inputStream] : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1970,
+                      "startColumn": 23,
+                      "endColumn": 34
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : HttpURLConnection [inputStream] : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1970,
+                      "startColumn": 23,
+                      "endColumn": 34
+                    }
+                  },
+                  "message": {
+                    "text": "inputStream : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1985,
+                      "startColumn": 24,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "inputStream : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1581,
+                      "startColumn": 24,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "getInputStream0(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/net/URLClassLoader.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 31
+                    },
+                    "region": {
+                      "startLine": 296,
+                      "startColumn": 30,
+                      "endColumn": 51
+                    }
+                  },
+                  "message": {
+                    "text": "getInputStream(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/net/URLClassLoader.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 31
+                    },
+                    "region": {
+                      "startLine": 309,
+                      "startColumn": 20,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "is : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/java/beans/Beans.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 32
+                    },
+                    "region": {
+                      "startLine": 203,
+                      "startColumn": 20,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "getResourceAsStream(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/java/beans/Beans.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 32
+                    },
+                    "region": {
+                      "startLine": 209,
+                      "startColumn": 60,
+                      "endColumn": 63
+                    }
+                  },
+                  "message": {
+                    "text": "ins : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/java/beans/Beans.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 32
+                    },
+                    "region": {
+                      "startLine": 498,
+                      "startColumn": 40,
+                      "endColumn": 54
+                    }
+                  },
+                  "message": {
+                    "text": "in : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/java/beans/Beans.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 32
+                    },
+                    "region": {
+                      "startLine": 501,
+                      "startColumn": 15,
+                      "endColumn": 17
+                    }
+                  },
+                  "message": {
+                    "text": "in : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/java/beans/Beans.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 32
+                    },
+                    "region": {
+                      "startLine": 501,
+                      "startColumn": 9,
+                      "endColumn": 19
+                    }
+                  },
+                  "message": {
+                    "text": "this <constr(this)> [post update] : ObjectInputStreamWithLoader [bin, in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/java/beans/Beans.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 32
+                    },
+                    "region": {
+                      "startLine": 209,
+                      "startColumn": 28,
+                      "endColumn": 69
+                    }
+                  },
+                  "message": {
+                    "text": "new ObjectInputStreamWithLoader(...) : ObjectInputStreamWithLoader [bin, in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/java/beans/Beans.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 32
+                    },
+                    "region": {
+                      "startLine": 211,
+                      "startColumn": 26,
+                      "endColumn": 30
+                    }
+                  },
+                  "message": {
+                    "text": "oins : ObjectInputStreamWithLoader [bin, in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 494,
+                      "startColumn": 25,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : ObjectInputStreamWithLoader [bin, in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 496,
+                      "startColumn": 16,
+                      "endColumn": 40
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : ObjectInputStreamWithLoader [bin, in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 525,
+                      "startColumn": 26,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : ObjectInputStreamWithLoader [bin, in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 538,
+                      "startColumn": 26,
+                      "endColumn": 50
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : ObjectInputStreamWithLoader [bin, in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 1692,
+                      "startColumn": 20,
+                      "endColumn": 31
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : ObjectInputStreamWithLoader [bin, in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 1748,
+                      "startColumn": 41,
+                      "endColumn": 60
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : ObjectInputStreamWithLoader [bin, in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 2132,
+                      "startColumn": 20,
+                      "endColumn": 29
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : ObjectInputStreamWithLoader [bin, in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 2163,
+                      "startColumn": 17,
+                      "endColumn": 20
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : ObjectInputStreamWithLoader [bin, in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 2163,
+                      "startColumn": 17,
+                      "endColumn": 20
+                    }
+                  },
+                  "message": {
+                    "text": "bin : BlockDataInputStream [in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 3368,
+                      "startColumn": 21,
+                      "endColumn": 30
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : BlockDataInputStream [in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 3372,
+                      "startColumn": 25,
+                      "endColumn": 48
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : BlockDataInputStream [in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 3327,
+                      "startColumn": 13,
+                      "endColumn": 17
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : BlockDataInputStream [in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 3348,
+                      "startColumn": 24,
+                      "endColumn": 26
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : BlockDataInputStream [in] : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 3348,
+                      "startColumn": 24,
+                      "endColumn": 26
+                    }
+                  },
+                  "message": {
+                    "text": "in : PeekInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 3348,
+                      "startColumn": 32,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "b [post update] : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 1,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 408,
+                      "startColumn": 15,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "new BlockDataInputStream(...) : BlockDataInputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "id": "AdditionalTaintStep",
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 408,
+                      "startColumn": 9,
+                      "endColumn": 12
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> [post update] : ObjectInputStream [bin] : BlockDataInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.naming/share/classes/com/sun/jndi/ldap/Obj.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 34
+                    },
+                    "region": {
+                      "startLine": 539,
+                      "startColumn": 21,
+                      "endColumn": 49
+                    }
+                  },
+                  "message": {
+                    "text": "new ObjectInputStream(...) : ObjectInputStream [bin] : BlockDataInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.naming/share/classes/com/sun/jndi/ldap/Obj.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 34
+                    },
+                    "region": {
+                      "startLine": 541,
+                      "startColumn": 24,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "deserial : ObjectInputStream [bin] : BlockDataInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 494,
+                      "startColumn": 25,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : ObjectInputStream [bin] : BlockDataInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 496,
+                      "startColumn": 16,
+                      "endColumn": 40
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : ObjectInputStream [bin] : BlockDataInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 525,
+                      "startColumn": 26,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : ObjectInputStream [bin] : BlockDataInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 538,
+                      "startColumn": 26,
+                      "endColumn": 50
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : ObjectInputStream [bin] : BlockDataInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 1692,
+                      "startColumn": 20,
+                      "endColumn": 31
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : ObjectInputStream [bin] : BlockDataInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 1742,
+                      "startColumn": 41,
+                      "endColumn": 61
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : ObjectInputStream [bin] : BlockDataInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 2115,
+                      "startColumn": 20,
+                      "endColumn": 30
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : ObjectInputStream [bin] : BlockDataInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 2118,
+                      "startColumn": 36,
+                      "endColumn": 39
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : ObjectInputStream [bin] : BlockDataInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 2118,
+                      "startColumn": 36,
+                      "endColumn": 39
+                    }
+                  },
+                  "message": {
+                    "text": "bin : BlockDataInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 2118,
+                      "startColumn": 36,
+                      "endColumn": 49
+                    }
+                  },
+                  "message": {
+                    "text": "readUTF(...) : String"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 9,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 2125,
+                      "startColumn": 16,
+                      "endColumn": 19
+                    }
+                  },
+                  "message": {
+                    "text": "str : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 1742,
+                      "startColumn": 41,
+                      "endColumn": 61
+                    }
+                  },
+                  "message": {
+                    "text": "readString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 1807,
+                      "startColumn": 33,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "obj : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 1809,
+                      "startColumn": 20,
+                      "endColumn": 23
+                    }
+                  },
+                  "message": {
+                    "text": "obj : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 1742,
+                      "startColumn": 28,
+                      "endColumn": 62
+                    }
+                  },
+                  "message": {
+                    "text": "checkResolve(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 538,
+                      "startColumn": 26,
+                      "endColumn": 50
+                    }
+                  },
+                  "message": {
+                    "text": "readObject0(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 548,
+                      "startColumn": 20,
+                      "endColumn": 23
+                    }
+                  },
+                  "message": {
+                    "text": "obj : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/io/ObjectInputStream.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 33
+                    },
+                    "region": {
+                      "startLine": 496,
+                      "startColumn": 16,
+                      "endColumn": 40
+                    }
+                  },
+                  "message": {
+                    "text": "readObject(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.naming/share/classes/com/sun/jndi/ldap/Obj.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 34
+                    },
+                    "region": {
+                      "startLine": 541,
+                      "startColumn": 24,
+                      "endColumn": 45
+                    }
+                  },
+                  "message": {
+                    "text": "readObject(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.naming/share/classes/com/sun/jndi/ldap/Obj.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 34
+                    },
+                    "region": {
+                      "startLine": 240,
+                      "startColumn": 24,
+                      "endColumn": 65
+                    }
+                  },
+                  "message": {
+                    "text": "deserializeObject(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.naming/share/classes/com/sun/jndi/ldap/LdapBindingEnumeration.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 35
+                    },
+                    "region": {
+                      "startLine": 65,
+                      "startColumn": 62,
+                      "endColumn": 85
+                    }
+                  },
+                  "message": {
+                    "text": "decodeObject(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 809,
+                      "startColumn": 20,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "run(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 816,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "result : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 714,
+                      "startColumn": 20,
+                      "endColumn": 62
+                    }
+                  },
+                  "message": {
+                    "text": "executePrivileged(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1586,
+                      "startColumn": 28,
+                      "endLine": 1588,
+                      "endColumn": 73
+                    }
+                  },
+                  "message": {
+                    "text": "doPrivileged(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1632,
+                      "startColumn": 20,
+                      "endColumn": 71
+                    }
+                  },
+                  "message": {
+                    "text": "unwrap(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1071,
+                      "startColumn": 13,
+                      "endColumn": 92
+                    }
+                  },
+                  "message": {
+                    "text": "unwrap(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1075,
+                      "startColumn": 61,
+                      "endColumn": 74
+                    }
+                  },
+                  "message": {
+                    "text": "handbackValue : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1075,
+                      "startColumn": 17,
+                      "endColumn": 76
+                    }
+                  },
+                  "message": {
+                    "text": "{...} : Object[] [[]] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1087,
+                      "startColumn": 15,
+                      "endColumn": 21
+                    }
+                  },
+                  "message": {
+                    "text": "params : Object[] [[]] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1380,
+                      "startColumn": 42,
+                      "endColumn": 63
+                    }
+                  },
+                  "message": {
+                    "text": "params : Object[] [[]] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1402,
+                      "startColumn": 52,
+                      "endColumn": 58
+                    }
+                  },
+                  "message": {
+                    "text": "params : Object[] [[]] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1304,
+                      "startColumn": 51,
+                      "endColumn": 66
+                    }
+                  },
+                  "message": {
+                    "text": "params : Object[] [[]] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1306,
+                      "startColumn": 27,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "params : Object[] [[]] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1306,
+                      "startColumn": 13,
+                      "endColumn": 17
+                    }
+                  },
+                  "message": {
+                    "text": "this [post update] : PrivilegedOperation [params, []] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1402,
+                      "startColumn": 17,
+                      "endColumn": 59
+                    }
+                  },
+                  "message": {
+                    "text": "new PrivilegedOperation(...) : PrivilegedOperation [params, []] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1405,
+                      "startColumn": 28,
+                      "endColumn": 30
+                    }
+                  },
+                  "message": {
+                    "text": "op : PrivilegedOperation [params, []] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1309,
+                      "startColumn": 23,
+                      "endColumn": 26
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : PrivilegedOperation [params, []] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1310,
+                      "startColumn": 43,
+                      "endColumn": 49
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : PrivilegedOperation [params, []] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1310,
+                      "startColumn": 43,
+                      "endColumn": 49
+                    }
+                  },
+                  "message": {
+                    "text": "params : Object[] [[]] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1421,
+                      "startColumn": 47,
+                      "endColumn": 62
+                    }
+                  },
+                  "message": {
+                    "text": "params : Object[] [[]] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1427,
+                      "startColumn": 52,
+                      "endColumn": 58
+                    }
+                  },
+                  "message": {
+                    "text": "params : Object[] [[]] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1427,
+                      "startColumn": 52,
+                      "endColumn": 61
+                    }
+                  },
+                  "message": {
+                    "text": "...[...] : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 2
+                    },
+                    "region": {
+                      "startLine": 1427,
+                      "startColumn": 44,
+                      "endColumn": 61
+                    }
+                  },
+                  "message": {
+                    "text": "(...)... : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerAccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 3
+                    },
+                    "region": {
+                      "startLine": 170,
+                      "startColumn": 39,
+                      "endColumn": 55
+                    }
+                  },
+                  "message": {
+                    "text": "className : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerAccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 3
+                    },
+                    "region": {
+                      "startLine": 177,
+                      "startColumn": 21,
+                      "endColumn": 30
+                    }
+                  },
+                  "message": {
+                    "text": "className : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerFileAccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 4
+                    },
+                    "region": {
+                      "startLine": 247,
+                      "startColumn": 29,
+                      "endColumn": 45
+                    }
+                  },
+                  "message": {
+                    "text": "className : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerFileAccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 4
+                    },
+                    "region": {
+                      "startLine": 248,
+                      "startColumn": 40,
+                      "endColumn": 49
+                    }
+                  },
+                  "message": {
+                    "text": "className : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerFileAccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 4
+                    },
+                    "region": {
+                      "startLine": 303,
+                      "startColumn": 70,
+                      "endColumn": 80
+                    }
+                  },
+                  "message": {
+                    "text": "arg : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerFileAccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 4
+                    },
+                    "region": {
+                      "startLine": 333,
+                      "startColumn": 56,
+                      "endColumn": 59
+                    }
+                  },
+                  "message": {
+                    "text": "arg : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerFileAccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 4
+                    },
+                    "region": {
+                      "startLine": 360,
+                      "startColumn": 61,
+                      "endColumn": 77
+                    }
+                  },
+                  "message": {
+                    "text": "className : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerFileAccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 4
+                    },
+                    "region": {
+                      "startLine": 362,
+                      "startColumn": 50,
+                      "endColumn": 59
+                    }
+                  },
+                  "message": {
+                    "text": "className : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerFileAccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 4
+                    },
+                    "region": {
+                      "startLine": 368,
+                      "startColumn": 59,
+                      "endColumn": 75
+                    }
+                  },
+                  "message": {
+                    "text": "className : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.management/share/classes/com/sun/jmx/remote/security/MBeanServerFileAccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 4
+                    },
+                    "region": {
+                      "startLine": 387,
+                      "startColumn": 16,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "className : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 2854,
+                      "startColumn": 20,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 2855,
+                      "startColumn": 39,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "this"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "threadFlows": [
+          {
+            "locations": [
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 654,
+                      "startColumn": 30,
+                      "endColumn": 54
+                    }
+                  },
+                  "message": {
+                    "text": "getInputStream(...) : InputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 0,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "source"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 697,
+                      "startColumn": 80,
+                      "endColumn": 86
+                    }
+                  },
+                  "message": {
+                    "text": "stream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3003,
+                      "startColumn": 38,
+                      "endColumn": 52
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3005,
+                      "startColumn": 28,
+                      "endColumn": 30
+                    }
+                  },
+                  "message": {
+                    "text": "is : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3005,
+                      "startColumn": 13,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> [post update] : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 697,
+                      "startColumn": 54,
+                      "endColumn": 87
+                    }
+                  },
+                  "message": {
+                    "text": "new RewindableInputStream(...) : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 779,
+                      "startColumn": 29,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "stream : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3089,
+                      "startColumn": 21,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3099,
+                      "startColumn": 24,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : RewindableInputStream [fInputStream] : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 9
+                    },
+                    "region": {
+                      "startLine": 3099,
+                      "startColumn": 24,
+                      "endColumn": 36
+                    }
+                  },
+                  "message": {
+                    "text": "fInputStream : InputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3687,
+                      "startColumn": 21,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3701,
+                      "startColumn": 22,
+                      "endLine": 3702,
+                      "endColumn": 71
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3649,
+                      "startColumn": 20,
+                      "endColumn": 24
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3652,
+                      "startColumn": 30,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "super : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 3652,
+                      "startColumn": 41,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "b [post update] : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 1,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1971,
+                      "startColumn": 35,
+                      "endColumn": 67
+                    }
+                  },
+                  "message": {
+                    "text": "new HttpInputStream(...) : HttpInputStream"
+                  }
+                },
+                "taxa": [
+                  {
+                    "id": "AdditionalTaintStep",
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1971,
+                      "startColumn": 21,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> [post update] : HttpURLConnection [inputStream] : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1983,
+                      "startColumn": 17,
+                      "endColumn": 23
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : HttpURLConnection [inputStream] : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1984,
+                      "startColumn": 17,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : HttpURLConnection [inputStream] : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1985,
+                      "startColumn": 24,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : HttpURLConnection [inputStream] : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1985,
+                      "startColumn": 24,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "inputStream : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/http/HttpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 10
+                    },
+                    "region": {
+                      "startLine": 1581,
+                      "startColumn": 24,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "getInputStream0(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/net/www/protocol/ftp/FtpURLConnection.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 36
+                    },
+                    "region": {
+                      "startLine": 424,
+                      "startColumn": 20,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "getInputStream(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/net/URL.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 22
+                    },
+                    "region": {
+                      "startLine": 1317,
+                      "startColumn": 16,
+                      "endColumn": 49
+                    }
+                  },
+                  "message": {
+                    "text": "getInputStream(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/Module.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 37
+                    },
+                    "region": {
+                      "startLine": 1735,
+                      "startColumn": 24,
+                      "endColumn": 40
+                    }
+                  },
+                  "message": {
+                    "text": "openStream(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 86,
+                      "startColumn": 20,
+                      "endColumn": 68
+                    }
+                  },
+                  "message": {
+                    "text": "getResourceAsStream(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 809,
+                      "startColumn": 20,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "run(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 816,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "result : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/security/AccessController.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 5
+                    },
+                    "region": {
+                      "startLine": 571,
+                      "startColumn": 20,
+                      "endColumn": 62
+                    }
+                  },
+                  "message": {
+                    "text": "executePrivileged(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 89,
+                      "startColumn": 18,
+                      "endColumn": 51
+                    }
+                  },
+                  "message": {
+                    "text": "doPrivileged(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 93,
+                      "startColumn": 16,
+                      "endColumn": 18
+                    }
+                  },
+                  "message": {
+                    "text": "is : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 75,
+                      "startColumn": 31,
+                      "endColumn": 56
+                    }
+                  },
+                  "message": {
+                    "text": "getResourceAsStream(...) : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 76,
+                      "startColumn": 20,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "is : HttpInputStream"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 76,
+                      "startColumn": 20,
+                      "endColumn": 37
+                    }
+                  },
+                  "message": {
+                    "text": "readAllBytes(...) : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 2,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 11
+                    },
+                    "region": {
+                      "startLine": 80,
+                      "startColumn": 16,
+                      "endColumn": 20
+                    }
+                  },
+                  "message": {
+                    "text": "data : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/util/ResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 12
+                    },
+                    "region": {
+                      "startLine": 561,
+                      "startColumn": 22,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "handleGetObject(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/util/ResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 12
+                    },
+                    "region": {
+                      "startLine": 574,
+                      "startColumn": 16,
+                      "endColumn": 19
+                    }
+                  },
+                  "message": {
+                    "text": "obj : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/util/ResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 12
+                    },
+                    "region": {
+                      "startLine": 564,
+                      "startColumn": 23,
+                      "endColumn": 44
+                    }
+                  },
+                  "message": {
+                    "text": "getObject(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/util/ResourceBundle.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 12
+                    },
+                    "region": {
+                      "startLine": 574,
+                      "startColumn": 16,
+                      "endColumn": 19
+                    }
+                  },
+                  "message": {
+                    "text": "obj : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 326,
+                      "startColumn": 44,
+                      "endColumn": 60
+                    }
+                  },
+                  "message": {
+                    "text": "getObject(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 328,
+                      "startColumn": 45,
+                      "endColumn": 50
+                    }
+                  },
+                  "message": {
+                    "text": "value : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 328,
+                      "startColumn": 29,
+                      "endColumn": 35
+                    }
+                  },
+                  "message": {
+                    "text": "values [post update] : TextAndMnemonicHashMap [<map.value>] : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 3,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 335,
+                      "startColumn": 34,
+                      "endColumn": 40
+                    }
+                  },
+                  "message": {
+                    "text": "values : TextAndMnemonicHashMap [<map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 335,
+                      "startColumn": 13,
+                      "endColumn": 26
+                    }
+                  },
+                  "message": {
+                    "text": "resourceCache [post update] : HashMap [<map.value>, <map.value>] : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 3,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 335,
+                      "startColumn": 13,
+                      "endColumn": 26
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> [post update] : UIDefaults [resourceCache, <map.value>, <map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 298,
+                      "startColumn": 20,
+                      "endColumn": 39
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> [post update] : UIDefaults [resourceCache, <map.value>, <map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 172,
+                      "startColumn": 42,
+                      "endColumn": 74
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> [post update] : UIDefaults [resourceCache, <map.value>, <map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/plaf/nimbus/NimbusLookAndFeel.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 38
+                    },
+                    "region": {
+                      "startLine": 544,
+                      "startColumn": 23,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "uiDefaults [post update] : UIDefaults [resourceCache, <map.value>, <map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/plaf/nimbus/NimbusLookAndFeel.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 38
+                    },
+                    "region": {
+                      "startLine": 548,
+                      "startColumn": 23,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "uiDefaults : UIDefaults [resourceCache, <map.value>, <map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 170,
+                      "startColumn": 19,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : UIDefaults [resourceCache, <map.value>, <map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 172,
+                      "startColumn": 42,
+                      "endColumn": 74
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : UIDefaults [resourceCache, <map.value>, <map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 281,
+                      "startColumn": 20,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : UIDefaults [resourceCache, <map.value>, <map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 298,
+                      "startColumn": 20,
+                      "endColumn": 39
+                    }
+                  },
+                  "message": {
+                    "text": "this <.method> : UIDefaults [resourceCache, <map.value>, <map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 305,
+                      "startColumn": 33,
+                      "endColumn": 49
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : UIDefaults [resourceCache, <map.value>, <map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 306,
+                      "startColumn": 38,
+                      "endColumn": 51
+                    }
+                  },
+                  "message": {
+                    "text": "this <.field> : UIDefaults [resourceCache, <map.value>, <map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 306,
+                      "startColumn": 38,
+                      "endColumn": 51
+                    }
+                  },
+                  "message": {
+                    "text": "resourceCache : HashMap [<map.value>, <map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 306,
+                      "startColumn": 38,
+                      "endColumn": 58
+                    }
+                  },
+                  "message": {
+                    "text": "get(...) : TextAndMnemonicHashMap [<map.value>] : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 4,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 337,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "values : TextAndMnemonicHashMap [<map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 298,
+                      "startColumn": 20,
+                      "endColumn": 39
+                    }
+                  },
+                  "message": {
+                    "text": "getResourceCache(...) : TextAndMnemonicHashMap [<map.value>] : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 298,
+                      "startColumn": 20,
+                      "endColumn": 48
+                    }
+                  },
+                  "message": {
+                    "text": "get(...) : byte[]"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 4,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 172,
+                      "startColumn": 42,
+                      "endColumn": 74
+                    }
+                  },
+                  "message": {
+                    "text": "getFromResourceBundle(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 172,
+                      "startColumn": 16,
+                      "endColumn": 74
+                    }
+                  },
+                  "message": {
+                    "text": "...?...:... : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/plaf/nimbus/NimbusLookAndFeel.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 38
+                    },
+                    "region": {
+                      "startLine": 548,
+                      "startColumn": 23,
+                      "endColumn": 65
+                    }
+                  },
+                  "message": {
+                    "text": "get(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/plaf/nimbus/NimbusLookAndFeel.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 38
+                    },
+                    "region": {
+                      "startLine": 558,
+                      "startColumn": 20,
+                      "endColumn": 23
+                    }
+                  },
+                  "message": {
+                    "text": "obj : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 241,
+                      "startColumn": 21,
+                      "endColumn": 59
+                    }
+                  },
+                  "message": {
+                    "text": "createValue(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 244,
+                      "startColumn": 16,
+                      "endColumn": 21
+                    }
+                  },
+                  "message": {
+                    "text": "value : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 171,
+                      "startColumn": 24,
+                      "endColumn": 47
+                    }
+                  },
+                  "message": {
+                    "text": "getFromHashtable(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/UIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 13
+                    },
+                    "region": {
+                      "startLine": 172,
+                      "startColumn": 16,
+                      "endColumn": 74
+                    }
+                  },
+                  "message": {
+                    "text": "...?...:... : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/MultiUIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 39
+                    },
+                    "region": {
+                      "startLine": 59,
+                      "startColumn": 24,
+                      "endColumn": 38
+                    }
+                  },
+                  "message": {
+                    "text": "get(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/MultiUIDefaults.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 39
+                    },
+                    "region": {
+                      "startLine": 61,
+                      "startColumn": 20,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "value : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/rtf/MockAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 14
+                    },
+                    "region": {
+                      "startLine": 67,
+                      "startColumn": 16,
+                      "endColumn": 33
+                    }
+                  },
+                  "message": {
+                    "text": "get(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/StyleContext.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 40
+                    },
+                    "region": {
+                      "startLine": 1496,
+                      "startColumn": 20,
+                      "endColumn": 53
+                    }
+                  },
+                  "message": {
+                    "text": "getAttribute(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 15
+                    },
+                    "region": {
+                      "startLine": 151,
+                      "startColumn": 25,
+                      "endColumn": 50
+                    }
+                  },
+                  "message": {
+                    "text": "getAttribute(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 15
+                    },
+                    "region": {
+                      "startLine": 154,
+                      "startColumn": 16,
+                      "endColumn": 21
+                    }
+                  },
+                  "message": {
+                    "text": "value : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/html/StyleSheet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 41
+                    },
+                    "region": {
+                      "startLine": 845,
+                      "startColumn": 20,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "getAttribute(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 15
+                    },
+                    "region": {
+                      "startLine": 328,
+                      "startColumn": 28,
+                      "endColumn": 45
+                    }
+                  },
+                  "message": {
+                    "text": "getAttribute(...) : byte[]"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/text/SimpleAttributeSet.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 15
+                    },
+                    "region": {
+                      "startLine": 336,
+                      "startColumn": 16,
+                      "endColumn": 17
+                    }
+                  },
+                  "message": {
+                    "text": "s : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.desktop/share/classes/javax/swing/tree/DefaultMutableTreeNode.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 42
+                    },
+                    "region": {
+                      "startLine": 1264,
+                      "startColumn": 20,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 1304,
+                      "startColumn": 27,
+                      "endColumn": 41
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 1349,
+                      "startColumn": 35,
+                      "endColumn": 38
+                    }
+                  },
+                  "message": {
+                    "text": "arg : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 311,
+                      "startColumn": 45,
+                      "endColumn": 55
+                    }
+                  },
+                  "message": {
+                    "text": "str : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 313,
+                      "startColumn": 22,
+                      "endColumn": 25
+                    }
+                  },
+                  "message": {
+                    "text": "str : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 313,
+                      "startColumn": 9,
+                      "endColumn": 14
+                    }
+                  },
+                  "message": {
+                    "text": "super [post update] : StringBuffer"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 5,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 1349,
+                      "startColumn": 21,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "result [post update] : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 1364,
+                      "startColumn": 16,
+                      "endColumn": 22
+                    }
+                  },
+                  "message": {
+                    "text": "result : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/MessageFormat.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 16
+                    },
+                    "region": {
+                      "startLine": 885,
+                      "startColumn": 16,
+                      "endColumn": 66
+                    }
+                  },
+                  "message": {
+                    "text": "subformat(...) : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/Format.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 18
+                    },
+                    "region": {
+                      "startLine": 159,
+                      "startColumn": 16,
+                      "endColumn": 69
+                    }
+                  },
+                  "message": {
+                    "text": "format(...) : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 713,
+                      "startColumn": 32,
+                      "endColumn": 40
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 715,
+                      "startColumn": 47,
+                      "endColumn": 51
+                    }
+                  },
+                  "message": {
+                    "text": "this : StringBuffer"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 715,
+                      "startColumn": 36,
+                      "endColumn": 58
+                    }
+                  },
+                  "message": {
+                    "text": "new String(...) : String"
+                  }
+                },
+                "taxa": [
+                  {
+                    "index": 6,
+                    "toolComponent": {
+                      "index": 13
+                    },
+                    "properties": {
+                      "CodeQL/DataflowRole": "step"
+                    }
+                  }
+                ]
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/StringBuffer.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 17
+                    },
+                    "region": {
+                      "startLine": 715,
+                      "startColumn": 20,
+                      "endColumn": 58
+                    }
+                  },
+                  "message": {
+                    "text": "...=... : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/text/Format.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 18
+                    },
+                    "region": {
+                      "startLine": 159,
+                      "startColumn": 16,
+                      "endColumn": 80
+                    }
+                  },
+                  "message": {
+                    "text": "toString(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/jdk.internal.opt/share/classes/jdk/internal/joptsimple/internal/Messages.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 43
+                    },
+                    "region": {
+                      "startLine": 75,
+                      "startColumn": 16,
+                      "endColumn": 37
+                    }
+                  },
+                  "message": {
+                    "text": "format(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/jdk.internal.opt/share/classes/jdk/internal/joptsimple/OptionException.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 44
+                    },
+                    "region": {
+                      "startLine": 152,
+                      "startColumn": 16,
+                      "endColumn": 121
+                    }
+                  },
+                  "message": {
+                    "text": "message(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/jdk.internal.opt/share/classes/jdk/internal/joptsimple/OptionException.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 44
+                    },
+                    "region": {
+                      "startLine": 148,
+                      "startColumn": 16,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "formattedMessage(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/jdk.internal.opt/share/classes/jdk/internal/joptsimple/OptionException.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 44
+                    },
+                    "region": {
+                      "startLine": 144,
+                      "startColumn": 16,
+                      "endColumn": 55
+                    }
+                  },
+                  "message": {
+                    "text": "localizedMessage(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.xml/share/classes/javax/xml/transform/TransformerFactoryConfigurationError.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 45
+                    },
+                    "region": {
+                      "startLine": 110,
+                      "startColumn": 20,
+                      "endColumn": 42
+                    }
+                  },
+                  "message": {
+                    "text": "getMessage(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "make/jdk/src/classes/build/tools/module/ModuleInfoExtraTest.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 21
+                    },
+                    "region": {
+                      "startLine": 254,
+                      "startColumn": 18,
+                      "endColumn": 32
+                    }
+                  },
+                  "message": {
+                    "text": "getMessage(...) : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 2854,
+                      "startColumn": 20,
+                      "endColumn": 27
+                    }
+                  },
+                  "message": {
+                    "text": "parameter this : String"
+                  }
+                }
+              },
+              {
+                "location": {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "src/java.base/share/classes/java/lang/String.java",
+                      "uriBaseId": "%SRCROOT%",
+                      "index": 0
+                    },
+                    "region": {
+                      "startLine": 2855,
+                      "startColumn": 39,
+                      "endColumn": 43
+                    }
+                  },
+                  "message": {
+                    "text": "this"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "relatedLocations": [
+      {
+        "id": 1,
+        "physicalLocation": {
+          "artifactLocation": {
+            "uri": "src/jdk.compiler/share/classes/com/sun/tools/javac/main/Main.java",
+            "uriBaseId": "%SRCROOT%",
+            "index": 1
+          },
+          "region": {
+            "startLine": 379,
+            "startColumn": 42,
+            "endColumn": 46
+          }
+        },
+        "message": {
+          "text": "regular expression"
+        }
+      },
+      {
+        "id": 2,
+        "physicalLocation": {
+          "artifactLocation": {
+            "uri": "src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/XMLEntityManager.java",
+            "uriBaseId": "%SRCROOT%",
+            "index": 9
+          },
+          "region": {
+            "startLine": 654,
+            "startColumn": 30,
+            "endColumn": 54
+          }
+        },
+        "message": {
+          "text": "user-provided value"
+        }
+      }
+    ]
+  }
+}

--- a/extensions/ql-vscode/test/unit-tests/compare/sarif-diff.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/compare/sarif-diff.test.ts
@@ -1,5 +1,7 @@
 import type { Result } from "sarif";
 import { sarifDiff } from "../../../src/compare/sarif-diff";
+import { readJson } from "fs-extra";
+import { resolve } from "path";
 
 describe("sarifDiff", () => {
   const result1: Result = {
@@ -492,6 +494,28 @@ describe("sarifDiff", () => {
 
     expect(sarifDiff([result1], [result2])).toEqual({
       from: [],
+      to: [],
+    });
+  });
+
+  it("only compares the source and sink of a result", async () => {
+    const { result1, result2 } = (await readJson(
+      resolve(__dirname, "differentPathsSameSourceSink.json"),
+    )) as { result1: Result; result2: Result };
+
+    expect(sarifDiff([result1], [result2])).toEqual({
+      from: [],
+      to: [],
+    });
+  });
+
+  it("gives a diff when the source and sink of a result differ", async () => {
+    const { result1, result2 } = (await readJson(
+      resolve(__dirname, "differentPathsDifferentSourceSink.json"),
+    )) as { result1: Result; result2: Result };
+
+    expect(sarifDiff([result1, result2], [result2])).toEqual({
+      from: [result1],
       to: [],
     });
   });


### PR DESCRIPTION
This changes the SARIF comparison to only include the source and the sink of a path as an input into the comparison. This will result in a more useful comparison by filtering out results that are the same except for their path.

The results of a comparison on this branch:
![Screenshot 2024-10-23 at 13 11 02](https://github.com/user-attachments/assets/568f34f8-e80d-4aeb-89bb-eca71f98077c)

The same comparison on `main`:

![Screenshot 2024-10-23 at 13 15 06](https://github.com/user-attachments/assets/0d6fc101-bea1-4faa-9e63-fef6657d2482)
