### PR TITLE
Fix graph viewer not re-rendering correctly after loading a second graph

### DIFF
--- a/extensions/ql-vscode/src/view/results/ResultsApp.tsx
+++ b/extensions/ql-vscode/src/view/results/ResultsApp.tsx
@@ -197,7 +197,9 @@ export function ResultsApp() {
   ) {
     const parsedResultSets = displayedResults.resultsInfo.parsedResultSets;
     const key =
-      (parsedResultSets.selectedTable || "") + parsedResultSets.pageNumber;
+      displayedResults.resultsInfo.resultsPath +
+      (parsedResultSets.selectedTable || "") +
+      parsedResultSets.pageNumber;
     const data = displayedResults.resultsInfo.interpretation?.data;
 
     return (


### PR DESCRIPTION
This PR fixes an issue with the graph viewer (CFG viewer) that appears after loading two CFGs without closing the webview in-between.

To reproduce the issue:
- Open the CFG viewer
- Observe that pan-to-scroll works. And that clicking a node doesn't reset the scroll position within the webview.
- Open the CFG viewer for a different function without closing the webview.
- Pan-to-scroll no longer works. Clicking a node resets the scroll position.
- Closing the webview and opening another CFG makes it work again.

Copilot CLI duly noticed that the `key` for the `ResultsApp` component was not changing when loading a new query run. Changing the key ensures the underlying `d3-graphviz` component gets reset properly when rendering a new graph.