### PR TITLE
Add command for running a query suite

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -572,6 +572,10 @@
         "title": "CodeQL: Run Queries in Selected Files"
       },
       {
+        "command": "codeQL.runQuerySuite",
+        "title": "CodeQL: Run Selected Query Suite"
+      },
+      {
         "command": "codeQL.quickEval",
         "title": "CodeQL: Quick Evaluation"
       },
@@ -1362,6 +1366,11 @@
           "when": "resourceScheme != codeql-zip-archive"
         },
         {
+          "command": "codeQL.runQuerySuite",
+          "group": "9_qlCommands",
+          "when": "resourceScheme != codeql-zip-archive && resourceExtname == .qls && !explorerResourceIsFolder && !listMultiSelection && config.codeQL.canary"
+        },
+        {
           "command": "codeQL.runVariantAnalysisContextExplorer",
           "group": "9_qlCommands",
           "when": "resourceExtname == .ql && config.codeQL.canary && config.codeQL.variantAnalysis.multiQuery"
@@ -1456,6 +1465,10 @@
         },
         {
           "command": "codeQL.runQueries",
+          "when": "false"
+        },
+        {
+          "command": "codeQL.runQuerySuite",
           "when": "false"
         },
         {

--- a/extensions/ql-vscode/src/codeql-cli/cli-version.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli-version.ts
@@ -13,6 +13,7 @@ export interface CliFeatures {
   featuresInVersionResult?: boolean;
   mrvaPackCreate?: boolean;
   generateSummarySymbolMap?: boolean;
+  queryServerRunQueries?: boolean;
 }
 
 export interface VersionAndFeatures {

--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -138,6 +138,7 @@ export type LocalQueryCommands = {
   "codeQLQueries.createQuery": () => Promise<void>;
   "codeQL.runLocalQueryFromFileTab": (uri: Uri) => Promise<void>;
   "codeQL.runQueries": ExplorerSelectionCommandFunction<Uri>;
+  "codeQL.runQuerySuite": ExplorerSelectionCommandFunction<Uri>;
   "codeQL.quickEval": (uri: Uri) => Promise<void>;
   "codeQL.quickEvalCount": (uri: Uri) => Promise<void>;
   "codeQL.quickEvalContextEditor": (uri: Uri) => Promise<void>;

--- a/extensions/ql-vscode/src/compare/compare-view.ts
+++ b/extensions/ql-vscode/src/compare/compare-view.ts
@@ -70,22 +70,20 @@ export class CompareView extends AbstractWebview<
     selectedResultSetName?: string,
   ) {
     const [fromSchemas, toSchemas] = await Promise.all([
-      this.cliServer.bqrsInfo(
-        from.completedQuery.query.resultsPaths.resultsPath,
-      ),
-      this.cliServer.bqrsInfo(to.completedQuery.query.resultsPaths.resultsPath),
+      this.cliServer.bqrsInfo(from.completedQuery.query.resultsPath),
+      this.cliServer.bqrsInfo(to.completedQuery.query.resultsPath),
     ]);
 
     const [fromSchemaNames, toSchemaNames] = await Promise.all([
       getResultSetNames(
         fromSchemas,
         from.completedQuery.query.metadata,
-        from.completedQuery.query.resultsPaths.interpretedResultsPath,
+        from.completedQuery.query.interpretedResultsPath,
       ),
       getResultSetNames(
         toSchemas,
         to.completedQuery.query.metadata,
-        to.completedQuery.query.resultsPaths.interpretedResultsPath,
+        to.completedQuery.query.interpretedResultsPath,
       ),
     ]);
 
@@ -101,15 +99,14 @@ export class CompareView extends AbstractWebview<
         schemaNames: fromSchemaNames,
         metadata: from.completedQuery.query.metadata,
         interpretedResultsPath:
-          from.completedQuery.query.resultsPaths.interpretedResultsPath,
+          from.completedQuery.query.interpretedResultsPath,
       },
       to,
       toInfo: {
         schemas: toSchemas,
         schemaNames: toSchemaNames,
         metadata: to.completedQuery.query.metadata,
-        interpretedResultsPath:
-          to.completedQuery.query.resultsPaths.interpretedResultsPath,
+        interpretedResultsPath: to.completedQuery.query.interpretedResultsPath,
       },
       commonResultSetNames,
     };
@@ -392,12 +389,12 @@ export class CompareView extends AbstractWebview<
       this.getResultSet(
         fromInfo.schemas,
         fromResultSetName,
-        from.completedQuery.query.resultsPaths.resultsPath,
+        from.completedQuery.query.resultsPath,
       ),
       this.getResultSet(
         toInfo.schemas,
         toResultSetName,
-        to.completedQuery.query.resultsPaths.resultsPath,
+        to.completedQuery.query.resultsPath,
       ),
     ]);
 

--- a/extensions/ql-vscode/src/compare/interpreted-results.ts
+++ b/extensions/ql-vscode/src/compare/interpreted-results.ts
@@ -36,11 +36,9 @@ export async function compareInterpretedResults(
 
   const [fromResultSet, toResultSet, sourceLocationPrefix] = await Promise.all([
     getInterpretedResults(
-      fromQuery.completedQuery.query.resultsPaths.interpretedResultsPath,
+      fromQuery.completedQuery.query.interpretedResultsPath,
     ),
-    getInterpretedResults(
-      toQuery.completedQuery.query.resultsPaths.interpretedResultsPath,
-    ),
+    getInterpretedResults(toQuery.completedQuery.query.interpretedResultsPath),
     database.getSourceLocationPrefix(cliServer),
   ]);
 

--- a/extensions/ql-vscode/src/debugger/debug-protocol.ts
+++ b/extensions/ql-vscode/src/debugger/debug-protocol.ts
@@ -39,6 +39,7 @@ export interface EvaluationCompletedEvent extends Event {
     resultType: QueryResultType;
     message: string | undefined;
     evaluationTime: number;
+    outputBaseName: string;
   };
 }
 

--- a/extensions/ql-vscode/src/debugger/debugger-ui.ts
+++ b/extensions/ql-vscode/src/debugger/debugger-ui.ts
@@ -8,7 +8,7 @@ import { debug, Uri, CancellationTokenSource } from "vscode";
 import type { DebuggerCommands } from "../common/commands";
 import type { DatabaseManager } from "../databases/local-databases";
 import { DisposableObject } from "../common/disposable-object";
