### PR TITLE
Refactor: Store EvaluatorLogPaths object on LocalQueryInfo

### DIFF
--- a/extensions/ql-vscode/src/log-insights/log-scanner-service.ts
+++ b/extensions/ql-vscode/src/log-insights/log-scanner-service.ts
@@ -94,19 +94,19 @@ export class LogScannerService extends DisposableObject {
   public async scanEvalLog(query: QueryHistoryInfo | undefined): Promise<void> {
     this.diagnosticCollection.clear();
 
-    if (
-      query?.t !== "local" ||
-      query.evalLogSummaryLocation === undefined ||
-      query.jsonEvalLogSummaryLocation === undefined
-    ) {
+    if (query?.t !== "local" || query.evalutorLogPaths === undefined) {
       return;
     }
 
-    const diagnostics = await this.scanLog(
-      query.jsonEvalLogSummaryLocation,
-      query.evalLogSummarySymbolsLocation,
-    );
-    const uri = Uri.file(query.evalLogSummaryLocation);
+    const { summarySymbols, jsonSummary, humanReadableSummary } =
+      query.evalutorLogPaths;
+
+    if (jsonSummary === undefined || humanReadableSummary === undefined) {
+      return;
+    }
+
+    const diagnostics = await this.scanLog(jsonSummary, summarySymbols);
+    const uri = Uri.file(humanReadableSummary);
     this.diagnosticCollection.set(uri, diagnostics);
   }
 

--- a/extensions/ql-vscode/src/log-insights/log-scanner-service.ts
+++ b/extensions/ql-vscode/src/log-insights/log-scanner-service.ts
@@ -94,12 +94,12 @@ export class LogScannerService extends DisposableObject {
   public async scanEvalLog(query: QueryHistoryInfo | undefined): Promise<void> {
     this.diagnosticCollection.clear();
 
-    if (query?.t !== "local" || query.evalutorLogPaths === undefined) {
+    if (query?.t !== "local" || query.evaluatorLogPaths === undefined) {
       return;
     }
 
     const { summarySymbols, jsonSummary, humanReadableSummary } =
-      query.evalutorLogPaths;
+      query.evaluatorLogPaths;
 
     if (jsonSummary === undefined || humanReadableSummary === undefined) {
       return;

--- a/extensions/ql-vscode/src/query-history/query-history-manager.ts
+++ b/extensions/ql-vscode/src/query-history/query-history-manager.ts
@@ -781,7 +781,7 @@ export class QueryHistoryManager extends DisposableObject {
 
   private async warnNoEvalLogSummary(item: LocalQueryInfo) {
     const evalLogLocation =
-      item.evalLogLocation ?? item.initialInfo.outputDir?.evalLogPath;
+      item.evalutorLogPaths?.log ?? item.initialInfo.outputDir?.evalLogPath;
 
     // Summary log file doesn't exist.
     if (evalLogLocation && (await pathExists(evalLogLocation))) {
@@ -801,7 +801,7 @@ export class QueryHistoryManager extends DisposableObject {
     }
 
     const evalLogLocation =
-      item.evalLogLocation ?? item.initialInfo.outputDir?.evalLogPath;
+      item.evalutorLogPaths?.log ?? item.initialInfo.outputDir?.evalLogPath;
 
     if (evalLogLocation && (await pathExists(evalLogLocation))) {
       await tryOpenExternalFile(this.app.commands, evalLogLocation);
@@ -816,12 +816,15 @@ export class QueryHistoryManager extends DisposableObject {
     }
 
     // If the summary file location wasn't saved, display error
-    if (!item.evalLogSummaryLocation) {
+    if (!item.evalutorLogPaths?.humanReadableSummary) {
       await this.warnNoEvalLogSummary(item);
       return;
     }
 
-    await tryOpenExternalFile(this.app.commands, item.evalLogSummaryLocation);
+    await tryOpenExternalFile(
+      this.app.commands,
+      item.evalutorLogPaths.humanReadableSummary,
+    );
   }
 
   async handleShowEvalLogViewer(item: QueryHistoryInfo) {
@@ -830,7 +833,7 @@ export class QueryHistoryManager extends DisposableObject {
     }
 
     // If the JSON summary file location wasn't saved, display error
-    if (item.jsonEvalLogSummaryLocation === undefined) {
+    if (item.evalutorLogPaths?.jsonSummary === undefined) {
       await this.warnNoEvalLogSummary(item);
       return;
     }
@@ -838,7 +841,7 @@ export class QueryHistoryManager extends DisposableObject {
     // TODO(angelapwen): Stream the file in.
     try {
       const evalLogData: EvalLogData[] = await parseViewerData(
-        item.jsonEvalLogSummaryLocation,
+        item.evalutorLogPaths.jsonSummary,
       );
       const evalLogTreeBuilder = new EvalLogTreeBuilder(
         item.getQueryName(),
@@ -847,7 +850,7 @@ export class QueryHistoryManager extends DisposableObject {
       this.evalLogViewer.updateRoots(await evalLogTreeBuilder.getRoots());
     } catch {
       throw new Error(
-        `Could not read evaluator log summary JSON file to generate viewer data at ${item.jsonEvalLogSummaryLocation}.`,
+        `Could not read evaluator log summary JSON file to generate viewer data at ${item.evalutorLogPaths.jsonSummary}.`,
       );
     }
   }

--- a/extensions/ql-vscode/src/query-history/query-history-manager.ts
+++ b/extensions/ql-vscode/src/query-history/query-history-manager.ts
@@ -781,7 +781,7 @@ export class QueryHistoryManager extends DisposableObject {
 
   private async warnNoEvalLogSummary(item: LocalQueryInfo) {
     const evalLogLocation =
-      item.evalutorLogPaths?.log ?? item.initialInfo.outputDir?.evalLogPath;
+      item.evaluatorLogPaths?.log ?? item.initialInfo.outputDir?.evalLogPath;
 
     // Summary log file doesn't exist.
     if (evalLogLocation && (await pathExists(evalLogLocation))) {
@@ -801,7 +801,7 @@ export class QueryHistoryManager extends DisposableObject {
     }
 
     const evalLogLocation =
-      item.evalutorLogPaths?.log ?? item.initialInfo.outputDir?.evalLogPath;
+      item.evaluatorLogPaths?.log ?? item.initialInfo.outputDir?.evalLogPath;
 
     if (evalLogLocation && (await pathExists(evalLogLocation))) {
       await tryOpenExternalFile(this.app.commands, evalLogLocation);
@@ -816,14 +816,14 @@ export class QueryHistoryManager extends DisposableObject {
     }
 
     // If the summary file location wasn't saved, display error
-    if (!item.evalutorLogPaths?.humanReadableSummary) {
+    if (!item.evaluatorLogPaths?.humanReadableSummary) {
       await this.warnNoEvalLogSummary(item);
       return;
     }
 
     await tryOpenExternalFile(
       this.app.commands,
-      item.evalutorLogPaths.humanReadableSummary,
+      item.evaluatorLogPaths.humanReadableSummary,
     );
   }
 
@@ -833,7 +833,7 @@ export class QueryHistoryManager extends DisposableObject {
     }
 
     // If the JSON summary file location wasn't saved, display error
-    if (item.evalutorLogPaths?.jsonSummary === undefined) {
+    if (item.evaluatorLogPaths?.jsonSummary === undefined) {
       await this.warnNoEvalLogSummary(item);
       return;
     }
@@ -841,7 +841,7 @@ export class QueryHistoryManager extends DisposableObject {
     // TODO(angelapwen): Stream the file in.
     try {
       const evalLogData: EvalLogData[] = await parseViewerData(
-        item.evalutorLogPaths.jsonSummary,
+        item.evaluatorLogPaths.jsonSummary,
       );
       const evalLogTreeBuilder = new EvalLogTreeBuilder(
         item.getQueryName(),
@@ -850,7 +850,7 @@ export class QueryHistoryManager extends DisposableObject {
       this.evalLogViewer.updateRoots(await evalLogTreeBuilder.getRoots());
     } catch {
       throw new Error(
-        `Could not read evaluator log summary JSON file to generate viewer data at ${item.evalutorLogPaths.jsonSummary}.`,
+        `Could not read evaluator log summary JSON file to generate viewer data at ${item.evaluatorLogPaths.jsonSummary}.`,
       );
     }
   }

--- a/extensions/ql-vscode/src/query-history/store/query-history-local-query-domain-mapper.ts
+++ b/extensions/ql-vscode/src/query-history/store/query-history-local-query-domain-mapper.ts
@@ -25,10 +25,10 @@ export function mapLocalQueryInfoToDto(
   return {
     initialInfo: mapInitialQueryInfoToDto(query.initialInfo),
     t: "local",
-    evalLogLocation: query.evalLogLocation,
-    evalLogSummaryLocation: query.evalLogSummaryLocation,
-    jsonEvalLogSummaryLocation: query.jsonEvalLogSummaryLocation,
-    evalLogSummarySymbolsLocation: query.evalLogSummarySymbolsLocation,
+    evalLogLocation: query.evalutorLogPaths?.log,
+    evalLogSummaryLocation: query.evalutorLogPaths?.humanReadableSummary,
+    jsonEvalLogSummaryLocation: query.evalutorLogPaths?.jsonSummary,
+    evalLogSummarySymbolsLocation: query.evalutorLogPaths?.summarySymbols,
     failureReason: query.failureReason,
     completedQuery:
       query.completedQuery && mapCompletedQueryToDto(query.completedQuery),

--- a/extensions/ql-vscode/src/query-history/store/query-history-local-query-domain-mapper.ts
+++ b/extensions/ql-vscode/src/query-history/store/query-history-local-query-domain-mapper.ts
@@ -25,10 +25,10 @@ export function mapLocalQueryInfoToDto(
   return {
     initialInfo: mapInitialQueryInfoToDto(query.initialInfo),
     t: "local",
-    evalLogLocation: query.evalutorLogPaths?.log,
-    evalLogSummaryLocation: query.evalutorLogPaths?.humanReadableSummary,
-    jsonEvalLogSummaryLocation: query.evalutorLogPaths?.jsonSummary,
-    evalLogSummarySymbolsLocation: query.evalutorLogPaths?.summarySymbols,
+    evalLogLocation: query.evaluatorLogPaths?.log,
+    evalLogSummaryLocation: query.evaluatorLogPaths?.humanReadableSummary,
+    jsonEvalLogSummaryLocation: query.evaluatorLogPaths?.jsonSummary,
+    evalLogSummarySymbolsLocation: query.evaluatorLogPaths?.summarySymbols,
     failureReason: query.failureReason,
     completedQuery:
       query.completedQuery && mapCompletedQueryToDto(query.completedQuery),

--- a/extensions/ql-vscode/src/query-history/store/query-history-local-query-dto-mapper.ts
+++ b/extensions/ql-vscode/src/query-history/store/query-history-local-query-dto-mapper.ts
@@ -32,13 +32,15 @@ export function mapLocalQueryItemToDomainModel(
     localQuery.failureReason,
     localQuery.completedQuery &&
       mapCompletedQueryInfoToDomainModel(localQuery.completedQuery),
-    {
-      log: localQuery.evalLogLocation,
-      humanReadableSummary: localQuery.evalLogSummaryLocation,
-      jsonSummary: localQuery.jsonEvalLogSummaryLocation,
-      summarySymbols: localQuery.evalLogSummarySymbolsLocation,
-      endSummary: undefined,
-    },
+    localQuery.evalLogLocation
+      ? {
+          log: localQuery.evalLogLocation,
+          humanReadableSummary: localQuery.evalLogSummaryLocation,
+          jsonSummary: localQuery.jsonEvalLogSummaryLocation,
+          summarySymbols: localQuery.evalLogSummarySymbolsLocation,
+          endSummary: undefined,
+        }
+      : undefined,
   );
 }
 

--- a/extensions/ql-vscode/src/query-history/store/query-history-local-query-dto-mapper.ts
+++ b/extensions/ql-vscode/src/query-history/store/query-history-local-query-dto-mapper.ts
@@ -32,10 +32,13 @@ export function mapLocalQueryItemToDomainModel(
     localQuery.failureReason,
     localQuery.completedQuery &&
       mapCompletedQueryInfoToDomainModel(localQuery.completedQuery),
-    localQuery.evalLogLocation,
-    localQuery.evalLogSummaryLocation,
-    localQuery.jsonEvalLogSummaryLocation,
-    localQuery.evalLogSummarySymbolsLocation,
+    {
+      log: localQuery.evalLogLocation,
+      humanReadableSummary: localQuery.evalLogSummaryLocation,
+      jsonSummary: localQuery.jsonEvalLogSummaryLocation,
+      summarySymbols: localQuery.evalLogSummarySymbolsLocation,
+      endSummary: undefined,
+    },
   );
 }
 

--- a/extensions/ql-vscode/src/query-results.ts
+++ b/extensions/ql-vscode/src/query-results.ts
@@ -200,10 +200,7 @@ export class LocalQueryInfo {
     private cancellationSource?: CancellationTokenSource, // used to cancel in progress queries
     public failureReason?: string,
     public completedQuery?: CompletedQueryInfo,
-    public evalLogLocation?: string,
-    public evalLogSummaryLocation?: string,
-    public jsonEvalLogSummaryLocation?: string,
-    public evalLogSummarySymbolsLocation?: string,
+    public evalutorLogPaths?: EvaluatorLogPaths,
   ) {
     /**/
   }
@@ -229,10 +226,7 @@ export class LocalQueryInfo {
 
   /** Sets the paths to the various structured evaluator logs. */
   public setEvaluatorLogPaths(logPaths: EvaluatorLogPaths): void {
-    this.evalLogLocation = logPaths.log;
-    this.evalLogSummaryLocation = logPaths.humanReadableSummary;
-    this.jsonEvalLogSummaryLocation = logPaths.jsonSummary;
-    this.evalLogSummarySymbolsLocation = logPaths.summarySymbols;
+    this.evalutorLogPaths = logPaths;
   }
 
   /**

--- a/extensions/ql-vscode/src/query-results.ts
+++ b/extensions/ql-vscode/src/query-results.ts
@@ -200,7 +200,7 @@ export class LocalQueryInfo {
     private cancellationSource?: CancellationTokenSource, // used to cancel in progress queries
     public failureReason?: string,
     public completedQuery?: CompletedQueryInfo,
-    public evalutorLogPaths?: EvaluatorLogPaths,
+    public evaluatorLogPaths?: EvaluatorLogPaths,
   ) {
     /**/
   }
@@ -226,7 +226,7 @@ export class LocalQueryInfo {
 
   /** Sets the paths to the various structured evaluator logs. */
   public setEvaluatorLogPaths(logPaths: EvaluatorLogPaths): void {
-    this.evalutorLogPaths = logPaths;
+    this.evaluatorLogPaths = logPaths;
   }
 
   /**

--- a/extensions/ql-vscode/src/query-results.ts
+++ b/extensions/ql-vscode/src/query-results.ts
@@ -200,7 +200,13 @@ export class LocalQueryInfo {
     private cancellationSource?: CancellationTokenSource, // used to cancel in progress queries
     public failureReason?: string,
     public completedQuery?: CompletedQueryInfo,
-    public evalutorLogPaths?: EvaluatorLogPaths,
+    public evalutorLogPaths: EvaluatorLogPaths = {
+      log: undefined,
+      humanReadableSummary: undefined,
+      endSummary: undefined,
+      jsonSummary: undefined,
+      summarySymbols: undefined,
+    },
   ) {
     /**/
   }

--- a/extensions/ql-vscode/src/query-results.ts
+++ b/extensions/ql-vscode/src/query-results.ts
@@ -200,13 +200,7 @@ export class LocalQueryInfo {
     private cancellationSource?: CancellationTokenSource, // used to cancel in progress queries
     public failureReason?: string,
     public completedQuery?: CompletedQueryInfo,
-    public evalutorLogPaths: EvaluatorLogPaths = {
-      log: undefined,
-      humanReadableSummary: undefined,
-      endSummary: undefined,
-      jsonSummary: undefined,
-      summarySymbols: undefined,
-    },
+    public evalutorLogPaths?: EvaluatorLogPaths,
   ) {
     /**/
   }

--- a/extensions/ql-vscode/src/run-queries-shared.ts
+++ b/extensions/ql-vscode/src/run-queries-shared.ts
@@ -45,7 +45,7 @@ import type { ProgressCallback } from "./common/vscode/progress";
  * Holds the paths to the various structured log summary files generated for a query evaluation.
  */
 export interface EvaluatorLogPaths {
-  log: string;
+  log: string | undefined;
   humanReadableSummary: string | undefined;
   endSummary: string | undefined;
   jsonSummary: string | undefined;

--- a/extensions/ql-vscode/src/run-queries-shared.ts
+++ b/extensions/ql-vscode/src/run-queries-shared.ts
@@ -45,7 +45,7 @@ import type { ProgressCallback } from "./common/vscode/progress";
  * Holds the paths to the various structured log summary files generated for a query evaluation.
  */
 export interface EvaluatorLogPaths {
-  log: string | undefined;
+  log: string;
   humanReadableSummary: string | undefined;
   endSummary: string | undefined;
   jsonSummary: string | undefined;


### PR DESCRIPTION
Previously the fields from `EvaluatorLogPaths` were copied 1:1 into `LocalQueryInfo` but under different names. It seems easier to keep track of the different kinds of logs if they are called the same everywhere.
