### PR TITLE
Release v1.17.1

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -1,10 +1,10 @@
 # CodeQL for Visual Studio Code: Changelog
 
-## [UNRELEASED]
+## 1.17.1 - 23 January 2025
 
 - Remove support for CodeQL CLI versions older than 2.18.4. [#3895](https://github.com/github/vscode-codeql/pull/3895)
 
-## 1.7.0 - 20 December 2024
+## 1.17.0 - 20 December 2024
 
 - Add a palette command that allows importing all databases directly inside of a parent folder. [#3797](https://github.com/github/vscode-codeql/pull/3797)
 - Only use VS Code telemetry settings instead of using `codeQL.telemetry.enableTelemetry` [#3853](https://github.com/github/vscode-codeql/pull/3853)


### PR DESCRIPTION
Release changes for v1.17.1

Updates the changelog, including fixing a typo from the previous release.

I don't think there's any other changes that need changelog entries. There was https://github.com/github/vscode-codeql/pull/3843 bit this is only available under the canary feature flag.

See https://github.com/github/vscode-codeql/actions/runs/12928683306 where I ran the CLI tests on latest main (same as this branch without the changelog changes).