### PR TITLE
Hackathon: support mono view of remote logs

### DIFF
--- a/extensions/ql-vscode/src/compare-performance/compare-performance-view.ts
+++ b/extensions/ql-vscode/src/compare-performance/compare-performance-view.ts
@@ -65,7 +65,7 @@ export class ComparePerformanceView extends AbstractWebview<
       const bytes = statSync(log).size;
       return withProgress(
         async (progress) =>
-          scanLog(log, new PerformanceOverviewScanner(), progress),
+          await scanLog(log, new PerformanceOverviewScanner(), progress),
 
         {
           title: `Scanning evaluator log ${logDescription} (${(bytes / 1024 / 1024).toFixed(1)} MB)`,

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -1225,9 +1225,14 @@ async function showPerformanceComparison(
   const fromLog = from?.evalutorLogPaths?.jsonSummary;
   const toLog = to.evalutorLogPaths?.jsonSummary;
 
-  if (fromLog === undefined || toLog === undefined) {
+  if (from && fromLog === undefined) {
     return extLogger.showWarningMessage(
-      `Cannot compare performance as the structured logs are missing. Did they queries complete normally?`,
+      `Cannot compare performance as the "from" structured logs are missing. Did they queries complete normally?`,
+    );
+  }
+  if (toLog === undefined) {
+    return extLogger.showWarningMessage(
+      `Cannot compare performance as the "to" structured logs are missing. Did they queries complete normally?`,
     );
   }
   if (from) {

--- a/extensions/ql-vscode/src/log-insights/performance-comparison.ts
+++ b/extensions/ql-vscode/src/log-insights/performance-comparison.ts
@@ -62,7 +62,7 @@ export type ComparePerformanceDescriptionData =
   | {
       kind: "remote-logs";
       experimentName: string;
-      fromTarget: string;
+      fromTarget?: string;
       toTarget: string;
       info: MinimalDownloadsType;
     };

--- a/extensions/ql-vscode/src/view/common/ComparePerformanceLocalRunDescription.tsx
+++ b/extensions/ql-vscode/src/view/common/ComparePerformanceLocalRunDescription.tsx
@@ -10,11 +10,13 @@ export const ComparePerformanceLocalRunDescription = ({
 }: Props) => {
   return (
     <div>
-      (fromQuery?
-      <strong>
-        Comparison of local runs of {fromQuery} and {toQuery}
-      </strong>
-      : Local run of {toQuery})
+      {fromQuery ? (
+        <strong>
+          Comparison of local runs of {fromQuery} and {toQuery}
+        </strong>
+      ) : (
+        <strong>Local run of {toQuery}</strong>
+      )}
     </div>
   );
 };

--- a/extensions/ql-vscode/src/view/common/ComparePerformanceRemoteLogsDescription.tsx
+++ b/extensions/ql-vscode/src/view/common/ComparePerformanceRemoteLogsDescription.tsx
@@ -34,7 +34,7 @@ const TargetRow = ({
   info,
 }: {
   kind: string;
-  target: Props["fromTarget"] | Props["toTarget"];
+  target: Exclude<Props["fromTarget"] | Props["toTarget"], undefined>;
   info: Props["info"];
 }) => {
   const targetObj = info.targets[target];
@@ -90,7 +90,9 @@ const TargetTable = ({
         </tr>
       </thead>
       <tbody>
-        <TargetRow kind="from" target={fromTarget} info={info} />
+        {fromTarget ? (
+          <TargetRow kind="from" target={fromTarget} info={info} />
+        ) : null}
         <TargetRow kind="to" target={toTarget} info={info} />
       </tbody>
     </table>


### PR DESCRIPTION
Allows the `NONE` choice for the second remote log - enabling the mono-view of the remote logs as well 🎉 