### PR TITLE
Faster streaming 'jsonl' parser

### DIFF
--- a/extensions/ql-vscode/src/common/jsonl-reader.ts
+++ b/extensions/ql-vscode/src/common/jsonl-reader.ts
@@ -1,6 +1,7 @@
 import { stat } from "fs/promises";
 import { createReadStream } from "fs-extra";
-import { createInterface } from "readline";
+
+const doubleLineBreakRegexp = /\n\r?\n/;
 
 /**
  * Read a file consisting of multiple JSON objects. Each object is separated from the previous one
@@ -10,64 +11,6 @@ import { createInterface } from "readline";
  * @param handler Callback to be invoked for each top-level JSON object in order.
  */
 export async function readJsonlFile<T>(
-  path: string,
-  handler: (value: T) => Promise<void>,
-  logger?: { log: (message: string) => void },
-): Promise<void> {
-  function parseJsonFromCurrentLines() {
-    try {
-      return JSON.parse(currentLineSequence.join("\n")) as T;
-    } catch (e) {
-      void logger?.log(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        `Error: Failed to parse at line ${lineCount} of ${path} as JSON: ${(e as any)?.message ?? "UNKNOWN REASON"}. Problematic line below:\n${JSON.stringify(currentLineSequence, null, 2)}`,
-      );
-      throw e;
-    }
-  }
-
-  function logProgress() {
-    void logger?.log(
-      `Processed ${lineCount} lines with ${parseCounts} parses...`,
-    );
-  }
-
-  void logger?.log(
-    `Parsing ${path} (${(await stat(path)).size / 1024 / 1024} MB)...`,
-  );
-  const fileStream = createReadStream(path, "utf8");
-  const rl = createInterface({
-    input: fileStream,
-    crlfDelay: Infinity,
-  });
-
-  let lineCount = 0;
-  let parseCounts = 0;
-  let currentLineSequence: string[] = [];
-  for await (const line of rl) {
-    if (line === "") {
-      // as mentioned above: a double newline sequence indicates the end of the current JSON object, so we parse it and pass it to the handler
-      await handler(parseJsonFromCurrentLines());
-      parseCounts++;
-      currentLineSequence = [];
-    } else {
-      currentLineSequence.push(line);
-    }
-    lineCount++;
-    if (lineCount % 1000000 === 0) {
-      logProgress();
-    }
-  }
-  // in case the file is not newline-terminated, we need to handle the last JSON object
-  if (currentLineSequence.length > 0) {
-    await handler(parseJsonFromCurrentLines());
-  }
-  logProgress();
-}
-
-const doubleLineBreakRegexp = /\n\r?\n/;
-
-export async function readJsonlFile2<T>(
   path: string,
   handler: (value: T) => Promise<void>,
   logger?: { log: (message: string) => void },

--- a/extensions/ql-vscode/test/benchmarks/jsonl-reader.bench.ts
+++ b/extensions/ql-vscode/test/benchmarks/jsonl-reader.bench.ts
@@ -2,6 +2,8 @@ import { readFile } from "fs-extra";
 import { readJsonlFile, readJsonlFile2 } from "../../src/common/jsonl-reader";
 import { performance } from "perf_hooks";
 import { join } from "path";
+import { createReadStream } from "fs";
+import { createInterface } from "readline";
 
 /** An "obviously correct" implementation to test against. */
 async function readJsonlReferenceImpl<T>(
@@ -19,6 +21,18 @@ async function readJsonlReferenceImpl<T>(
   }
 }
 
+async function justReadline(
+  path: string,
+  handler: (value: unknown) => Promise<void>,
+) {
+  const stream = createReadStream(path, "utf8");
+  const rl = createInterface(stream);
+
+  for await (const line of rl) {
+    await handler(line);
+  }
+}
+
 type ParserFn = (
   text: string,
   callback: (v: unknown) => Promise<void>,
@@ -28,6 +42,7 @@ const parsers: Record<string, ParserFn> = {
   readJsonlReferenceImpl,
   readJsonlFile,
   readJsonlFile2,
+  justReadline,
 };
 
 async function main() {

--- a/extensions/ql-vscode/test/benchmarks/jsonl-reader.bench.ts
+++ b/extensions/ql-vscode/test/benchmarks/jsonl-reader.bench.ts
@@ -1,0 +1,74 @@
+import { readFile } from "fs-extra";
+import { readJsonlFile, readJsonlFile2 } from "../../src/common/jsonl-reader";
+import { performance } from "perf_hooks";
+import { join } from "path";
+
+/** An "obviously correct" implementation to test against. */
+async function readJsonlReferenceImpl<T>(
+  path: string,
+  handler: (value: T) => Promise<void>,
+): Promise<void> {
+  const logSummary = await readFile(path, "utf-8");
+
+  // Remove newline delimiters because summary is in .jsonl format.
+  const jsonSummaryObjects: string[] = logSummary.split(/\r?\n\r?\n/g);
+
+  for (const obj of jsonSummaryObjects) {
+    const jsonObj = JSON.parse(obj) as T;
+    await handler(jsonObj);
+  }
+}
+
+type ParserFn = (
+  text: string,
+  callback: (v: unknown) => Promise<void>,
+) => Promise<void>;
+
+const parsers: Record<string, ParserFn> = {
+  readJsonlReferenceImpl,
+  readJsonlFile,
+  readJsonlFile2,
+};
+
+async function main() {
+  const args = process.argv.slice(2);
+  const file =
+    args.length > 0
+      ? args[0]
+      : join(
+          __dirname,
+          "../unit-tests/data/evaluator-log-summaries/bad-join-order.jsonl",
+        );
+  const numTrials = args.length > 1 ? Number(args[1]) : 100;
+  const referenceValues: any[] = [];
+  await readJsonlReferenceImpl(file, async (event) => {
+    referenceValues.push(event);
+  });
+  const referenceValueString = JSON.stringify(referenceValues);
+  // Do warm-up runs and check against reference implementation
+  for (const [name, parser] of Object.entries(parsers)) {
+    const values: unknown[] = [];
+    await parser(file, async (event) => {
+      values.push(event);
+    });
+    if (JSON.stringify(values) !== referenceValueString) {
+      console.error(`${name}: failed to match reference implementation`);
+    }
+  }
+  for (const [name, parser] of Object.entries(parsers)) {
+    const startTime = performance.now();
+    for (let i = 0; i < numTrials; ++i) {
+      await Promise.all([
+        parser(file, async () => {}),
+        parser(file, async () => {}),
+      ]);
+    }
+    const duration = performance.now() - startTime;
+    const durationPerTrial = duration / numTrials;
+    console.log(`${name}: ${durationPerTrial.toFixed(1)} ms`);
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error(err);
+});

--- a/extensions/ql-vscode/test/benchmarks/jsonl-reader.bench.ts
+++ b/extensions/ql-vscode/test/benchmarks/jsonl-reader.bench.ts
@@ -1,9 +1,7 @@
 import { readFile } from "fs-extra";
-import { readJsonlFile, readJsonlFile2 } from "../../src/common/jsonl-reader";
+import { readJsonlFile } from "../../src/common/jsonl-reader";
 import { performance } from "perf_hooks";
 import { join } from "path";
-import { createReadStream } from "fs";
-import { createInterface } from "readline";
 
 /** An "obviously correct" implementation to test against. */
 async function readJsonlReferenceImpl<T>(
@@ -21,18 +19,6 @@ async function readJsonlReferenceImpl<T>(
   }
 }
 
-async function justReadline(
-  path: string,
-  handler: (value: unknown) => Promise<void>,
-) {
-  const stream = createReadStream(path, "utf8");
-  const rl = createInterface(stream);
-
-  for await (const line of rl) {
-    await handler(line);
-  }
-}
-
 type ParserFn = (
   text: string,
   callback: (v: unknown) => Promise<void>,
@@ -41,8 +27,6 @@ type ParserFn = (
 const parsers: Record<string, ParserFn> = {
   readJsonlReferenceImpl,
   readJsonlFile,
-  readJsonlFile2,
-  justReadline,
 };
 
 async function main() {


### PR DESCRIPTION
Replaces the streaming JSONL parser with a faster one that doesn't call `readline`. The streaming JSONL parser on our branch was slower than the original sync version (but doesn't run out of memory), and it seems `readline` is a bottleneck:

Running the benchmark on a 21 MB logfile:
- `readJsonlReferenceImpl`: 172.4 ms (original non-streaming version)
- `readJsonlFile`: 283.3 ms (streaming version based on `readline`)
- `readJsonlFile2`: 151.3 ms (🚀  new version without `readline`)
- `justReadline`: 187.5 ms (consumes the file with `readline` and nothing else)

Note: targeting the hackathon branch. I think it's best to polish that up and try to merge it into `main`.