### PR TITLE
Bump vite from 7.3.2 to 7.3.5

### DIFF
--- a/extensions/ql-vscode/package-lock.json
+++ b/extensions/ql-vscode/package-lock.json
@@ -134,7 +134,7 @@
         "ts-unused-exports": "^11.0.1",
         "typescript": "^5.9.3",
         "typescript-plugin-css-modules": "^5.2.0",
-        "vite": "^7.3.2",
+        "vite": "^7.3.5",
         "vite-node": "^5.3.0"
       },
       "engines": {
@@ -29454,9 +29454,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -2192,7 +2192,7 @@
     "ts-unused-exports": "^11.0.1",
     "typescript": "^5.9.3",
     "typescript-plugin-css-modules": "^5.2.0",
-    "vite": "^7.3.2",
+    "vite": "^7.3.5",
     "vite-node": "^5.3.0"
   },
   "overrides": {


### PR DESCRIPTION
This PR bumps `vite` dependency from 7.3.2 to 7.3.5.