### PR TITLE
Disable running e2e tests on PRs and pushes to main

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,10 +1,11 @@
 name: Run E2E Playwright tests
 on:
   workflow_dispatch:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+# Temporarily disable running tests until they're fixed
+#   push:
+#     branches: [main]
+#   pull_request:
+#     branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
This is to avoid all PRs and pushes looking broken, until we fix the e2e tests.