### PR TITLE
Upgrade node-ipc to support Node 22

### DIFF
--- a/extensions/ql-vscode/package-lock.json
+++ b/extensions/ql-vscode/package-lock.json
@@ -160,17 +160,18 @@
       }
     },
     "node_modules/@achrinza/node-ipc": {
-      "version": "9.2.8",
-      "resolved": "https://registry.npmjs.org/@achrinza/node-ipc/-/node-ipc-9.2.8.tgz",
-      "integrity": "sha512-DSzEEkbMYbAUVlhy7fg+BzccoRuSQzqHbIPGxGv19OJ2WKwS3/9ChAnQcII4g+GujcHhyJ8BUuOVAx/S5uAfQg==",
+      "version": "9.2.9",
+      "resolved": "https://registry.npmjs.org/@achrinza/node-ipc/-/node-ipc-9.2.9.tgz",
+      "integrity": "sha512-7s0VcTwiK/0tNOVdSX9FWMeFdOEcsAOz9HesBldXxFMaGvIak7KC2z9tV9EgsQXn6KUsWsfIkViMNuIo0GoZDQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@node-ipc/js-queue": "2.0.3",
         "event-pubsub": "4.3.0",
         "js-message": "1.0.7"
       },
       "engines": {
-        "node": "8 || 9 || 10 || 11 || 12 || 13 || 14 || 15 || 16 || 17 || 18 || 19 || 20 || 21"
+        "node": "8 || 9 || 10 || 11 || 12 || 13 || 14 || 15 || 16 || 17 || 18 || 19 || 20 || 21 || 22"
       }
     },
     "node_modules/@adobe/css-tools": {


### PR DESCRIPTION
This upgrades node-ipc to remove a warning that Node 22 is unsupported. There are [no changes in the package itself](https://github.com/achrinza/node-ipc/compare/v9.2.8...v9.2.9).