### PR TITLE
Remove the ready-for-review CI workaround

### DIFF
--- a/.github/actions/create-pr/action.yml
+++ b/.github/actions/create-pr/action.yml
@@ -75,7 +75,7 @@ runs:
           echo "Found existing open PR: $PR_NUMBERS"
           exit 0
         fi
-        gh pr create --head "$HEAD_BRANCH" --base "$BASE_BRANCH" --title "$TITLE" --body "$BODY" --assignee ${{ github.actor }} --draft
+        gh pr create --head "$HEAD_BRANCH" --base "$BASE_BRANCH" --title "$TITLE" --body "$BODY" --assignee ${{ github.actor }}
         if [[ $? -ne 0 ]]; then
           echo "Failed to create new PR."
           exit 1

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -3,7 +3,7 @@ name: Build Storybook
 on:
   workflow_dispatch:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened]
   push:
     branches:
       - main

--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '0 0 * * *'
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened]
     paths:
       - .github/workflows/cli-test.yml
       - extensions/ql-vscode/src/codeql-cli/**

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Build Extension
 on:
   workflow_dispatch:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened]
   push:
     branches:
       - main


### PR DESCRIPTION
Remove `ready_for_review` from the build, Storybook, and CLI-test workflow triggers, and stop opening automated version-bump PRs as drafts.

Maintainers can approve pending checks on PRs created with `GITHUB_TOKEN`, so the draft-to-ready transition is no longer needed to trigger CI.