### PR TITLE
Fix VS Code integration tests on macOS

### DIFF
--- a/extensions/ql-vscode/package-lock.json
+++ b/extensions/ql-vscode/package-lock.json
@@ -91,7 +91,7 @@
         "@types/yauzl": "^3.4.0",
         "@typescript-eslint/eslint-plugin": "^8.65.0",
         "@typescript-eslint/parser": "^8.65.0",
-        "@vscode/test-electron": "^2.5.2",
+        "@vscode/test-electron": "^3.1.0",
         "@vscode/vsce": "^3.9.2",
         "ansi-colors": "^4.1.1",
         "applicationinsights": "^2.9.8",
@@ -10201,9 +10201,9 @@
       "integrity": "sha512-2J27dysaXmvnfuhFGhfeuxfHRXunqNPxtBoR3koiTOA9rdxWNDTa1zIFLCFMSHJ9MPTPKFcBeblsyaCJCIlQxg=="
     },
     "node_modules/@vscode/test-electron": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
-      "integrity": "sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.1.0.tgz",
+      "integrity": "sha512-CRqv5u+YYoseuNVJ6Tyo4k0sF0mx4qnKMihRB0PjsUF8Dc0WKtCXo6CNL6nWWm5esfFQsQA/pejMj4ZbpJVLTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10214,7 +10214,7 @@
         "semver": "^7.6.2"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=22"
       }
     },
     "node_modules/@vscode/vsce": {

--- a/extensions/ql-vscode/package.json
+++ b/extensions/ql-vscode/package.json
@@ -2149,7 +2149,7 @@
     "@types/yauzl": "^3.4.0",
     "@typescript-eslint/eslint-plugin": "^8.65.0",
     "@typescript-eslint/parser": "^8.65.0",
-    "@vscode/test-electron": "^2.5.2",
+    "@vscode/test-electron": "^3.1.0",
     "@vscode/vsce": "^3.9.2",
     "ansi-colors": "^4.1.1",
     "applicationinsights": "^2.9.8",
@@ -2198,7 +2198,10 @@
     "d3-graphviz": {
       "@hpcc-js/wasm": "2.30.0"
     },
-    "@azure/identity": "^4.13.1"
+    "@azure/identity": "^4.13.1",
+    "jest-runner-vscode": {
+      "@vscode/test-electron": "^3.1.0"
+    }
   },
   "lint-staged": {
     "./**/*.{json,css,scss}": [

--- a/extensions/ql-vscode/test/vscode-tests/minimal-workspace/activation.test.ts
+++ b/extensions/ql-vscode/test/vscode-tests/minimal-workspace/activation.test.ts
@@ -24,9 +24,9 @@ describe("launching with a minimal workspace", () => {
     const document = await workspace.openTextDocument(documentPath);
     expect(document.languageId).toEqual("ql");
     // Wait for the extension to activate, polling with a timeout.
-    await waitForActivation(ext!, 30_000);
+    await waitForActivation(ext!, 90_000);
     expect(ext!.isActive).toBeTruthy();
-  }, 60_000);
+  }, 120_000);
 
   async function waitForActivation(
     extension: Extension<any>,


### PR DESCRIPTION
## Summary

VS Code 1.131 removed the legacy `Contents/MacOS/Electron` compatibility executable on macOS, causing the existing test harness to launch a path that no longer exists. This PR upgrades `@vscode/test-electron` to 3.1.0 so the executable is resolved from the application bundle metadata.

It also overrides the version used transitively by `jest-runner-vscode`; without the override, npm installs a private 2.5.2 copy and the runner continues using the obsolete executable lookup.

The minimal-workspace activation timeout is increased because extension activation on macOS can now exceed the previous 30-second polling allowance. These failures were specific to local macOS runs; GitHub Actions runs this suite on Linux and Windows, where it was already passing.

## Testing

- `npm run test:vscode-integration`