### PR TITLE
Avoid resetting scroll position after clicking a node in the graph viewer

### DIFF
--- a/extensions/ql-vscode/src/view/results/Graph.tsx
+++ b/extensions/ql-vscode/src/view/results/Graph.tsx
@@ -48,7 +48,10 @@ export function Graph({ graphData, databaseUri }: GraphProps) {
             d.attributes["xlink:href"] = "#";
             d.attributes["href"] = "#";
             loc.uri = `file://${loc.uri}`;
-            select(this).on("click", () => jumpToLocation(loc, databaseUri));
+            select(this).on("click", (event: Event) => {
+              jumpToLocation(loc, databaseUri);
+              event.preventDefault(); // Avoid resetting scroll position
+            });
           }
         }
         if ("fill" in d.attributes) {


### PR DESCRIPTION
When clicking a node in the graph viewer, it would reset the scroll position, similar to what happens when clicking a link with `href="#"` ([such as this link](#)). This PR fixes that.

![reset-scroll](https://github.com/user-attachments/assets/9a81fec1-2b28-4d90-8c5d-4594ded0d8a6)
