### PR TITLE
CI: Run CodeQL analysis using nightly tools

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
         with:
             languages: ${{ matrix.language }}
             config-file: ./.github/codeql/codeql-config.yml
-            tools: latest
+            tools: nightly
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@main


### PR DESCRIPTION
Dogfood the nightly CodeQL bundle so we can find issues earlier.
