### PR TITLE
Add streaming 'jsonl' parser

### DIFF
--- a/extensions/ql-vscode/src/common/jsonl-reader.ts
+++ b/extensions/ql-vscode/src/common/jsonl-reader.ts
@@ -15,6 +15,8 @@ export async function readJsonlFile<T>(
   handler: (value: T) => Promise<void>,
   logger?: { log: (message: string) => void },
 ): Promise<void> {
+  // Stream the data as large evaluator logs won't fit in memory.
+  // Also avoid using 'readline' as it is slower than our manual line splitting.
   void logger?.log(
     `Parsing ${path} (${(await stat(path)).size / 1024 / 1024} MB)...`,
   );

--- a/extensions/ql-vscode/src/common/jsonl-reader.ts
+++ b/extensions/ql-vscode/src/common/jsonl-reader.ts
@@ -41,16 +41,15 @@ export async function readJsonlFile<T>(
       }
     });
     stream.on("end", async () => {
-      if (buffer.trim().length > 0) {
-        try {
+      try {
+        if (buffer.trim().length > 0) {
           await handler(JSON.parse(buffer));
-        } catch (e) {
-          reject(e);
-          return;
         }
+        void logger?.log(`Finished parsing ${path}`);
+        resolve();
+      } catch (e) {
+        reject(e);
       }
-      void logger?.log(`Finished parsing ${path}`);
-      resolve();
     });
     stream.on("error", reject);
   });

--- a/extensions/ql-vscode/src/common/jsonl-reader.ts
+++ b/extensions/ql-vscode/src/common/jsonl-reader.ts
@@ -13,7 +13,7 @@ const doubleLineBreakRegexp = /\n\r?\n/;
 export async function readJsonlFile<T>(
   path: string,
   handler: (value: T) => Promise<void>,
-  logger?: { log: (message: string) => void },
+  logger?: BaseLogger,
 ): Promise<void> {
   // Stream the data as large evaluator logs won't fit in memory.
   // Also avoid using 'readline' as it is slower than our manual line splitting.
@@ -48,7 +48,7 @@ export async function readJsonlFile<T>(
           return;
         }
       }
-      void logger?.log(`Finishing parsing ${path}`);
+      void logger?.log(`Finished parsing ${path}`);
       resolve();
     });
     stream.on("error", reject);

--- a/extensions/ql-vscode/src/common/jsonl-reader.ts
+++ b/extensions/ql-vscode/src/common/jsonl-reader.ts
@@ -1,5 +1,6 @@
 import { stat } from "fs/promises";
 import { createReadStream } from "fs-extra";
+import type { BaseLogger } from "./logging";
 
 const doubleLineBreakRegexp = /\n\r?\n/;
 

--- a/extensions/ql-vscode/src/common/jsonl-reader.ts
+++ b/extensions/ql-vscode/src/common/jsonl-reader.ts
@@ -1,11 +1,11 @@
-import { readFile } from "fs-extra";
+import { stat } from "fs/promises";
+import { createReadStream } from "fs-extra";
+
+const doubleLineBreakRegexp = /\n\r?\n/;
 
 /**
  * Read a file consisting of multiple JSON objects. Each object is separated from the previous one
  * by a double newline sequence. This is basically a more human-readable form of JSONL.
- *
- * The current implementation reads the entire text of the document into memory, but in the future
- * it will stream the document to improve the performance with large documents.
  *
  * @param path The path to the file.
  * @param handler Callback to be invoked for each top-level JSON object in order.
@@ -13,14 +13,42 @@ import { readFile } from "fs-extra";
 export async function readJsonlFile<T>(
   path: string,
   handler: (value: T) => Promise<void>,
+  logger?: { log: (message: string) => void },
 ): Promise<void> {
-  const logSummary = await readFile(path, "utf-8");
-
-  // Remove newline delimiters because summary is in .jsonl format.
-  const jsonSummaryObjects: string[] = logSummary.split(/\r?\n\r?\n/g);
-
-  for (const obj of jsonSummaryObjects) {
-    const jsonObj = JSON.parse(obj) as T;
-    await handler(jsonObj);
-  }
+  void logger?.log(
+    `Parsing ${path} (${(await stat(path)).size / 1024 / 1024} MB)...`,
+  );
+  return new Promise((resolve, reject) => {
+    const stream = createReadStream(path, { encoding: "utf8" });
+    let buffer = "";
+    stream.on("data", async (chunk: string) => {
+      const parts = (buffer + chunk).split(doubleLineBreakRegexp);
+      buffer = parts.pop()!;
+      if (parts.length > 0) {
+        try {
+          stream.pause();
+          for (const part of parts) {
+            await handler(JSON.parse(part));
+          }
+          stream.resume();
+        } catch (e) {
+          stream.destroy();
+          reject(e);
+        }
+      }
+    });
+    stream.on("end", async () => {
+      if (buffer.trim().length > 0) {
+        try {
+          await handler(JSON.parse(buffer));
+        } catch (e) {
+          reject(e);
+          return;
+        }
+      }
+      void logger?.log(`Finishing parsing ${path}`);
+      resolve();
+    });
+    stream.on("error", reject);
+  });
 }

--- a/extensions/ql-vscode/test/benchmarks/jsonl-reader.bench.ts
+++ b/extensions/ql-vscode/test/benchmarks/jsonl-reader.bench.ts
@@ -1,3 +1,17 @@
+/**
+ * Benchmarks the jsonl-parser against a reference implementation and checks that it generates
+ * the same output.
+ *
+ * Usage:
+ *
+ *   ts-node json-reader.bench.ts [evaluator-log.summary.jsonl] [count]
+ *
+ * The log file defaults to a small checked-in log and count defaults to 100
+ * (and should be lowered significantly for large files).
+ *
+ * At the time of writing it is about as fast as the synchronous reference implementation,
+ * but doesn't run out of memory for large files.
+ */
 import { readFile } from "fs-extra";
 import { readJsonlFile } from "../../src/common/jsonl-reader";
 import { performance } from "perf_hooks";

