### PR TITLE
Fix flaky query history reveal test via stable TreeItem ids

### DIFF
--- a/extensions/ql-vscode/src/query-history/history-tree-data-provider.ts
+++ b/extensions/ql-vscode/src/query-history/history-tree-data-provider.ts
@@ -3,7 +3,7 @@ import { env, EventEmitter, ThemeColor, ThemeIcon, TreeItem } from "vscode";
 import { DisposableObject } from "../common/disposable-object";
 import { assertNever } from "../common/helpers-pure";
 import type { QueryHistoryInfo } from "./query-history-info";
-import { getLanguage } from "./query-history-info";
+import { getLanguage, getQueryId } from "./query-history-info";
 import { QueryStatus } from "./query-status";
 import type { HistoryItemLabelProvider } from "./history-item-label-provider";
 import type { LanguageContextStore } from "../language-context-store";
@@ -15,6 +15,25 @@ export enum SortOrder {
   DateDesc = "DateDesc",
   CountAsc = "CountAsc",
   CountDesc = "CountDesc",
+}
+
+/**
+ * Computes a stable, unique id for a query history item, suitable for use as a
+ * `TreeItem.id`. `getQueryId` alone is not unique because a multi-query run
+ * produces several local-query items that share the same `initialInfo.id`; for
+ * those we also include the (per-result) output base name.
+ */
+function getTreeItemId(element: QueryHistoryInfo): string {
+  switch (element.t) {
+    case "local":
+      return `local:${element.initialInfo.id}:${
+        element.completedQuery?.query.outputBaseName ?? ""
+      }`;
+    case "variant-analysis":
+      return `variant-analysis:${getQueryId(element)}`;
+    default:
+      assertNever(element);
+  }
 }
 
 /**
@@ -53,6 +72,22 @@ export class HistoryTreeDataProvider
 
   async getTreeItem(element: QueryHistoryInfo): Promise<TreeItem> {
     const treeItem = new TreeItem(this.labelProvider.getLabel(element));
+
+    // Give the tree item a stable, unique id. Without this, VS Code identifies
+    // tree nodes by their label plus their position in the list. When multiple
+    // history items share the same label, that positional identity is ambiguous
+    // and makes `treeView.reveal` resolve to the wrong item (or fail outright)
+    // when the list is re-sorted or refreshed. The default label format includes
+    // the start time, so labels are effectively unique in practice and users are
+    // unlikely to hit this; it mainly affects tests (and any user who customises
+    // the label format to something non-unique).
+    //
+    // `getQueryId` is not guaranteed to be unique: a multi-query run produces
+    // several local-query items that share the same `initialInfo.id`. Those
+    // items differ by their output base name, so we include it to keep the id
+    // unique (VS Code de-duplicates nodes that share an id, which would break
+    // reveal/selection for all but one of them).
+    treeItem.id = getTreeItemId(element);
 
     treeItem.command = {
       title: "Query History Item",


### PR DESCRIPTION
## Summary

Fixes a flaky test in `query-history-manager.test.ts` (the `handleRemoveHistoryItem` › "should not change the selection" cases), which was failing on CI (e.g. [this windows-latest run](https://github.com/github/vscode-codeql/actions/runs/29611545650/job/87987136543)).

## Root cause

`HistoryTreeDataProvider.getTreeItem` never set a `TreeItem.id`. When no `id` is provided, VS Code identifies tree nodes by their **label plus their position** in the list (`<parent>/<index>:<label>`). When multiple history items share the same label, that positional identity is ambiguous, so `treeView.reveal(item)` can resolve to the **wrong** item or fail outright (`Data tree node not found`) whenever the list is re-sorted or refreshed.

The test overrides the label format to just `${queryName}`, so all six mock variant-analysis items render with the identical label `a-query-name (javascript)`. Combined with the randomised sort order (`executionStartTime` is `faker.number.int()`), `reveal(selected)` intermittently selected the wrong item, so `getCurrent()` no longer equalled `selected`.

## Impact

**Mainly test-only.** The production default label format is `${queryName} on ${databaseName} - ${status} ${resultCount} [${startTime}]`, which includes the start time — so real history labels are effectively unique and users are very unlikely to hit this. The one exception is a user who customises `codeQL.queryHistory.format` to something non-unique. Because the impact is effectively test-only, no changelog entry is added.

## Fix

Set a stable, unique `id` on each tree item so `reveal` resolves deterministically regardless of duplicate labels or sort order.

The id must be **unique per item**. `getQueryId` alone is not sufficient: a multi-query run (a query suite / multiple `.ql` files) produces several local-query history entries that are cloned from the same `initialInfo` and therefore share the same `initialInfo.id` (see `completeQueries` in `query-history-manager.ts`). Since VS Code de-duplicates nodes that share an `id` — which would break reveal/selection for all but one of the colliding rows — the id for local queries also includes the per-result `outputBaseName`, which is distinct for each entry (and is persisted, so this also disambiguates already-saved histories). Variant-analysis ids are already unique.

## Validation

- `tsc --noEmit` and `eslint` pass.
- Ran the affected test in a loop (retries disabled) on macOS:
  - **Before:** ~20/40 failures (~50%).
  - **After (initial fix and after addressing review feedback):** 0 failures across repeated runs.
