### PR TITLE
Enable the @typescript-eslint/no-unsafe-return rule

### DIFF
--- a/extensions/ql-vscode/eslint.config.mjs
+++ b/extensions/ql-vscode/eslint.config.mjs
@@ -70,7 +70,6 @@ export default tseslint.config(
       // Rules disabled during eslint 9 migration
       "github/filenames-match-regex": "off",
       "@typescript-eslint/restrict-template-expressions": "off",
-      "@typescript-eslint/no-unsafe-return": "off",
       "@typescript-eslint/no-unsafe-assignment": "off",
       "@typescript-eslint/no-unsafe-argument": "off",
       "@typescript-eslint/no-unsafe-member-access": "off",

--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -979,7 +979,7 @@ export class CodeQLCliServer implements Disposable {
         subcommandArgs,
         "Resolving query by language",
       ),
-    );
+    ) as QueryInfoByLanguage;
   }
 
   /**

--- a/extensions/ql-vscode/src/common/mock-gh-api/recorder.ts
+++ b/extensions/ql-vscode/src/common/mock-gh-api/recorder.ts
@@ -283,7 +283,7 @@ async function jsonResponseBody<T>(response: Response): Promise<T> {
   const body = await responseBody(response);
   const text = new TextDecoder("utf-8").decode(body);
 
-  return JSON.parse(text);
+  return JSON.parse(text) as T;
 }
 
 function shouldWriteBodyToFile(

--- a/extensions/ql-vscode/src/extension.ts
+++ b/extensions/ql-vscode/src/extension.ts
@@ -251,7 +251,7 @@ function registerErrorStubs(
   stubGenerator: (command: string) => () => Promise<void>,
 ): void {
   // Remove existing stubs
-  errorStubs.forEach((stub) => stub.dispose());
+  errorStubs.forEach((stub) => void stub.dispose());
 
   if (extension === undefined) {
     throw new Error(`Can't find extension ${extensionId}`);
@@ -757,7 +757,7 @@ async function activateWithInstalledDistribution(
   beganMainExtensionActivation = true;
   // Remove any error stubs command handlers left over from first part
   // of activation.
-  errorStubs.forEach((stub) => stub.dispose());
+  errorStubs.forEach((stub) => void stub.dispose());
 
   void extLogger.log("Initializing configuration listener...");
   const qlConfigurationListener =
@@ -1167,7 +1167,7 @@ async function activateWithInstalledDistribution(
     databaseUI,
     variantAnalysisManager,
     dispose: () => {
-      ctx.subscriptions.forEach((d) => d.dispose());
+      ctx.subscriptions.forEach((d) => void d.dispose());
     },
   };
 }

--- a/extensions/ql-vscode/src/variant-analysis/shared/variant-analysis.ts
+++ b/extensions/ql-vscode/src/variant-analysis/shared/variant-analysis.ts
@@ -287,9 +287,11 @@ export function getSkippedRepoCount(
     return 0;
   }
 
-  return Object.values(skippedRepos).reduce(
-    (acc, group) => acc + group.repositoryCount,
-    0,
+  return (
+    (skippedRepos.accessMismatchRepos?.repositoryCount ?? 0) +
+    (skippedRepos.notFoundRepos?.repositoryCount ?? 0) +
+    (skippedRepos.noCodeqlDbRepos?.repositoryCount ?? 0) +
+    (skippedRepos.overLimitRepos?.repositoryCount ?? 0)
   );
 }
 

--- a/extensions/ql-vscode/src/view/common/SuggestBox/SuggestBox.tsx
+++ b/extensions/ql-vscode/src/view/common/SuggestBox/SuggestBox.tsx
@@ -22,11 +22,15 @@ import type { Diagnostic } from "./diagnostics";
 import { useOpenKey } from "./useOpenKey";
 import { VscodeTextfield } from "@vscode-elements/react-elements";
 
-const Input = styled(VscodeTextfield)<{ $error: boolean }>`
+interface InputProps {
+  $error: boolean;
+}
+
+const Input = styled(VscodeTextfield)<InputProps>`
   width: 100%;
   font-family: var(--vscode-editor-font-family);
 
-  ${(props) =>
+  ${(props: InputProps) =>
     props.$error &&
     css`
       --dropdown-border: var(--vscode-inputValidation-errorBorder);

--- a/extensions/ql-vscode/src/view/common/SuggestBox/useEffectEvent.ts
+++ b/extensions/ql-vscode/src/view/common/SuggestBox/useEffectEvent.ts
@@ -18,6 +18,7 @@ export function useEffectEvent<T extends (...args: any[]) => any>(callback: T) {
   });
 
   return useCallback<(...args: Parameters<T>) => ReturnType<T>>(
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     (...args) => ref.current(...args),
     [],
   ) as T;

--- a/extensions/ql-vscode/test/mock-memento.ts
+++ b/extensions/ql-vscode/test/mock-memento.ts
@@ -17,7 +17,7 @@ class MockMemento<T> implements Memento {
 
   public get<T>(key: string): T | undefined;
   public get<T>(key: string, defaultValue: T): T;
-  public get(key: any, defaultValue?: any): T | undefined {
+  public get(key: any, defaultValue?: T): T | undefined {
     return this.map.get(key) || defaultValue;
   }
 

--- a/extensions/ql-vscode/test/mocked-object.ts
+++ b/extensions/ql-vscode/test/mocked-object.ts
@@ -25,9 +25,11 @@ export function mockedObject<T extends object>(
   return new Proxy<T>({} as unknown as T, {
     get: (_target, prop) => {
       if (prop in props) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return (props as any)[prop];
       }
       if (dynamicProperties && prop in dynamicProperties) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return (dynamicProperties as any)[prop]();
       }
 

--- a/extensions/ql-vscode/test/unit-tests/common/disposable-object.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/common/disposable-object.test.ts
@@ -77,10 +77,10 @@ describe("DisposableObject and DisposeHandler", () => {
     expect(disposable1.dispose).toHaveBeenCalled();
   });
 
-  it("ahould use a dispose handler", () => {
+  it("should use a dispose handler", () => {
     const handler = (d: any) =>
       d === disposable1 || d === disposable3 || d === nestedDisposableObject
-        ? d.dispose(handler)
+        ? void d.dispose(handler)
         : void 0;
 
     disposableObject.push(disposable1);

--- a/extensions/ql-vscode/test/unit-tests/common/invocation-rate-limiter.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/common/invocation-rate-limiter.test.ts
@@ -40,7 +40,7 @@ describe("Invocation rate limiter", () => {
      * @return The stored value or the defaultValue.
      */
     get<T>(key: string, defaultValue?: T): T | undefined {
-      return this.map.has(key) ? this.map.get(key) : defaultValue;
+      return this.map.has(key) ? (this.map.get(key) as T) : defaultValue;
     }
 
     /**

--- a/extensions/ql-vscode/test/unit-tests/variant-analysis/custom-errors.test.ts
+++ b/extensions/ql-vscode/test/unit-tests/variant-analysis/custom-errors.test.ts
@@ -173,8 +173,9 @@ function toErrorMessage(data: any) {
     if (Array.isArray(data.errors)) {
       return `${data.message}: ${data.errors.map(JSON.stringify).join(", ")}`;
     }
-
-    return data.message;
+    if (typeof data.message === "string") {
+      return data.message as string;
+    }
   }
 
   // istanbul ignore next - just in case

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/codeql-cli/distribution.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/codeql-cli/distribution.test.ts
@@ -38,7 +38,7 @@ import type { Release } from "../../../../src/codeql-cli/distribution/release";
 import { zip } from "zip-a-folder";
 
 jest.mock("os", () => {
-  const original = jest.requireActual("os");
+  const original: typeof os = jest.requireActual("os");
   return {
     ...original,
     platform: jest.fn(),

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/index.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/index.ts
@@ -4,12 +4,12 @@ export function createMockExtensionContext(): ExtensionContext {
   return {
     globalState: {
       _state: {} as Record<string, any>,
-      get(key: string) {
-        return this._state[key];
+      get<T>(key: string): T | undefined {
+        return this._state[key] as T | undefined;
       },
       update(key: string, val: any) {
         this._state[key] = val;
       },
     },
-  } as any;
+  } as unknown as ExtensionContext;
 }

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/language-support/ast-viewer/ast-builder.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/language-support/ast-viewer/ast-builder.test.ts
@@ -5,6 +5,7 @@ import { Uri } from "vscode";
 import { mockDatabaseItem, mockedObject } from "../../../utils/mocking.helpers";
 import path from "path";
 import { AstBuilder } from "../../../../../src/language-support";
+import type { DecodedBqrsChunk } from "../../../../../src/common/bqrs-cli-types";
 
 /**
  *
@@ -29,7 +30,7 @@ int disable_interrupts(void)
 
 describe("AstBuilder", () => {
   let mockCli: CodeQLCliServer;
-  let overrides: Record<string, Record<string, unknown> | undefined>;
+  let overrides: Record<string, DecodedBqrsChunk | undefined>;
 
   beforeEach(() => {
     mockCli = mockedObject<CodeQLCliServer>({
@@ -132,6 +133,7 @@ describe("AstBuilder", () => {
   it("should fail when graphProperties are not correct", async () => {
     overrides.graphProperties = {
       tuples: [["semmle.graphKind", "hucairz"]],
+      columns: [],
     };
 
     const astBuilder = createAstBuilder();
@@ -149,7 +151,9 @@ describe("AstBuilder", () => {
     );
   }
 
-  function mockDecode(resultSet: "nodes" | "edges" | "graphProperties") {
+  async function mockDecode(
+    resultSet: "nodes" | "edges" | "graphProperties",
+  ): Promise<DecodedBqrsChunk> {
     if (overrides[resultSet]) {
       return overrides[resultSet];
     }
@@ -166,7 +170,7 @@ describe("AstBuilder", () => {
           `${__dirname}/../../data/language-support/ast-viewer/ast-builder.json`,
           "utf8",
         ),
-      )[index];
+      )[index] as DecodedBqrsChunk;
     } else {
       throw new Error(`Invalid resultSet: ${resultSet}`);
     }

--- a/extensions/ql-vscode/test/vscode-tests/no-workspace/query-testing/test-runner.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/no-workspace/query-testing/test-runner.test.ts
@@ -1,4 +1,5 @@
 import { CancellationTokenSource, Uri } from "vscode";
+import type * as fsExtra from "fs-extra";
 import type { CodeQLCliServer } from "../../../../src/codeql-cli/cli";
 import type {
   DatabaseItem,
@@ -15,7 +16,7 @@ import {
 } from "./test-runner-helpers";
 
 jest.mock("fs-extra", () => {
-  const original = jest.requireActual("fs-extra");
+  const original: typeof fsExtra = jest.requireActual("fs-extra");
   return {
     ...original,
     access: jest.fn(),


### PR DESCRIPTION
This PR enables the `@typescript-eslint/no-unsafe-return` rule that was disabled in the eslint 9 migration.

Each case is a little bit different. A lot were fixed by using `as`, though some needed other changes. I _think_ the only production code change is `getSkippedRepoCount` and everything else is either just compile-time or is in test code.