### PR TITLE
Fix Storybook build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ artifacts/
 # E2E Reports
 **/playwright-report/**
 **/test-results/**
+
+# Storybook artifacts
+**/storybook-static/**

--- a/extensions/ql-vscode/test/factories/model-editor/extension-pack.ts
+++ b/extensions/ql-vscode/test/factories/model-editor/extension-pack.ts
@@ -1,5 +1,4 @@
 import type { ExtensionPack } from "../../../src/model-editor/shared/extension-pack";
-import { join } from "path";
 
 export function createMockExtensionPack({
   path = "/path/to/extension-pack",
@@ -7,7 +6,7 @@ export function createMockExtensionPack({
 }: Partial<ExtensionPack> = {}): ExtensionPack {
   return {
     path,
-    yamlPath: join(path, "codeql-pack.yml"),
+    yamlPath: `${path}/codeql-pack.yml`,
     name: "sql2o",
     version: "0.0.0",
     language: "java",


### PR DESCRIPTION
This fixes `npm run build-storybook` by ensuring we're not importing anything from the `path` module in stories.