### PR TITLE
Fix Spurious Compilation Errors

### DIFF
--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -1634,7 +1634,7 @@ export class CodeQLCliServer implements Disposable {
       args.push(
         // Allow prerelease packs from the ql submodule.
         "--allow-prerelease",
-        // Allow the use of --additional-packs argument without issueing a warning
+        // Allow the use of --additional-packs argument without issuing a warning
         "--no-strict-mode",
         ...this.getAdditionalPacksArg(workspaceFolders),
       );

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -748,9 +748,13 @@ async function activateWithInstalledDistribution(
     );
   ctx.subscriptions.push(qlConfigurationListener);
 
+  void extLogger.log("Initializing CodeQL language server.");
+  const languageClient = createLanguageClient(qlConfigurationListener);
+
   void extLogger.log("Initializing CodeQL cli server...");
   const cliServer = new CodeQLCliServer(
     app,
+    languageClient,
     distributionManager,
     new CliConfigListener(),
     extLogger,
@@ -960,9 +964,6 @@ async function activateWithInstalledDistribution(
   ctx.subscriptions.push({ dispose: qhelpTmpDir.removeCallback });
 
   ctx.subscriptions.push(tmpDirDisposal);
-
-  void extLogger.log("Initializing CodeQL language server.");
-  const languageClient = createLanguageClient(qlConfigurationListener);
 
   const localQueries = new LocalQueries(
     app,


### PR DESCRIPTION
Closes #3220

issue: https://github.com/github/codeql-core/issues/4654

This notifies the language server of newly downloaded packs once a pack is added to the current ql pack, or a pack's dependencies are installed.

This is the user facing behaviour I observed:

 - ✅ creating a query pack and example.ql file using the skeleton wizard:
   - works as expected
 - ✅ creating a query pack and ql file manually, then installing the ql pack's dependencies using the vs code command palette:
   - works: this removes the spurious compilation errors, even in open files.
   - :warning: the price of supporting that is that we restart the language server each time a pack is added or a pack's dependencies are installed. There might be cheaper solutions, but I don't know them. If the reviewers don't know of a cheaper solution: I think this overhead is worth it because pack add/pack install are rare operations and the user would likely have to manually restart or reload vs code instead to make it work.



## Dear Reviewer
 - This is a PoC that works for me.
 - I had to inject the language server reference into the cli server.
   - I'm not sure if this would be considered a design violation. I'd appreciate some feedback.
   - If that's a problem, I could refactor this to break the dependency using dependency injection. Meaning: pass in a lambda function that does the notification.
 - Maybe, the same effect could also be achieved by different means (like watching the `~/.codeql/packages` subdirectories, ...). Chances are, there's room for improvement.
