### PR TITLE
Remove unnecessary @types/nanoid dependency

### DIFF
--- a/extensions/ql-vscode/package-lock.json
+++ b/extensions/ql-vscode/package-lock.json
@@ -81,7 +81,6 @@
         "@types/gulp-replace": "^1.1.0",
         "@types/jest": "^29.5.12",
         "@types/js-yaml": "^4.0.6",
-        "@types/nanoid": "^3.0.0",
         "@types/node": "20.16.*",
         "@types/proper-lockfile": "^4.1.4",
         "@types/react": "^18.3.1",
@@ -6312,16 +6311,6 @@
       "integrity": "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==",
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/nanoid": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/nanoid/-/nanoid-3.0.0.tgz",
-      "integrity": "sha512-UXitWSmXCwhDmAKe7D3hNQtQaHeHt5L8LO1CB8GF8jlYVzOv5cBWDNqiJ+oPEWrWei3i3dkZtHY/bUtd0R/uOQ==",
-      "deprecated": "This is a stub types definition. nanoid provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "nanoid": "*"
       }
     },
     "node_modules/@types/node": {

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -2039,7 +2039,6 @@
     "@types/gulp-replace": "^1.1.0",
     "@types/jest": "^29.5.12",
     "@types/js-yaml": "^4.0.6",
-    "@types/nanoid": "^3.0.0",
     "@types/node": "20.16.*",
     "@types/proper-lockfile": "^4.1.4",
     "@types/react": "^18.3.1",


### PR DESCRIPTION
See [`@types/nanoid`](https://www.npmjs.com/package/@types/nanoid): "nanoid provides its own type definitions, so you do not need this installed."