### PR TITLE
Compare perf: Fix missing unit in grouped predicate entry

### DIFF
--- a/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
+++ b/extensions/ql-vscode/src/view/compare-performance/ComparePerformance.tsx
@@ -81,7 +81,7 @@ class ComparisonDataset {
   }
 }
 
-function renderOptionalValue(x: Optional<number>, unit?: string) {
+function renderOptionalValue(x: Optional<number>, unit: string | undefined) {
   switch (x) {
     case AbsentReason.NotSeen:
       return <AbsentNumberCell>n/a</AbsentNumberCell>;
@@ -712,8 +712,8 @@ function PredicateRowGroup(props: PredicateRowGroupProps) {
           <ChevronCell>
             <Chevron expanded={isExpanded} />
           </ChevronCell>
-          {comparison && renderOptionalValue(rowGroup.before)}
-          {renderOptionalValue(rowGroup.after)}
+          {comparison && renderOptionalValue(rowGroup.before, metric.unit)}
+          {renderOptionalValue(rowGroup.after, metric.unit)}
           {comparison && renderDelta(rowGroup.diff, metric.unit)}
           <NameCell>
             {renderedName} ({rowGroup.rows.length} predicates)


### PR DESCRIPTION
Fixes a minor bug in the compare performance view, where the "ms" unit was not displayed on a grouped predicate entry.

Since the optional parameter `unit` is now provided at all call sites, and its absence was the cause of the bug, I also decided to make the parameter mandatory.

# Before: missing unit
The unit was missing next to the first `2` in this screenshot:
<img width="598" alt="Screenshot 2025-04-03 at 14 52 45" src="https://github.com/user-attachments/assets/f0ff9ce3-dced-40d4-b161-226b09bf5cd4" />

# After: unit is there
(sorry, I didn't have the same query history item available for both screenshots)

<img width="603" alt="Screenshot 2025-04-03 at 14 52 16" src="https://github.com/user-attachments/assets/9841ec01-b958-4f0e-9761-aaed28d61642" />
