### PR TITLE
Pin azure/login Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,7 +147,7 @@ jobs:
           name: vscode-codeql-extension
 
       - name: Azure User-assigned managed identity login
-        uses: azure/login@v2
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}


### PR DESCRIPTION
Closes https://github.com/github/vscode-codeql/security/code-scanning/646

Dependabot is configured to update actions, so when a new version of this action is released Dependabot should open a PR to update the SHA and comment.
