### PR TITLE
Avoid specifying error type since the default is unknown

### DIFF
--- a/extensions/ql-vscode/scripts/source-map.ts
+++ b/extensions/ql-vscode/scripts/source-map.ts
@@ -131,7 +131,7 @@ async function extractSourceMap() {
               resolve(sourceMapsDirectory, `${basename(file)}.map`),
             );
             rawSourceMaps.set(file, rawSourceMap);
-          } catch (e: unknown) {
+          } catch (e) {
             // If the file is not found, we will not decode it and not try reading this source map again
             if (e instanceof Error && "code" in e && e.code === "ENOENT") {
               rawSourceMaps.set(file, null);

--- a/extensions/ql-vscode/scripts/update-node-version.ts
+++ b/extensions/ql-vscode/scripts/update-node-version.ts
@@ -93,7 +93,7 @@ async function updateNodeVersion() {
 
       // If it exists, we can break out of this loop
       break;
-    } catch (e: unknown) {
+    } catch (e) {
       if (!isExecError(e)) {
         throw e;
       }

--- a/extensions/ql-vscode/src/codeql-cli/distribution.ts
+++ b/extensions/ql-vscode/src/codeql-cli/distribution.ts
@@ -336,7 +336,7 @@ class ExtensionSpecificDistributionManager {
     const distributionStatePath = this.getDistributionStatePath();
     try {
       this.distributionState = await readJson(distributionStatePath);
-    } catch (e: unknown) {
+    } catch (e) {
       if (isIOError(e) && e.code === "ENOENT") {
         // If the file doesn't exist, that just means we need to create it
 

--- a/extensions/ql-vscode/src/common/short-paths.ts
+++ b/extensions/ql-vscode/src/common/short-paths.ts
@@ -45,7 +45,7 @@ export async function expandShortPaths(
 
   try {
     return await expandShortPathNative(absoluteShortPath, logger);
-  } catch (e: unknown) {
+  } catch (e) {
     void logger.log(
       `Failed to expand short path using native method: ${getErrorMessage(e)}`,
     );

--- a/extensions/ql-vscode/src/databases/local-databases-ui.ts
+++ b/extensions/ql-vscode/src/databases/local-databases-ui.ts
@@ -505,7 +505,7 @@ export class DatabaseUI extends DisposableObject {
   ): Promise<void> {
     try {
       await this.chooseAndSetDatabase(false, progress);
-    } catch (e: unknown) {
+    } catch (e) {
       void showAndLogExceptionWithTelemetry(
         this.app.logger,
         this.app.telemetry,

--- a/extensions/ql-vscode/src/databases/local-databases/database-manager.ts
+++ b/extensions/ql-vscode/src/databases/local-databases/database-manager.ts
@@ -411,7 +411,7 @@ export class DatabaseManager extends DisposableObject {
         qlpackStoragePath,
       );
       await qlPackGenerator.generate();
-    } catch (e: unknown) {
+    } catch (e) {
       void this.logger.log(
         `Could not create skeleton QL pack: ${getErrorMessage(e)}`,
       );

--- a/extensions/ql-vscode/src/databases/ui/db-panel.ts
+++ b/extensions/ql-vscode/src/databases/ui/db-panel.ts
@@ -432,7 +432,7 @@ export class DbPanel extends DisposableObject {
     try {
       // This will also validate that the controller repository is valid
       await getControllerRepo(this.app.credentials);
-    } catch (e: unknown) {
+    } catch (e) {
       if (e instanceof UserCancellationException) {
         return;
       }

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -667,7 +667,7 @@ async function installOrUpdateThenTryActivate(
 
   try {
     await prepareCodeTour(app.commands);
-  } catch (e: unknown) {
+  } catch (e) {
     void extLogger.log(
       `Could not open tutorial workspace automatically: ${getErrorMessage(e)}`,
     );

--- a/extensions/ql-vscode/src/local-queries/skeleton-query-wizard.ts
+++ b/extensions/ql-vscode/src/local-queries/skeleton-query-wizard.ts
@@ -132,7 +132,7 @@ export class SkeletonQueryWizard {
     // open the query file
     try {
       await this.openExampleFile();
-    } catch (e: unknown) {
+    } catch (e) {
       void this.app.logger.log(
         `Could not open example query file: ${getErrorMessage(e)}`,
       );
@@ -279,7 +279,7 @@ export class SkeletonQueryWizard {
       const qlPackGenerator = this.createQlPackGenerator();
 
       await qlPackGenerator.generate();
-    } catch (e: unknown) {
+    } catch (e) {
       void this.app.logger.log(
         `Could not create skeleton QL pack: ${getErrorMessage(e)}`,
       );
@@ -299,7 +299,7 @@ export class SkeletonQueryWizard {
 
       this.fileName = await this.determineNextFileName();
       await qlPackGenerator.createExampleQlFile(this.fileName);
-    } catch (e: unknown) {
+    } catch (e) {
       void this.app.logger.log(
         `Could not create query example file: ${getErrorMessage(e)}`,
       );
@@ -342,7 +342,7 @@ export class SkeletonQueryWizard {
       void withProgress(async (progress) => {
         try {
           await this.downloadDatabase(progress);
-        } catch (e: unknown) {
+        } catch (e) {
           if (e instanceof UserCancellationException) {
             return;
           }

--- a/extensions/ql-vscode/src/log-insights/summary-language-support.ts
+++ b/extensions/ql-vscode/src/log-insights/summary-language-support.ts
@@ -113,7 +113,7 @@ export class SummaryLanguageSupport extends DisposableObject {
         const sourceMapText = await readFile(mapPath, "utf-8");
         const rawMap: RawSourceMap = JSON.parse(sourceMapText);
         this.sourceMap = await new SourceMapConsumer(rawMap);
-      } catch (e: unknown) {
+      } catch (e) {
         // Error reading sourcemap. Pretend there was no sourcemap.
         void extLogger.log(
           `Error reading sourcemap file '${mapPath}': ${getErrorMessage(e)}`,

--- a/extensions/ql-vscode/src/model-editor/extension-pack-picker.ts
+++ b/extensions/ql-vscode/src/model-editor/extension-pack-picker.ts
@@ -115,7 +115,7 @@ export async function pickExtensionPack(
         existingExtensionPackPaths[0],
         databaseItem.language,
       );
-    } catch (e: unknown) {
+    } catch (e) {
       void showAndLogErrorMessage(
         logger,
         `Could not read extension pack ${formatPackName(packName)}`,

--- a/extensions/ql-vscode/src/model-editor/model-editor-view.ts
+++ b/extensions/ql-vscode/src/model-editor/model-editor-view.ts
@@ -455,7 +455,7 @@ export class ModelEditorView extends AbstractWebview<
         this.app.logger,
       );
       this.modelingStore.setModeledMethods(this.databaseItem, modeledMethods);
-    } catch (e: unknown) {
+    } catch (e) {
       void showAndLogErrorMessage(
         this.app.logger,
         `Unable to read data extension YAML: ${getErrorMessage(e)}`,
@@ -561,7 +561,7 @@ export class ModelEditorView extends AbstractWebview<
             t: "setAccessPathSuggestions",
             accessPathSuggestions: options,
           });
-        } catch (e: unknown) {
+        } catch (e) {
           void showAndLogExceptionWithTelemetry(
             this.app.logger,
             this.app.telemetry,
@@ -645,7 +645,7 @@ export class ModelEditorView extends AbstractWebview<
             progress,
             token: this.cancellationTokenSource.token,
           });
-        } catch (e: unknown) {
+        } catch (e) {
           void showAndLogExceptionWithTelemetry(
             this.app.logger,
             this.app.telemetry,
@@ -733,7 +733,7 @@ export class ModelEditorView extends AbstractWebview<
             progress,
             token: this.cancellationTokenSource.token,
           });
-        } catch (e: unknown) {
+        } catch (e) {
           void showAndLogExceptionWithTelemetry(
             this.app.logger,
             this.app.telemetry,

--- a/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
+++ b/extensions/ql-vscode/src/variant-analysis/variant-analysis-manager.ts
@@ -425,7 +425,7 @@ export class VariantAnalysisManager
         this.app.credentials,
         variantAnalysisSubmission,
       );
-    } catch (e: unknown) {
+    } catch (e) {
       // If the error is handled by the handleRequestError function, we don't need to throw
       if (
         e instanceof RequestError &&

--- a/extensions/ql-vscode/test/unit-tests/common/errors.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/common/errors.test.ts
@@ -37,7 +37,7 @@ describe("errorMessage", () => {
       myRealFunction();
 
       fail("Expected an error to be thrown");
-    } catch (e: unknown) {
+    } catch (e) {
       if (!(e instanceof Error)) {
         throw new Error("Expected an Error to be thrown");
       }

--- a/extensions/ql-vscode/test/vscode-tests/activated-extension/variant-analysis/variant-analysis-manager.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/activated-extension/variant-analysis/variant-analysis-manager.test.ts
@@ -50,6 +50,7 @@ import { createMockVariantAnalysisConfig } from "../../../factories/config";
 import { setupServer } from "msw/node";
 import type { RequestHandler } from "msw";
 import { http } from "msw";
+import { getErrorMessage } from "../../../../src/common/helpers-pure";
 
 // up to 3 minutes per test
 jest.setTimeout(3 * 60 * 1000);
@@ -622,8 +623,8 @@ describe("Variant Analysis Manager", () => {
         await variantAnalysisManager.cancelVariantAnalysis(
           variantAnalysis.id + 100,
         );
-      } catch (error: any) {
-        expect(error.message).toBe(
+      } catch (error) {
+        expect(getErrorMessage(error)).toBe(
           `No variant analysis with id: ${variantAnalysis.id + 100}`,
         );
       }
@@ -637,8 +638,8 @@ describe("Variant Analysis Manager", () => {
 
       try {
         await variantAnalysisManager.cancelVariantAnalysis(variantAnalysis.id);
-      } catch (error: any) {
-        expect(error.message).toBe(
+      } catch (error) {
+        expect(getErrorMessage(error)).toBe(
           `No workflow run id for variant analysis with id: ${variantAnalysis.id}`,
         );
       }


### PR DESCRIPTION
Since typescript 4.4 ([release notes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-4.html#defaulting-to-the-unknown-type-in-catch-variables---useunknownincatchvariables)), values in a `catch` default to the `unknown` type. So we don't need to specify it, and there were a couple of places where we were explicitly using `any` that would be better off as `unknown`.

Discovered while working on https://github.com/github/vscode-codeql/pull/4056