### PR TITLE
Update docs/test-plan.md: "GitHub database download, Test case 1" regression

### DIFF
--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -239,6 +239,7 @@ Open a clone of the [`github/codeql`](https://github.com/github/codeql) reposito
 3. Select the "C#" and "JavaScript" databases.
    - Check that there are separate notifications for both downloads.
    - Check that both databases are added when the downloads are complete.
+     - Note: if only one of the databases appears in the list, this is a known regression for which a fix has not been prioritized at the time of writing.
 
 ### General
 


### PR DESCRIPTION
This concerns a regression which I've reproduced in releases 1.17.5 and 1.17.6. Not sure how long it's been there or how common it is, but fixing it has not been prioritized, so I'm amending the docs with a caveat for future release testers.

Downloading more than one database for the current repo (via the pop-up notification) does download them to disk, but adds only one of the databases to the database list after the downloads are complete.

Also, deleting the database that does appear in the UI deletes all of the other databases downloaded alongside it.