### PR TITLE
Handle CLI server stdin EPIPE on teardown

### DIFF
--- a/extensions/ql-vscode/src/codeql-cli/cli.ts
+++ b/extensions/ql-vscode/src/codeql-cli/cli.ts
@@ -313,11 +313,26 @@ export class CodeQLCliServer implements Disposable {
 
   killProcessIfRunning(): void {
     if (this.process) {
+      const proc = this.process;
+
+      // The shutdown write below is buffered and, on Windows, can flush
+      // asynchronously *after* we end()/kill() the process, closing the read
+      // end and producing an EPIPE 'error' on stdin. Without a handler that
+      // async error is unhandled and gets attributed to an unrelated
+      // in-progress operation. Attach a handler scoped to this teardown so it
+      // is swallowed here; the process is killed and dereferenced immediately
+      // afterwards, so the listener is short-lived and does not accumulate.
+      proc.stdin.on("error", (e) => {
+        void this.logger.log(
+          `CodeQL CLI Server shutdown stdin error (ignored): ${getErrorMessage(e)}`,
+        );
+      });
+
       // Tell the Java CLI server process to shut down.
       void this.logger.log("Sending shutdown request");
       try {
-        this.process.stdin.write(JSON.stringify(["shutdown"]), "utf8");
-        this.process.stdin.write(this.nullBuffer);
+        proc.stdin.write(JSON.stringify(["shutdown"]), "utf8");
+        proc.stdin.write(this.nullBuffer);
         void this.logger.log("Sent shutdown request");
       } catch (e) {
         // We are probably fine here, the process has already closed stdin.
@@ -328,10 +343,10 @@ export class CodeQLCliServer implements Disposable {
       }
       // Close the stdin and stdout streams.
       // This is important on Windows where the child process may not die cleanly.
-      this.process.stdin.end();
-      this.process.kill();
-      this.process.stdout.destroy();
-      this.process.stderr.destroy();
+      proc.stdin.end();
+      proc.kill();
+      proc.stdout.destroy();
+      proc.stderr.destroy();
       this.process = undefined;
     }
   }


### PR DESCRIPTION
## Summary

Fixes a flaky `write EPIPE` failure that intermittently fails the CLI integration tests on **Windows** (e.g. `queries.test.ts` → "should restart the database and run a query"). Related: #4456.

## Root cause

`codeQL.restartQueryServer` also restarts the persistent CLI server process (`codeql execute cli-server`) via `cliServer.restartCliServer()`. During teardown, `killProcessIfRunning()` writes a `["shutdown"]` request to the child's stdin and then synchronously calls `stdin.end()` + `kill()`. On Windows the buffered write can flush **asynchronously** and emit an `'error'` (EPIPE) after the read end has already closed.

With no `'error'` listener on that stream, Node treats it as an unhandled stream error, which jest then attributes to whichever test happened to be running — surfacing as a bare `write EPIPE`.

This is Windows-specific because the pipe-close/kill timing loses the in-flight write; on Linux the write drains first.

## Fix

Attach an `'error'` listener to the CLI server's stdin **inside `killProcessIfRunning()`**, scoped to teardown, before issuing the shutdown write. The process is killed and dereferenced (`this.process = undefined`) immediately afterwards, so the listener is short-lived and does not accumulate across restarts.

Scoping the listener to teardown (rather than attaching it once-per-process in `launchProcess()`) is deliberate:

- **Cannot mask real failures / hang the queue** — command completion is tracked via the stdout null-terminator and process `close`/`error` events, never via stdin. Because the listener only exists during teardown, stdin errors during an *active command* retain their existing behavior and cannot be swallowed.
- **No listener leak** — `killProcessIfRunning()` is fully synchronous, so it can't re-enter on the same process; each restart spawns a fresh child, and the old stream plus its lone listener are GC'd.
- The existing synchronous `try/catch` (which only guards the *synchronous* throw from `write()`) and the new async `'error'` listener are complementary and non-overlapping.

## Diagnosis

Root cause was confirmed via two instrumented CI runs on a throwaway branch: instrumenting the query server showed it healthy, while instrumenting the CLI server captured the stdin `'error'` immediately after `killProcessIfRunning`, and handling it turned the Windows lane green.
