### PR TITLE
ComparePerformance: fix crash in RTJO mode

### DIFF
--- a/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
+++ b/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
@@ -798,7 +798,7 @@ function PredicateRow(props: PredicateRowProps) {
                     </>
                   }
                 />
-                {abbreviateRASteps(first?.steps ?? second!.steps).map(
+                {abbreviateRASteps(first?.steps ?? second?.steps ?? []).map(
                   (step, index) => (
                     <PipelineStep
                       key={index}


### PR DESCRIPTION
With `--dynamic-join-order-mode=all`, both `first` and `second` are
undefined, leading to a crash. Until RTJO mode gets proper tuple
counting, this change prevents a crash when unfurling the steps of a
predicate.
