### PR TITLE
Upgrade @faker-js/faker to v9

### DIFF
--- a/extensions/ql-vscode/package-lock.json
+++ b/extensions/ql-vscode/package-lock.json
@@ -51,7 +51,7 @@
         "@babel/preset-env": "^7.24.4",
         "@babel/preset-react": "^7.24.1",
         "@babel/preset-typescript": "^7.21.4",
-        "@faker-js/faker": "^8.4.1",
+        "@faker-js/faker": "^9.0.3",
         "@github/markdownlint-github": "^0.6.2",
         "@microsoft/eslint-formatter-sarif": "^3.1.0",
         "@playwright/test": "^1.40.1",
@@ -2748,9 +2748,9 @@
       }
     },
     "node_modules/@faker-js/faker": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.4.1.tgz",
-      "integrity": "sha512-XQ3cU+Q8Uqmrbf2e0cIC/QN43sTBSC8KF12u29Mb47tWrt2hAgBXSgpZMj4Ao8Uk0iJcU99QsOCaIL8934obCg==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.0.3.tgz",
+      "integrity": "sha512-lWrrK4QNlFSU+13PL9jMbMKLJYXDFu3tQfayBsMXX7KL/GiQeqfB1CzHkqD5UHBUtPAuPo6XwGbMFNdVMZObRA==",
       "dev": true,
       "funding": [
         {
@@ -2758,9 +2758,10 @@
           "url": "https://opencollective.com/fakerjs"
         }
       ],
+      "license": "MIT",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
-        "npm": ">=6.14.13"
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
       }
     },
     "node_modules/@floating-ui/core": {

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -2009,7 +2009,7 @@
     "@babel/preset-env": "^7.24.4",
     "@babel/preset-react": "^7.24.1",
     "@babel/preset-typescript": "^7.21.4",
-    "@faker-js/faker": "^8.4.1",
+    "@faker-js/faker": "^9.0.3",
     "@github/markdownlint-github": "^0.6.2",
     "@microsoft/eslint-formatter-sarif": "^3.1.0",
     "@playwright/test": "^1.40.1",


### PR DESCRIPTION
This just upgrades Faker to v9 since this version was released more than a month ago and we haven't received a Dependabot update for it. [The upgrade guide](https://fakerjs.dev/guide/upgrading.html) doesn't seem to contain anything that is relevant for us, so it's a simple bump of the dependency.