### PR TITLE
Harden cli-test workflow against script injection

### DIFF
--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -89,11 +89,18 @@ jobs:
         id: choose-ref
         shell: bash
         run: |
-          if [[ "${{ matrix.version }}" == "nightly" ]]
+          if [[ "$CLI_VERSION" == "nightly" ]]
           then
             REF="codeql-cli/latest"
           else
-            REF="codeql-cli/${{ matrix.version }}"
+            # Validate the version read from supported_cli_versions.json before
+            # using it, to guard against script injection from untrusted input.
+            if [[ ! "$CLI_VERSION" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]
+            then
+              echo "Unexpected CLI version: '$CLI_VERSION'" >&2
+              exit 1
+            fi
+            REF="codeql-cli/$CLI_VERSION"
           fi
           echo "ref=$REF" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
Use the `$CLI_VERSION` env var instead of interpolating `${{ matrix.version }}` directly into the shell script, and validate the version string read from `supported_cli_versions.json` before using it to build the checkout ref.

Copilot-Session: dc84e21b-6038-4939-b81a-7b477b0c9634

<!-- Thank you for submitting a pull request. Please read our pull request guidelines before
  submitting your pull request:
  https://github.com/github/vscode-codeql/blob/main/CONTRIBUTING.md#submitting-a-pull-request.
-->
