### PR TITLE
Publish extension using Azure credentials

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,8 +124,9 @@ jobs:
     needs: build
     environment: publish-vscode-marketplace
     runs-on: ubuntu-latest
-    env:
-      VSCE_TOKEN: ${{ secrets.VSCE_TOKEN }}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -139,9 +140,19 @@ jobs:
         with:
           name: vscode-codeql-extension
 
+      - name: Azure User-assigned managed identity login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+
       - name: Publish to Registry
-        run: |
-          npx @vscode/vsce publish -p $VSCE_TOKEN --packagePath *.vsix
+        uses: azure/cli@v2
+        with:
+          azcliversion: latest
+          inlineScript: |
+            npx @vscode/vsce publish --azure-credential --packagePath *.vsix
 
   open-vsx-publish:
     name: Publish to Open VSX Registry


### PR DESCRIPTION
This will change the publishing of the extension to the VS Code Marketplace to use [a user-assigned managed identity](https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/how-manage-user-assigned-managed-identities). We are [using a federated credential](https://learn.microsoft.com/en-us/azure/developer/github/connect-from-azure-identity) to allow logging in to this managed identity from the `publish-vscode-marketplace` environment. The secrets have already been set in the environment and I've tested them when retrieving the user ID.

The `@vscode/vsce` CLI will automatically retrieve the credentials when we pass the `--azure-credential` flag and run it within the context of the `azure/cli` Action.