### PR TITLE
Fix rendering of settings by adding ids to package.json

### DIFF
--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -164,6 +164,7 @@
       {
         "type": "object",
         "title": "CLI",
+        "id": "codeQL.cli",
         "order": 0,
         "properties": {
           "codeQL.cli.executablePath": {
@@ -182,6 +183,7 @@
       {
         "type": "object",
         "title": "Running queries",
+        "id": "codeQL.runningQueries",
         "order": 1,
         "properties": {
           "codeQL.runningQueries.numberOfThreads": {
@@ -279,6 +281,7 @@
       {
         "type": "object",
         "title": "Results",
+        "id": "codeQL.resultsDisplay",
         "order": 2,
         "properties": {
           "codeQL.resultsDisplay.pageSize": {
@@ -291,6 +294,7 @@
       {
         "type": "object",
         "title": "Query history",
+        "id": "codeQL.queryHistory",
         "order": 3,
         "properties": {
           "codeQL.queryHistory.format": {
@@ -309,6 +313,7 @@
       {
         "type": "object",
         "title": "Running tests",
+        "id": "codeQL.runningTests",
         "order": 4,
         "properties": {
           "codeQL.runningTests.additionalTestArguments": {
@@ -330,6 +335,7 @@
       {
         "type": "object",
         "title": "Variant analysis",
+        "id": "codeQL.variantAnalysis",
         "order": 5,
         "properties": {
           "codeQL.variantAnalysis.controllerRepo": {
@@ -372,6 +378,7 @@
       {
         "type": "object",
         "title": "Adding databases",
+        "id": "codeQL.addingDatabases",
         "order": 6,
         "properties": {
           "codeQL.addingDatabases.downloadTimeout": {
@@ -399,6 +406,7 @@
       {
         "type": "object",
         "title": "Creating queries",
+        "id": "codeQL.createQuery",
         "order": 7,
         "properties": {
           "codeQL.createQuery.qlPackLocation": {
@@ -424,6 +432,7 @@
       {
         "type": "object",
         "title": "GitHub Databases",
+        "id": "codeQL.githubDatabase",
         "order": 8,
         "properties": {
           "codeQL.githubDatabase.download": {
@@ -457,6 +466,7 @@
       {
         "type": "object",
         "title": "Model Editor",
+        "id": "codeQL.model",
         "order": 9,
         "properties": {
           "codeQL.model.packLocation": {
@@ -474,6 +484,7 @@
       {
         "type": "object",
         "title": "Log insights",
+        "id": "codeQL.logInsights",
         "order": 10,
         "properties": {
           "codeQL.logInsights.joinOrderWarningThreshold": {
@@ -488,6 +499,7 @@
       {
         "type": "object",
         "title": "Telemetry",
+        "id": "codeQL.telemetry",
         "order": 11,
         "properties": {
           "codeQL.telemetry.logTelemetry": {


### PR DESCRIPTION
This appears to fix a problem I noticed, where all the settings defined by this extension appeared in the settings UI under "Extensions->CLI" (the name of our first config category), rather than "Extensions->CodeQL->CLI", "Extensions->CodeQL->Running queries", etc.

I don't know exactly why this works, but I was just looking for differences between our `package.json` and that of a different open-source extension.

### Before
<img width="1035" height="791" alt="Screenshot 2025-11-25 at 16 43 51" src="https://github.com/user-attachments/assets/184e81a0-393c-4019-9863-07653bab010a" />

### After
<img width="1110" height="859" alt="Screenshot 2025-11-25 at 16 43 38" src="https://github.com/user-attachments/assets/d36ab987-381f-424c-843a-da5457da26e7" />
