### PR TITLE
Avoid unhandled errors in build streams

### DIFF
--- a/extensions/ql-vscode/gulpfile.ts/textmate.ts
+++ b/extensions/ql-vscode/gulpfile.ts/textmate.ts
@@ -9,6 +9,7 @@ import type {
   Pattern,
   TextmateGrammar,
 } from "./textmate-grammar";
+import { pipeline } from "stream/promises";
 
 /**
  * Replaces all rule references with the match pattern of the referenced rule.
@@ -276,7 +277,9 @@ export function transpileTextMateGrammar() {
 }
 
 export function compileTextMateGrammar() {
-  return src("syntaxes/*.tmLanguage.yml")
-    .pipe(transpileTextMateGrammar())
-    .pipe(dest("out/syntaxes"));
+  return pipeline(
+    src("syntaxes/*.tmLanguage.yml"),
+    transpileTextMateGrammar(),
+    dest("out/syntaxes"),
+  );
 }

--- a/extensions/ql-vscode/gulpfile.ts/typescript.ts
+++ b/extensions/ql-vscode/gulpfile.ts/typescript.ts
@@ -4,6 +4,7 @@ import esbuild from "gulp-esbuild";
 import type { reporter } from "gulp-typescript";
 import { createProject } from "gulp-typescript";
 import del from "del";
+import { pipeline } from "stream/promises";
 
 export function goodReporter(): reporter.Reporter {
   return {
@@ -37,23 +38,23 @@ export function cleanOutput() {
 }
 
 export function compileEsbuild() {
-  return src("./src/extension.ts")
-    .pipe(
-      esbuild({
-        outfile: "extension.js",
-        bundle: true,
-        external: ["vscode", "fsevents"],
-        format: "cjs",
-        platform: "node",
-        target: "es2020",
-        sourcemap: "linked",
-        sourceRoot: "..",
-        loader: {
-          ".node": "copy",
-        },
-      }),
-    )
-    .pipe(dest("out"));
+  return pipeline(
+    src("./src/extension.ts"),
+    esbuild({
+      outfile: "extension.js",
+      bundle: true,
+      external: ["vscode", "fsevents"],
+      format: "cjs",
+      platform: "node",
+      target: "es2020",
+      sourcemap: "linked",
+      sourceRoot: "..",
+      loader: {
+        ".node": "copy",
+      },
+    }),
+    dest("out"),
+  );
 }
 
 export function watchEsbuild() {

--- a/extensions/ql-vscode/gulpfile.ts/view.ts
+++ b/extensions/ql-vscode/gulpfile.ts/view.ts
@@ -3,28 +3,29 @@ import esbuild from "gulp-esbuild";
 import { createProject } from "gulp-typescript";
 import { goodReporter } from "./typescript";
 
+import { pipeline } from "stream/promises";
 import chromiumVersion from "./chromium-version.json";
 
 const tsProject = createProject("src/view/tsconfig.json");
 
 export function compileViewEsbuild() {
-  return src("./src/view/webview.tsx")
-    .pipe(
-      esbuild({
-        outfile: "webview.js",
-        bundle: true,
-        format: "iife",
-        platform: "browser",
-        target: `chrome${chromiumVersion.chromiumVersion}`,
-        jsx: "automatic",
-        sourcemap: "linked",
-        sourceRoot: "..",
-        loader: {
-          ".ttf": "file",
-        },
-      }),
-    )
-    .pipe(dest("out"));
+  return pipeline(
+    src("./src/view/webview.tsx"),
+    esbuild({
+      outfile: "webview.js",
+      bundle: true,
+      format: "iife",
+      platform: "browser",
+      target: `chrome${chromiumVersion.chromiumVersion}`,
+      jsx: "automatic",
+      sourcemap: "linked",
+      sourceRoot: "..",
+      loader: {
+        ".ttf": "file",
+      },
+    }),
+    dest("out"),
+  );
 }
 
 export function watchViewEsbuild() {


### PR DESCRIPTION
The `.pipe()` method on Node.js streams have a gotcha in that they do not propagate errors downstream. This PR changes a few uses of `.pipe()` in our build scripts to the more modern `stream.pipeline()`, which propagates errors correctly.

Previously, if compilation failed with an error, the error would not be visible to Gulp because Gulp only sees the stream that writes to a file, not the intermediate 'esbuild' stream that generated the error. This resulted in unhelpful errors of the form:
```
[13:56:21] The following tasks did not complete: default, <series>, <parallel>, compileViewEsbuild
Did you forget to signal async completion?`
```

Now that the errors is propagated correctly, the TypeScript build error is surfaced correctly. In my concrete case this became the build error
```
[13:58:54] 'compileViewEsbuild' errored after 410 ms
[13:58:54] Error in plugin "gulp-esbuild"
Message:
    Build failed with 1 error:
src/view/compare-performance/ComparePerformance.tsx:24:27: ERROR: Could not resolve "crypto"
```
