### PR TITLE
Remove the use of `VSCodeTag`

### DIFF
--- a/extensions/ql-vscode/src/view/common/CodePaths/ThreadPath.tsx
+++ b/extensions/ql-vscode/src/view/common/CodePaths/ThreadPath.tsx
@@ -1,5 +1,5 @@
 import { styled } from "styled-components";
-import { VSCodeTag } from "@vscode/webview-ui-toolkit/react";
+import { Tag } from "../Tag";
 
 import type {
   AnalysisMessage,
@@ -56,12 +56,12 @@ export const ThreadPath = ({
       </TitleContainer>
       {isSource && (
         <TagContainer>
-          <VSCodeTag>Source</VSCodeTag>
+          <Tag>Source</Tag>
         </TagContainer>
       )}
       {isSink && (
         <TagContainer>
-          <VSCodeTag>Sink</VSCodeTag>
+          <Tag>Sink</Tag>
         </TagContainer>
       )}
     </HeaderContainer>

--- a/extensions/ql-vscode/src/view/common/Tag.tsx
+++ b/extensions/ql-vscode/src/view/common/Tag.tsx
@@ -1,0 +1,14 @@
+import { styled } from "styled-components";
+
+export const Tag = styled.div`
+  background-color: var(--vscode-badge-background);
+  border: 1px solid var(--vscode-button-border, transparent);
+  border-radius: 2px;
+  color: var(--vscode-badge-foreground);
+  padding: 2px 4px;
+  text-transform: uppercase;
+  box-sizing: border-box;
+  font-family: var(--vscode-font-family);
+  font-size: 11px;
+  line-height: 16px;
+`;

--- a/extensions/ql-vscode/src/view/common/Tag.tsx
+++ b/extensions/ql-vscode/src/view/common/Tag.tsx
@@ -1,10 +1,10 @@
 import { styled } from "styled-components";
 
-export const Tag = styled.div`
-  background-color: var(--vscode-badge-background);
-  border: 1px solid var(--vscode-button-border, transparent);
+export const Tag = styled.span`
+  background-color: #4d4d4d;
+  border: 1px solid transparent;
   border-radius: 2px;
-  color: var(--vscode-badge-foreground);
+  color: #ffffff;
   padding: 2px 4px;
   text-transform: uppercase;
   box-sizing: border-box;

--- a/extensions/ql-vscode/src/view/method-modeling/MethodModeling.tsx
+++ b/extensions/ql-vscode/src/view/method-modeling/MethodModeling.tsx
@@ -4,7 +4,7 @@ import { ModelingStatusIndicator } from "../model-editor/ModelingStatusIndicator
 import type { Method } from "../../model-editor/method";
 import { MethodName } from "../model-editor/MethodName";
 import type { ModeledMethod } from "../../model-editor/modeled-method";
-import { VSCodeTag } from "@vscode/webview-ui-toolkit/react";
+import { Tag } from "../common/Tag";
 import { ReviewInEditorButton } from "./ReviewInEditorButton";
 import { MultipleModeledMethodsPanel } from "./MultipleModeledMethodsPanel";
 import type { QueryLanguage } from "../../common/query-language";
@@ -39,14 +39,12 @@ const DependencyContainer = styled.div`
   margin-bottom: 0.8rem;
 `;
 
-const StyledVSCodeTag = styled(VSCodeTag)<{ $visible: boolean }>`
+const StyledTag = styled(Tag)<{ $visible: boolean }>`
   visibility: ${(props) => (props.$visible ? "visible" : "hidden")};
 `;
 
 const UnsavedTag = ({ modelingStatus }: { modelingStatus: ModelingStatus }) => (
-  <StyledVSCodeTag $visible={modelingStatus === "unsaved"}>
-    Unsaved
-  </StyledVSCodeTag>
+  <StyledTag $visible={modelingStatus === "unsaved"}>Unsaved</StyledTag>
 );
 
 export type MethodModelingProps = {

--- a/extensions/ql-vscode/src/view/model-editor/LibraryRow.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/LibraryRow.tsx
@@ -7,14 +7,11 @@ import { calculateModeledPercentage } from "../../model-editor/shared/modeled-pe
 import { percentFormatter } from "./formatters";
 import { Codicon } from "../common";
 import { Mode } from "../../model-editor/shared/mode";
-import {
-  VSCodeButton,
-  VSCodeDivider,
-  VSCodeTag,
-} from "@vscode/webview-ui-toolkit/react";
+import { VSCodeButton, VSCodeDivider } from "@vscode/webview-ui-toolkit/react";
 import type { ModelEditorViewState } from "../../model-editor/shared/view-state";
 import type { AccessPathSuggestionOptions } from "../../model-editor/suggestions";
 import type { ModelEvaluationRunState } from "../../model-editor/shared/model-evaluation-run-state";
+import { Tag } from "../common/Tag";
 
 const LibraryContainer = styled.div`
   background-color: var(--vscode-peekViewResult-background);
@@ -169,7 +166,7 @@ export const LibraryRow = ({
           <ModeledPercentage>
             {percentFormatter.format(modeledPercentage / 100)} modeled
           </ModeledPercentage>
-          {hasUnsavedChanges ? <VSCodeTag>UNSAVED</VSCodeTag> : null}
+          {hasUnsavedChanges ? <Tag>UNSAVED</Tag> : null}
         </NameContainer>
         {viewState.showGenerateButton &&
           viewState.mode === Mode.Application && (

--- a/extensions/ql-vscode/src/view/model-editor/MethodClassifications.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/MethodClassifications.tsx
@@ -1,8 +1,8 @@
 import { useMemo } from "react";
 import type { Method } from "../../model-editor/method";
 import { CallClassification } from "../../model-editor/method";
-import { VSCodeTag } from "@vscode/webview-ui-toolkit/react";
 import { styled } from "styled-components";
+import { Tag } from "../common/Tag";
 
 const ClassificationsContainer = styled.div`
   display: inline-flex;
@@ -10,7 +10,7 @@ const ClassificationsContainer = styled.div`
   gap: 0.5rem;
 `;
 
-const ClassificationTag = styled(VSCodeTag)`
+const ClassificationTag = styled(Tag)`
   font-size: 0.75em;
   white-space: nowrap;
 `;

--- a/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
+++ b/extensions/ql-vscode/src/view/model-editor/ModelEditor.tsx
@@ -1,10 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { ToModelEditorMessage } from "../../common/interface-types";
-import {
-  VSCodeButton,
-  VSCodeCheckbox,
-  VSCodeTag,
-} from "@vscode/webview-ui-toolkit/react";
+import { VSCodeButton, VSCodeCheckbox } from "@vscode/webview-ui-toolkit/react";
 import { styled } from "styled-components";
 import type { Method } from "../../model-editor/method";
 import type { ModeledMethod } from "../../model-editor/modeled-method";
@@ -22,6 +18,7 @@ import type { AccessPathSuggestionOptions } from "../../model-editor/suggestions
 import type { ModelEvaluationRunState } from "../../model-editor/shared/model-evaluation-run-state";
 import { ModelEvaluation } from "./ModelEvaluation";
 import { useMessageFromExtension } from "../common/useMessageFromExtension";
+import { Tag } from "../common/Tag";
 
 const LoadingContainer = styled.div`
   text-align: center;
@@ -305,9 +302,9 @@ export function ModelEditor({
             <ViewTitle>
               {getLanguageDisplayName(viewState.extensionPack.language)}
             </ViewTitle>
-            <VSCodeTag>
+            <Tag>
               {percentFormatter.format(modeledPercentage / 100)} modeled
-            </VSCodeTag>
+            </Tag>
           </HeaderRow>
           <HeaderRow>
             <>{viewState.extensionPack.name}</>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

This is part of the work to remove the use of `@vscode/webview-ui-toolkit`. The new library `@vscode-elements/elements` does not have a direct replacement for `VSCodeTag`, this implements a new `Tag` component for which the styles have been mostly copied from [here](https://github.com/microsoft/vscode-webview-ui-toolkit/blob/main/src/tag/tag.styles.ts). Some of the css attributes are hard-coded (e.g. `background-color` and `color`) because using the corresponding CSS variables makes the styles different for different themes. I have attached comparison screenshots of the old and new component.

Dark theme
<img width="251" alt="Screenshot 2025-04-01 at 10 13 32" src="https://github.com/user-attachments/assets/35b3303e-6992-4bd8-9238-4c3c49020f76" />

Light theme
<img width="242" alt="Screenshot 2025-04-01 at 10 13 38" src="https://github.com/user-attachments/assets/7f28371f-a1ea-4189-97e8-3b7ee90e81b1" />

