### PR TITLE
Add 3-day cooldown for Dependabot and npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,8 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "extensions/ql-vscode"
+    cooldown:
+      default-days: 3
     schedule:
       interval: "weekly"
       day: "thursday" # Thursday is arbitrary
@@ -32,6 +34,8 @@ updates:
           - "@typescript-eslint/*"
   - package-ecosystem: "github-actions"
     directory: "/"
+    cooldown:
+      default-days: 3
     schedule:
       interval: "weekly"
       day: "thursday" # Thursday is arbitrary
@@ -39,6 +43,8 @@ updates:
       - "Update dependencies"
   - package-ecosystem: docker
     directory: "extensions/ql-vscode/test/e2e/docker"
+    cooldown:
+      default-days: 3
     schedule:
       interval: "weekly"
       day: "thursday" # Thursday is arbitrary

--- a/extensions/ql-vscode/.npmrc
+++ b/extensions/ql-vscode/.npmrc
@@ -1,2 +1,4 @@
 # Storybook requires this option to be set. See https://github.com/storybookjs/storybook/issues/18298
 legacy-peer-deps=true
+# Supply chain security: require packages to be at least 3 days old before install
+min-release-age=3


### PR DESCRIPTION
This adds a 72-hour buffer before newly-published package versions are eligible for installation.