### PR TITLE
Change Dependabot Docker directory for e2e tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,7 +38,7 @@ updates:
     labels:
       - "Update dependencies"
   - package-ecosystem: docker
-    directory: "extensions/ql-vscode/test/e2e"
+    directory: "extensions/ql-vscode/test/e2e/docker"
     schedule:
       interval: "weekly"
       day: "thursday" # Thursday is arbitrary


### PR DESCRIPTION
It seems like Dependabot is not picking up the `Dockerfile` located in `extensions/ql-vscode/test/e2e/docker`, so this changes the directory in the Dependabot configuration to specify that directory directly instead of specifying a parent directory.