### PR TITLE
Replace deprecated `FormEvent` with `InputEvent`

### DIFF
--- a/extensions/ql-vscode/src/view/common/SuggestBox/SuggestBox.tsx
+++ b/extensions/ql-vscode/src/view/common/SuggestBox/SuggestBox.tsx
@@ -1,4 +1,4 @@
-import type { FormEvent, ReactNode } from "react";
+import type { InputEvent, ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   autoUpdate,
@@ -173,7 +173,7 @@ export const SuggestBox = <
   );
 
   const handleInput = useCallback(
-    (event: FormEvent<HTMLInputElement>) => {
+    (event: InputEvent<HTMLInputElement>) => {
       const value = event.currentTarget.value;
       onChange(value);
       setIsOpen(true);


### PR DESCRIPTION
`FormEvent` is deprecated:

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/ca06abb4cc3399ea070c122be329a22f1c3b6800/types/react/index.d.ts#L2078-L2082

For manual testing, I couldn't see how to trigger the `SuggestBox` in the extension UI, but it works just fine in the Storybook (and I temporarily added an `alert(...)` to confirm the handler was being called with the right input.)

I believe this will also fix the failures in https://github.com/github/vscode-codeql/pull/4383