### PR TITLE
compare-perf: Add positive/negative 

### DIFF
--- a/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
+++ b/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
@@ -92,10 +92,12 @@ function renderAbsoluteValue(x: OptionalValue) {
 
 function renderDelta(x: number) {
   const sign = x > 0 ? "+" : "";
+  const symbol = x > 0 ? "🔺" : "🟢";
   return (
     <NumberCell>
       {sign}
       {formatDecimal(x)}
+      {symbol}
     </NumberCell>
   );
 }


### PR DESCRIPTION
Sadly there is no Unicode symbol for "green triangle down".

Here's what it looks like in action:
![image](https://github.com/user-attachments/assets/6e0c5e5e-1379-4872-a2c4-819bae27abe8)
