### PR TITLE
compare-perf: Add support for selecting a single run as input

### DIFF
--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -403,6 +403,7 @@ export interface SetPerformanceComparisonQueries {
   readonly t: "setPerformanceComparison";
   readonly from: PerformanceComparisonDataFromLog;
   readonly to: PerformanceComparisonDataFromLog;
+  readonly comparison: boolean;
 }
 
 export type FromComparePerformanceViewMessage = CommonFromViewMessages;

--- a/extensions/ql-vscode/src/compare-performance/compare-performance-view.ts
+++ b/extensions/ql-vscode/src/compare-performance/compare-performance-view.ts
@@ -81,6 +81,7 @@ export class ComparePerformanceView extends AbstractWebview<
       t: "setPerformanceComparison",
       from: fromPerf.getData(),
       to: toPerf.getData(),
+      comparison: fromJsonLog !== "",
     });
   }
 

--- a/extensions/ql-vscode/src/compare-performance/compare-performance-view.ts
+++ b/extensions/ql-vscode/src/compare-performance/compare-performance-view.ts
@@ -69,8 +69,10 @@ export class ComparePerformanceView extends AbstractWebview<
     }
 
     const [fromPerf, toPerf] = await Promise.all([
-      scanLogWithProgress(fromJsonLog, "1/2"),
-      scanLogWithProgress(toJsonLog, "2/2"),
+      fromJsonLog === ""
+        ? new PerformanceOverviewScanner()
+        : scanLogWithProgress(fromJsonLog, "1/2"),
+      scanLogWithProgress(toJsonLog, fromJsonLog === "" ? "1/1" : "2/2"),
     ]);
 
     // TODO: filter out irrelevant common predicates before transfer?

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -927,7 +927,7 @@ async function activateWithInstalledDistribution(
     ): Promise<void> => showResultsForComparison(compareView, from, to),
     async (
       from: CompletedLocalQueryInfo,
-      to: CompletedLocalQueryInfo,
+      to: CompletedLocalQueryInfo | undefined,
     ): Promise<void> =>
       showPerformanceComparison(comparePerformanceView, from, to),
   );
