### PR TITLE
Change database download to always be authenticated

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [UNRELEASED]
 
-- Always authenticate when downloading databases from github, instead of only when in canary mode. [#3941](https://github.com/github/vscode-codeql/pull/3941)
+- Always authenticate when downloading databases from GitHub, instead of only when in canary mode. [#3941](https://github.com/github/vscode-codeql/pull/3941)
 
 ## 1.17.1 - 23 January 2025
 

--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [UNRELEASED]
 
+- Always authenticate when downloading databases from github, instead of only when in canary mode. [#3941](https://github.com/github/vscode-codeql/pull/3941)
+
 ## 1.17.1 - 23 January 2025
 
 - Remove support for CodeQL CLI versions older than 2.18.4. [#3895](https://github.com/github/vscode-codeql/pull/3895)

--- a/extensions/ql-vscode/src/databases/database-fetcher.ts
+++ b/extensions/ql-vscode/src/databases/database-fetcher.ts
@@ -28,11 +28,8 @@ import {
   allowHttp,
   downloadTimeout,
   getGitHubInstanceUrl,
-  hasGhecDrUri,
-  isCanary,
 } from "../config";
 import { showAndLogInformationMessage } from "../common/logging";
-import { AppOctokit } from "../common/octokit";
 import type { DatabaseOrigin } from "./local-databases/database-origin";
 import { createTimeoutSignal } from "../common/fetch-stream";
 import type { App } from "../common/app";
@@ -187,12 +184,7 @@ export class DatabaseFetcher {
       throw new Error(`Invalid GitHub repository: ${githubRepo}`);
     }
 
-    const credentials =
-      isCanary() || hasGhecDrUri() ? this.app.credentials : undefined;
-
-    const octokit = credentials
-      ? await credentials.getOctokit()
-      : new AppOctokit();
+    const octokit = await this.app.credentials.getOctokit();
 
     const result = await convertGithubNwoToDatabaseUrl(
       nwo,


### PR DESCRIPTION
This PR changes the behaviour when requesting to download a CodeQL database from GitHub to always require logging in.

I have only applied this change in behaviour to user-initiated command (either from the UI or command palette) and after this there will be no way to avoid logging in, but if there's extreme backlash we could implement an opt-out config option. There's also a flow when the extension starts up but I have avoided changing this to keep the changes smaller.

The existing behaviour of the extension is that it would require you to login and make the requests authenticated only if canary mode was enabled (or you were using GHEC-DR). If canary mode was disabled then it would authenticate if a token was available but otherwise it would make unauthenticated requests.

Here are some flowchats showing the change:

## Old behaviour for user-initiated download:

![Screenshot 2025-02-26 at 14 55 16](https://github.com/user-attachments/assets/c3e9fba8-f62c-47eb-a870-8463228bc957)

## New behaviour for user-initiated download:

![Screenshot 2025-02-26 at 14 59 44](https://github.com/user-attachments/assets/7ef8e70c-ce37-4308-8e08-7ce92a8807a2)



