### PR TITLE
Fix and re-enable variant analysis submission integration tests

### DIFF
--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -348,7 +348,9 @@ export type MockGitHubApiServerCommands = {
   "codeQL.mockGitHubApiServer.startRecording": () => Promise<void>;
   "codeQL.mockGitHubApiServer.saveScenario": () => Promise<void>;
   "codeQL.mockGitHubApiServer.cancelRecording": () => Promise<void>;
-  "codeQL.mockGitHubApiServer.loadScenario": () => Promise<void>;
+  "codeQL.mockGitHubApiServer.loadScenario": (
+    scenario?: string,
+  ) => Promise<void>;
   "codeQL.mockGitHubApiServer.unloadScenario": () => Promise<void>;
 };
 


### PR DESCRIPTION
This fixes the variant analysis submission integration tests by using the mock GitHub API server included in the extension to avoid issues with overriding the `fetch` function from outside of the extension code.