### PR TITLE
Fix update-node-version script

### DIFF
--- a/extensions/ql-vscode/scripts/update-node-version.ts
+++ b/extensions/ql-vscode/scripts/update-node-version.ts
@@ -86,6 +86,7 @@ async function updateNodeVersion() {
       execSync(`npm view --json "@types/node@${typesNodeVersion}"`, {
         encoding: "utf-8",
         stdio: "pipe",
+        maxBuffer: 10 * 1024 * 1024,
       });
 
       console.log(`@types/node@${typesNodeVersion} exists`);


### PR DESCRIPTION
The `update-node-version` script [is crashing](https://github.com/github/vscode-codeql/actions/runs/12050249345/job/33598727965#step:6:12) because the output is too large to fit into the default 1MB buffer. This increases the buffer to 10MB to ensure the script doesn't crash.