### PR TITLE
Add workflow for building and deploying Storybook

### DIFF
--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -1,0 +1,57 @@
+name: Build Storybook
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: extensions/ql-vscode/.nvmrc
+
+      - name: Install dependencies
+        run: |
+          cd extensions/ql-vscode
+          npm ci
+        shell: bash
+
+      - name: Build Storybook
+        run: |
+          cd extensions/ql-vscode
+          npm run build-storybook
+        shell: bash
+
+      - name: Upload to GitHub Pages
+        id: deployment
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: extensions/ql-vscode/storybook-static
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      pages: write
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This adds a workflow for building Storybook and deploying it to GitHub Pages. This is based on [the official Storybook documentation](https://storybook.js.org/docs/sharing/publish-storybook#github-pages), although I didn't use [the recommended action](https://github.com/bitovi/github-actions-storybook-to-github-pages) because we would like to split this up into two steps: building and deploying. That is the recommendation from [`actions/upload-pages-artifact`](https://github.com/actions/upload-pages-artifact) and also allows us to only deploy to GitHub Pages on a push to `main`, but still build Storybook in PRs.

You can view the deployment at https://github.github.com/vscode-codeql/.