### PR TITLE
Hackathon: description on top of performance table

### DIFF
--- a/extensions/ql-vscode/src/common/dca.ts
+++ b/extensions/ql-vscode/src/common/dca.ts
@@ -1,0 +1,42 @@
+type VariantId = string;
+type SourceId = string;
+type TargetId = string;
+
+type TargetInfo = {
+  target_id: TargetId;
+  variant_id: VariantId;
+  source_id: SourceId;
+};
+
+type SourceInfo = {
+  source_id: SourceId;
+  repository: string;
+  sha: string;
+};
+
+export type ArtifactDownload = {
+  repository: string;
+  run_id: number;
+  artifact_name: string;
+};
+
+type TargetDownloads = {
+  "evaluator-logs": ArtifactDownload;
+};
+
+export type MinimalDownloadsType = {
+  sources: {
+    [source: SourceId]: { info: SourceInfo };
+  };
+  targets: {
+    [target: string]: {
+      info: TargetInfo;
+      downloads: TargetDownloads;
+    };
+  };
+};
+
+export const dcaControllerRepository = {
+  owner: "github",
+  repo: "codeql-dca-main",
+};

--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -27,7 +27,10 @@ import type {
 } from "./raw-result-types";
 import type { AccessPathSuggestionOptions } from "../model-editor/suggestions";
 import type { ModelEvaluationRunState } from "../model-editor/shared/model-evaluation-run-state";
