### PR TITLE
Fix legacy label regex

### DIFF
--- a/extensions/ql-vscode/src/query-history/history-item-label-provider.ts
+++ b/extensions/ql-vscode/src/query-history/history-item-label-provider.ts
@@ -64,6 +64,7 @@ export class HistoryItemLabelProvider {
     const rawLabel =
       item.userSpecifiedLabel ?? (this.config.format || "${queryName}");
 
+    legacyLabelRegex.lastIndex = 0; // Reset the regex index to start searching from the start of the string if the strings are the same
     if (legacyLabelRegex.test(rawLabel)) {
       return this.legacyInterpolate(rawLabel, variables);
     }


### PR DESCRIPTION
When the `legacyLabelRegex` is tested multiple times against the same string (as happens most of the time, unless a user-specified label is added), it would start searching from the end of the previous match instead of from the start of the string:

[“JavaScript RegExp objects are stateful when they have the global or sticky flags set (e.g., /foo/g or /foo/y). They store a lastIndex from the previous match. Using this internally, test() can be used to iterate over multiple matches in a string of text (with capture groups).”](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test)

This fixes it by resetting `lastIndex` before running the `test` method.