--- a/extensions/ql-vscode/test/benchmarks/jsonl-reader.bench.ts
+++ b/extensions/ql-vscode/test/benchmarks/jsonl-reader.bench.ts
@@ -1,0 +1,73 @@
+import { readFile } from "fs-extra";
+import { readJsonlFile } from "../../src/common/jsonl-reader";
+import { performance } from "perf_hooks";
+import { join } from "path";
+
+/** An "obviously correct" implementation to test against. */
+async function readJsonlReferenceImpl<T>(
+  path: string,
+  handler: (value: T) => Promise<void>,
+): Promise<void> {
+  const logSummary = await readFile(path, "utf-8");
+
+  // Remove newline delimiters because summary is in .jsonl format.
+  const jsonSummaryObjects: string[] = logSummary.split(/\r?\n\r?\n/g);
+
+  for (const obj of jsonSummaryObjects) {
+    const jsonObj = JSON.parse(obj) as T;
+    await handler(jsonObj);
+  }
+}
+
+type ParserFn = (
+  text: string,
+  callback: (v: unknown) => Promise<void>,
+) => Promise<void>;
+
+const parsers: Record<string, ParserFn> = {
+  readJsonlReferenceImpl,
+  readJsonlFile,
+};
+
+async function main() {
+  const args = process.argv.slice(2);
+  const file =
+    args.length > 0
+      ? args[0]
+      : join(
+          __dirname,
+          "../unit-tests/data/evaluator-log-summaries/bad-join-order.jsonl",
+        );
+  const numTrials = args.length > 1 ? Number(args[1]) : 100;
+  const referenceValues: any[] = [];
+  await readJsonlReferenceImpl(file, async (event) => {
+    referenceValues.push(event);
+  });
+  const referenceValueString = JSON.stringify(referenceValues);
+  // Do warm-up runs and check against reference implementation
+  for (const [name, parser] of Object.entries(parsers)) {
+    const values: unknown[] = [];
+    await parser(file, async (event) => {
+      values.push(event);
+    });
+    if (JSON.stringify(values) !== referenceValueString) {
+      console.error(`${name}: failed to match reference implementation`);
+    }
+  }
+  for (const [name, parser] of Object.entries(parsers)) {
+    const startTime = performance.now();
+    for (let i = 0; i < numTrials; ++i) {
+      await Promise.all([
+        parser(file, async () => {}),
+        parser(file, async () => {}),
+      ]);
+    }
+    const duration = performance.now() - startTime;
+    const durationPerTrial = duration / numTrials;
+    console.log(`${name}: ${durationPerTrial.toFixed(1)} ms`);
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error(err);
+});


### PR DESCRIPTION
Replaces the jsonl parser with a streaming version that is at least as fast as the sync version. Also see [original PR](https://github.com/github/vscode-codeql/pull/3829) against the hackathon branch.

Thanks to @esbena for the initial streaming version used for the hackaton. That version used the `readline` library to split lines, which turned out to be a bottleneck, however, making the streaming parser slower than the original sync version. So I wrote one that doesn't use `readline`.

Running the benchmark on a 21 MB logfile:
- `readJsonlReferenceImpl`: 172.4 ms (original non-streaming version)
- `readJsonlFile`: 283.3 ms (streaming version based on `readline`)
- `readJsonlFile2`: 151.3 ms (new version without `readline`)
- `justReadline`: 187.5 ms (consumes the file with `readline` and nothing else)

On a 520 MB logfile:
- `readJsonlReferenceImpl`: out of memory
- `readJsonlFile`: 6439.4 ms
- `readJsonlFile2`: 3538.4 ms
- `justReadline`: 3664.3 ms

I've added the benchmark script although the project doesn't seem to have much infrastructure for benchmark scripts. At the moment you'll have to run it with something like `ts-node` and there's no tests to ensure the benchmark script keeps working (but it will be checked for compilation errors). I'm on the fence about whether it should be committed.