-import type { PerformanceComparisonDataFromLog } from "../log-insights/performance-comparison";
+import type {
+  ComparePerformanceDescriptionData,
+  PerformanceComparisonDataFromLog,
+} from "../log-insights/performance-comparison";
 
 /**
  * This module contains types and code that are shared between
@@ -398,9 +401,9 @@ export interface SetComparisonsMessage {
 }
 
 export type ToComparePerformanceViewMessage = SetPerformanceComparisonQueries;
-
 export interface SetPerformanceComparisonQueries {
   readonly t: "setPerformanceComparison";
+  readonly description: ComparePerformanceDescriptionData;
   readonly from: PerformanceComparisonDataFromLog;
   readonly to: PerformanceComparisonDataFromLog;
   readonly comparison: boolean;

--- a/extensions/ql-vscode/src/compare-performance/compare-performance-view.ts
+++ b/extensions/ql-vscode/src/compare-performance/compare-performance-view.ts
@@ -47,7 +47,7 @@ export class ComparePerformanceView extends AbstractWebview<
   }
 
   async showResults(
-    fromJsonLog: string,
+    fromJsonLog: string | undefined,
     toJsonLog: string,
     description: ComparePerformanceDescriptionData,
   ) {
@@ -74,10 +74,10 @@ export class ComparePerformanceView extends AbstractWebview<
     }
 
     const [fromPerf, toPerf] = await Promise.all([
-      fromJsonLog === ""
-        ? new PerformanceOverviewScanner()
-        : scanLogWithProgress(fromJsonLog, "1/2"),
-      scanLogWithProgress(toJsonLog, fromJsonLog === "" ? "1/1" : "2/2"),
+      fromJsonLog
+        ? scanLogWithProgress(fromJsonLog, "1/2")
+        : new PerformanceOverviewScanner(),
+      scanLogWithProgress(toJsonLog, fromJsonLog ? "2/2" : "1/1"),
     ]);
 
     // TODO: filter out irrelevant common predicates before transfer?
@@ -87,7 +87,7 @@ export class ComparePerformanceView extends AbstractWebview<
       description,
       from: fromPerf.getData(),
       to: toPerf.getData(),
-      comparison: fromJsonLog !== "",
+      comparison: !!fromJsonLog,
     });
   }
 

--- a/extensions/ql-vscode/src/compare-performance/compare-performance-view.ts
+++ b/extensions/ql-vscode/src/compare-performance/compare-performance-view.ts
@@ -17,6 +17,7 @@ import { withProgress } from "../common/vscode/progress";
 import { telemetryListener } from "../common/vscode/telemetry";
 import type { ResultsView } from "../local-queries";
 import { scanLog } from "../log-insights/log-scanner";
+import type { ComparePerformanceDescriptionData } from "../log-insights/performance-comparison";
 import { PerformanceOverviewScanner } from "../log-insights/performance-comparison";
 import type { HistoryItemLabelProvider } from "../query-history/history-item-label-provider";
 import { RemoteLogs } from "./remote-logs";
@@ -45,7 +46,11 @@ export class ComparePerformanceView extends AbstractWebview<
     );
   }
 
-  async showResults(fromJsonLog: string, toJsonLog: string) {
+  async showResults(
+    fromJsonLog: string,
+    toJsonLog: string,
+    description: ComparePerformanceDescriptionData,
+  ) {
     const panel = await this.getPanel();
     panel.reveal(undefined, false);
 
@@ -79,6 +84,7 @@ export class ComparePerformanceView extends AbstractWebview<
 
     await this.postMessage({
       t: "setPerformanceComparison",
+      description,
       from: fromPerf.getData(),
       to: toPerf.getData(),
       comparison: fromJsonLog !== "",
@@ -140,6 +146,6 @@ export class ComparePerformanceView extends AbstractWebview<
       );
       return;
     }
-    await this.showResults(result.before, result.after);
+    await this.showResults(result.before, result.after, result.description);
   }
 }

--- a/extensions/ql-vscode/src/compare-performance/remote-logs.ts
+++ b/extensions/ql-vscode/src/compare-performance/remote-logs.ts
@@ -14,6 +14,8 @@ import { basename, dirname, join, relative } from "path";
 import { Uri, window, workspace } from "vscode";
 import type { CodeQLCliServer } from "../codeql-cli/cli";
 import type { App } from "../common/app";
+import type { ArtifactDownload, MinimalDownloadsType } from "../common/dca";
+import { dcaControllerRepository } from "../common/dca";
 import { createTimeoutSignal } from "../common/fetch-stream";
 import { extLogger } from "../common/logging/vscode";
 import type { ProgressCallback } from "../common/vscode/progress";
@@ -22,39 +24,6 @@ import { downloadTimeout, GITHUB_URL } from "../config";
 import { QueryOutputDir } from "../local-queries/query-output-dir";
 import { tmpDir } from "../tmp-dir";
 
-type VariantId = string;
-type SourceId = string;
-type TargetId = string;
-
-type TargetInfo = {
-  target_id: TargetId;
-  variant_id: VariantId;
-  source_id: SourceId;
-};
-
-type ArtifactDownload = {
-  repository: string;
-  run_id: number;
-  artifact_name: string;
-};
-
-type TargetDownloads = {
-  "evaluator-logs": ArtifactDownload;
-};
-
-type MinimalDownloadsType = {
-  targets: {
-    [target: string]: {
-      info: TargetInfo;
-      downloads: TargetDownloads;
-    };
-  };
-};
-
-const dcaControllerRepository = {
-  owner: "github",
-  repo: "codeql-dca-main",
-};
 export class RemoteLogs {
   private LOG_DOWNLOAD_AND_PROCESS_PROGRESS_STEPS = 4;
   private PICK_TARGETS_PROGRESS_STEPS = 4;
@@ -502,7 +471,7 @@ export class RemoteLogs {
   }
 
   /**
-   * Gets the "downloads" metadata from a taksks directory.
+   * Gets the "downloads" metadata from a tasks directory.
    */
   private async getDownloadsFromTasks(
     tasksDir: string,

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -1228,7 +1228,11 @@ async function showPerformanceComparison(
     `Comparing performance of ${from.getQueryName()} and ${to?.getQueryName() ?? "baseline"}`,
   );
 
-  await view.showResults(fromLog, toLog);
+  await view.showResults(fromLog, toLog, {
+    kind: "local-run",
+    fromQuery: from.getQueryName(),
+    toQuery: to.getQueryName(),
+  });
 }
 
 function addUnhandledRejectionListener() {

--- a/extensions/ql-vscode/src/log-insights/performance-comparison.ts
+++ b/extensions/ql-vscode/src/log-insights/performance-comparison.ts
@@ -1,3 +1,4 @@
+import type { MinimalDownloadsType } from "../common/dca";
 import type { EvaluationLogScanner } from "./log-scanner";
 import type { SummaryEvent } from "./log-summary";
 
@@ -51,6 +52,19 @@ export interface PerformanceComparisonDataFromLog {
    */
   pipelineSummaryList: Array<Record<string, PipelineSummary>>;
 }
+
+export type ComparePerformanceDescriptionData =
+  | {
+      kind: "local-run";
+      fromQuery: string;
+      toQuery: string;
+    }
+  | {
+      kind: "remote-logs";
+      experimentName: string;
+      fromTarget: MinimalDownloadsType["targets"]["string"];
+      toTarget: MinimalDownloadsType["targets"]["string"];
+    };
 
 export class PerformanceOverviewScanner implements EvaluationLogScanner {
   private readonly nameToIndex = new Map<string, number>();

--- a/extensions/ql-vscode/src/log-insights/performance-comparison.ts
+++ b/extensions/ql-vscode/src/log-insights/performance-comparison.ts
@@ -56,7 +56,7 @@ export interface PerformanceComparisonDataFromLog {
 export type ComparePerformanceDescriptionData =
   | {
       kind: "local-run";
-      fromQuery: string;
+      fromQuery?: string;
       toQuery: string;
     }
   | {

--- a/extensions/ql-vscode/src/log-insights/performance-comparison.ts
+++ b/extensions/ql-vscode/src/log-insights/performance-comparison.ts
@@ -62,8 +62,9 @@ export type ComparePerformanceDescriptionData =
   | {
       kind: "remote-logs";
       experimentName: string;
-      fromTarget: MinimalDownloadsType["targets"]["string"];
-      toTarget: MinimalDownloadsType["targets"]["string"];
+      fromTarget: string;
+      toTarget: string;
+      info: MinimalDownloadsType;
     };
 
 export class PerformanceOverviewScanner implements EvaluationLogScanner {

--- a/extensions/ql-vscode/src/view/common/ComparePerformanceDescription.tsx
+++ b/extensions/ql-vscode/src/view/common/ComparePerformanceDescription.tsx
@@ -1,0 +1,13 @@
+import type { ComparePerformanceDescriptionData } from "../../log-insights/performance-comparison";
+import { ComparePerformanceLocalRunDescription } from "./ComparePerformanceLocalRunDescription";
+import { ComparePerformanceRemoteLogsDescription } from "./ComparePerformanceRemoteLogsDescription";
+
+type Props = ComparePerformanceDescriptionData;
+
+export const ComparePerformanceDescription = (props: Props) => {
+  return props.kind === "remote-logs" ? (
+    <ComparePerformanceRemoteLogsDescription {...props} />
+  ) : (
+    <ComparePerformanceLocalRunDescription {...props} />
+  );
+};

--- a/extensions/ql-vscode/src/view/common/ComparePerformanceLocalRunDescription.tsx
+++ b/extensions/ql-vscode/src/view/common/ComparePerformanceLocalRunDescription.tsx
@@ -10,9 +10,11 @@ export const ComparePerformanceLocalRunDescription = ({
 }: Props) => {
   return (
     <div>
+      (fromQuery?
       <strong>
         Comparison of local runs of {fromQuery} and {toQuery}
       </strong>
+      : Local run of {toQuery})
     </div>
   );
 };

--- a/extensions/ql-vscode/src/view/common/ComparePerformanceLocalRunDescription.tsx
+++ b/extensions/ql-vscode/src/view/common/ComparePerformanceLocalRunDescription.tsx
@@ -1,0 +1,18 @@
+import type { ComparePerformanceDescriptionData } from "../../log-insights/performance-comparison";
+
+type Props = ComparePerformanceDescriptionData & {
+  kind: "local-run";
+};
+
+export const ComparePerformanceLocalRunDescription = ({
+  fromQuery,
+  toQuery,
+}: Props) => {
+  return (
+    <div>
+      <strong>
+        Comparison of local runs of {fromQuery} and {toQuery}
+      </strong>
+    </div>
+  );
+};

--- a/extensions/ql-vscode/src/view/common/ComparePerformanceRemoteLogsDescription.tsx
+++ b/extensions/ql-vscode/src/view/common/ComparePerformanceRemoteLogsDescription.tsx
@@ -1,0 +1,91 @@
+import type { ComparePerformanceDescriptionData } from "../../log-insights/performance-comparison";
+
+// XXX same as in dca.ts, but importing that file here hangs esbuild?!
+const dcaControllerRepository = {
+  owner: "github",
+  repo: "codeql-dca-main",
+};
+// XXX same as in config.ts, but importing that file here hangs esbuild?!
+const GITHUB_URL = new URL("https://github.com");
+
+type Props = ComparePerformanceDescriptionData & {
+  kind: "remote-logs";
+};
+
+/**
+ * Gets the reports URL for an experiment.
+ */
+function getExperimentUrl(experimentName: string) {
+  return `${GITHUB_URL.toString()}${dcaControllerRepository.owner}/${dcaControllerRepository.repo}/tree/data/${experimentName}/reports`;
+}
+
+function getActionsRunUrl(run: { repository: string; run_id: number }) {
+  return `${GITHUB_URL.toString()}${run.repository}/actions/runs/${run.run_id}`;
+}
+
+const TargetRow = ({
+  kind,
+  target,
+}: {
+  kind: string;
+  target: Props["fromTarget"] | Props["toTarget"];
+}) => {
+  return (
+    // TODO make these rows richer
+    <tr>
+      <td>{kind}</td>
+      <td>{target.info.target_id}</td>
+      <td>{target.info.variant_id}</td>
+      <td>{target.info.source_id}</td>
+      <td>
+        <a href={getActionsRunUrl(target.downloads["evaluator-logs"])}>
+          {target.downloads["evaluator-logs"].run_id}
+        </a>
+      </td>
+    </tr>
+  );
+};
+const TargetTable = ({
+  fromTarget,
+  toTarget,
+}: {
+  fromTarget: Props["fromTarget"];
+  toTarget: Props["toTarget"];
+}) => {
+  // show a table of the targets and their details: fullTargetId, variantId, source repository, runId
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th>Kind</th>
+          <th>Target</th>
+          <th>Variant</th>
+          <th>Source</th>
+          <th>Run</th>
+        </tr>
+      </thead>
+      <tbody>
+        <TargetRow kind="from" target={fromTarget} />
+        <TargetRow kind="to" target={toTarget} />
+      </tbody>
+    </table>
+  );
+};
+
+export const ComparePerformanceRemoteLogsDescription = ({
+  experimentName,
+  fromTarget,
+  toTarget,
+}: Props) => {
+  return (
+    <div>
+      <p>
+        <strong>
+          Comparison for{" "}
+          <a href={getExperimentUrl(experimentName)}>{experimentName}</a>
+        </strong>
+      </p>
+      {TargetTable({ fromTarget, toTarget })}
+    </div>
+  );
+};

--- a/extensions/ql-vscode/src/view/common/InfoBox.tsx
+++ b/extensions/ql-vscode/src/view/common/InfoBox.tsx
@@ -1,0 +1,21 @@
+import { styled } from "styled-components";
+
+const InfoBoxDiv = styled.div`
+  max-width: 100em;
+  padding: 0.5em 1em;
+  border: 1px solid var(--vscode-widget-border);
+  box-shadow: var(--vscode-widget-shadow) 0px 3px 8px;
+  display: flex;
+`;
+
+interface InfoBoxProps {
+  children: React.ReactNode;
+}
+
+export function InfoBox(props: InfoBoxProps) {
+  return (
+    <InfoBoxDiv>
+      <p>{props.children}</p>
+    </InfoBoxDiv>
+  );
+}

--- a/extensions/ql-vscode/src/view/common/index.ts
+++ b/extensions/ql-vscode/src/view/common/index.ts
@@ -7,3 +7,5 @@ export * from "./SectionTitle";
 export * from "./VerticalSpace";
 export * from "./ViewTitle";
 export * from "./WarningBox";
+export * from "./InfoBox";
+export * from "./ComparePerformanceDescription";

--- a/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
+++ b/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
@@ -1,17 +1,23 @@
 import type { ChangeEvent } from "react";
-import { useMemo, useState, Fragment } from "react";
+import { Fragment, useMemo, useState } from "react";
+import { styled } from "styled-components";
 import type {
   SetPerformanceComparisonQueries,
   ToComparePerformanceViewMessage,
 } from "../../common/interface-types";
-import { useMessageFromExtension } from "../common/useMessageFromExtension";
+import { formatDecimal } from "../../common/number";
 import type {
   PerformanceComparisonDataFromLog,
   PipelineSummary,
 } from "../../log-insights/performance-comparison";
-import { formatDecimal } from "../../common/number";
-import { styled } from "styled-components";
-import { Codicon, ViewTitle, WarningBox } from "../common";
+import {
+  Codicon,
+  ComparePerformanceDescription,
+  InfoBox,
+  ViewTitle,
+  WarningBox,
+} from "../common";
+import { useMessageFromExtension } from "../common/useMessageFromExtension";
 import { abbreviateRANames, abbreviateRASteps } from "./RAPrettyPrinter";
 
 const enum AbsentReason {
@@ -443,6 +449,11 @@ function ComparePerformanceWithData(props: {
   return (
     <>
       <ViewTitle>Performance comparison</ViewTitle>
+      {data?.description && (
+        <InfoBox>
+          <ComparePerformanceDescription {...data.description} />
+        </InfoBox>
+      )}
       {hasCacheHitMismatch && (
         <WarningBox>
           <strong>Inconsistent cache hits</strong>


### PR DESCRIPTION
~Adds a generic InfoBox similar to the existing WarningBox.~
~Currently threads through a string as the description, but it should be trivial to change that to a ReactNode if needed...~
Adds a table to the top of the view when remote logs are used. 
Shows a simple string for local runs.

On top of https://github.com/github/vscode-codeql/pull/3817

<img width="879" alt="image" src="https://github.com/user-attachments/assets/3d31ecb0-b5f2-44bc-9268-6fc082128e53">
