### PR TITLE
Upgrade code-server version for E2E tests

### DIFF
--- a/extensions/ql-vscode/test/e2e/README.md
+++ b/extensions/ql-vscode/test/e2e/README.md
@@ -9,12 +9,12 @@ Setup
 - install playwright if you haven't yet (`npx playwright install`)
 - go to the e2e test folder on your terminal
 - make sure docker is running
-- run `docker-compose build`
-- run `docker-compose up`
+- run `docker compose build`
+- run `docker compose up`
 
 Run tests
 
-- run  `npx playwright test --ui` from the e2e test folder to follow the test while it's running. This UI has a 'locator' tool with which elements on the test screen can be found
+- run `npx playwright test --ui` from the e2e test folder to follow the test while it's running. This UI has a 'locator' tool with which elements on the test screen can be found
 - use `npx playwright test --debug` to follow the test in real time and interact with the interface, e.g. press enter or input into fields, stop and start
 
 During the test elements are created in the docker volume, e.g. the downloaded database or query data. This might interfer with other tests or when running a test twice. If that happens restart your docker volume by using `docker-compose down -v` and `docker-compose up`. Sometimes already existing queries from former runs change the input the extension needs.

--- a/extensions/ql-vscode/test/e2e/docker-compose.yml
+++ b/extensions/ql-vscode/test/e2e/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   code-server:
     build:
@@ -38,7 +36,7 @@ services:
     depends_on:
       - files-init
   files-init:
-    image: alpine:3.19.1
+    image: alpine:3.21.0
     restart: "no"
     # Since we're not running the code-server container using the same user as our host user,
     # we need to set the permissions on the mounted volumes to match the user inside the container.

--- a/extensions/ql-vscode/test/e2e/docker/Dockerfile
+++ b/extensions/ql-vscode/test/e2e/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM codercom/code-server:4.23.1
+FROM codercom/code-server:4.95.3
 
 USER root
 


### PR DESCRIPTION
This upgrades the version of `code-server` and `alpine` as used in the E2E tests. The E2E tests are currently expected to fail until we do a release due to the changes in https://github.com/github/vscode-codeql/pull/3853.