### PR TITLE
Allow import all database subfolders by selecting a folder

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [UNRELEASED]
 
-- Add a palette command that allow user to select a folder and import all database subfolders.
+- Add a palette command that allows importing of all databases inside of a parent folder. [3797](https://github.com/github/vscode-codeql/pull/3797)
 
 ## 1.16.1 - 6 November 2024
 

--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [UNRELEASED]
 
-- Add a palette command that allows importing of all databases inside of a parent folder. [3797](https://github.com/github/vscode-codeql/pull/3797)
+- Add a palette command that allows importing all databases directly inside of a parent folder. [3797](https://github.com/github/vscode-codeql/pull/3797)
 
 ## 1.16.1 - 6 November 2024
 

--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [UNRELEASED]
 
+- Add a palette command that allow user to select a folder and import all database subfolders.
+
 ## 1.16.1 - 6 November 2024
 
 - Support result columns of type `QlBuiltins::BigInt` in quick evaluations. [#3647](https://github.com/github/vscode-codeql/pull/3647)

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -841,7 +841,7 @@
       },
       {
         "command": "codeQL.chooseDatabaseFoldersParent",
-        "title": "CodeQL: Choose Parent Folder and import all databases directly contained in it"
+        "title": "CodeQL: Import All Databases Directly Contained in a Parent Folder"
       },
       {
         "command": "codeQL.chooseDatabaseArchive",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -841,7 +841,7 @@
       },
       {
         "command": "codeQL.chooseDatabaseFoldersParent",
-        "title": "CodeQL: Choose Folder to import all databases contained in it"
+        "title": "CodeQL: Choose Parent Folder and import all databases directly contained in it"
       },
       {
         "command": "codeQL.chooseDatabaseArchive",

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -840,7 +840,7 @@
         "title": "CodeQL: Choose Database from Folder"
       },
       {
-        "command": "codeQL.chooseMultipleDatabaseFolder",
+        "command": "codeQL.chooseDatabaseFoldersParent",
         "title": "CodeQL: Choose Folder to import all databases contained in it"
       },
       {

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -840,6 +840,10 @@
         "title": "CodeQL: Choose Database from Folder"
       },
       {
+        "command": "codeQL.chooseMultipleDatabaseFolder",
+        "title": "CodeQL: Choose Folder contains all Database Folders to import"
+      },
+      {
         "command": "codeQL.chooseDatabaseArchive",
         "title": "CodeQL: Choose Database from Archive"
       },

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -841,7 +841,7 @@
       },
       {
         "command": "codeQL.chooseMultipleDatabaseFolder",
-        "title": "CodeQL: Choose Folder contains all Database Folders to import"
+        "title": "CodeQL: Choose Folder to import all databases contained in it"
       },
       {
         "command": "codeQL.chooseDatabaseArchive",

--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -211,6 +211,7 @@ export type LanguageSelectionCommands = {
 export type LocalDatabasesCommands = {
   // Command palette commands
   "codeQL.chooseDatabaseFolder": () => Promise<void>;
+  "codeQL.chooseMultipleDatabaseFolder": () => Promise<void>;
   "codeQL.chooseDatabaseArchive": () => Promise<void>;
   "codeQL.chooseDatabaseInternet": () => Promise<void>;
   "codeQL.chooseDatabaseGithub": () => Promise<void>;

--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -211,7 +211,7 @@ export type LanguageSelectionCommands = {
 export type LocalDatabasesCommands = {
   // Command palette commands
   "codeQL.chooseDatabaseFolder": () => Promise<void>;
-  "codeQL.chooseMultipleDatabaseFolder": () => Promise<void>;
+  "codeQL.chooseDatabaseFoldersParent": () => Promise<void>;
   "codeQL.chooseDatabaseArchive": () => Promise<void>;
   "codeQL.chooseDatabaseInternet": () => Promise<void>;
   "codeQL.chooseDatabaseGithub": () => Promise<void>;

--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -1016,6 +1016,7 @@ export class DatabaseUI extends DisposableObject {
     const databases: DatabaseItem[] = [];
     const failures: string[] = [];
     const entries = await workspace.fs.readDirectory(uri);
+
     for (const [index, entry] of entries.entries()) {
       progress({
         step: index + 1,
@@ -1040,8 +1041,14 @@ export class DatabaseUI extends DisposableObject {
       void showAndLogErrorMessage(
         this.app.logger,
         `Failed to import ${failures.length} database(s), successfully imported ${databases.length} database(s).`,
-        { fullMessage: `Failed imports: \n${failures.join("\n")}` },
+        { fullMessage: `Failed folders to import:\n${failures.join("\n")}` },
       );
+    } else if (databases.length === 0) {
+      void showAndLogErrorMessage(
+        this.app.logger,
+        `No database folder to import.`,
+      );
+      return undefined;
     } else {
       void showAndLogInformationMessage(
         this.app.logger,

--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -269,8 +269,8 @@ export class DatabaseUI extends DisposableObject {
       "codeQL.getCurrentDatabase": this.handleGetCurrentDatabase.bind(this),
       "codeQL.chooseDatabaseFolder":
         this.handleChooseDatabaseFolderFromPalette.bind(this),
-      "codeQL.chooseMultipleDatabaseFolder":
-        this.handleChooseMultipleDatabaseFolderFromPalette.bind(this),
+      "codeQL.chooseDatabaseFoldersParent":
+        this.handleChooseDatabaseFoldersParentFromPalette.bind(this),
       "codeQL.chooseDatabaseArchive":
         this.handleChooseDatabaseArchiveFromPalette.bind(this),
       "codeQL.chooseDatabaseInternet":
@@ -363,7 +363,7 @@ export class DatabaseUI extends DisposableObject {
     );
   }
 
-  private async handleChooseMultipleDatabaseFolderFromPalette(): Promise<void> {
+  private async handleChooseDatabaseFoldersParentFromPalette(): Promise<void> {
     return withProgress(
       async (progress) => {
         await this.chooseDatabasesParentFolder(progress);

--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -1041,7 +1041,7 @@ export class DatabaseUI extends DisposableObject {
       void showAndLogErrorMessage(
         this.app.logger,
         `Failed to import ${failures.length} database(s), successfully imported ${databases.length} database(s).`,
-        { fullMessage: `Failed folders to import:\n${failures.join("\n")}` },
+        { fullMessage: `Failed to import ${failures.length} database(s), successfully imported ${databases.length} database(s). Failed folders to import:\n  ${failures.join("\n  ")}` },
       );
     } else if (databases.length === 0) {
       void showAndLogErrorMessage(

--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -1034,14 +1034,14 @@ export class DatabaseUI extends DisposableObject {
       progress({
         step: index + 1,
         maxStep: entries.length,
-        message: `Importing ${entry[0]}`,
+        message: `Importing '${entry[0]}'`,
       });
 
       const subProgress: ProgressCallback = (p) => {
         progress({
           step: index + 1,
           maxStep: entries.length,
-          message: `Importing '${entry[0]}' (${p.step}/${p.maxStep}): ${p.message}`,
+          message: `Importing '${entry[0]}': (${p.step}/${p.maxStep}) ${p.message}`,
         });
       };
 

--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -364,14 +364,9 @@ export class DatabaseUI extends DisposableObject {
   }
 
   private async handleChooseDatabaseFoldersParentFromPalette(): Promise<void> {
-    return withProgress(
-      async (progress) => {
-        await this.chooseDatabasesParentFolder(progress);
-      },
-      {
-        title: "Importing all databases contained in parent folder",
-      },
-    );
+    return withProgress(async (progress) => {
+      await this.chooseDatabasesParentFolder(progress);
+    });
   }
 
   private async handleSetDefaultTourDatabase(): Promise<void> {

--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -369,7 +369,7 @@ export class DatabaseUI extends DisposableObject {
         await this.chooseDatabasesParentFolder(progress);
       },
       {
-        title: "Choose a Folder contains all Database Folders",
+        title: "Choose a Parent Folder contains all Databases to import",
       },
     );
   }
@@ -1076,7 +1076,7 @@ export class DatabaseUI extends DisposableObject {
         this.app.logger,
         `Failed to import ${failures.length} database(s), successfully imported ${databases.length} database(s).`,
         {
-          fullMessage: `Failed to import ${failures.length} database(s), successfully imported ${databases.length} database(s). Failed folders to import:\n  - ${failures.join("\n  - ")}`,
+          fullMessage: `Failed to import ${failures.length} database(s), successfully imported ${databases.length} database(s).\nFailed databases to import:\n  - ${failures.join("\n  - ")}`,
         },
       );
     } else if (databases.length === 0) {

--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -978,7 +978,7 @@ export class DatabaseUI extends DisposableObject {
   private async chooseAndSetDatabase(
     byFolder: boolean,
     progress: ProgressCallback,
-  ): Promise<DatabaseItem[] | DatabaseItem | undefined> {
+  ): Promise<DatabaseItem | undefined> {
     const uri = await chooseDatabaseDir(byFolder);
     if (!uri) {
       return undefined;

--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -1067,7 +1067,7 @@ export class DatabaseUI extends DisposableObject {
           failures.push(entry[0]);
         }
       } catch (e) {
-        failures.push(`${entry[0]}: ${toErrorMessag(e)}`);
+        failures.push(`${entry[0]}: ${getErrorMessage(e)}`);
       }
     }
 

--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -369,7 +369,7 @@ export class DatabaseUI extends DisposableObject {
         await this.chooseDatabasesParentFolder(progress);
       },
       {
-        title: "Choose a Parent Folder contains all Databases to import",
+        title: "Importing all databases contained in parent folder",
       },
     );
   }
@@ -973,7 +973,7 @@ export class DatabaseUI extends DisposableObject {
 
   /**
    * Import database from uri. Returns the imported database, or `undefined` if the
-   * operation was unsuccessful.
+   * operation was unsuccessful or canceled.
    */
   private async importDatabase(
     uri: Uri,
@@ -1041,13 +1041,13 @@ export class DatabaseUI extends DisposableObject {
         progress({
           step: index + 1,
           maxStep: entries.length,
-          message: `Importing ${entry[0]} (${p.step}/${p.maxStep}): ${p.message}`,
+          message: `Importing '${entry[0]}' (${p.step}/${p.maxStep}): ${p.message}`,
         });
       };
 
       if (!validFileTypes.includes(entry[1])) {
         void this.app.logger.log(
-          `Skip import ${entry}, invalid FileType: ${entry[1]}`,
+          `Skipping import for '${entry}', invalid file type: ${entry[1]}`,
         );
         continue;
       }
@@ -1066,8 +1066,8 @@ export class DatabaseUI extends DisposableObject {
         } else {
           failures.push(entry[0]);
         }
-      } catch {
-        failures.push(entry[0]);
+      } catch (e) {
+        failures.push(`${entry[0]}: ${toErrorMessag(e)}`);
       }
     }
 
@@ -1076,7 +1076,7 @@ export class DatabaseUI extends DisposableObject {
         this.app.logger,
         `Failed to import ${failures.length} database(s), successfully imported ${databases.length} database(s).`,
         {
-          fullMessage: `Failed to import ${failures.length} database(s), successfully imported ${databases.length} database(s).\nFailed databases to import:\n  - ${failures.join("\n  - ")}`,
+          fullMessage: `Failed to import ${failures.length} database(s), successfully imported ${databases.length} database(s).\nFailed databases:\n  - ${failures.join("\n  - ")}`,
         },
       );
     } else if (databases.length === 0) {

--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -1067,7 +1067,7 @@ export class DatabaseUI extends DisposableObject {
           failures.push(entry[0]);
         }
       } catch (e) {
-        failures.push(`${entry[0]}: ${getErrorMessage(e)}`);
+        failures.push(`${entry[0]}: ${getErrorMessage(e)}`.trim());
       }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

Add a palette command that allow user to select a folder and import all database subfolders.

This helps a lot when dealing with micro services that has dozens of databases and save user's time from repeatly choosing folders one by one.

![image](https://github.com/user-attachments/assets/615ee130-07de-4ef5-a6f3-9d7a346ede6a)