@@ -1210,17 +1210,22 @@ async function showResultsForComparison(
 async function showPerformanceComparison(
   view: ComparePerformanceView,
   from: CompletedLocalQueryInfo,
-  to: CompletedLocalQueryInfo,
+  to: CompletedLocalQueryInfo | undefined,
 ): Promise<void> {
-  const fromLog = from.evalutorLogPaths?.jsonSummary;
-  const toLog = to.evalutorLogPaths?.jsonSummary;
+  let fromLog = from.evalutorLogPaths?.jsonSummary;
+  let toLog = to?.evalutorLogPaths?.jsonSummary;
+
+  if (to === undefined) {
+    toLog = fromLog;
+    fromLog = "";
+  }
   if (fromLog === undefined || toLog === undefined) {
     return extLogger.showWarningMessage(
       `Cannot compare performance as the structured logs are missing. Did they queries complete normally?`,
     );
   }
   await extLogger.log(
-    `Comparing performance of ${from.getQueryName()} and ${to.getQueryName()}`,
+    `Comparing performance of ${from.getQueryName()} and ${to?.getQueryName() ?? "baseline"}`,
   );
 
   await view.showResults(fromLog, toLog);

--- a/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
+++ b/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
@@ -218,6 +218,7 @@ const Dropdown = styled.select``;
 interface PipelineStepProps {
   before: number | undefined;
   after: number | undefined;
+  comparison: boolean;
   step: React.ReactNode;
 }
 
@@ -225,7 +226,7 @@ interface PipelineStepProps {
  * Row with details of a pipeline step, or one of the high-level stats appearing above the pipelines (evaluation/iteration counts).
  */
 function PipelineStep(props: PipelineStepProps) {
-  let { before, after, step } = props;
+  let { before, after, comparison, step } = props;
   if (before != null && before < 0) {
     before = undefined;
   }
@@ -236,9 +237,11 @@ function PipelineStep(props: PipelineStepProps) {
   return (
     <PipelineStepTR>
       <ChevronCell />
-      <NumberCell>{before != null ? formatDecimal(before) : ""}</NumberCell>
+      {comparison && (
+        <NumberCell>{before != null ? formatDecimal(before) : ""}</NumberCell>
+      )}
       <NumberCell>{after != null ? formatDecimal(after) : ""}</NumberCell>
-      {delta != null ? renderDelta(delta) : <td></td>}
+      {comparison && (delta != null ? renderDelta(delta) : <td></td>)}
       <NameCell>{step}</NameCell>
     </PipelineStepTR>
   );
@@ -251,10 +254,11 @@ const HeaderTR = styled.tr`
 interface HighLevelStatsProps {
   before: PredicateInfo;
   after: PredicateInfo;
+  comparison: boolean;
 }
 
 function HighLevelStats(props: HighLevelStatsProps) {
-  const { before, after } = props;
+  const { before, after, comparison } = props;
   const hasBefore = before.absentReason !== AbsentReason.NotSeen;
   const hasAfter = after.absentReason !== AbsentReason.NotSeen;
   const showEvaluationCount =
@@ -263,21 +267,25 @@ function HighLevelStats(props: HighLevelStatsProps) {
     <>
       <HeaderTR>
         <ChevronCell></ChevronCell>
-        <NumberHeader>{hasBefore ? "Before" : ""}</NumberHeader>
+        {comparison && <NumberHeader>{hasBefore ? "Before" : ""}</NumberHeader>}
         <NumberHeader>{hasAfter ? "After" : ""}</NumberHeader>
-        <NumberHeader>{hasBefore && hasAfter ? "Delta" : ""}</NumberHeader>
+        {comparison && (
+          <NumberHeader>{hasBefore && hasAfter ? "Delta" : ""}</NumberHeader>
+        )}
         <NameHeader>Stats</NameHeader>
       </HeaderTR>
       {showEvaluationCount && (
         <PipelineStep
           before={before.evaluationCount || undefined}
           after={after.evaluationCount || undefined}
+          comparison={comparison}
           step="Number of evaluations"
         />
       )}
       <PipelineStep
         before={before.iterationCount / before.evaluationCount || undefined}
         after={after.iterationCount / after.evaluationCount || undefined}
+        comparison={comparison}
         step={
           showEvaluationCount
             ? "Number of iterations per evaluation"
@@ -378,6 +386,8 @@ function ComparePerformanceWithData(props: {
     }),
     [data],
   );
+
+  const comparison = data?.comparison;
 
   const [expandedPredicates, setExpandedPredicates] = useState<Set<string>>(
     () => new Set<string>(),
@@ -480,9 +490,9 @@ function ComparePerformanceWithData(props: {
         <thead>
           <HeaderTR>
             <ChevronCell />
-            <NumberHeader>Before</NumberHeader>
-            <NumberHeader>After</NumberHeader>
-            <NumberHeader>Delta</NumberHeader>
+            {comparison && <NumberHeader>Before</NumberHeader>}
+            <NumberHeader>{comparison ? "After" : "Value"}</NumberHeader>
+            {comparison && <NumberHeader>Delta</NumberHeader>}
             <NameHeader>Predicate</NameHeader>
           </HeaderTR>
         </thead>
@@ -505,14 +515,18 @@ function ComparePerformanceWithData(props: {
               <ChevronCell>
                 <Chevron expanded={expandedPredicates.has(row.name)} />
               </ChevronCell>
-              {renderAbsoluteValue(row.before, metric)}
+              {comparison && renderAbsoluteValue(row.before, metric)}
               {renderAbsoluteValue(row.after, metric)}
-              {renderDelta(row.diff, metric.unit)}
+              {comparison && renderDelta(row.diff, metric.unit)}
               <NameCell>{rowNames[rowIndex]}</NameCell>
             </PredicateTR>
             {expandedPredicates.has(row.name) && (
               <>
-                <HighLevelStats before={row.before} after={row.after} />
+                <HighLevelStats
+                  before={row.before}
+                  after={row.after}
+                  comparison={comparison}
+                />
                 {collatePipelines(
                   row.before.pipelines,
                   row.after.pipelines,
@@ -520,18 +534,25 @@ function ComparePerformanceWithData(props: {
                   <Fragment key={pipelineIndex}>
                     <HeaderTR>
                       <td></td>
-                      <NumberHeader>{first != null && "Before"}</NumberHeader>
+                      {comparison && (
+                        <NumberHeader>{first != null && "Before"}</NumberHeader>
+                      )}
                       <NumberHeader>{second != null && "After"}</NumberHeader>
-                      <NumberHeader>
-                        {first != null && second != null && "Delta"}
-                      </NumberHeader>
+                      {comparison && (
+                        <NumberHeader>
+                          {first != null &&
+                            second != null &&
+                            (comparison ? "Delta" : "Value")}
+                        </NumberHeader>
+                      )}
                       <NameHeader>
                         Tuple counts for &apos;{name}&apos; pipeline
-                        {first == null
-                          ? " (after)"
-                          : second == null
-                            ? " (before)"
-                            : ""}
+                        {comparison &&
+                          (first == null
+                            ? " (after)"
+                            : second == null
+                              ? " (before)"
+                              : "")}
                       </NameHeader>
                     </HeaderTR>
                     {abbreviateRASteps(first?.steps ?? second!.steps).map(
@@ -540,6 +561,7 @@ function ComparePerformanceWithData(props: {
                           key={index}
                           before={first?.counts[index]}
                           after={second?.counts[index]}
+                          comparison={comparison}
                           step={step}
                         />
                       ),
@@ -558,9 +580,11 @@ function ComparePerformanceWithData(props: {
           </tr>
           <tr key="total">
             <ChevronCell />
-            <NumberCell>{formatDecimal(totalBefore)}</NumberCell>
+            {comparison && (
+              <NumberCell>{formatDecimal(totalBefore)}</NumberCell>
+            )}
             <NumberCell>{formatDecimal(totalAfter)}</NumberCell>
-            {renderDelta(totalDiff)}
+            {comparison && renderDelta(totalDiff)}
             <NameCell>TOTAL</NameCell>
           </tr>
         </tfoot>

--- a/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
+++ b/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
@@ -540,9 +540,7 @@ function ComparePerformanceWithData(props: {
                       <NumberHeader>{second != null && "After"}</NumberHeader>
                       {comparison && (
                         <NumberHeader>
-                          {first != null &&
-                            second != null &&
-                            (comparison ? "Delta" : "Value")}
+                          {first != null && second != null && "Delta"}
                         </NumberHeader>
                       )}
                       <NameHeader>


### PR DESCRIPTION
A very hacky implementation that simply instantiates an empty `PerformanceOverviewScanner` as the "from" column (i.e. with all values empty). To see it in action, select a single query run in the query history and pick "Compare Performance" from the context menu. Then select the "Single run" option when prompted.

Second commit takes care of simplifying the view when not in comparison mode.