### PR TITLE
Don't attempt to interpret results when running quick-eval

### DIFF
--- a/extensions/ql-vscode/CHANGELOG.md
+++ b/extensions/ql-vscode/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add new command "CodeQL: Trim Overlay Base Cache" that returns a database to the state prior to overlay evaluation, leaving only base predicates and types that may later be referenced during overlay evaluation. [#4082](https://github.com/github/vscode-codeql/pull/4082)
 - Remove support for CodeQL CLI versions older than 2.19.4. [#4108](https://github.com/github/vscode-codeql/pull/4108)
+- Fix a bug where quick evaluation within a `.ql` file could cause spurious errors about processing query metadata. [#4141](https://github.com/github/vscode-codeql/pull/4141)
 
 ## 1.17.4 - 10 July 2025
 

--- a/extensions/ql-vscode/src/local-queries/local-query-run.ts
+++ b/extensions/ql-vscode/src/local-queries/local-query-run.ts
@@ -188,7 +188,7 @@ export class LocalQueryRun {
         result.outputBaseName,
         this.dbItem.databaseUri.fsPath,
         await this.dbItem.hasMetadataFile(),
-        undefined,
+        this.queryInfo.initialInfo.quickEvalPosition,
         metadata,
       );
 


### PR DESCRIPTION
#4037 introduced a bug where `quickEvalPosition` — which indicates that the query was spawned via quick-eval — was not being passed through in the completed query info. This meant the extension tried to interpret the results with the metadata from the enclosing file, which would then fail if it was a `.ql` file with a `@kind` that required a particular named query-predicate.