### PR TITLE
New command: expose `--cache-cleanup=overlay` base cache cleaning

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [UNRELEASED]
 
+- Add new command "CodeQL: Trim Overlay Base Cache" that returns a database to the state prior to overlay evaluation, leaving only base predicates and types that may later be referenced during overlay evaluation. [#4082](https://github.com/github/vscode-codeql/pull/4082)
+
 ## 1.17.4 - 10 July 2025
 
 - Fix variant analysis pack creation on some Windows systems [#4068](https://github.com/github/vscode-codeql/pull/4068)

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -791,6 +791,10 @@
         "title": "CodeQL: Trim Cache"
       },
       {
+        "command": "codeQL.trimOverlayBaseCache",
+        "title": "CodeQL: Trim Overlay Base Cache"
+      },
+      {
         "command": "codeQL.installPackDependencies",
         "title": "CodeQL: Install Pack Dependencies"
       },
@@ -1817,6 +1821,10 @@
         },
         {
           "command": "codeQL.trimCache"
+        },
+        {
+          "command": "codeQL.trimOverlayBaseCache",
+          "when": "codeQL.cliFeatures.queryServerTrimCacheWithMode"
         }
       ],
       "editor/context": [

--- a/extensions/ql-vscode/src/common/commands.ts
+++ b/extensions/ql-vscode/src/common/commands.ts
@@ -221,6 +221,7 @@ export type LocalDatabasesCommands = {
   "codeQL.upgradeCurrentDatabase": () => Promise<void>;
   "codeQL.clearCache": () => Promise<void>;
   "codeQL.trimCache": () => Promise<void>;
+  "codeQL.trimOverlayBaseCache": () => Promise<void>;
 
   // Explorer context menu
   "codeQL.setCurrentDatabase": (uri: Uri) => Promise<void>;

--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -284,6 +284,7 @@ export class DatabaseUI extends DisposableObject {
         this.handleUpgradeCurrentDatabase.bind(this),
       "codeQL.clearCache": this.handleClearCache.bind(this),
       "codeQL.trimCache": this.handleTrimCache.bind(this),
+      "codeQL.trimOverlayBaseCache": this.handleTrimOverlayBaseCache.bind(this),
       "codeQLDatabases.chooseDatabaseFolder":
         this.handleChooseDatabaseFolder.bind(this),
       "codeQLDatabases.chooseDatabaseArchive":
@@ -684,6 +685,25 @@ export class DatabaseUI extends DisposableObject {
       },
       {
         title: "Trimming cache",
+      },
+    );
+  }
+
+  private async handleTrimOverlayBaseCache(): Promise<void> {
+    return withProgress(
+      async () => {
+        if (
+          this.queryServer !== undefined &&
+          this.databaseManager.currentDatabaseItem !== undefined
+        ) {
+          await this.queryServer.trimCacheWithModeInDatabase(
+            this.databaseManager.currentDatabaseItem,
+            "overlay",
+          );
+        }
+      },
+      {
+        title: "Removing all overlay-dependent data from cache",
       },
     );
   }

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -463,6 +463,25 @@ export async function activate(
       );
       unsupportedWarningShown = true;
     });
+
+    // Expose the CodeQL CLI features to the extension context under `codeQL.cliFeatures.*`.
+    let cliFeatures: { [feature: string]: boolean | undefined } = {};
+    codeQlExtension.cliServer.addVersionChangedListener(async (ver) => {
+      for (const feat of Object.keys(cliFeatures)) {
+        cliFeatures[feat] = false;
+      }
+      cliFeatures = {
+        ...cliFeatures,
+        ...(ver?.features ?? {}),
+      };
+      for (const feat of Object.keys(cliFeatures)) {
+        await app.commands.execute(
+          "setContext",
+          `codeQL.cliFeatures.${feat}`,
+          cliFeatures[feat] ?? false,
+        );
+      }
+    });
   }
 
   return codeQlExtension;

--- a/extensions/ql-vscode/src/query-server/messages.ts
+++ b/extensions/ql-vscode/src/query-server/messages.ts
@@ -43,6 +43,22 @@ export interface TrimCacheParams {
 }
 
 /**
+ * Parameters for trimming the cache of a dataset with a specific mode.
+ */
+export interface TrimCacheWithModeParams {
+  /**
+   * The dataset that we want to trim the cache of.
+   */
+  db: string;
+  /**
+   * The cache cleanup mode to use.
+   */
+  mode: ClearCacheMode;
+}
+
+export type ClearCacheMode = "clear" | "trim" | "fit" | "overlay";
+
+/**
  * The result of trimming or clearing the cache.
  */
 interface ClearCacheResult {
@@ -193,6 +209,14 @@ export const trimCache = new RequestType<
   ClearCacheResult,
   void
 >("evaluation/trimCache");
+/**
+ * Trim the cache of a dataset with a specific mode.
+ */
+export const trimCacheWithMode = new RequestType<
+  WithProgressId<TrimCacheWithModeParams>,
+  ClearCacheResult,
+  void
+>("evaluation/trimCacheWithMode");
 
 /**
  * Clear the pack cache

--- a/extensions/ql-vscode/src/query-server/query-runner.ts
+++ b/extensions/ql-vscode/src/query-server/query-runner.ts
@@ -6,10 +6,12 @@ import { UserCancellationException } from "../common/vscode/progress";
 import type { DatabaseItem } from "../databases/local-databases/database-item";
 import { QueryOutputDir } from "../local-queries/query-output-dir";
 import type {
+  ClearCacheMode,
   ClearCacheParams,
   Position,
   QueryResultType,
   TrimCacheParams,
+  TrimCacheWithModeParams,
 } from "./messages";
 import {
   clearCache,
@@ -17,6 +19,7 @@ import {
   deregisterDatabases,
   registerDatabases,
   trimCache,
+  trimCacheWithMode,
   upgradeDatabase,
 } from "./messages";
 import type { BaseLogger, Logger } from "../common/logging";
@@ -140,6 +143,22 @@ export class QueryRunner {
       db,
     };
     await this.qs.sendRequest(trimCache, params);
+  }
+
+  async trimCacheWithModeInDatabase(
+    dbItem: DatabaseItem,
+    mode: ClearCacheMode,
+  ): Promise<void> {
+    if (dbItem.contents === undefined) {
+      throw new Error("Can't clean the cache in an invalid database.");
+    }
+
+    const db = dbItem.databaseUri.fsPath;
+    const params: TrimCacheWithModeParams = {
+      db,
+      mode,
+    };
+    await this.qs.sendRequest(trimCacheWithMode, params);
   }
 
   public async compileAndRunQueryAgainstDatabaseCore(


### PR DESCRIPTION
Add new command "CodeQL: Trim Overlay Base Cache" that returns a database to the state prior to overlay evaluation, leaving only base predicates and types that may later be referenced during overlay evaluation.

* Requires a recent enough query server. So the command is hidden behind a version check.
* Tested locally and with unit tests.