### PR TITLE
Update CODEOWNERS to remove secexp

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,1 @@
 **/* @github/codeql-vscode-reviewers
-**/variant-analysis/ @github/code-scanning-secexp-reviewers
-**/databases/ @github/code-scanning-secexp-reviewers
-**/method-modeling/ @github/code-scanning-secexp-reviewers
-**/model-editor/ @github/code-scanning-secexp-reviewers
-**/queries-panel/ @github/code-scanning-secexp-reviewers


### PR DESCRIPTION
I think these have all been handed over to CodeQL, so @github/code-scanning-secexp-reviewers probably don't need to be codeowners any more? 

