### PR TITLE
Change mention of failing CLI tests to vscode-codeql-reviewers

### DIFF
--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -142,7 +142,7 @@ jobs:
             echo "Did not find an open tracking issue. Creating one."
 
             ISSUE_BODY="issue-body.md"
-            printf "CLI tests have failed on the default branch.\n\n@github/code-scanning-secexp-reviewers" > "$ISSUE_BODY"
+            printf "CLI tests have failed on the default branch.\n\n@github/codeql-vscode-reviewers" > "$ISSUE_BODY"
 
             ISSUE="$(gh issue create --repo "$GITHUB_REPOSITORY" --label "cli-test-failure" --title "CLI test failure" --body-file "$ISSUE_BODY")"
             # `gh issue create` returns the full issue URL, not just the number.


### PR DESCRIPTION
This changes the mention on the failing CLI test issues (for example https://github.com/github/vscode-codeql/issues/4189) to `@github/vscode-codeql-reviewers` instead of SecExp.