-import type { CoreQueryResults } from "../query-server";
+import type { CoreQueryResult } from "../query-server";
 import {
   getQuickEvalContext,
   saveBeforeStart,
@@ -134,8 +134,15 @@ class QLDebugAdapterTracker
     body: EvaluationCompletedEvent["body"],
   ): Promise<void> {
     if (this.localQueryRun !== undefined) {
-      const results: CoreQueryResults = body;
-      await this.localQueryRun.complete(results, (_) => {});
+      const results: CoreQueryResult = body;
+      await this.localQueryRun.complete(
+        {
+          results: new Map<string, CoreQueryResult>([
+            [this.configuration.query, results],
+          ]),
+        },
+        (_) => {},
+      );
       this.localQueryRun = undefined;
     }
   }

--- a/extensions/ql-vscode/src/language-support/ast-viewer/ast-builder.ts
+++ b/extensions/ql-vscode/src/language-support/ast-viewer/ast-builder.ts
@@ -7,7 +7,6 @@ import type {
 import type { DatabaseItem } from "../../databases/local-databases";
 import type { ChildAstItem, AstItem } from "./ast-viewer";
 import type { Uri } from "vscode";
-import type { QueryOutputDir } from "../../local-queries/query-output-dir";
 import { fileRangeFromURI } from "../contextual/file-range-from-uri";
 import { mapUrlValue } from "../../common/bqrs-raw-results-mapper";
 
@@ -17,15 +16,12 @@ import { mapUrlValue } from "../../common/bqrs-raw-results-mapper";
  */
 export class AstBuilder {
   private roots: AstItem[] | undefined;
-  private bqrsPath: string;
   constructor(
-    outputDir: QueryOutputDir,
+    private readonly bqrsPath: string,
     private cli: CodeQLCliServer,
     public db: DatabaseItem,
     public fileName: Uri,
-  ) {
-    this.bqrsPath = outputDir.bqrsPath;
-  }
+  ) {}
 
   async getRoots(): Promise<AstItem[]> {
     if (!this.roots) {

--- a/extensions/ql-vscode/src/language-support/contextual/query-resolver.ts
+++ b/extensions/ql-vscode/src/language-support/contextual/query-resolver.ts
@@ -14,6 +14,7 @@ import type { CancellationToken } from "vscode";
 import type { ProgressCallback } from "../../common/vscode/progress";
 import type { CoreCompletedQuery, QueryRunner } from "../../query-server";
 import { createLockFileForStandardQuery } from "../../local-queries/standard-queries";
+import { basename } from "path";
 
 /**
  * This wil try to determine the qlpacks for a given database. If it can't find a matching
@@ -80,13 +81,19 @@ export async function runContextualQuery(
   const { cleanup } = await createLockFileForStandardQuery(cli, query);
   const queryRun = qs.createQueryRun(
     db.databaseUri.fsPath,
-    { queryPath: query, quickEvalPosition: undefined },
+    [
+      {
+        queryPath: query,
+        outputBaseName: "results",
+        quickEvalPosition: undefined,
+      },
+    ],
     false,
     getOnDiskWorkspaceFolders(),
     undefined,
     {},
     queryStorageDir,
-    undefined,
+    basename(query),
     templates,
   );
   void extLogger.log(

--- a/extensions/ql-vscode/src/language-support/contextual/template-provider.ts
+++ b/extensions/ql-vscode/src/language-support/contextual/template-provider.ts
@@ -209,8 +209,14 @@ export class TemplatePrintAstProvider {
       ? await this.cache.get(fileUri.toString(), progress, token)
       : await this.getAst(fileUri.toString(), progress, token);
 
+    const queryResults = Array.from(completedQuery.results.values());
+    if (queryResults.length !== 1) {
+      throw new Error(
+        `Expected exactly one query result, but found ${queryResults.length}.`,
+      );
+    }
     return new AstBuilder(
-      completedQuery.outputDir,
+      completedQuery.outputDir.getBqrsPath(queryResults[0].outputBaseName),
       this.cli,
       this.dbm.findDatabaseItem(Uri.file(completedQuery.dbPath))!,
       fileUri,

--- a/extensions/ql-vscode/src/local-queries/query-output-dir.ts
+++ b/extensions/ql-vscode/src/local-queries/query-output-dir.ts
@@ -30,19 +30,11 @@ function findQueryEvalLogEndSummaryFile(resultPath: string): string {
 export class QueryOutputDir {
   constructor(public readonly querySaveDir: string) {}
 
-  get dilPath() {
-    return join(this.querySaveDir, "results.dil");
-  }
-
   /**
    * Get the path that the compiled query is if it exists. Note that it only exists when using the legacy query server.
    */
   get compileQueryPath() {
     return join(this.querySaveDir, "compiledQuery.qlo");
-  }
-
-  get csvPath() {
-    return join(this.querySaveDir, "results.csv");
   }
 
   get logPath() {
@@ -69,7 +61,25 @@ export class QueryOutputDir {
     return findQueryEvalLogEndSummaryFile(this.querySaveDir);
   }
 
-  get bqrsPath() {
-    return join(this.querySaveDir, "results.bqrs");
+  getBqrsPath(outputBaseName: string): string {
+    return join(this.querySaveDir, `${outputBaseName}.bqrs`);
+  }
+
+  getInterpretedResultsPath(
+    metadataKind: string | undefined,
+    outputBaseName: string,
+  ): string {
+    return join(
+      this.querySaveDir,
+      `${outputBaseName}-${metadataKind === "graph" ? "graph" : `interpreted.sarif`}`,
+    );
+  }
+
+  getCsvPath(outputBaseName: string): string {
+    return join(this.querySaveDir, `${outputBaseName}.csv`);
+  }
+
+  getDilPath(outputBaseName: string): string {
+    return join(this.querySaveDir, `${outputBaseName}.dil`);
   }
 }

--- a/extensions/ql-vscode/src/local-queries/results-view.ts
+++ b/extensions/ql-vscode/src/local-queries/results-view.ts
@@ -556,10 +556,14 @@ export class ResultsView extends AbstractWebview<
     await this.postMessage({
       t: "setState",
       interpretation: interpretationPage,
-      origResultsPaths: fullQuery.completedQuery.query.resultsPaths,
+      origResultsPaths: {
+        resultsPath: fullQuery.completedQuery.query.resultsPath,
+        interpretedResultsPath:
+          fullQuery.completedQuery.query.interpretedResultsPath,
+      },
       resultsPath: this.convertPathToWebviewUri(
         panel,
-        fullQuery.completedQuery.query.resultsPaths.resultsPath,
+        fullQuery.completedQuery.query.resultsPath,
       ),
       parsedResultSets,
       sortedResultsMap,
@@ -704,10 +708,14 @@ export class ResultsView extends AbstractWebview<
     await this.postMessage({
       t: "setState",
       interpretation: this._interpretation,
-      origResultsPaths: results.completedQuery.query.resultsPaths,
+      origResultsPaths: {
+        resultsPath: results.completedQuery.query.resultsPath,
+        interpretedResultsPath:
+          results.completedQuery.query.interpretedResultsPath,
+      },
       resultsPath: this.convertPathToWebviewUri(
         panel,
-        results.completedQuery.query.resultsPaths.resultsPath,
+        results.completedQuery.query.resultsPath,
       ),
       parsedResultSets,
       sortedResultsMap,
@@ -842,7 +850,10 @@ export class ResultsView extends AbstractWebview<
               };
         await this._getInterpretedResults(
           query.metadata,
-          query.resultsPaths,
+          {
+            resultsPath: query.resultsPath,
+            interpretedResultsPath: query.interpretedResultsPath,
+          },
           sourceInfo,
           sourceLocationPrefix,
           sortState,

--- a/extensions/ql-vscode/src/local-queries/run-query.ts
+++ b/extensions/ql-vscode/src/local-queries/run-query.ts
@@ -33,17 +33,20 @@ export async function runQuery({
   // Create a query run to execute
   const queryRun = queryRunner.createQueryRun(
     databaseItem.databaseUri.fsPath,
-    {
-      queryPath,
-      quickEvalPosition: undefined,
-      quickEvalCountOnly: false,
-    },
+    [
+      {
+        queryPath,
+        outputBaseName: "results",
+        quickEvalPosition: undefined,
+        quickEvalCountOnly: false,
+      },
+    ],
     false,
     additionalPacks,
     extensionPacks,
     {},
     queryStorageDir,
-    undefined,
+    basename(queryPath),
     undefined,
   );
 
@@ -54,13 +57,14 @@ export async function runQuery({
 
   try {
     const completedQuery = await queryRun.evaluate(progress, token, teeLogger);
+    const result = completedQuery.results.get(queryPath);
 
-    if (completedQuery.resultType !== QueryResultType.SUCCESS) {
+    if (result?.resultType !== QueryResultType.SUCCESS) {
       void showAndLogExceptionWithTelemetry(
         extLogger,
         telemetryListener,
         redactableError`Failed to run ${basename(queryPath)} query: ${
-          completedQuery.message ?? "No message"
+          result?.message ?? "No message"
         }`,
       );
       return;

--- a/extensions/ql-vscode/src/model-editor/generate.ts
+++ b/extensions/ql-vscode/src/model-editor/generate.ts
@@ -91,6 +91,14 @@ async function runSingleGenerateQuery(
   if (!completedQuery) {
     return undefined;
   }
+  const queryResults = Array.from(completedQuery.results.values());
+  if (queryResults.length !== 1) {
+    throw new Error(
+      `Expected exactly one query result, but got ${queryResults.length}`,
+    );
+  }
 
-  return cliServer.bqrsDecodeAll(completedQuery.outputDir.bqrsPath);
+  return cliServer.bqrsDecodeAll(
+    completedQuery.outputDir.getBqrsPath(queryResults[0].outputBaseName),
+  );
 }

--- a/extensions/ql-vscode/src/model-editor/model-editor-queries.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-queries.ts
@@ -172,10 +172,19 @@ export async function runModelEditorQueries(
     maxStep: externalApiQueriesProgressMaxStep,
   });
 
+  const queryResults = Array.from(completedQuery.results.values());
+  if (queryResults.length !== 1) {
+    throw new Error(
+      `Expected exactly one query result, but got ${queryResults.length}`,
+    );
+  }
+
   const bqrsChunk = await readQueryResults({
     cliServer,
     logger,
-    bqrsPath: completedQuery.outputDir.bqrsPath,
+    bqrsPath: completedQuery.outputDir.getBqrsPath(
+      queryResults[0].outputBaseName,
+    ),
   });
   if (!bqrsChunk) {
     return;

--- a/extensions/ql-vscode/src/model-editor/suggestion-queries.ts
+++ b/extensions/ql-vscode/src/model-editor/suggestion-queries.ts
@@ -109,7 +109,15 @@ export async function runSuggestionsQuery(
     maxStep,
   });
 
-  const bqrs = await cliServer.bqrsDecodeAll(completedQuery.outputDir.bqrsPath);
+  const queryResults = Array.from(completedQuery.results.values());
+  if (queryResults.length !== 1) {
+    throw new Error(
+      `Expected exactly one query result, but got ${queryResults.length}`,
+    );
+  }
+  const bqrs = await cliServer.bqrsDecodeAll(
+    completedQuery.outputDir.getBqrsPath(queryResults[0].outputBaseName),
+  );
 
   progress({
     message: "Finalizing results",

--- a/extensions/ql-vscode/src/query-history/history-item-label-provider.ts
+++ b/extensions/ql-vscode/src/query-history/history-item-label-provider.ts
@@ -115,7 +115,7 @@ export class HistoryItemLabelProvider {
       startTime: item.startTime,
       queryName: item.getQueryName(),
       databaseName: item.databaseName,
-      resultCount: `(${resultCount} results)`,
+      resultCount: resultCount === -1 ? "" : `(${resultCount} results)`,
       status: message,
       queryFileBasename: item.getQueryFileName(),
       queryLanguage: this.getLanguageLabel(item),

--- a/extensions/ql-vscode/src/query-history/store/query-history-local-query-domain-mapper.ts
+++ b/extensions/ql-vscode/src/query-history/store/query-history-local-query-domain-mapper.ts
@@ -118,6 +118,6 @@ function mapQueryEvaluationInfoToDto(
     databaseHasMetadataFile: queryEvaluationInfo.databaseHasMetadataFile,
     quickEvalPosition: queryEvaluationInfo.quickEvalPosition,
     metadata: queryEvaluationInfo.metadata,
-    resultsPaths: queryEvaluationInfo.resultsPaths,
+    outputBaseName: queryEvaluationInfo.outputBaseName,
   };
 }

--- a/extensions/ql-vscode/src/query-history/store/query-history-local-query-dto-mapper.ts
+++ b/extensions/ql-vscode/src/query-history/store/query-history-local-query-dto-mapper.ts
@@ -104,6 +104,7 @@ function mapQueryEvaluationInfoToDomainModel(
 ): QueryEvaluationInfo {
   return new QueryEvaluationInfo(
     evaluationInfo.querySaveDir,
+    evaluationInfo.outputBaseName ?? "results",
     evaluationInfo.dbItemPath,
     evaluationInfo.databaseHasMetadataFile,
     evaluationInfo.quickEvalPosition,

--- a/extensions/ql-vscode/src/query-history/store/query-history-local-query-dto.ts
+++ b/extensions/ql-vscode/src/query-history/store/query-history-local-query-dto.ts
@@ -86,7 +86,10 @@ export interface QueryEvaluationInfoDto {
   databaseHasMetadataFile: boolean;
   quickEvalPosition?: PositionDto;
   metadata?: QueryMetadataDto;
-  resultsPaths: {
+  outputBaseName?: string;
+
+  // Superceded by outputBaseName
+  resultsPaths?: {
     resultsPath: string;
     interpretedResultsPath: string;
   };

--- a/extensions/ql-vscode/src/query-history/store/query-history-store.ts
+++ b/extensions/ql-vscode/src/query-history/store/query-history-store.ts
@@ -61,7 +61,7 @@ export async function readQueryHistoryFromFile(
           // to see if they exist on disk.
           return true;
         }
-        const resultsPath = q.completedQuery?.query.resultsPaths.resultsPath;
+        const resultsPath = q.completedQuery?.query.resultsPath;
         return !!resultsPath && (await pathExists(resultsPath));
       },
     );

--- a/extensions/ql-vscode/src/query-results.ts
+++ b/extensions/ql-vscode/src/query-results.ts
@@ -64,7 +64,7 @@ export class CompletedQueryInfo implements QueryWithResults {
      * sarif file.
      */
     public interpretedResultsSortState: InterpretedResultsSortState | undefined,
-    public resultCount: number = 0,
+    public resultCount: number = -1,
 
     /**
      * Map from result set name to SortedResultSetInfo.
@@ -78,11 +78,11 @@ export class CompletedQueryInfo implements QueryWithResults {
 
   getResultsPath(selectedTable: string, useSorted = true): string {
     if (!useSorted) {
-      return this.query.resultsPaths.resultsPath;
+      return this.query.resultsPath;
     }
     return (
       this.sortedResultsInfo[selectedTable]?.resultsPath ||
-      this.query.resultsPaths.resultsPath
+      this.query.resultsPath
     );
   }
 
@@ -102,7 +102,7 @@ export class CompletedQueryInfo implements QueryWithResults {
     };
 
     await server.sortBqrs(
-      this.query.resultsPaths.resultsPath,
+      this.query.resultsPath,
       sortedResultSetInfo.resultsPath,
       resultSetName,
       [sortState.columnIndex],

--- a/extensions/ql-vscode/src/query-server/messages.ts
+++ b/extensions/ql-vscode/src/query-server/messages.ts
@@ -130,11 +130,27 @@ export interface RunQueryParams {
   extensionPacks?: string[];
 }
 
-interface RunQueryResult {
+export interface RunQueryResult {
   resultType: QueryResultType;
   message?: string;
   expectedDbschemeName?: string;
   evaluationTime: number;
+}
+
+export interface RunQueryInputOutput {
+  queryPath: string;
+  outputPath: string;
+  dilPath: string;
+}
+
+export interface RunQueriesParams {
+  inputOutputPaths: RunQueryInputOutput[];
+  db: string;
+  additionalPacks: string[];
+  externalInputs: Record<string, string>;
+  singletonExternalInputs: Record<string, string>;
+  logPath?: string;
+  extensionPacks?: string[];
 }
 
 interface UpgradeParams {
@@ -195,6 +211,12 @@ export const runQuery = new RequestType<
   RunQueryResult,
   void
 >("evaluation/runQuery");
+
+export const runQueries = new RequestType<
+  WithProgressId<RunQueriesParams>,
+  Record<string, RunQueryResult>,
+  void
+>("evaluation/runQueries");
 
 export const registerDatabases = new RequestType<
   WithProgressId<RegisterDatabasesParams>,

--- a/extensions/ql-vscode/src/query-server/query-server-client.ts
+++ b/extensions/ql-vscode/src/query-server/query-server-client.ts
@@ -95,6 +95,14 @@ export class QueryServerClient extends DisposableObject {
     return this.opts.logger;
   }
 
+  /**
+   * Whether this query server supports the 'evaluation/runQueries' method for running multiple
+   * queries at once.
+   */
+  async supportsRunQueriesMethod(): Promise<boolean> {
+    return (await this.cliServer.getFeatures()).queryServerRunQueries === true;
+  }
+
   /** Stops the query server by disposing of the current server process. */
   private stopQueryServer(): void {
     if (this.serverProcess !== undefined) {

--- a/extensions/ql-vscode/src/query-server/run-queries.ts
+++ b/extensions/ql-vscode/src/query-server/run-queries.ts
@@ -1,10 +1,19 @@
 import type { CancellationToken } from "vscode";
 import type { ProgressCallback } from "../common/vscode/progress";
-import type { RunQueryParams } from "./messages";
-import { runQuery } from "./messages";
+import type {
+  RunQueryParams,
+  RunQueryResult,
+  RunQueriesParams,
+  RunQueryInputOutput,
+} from "./messages";
+import { runQueries, runQuery } from "./messages";
 import type { QueryOutputDir } from "../local-queries/query-output-dir";
 import type { QueryServerClient } from "./query-server-client";
-import type { CoreQueryResults, CoreQueryTarget } from "./query-runner";
+import type {
+  CoreQueryResult,
+  CoreQueryResults,
+  CoreQueryTarget,
+} from "./query-runner";
 import type { BaseLogger } from "../common/logging";
 
 /**
@@ -24,7 +33,7 @@ import type { BaseLogger } from "../common/logging";
 export async function compileAndRunQueryAgainstDatabaseCore(
   qs: QueryServerClient,
   dbPath: string,
-  query: CoreQueryTarget,
+  targets: CoreQueryTarget[],
   generateEvalLog: boolean,
   additionalPacks: string[],
   extensionPacks: string[] | undefined,
@@ -35,12 +44,36 @@ export async function compileAndRunQueryAgainstDatabaseCore(
   templates: Record<string, string> | undefined,
   logger: BaseLogger,
 ): Promise<CoreQueryResults> {
-  const target =
-    query.quickEvalPosition !== undefined
+  if (targets.length > 1) {
+    // We are running a batch of multiple queries; use the new query server API for that.
+    if (targets.some((target) => target.quickEvalPosition !== undefined)) {
+      throw new Error(
+        "Quick evaluation is not supported when running multiple queries.",
+      );
+    }
+    return compileAndRunQueriesAgainstDatabaseCore(
+      qs,
+      dbPath,
+      targets,
+      generateEvalLog,
+      additionalPacks,
+      extensionPacks,
+      additionalRunQueryArgs,
+      outputDir,
+      progress,
+      token,
+      templates,
+      logger,
+    );
+  }
+
+  const target = targets[0];
+  const compilationTarget =
+    target.quickEvalPosition !== undefined
       ? {
           quickEval: {
-            quickEvalPos: query.quickEvalPosition,
-            countOnly: query.quickEvalCountOnly,
+            quickEvalPos: target.quickEvalPosition,
+            countOnly: target.quickEvalCountOnly,
           },
         }
       : { query: {} };
@@ -51,11 +84,11 @@ export async function compileAndRunQueryAgainstDatabaseCore(
     additionalPacks,
     externalInputs: {},
     singletonExternalInputs: templates || {},
-    outputPath: outputDir.bqrsPath,
-    queryPath: query.queryPath,
-    dilPath: outputDir.dilPath,
+    queryPath: target.queryPath,
+    outputPath: outputDir.getBqrsPath(target.outputBaseName),
+    dilPath: outputDir.getDilPath(target.outputBaseName),
     logPath: evalLogPath,
-    target,
+    target: compilationTarget,
     extensionPacks,
     // Add any additional arguments without interpretation.
     ...additionalRunQueryArgs,
@@ -67,10 +100,83 @@ export async function compileAndRunQueryAgainstDatabaseCore(
   // properly will require a change in the query server.
   qs.activeQueryLogger = logger;
   const result = await qs.sendRequest(runQuery, queryToRun, token, progress);
-
   return {
-    resultType: result.resultType,
-    message: result.message,
-    evaluationTime: result.evaluationTime,
+    results: new Map<string, CoreQueryResult>([
+      [
+        target.queryPath,
+        {
+          resultType: result.resultType,
+          message: result.message,
+          evaluationTime: result.evaluationTime,
+          outputBaseName: target.outputBaseName,
+        },
+      ],
+    ]),
+  };
+}
+
+async function compileAndRunQueriesAgainstDatabaseCore(
+  qs: QueryServerClient,
+  dbPath: string,
+  targets: CoreQueryTarget[],
+  generateEvalLog: boolean,
+  additionalPacks: string[],
+  extensionPacks: string[] | undefined,
+  additionalRunQueryArgs: Record<string, unknown>,
+  outputDir: QueryOutputDir,
+  progress: ProgressCallback,
+  token: CancellationToken,
+  templates: Record<string, string> | undefined,
+  logger: BaseLogger,
+): Promise<CoreQueryResults> {
+  if (!(await qs.supportsRunQueriesMethod())) {
+    throw new Error(
+      "The CodeQL CLI does not support the 'evaluation/runQueries' query-server command. Please update to the latest version.",
+    );
+  }
+  const inputOutputPaths: RunQueryInputOutput[] = targets.map((target) => {
+    return {
+      queryPath: target.queryPath,
+      outputPath: outputDir.getBqrsPath(target.outputBaseName),
+      dilPath: outputDir.getDilPath(target.outputBaseName),
+    };
+  });
+
+  const evalLogPath = generateEvalLog ? outputDir.evalLogPath : undefined;
+  const queriesToRun: RunQueriesParams = {
+    db: dbPath,
+    additionalPacks,
+    externalInputs: {},
+    singletonExternalInputs: templates || {},
+    inputOutputPaths,
+    logPath: evalLogPath,
+    extensionPacks,
+    // Add any additional arguments without interpretation.
+    ...additionalRunQueryArgs,
+  };
+
+  // Update the active query logger every time there is a new request to compile.
+  // This isn't ideal because in situations where there are queries running
+  // in parallel, each query's log messages are interleaved. Fixing this
+  // properly will require a change in the query server.
+  qs.activeQueryLogger = logger;
+  const queryResults: Record<string, RunQueryResult> = await qs.sendRequest(
+    runQueries,
+    queriesToRun,
+    token,
+    progress,
+  );
+  const coreQueryResults = new Map<string, CoreQueryResult>();
+  targets.forEach((target) => {
+    const queryResult = queryResults[target.queryPath];
+    coreQueryResults.set(target.queryPath, {
+      resultType: queryResult.resultType,
+      message: queryResult.message,
+      evaluationTime: queryResult.evaluationTime,
+      outputBaseName: target.outputBaseName,
+    });
+  });
+  return {
+    results: coreQueryResults,
   };
 }

--- a/extensions/ql-vscode/src/run-queries-shared.ts
+++ b/extensions/ql-vscode/src/run-queries-shared.ts
@@ -65,6 +65,7 @@ export class QueryEvaluationInfo extends QueryOutputDir {
    */
   constructor(
     querySaveDir: string,
+    public readonly outputBaseName: string,
     public readonly dbItemPath: string,
     public readonly databaseHasMetadataFile: boolean,
     public readonly quickEvalPosition?: Position,
@@ -73,23 +74,30 @@ export class QueryEvaluationInfo extends QueryOutputDir {
     super(querySaveDir);
   }
 
-  get resultsPaths() {
-    return {
-      resultsPath: this.bqrsPath,
-      interpretedResultsPath: join(
-        this.querySaveDir,
-        this.metadata?.kind === "graph"
-          ? "graphResults"
-          : "interpretedResults.sarif",
-      ),
-    };
+  get resultsPath() {
+    return this.getBqrsPath(this.outputBaseName);
   }
+
+  get interpretedResultsPath() {
+    return this.getInterpretedResultsPath(
+      this.metadata?.kind,
+      this.outputBaseName,
+    );
+  }
+
+  get csvPath() {
+    return this.getCsvPath(this.outputBaseName);
+  }
+
+  get dilPath() {
+    return this.getDilPath(this.outputBaseName);
+  }
+
   getSortedResultSetPath(resultSetName: string) {
     const hasher = createHash("sha256");
     hasher.update(resultSetName);
-    return join(
-      this.querySaveDir,
-      `sortedResults-${hasher.digest("hex")}.bqrs`,
+    return this.getBqrsPath(
+      `${this.outputBaseName}-sorted-${hasher.digest("hex")}`,
     );
   }
 
@@ -127,7 +135,7 @@ export class QueryEvaluationInfo extends QueryOutputDir {
    * Holds if this query actually has produced interpreted results.
    */
   async hasInterpretedResults(): Promise<boolean> {
-    return pathExists(this.resultsPaths.interpretedResultsPath);
+    return pathExists(this.interpretedResultsPath);
   }
 
   /**
@@ -205,7 +213,7 @@ export class QueryEvaluationInfo extends QueryOutputDir {
     let nextOffset: number | undefined = 0;
     do {
       const chunk: DecodedBqrsChunk = await cliServer.bqrsDecode(
-        this.resultsPaths.resultsPath,
+        this.resultsPath,
         resultSet,
         {
           pageSize: 100,
@@ -243,9 +251,9 @@ export class QueryEvaluationInfo extends QueryOutputDir {
    * If the query has no result sets, then return undefined.
    */
   async chooseResultSet(cliServer: CodeQLCliServer) {
-    const resultSets = (
-      await cliServer.bqrsInfo(this.resultsPaths.resultsPath)
-    )["result-sets"];
+    const resultSets = (await cliServer.bqrsInfo(this.resultsPath))[
+      "result-sets"
+    ];
     if (!resultSets.length) {
       return undefined;
     }
@@ -284,7 +292,7 @@ export class QueryEvaluationInfo extends QueryOutputDir {
     }
     await cliServer.generateResultsCsv(
       ensureMetadataIsComplete(this.metadata),
-      this.resultsPaths.resultsPath,
+      this.resultsPath,
       this.csvPath,
       sourceInfo,
     );
@@ -346,6 +354,23 @@ export function validateQueryPath(
       );
     }
   }
+}
+
+/**
+ * Validates that the specified URI represents a QL query suite (QLS), and returns the file system
+ * path to that suite.
+ */
+export function validateQuerySuiteUri(suiteUri: Uri): string {
+  if (suiteUri.scheme !== "file") {
+    throw new Error("Can only run queries that are on disk.");
+  }
+  const suitePath = suiteUri.fsPath;
+  if (!suitePath.endsWith(".qls")) {
+    throw new Error(
+      'The selected resource is not a CodeQL query suite; It should have the extension ".qls".',
+    );
+  }
+  return suitePath;
 }
 
 export interface QuickEvalContext {

--- a/extensions/ql-vscode/test/data-extensions/pack-using-extensions/codeql-pack.lock.yml
+++ b/extensions/ql-vscode/test/data-extensions/pack-using-extensions/codeql-pack.lock.yml
@@ -1,0 +1,26 @@
+---
+lockVersion: 1.0.0
+dependencies:
+  codeql/dataflow:
+    version: 2.0.7
+  codeql/javascript-all:
+    version: 2.6.3
+  codeql/mad:
+    version: 1.0.23
+  codeql/regex:
+    version: 1.0.23
+  codeql/ssa:
+    version: 1.1.2
+  codeql/threat-models:
+    version: 1.0.23
+  codeql/tutorial:
+    version: 1.0.23
+  codeql/typetracking:
+    version: 2.0.7
+  codeql/util:
+    version: 2.0.10
+  codeql/xml:
+    version: 1.0.23
+  codeql/yaml:
+    version: 1.0.23
+compiled: false

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/debugger/debug-controller.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/debugger/debug-controller.ts
@@ -83,14 +83,17 @@ class Tracker implements DebugAdapterTracker {
           kind: "evaluationCompleted",
           started: this.started!,
           results: {
-            ...this.started!,
-            ...this.completed!,
+            id: this.started!.id,
+            results: new Map([[this.queryPath!, this.completed!]]),
             outputDir: new QueryOutputDir(this.started!.outputDir),
-            queryTarget: {
-              queryPath: this.queryPath!,
-              quickEvalPosition:
-                this.started!.quickEvalContext?.quickEvalPosition,
-            },
+            queryTargets: [
+              {
+                queryPath: this.queryPath!,
+                outputBaseName: "results",
+                quickEvalPosition:
+                  this.started!.quickEvalContext?.quickEvalPosition,
+              },
+            ],
             dbPath: this.database!,
           },
         });
@@ -350,15 +353,19 @@ class DebugController
 
   public async expectSucceeded(): Promise<EvaluationCompletedEvent> {
     const event = await this.expectCompleted();
-    if (event.results.resultType !== QueryResultType.SUCCESS) {
-      expect(event.results.message).toBe("success");
+    const results = Array.from(event.results.results.values());
+    expect(results.length).toBe(1);
+    if (results[0].resultType !== QueryResultType.SUCCESS) {
+      expect(results[0].message).toBe("success");
     }
     return event;
   }
 
   public async expectFailed(): Promise<EvaluationCompletedEvent> {
     const event = await this.expectCompleted();
-    expect(event.results.resultType).not.toEqual(QueryResultType.SUCCESS);
+    const results = Array.from(event.results.results.values());
+    expect(results.length).toBe(1);
+    expect(results[0].resultType).not.toEqual(QueryResultType.SUCCESS);
     return event;
   }
 

--- a/extensions/ql-vscode/test/vscode-tests/cli-integration/queries.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/cli-integration/queries.test.ts
@@ -162,7 +162,7 @@ describeWithCodeQL()("Queries", () => {
 
     async function runQueryWithExtensions() {
       console.log("Calling compileAndRunQuery");
-      const result = await compileAndRunQuery(
+      const completedQuery = await compileAndRunQuery(
         mode,
         appCommandManager,
         localQueries,
@@ -176,12 +176,14 @@ describeWithCodeQL()("Queries", () => {
       console.log("Completed compileAndRunQuery");
 
       // Check that query was successful
-      expect(result.resultType).toBe(QueryResultType.SUCCESS);
+      const results = Array.from(completedQuery.results.values());
+      expect(results.length).toBe(1);
+      expect(results[0].resultType).toBe(QueryResultType.SUCCESS);
 
       console.log("Loading query results");
       // Load query results
       const chunk = await qs.cliServer.bqrsDecode(
-        result.outputDir.bqrsPath,
+        completedQuery.outputDir.getBqrsPath(results[0].outputBaseName),
         SELECT_QUERY_NAME,
         {
           // there should only be one result
@@ -198,7 +200,7 @@ describeWithCodeQL()("Queries", () => {
 
   describe.each(MODES)("running queries (%s)", (mode) => {
     it("should run a query", async () => {
-      const result = await compileAndRunQuery(
+      const completedQuery = await compileAndRunQuery(
         mode,
         appCommandManager,
         localQueries,
@@ -211,13 +213,15 @@ describeWithCodeQL()("Queries", () => {
       );
 
       // just check that the query was successful
-      expect(result.resultType).toBe(QueryResultType.SUCCESS);
+      const results = Array.from(completedQuery.results.values());
+      expect(results.length).toBe(1);
+      expect(results[0].resultType).toBe(QueryResultType.SUCCESS);
     });
 
     // Asserts a fix for bug https://github.com/github/vscode-codeql/issues/733
     it("should restart the database and run a query", async () => {
       await appCommandManager.execute("codeQL.restartQueryServer");
-      const result = await compileAndRunQuery(
+      const completedQuery = await compileAndRunQuery(
         mode,
         appCommandManager,
         localQueries,
@@ -229,7 +233,9 @@ describeWithCodeQL()("Queries", () => {
         undefined,
       );
 
-      expect(result.resultType).toBe(QueryResultType.SUCCESS);
+      const results = Array.from(completedQuery.results.values());
+      expect(results.length).toBe(1);
+      expect(results[0].resultType).toBe(QueryResultType.SUCCESS);
     });
   });
 

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/language-support/ast-viewer/ast-builder.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/language-support/ast-viewer/ast-builder.test.ts
@@ -2,7 +2,6 @@ import { readFileSync } from "fs-extra";
 
 import type { CodeQLCliServer } from "../../../../../src/codeql-cli/cli";
 import { Uri } from "vscode";
-import { QueryOutputDir } from "../../../../../src/local-queries/query-output-dir";
 import { mockDatabaseItem, mockedObject } from "../../../utils/mocking.helpers";
 import path from "path";
 import { AstBuilder } from "../../../../../src/language-support";
@@ -141,7 +140,7 @@ describe("AstBuilder", () => {
 
   function createAstBuilder() {
     return new AstBuilder(
-      new QueryOutputDir("/a/b/c"),
+      path.normalize("/a/b/c/results.bqrs"),
       mockCli,
       mockDatabaseItem({
         resolveSourceFile: undefined,

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/external-api-usage-query.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/external-api-usage-query.test.ts
@@ -30,15 +30,13 @@ describe("runModelEditorQueries", () => {
     > = jest.spyOn(log, "showAndLogExceptionWithTelemetry");
 
     const outputDir = new QueryOutputDir(join((await file()).path, "1"));
-
+    const queryPath = "/a/b/c/ApplicationModeEndpoints.ql";
     const options = {
       cliServer: mockedObject<CodeQLCliServer>({
         resolveQlpacks: jest.fn().mockResolvedValue({
           "my/extensions": "/a/b/c/",
         }),
-        resolveQueriesInSuite: jest
-          .fn()
-          .mockResolvedValue(["/a/b/c/ApplicationModeEndpoints.ql"]),
+        resolveQueriesInSuite: jest.fn().mockResolvedValue([queryPath]),
         packPacklist: jest
           .fn()
           .mockResolvedValue([
@@ -50,7 +48,9 @@ describe("runModelEditorQueries", () => {
       queryRunner: mockedObject<QueryRunner>({
         createQueryRun: jest.fn().mockReturnValue({
           evaluate: jest.fn().mockResolvedValue({
-            resultType: QueryResultType.CANCELLATION,
+            results: new Map([
+              [queryPath, { resultType: QueryResultType.CANCELLATION }],
+            ]),
           }),
           outputDir,
         }),
@@ -88,15 +88,13 @@ describe("runModelEditorQueries", () => {
 
   it("should run query for random language", async () => {
     const outputDir = new QueryOutputDir(join((await file()).path, "1"));
-
+    const queryPath = "/a/b/c/ApplicationModeEndpoints.ql";
     const options = {
       cliServer: mockedObject<CodeQLCliServer>({
         resolveQlpacks: jest.fn().mockResolvedValue({
           "my/extensions": "/a/b/c/",
         }),
-        resolveQueriesInSuite: jest
-          .fn()
-          .mockResolvedValue(["/a/b/c/ApplicationModeEndpoints.ql"]),
+        resolveQueriesInSuite: jest.fn().mockResolvedValue([queryPath]),
         packPacklist: jest
           .fn()
           .mockResolvedValue([
@@ -122,6 +120,9 @@ describe("runModelEditorQueries", () => {
         createQueryRun: jest.fn().mockReturnValue({
           evaluate: jest.fn().mockResolvedValue({
             resultType: QueryResultType.SUCCESS,
+            results: new Map([
+              [queryPath, { resultType: QueryResultType.SUCCESS }],
+            ]),
             outputDir,
           }),
           outputDir,
@@ -156,17 +157,20 @@ describe("runModelEditorQueries", () => {
     expect(options.cliServer.resolveQlpacks).toHaveBeenCalledWith([], true);
     expect(options.queryRunner.createQueryRun).toHaveBeenCalledWith(
       "/a/b/c/src.zip",
-      {
-        queryPath: expect.stringMatching(/\S*ModeEndpoints\.ql/),
-        quickEvalPosition: undefined,
-        quickEvalCountOnly: false,
-      },
+      [
+        {
+          outputBaseName: "results",
+          queryPath: expect.stringMatching(/\S*ModeEndpoints\.ql/),
+          quickEvalPosition: undefined,
+          quickEvalCountOnly: false,
+        },
+      ],
       false,
       [],
       ["my/extensions"],
       {},
       "/tmp/queries",
-      undefined,
+      "ApplicationModeEndpoints.ql",
       undefined,
     );
   });

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/generate.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/generate.test.ts
@@ -28,12 +28,10 @@ describe("runGenerateQueries", () => {
     const outputDir = new QueryOutputDir(join(queryStorageDir, "1"));
 
     const onResults = jest.fn();
-
+    const queryPath = "/a/b/c/GenerateModel.ql";
     const options = {
       cliServer: mockedObject<CodeQLCliServer>({
-        resolveQueriesInSuite: jest
-          .fn()
-          .mockResolvedValue(["/a/b/c/GenerateModel.ql"]),
+        resolveQueriesInSuite: jest.fn().mockResolvedValue([queryPath]),
         bqrsDecodeAll: jest.fn().mockResolvedValue({
           sourceModel: {
             columns: [
@@ -101,7 +99,9 @@ describe("runGenerateQueries", () => {
       queryRunner: mockedObject<QueryRunner>({
         createQueryRun: jest.fn().mockReturnValue({
           evaluate: jest.fn().mockResolvedValue({
-            resultType: QueryResultType.SUCCESS,
+            results: new Map([
+              [queryPath, { resultType: QueryResultType.SUCCESS }],
+            ]),
             outputDir,
           }),
           outputDir,
@@ -221,17 +221,20 @@ describe("runGenerateQueries", () => {
     expect(options.queryRunner.createQueryRun).toHaveBeenCalledTimes(1);
     expect(options.queryRunner.createQueryRun).toHaveBeenCalledWith(
       "/a/b/c/src.zip",
-      {
-        queryPath: "/a/b/c/GenerateModel.ql",
-        quickEvalPosition: undefined,
-        quickEvalCountOnly: false,
-      },
+      [
+        {
+          outputBaseName: "results",
+          queryPath: "/a/b/c/GenerateModel.ql",
+          quickEvalPosition: undefined,
+          quickEvalCountOnly: false,
+        },
+      ],
       false,
       [],
       undefined,
       {},
       "/tmp/queries",
-      undefined,
+      "GenerateModel.ql",
       undefined,
     );
   });

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/suggestion-queries.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/model-editor/suggestion-queries.test.ts
@@ -146,9 +146,8 @@ describe("runSuggestionsQuery", () => {
       .mockResolvedValueOnce(mockInputSuggestions)
       .mockResolvedValueOnce(mockOutputSuggestions);
 
-    const resolveQueriesInSuite = jest
-      .fn()
-      .mockResolvedValue(["/a/b/c/FrameworkModeAccessPathSuggestions.ql"]);
+    const queryPath = "/a/b/c/FrameworkModeAccessPathSuggestions.ql";
+    const resolveQueriesInSuite = jest.fn().mockResolvedValue([queryPath]);
 
     const options = {
       parseResults,
@@ -173,7 +172,9 @@ describe("runSuggestionsQuery", () => {
       queryRunner: mockedObject<QueryRunner>({
         createQueryRun: jest.fn().mockReturnValue({
           evaluate: jest.fn().mockResolvedValue({
-            resultType: QueryResultType.SUCCESS,
+            results: new Map([
+              [queryPath, { resultType: QueryResultType.SUCCESS }],
+            ]),
             outputDir,
           }),
           outputDir,
@@ -206,17 +207,20 @@ describe("runSuggestionsQuery", () => {
     expect(options.cliServer.resolveQlpacks).toHaveBeenCalledWith([], true);
     expect(options.queryRunner.createQueryRun).toHaveBeenCalledWith(
       "/a/b/c/src.zip",
-      {
-        queryPath: expect.stringMatching(/\S*AccessPathSuggestions\.ql/),
-        quickEvalPosition: undefined,
-        quickEvalCountOnly: false,
-      },
+      [
+        {
+          queryPath: expect.stringMatching(/\S*AccessPathSuggestions\.ql/),
+          outputBaseName: "results",
+          quickEvalPosition: undefined,
+          quickEvalCountOnly: false,
+        },
+      ],
       false,
       [],
       ["my/extensions"],
       {},
       "/tmp/queries",
-      undefined,
+      "FrameworkModeAccessPathSuggestions.ql",
       undefined,
     );
     expect(options.cliServer.resolveQueriesInSuite).toHaveBeenCalledTimes(1);

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/store/query-history-store.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-history/store/query-history-store.test.ts
@@ -237,12 +237,12 @@ describe("write and read", () => {
     dbPath = "/a/b/c",
   ): QueryWithResults {
     // pretend that the results path exists
-    const resultsPath = join(queryPath, "results.bqrs");
     mkdirpSync(queryPath);
-    writeFileSync(resultsPath, "", "utf8");
+    writeFileSync(join(queryPath, "results.bqrs"), "", "utf8");
 
     const queryEvalInfo = new QueryEvaluationInfo(
       queryPath,
+      "results",
       Uri.file(dbPath).fsPath,
       true,
       undefined,

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-results.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-results.test.ts
@@ -127,7 +127,7 @@ describe("query-results", () => {
       const expectedResultsPath = join(queryPath, "results.bqrs");
       const expectedSortedResultsPath = join(
         queryPath,
-        "sortedResults-cc8589f226adc134f87f2438e10075e0667571c72342068e2281e0b3b65e1092.bqrs",
+        "results-sorted-cc8589f226adc134f87f2438e10075e0667571c72342068e2281e0b3b65e1092.bqrs",
       );
       expect(spy).toHaveBeenCalledWith(
         expectedResultsPath,
@@ -419,12 +419,12 @@ describe("query-results", () => {
     dbPath = "/a/b/c",
   ): QueryWithResults {
     // pretend that the results path exists
-    const resultsPath = join(queryPath, "results.bqrs");
     mkdirpSync(queryPath);
-    writeFileSync(resultsPath, "", "utf8");
+    writeFileSync(join(queryPath, "results.bqrs"), "", "utf8");
 
     const queryEvalInfo = new QueryEvaluationInfo(
       queryPath,
+      "results",
       Uri.file(dbPath).fsPath,
       true,
       undefined,

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/run-queries.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/run-queries.test.ts
@@ -28,12 +28,10 @@ describe("run-queries", () => {
     const saveDir = "query-save-dir";
     const queryEvalInfo = createMockQueryEvaluationInfo(true, saveDir);
 
-    expect(queryEvalInfo.dilPath).toBe(join(saveDir, "results.dil"));
-    expect(queryEvalInfo.resultsPaths.resultsPath).toBe(
-      join(saveDir, "results.bqrs"),
-    );
-    expect(queryEvalInfo.resultsPaths.interpretedResultsPath).toBe(
-      join(saveDir, "interpretedResults.sarif"),
+    expect(queryEvalInfo.dilPath).toBe(join(saveDir, "foo.dil"));
+    expect(queryEvalInfo.resultsPath).toBe(join(saveDir, "foo.bqrs"));
+    expect(queryEvalInfo.interpretedResultsPath).toBe(
+      join(saveDir, "foo-interpreted.sarif"),
     );
     expect(queryEvalInfo.dbItemPath).toBe(Uri.file("/abc").fsPath);
   });
@@ -215,6 +213,7 @@ describe("run-queries", () => {
   ) {
     return new QueryEvaluationInfo(
       saveDir,
+      "foo",
       Uri.parse("file:///abc").fsPath,
       databaseHasMetadataFile,
       undefined,


### PR DESCRIPTION
The command is visible in the context menu for a `.qls` file in the Explorer pane, only when canary mode is enabled.

This uses a new query-server command for running multiple queries, so that a single evaluator log will be produced for the entire run. The intended use case is an internal QL author who wants to judge performance by viewing the evaluator log for the entire query suite.

It would have been much simpler to use the existing functionality for running multiple queries, but that functionality does not work very well when one wants to inspect the evaluator logs – since each query gets started in turn, which truncates the log for the previous query and starts a new one.

To avoid too much code duplication, I have updated a lot of the code paths involved in running local queries to work with multiple query paths. This also required some refactoring to explicitly associate an output basename (used to produce the `.bqrs`, `.csv`, etc. paths) with each input query, where before those output filenames were hard-coded. As a result, the diff is fairly big (but the changes should be easily understandable).

Since this is a canary feature intended for internal users, and in the interest of shipping it quickly, there are a few rough edges, particularly with the UI for the query history pane:
- There's one entry while the suite is running, and then, when it completes, we add entries for each query in the suite.
- Since all those entries point to the same results directory, deleting an entry in the query history pane will now also delete any others that have the same results directory.
- The summary text for each additional entry in the query history pane will *not* include the number of results – this number is normally computed when showing the results window, as we decode the BQRS. It would be too slow and visually disturbing to do this for every query in the suite.

In the long term, it would be ideal to have a first-class concept of a multi-query run in the query history pane, which would allow us to create hierarchical entries, where run-specific commands like "Show evaluator log summary" would appear on the root node for the run, while query-specific commands like "Show CSV" would appear on the child nodes for each query. But I think what's implemented here is good enough for a canary/internal feature.

Also, if the CLI is too old to support the new `evaluation/runQueries` query-server command, the run will fail with an error message explaining this. I decided not to implement a fallback to running the queries one by one.

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->

This is a canary feature, so I won't update the changelog.