### PR TITLE
Fix publishing to VS Code Marketplace

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,13 +146,10 @@ jobs:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           allow-no-subscriptions: true
+          enable-AzPSSession: true
 
       - name: Publish to Registry
-        uses: azure/cli@v2
-        with:
-          azcliversion: latest
-          inlineScript: |
-            npx @vscode/vsce publish --azure-credential --packagePath *.vsix
+        run: npx @vscode/vsce publish --azure-credential --packagePath *.vsix
 
   open-vsx-publish:
     name: Publish to Open VSX Registry


### PR DESCRIPTION
This may fix publishing to the VS Code Marketplace, which is currently broken because `npx` isn't included in the `azure/cli` Docker image. This is based on the publishing steps of a Microsoft VS Code extension: https://github.com/microsoft/vscode-azureapicenter/blob/13175ef0638b56fa1e605bd4750ec77b1ba5b72d/.github/workflows/publish.yml#L57-L71

I don't think we can test this without creating another release.