### PR TITLE
Add 'compare performance' view

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -960,6 +960,10 @@
         "title": "Compare Results"
       },
       {
+        "command": "codeQLQueryHistory.comparePerformanceWith",
+        "title": "Compare Performance"
+      },
+      {
         "command": "codeQLQueryHistory.openOnGithub",
         "title": "View Logs"
       },
@@ -1228,6 +1232,11 @@
         {
           "command": "codeQLQueryHistory.compareWith",
           "group": "3_queryHistory@0",
+          "when": "viewItem == rawResultsItem || viewItem == interpretedResultsItem"
+        },
+        {
+          "command": "codeQLQueryHistory.comparePerformanceWith",
+          "group": "3_queryHistory@1",
           "when": "viewItem == rawResultsItem || viewItem == interpretedResultsItem"
         },
         {
@@ -1731,6 +1740,10 @@
         },
         {
           "command": "codeQLQueryHistory.compareWith",
+          "when": "false"
+        },
+        {
+          "command": "codeQLQueryHistory.comparePerformanceWith",
           "when": "false"
         },
         {

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -1237,7 +1237,7 @@
         {
           "command": "codeQLQueryHistory.comparePerformanceWith",
           "group": "3_queryHistory@1",
-          "when": "viewItem == rawResultsItem || viewItem == interpretedResultsItem"
+          "when": "viewItem == rawResultsItem && config.codeQL.canary || viewItem == interpretedResultsItem && config.codeQL.canary"
         },
         {
           "command": "codeQLQueryHistory.showQueryLog",

--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -180,6 +180,7 @@ export type QueryHistoryCommands = {
   "codeQLQueryHistory.removeHistoryItemContextInline": TreeViewContextMultiSelectionCommandFunction<QueryHistoryInfo>;
   "codeQLQueryHistory.renameItem": TreeViewContextMultiSelectionCommandFunction<QueryHistoryInfo>;
   "codeQLQueryHistory.compareWith": TreeViewContextMultiSelectionCommandFunction<QueryHistoryInfo>;
+  "codeQLQueryHistory.comparePerformanceWith": TreeViewContextMultiSelectionCommandFunction<QueryHistoryInfo>;
   "codeQLQueryHistory.showEvalLog": TreeViewContextMultiSelectionCommandFunction<QueryHistoryInfo>;
   "codeQLQueryHistory.showEvalLogSummary": TreeViewContextMultiSelectionCommandFunction<QueryHistoryInfo>;
   "codeQLQueryHistory.showEvalLogViewer": TreeViewContextMultiSelectionCommandFunction<QueryHistoryInfo>;

--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -403,6 +403,7 @@ export interface SetPerformanceComparisonQueries {
   readonly t: "setPerformanceComparison";
   readonly from: PerformanceComparisonDataFromLog;
   readonly to: PerformanceComparisonDataFromLog;
+  readonly comparison: boolean;
 }
 
 export type FromComparePerformanceViewMessage = CommonFromViewMessages;

--- a/extensions/ql-vscode/src/common/interface-types.ts
+++ b/extensions/ql-vscode/src/common/interface-types.ts
@@ -27,6 +27,7 @@ import type {
 } from "./raw-result-types";
 import type { AccessPathSuggestionOptions } from "../model-editor/suggestions";
 import type { ModelEvaluationRunState } from "../model-editor/shared/model-evaluation-run-state";
+import type { PerformanceComparisonDataFromLog } from "../log-insights/performance-comparison";
 
 /**
  * This module contains types and code that are shared between
@@ -395,6 +396,16 @@ export interface SetComparisonsMessage {
   readonly result: QueryCompareResult | undefined;
   readonly message: string | undefined;
 }
+
+export type ToComparePerformanceViewMessage = SetPerformanceComparisonQueries;
+
+export interface SetPerformanceComparisonQueries {
+  readonly t: "setPerformanceComparison";
+  readonly from: PerformanceComparisonDataFromLog;
+  readonly to: PerformanceComparisonDataFromLog;
+}
+
+export type FromComparePerformanceViewMessage = CommonFromViewMessages;
 
 export type QueryCompareResult =
   | RawQueryCompareResult

--- a/extensions/ql-vscode/src/common/vscode/abstract-webview.ts
+++ b/extensions/ql-vscode/src/common/vscode/abstract-webview.ts
@@ -41,6 +41,13 @@ export abstract class AbstractWebview<
 
   constructor(protected readonly app: App) {}
 
+  public hidePanel() {
+    if (this.panel !== undefined) {
+      this.panel.dispose();
+      this.panel = undefined;
+    }
+  }
+
   public async restoreView(panel: WebviewPanel): Promise<void> {
     this.panel = panel;
     const config = await this.getPanelConfig();

--- a/extensions/ql-vscode/src/common/vscode/webview-html.ts
+++ b/extensions/ql-vscode/src/common/vscode/webview-html.ts
@@ -7,6 +7,7 @@ import type { App } from "../app";
 export type WebviewKind =
   | "results"
   | "compare"
+  | "compare-performance"
   | "variant-analysis"
   | "data-flow-paths"
   | "model-editor"

--- a/extensions/ql-vscode/src/compare-performance/compare-performance-view.ts
+++ b/extensions/ql-vscode/src/compare-performance/compare-performance-view.ts
@@ -1,0 +1,93 @@
+import { ViewColumn } from "vscode";
+
+import type { App } from "../common/app";
+import { redactableError } from "../common/errors";
+import type {
+  FromComparePerformanceViewMessage,
+  ToComparePerformanceViewMessage,
+} from "../common/interface-types";
+import type { Logger } from "../common/logging";
+import { showAndLogExceptionWithTelemetry } from "../common/logging";
+import { extLogger } from "../common/logging/vscode";
+import type { WebviewPanelConfig } from "../common/vscode/abstract-webview";
+import { AbstractWebview } from "../common/vscode/abstract-webview";
+import { telemetryListener } from "../common/vscode/telemetry";
+import type { HistoryItemLabelProvider } from "../query-history/history-item-label-provider";
+import { PerformanceOverviewScanner } from "../log-insights/performance-comparison";
+import { scanLog } from "../log-insights/log-scanner";
+import type { ResultsView } from "../local-queries";
+
+export class ComparePerformanceView extends AbstractWebview<
+  ToComparePerformanceViewMessage,
+  FromComparePerformanceViewMessage
+> {
+  constructor(
+    app: App,
+    public logger: Logger,
+    public labelProvider: HistoryItemLabelProvider,
+    private resultsView: ResultsView,
+  ) {
+    super(app);
+  }
+
+  async showResults(fromJsonLog: string, toJsonLog: string) {
+    const panel = await this.getPanel();
+    panel.reveal(undefined, false);
+
+    // Close the results viewer as it will have opened when the user clicked the query in the history view
+    // (which they must do as part of the UI interaction for opening the performance view).
+    // The performance view generally needs a lot of width so it's annoying to have the result viewer open.
+    this.resultsView.hidePanel();
+
+    await this.waitForPanelLoaded();
+
+    // TODO: try processing in (async) parallel once readJsonl is streaming
+    const fromPerf = await scanLog(
+      fromJsonLog,
+      new PerformanceOverviewScanner(),
+    );
+    const toPerf = await scanLog(toJsonLog, new PerformanceOverviewScanner());
+
+    await this.postMessage({
+      t: "setPerformanceComparison",
+      from: fromPerf.getData(),
+      to: toPerf.getData(),
+    });
+  }
+
+  protected getPanelConfig(): WebviewPanelConfig {
+    return {
+      viewId: "comparePerformanceView",
+      title: "Compare CodeQL Performance",
+      viewColumn: ViewColumn.Active,
+      preserveFocus: true,
+      view: "compare-performance",
+    };
+  }
+
+  protected onPanelDispose(): void {}
+
+  protected async onMessage(
+    msg: FromComparePerformanceViewMessage,
+  ): Promise<void> {
+    switch (msg.t) {
+      case "viewLoaded":
+        this.onWebViewLoaded();
+        break;
+
+      case "telemetry":
+        telemetryListener?.sendUIInteraction(msg.action);
+        break;
+
+      case "unhandledError":
+        void showAndLogExceptionWithTelemetry(
+          extLogger,
+          telemetryListener,
+          redactableError(
+            msg.error,
+          )`Unhandled error in performance comparison view: ${msg.error.message}`,
+        );
+        break;
+    }
+  }
+}

--- a/extensions/ql-vscode/src/compare-performance/compare-performance-view.ts
+++ b/extensions/ql-vscode/src/compare-performance/compare-performance-view.ts
@@ -56,8 +56,10 @@ export class ComparePerformanceView extends AbstractWebview<
     }
 
     const [fromPerf, toPerf] = await Promise.all([
-      scanLogWithProgress(fromJsonLog, "1/2"),
-      scanLogWithProgress(toJsonLog, "2/2"),
+      fromJsonLog === ""
+        ? new PerformanceOverviewScanner()
+        : scanLogWithProgress(fromJsonLog, "1/2"),
+      scanLogWithProgress(toJsonLog, fromJsonLog === "" ? "1/1" : "2/2"),
     ]);
 
     await this.postMessage({

--- a/extensions/ql-vscode/src/compare-performance/compare-performance-view.ts
+++ b/extensions/ql-vscode/src/compare-performance/compare-performance-view.ts
@@ -66,6 +66,7 @@ export class ComparePerformanceView extends AbstractWebview<
       t: "setPerformanceComparison",
       from: fromPerf.getData(),
       to: toPerf.getData(),
+      comparison: fromJsonLog !== "",
     });
   }
 

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -927,7 +927,7 @@ async function activateWithInstalledDistribution(
     ): Promise<void> => showResultsForComparison(compareView, from, to),
     async (
       from: CompletedLocalQueryInfo,
-      to: CompletedLocalQueryInfo,
+      to: CompletedLocalQueryInfo | undefined,
     ): Promise<void> =>
       showPerformanceComparison(comparePerformanceView, from, to),
   );
@@ -1208,17 +1208,22 @@ async function showResultsForComparison(
 async function showPerformanceComparison(
   view: ComparePerformanceView,
   from: CompletedLocalQueryInfo,
-  to: CompletedLocalQueryInfo,
+  to: CompletedLocalQueryInfo | undefined,
 ): Promise<void> {
-  const fromLog = from.evaluatorLogPaths?.jsonSummary;
-  const toLog = to.evaluatorLogPaths?.jsonSummary;
+  let fromLog = from.evaluatorLogPaths?.jsonSummary;
+  let toLog = to?.evaluatorLogPaths?.jsonSummary;
+
+  if (to === undefined) {
+    toLog = fromLog;
+    fromLog = "";
+  }
   if (fromLog === undefined || toLog === undefined) {
     return extLogger.showWarningMessage(
       `Cannot compare performance as the structured logs are missing. Did they queries complete normally?`,
     );
   }
   await extLogger.log(
-    `Comparing performance of ${from.getQueryName()} and ${to.getQueryName()}`,
+    `Comparing performance of ${from.getQueryName()} and ${to?.getQueryName() ?? "baseline"}`,
   );
 
   await view.showResults(fromLog, toLog);

--- a/extensions/ql-vscode/src/log-insights/log-scanner.ts
+++ b/extensions/ql-vscode/src/log-insights/log-scanner.ts
@@ -1,6 +1,7 @@
-import type { SummaryEvent } from "./log-summary";
-import { readJsonlFile } from "../common/jsonl-reader";
 import type { Disposable } from "../common/disposable-object";
+import { readJsonlFile } from "../common/jsonl-reader";
+import type { ProgressCallback } from "../common/vscode/progress";
+import type { SummaryEvent } from "./log-summary";
 
 /**
  * Callback interface used to report diagnostics from a log scanner.
@@ -114,7 +115,7 @@ export class EvaluationLogScannerSet {
 }
 
 /**
- * Scan the evaluator summary log using the given scanner. For conveience, returns the scanner.
+ * Scan the evaluator summary log using the given scanner. For convenience, returns the scanner.
  *
  * @param jsonSummaryLocation The file path of the JSON summary log.
  * @param scanner The scanner to process events from the log
@@ -122,7 +123,14 @@ export class EvaluationLogScannerSet {
 export async function scanLog<T extends EvaluationLogScanner>(
   jsonSummaryLocation: string,
   scanner: T,
+  progress?: ProgressCallback,
 ): Promise<T> {
+  progress?.({
+    // XXX all scans have step 1 - the backing progress tracker allows increments instead of steps - but for now we are happy with a tiny UI that says what is happening
+    message: `Scanning ...`,
+    step: 1,
+    maxStep: 2,
+  });
   await readJsonlFile<SummaryEvent>(jsonSummaryLocation, async (obj) => {
     scanner.onEvent(obj);
   });

--- a/extensions/ql-vscode/src/log-insights/log-scanner.ts
+++ b/extensions/ql-vscode/src/log-insights/log-scanner.ts
@@ -112,3 +112,20 @@ export class EvaluationLogScannerSet {
     scanners.forEach((scanner) => scanner.onDone());
   }
 }
+
+/**
+ * Scan the evaluator summary log using the given scanner. For conveience, returns the scanner.
+ *
+ * @param jsonSummaryLocation The file path of the JSON summary log.
+ * @param scanner The scanner to process events from the log
+ */
+export async function scanLog<T extends EvaluationLogScanner>(
+  jsonSummaryLocation: string,
+  scanner: T,
+): Promise<T> {
+  await readJsonlFile<SummaryEvent>(jsonSummaryLocation, async (obj) => {
+    scanner.onEvent(obj);
+  });
+  scanner.onDone();
+  return scanner;
+}

--- a/extensions/ql-vscode/src/log-insights/log-summary.ts
+++ b/extensions/ql-vscode/src/log-insights/log-summary.ts
@@ -33,6 +33,7 @@ interface ResultEventBase extends SummaryEventBase {
 export interface ComputeSimple extends ResultEventBase {
   evaluationStrategy: "COMPUTE_SIMPLE";
   ra: Ra;
+  millis: number;
   pipelineRuns?: [PipelineRun];
   queryCausingWork?: string;
   dependencies: { [key: string]: string };
@@ -42,6 +43,7 @@ export interface ComputeRecursive extends ResultEventBase {
   evaluationStrategy: "COMPUTE_RECURSIVE";
   deltaSizes: number[];
   ra: Ra;
+  millis: number;
   pipelineRuns: PipelineRun[];
   queryCausingWork?: string;
   dependencies: { [key: string]: string };

--- a/extensions/ql-vscode/src/log-insights/performance-comparison.ts
+++ b/extensions/ql-vscode/src/log-insights/performance-comparison.ts
@@ -115,9 +115,13 @@ export class PerformanceOverviewScanner implements EvaluationLogScanner {
       }
       case "CACHE_HIT":
       case "CACHACA": {
-        this.data.cacheHitIndices.push(
-          this.getPredicateIndex(event.predicateName),
-        );
+        // Record a cache hit, but only if the predicate has not been seen before.
+        // We're mainly interested in the reuse of caches from an earlier query run as they can distort comparisons.
+        if (!this.nameToIndex.has(event.predicateName)) {
+          this.data.cacheHitIndices.push(
+            this.getPredicateIndex(event.predicateName),
+          );
+        }
         break;
       }
       case "SENTINEL_EMPTY": {

--- a/extensions/ql-vscode/src/log-insights/performance-comparison.ts
+++ b/extensions/ql-vscode/src/log-insights/performance-comparison.ts
@@ -51,8 +51,6 @@ export interface PerformanceComparisonDataFromLog {
 
   /**
    * All the pipeline runs seen for the `i`th predicate from the `names` array.
-   *
-   * TODO: replace with more compact representation
    */
   pipelineSummaryList: Array<Record<string, PipelineSummary>>;
 }
@@ -161,7 +159,6 @@ export class PerformanceOverviewScanner implements EvaluationLogScanner {
           });
           const { counts: totalTuplesPerStep } = pipelineSummary;
           for (let i = 0, length = counts.length; i < length; ++i) {
-            // TODO: possibly exclude unions here
             const count = counts[i];
             if (count < 0) {
               // Empty RA lines have a tuple count of -1. Do not count them when aggregating.

--- a/extensions/ql-vscode/src/log-insights/performance-comparison.ts
+++ b/extensions/ql-vscode/src/log-insights/performance-comparison.ts
@@ -1,0 +1,177 @@
+import type { EvaluationLogScanner } from "./log-scanner";
+import type { SummaryEvent } from "./log-summary";
+
+export interface PipelineSummary {
+  steps: string[];
+  /** Total counts for each step in the RA array, across all iterations */
+  counts: number[];
+}
+
+/**
+ * Data extracted from a log for the purpose of doing a performance comparison.
+ *
+ * Memory compactness is important since we keep this data in memory; once for
+ * each side of the comparison.
+ *
+ * This object must be able to survive a `postMessage` transfer from the extension host
+ * to a web view (which rules out `Map` values, for example).
+ */
+export interface PerformanceComparisonDataFromLog {
+  /** Names of predicates mentioned in the log */
+  names: string[];
+
+  /** Number of milliseconds spent evaluating the `i`th predicate from the `names` array. */
+  timeCosts: number[];
+
+  /** Number of tuples seen in pipelines evaluating the `i`th predicate from the `names` array. */
+  tupleCosts: number[];
+
+  /** Number of iterations seen when evaluating the `i`th predicate from the `names` array. */
+  iterationCounts: number[];
+
+  /** Number of executions of pipelines evaluating the `i`th predicate from the `names` array. */
+  evaluationCounts: number[];
+
+  /**
+   * List of indices into the `names` array for which we have seen a cache hit.
+   *
+   * TODO: only count cache hits prior to first evaluation?
+   */
+  cacheHitIndices: number[];
+
+  /**
+   * List of indices into the `names` array where the predicate was deemed empty due to a sentinel check.
+   */
+  sentinelEmptyIndices: number[];
+
+  /**
+   * All the pipeline runs seen for the `i`th predicate from the `names` array.
+   *
+   * TODO: replace with more compact representation
+   */
+  pipelineSummaryList: Array<Record<string, PipelineSummary>>;
+}
+
+export class PerformanceOverviewScanner implements EvaluationLogScanner {
+  private readonly nameToIndex = new Map<string, number>();
+  private readonly data: PerformanceComparisonDataFromLog = {
+    names: [],
+    timeCosts: [],
+    tupleCosts: [],
+    cacheHitIndices: [],
+    sentinelEmptyIndices: [],
+    pipelineSummaryList: [],
+    evaluationCounts: [],
+    iterationCounts: [],
+  };
+
+  private getPredicateIndex(name: string): number {
+    const { nameToIndex } = this;
+    let index = nameToIndex.get(name);
+    if (index === undefined) {
+      index = nameToIndex.size;
+      nameToIndex.set(name, index);
+      const {
+        names,
+        timeCosts,
+        tupleCosts,
+        iterationCounts,
+        evaluationCounts,
+        pipelineSummaryList,
+      } = this.data;
+      names.push(name);
+      timeCosts.push(0);
+      tupleCosts.push(0);
+      iterationCounts.push(0);
+      evaluationCounts.push(0);
+      pipelineSummaryList.push({});
+    }
+    return index;
+  }
+
+  getData(): PerformanceComparisonDataFromLog {
+    return this.data;
+  }
+
+  onEvent(event: SummaryEvent): void {
+    if (
+      event.completionType !== undefined &&
+      event.completionType !== "SUCCESS"
+    ) {
+      return; // Skip any evaluation that wasn't successful
+    }
+
+    switch (event.evaluationStrategy) {
+      case "EXTENSIONAL":
+      case "COMPUTED_EXTENSIONAL": {
+        break;
+      }
+      case "CACHE_HIT":
+      case "CACHACA": {
+        this.data.cacheHitIndices.push(
+          this.getPredicateIndex(event.predicateName),
+        );
+        break;
+      }
+      case "SENTINEL_EMPTY": {
+        this.data.sentinelEmptyIndices.push(
+          this.getPredicateIndex(event.predicateName),
+        );
+        break;
+      }
+      case "COMPUTE_RECURSIVE":
+      case "COMPUTE_SIMPLE":
+      case "IN_LAYER": {
+        const index = this.getPredicateIndex(event.predicateName);
+        let totalTime = 0;
+        let totalTuples = 0;
+        if (event.evaluationStrategy !== "IN_LAYER") {
+          totalTime += event.millis;
+        } else {
+          // IN_LAYER events do no record of their total time.
+          // Make a best-effort estimate by adding up the positive iteration times (they can be negative).
+          for (const millis of event.predicateIterationMillis ?? []) {
+            if (millis > 0) {
+              totalTime += millis;
+            }
+          }
+        }
+        const {
+          timeCosts,
+          tupleCosts,
+          iterationCounts,
+          evaluationCounts,
+          pipelineSummaryList,
+        } = this.data;
+        const pipelineSummaries = pipelineSummaryList[index];
+        for (const { counts, raReference } of event.pipelineRuns ?? []) {
+          // Get or create the pipeline summary for this RA
+          const pipelineSummary = (pipelineSummaries[raReference] ??= {
+            steps: event.ra[raReference],
+            counts: counts.map(() => 0),
+          });
+          const { counts: totalTuplesPerStep } = pipelineSummary;
+          for (let i = 0, length = counts.length; i < length; ++i) {
+            // TODO: possibly exclude unions here
+            const count = counts[i];
+            if (count < 0) {
+              // Empty RA lines have a tuple count of -1. Do not count them when aggregating.
+              // But retain the fact that this step had a negative count for rendering purposes.
+              totalTuplesPerStep[i] = count;
+              continue;
+            }
+            totalTuples += count;
+            totalTuplesPerStep[i] += count;
+          }
+        }
+        timeCosts[index] += totalTime;
+        tupleCosts[index] += totalTuples;
+        iterationCounts[index] += event.pipelineRuns?.length ?? 0;
+        evaluationCounts[index] += 1;
+        break;
+      }
+    }
+  }
+
+  onDone(): void {}
+}

--- a/extensions/ql-vscode/src/log-insights/performance-comparison.ts
+++ b/extensions/ql-vscode/src/log-insights/performance-comparison.ts
@@ -41,8 +41,6 @@ export interface PerformanceComparisonDataFromLog {
 
   /**
    * List of indices into the `names` array for which we have seen a cache hit.
-   *
-   * TODO: only count cache hits prior to first evaluation?
    */
   cacheHitIndices: number[];
 

--- a/extensions/ql-vscode/src/log-insights/performance-comparison.ts
+++ b/extensions/ql-vscode/src/log-insights/performance-comparison.ts
@@ -17,7 +17,14 @@ export interface PipelineSummary {
  * to a web view (which rules out `Map` values, for example).
  */
 export interface PerformanceComparisonDataFromLog {
-  /** Names of predicates mentioned in the log */
+  /**
+   * Names of predicates mentioned in the log.
+   *
+   * For compactness, details of these predicates are stored in a "struct of arrays" style.
+   *
+   * All fields (except those ending with `Indices`) should contain an array of the same length as `names`;
+   * details of a given predicate should be stored at the same index in each of those arrays.
+   */
   names: string[];
 
   /** Number of milliseconds spent evaluating the `i`th predicate from the `names` array. */

--- a/extensions/ql-vscode/src/query-history/query-history-manager.ts
+++ b/extensions/ql-vscode/src/query-history/query-history-manager.ts
@@ -689,14 +689,12 @@ export class QueryHistoryManager extends DisposableObject {
     singleItem: QueryHistoryInfo,
     multiSelect: QueryHistoryInfo[] | undefined,
   ) {
-    // TODO: reduce duplication with 'handleCompareWith'
     multiSelect ||= [singleItem];
 
     if (
       !this.isSuccessfulCompletedLocalQueryInfo(singleItem) ||
       !multiSelect.every(this.isSuccessfulCompletedLocalQueryInfo)
     ) {
-      // TODO: support performance comparison with partially-evaluated query (technically possible)
       throw new Error(
         "Please only select local queries that have completed successfully.",
       );

--- a/extensions/ql-vscode/src/query-history/query-history-manager.ts
+++ b/extensions/ql-vscode/src/query-history/query-history-manager.ts
@@ -1128,8 +1128,6 @@ export class QueryHistoryManager extends DisposableObject {
     fromItem: CompletedLocalQueryInfo,
     allSelectedItems: CompletedLocalQueryInfo[],
   ): Promise<CompletedLocalQueryInfo | undefined> {
-    const dbName = fromItem.databaseName;
-
     // If exactly 2 items are selected, return the one that
     // isn't being used as the "from" item.
     if (allSelectedItems.length === 2) {
@@ -1137,9 +1135,6 @@ export class QueryHistoryManager extends DisposableObject {
         fromItem === allSelectedItems[0]
           ? allSelectedItems[1]
           : allSelectedItems[0];
-      if (otherItem.databaseName !== dbName) {
-        throw new Error("Query databases must be the same.");
-      }
       return otherItem;
     }
 
@@ -1150,10 +1145,7 @@ export class QueryHistoryManager extends DisposableObject {
     // Otherwise, present a dialog so the user can choose the item they want to use.
     const comparableQueryLabels = this.treeDataProvider.allHistory
       .filter(this.isSuccessfulCompletedLocalQueryInfo)
-      .filter(
-        (otherItem) =>
-          otherItem !== fromItem && otherItem.databaseName === dbName,
-      )
+      .filter((otherItem) => otherItem !== fromItem)
       .map((item) => ({
         label: this.labelProvider.getLabel(item),
         description: item.databaseName,

--- a/extensions/ql-vscode/src/view/common/WarningBox.tsx
+++ b/extensions/ql-vscode/src/view/common/WarningBox.tsx
@@ -1,0 +1,31 @@
+import { styled } from "styled-components";
+import { WarningIcon } from "./icon/WarningIcon";
+
+const WarningBoxDiv = styled.div`
+  max-width: 100em;
+  padding: 0.5em 1em;
+  border: 1px solid var(--vscode-widget-border);
+  box-shadow: var(--vscode-widget-shadow) 0px 3px 8px;
+  display: flex;
+`;
+
+const IconPane = styled.p`
+  width: 3em;
+  flex-shrink: 0;
+  text-align: center;
+`;
+
+export interface WarningBoxProps {
+  children: React.ReactNode;
+}
+
+export function WarningBox(props: WarningBoxProps) {
+  return (
+    <WarningBoxDiv>
+      <IconPane>
+        <WarningIcon />
+      </IconPane>
+      <p>{props.children}</p>
+    </WarningBoxDiv>
+  );
+}

--- a/extensions/ql-vscode/src/view/common/index.ts
+++ b/extensions/ql-vscode/src/view/common/index.ts
@@ -6,3 +6,4 @@ export * from "./HorizontalSpace";
 export * from "./SectionTitle";
 export * from "./VerticalSpace";
 export * from "./ViewTitle";
+export * from "./WarningBox";

--- a/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
+++ b/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
@@ -93,7 +93,7 @@ function renderAbsoluteValue(x: OptionalValue) {
 function renderDelta(x: number) {
   const sign = x > 0 ? "+" : "";
   return (
-    <NumberCell>
+    <NumberCell className={x > 0 ? "bad-value" : x < 0 ? "good-value" : ""}>
       {sign}
       {formatDecimal(x)}
     </NumberCell>
@@ -126,6 +126,19 @@ const NameCell = styled.td``;
 const NumberCell = styled.td`
   text-align: right;
   width: 10em !important;
+
+  &.bad-value {
+    color: var(--vscode-problemsErrorIcon-foreground);
+    tr.expanded & {
+      color: inherit;
+    }
+  }
+  &.good-value {
+    color: var(--vscode-problemsInfoIcon-foreground);
+    tr.expanded & {
+      color: inherit;
+    }
+  }
 `;
 
 const AbsentNumberCell = styled.td`

--- a/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
+++ b/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
@@ -190,7 +190,7 @@ const SortOrderDropdown = styled.select``;
 interface PipelineStepProps {
   before: number | undefined;
   after: number | undefined;
-  step: string;
+  step: React.ReactNode;
 }
 
 /**

--- a/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
+++ b/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
@@ -216,6 +216,10 @@ function PipelineStep(props: PipelineStepProps) {
   );
 }
 
+const HeaderTR = styled.tr`
+  background-color: var(--vscode-sideBar-background);
+`;
+
 interface HighLevelStatsProps {
   before: PredicateInfo;
   after: PredicateInfo;
@@ -229,13 +233,13 @@ function HighLevelStats(props: HighLevelStatsProps) {
     before.evaluationCount > 1 || after.evaluationCount > 1;
   return (
     <>
-      <tr>
+      <HeaderTR>
         <ChevronCell></ChevronCell>
         <NumberHeader>{hasBefore ? "Before" : ""}</NumberHeader>
         <NumberHeader>{hasAfter ? "After" : ""}</NumberHeader>
         <NumberHeader>{hasBefore && hasAfter ? "Delta" : ""}</NumberHeader>
         <NameHeader>Stats</NameHeader>
-      </tr>
+      </HeaderTR>
       {showEvaluationCount && (
         <PipelineStep
           before={before.evaluationCount || undefined}
@@ -393,13 +397,13 @@ export function ComparePerformance(_: Record<string, never>) {
       </SortOrderDropdown>
       <Table>
         <thead>
-          <tr>
+          <HeaderTR>
             <ChevronCell />
             <NumberHeader>Before</NumberHeader>
             <NumberHeader>After</NumberHeader>
             <NumberHeader>Delta</NumberHeader>
             <NameHeader>Predicate</NameHeader>
-          </tr>
+          </HeaderTR>
         </thead>
       </Table>
       {rows.map((row) => (
@@ -433,7 +437,7 @@ export function ComparePerformance(_: Record<string, never>) {
                   row.after.pipelines,
                 ).map(({ name, first, second }, pipelineIndex) => (
                   <Fragment key={pipelineIndex}>
-                    <tr>
+                    <HeaderTR>
                       <td></td>
                       <NumberHeader>{first != null && "Before"}</NumberHeader>
                       <NumberHeader>{second != null && "After"}</NumberHeader>
@@ -448,7 +452,7 @@ export function ComparePerformance(_: Record<string, never>) {
                             ? " (before)"
                             : ""}
                       </NameHeader>
-                    </tr>
+                    </HeaderTR>
                     {abbreviateRASteps(first?.steps ?? second!.steps).map(
                       (step, index) => (
                         <PipelineStep

--- a/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
+++ b/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
@@ -28,6 +28,7 @@ interface OptionalValue {
 interface PredicateInfo extends OptionalValue {
   evaluationCount: number;
   iterationCount: number;
+  timeCost: number;
   pipelines: Record<string, PipelineSummary>;
 }
 
@@ -54,6 +55,7 @@ class ComparisonDataset {
         evaluationCount: 0,
         iterationCount: 0,
         tuples: 0,
+        timeCost: 0,
         absentReason: AbsentReason.NotSeen,
         pipelines: {},
       };
@@ -70,6 +72,7 @@ class ComparisonDataset {
     return {
       evaluationCount: data.evaluationCounts[index],
       iterationCount: data.iterationCounts[index],
+      timeCost: data.timeCosts[index],
       tuples: tupleCost,
       absentReason,
       pipelines: data.pipelineSummaryList[index],
@@ -77,7 +80,7 @@ class ComparisonDataset {
   }
 }
 
-function renderAbsoluteValue(x: OptionalValue) {
+function renderAbsoluteValue(x: PredicateInfo, metric: Metric) {
   switch (x.absentReason) {
     case AbsentReason.NotSeen:
       return <AbsentNumberCell>n/a</AbsentNumberCell>;
@@ -86,18 +89,28 @@ function renderAbsoluteValue(x: OptionalValue) {
     case AbsentReason.Sentinel:
       return <AbsentNumberCell>sentinel empty</AbsentNumberCell>;
     default:
-      return <NumberCell>{formatDecimal(x.tuples)}</NumberCell>;
+      return (
+        <NumberCell>
+          {formatDecimal(metric.get(x))}
+          {renderUnit(metric.unit)}
+        </NumberCell>
+      );
   }
 }
 
-function renderDelta(x: number) {
+function renderDelta(x: number, unit?: string) {
   const sign = x > 0 ? "+" : "";
   return (
     <NumberCell className={x > 0 ? "bad-value" : x < 0 ? "good-value" : ""}>
       {sign}
       {formatDecimal(x)}
+      {renderUnit(unit)}
     </NumberCell>
   );
+}
+
+function renderUnit(unit: string | undefined) {
+  return unit == null ? "" : ` ${unit}`;
 }
 
 function orderBy<T>(fn: (x: T) => number | string) {
@@ -198,7 +211,7 @@ const PipelineStepTR = styled.tr`
   }
 `;
 
-const SortOrderDropdown = styled.select``;
+const Dropdown = styled.select``;
 
 interface PipelineStepProps {
   before: number | undefined;
@@ -287,6 +300,37 @@ function getSortOrder(sortOrder: "delta" | "absDelta") {
   return orderBy((row: TRow) => row.diff);
 }
 
+interface Metric {
+  title: string;
+  get(info: PredicateInfo): number;
+  unit?: string;
+}
+
+const metrics: Record<string, Metric> = {
+  tuples: {
+    title: "Tuples in pipeline",
+    get: (info) => info.tuples,
+  },
+  time: {
+    title: "Time spent (milliseconds)",
+    get: (info) => info.timeCost,
+    unit: "ms",
+  },
+  evaluations: {
+    title: "Evaluations",
+    get: (info) => info.evaluationCount,
+  },
+  iterations: {
+    title: "Iterations (per evaluation)",
+    get: (info) =>
+      info.absentReason ? 0 : info.iterationCount / info.evaluationCount,
+  },
+  iterationsTotal: {
+    title: "Iterations (total)",
+    get: (info) => info.iterationCount,
+  },
+};
+
 function Chevron({ expanded }: { expanded: boolean }) {
   return <Codicon name={expanded ? "chevron-down" : "chevron-right"} />;
 }
@@ -332,6 +376,8 @@ export function ComparePerformance(_: Record<string, never>) {
 
   const [sortOrder, setSortOrder] = useState<"delta" | "absDelta">("absDelta");
 
+  const [metric, setMetric] = useState<Metric>(metrics.tuples);
+
   if (!datasets) {
     return <div>Loading performance comparison...</div>;
   }
@@ -349,7 +395,9 @@ export function ComparePerformance(_: Record<string, never>) {
     .map((name) => {
       const before = from.getTupleCountInfo(name);
       const after = to.getTupleCountInfo(name);
-      if (before.tuples === after.tuples) {
+      const beforeValue = metric.get(before);
+      const afterValue = metric.get(after);
+      if (beforeValue === afterValue) {
         return undefined!;
       }
       if (
@@ -361,7 +409,7 @@ export function ComparePerformance(_: Record<string, never>) {
           return undefined!;
         }
       }
-      const diff = after.tuples - before.tuples;
+      const diff = afterValue - beforeValue;
       return { name, before, after, diff };
     })
     .filter((x) => !!x)
@@ -372,8 +420,8 @@ export function ComparePerformance(_: Record<string, never>) {
   let totalDiff = 0;
 
   for (const row of rows) {
-    totalBefore += row.before.tuples;
-    totalAfter += row.after.tuples;
+    totalBefore += metric.get(row.before);
+    totalAfter += metric.get(row.after);
     totalDiff += row.diff;
   }
 
@@ -401,7 +449,20 @@ export function ComparePerformance(_: Record<string, never>) {
           </label>
         </WarningBox>
       )}
-      <SortOrderDropdown
+      Compare{" "}
+      <Dropdown
+        onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+          setMetric(metrics[e.target.value])
+        }
+      >
+        {Object.entries(metrics).map(([key, value]) => (
+          <option key={key} value={key}>
+            {value.title}
+          </option>
+        ))}
+      </Dropdown>{" "}
+      sorted by{" "}
+      <Dropdown
         onChange={(e: ChangeEvent<HTMLSelectElement>) =>
           setSortOrder(e.target.value as "delta" | "absDelta")
         }
@@ -409,7 +470,7 @@ export function ComparePerformance(_: Record<string, never>) {
       >
         <option value="delta">Delta</option>
         <option value="absDelta">Absolute delta</option>
-      </SortOrderDropdown>
+      </Dropdown>
       <Table>
         <thead>
           <HeaderTR>
@@ -439,9 +500,9 @@ export function ComparePerformance(_: Record<string, never>) {
               <ChevronCell>
                 <Chevron expanded={expandedPredicates.has(row.name)} />
               </ChevronCell>
-              {renderAbsoluteValue(row.before)}
-              {renderAbsoluteValue(row.after)}
-              {renderDelta(row.diff)}
+              {renderAbsoluteValue(row.before, metric)}
+              {renderAbsoluteValue(row.after, metric)}
+              {renderDelta(row.diff, metric.unit)}
               <NameCell>{rowNames[rowIndex]}</NameCell>
             </PredicateTR>
             {expandedPredicates.has(row.name) && (

--- a/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
+++ b/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
@@ -262,6 +262,32 @@ const HeaderTR = styled.tr`
   background-color: var(--vscode-sideBar-background);
 `;
 
+interface HeaderRowProps {
+  hasBefore?: boolean;
+  hasAfter?: boolean;
+  comparison: boolean;
+  title: React.ReactNode;
+}
+
+function HeaderRow(props: HeaderRowProps) {
+  const { comparison, hasBefore, hasAfter, title } = props;
+  return (
+    <HeaderTR>
+      <ChevronCell />
+      {comparison ? (
+        <>
+          <NumberHeader>{hasBefore ? "Before" : ""}</NumberHeader>
+          <NumberHeader>{hasAfter ? "After" : ""}</NumberHeader>
+          <NumberHeader>{hasBefore && hasAfter ? "Delta" : ""}</NumberHeader>
+        </>
+      ) : (
+        <NumberHeader>Value</NumberHeader>
+      )}
+      <NameHeader>{title}</NameHeader>
+    </HeaderTR>
+  );
+}
+
 interface HighLevelStatsProps {
   before: Optional<PredicateInfo>;
   after: Optional<PredicateInfo>;
@@ -277,15 +303,12 @@ function HighLevelStats(props: HighLevelStatsProps) {
     (hasAfter && after.evaluationCount > 1);
   return (
     <>
-      <HeaderTR>
-        <ChevronCell></ChevronCell>
-        {comparison && <NumberHeader>{hasBefore ? "Before" : ""}</NumberHeader>}
-        <NumberHeader>{hasAfter ? "After" : ""}</NumberHeader>
-        {comparison && (
-          <NumberHeader>{hasBefore && hasAfter ? "Delta" : ""}</NumberHeader>
-        )}
-        <NameHeader>Stats</NameHeader>
-      </HeaderTR>
+      <HeaderRow
+        hasBefore={hasBefore}
+        hasAfter={hasAfter}
+        title="Stats"
+        comparison={comparison}
+      />
       {showEvaluationCount && (
         <PipelineStep
           before={hasBefore ? before.evaluationCount : undefined}
@@ -607,13 +630,7 @@ function ComparePerformanceWithData(props: {
       )}
       <Table>
         <thead>
-          <HeaderTR>
-            <ChevronCell />
-            {comparison && <NumberHeader>Before</NumberHeader>}
-            <NumberHeader>{comparison ? "After" : "Value"}</NumberHeader>
-            {comparison && <NumberHeader>Delta</NumberHeader>}
-            <NameHeader>Predicate</NameHeader>
-          </HeaderTR>
+          <HeaderRow comparison={comparison} title="Predicate" />
         </thead>
         <tbody>
           <tr key="total">
@@ -765,27 +782,22 @@ function PredicateRow(props: PredicateRowProps) {
               isPresent(row.after) ? row.after.pipelines : {},
             ).map(({ name, first, second }, pipelineIndex) => (
               <Fragment key={pipelineIndex}>
-                <HeaderTR>
-                  <td></td>
-                  {comparison && (
-                    <NumberHeader>{first != null && "Before"}</NumberHeader>
-                  )}
-                  <NumberHeader>{second != null && "After"}</NumberHeader>
-                  {comparison && (
-                    <NumberHeader>
-                      {first != null && second != null && "Delta"}
-                    </NumberHeader>
-                  )}
-                  <NameHeader>
-                    Tuple counts for &apos;{name}&apos; pipeline
-                    {comparison &&
-                      (first == null
-                        ? " (after)"
-                        : second == null
-                          ? " (before)"
-                          : "")}
-                  </NameHeader>
-                </HeaderTR>
+                <HeaderRow
+                  hasBefore={first != null}
+                  hasAfter={second != null}
+                  comparison={comparison}
+                  title={
+                    <>
+                      Tuple counts for &apos;{name}&apos; pipeline
+                      {comparison &&
+                        (first == null
+                          ? " (after)"
+                          : second == null
+                            ? " (before)"
+                            : "")}
+                    </>
+                  }
+                />
                 {abbreviateRASteps(first?.steps ?? second!.steps).map(
                   (step, index) => (
                     <PipelineStep

--- a/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
+++ b/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
@@ -297,7 +297,7 @@ function HighLevelStats(props: HighLevelStatsProps) {
   );
 }
 
-interface TRow {
+interface Row {
   name: string;
   before: Optional<PredicateInfo>;
   after: Optional<PredicateInfo>;
@@ -306,9 +306,9 @@ interface TRow {
 
 function getSortOrder(sortOrder: "delta" | "absDelta") {
   if (sortOrder === "absDelta") {
-    return orderBy((row: TRow) => -Math.abs(row.diff));
+    return orderBy((row: Row) => -Math.abs(row.diff));
   }
-  return orderBy((row: TRow) => row.diff);
+  return orderBy((row: Row) => row.diff);
 }
 
 interface Metric {
@@ -410,7 +410,7 @@ function ComparePerformanceWithData(props: {
 
   const hasCacheHitMismatch = useRef(false);
 
-  const rows: TRow[] = useMemo(() => {
+  const rows: Row[] = useMemo(() => {
     hasCacheHitMismatch.current = false;
     return Array.from(nameSet)
       .map((name) => {
@@ -433,7 +433,7 @@ function ComparePerformanceWithData(props: {
         const diff =
           (isPresent(afterValue) ? afterValue : 0) -
           (isPresent(beforeValue) ? beforeValue : 0);
-        return { name, before, after, diff } satisfies TRow;
+        return { name, before, after, diff } satisfies Row;
       })
       .filter((x) => !!x)
       .sort(getSortOrder(sortOrder));
@@ -542,7 +542,7 @@ function ComparePerformanceWithData(props: {
 
 interface PredicateRowProps {
   renderedName: React.ReactNode;
-  row: TRow;
+  row: Row;
   comparison: boolean;
   metric: Metric;
 }

--- a/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
+++ b/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
@@ -369,7 +369,7 @@ function ComparePerformanceWithData(props: {
 }) {
   const { data } = props;
 
-  const datasets = useMemo(
+  const { from, to } = useMemo(
     () => ({
       from: new ComparisonDataset(data.from),
       to: new ComparisonDataset(data.to),
@@ -386,8 +386,6 @@ function ComparePerformanceWithData(props: {
   const [sortOrder, setSortOrder] = useState<"delta" | "absDelta">("absDelta");
 
   const [metric, setMetric] = useState<Metric>(metrics.tuples);
-
-  const { from, to } = datasets;
 
   const nameSet = new Set(from.data.names);
   for (const name of to.data.names) {

--- a/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
+++ b/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
@@ -416,30 +416,29 @@ function ComparePerformanceWithData(props: {
   const rows = useMemo(() => {
     hasCacheHitMismatch.current = false;
     return Array.from(nameSet)
-        .map((name) => {
-          const before = from.getTupleCountInfo(name);
-          const after = to.getTupleCountInfo(name);
-          const beforeValue = metric.get(before);
-          const afterValue = metric.get(after);
-          if (beforeValue === afterValue) {
+      .map((name) => {
+        const before = from.getTupleCountInfo(name);
+        const after = to.getTupleCountInfo(name);
+        const beforeValue = metric.get(before);
+        const afterValue = metric.get(after);
+        if (beforeValue === afterValue) {
+          return undefined!;
+        }
+        if (
+          before.absentReason === AbsentReason.CacheHit ||
+          after.absentReason === AbsentReason.CacheHit
+        ) {
+          hasCacheHitMismatch.current = true;
+          if (hideCacheHits) {
             return undefined!;
           }
-          if (
-            before.absentReason === AbsentReason.CacheHit ||
-            after.absentReason === AbsentReason.CacheHit
-          ) {
-            hasCacheHitMismatch.current = true;
-            if (hideCacheHits) {
-              return undefined!;
-            }
-          }
-          const diff = afterValue - beforeValue;
-          return { name, before, after, diff };
-        })
-        .filter((x) => !!x)
-        .sort(getSortOrder(sortOrder)),
-    [nameSet, from, to, metric, hideCacheHits, sortOrder],
-  );
+        }
+        const diff = afterValue - beforeValue;
+        return { name, before, after, diff };
+      })
+      .filter((x) => !!x)
+      .sort(getSortOrder(sortOrder));
+  }, [nameSet, from, to, metric, hideCacheHits, sortOrder]);
 
   const { totalBefore, totalAfter, totalDiff } = useMemo(() => {
     let totalBefore = 0;

--- a/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
+++ b/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
@@ -413,29 +413,31 @@ function ComparePerformanceWithData(props: {
 
   const hasCacheHitMismatch = useRef<boolean>(false);
 
-  const rows = useMemo(() => Array.from(nameSet)
-    .map((name) => {
-      const before = from.getTupleCountInfo(name);
-      const after = to.getTupleCountInfo(name);
-      const beforeValue = metric.get(before);
-      const afterValue = metric.get(after);
-      if (beforeValue === afterValue) {
-        return undefined!;
-      }
-      if (
-        before.absentReason === AbsentReason.CacheHit ||
-        after.absentReason === AbsentReason.CacheHit
-      ) {
-        hasCacheHitMismatch.current = true;
-        if (hideCacheHits) {
-          return undefined!;
-        }
-      }
-      const diff = afterValue - beforeValue;
-      return { name, before, after, diff };
-    })
-    .filter((x) => !!x)
-    .sort(getSortOrder(sortOrder)),
+  const rows = useMemo(
+    () =>
+      Array.from(nameSet)
+        .map((name) => {
+          const before = from.getTupleCountInfo(name);
+          const after = to.getTupleCountInfo(name);
+          const beforeValue = metric.get(before);
+          const afterValue = metric.get(after);
+          if (beforeValue === afterValue) {
+            return undefined!;
+          }
+          if (
+            before.absentReason === AbsentReason.CacheHit ||
+            after.absentReason === AbsentReason.CacheHit
+          ) {
+            hasCacheHitMismatch.current = true;
+            if (hideCacheHits) {
+              return undefined!;
+            }
+          }
+          const diff = afterValue - beforeValue;
+          return { name, before, after, diff };
+        })
+        .filter((x) => !!x)
+        .sort(getSortOrder(sortOrder)),
     [nameSet, from, to, metric, hideCacheHits, sortOrder],
   );
 

--- a/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
+++ b/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
@@ -1,5 +1,5 @@
 import type { ChangeEvent } from "react";
-import { Fragment, useMemo, useRef, useState } from "react";
+import { Fragment, memo, useMemo, useRef, useState } from "react";
 import type {
   SetPerformanceComparisonQueries,
   ToComparePerformanceViewMessage,
@@ -577,15 +577,12 @@ function ComparePerformanceWithData(props: {
           </HeaderTR>
         </thead>
       </Table>
-      {rowGroups.map((rowGroup, rowGroupIndex) => (
-        <PredicateRowGroup
-          key={rowGroupIndex}
-          renderedName={rowGroupNames[rowGroupIndex]}
-          rowGroup={rowGroup}
-          comparison={comparison}
-          metric={metric}
-        />
-      ))}
+      <PredicateTable
+        rowGroups={rowGroups}
+        rowGroupNames={rowGroupNames}
+        comparison={comparison}
+        metric={metric}
+      />
       <Table>
         <tfoot>
           <tr key="spacing">
@@ -605,6 +602,28 @@ function ComparePerformanceWithData(props: {
     </>
   );
 }
+
+interface PredicateTableProps {
+  rowGroups: RowGroup[];
+  rowGroupNames: React.ReactNode[];
+  comparison: boolean;
+  metric: Metric;
+}
+
+function PredicateTableRaw(props: PredicateTableProps) {
+  const { comparison, metric, rowGroupNames, rowGroups } = props;
+  return rowGroups.map((rowGroup, rowGroupIndex) => (
+    <PredicateRowGroup
+      key={rowGroupIndex}
+      renderedName={rowGroupNames[rowGroupIndex]}
+      rowGroup={rowGroup}
+      comparison={comparison}
+      metric={metric}
+    />
+  ));
+}
+
+const PredicateTable = memo(PredicateTableRaw);
 
 interface PredicateRowGroupProps {
   renderedName: React.ReactNode;

--- a/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
+++ b/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
@@ -411,11 +411,11 @@ function ComparePerformanceWithData(props: {
     [from, to],
   );
 
-  const hasCacheHitMismatch = useRef<boolean>(false);
+  const hasCacheHitMismatch = useRef(false);
 
-  const rows = useMemo(
-    () =>
-      Array.from(nameSet)
+  const rows = useMemo(() => {
+    hasCacheHitMismatch.current = false;
+    return Array.from(nameSet)
         .map((name) => {
           const before = from.getTupleCountInfo(name);
           const after = to.getTupleCountInfo(name);

--- a/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
+++ b/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
@@ -417,7 +417,7 @@ function addOptionals(a: Optional<number>, b: Optional<number>) {
 /**
  * Returns a "fingerprint" from the given name, which is used to group together similar names.
  */
-export function getNameFingerprint(name: string, renamings: Renaming[]) {
+function getNameFingerprint(name: string, renamings: Renaming[]) {
   for (const { patternRegexp, replacement } of renamings) {
     if (patternRegexp != null) {
       name = name.replace(patternRegexp, replacement);

--- a/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
+++ b/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
@@ -1,5 +1,5 @@
 import type { ChangeEvent } from "react";
-import { useMemo, useState, Fragment } from "react";
+import { Fragment, useMemo, useState } from "react";
 import type {
   SetPerformanceComparisonQueries,
   ToComparePerformanceViewMessage,
@@ -354,6 +354,14 @@ function withToggledValue<T>(set: Set<T>, value: T) {
   return result;
 }
 
+function union<T>(a: Set<T> | T[], b: Set<T> | T[]) {
+  const result = new Set(a);
+  for (const x of b) {
+    result.add(x);
+  }
+  return result;
+}
+
 export function ComparePerformance(_: Record<string, never>) {
   const [data, setData] = useState<
     SetPerformanceComparisonQueries | undefined
@@ -398,10 +406,10 @@ function ComparePerformanceWithData(props: {
 
   const [metric, setMetric] = useState<Metric>(metrics.tuples);
 
-  const nameSet = new Set(from.data.names);
-  for (const name of to.data.names) {
-    nameSet.add(name);
-  }
+  const nameSet = useMemo(
+    () => union(from.data.names, to.data.names),
+    [from, to],
+  );
 
   let hasCacheHitMismatch = false;
 

--- a/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
+++ b/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
@@ -1,3 +1,4 @@
+import type { ChangeEvent } from "react";
 import { useMemo, useState, Fragment } from "react";
 import type {
   SetPerformanceComparisonQueries,
@@ -184,6 +185,8 @@ const PipelineStepTR = styled.tr`
   }
 `;
 
+const SortOrderDropdown = styled.select``;
+
 interface PipelineStepProps {
   before: number | undefined;
   after: number | undefined;
@@ -253,6 +256,20 @@ function HighLevelStats(props: HighLevelStatsProps) {
   );
 }
 
+type TRow = {
+  name: string;
+  before: PredicateInfo;
+  after: PredicateInfo;
+  diff: number;
+};
+
+function getSortOrder(sortOrder: "delta" | "absDelta") {
+  if (sortOrder === "absDelta") {
+    return orderBy((row: TRow) => -Math.abs(row.diff));
+  }
+  return orderBy((row: TRow) => row.diff);
+}
+
 function Chevron({ expanded }: { expanded: boolean }) {
   return <Codicon name={expanded ? "chevron-down" : "chevron-right"} />;
 }
@@ -296,6 +313,8 @@ export function ComparePerformance(_: Record<string, never>) {
 
   const [hideCacheHits, setHideCacheHits] = useState(false);
 
+  const [sortOrder, setSortOrder] = useState<"delta" | "absDelta">("absDelta");
+
   if (!datasets) {
     return <div>Loading performance comparison...</div>;
   }
@@ -329,7 +348,7 @@ export function ComparePerformance(_: Record<string, never>) {
       return { name, before, after, diff };
     })
     .filter((x) => !!x)
-    .sort(orderBy((row) => row.diff));
+    .sort(getSortOrder(sortOrder));
 
   let totalBefore = 0;
   let totalAfter = 0;
@@ -363,6 +382,15 @@ export function ComparePerformance(_: Record<string, never>) {
           </label>
         </WarningBox>
       )}
+      <SortOrderDropdown
+        onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+          setSortOrder(e.target.value as "delta" | "absDelta")
+        }
+        value={sortOrder}
+      >
+        <option value="delta">Delta</option>
+        <option value="absDelta">Absolute delta</option>
+      </SortOrderDropdown>
       <Table>
         <thead>
           <tr>

--- a/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
+++ b/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
@@ -611,6 +611,20 @@ function ComparePerformanceWithData(props: {
             <NameHeader>Predicate</NameHeader>
           </HeaderTR>
         </thead>
+        <tbody>
+          <tr key="total">
+            <ChevronCell />
+            {comparison && renderOptionalValue(totalBefore, metric.unit)}
+            {renderOptionalValue(totalAfter, metric.unit)}
+            {comparison && renderDelta(totalDiff, metric.unit)}
+            <NameCell>
+              <strong>TOTAL</strong>
+            </NameCell>
+          </tr>
+          <tr key="spacing">
+            <td colSpan={5} style={{ height: "1em" }}></td>
+          </tr>
+        </tbody>
       </Table>
       <PredicateTable
         rowGroups={rowGroups}
@@ -619,22 +633,6 @@ function ComparePerformanceWithData(props: {
         metric={metric}
         isPerEvaluation={isPerEvaluation}
       />
-      <Table>
-        <tfoot>
-          <tr key="spacing">
-            <td colSpan={5} style={{ height: "1em" }}></td>
-          </tr>
-          <tr key="total">
-            <ChevronCell />
-            {comparison && (
-              <NumberCell>{formatDecimal(totalBefore)}</NumberCell>
-            )}
-            <NumberCell>{formatDecimal(totalAfter)}</NumberCell>
-            {comparison && renderDelta(totalDiff)}
-            <NameCell>TOTAL</NameCell>
-          </tr>
-        </tfoot>
-      </Table>
     </>
   );
 }

--- a/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
+++ b/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
@@ -591,16 +591,20 @@ function ComparePerformanceWithData(props: {
         <option value="total">Overall</option>
         <option value="per-evaluation">Per evaluation</option>
       </Dropdown>{" "}
-      sorted by{" "}
-      <Dropdown
-        onChange={(e: ChangeEvent<HTMLSelectElement>) =>
-          setSortOrder(e.target.value as "delta" | "absDelta")
-        }
-        value={sortOrder}
-      >
-        <option value="delta">Delta</option>
-        <option value="absDelta">Absolute delta</option>
-      </Dropdown>
+      {comparison && (
+        <>
+          sorted by{" "}
+          <Dropdown
+            onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+              setSortOrder(e.target.value as "delta" | "absDelta")
+            }
+            value={sortOrder}
+          >
+            <option value="delta">Delta</option>
+            <option value="absDelta">Absolute delta</option>
+          </Dropdown>
+        </>
+      )}
       <Table>
         <thead>
           <HeaderTR>

--- a/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
+++ b/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
@@ -574,7 +574,7 @@ function ComparePerformanceWithData(props: {
   return (
     <>
       <ViewTitle>Performance comparison</ViewTitle>
-      {hasCacheHitMismatch.current && (
+      {comparison && hasCacheHitMismatch.current && (
         <WarningBox>
           <strong>Inconsistent cache hits</strong>
           <br />

--- a/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
+++ b/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
@@ -441,15 +441,17 @@ function ComparePerformanceWithData(props: {
     [nameSet, from, to, metric, hideCacheHits, sortOrder],
   );
 
-  let totalBefore = 0;
-  let totalAfter = 0;
-  let totalDiff = 0;
-
-  for (const row of rows) {
-    totalBefore += metric.get(row.before);
-    totalAfter += metric.get(row.after);
-    totalDiff += row.diff;
-  }
+  const { totalBefore, totalAfter, totalDiff } = useMemo(() => {
+    let totalBefore = 0;
+    let totalAfter = 0;
+    let totalDiff = 0;
+    for (const row of rows) {
+      totalBefore += metric.get(row.before);
+      totalAfter += metric.get(row.after);
+      totalDiff += row.diff;
+    }
+    return { totalBefore, totalAfter, totalDiff };
+  }, [rows, metric]);
 
   const rowNames = useMemo(
     () => abbreviateRANames(rows.map((row) => row.name)),

--- a/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
+++ b/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
@@ -12,7 +12,7 @@ import type {
 import { formatDecimal } from "../../common/number";
 import { styled } from "styled-components";
 import { Codicon, ViewTitle, WarningBox } from "../common";
-import { abbreviateRASteps } from "./RAPrettyPrinter";
+import { abbreviateRANames, abbreviateRASteps } from "./RAPrettyPrinter";
 
 const enum AbsentReason {
   NotSeen = "NotSeen",
@@ -364,6 +364,8 @@ export function ComparePerformance(_: Record<string, never>) {
     totalDiff += row.diff;
   }
 
+  const rowNames = abbreviateRANames(rows.map((row) => row.name));
+
   return (
     <>
       <ViewTitle>Performance comparison</ViewTitle>
@@ -406,7 +408,7 @@ export function ComparePerformance(_: Record<string, never>) {
           </HeaderTR>
         </thead>
       </Table>
-      {rows.map((row) => (
+      {rows.map((row, rowIndex) => (
         <Table
           key={row.name}
           className={expandedPredicates.has(row.name) ? "expanded" : ""}
@@ -427,7 +429,7 @@ export function ComparePerformance(_: Record<string, never>) {
               {renderAbsoluteValue(row.before)}
               {renderAbsoluteValue(row.after)}
               {renderDelta(row.diff)}
-              <NameCell>{row.name}</NameCell>
+              <NameCell>{rowNames[rowIndex]}</NameCell>
             </PredicateTR>
             {expandedPredicates.has(row.name) && (
               <>

--- a/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
+++ b/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
@@ -73,7 +73,7 @@ class ComparisonDataset {
   }
 }
 
-function renderAbsoluteValue(x: Optional<PredicateInfo>, metric: Metric) {
+function renderOptionalValue(x: Optional<number>, unit?: string) {
   switch (x) {
     case AbsentReason.NotSeen:
       return <AbsentNumberCell>n/a</AbsentNumberCell>;
@@ -84,11 +84,15 @@ function renderAbsoluteValue(x: Optional<PredicateInfo>, metric: Metric) {
     default:
       return (
         <NumberCell>
-          {formatDecimal(metric.get(x))}
-          {renderUnit(metric.unit)}
+          {formatDecimal(x)}
+          {renderUnit(unit)}
         </NumberCell>
       );
   }
+}
+
+function renderPredicateMetric(x: Optional<PredicateInfo>, metric: Metric) {
+  return renderOptionalValue(metricGetOptional(metric, x), metric.unit);
 }
 
 function renderDelta(x: number, unit?: string) {
@@ -539,8 +543,8 @@ function ComparePerformanceWithData(props: {
               <ChevronCell>
                 <Chevron expanded={expandedPredicates.has(row.name)} />
               </ChevronCell>
-              {comparison && renderAbsoluteValue(row.before, metric)}
-              {renderAbsoluteValue(row.after, metric)}
+              {comparison && renderPredicateMetric(row.before, metric)}
+              {renderPredicateMetric(row.after, metric)}
               {comparison && renderDelta(row.diff, metric.unit)}
               <NameCell>{rowNames[rowIndex]}</NameCell>
             </PredicateTR>

--- a/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
+++ b/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
@@ -357,14 +357,23 @@ export function ComparePerformance(_: Record<string, never>) {
     [setData],
   );
 
+  if (!data) {
+    return <div>Loading performance comparison...</div>;
+  }
+
+  return <ComparePerformanceWithData data={data} />;
+}
+
+function ComparePerformanceWithData(props: {
+  data: SetPerformanceComparisonQueries;
+}) {
+  const { data } = props;
+
   const datasets = useMemo(
-    () =>
-      data == null
-        ? undefined
-        : {
-            from: new ComparisonDataset(data.from),
-            to: new ComparisonDataset(data.to),
-          },
+    () => ({
+      from: new ComparisonDataset(data.from),
+      to: new ComparisonDataset(data.to),
+    }),
     [data],
   );
 
@@ -377,10 +386,6 @@ export function ComparePerformance(_: Record<string, never>) {
   const [sortOrder, setSortOrder] = useState<"delta" | "absDelta">("absDelta");
 
   const [metric, setMetric] = useState<Metric>(metrics.tuples);
-
-  if (!datasets) {
-    return <div>Loading performance comparison...</div>;
-  }
 
   const { from, to } = datasets;
 

--- a/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
+++ b/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
@@ -1,0 +1,444 @@
+import { useMemo, useState, Fragment } from "react";
+import type {
+  SetPerformanceComparisonQueries,
+  ToComparePerformanceViewMessage,
+} from "../../common/interface-types";
+import { useMessageFromExtension } from "../common/useMessageFromExtension";
+import type {
+  PerformanceComparisonDataFromLog,
+  PipelineSummary,
+} from "../../log-insights/performance-comparison";
+import { formatDecimal } from "../../common/number";
+import { styled } from "styled-components";
+import { Codicon, ViewTitle, WarningBox } from "../common";
+import { abbreviateRASteps } from "./RAPrettyPrinter";
+
+const enum AbsentReason {
+  NotSeen = "NotSeen",
+  CacheHit = "CacheHit",
+  Sentinel = "Sentinel",
+}
+
+interface OptionalValue {
+  absentReason: AbsentReason | undefined;
+  tuples: number;
+}
+
+interface PredicateInfo extends OptionalValue {
+  pipelines: Record<string, PipelineSummary>;
+}
+
+class ComparisonDataset {
+  public nameToIndex = new Map<string, number>();
+  public cacheHitIndices: Set<number>;
+  public sentinelEmptyIndices: Set<number>;
+
+  constructor(public data: PerformanceComparisonDataFromLog) {
+    const { names } = data;
+    const { nameToIndex } = this;
+    for (let i = 0; i < names.length; i++) {
+      nameToIndex.set(names[i], i);
+    }
+    this.cacheHitIndices = new Set(data.cacheHitIndices);
+    this.sentinelEmptyIndices = new Set(data.sentinelEmptyIndices);
+  }
+
+  getTupleCountInfo(name: string): PredicateInfo {
+    const { data, nameToIndex, cacheHitIndices, sentinelEmptyIndices } = this;
+    const index = nameToIndex.get(name);
+    if (index == null) {
+      return {
+        tuples: 0,
+        absentReason: AbsentReason.NotSeen,
+        pipelines: {},
+      };
+    }
+    const tupleCost = data.tupleCosts[index];
+    let absentReason: AbsentReason | undefined;
+    if (tupleCost === 0) {
+      if (sentinelEmptyIndices.has(index)) {
+        absentReason = AbsentReason.Sentinel;
+      } else if (cacheHitIndices.has(index)) {
+        absentReason = AbsentReason.CacheHit;
+      }
+    }
+    return {
+      tuples: tupleCost,
+      absentReason,
+      pipelines: data.pipelineSummaryList[index],
+    };
+  }
+}
+
+function renderAbsoluteValue(x: OptionalValue) {
+  switch (x.absentReason) {
+    case AbsentReason.NotSeen:
+      return <AbsentNumberCell>n/a</AbsentNumberCell>;
+    case AbsentReason.CacheHit:
+      return <AbsentNumberCell>cache hit</AbsentNumberCell>;
+    case AbsentReason.Sentinel:
+      return <AbsentNumberCell>sentinel empty</AbsentNumberCell>;
+    default:
+      return <NumberCell>{formatDecimal(x.tuples)}</NumberCell>;
+  }
+}
+
+function renderDelta(x: number) {
+  const sign = x > 0 ? "+" : "";
+  return (
+    <NumberCell>
+      {sign}
+      {formatDecimal(x)}
+    </NumberCell>
+  );
+}
+
+function orderBy<T>(fn: (x: T) => number | string) {
+  return (x: T, y: T) => {
+    const fx = fn(x);
+    const fy = fn(y);
+    return fx === fy ? 0 : fx < fy ? -1 : 1;
+  };
+}
+
+const ChevronCell = styled.td`
+  width: 1em !important;
+`;
+
+const NameHeader = styled.th`
+  text-align: left;
+`;
+
+const NumberHeader = styled.th`
+  text-align: right;
+  width: 10em !important;
+`;
+
+const NameCell = styled.td``;
+
+const NumberCell = styled.td`
+  text-align: right;
+  width: 10em !important;
+`;
+
+const AbsentNumberCell = styled.td`
+  text-align: right;
+  color: var(--vscode-disabledForeground);
+
+  tr.expanded & {
+    color: inherit;
+  }
+  width: 10em !important;
+`;
+
+const Table = styled.table`
+  border-collapse: collapse;
+  width: 100%;
+  border-spacing: 0;
+  background-color: var(--vscode-background);
+  color: var(--vscode-foreground);
+  & td {
+    padding: 0.5em;
+  }
+  & th {
+    padding: 0.5em;
+  }
+  &.expanded {
+    border: 1px solid var(--vscode-list-activeSelectionBackground);
+    margin-bottom: 1em;
+  }
+`;
+
+const PredicateTR = styled.tr`
+  cursor: pointer;
+
+  &.expanded {
+    background-color: var(--vscode-list-activeSelectionBackground);
+    color: var(--vscode-list-activeSelectionForeground);
+    position: sticky;
+    top: 0;
+  }
+
+  & .codicon-chevron-right {
+    visibility: hidden;
+  }
+
+  &:hover:not(.expanded) {
+    background-color: var(--vscode-list-hoverBackground);
+    & .codicon-chevron-right {
+      visibility: visible;
+    }
+  }
+`;
+
+const PipelineStepTR = styled.tr`
+  & td {
+    padding-top: 0.3em;
+    padding-bottom: 0.3em;
+  }
+`;
+
+interface PipelineStepProps {
+  before: number | undefined;
+  after: number | undefined;
+  step: string;
+}
+
+function PipelineStep(props: PipelineStepProps) {
+  let { before, after, step } = props;
+  if (before != null && before < 0) {
+    before = undefined;
+  }
+  if (after != null && after < 0) {
+    after = undefined;
+  }
+  const delta = before != null && after != null ? after - before : undefined;
+  return (
+    <PipelineStepTR>
+      <ChevronCell />
+      <NumberCell>{before != null ? formatDecimal(before) : ""}</NumberCell>
+      <NumberCell>{after != null ? formatDecimal(after) : ""}</NumberCell>
+      {delta != null ? renderDelta(delta) : <td></td>}
+      <NameCell>{step}</NameCell>
+    </PipelineStepTR>
+  );
+}
+
+function Chevron({ expanded }: { expanded: boolean }) {
+  return <Codicon name={expanded ? "chevron-down" : "chevron-right"} />;
+}
+
+function withToggledValue<T>(set: Set<T>, value: T) {
+  const result = new Set(set);
+  if (result.has(value)) {
+    result.delete(value);
+  } else {
+    result.add(value);
+  }
+  return result;
+}
+
+export function ComparePerformance(_: Record<string, never>) {
+  const [data, setData] = useState<
+    SetPerformanceComparisonQueries | undefined
+  >();
+
+  useMessageFromExtension<ToComparePerformanceViewMessage>(
+    (msg) => {
+      setData(msg);
+    },
+    [setData],
+  );
+
+  const datasets = useMemo(
+    () =>
+      data == null
+        ? undefined
+        : {
+            from: new ComparisonDataset(data.from),
+            to: new ComparisonDataset(data.to),
+          },
+    [data],
+  );
+
+  const [expandedPredicates, setExpandedPredicates] = useState<Set<string>>(
+    () => new Set<string>(),
+  );
+
+  const [hideCacheHits, setHideCacheHits] = useState(false);
+
+  if (!datasets) {
+    return <div>Loading performance comparison...</div>;
+  }
+
+  const { from, to } = datasets;
+
+  const nameSet = new Set(from.data.names);
+  for (const name of to.data.names) {
+    nameSet.add(name);
+  }
+
+  let hasCacheHitMismatch = false;
+
+  const rows = Array.from(nameSet)
+    .map((name) => {
+      const before = from.getTupleCountInfo(name);
+      const after = to.getTupleCountInfo(name);
+      if (before.tuples === after.tuples) {
+        return undefined!;
+      }
+      if (
+        before.absentReason === AbsentReason.CacheHit ||
+        after.absentReason === AbsentReason.CacheHit
+      ) {
+        hasCacheHitMismatch = true;
+        if (hideCacheHits) {
+          return undefined!;
+        }
+      }
+      const diff = after.tuples - before.tuples;
+      return { name, before, after, diff };
+    })
+    .filter((x) => !!x)
+    .sort(orderBy((row) => row.diff));
+
+  let totalBefore = 0;
+  let totalAfter = 0;
+  let totalDiff = 0;
+
+  for (const row of rows) {
+    totalBefore += row.before.tuples;
+    totalAfter += row.after.tuples;
+    totalDiff += row.diff;
+  }
+
+  return (
+    <>
+      <ViewTitle>Performance comparison</ViewTitle>
+      {hasCacheHitMismatch && (
+        <WarningBox>
+          <strong>Inconsistent cache hits</strong>
+          <br />
+          Some predicates had a cache hit on one side but not the other. For
+          more accurate results, try running the{" "}
+          <strong>CodeQL: Clear Cache</strong> command before each query.
+          <br />
+          <br />
+          <label>
+            <input
+              type="checkbox"
+              checked={hideCacheHits}
+              onChange={() => setHideCacheHits(!hideCacheHits)}
+            />
+            Hide predicates with cache hits
+          </label>
+        </WarningBox>
+      )}
+      <Table>
+        <thead>
+          <tr>
+            <ChevronCell />
+            <NumberHeader>Before</NumberHeader>
+            <NumberHeader>After</NumberHeader>
+            <NumberHeader>Delta</NumberHeader>
+            <NameHeader>Predicate</NameHeader>
+          </tr>
+        </thead>
+      </Table>
+      {rows.map((row) => (
+        <Table
+          key={row.name}
+          className={expandedPredicates.has(row.name) ? "expanded" : ""}
+        >
+          <tbody>
+            <PredicateTR
+              className={expandedPredicates.has(row.name) ? "expanded" : ""}
+              key={"main"}
+              onClick={() =>
+                setExpandedPredicates(
+                  withToggledValue(expandedPredicates, row.name),
+                )
+              }
+            >
+              <ChevronCell>
+                <Chevron expanded={expandedPredicates.has(row.name)} />
+              </ChevronCell>
+              {renderAbsoluteValue(row.before)}
+              {renderAbsoluteValue(row.after)}
+              {renderDelta(row.diff)}
+              <NameCell>{row.name}</NameCell>
+            </PredicateTR>
+            {expandedPredicates.has(row.name) && (
+              <>
+                {collatePipelines(
+                  row.before.pipelines,
+                  row.after.pipelines,
+                ).map(({ name, first, second }, pipelineIndex) => (
+                  <Fragment key={pipelineIndex}>
+                    <tr>
+                      <td></td>
+                      <NumberHeader>{first != null && "Before"}</NumberHeader>
+                      <NumberHeader>{second != null && "After"}</NumberHeader>
+                      <NumberHeader>
+                        {first != null && second != null && "Delta"}
+                      </NumberHeader>
+                      <NameHeader>
+                        Tuple counts for &apos;{name}&apos; pipeline
+                        {first == null
+                          ? " (after)"
+                          : second == null
+                            ? " (before)"
+                            : ""}
+                      </NameHeader>
+                    </tr>
+                    {abbreviateRASteps(first?.steps ?? second!.steps).map(
+                      (step, index) => (
+                        <PipelineStep
+                          key={index}
+                          before={first?.counts[index]}
+                          after={second?.counts[index]}
+                          step={step}
+                        />
+                      ),
+                    )}
+                  </Fragment>
+                ))}
+              </>
+            )}
+          </tbody>
+        </Table>
+      ))}
+      <Table>
+        <tfoot>
+          <tr key="spacing">
+            <td colSpan={5} style={{ height: "1em" }}></td>
+          </tr>
+          <tr key="total">
+            <ChevronCell />
+            <NumberCell>{formatDecimal(totalBefore)}</NumberCell>
+            <NumberCell>{formatDecimal(totalAfter)}</NumberCell>
+            {renderDelta(totalDiff)}
+            <NameCell>TOTAL</NameCell>
+          </tr>
+        </tfoot>
+      </Table>
+    </>
+  );
+}
+
+interface PipelinePair {
+  name: string;
+  first: PipelineSummary | undefined;
+  second: PipelineSummary | undefined;
+}
+
+function collatePipelines(
+  before: Record<string, PipelineSummary>,
+  after: Record<string, PipelineSummary>,
+): PipelinePair[] {
+  const result: PipelinePair[] = [];
+
+  for (const [name, first] of Object.entries(before)) {
+    const second = after[name];
+    if (second == null) {
+      result.push({ name, first, second: undefined });
+    } else if (samePipeline(first.steps, second.steps)) {
+      result.push({ name, first, second });
+    } else {
+      result.push({ name, first, second: undefined });
+      result.push({ name, first: undefined, second });
+    }
+  }
+
+  for (const [name, second] of Object.entries(after)) {
+    if (before[name] == null) {
+      result.push({ name, first: undefined, second });
+    }
+  }
+
+  return result;
+}
+
+function samePipeline(a: string[], b: string[]) {
+  return a.length === b.length && a.every((x, i) => x === b[i]);
+}

--- a/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
+++ b/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
@@ -25,6 +25,8 @@ interface OptionalValue {
 }
 
 interface PredicateInfo extends OptionalValue {
+  evaluationCount: number;
+  iterationCount: number;
   pipelines: Record<string, PipelineSummary>;
 }
 
@@ -48,6 +50,8 @@ class ComparisonDataset {
     const index = nameToIndex.get(name);
     if (index == null) {
       return {
+        evaluationCount: 0,
+        iterationCount: 0,
         tuples: 0,
         absentReason: AbsentReason.NotSeen,
         pipelines: {},
@@ -63,6 +67,8 @@ class ComparisonDataset {
       }
     }
     return {
+      evaluationCount: data.evaluationCounts[index],
+      iterationCount: data.iterationCounts[index],
       tuples: tupleCost,
       absentReason,
       pipelines: data.pipelineSummaryList[index],
@@ -184,6 +190,9 @@ interface PipelineStepProps {
   step: string;
 }
 
+/**
+ * Row with details of a pipeline step, or one of the high-level stats appearing above the pipelines (evaluation/iteration counts).
+ */
 function PipelineStep(props: PipelineStepProps) {
   let { before, after, step } = props;
   if (before != null && before < 0) {
@@ -201,6 +210,46 @@ function PipelineStep(props: PipelineStepProps) {
       {delta != null ? renderDelta(delta) : <td></td>}
       <NameCell>{step}</NameCell>
     </PipelineStepTR>
+  );
+}
+
+interface HighLevelStatsProps {
+  before: PredicateInfo;
+  after: PredicateInfo;
+}
+
+function HighLevelStats(props: HighLevelStatsProps) {
+  const { before, after } = props;
+  const hasBefore = before.absentReason !== AbsentReason.NotSeen;
+  const hasAfter = after.absentReason !== AbsentReason.NotSeen;
+  const showEvaluationCount =
+    before.evaluationCount > 1 || after.evaluationCount > 1;
+  return (
+    <>
+      <tr>
+        <ChevronCell></ChevronCell>
+        <NumberHeader>{hasBefore ? "Before" : ""}</NumberHeader>
+        <NumberHeader>{hasAfter ? "After" : ""}</NumberHeader>
+        <NumberHeader>{hasBefore && hasAfter ? "Delta" : ""}</NumberHeader>
+        <NameHeader>Stats</NameHeader>
+      </tr>
+      {showEvaluationCount && (
+        <PipelineStep
+          before={before.evaluationCount || undefined}
+          after={after.evaluationCount || undefined}
+          step="Number of evaluations"
+        />
+      )}
+      <PipelineStep
+        before={before.iterationCount / before.evaluationCount || undefined}
+        after={after.iterationCount / after.evaluationCount || undefined}
+        step={
+          showEvaluationCount
+            ? "Number of iterations per evaluation"
+            : "Number of iterations"
+        }
+      />
+    </>
   );
 }
 
@@ -350,6 +399,7 @@ export function ComparePerformance(_: Record<string, never>) {
             </PredicateTR>
             {expandedPredicates.has(row.name) && (
               <>
+                <HighLevelStats before={row.before} after={row.after} />
                 {collatePipelines(
                   row.before.pipelines,
                   row.after.pipelines,

--- a/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
+++ b/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
@@ -295,12 +295,12 @@ function HighLevelStats(props: HighLevelStatsProps) {
   );
 }
 
-type TRow = {
+interface TRow {
   name: string;
   before: PredicateInfo;
   after: PredicateInfo;
   diff: number;
-};
+}
 
 function getSortOrder(sortOrder: "delta" | "absDelta") {
   if (sortOrder === "absDelta") {
@@ -413,7 +413,7 @@ function ComparePerformanceWithData(props: {
 
   const hasCacheHitMismatch = useRef(false);
 
-  const rows = useMemo(() => {
+  const rows: TRow[] = useMemo(() => {
     hasCacheHitMismatch.current = false;
     return Array.from(nameSet)
       .map((name) => {
@@ -434,7 +434,7 @@ function ComparePerformanceWithData(props: {
           }
         }
         const diff = afterValue - beforeValue;
-        return { name, before, after, diff };
+        return { name, before, after, diff } satisfies TRow;
       })
       .filter((x) => !!x)
       .sort(getSortOrder(sortOrder));

--- a/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
+++ b/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
@@ -180,6 +180,7 @@ const Table = styled.table`
     border: 1px solid var(--vscode-list-activeSelectionBackground);
     margin-bottom: 1em;
   }
+  word-break: break-all;
 `;
 
 const PredicateTR = styled.tr`

--- a/extensions/ql-vscode/src/view/compare-performance/RAPrettyPrinter.tsx
+++ b/extensions/ql-vscode/src/view/compare-performance/RAPrettyPrinter.tsx
@@ -1,0 +1,151 @@
+/**
+ * A set of names, for generating unambiguous abbreviations.
+ */
+class NameSet {
+  private readonly abbreviations = new Map<string, string>();
+
+  constructor(readonly names: string[]) {
+    const qnames = names.map(parseName);
+    const builder = new TrieBuilder();
+    qnames
+      .map((qname) => builder.visitQName(qname))
+      .forEach((r, index) => {
+        this.abbreviations.set(names[index], r.abbreviate());
+      });
+  }
+
+  public getAbbreviation(name: string) {
+    return this.abbreviations.get(name) ?? name;
+  }
+}
+
+/** Name parsed into the form `prefix::name<args>` */
+interface QualifiedName {
+  prefix?: QualifiedName;
+  name: string;
+  args?: QualifiedName[];
+}
+
+function tokeniseName(text: string) {
+  return Array.from(text.matchAll(/:+|<|>|,|"[^"]+"|`[^`]+`|[^:<>,"`]+/g));
+}
+
+function parseName(text: string): QualifiedName {
+  const tokens = tokeniseName(text);
+
+  function next() {
+    return tokens.pop()![0];
+  }
+  function peek() {
+    return tokens[tokens.length - 1][0];
+  }
+  function skipToken(token: string) {
+    if (tokens.length > 0 && peek() === token) {
+      tokens.pop();
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  function parseQName(): QualifiedName {
+    let args: QualifiedName[] | undefined;
+    if (skipToken(">")) {
+      args = [];
+      while (peek() !== "<") {
+        args.push(parseQName());
+        skipToken(",");
+      }
+      args.reverse();
+      skipToken("<");
+    }
+    const name = next();
+    const prefix = skipToken("::") ? parseQName() : undefined;
+    return {
+      prefix,
+      name,
+      args,
+    };
+  }
+
+  const result = parseQName();
+  if (tokens.length > 0) {
+    // It's a parse error if we did not consume all tokens.
+    // Just treat the whole text as the 'name'.
+    return { prefix: undefined, name: text, args: undefined };
+  }
+  return result;
+}
+
+class TrieNode {
+  children = new Map<string, TrieNode>();
+  constructor(readonly index: number) {}
+}
+
+interface VisitResult {
+  node: TrieNode;
+  abbreviate: () => string;
+}
+
+class TrieBuilder {
+  root = new TrieNode(0);
+  nextId = 1;
+
+  getOrCreate(trieNode: TrieNode, child: string) {
+    const { children } = trieNode;
+    let node = children.get(child);
+    if (node == null) {
+      node = new TrieNode(this.nextId++);
+      children.set(child, node);
+    }
+    return node;
+  }
+
+  visitQName(qname: QualifiedName): VisitResult {
+    const prefix =
+      qname.prefix != null ? this.visitQName(qname.prefix) : undefined;
+    const trieNodeBeforeArgs = this.getOrCreate(
+      prefix?.node ?? this.root,
+      qname.name,
+    );
+    let trieNode = trieNodeBeforeArgs;
+    const args = qname.args?.map((arg) => this.visitQName(arg));
+    if (args != null) {
+      const argKey = args.map((arg) => arg.node.index).join(",");
+      trieNode = this.getOrCreate(trieNodeBeforeArgs, argKey);
+    }
+    return {
+      node: trieNode,
+      abbreviate: () => {
+        let result = "";
+        if (prefix != null) {
+          result += prefix.abbreviate();
+          result += "::";
+        }
+        result += qname.name;
+        if (args != null) {
+          result += "<";
+          if (trieNodeBeforeArgs.children.size === 1) {
+            result += "...";
+          } else {
+            result += args.map((arg) => arg.abbreviate()).join(",");
+          }
+          result += ">";
+        }
+        return result;
+      },
+    };
+  }
+}
+
+const nameTokenRegex = /\b[^ ]+::[^ (]+\b/g;
+
+export function abbreviateRASteps(steps: string[]): string[] {
+  const nameTokens = steps.flatMap((step) =>
+    Array.from(step.matchAll(nameTokenRegex)).map((tok) => tok[0]),
+  );
+  const nameSet = new NameSet(nameTokens);
+  return steps.map((step) =>
+    step.replace(nameTokenRegex, (match) => nameSet.getAbbreviation(match)),
+  );
+}

--- a/extensions/ql-vscode/src/view/compare-performance/RAPrettyPrinter.tsx
+++ b/extensions/ql-vscode/src/view/compare-performance/RAPrettyPrinter.tsx
@@ -67,6 +67,7 @@ function parseName(text: string): QualifiedName {
   }
 
   function parseQName(): QualifiedName {
+    // Note that the tokens stream is parsed in reverse order. This is simpler, but may look confusing initially.
     let args: QualifiedName[] | undefined;
     if (skipToken(">")) {
       args = [];

--- a/extensions/ql-vscode/src/view/compare-performance/RAPrettyPrinter.tsx
+++ b/extensions/ql-vscode/src/view/compare-performance/RAPrettyPrinter.tsx
@@ -70,14 +70,14 @@ function parseName(text: string): QualifiedName {
     let args: QualifiedName[] | undefined;
     if (skipToken(">")) {
       args = [];
-      while (peek() !== "<") {
+      while (tokens.length > 0 && peek() !== "<") {
         args.push(parseQName());
         skipToken(",");
       }
       args.reverse();
       skipToken("<");
     }
-    const name = next();
+    const name = tokens.length === 0 ? "" : next();
     const prefix = skipToken("::") ? parseQName() : undefined;
     return {
       prefix,

--- a/extensions/ql-vscode/src/view/compare-performance/RAPrettyPrinter.tsx
+++ b/extensions/ql-vscode/src/view/compare-performance/RAPrettyPrinter.tsx
@@ -193,7 +193,12 @@ interface ExpandableNamePartProps {
 function ExpandableNamePart(props: ExpandableNamePartProps) {
   const [isExpanded, setExpanded] = useState(false);
   return (
-    <ExpandableTextButton onClick={() => setExpanded(!isExpanded)}>
+    <ExpandableTextButton
+      onClick={(event: Event) => {
+        setExpanded(!isExpanded);
+        event.stopPropagation();
+      }}
+    >
       {isExpanded ? props.children : "..."}
     </ExpandableTextButton>
   );
@@ -268,4 +273,9 @@ export function abbreviateRASteps(steps: string[]): React.ReactNode[] {
     });
     return <Fragment key={index}>{result}</Fragment>;
   });
+}
+
+export function abbreviateRANames(names: string[]): React.ReactNode[] {
+  const nameSet = new NameSet(names);
+  return names.map((name) => nameSet.getAbbreviation(name));
 }

--- a/extensions/ql-vscode/src/view/compare-performance/RenamingInput.tsx
+++ b/extensions/ql-vscode/src/view/compare-performance/RenamingInput.tsx
@@ -1,0 +1,106 @@
+import type { ChangeEvent } from "react";
+import { styled } from "styled-components";
+import {
+  VSCodeButton,
+  VSCodeTextField,
+} from "@vscode/webview-ui-toolkit/react";
+import { Codicon } from "../common";
+
+export class Renaming {
+  patternRegexp: RegExp | undefined;
+
+  constructor(
+    public pattern: string,
+    public replacement: string,
+  ) {
+    this.patternRegexp = tryCompilePattern(pattern);
+  }
+}
+
+function tryCompilePattern(pattern: string): RegExp | undefined {
+  try {
+    return new RegExp(pattern, "i");
+  } catch {
+    return undefined;
+  }
+}
+
+const Input = styled(VSCodeTextField)`
+  width: 20em;
+`;
+
+const Row = styled.div`
+  display: flex;
+  padding-bottom: 0.25em;
+`;
+
+const Details = styled.details`
+  padding: 1em;
+`;
+
+interface RenamingInputProps {
+  renamings: Renaming[];
+  setRenamings: (renamings: Renaming[]) => void;
+}
+
+export function RenamingInput(props: RenamingInputProps) {
+  const { renamings, setRenamings } = props;
+  return (
+    <Details>
+      <summary>Predicate renaming</summary>
+      <p>
+        The following regexp replacements are applied to every predicate name on
+        both sides. Predicates whose names clash after renaming are grouped
+        together. Can be used to correlate predicates that were renamed between
+        the two runs.
+        <br />
+        Can also be used to group related predicates, for example, renaming{" "}
+        <code>.*ssa.*</code> to <code>SSA</code> will group all SSA-related
+        predicates together.
+      </p>
+      {renamings.map((renaming, index) => (
+        <Row key={index}>
+          <Input
+            value={renaming.pattern}
+            placeholder="Pattern"
+            onInput={(e: ChangeEvent<HTMLInputElement>) => {
+              const newRenamings = [...renamings];
+              newRenamings[index] = new Renaming(
+                e.target.value,
+                renaming.replacement,
+              );
+              setRenamings(newRenamings);
+            }}
+          >
+            <Codicon name="search" slot="start" />
+          </Input>
+          <Input
+            value={renaming.replacement}
+            placeholder="Replacement"
+            onInput={(e: ChangeEvent<HTMLInputElement>) => {
+              const newRenamings = [...renamings];
+              newRenamings[index] = new Renaming(
+                renaming.pattern,
+                e.target.value,
+              );
+              setRenamings(newRenamings);
+            }}
+          ></Input>
+          <VSCodeButton
+            onClick={() =>
+              setRenamings(renamings.filter((_, i) => i !== index))
+            }
+          >
+            <Codicon name="trash" />
+          </VSCodeButton>
+          <br />
+        </Row>
+      ))}
+      <VSCodeButton
+        onClick={() => setRenamings([...renamings, new Renaming("", "")])}
+      >
+        Add renaming rule
+      </VSCodeButton>
+    </Details>
+  );
+}

--- a/extensions/ql-vscode/src/view/compare-performance/index.tsx
+++ b/extensions/ql-vscode/src/view/compare-performance/index.tsx
@@ -1,0 +1,8 @@
+import type { WebviewDefinition } from "../webview-definition";
+import { ComparePerformance } from "./ComparePerformance";
+
+const definition: WebviewDefinition = {
+  component: <ComparePerformance />,
+};
+
+export default definition;

--- a/extensions/ql-vscode/src/view/webview.tsx
+++ b/extensions/ql-vscode/src/view/webview.tsx
@@ -6,6 +6,7 @@ import { registerUnhandledErrorListener } from "./common/errors";
 import type { WebviewDefinition } from "./webview-definition";
 
 import compareView from "./compare";
+import comparePerformance from "./compare-performance";
 import dataFlowPathsView from "./data-flow-paths";
 import methodModelingView from "./method-modeling";
 import modelEditorView from "./model-editor";
@@ -18,6 +19,7 @@ import "@vscode/codicons/dist/codicon.css";
 
 const views: Record<string, WebviewDefinition> = {
   compare: compareView,
+  "compare-performance": comparePerformance,
   "data-flow-paths": dataFlowPathsView,
   "method-modeling": methodModelingView,
   "model-editor": modelEditorView,

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/history-tree-data-provider.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/history-tree-data-provider.test.ts
@@ -38,6 +38,7 @@ describe("HistoryTreeDataProvider", () => {
   let app: App;
   let configListener: QueryHistoryConfigListener;
   const doCompareCallback = jest.fn();
+  const doComparePerformanceCallback = jest.fn();
 
   let queryHistoryManager: QueryHistoryManager;
 
@@ -506,6 +507,7 @@ describe("HistoryTreeDataProvider", () => {
       }),
       languageContext,
       doCompareCallback,
+      doComparePerformanceCallback,
     );
     (qhm.treeDataProvider as any).history = [...allHistory];
     await workspace.saveAll();

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/query-history-manager.test.ts
@@ -40,6 +40,7 @@ describe("QueryHistoryManager", () => {
     typeof variantAnalysisManagerStub.cancelVariantAnalysis
   >;
   const doCompareCallback = jest.fn();
+  const doComparePerformanceCallback = jest.fn();
 
   let executeCommand: jest.MockedFn<
     (commandName: string, ...args: any[]) => Promise<any>
@@ -939,6 +940,7 @@ describe("QueryHistoryManager", () => {
       }),
       new LanguageContextStore(mockApp),
       doCompareCallback,
+      doComparePerformanceCallback,
     );
     (qhm.treeDataProvider as any).history = [...allHistory];
     await workspace.saveAll();

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/variant-analysis-history.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/variant-analysis-history.test.ts
@@ -105,6 +105,7 @@ describe("Variant Analyses and QueryHistoryManager", () => {
       }),
       new LanguageContextStore(app),
       asyncNoop,
+      asyncNoop,
     );
     disposables.push(qhm);
 


### PR DESCRIPTION
Adds the 'Compare Performance' UI from the hackathon.

### Activate via right-clicking on a query history item
<img width="475" alt="Screenshot 2024-11-27 at 14 37 31" src="https://github.com/user-attachments/assets/5cc9132f-29c2-4903-8e78-caa337e58567">

### Shows overview of predicate evaluation costs
<img width="1340" alt="Screenshot 2024-11-27 at 14 38 56" src="https://github.com/user-attachments/assets/025f53f0-5c10-4600-b44a-c6c4969757b8">

### Click a predicate to show its pipeline(s) and tuple counts per step
<img width="1577" alt="Screenshot 2024-11-27 at 14 37 11" src="https://github.com/user-attachments/assets/4ff5c41b-8922-474b-87a1-64b0f197a4e4">

### Changes since the hackathon:
- The integration with DCA has been left out for now. I'm hoping @esbena will follow up on this.
- Added support for predicate-renaming, which was WIP and not demoable in time for the Hackathon demo.
- Some UI performance improvements: using `useMemo` and moved some state into subcomponents where a state change cause as much re-rendering.
- Some clean up of the commit history; mainly squashing simple bugfixes into an earlier commit.

Despite my attempts at cleaning the commit history, it might actually be easiest to review as one giant diff.